### PR TITLE
Fix issue 27610: Better example for pointerlockchange event

### DIFF
--- a/files/en-us/web/api/document/pointerlockchange_event/index.md
+++ b/files/en-us/web/api/document/pointerlockchange_event/index.md
@@ -10,6 +10,8 @@ browser-compat: api.Document.pointerlockchange_event
 
 The `pointerlockchange` event is fired when the pointer is locked/unlocked.
 
+The event handler can use {{domxref("Document.pointerLockElement")}} to determine whether the pointer is locked, and if so, to which element it is locked.
+
 This event is not cancelable.
 
 ## Syntax
@@ -31,8 +33,12 @@ A generic {{domxref("Event")}}.
 Using `addEventListener()`:
 
 ```js
-document.addEventListener("pointerlockchange", (event) => {
-  console.log("Pointer lock changed");
+addEventListener("pointerlockchange", (event) => {
+  if (document.pointerLockElement)
+    console.log("The pointer is locked to: ", document.pointerLockElement);
+  else {
+    console.log("The pointer is not locked");
+  }
 });
 ```
 
@@ -40,7 +46,11 @@ Using the `onpointerlockchange` event handler property:
 
 ```js
 document.onpointerlockchange = (event) => {
-  console.log("Pointer lock changed");
+  if (document.pointerLockElement)
+    console.log("The pointer is locked to: ", document.pointerLockElement);
+  else {
+    console.log("The pointer is not locked");
+  }
 };
 ```
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/27610.

I've used more or less the code suggested by @allan-bonadio in the issue, except for the humour, because <strike>I don't have a sense of humour</strike> humour is _very_ culturally specific and is very likely to end up confusing people.

Thank you for the suggestion, @allan-bonadio !