### PR TITLE
Fix issue 27562: "Measuring performance" conclusion

### DIFF
--- a/files/en-us/learn/performance/measuring_performance/index.md
+++ b/files/en-us/learn/performance/measuring_performance/index.md
@@ -95,6 +95,6 @@ While this article does not dive into using these APIs, it is useful to know the
 
 ## Conclusion
 
-This article provided a brief overview of web performance tools that can help you measure performance on a web app or site. Next up, you'll look at perceived performance and some techniques to make unavoidable performance hits appear less severe to the user, or disguise them completely.
+This article provided a brief overview of some of the tools that can help you measure performance on a web app or site. In the next article, we'll see how you can optimize images on your site to improve its performance.
 
 {{PreviousMenuNext("Learn/Performance/Perceived_performance", "Learn/Performance/Multimedia", "Learn/Performance")}}


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/27562.

I think the problem here is that the forward-looking part of the ["Measuring performance" conclusion](https://developer.mozilla.org/en-US/docs/Learn/Performance/Measuring_performance#conclusion) expected the ["Perceived performance"](https://developer.mozilla.org/en-US/docs/Learn/Performance/Perceived_performance) article to come next, while actually the ["Multimedia: Images"](https://developer.mozilla.org/en-US/docs/Learn/Performance/Multimedia) article comes next.
