### PR TITLE
fix: improve the description of "reaching the declaration"

### DIFF
--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -826,7 +826,7 @@ This is useful because the code within [`main.js`](https://github.com/mdn/js-exa
 
 ## Import declarations are hoisted
 
-Import declarations are [hoisted](/en-US/docs/Glossary/Hoisting). In this case, it means that the imported values are available in the module's code even before the line that declares them, and that the imported module's side effects are produced before the rest of the module's code starts running.
+Import declarations are [hoisted](/en-US/docs/Glossary/Hoisting). In this case, it means that the imported values are available in the module's code even before the place that declares them, and that the imported module's side effects are produced before the rest of the module's code starts running.
 
 So for example, in `main.js`, importing `Canvas` in the middle of the code would still work:
 

--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -7,7 +7,7 @@ page-type: javascript-error
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "can't access lexical declaration \`_variable_' before initialization" occurs when a lexical variable was accessed before it was initialized.
-This happens within any block statement, when [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) variables are accessed before the line in which they are declared is executed.
+This happens within any block statement, when [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) variables are accessed before the place where they are declared is executed.
 
 ## Message
 
@@ -24,9 +24,9 @@ ReferenceError: Cannot access uninitialized variable. (Safari)
 ## What went wrong?
 
 A lexical variable was accessed before it was initialized.
-This happens within any block statement, when variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) are accessed before the line in which they are declared has been executed.
+This happens within any block statement, when variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) are accessed before the place where they are declared has been executed.
 
-Note that it is the execution order of access and variable declaration that matters, not the order in which the lines appear in the code.
+Note that it is the execution order of access and variable declaration that matters, not the order in which the statements appear in the code.
 For more information, see the description of [Temporal Dead Zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 
 This issue does not occur for variables declared using `var`, because they are initialized with a default value of `undefined` when they are [hoisted](/en-US/docs/Glossary/Hoisting).

--- a/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -54,7 +54,7 @@ const str = "Hello, "
 
 ### Assignments producing ReferenceErrors
 
-Invalid assignments don't always produce syntax errors. Sometimes the syntax is almost correct, but at runtime, the left hand side expression evaluates to a _value_ instead of a _reference_, so the assignment is still invalid. Such errors occur later in execution, when the line is actually executed.
+Invalid assignments don't always produce syntax errors. Sometimes the syntax is almost correct, but at runtime, the left hand side expression evaluates to a _value_ instead of a _reference_, so the assignment is still invalid. Such errors occur later in execution, when the statement is actually executed.
 
 ```js-nolint example-bad
 function foo() {

--- a/files/en-us/web/javascript/reference/operators/assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/assignment/index.md
@@ -56,7 +56,7 @@ This is equivalent to:
 const x = (y = 5);
 ```
 
-Which means `y` must be a pre-existing variable, and `x` is a newly declared `const` variable. `y` is assigned the value `5`, and `x` is initialized with the value of the `y = 5` expression, which is also `5`. If `y` is not a pre-existing variable, a global variable `y` is implicitly created in [non-strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), or a {{jsxref("ReferenceError")}} is thrown in strict mode. To declare two variables on the same line, use:
+Which means `y` must be a pre-existing variable, and `x` is a newly declared `const` variable. `y` is assigned the value `5`, and `x` is initialized with the value of the `y = 5` expression, which is also `5`. If `y` is not a pre-existing variable, a global variable `y` is implicitly created in [non-strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), or a {{jsxref("ReferenceError")}} is thrown in strict mode. To declare two variables within the same declaration, use:
 
 ```js
 const x = 5,

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -149,7 +149,7 @@ typeof (someData + " Wisen"); // "string"
 typeof undeclaredVariable; // "undefined"
 ```
 
-However, using `typeof` on lexical declarations ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}}, and [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)) in the same block before the line of declaration will throw a {{JSxRef("ReferenceError")}}. Block scoped variables are in a _[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)_ from the start of the block until the initialization is processed, during which it will throw an error if accessed.
+However, using `typeof` on lexical declarations ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}}, and [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)) in the same block before the place of declaration will throw a {{JSxRef("ReferenceError")}}. Block scoped variables are in a _[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)_ from the start of the block until the initialization is processed, during which it will throw an error if accessed.
 
 ```js example-bad
 typeof newLetVariable; // ReferenceError

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -29,7 +29,7 @@ class name extends otherName {
 The class body of a class declaration is executed in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode). The `class` declaration is very similar to {{jsxref("Statements/let", "let")}}:
 
 - `class` declarations are scoped to blocks as well as functions.
-- `class` declarations can only be accessed after the line of declaration is reached (see [temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)). For this reason, `class` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting) (unlike [function declarations](/en-US/docs/Web/JavaScript/Reference/Statements/function)).
+- `class` declarations can only be accessed after the place of declaration is reached (see [temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)). For this reason, `class` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting) (unlike [function declarations](/en-US/docs/Web/JavaScript/Reference/Statements/function)).
 - `class` declarations do not create properties on {{jsxref("globalThis")}} when declared at the top level of a script (unlike [function declarations](/en-US/docs/Web/JavaScript/Reference/Statements/function)).
 - `class` declarations cannot be [redeclared](/en-US/docs/Web/JavaScript/Reference/Statements/let#redeclarations) by any other declaration in the same scope.
 

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -29,7 +29,7 @@ const name1 = value1, name2 = value2, /* …, */ nameN = valueN;
 The `const` declaration is very similar to {{jsxref("Statements/let", "let")}}:
 
 - `const` declarations are scoped to blocks as well as functions.
-- `const` declarations can only be accessed after the line of declaration is reached (see [temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)). For this reason, `const` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting).
+- `const` declarations can only be accessed after the place of declaration is reached (see [temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)). For this reason, `const` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting).
 - `const` declarations do not create properties on {{jsxref("globalThis")}} when declared at the top level of a script.
 - `const` declarations cannot be [redeclared](/en-US/docs/Web/JavaScript/Reference/Statements/let#redeclarations) by any other declaration in the same scope.
 - `const` begins [_declarations_, not _statements_](/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations). That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -44,7 +44,7 @@ Or the current module or script, if it's contained in none of these.
 Compared with {{jsxref("Statements/var", "var")}}, `let` declarations have the following differences:
 
 - `let` declarations are scoped to blocks as well as functions.
-- `let` declarations can only be accessed after the line of declaration is reached (see [temporal dead zone](#temporal_dead_zone_tdz)). For this reason, `let` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting).
+- `let` declarations can only be accessed after its declaration is reached (see [temporal dead zone](#temporal_dead_zone_tdz)). For this reason, `let` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting).
 - `let` declarations do not create properties on {{jsxref("globalThis")}} when declared at the top level of a script.
 - `let` declarations cannot be [redeclared](#redeclarations) by any other declaration in the same scope.
 - `let` begins [_declarations_, not _statements_](/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations). That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -44,7 +44,7 @@ Or the current module or script, if it's contained in none of these.
 Compared with {{jsxref("Statements/var", "var")}}, `let` declarations have the following differences:
 
 - `let` declarations are scoped to blocks as well as functions.
-- `let` declarations can only be accessed after its declaration is reached (see [temporal dead zone](#temporal_dead_zone_tdz)). For this reason, `let` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting).
+- `let` declarations can only be accessed after the place of declaration is reached (see [temporal dead zone](#temporal_dead_zone_tdz)). For this reason, `let` declarations are commonly regarded as [non-hoisted](/en-US/docs/Glossary/Hoisting).
 - `let` declarations do not create properties on {{jsxref("globalThis")}} when declared at the top level of a script.
 - `let` declarations cannot be [redeclared](#redeclarations) by any other declaration in the same scope.
 - `let` begins [_declarations_, not _statements_](/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations). That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
@@ -61,11 +61,11 @@ The list that follows the `let` keyword is called a _{{glossary("binding")}} lis
 
 ### Temporal dead zone (TDZ)
 
-A variable declared with `let`, `const`, or `class` is said to be in a "temporal dead zone" (TDZ) from the start of the block until code execution reaches the line where the variable is declared and initialized.
+A variable declared with `let`, `const`, or `class` is said to be in a "temporal dead zone" (TDZ) from the start of the block until code execution reaches the place where the variable is declared and initialized.
 
-While inside the TDZ, the variable has not been initialized with a value, and any attempt to access it will result in a {{jsxref("ReferenceError")}}. The variable is initialized with a value when execution reaches the line of code where it was declared. If no initial value was specified with the variable declaration, it will be initialized with a value of `undefined`.
+While inside the TDZ, the variable has not been initialized with a value, and any attempt to access it will result in a {{jsxref("ReferenceError")}}. The variable is initialized with a value when execution reaches the place in the code where it was declared. If no initial value was specified with the variable declaration, it will be initialized with a value of `undefined`.
 
-This differs from {{jsxref("Statements/var", "var", "hoisting")}} variables, which will return a value of `undefined` if they are accessed before they are declared. The code below demonstrates the different result when `let` and `var` are accessed in code before the line in which they are declared.
+This differs from {{jsxref("Statements/var", "var", "hoisting")}} variables, which will return a value of `undefined` if they are accessed before they are declared. The code below demonstrates the different result when `let` and `var` are accessed in code before the place where they are declared.
 
 ```js example-bad
 {


### PR DESCRIPTION
### Description

As we may use webpack or other tools to "compress" the source code, all the declarations and statements would be in the same line. Using "the line of declaration" is not appropriate.

### Related issues and pull requests

https://github.com/mdn/translated-content/pull/15517#discussion_r1310150421
