### PR TITLE
,? not ?,

### DIFF
--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -100,17 +100,17 @@ For {{SVGElement('marker')}}, `viewBox` defines the position and dimension for t
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
@@ -142,17 +142,17 @@ For {{SVGElement('pattern')}}, `viewBox` defines the position and dimension for 
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
@@ -184,17 +184,17 @@ For {{SVGElement('svg')}}, `viewBox` defines the position and dimension for the 
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
@@ -226,17 +226,17 @@ For {{SVGElement('symbol')}}, `viewBox` defines the position and dimension for t
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
@@ -268,17 +268,17 @@ For {{SVGElement('view')}}, `viewBox` defines the position and dimension for the
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a
           ></strong
-        >?,
+        >,?
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#number"
             >&#x3C;number></a


### PR DESCRIPTION
These changes reflect the way the spec does it here, at the very top of this section: https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute

`[<min-x>,? <min-y>,? <width>,? <height>]`

I assume that this docs page is intending to imitate the spec on this, but I am not even certain what the `?` means.  I think it means that these arguments are optional, thus that `viewBox` requires only one argument.  I am submitting this PR largely because I want to find out for certain what the `?` means here and in the spec.  I don't see any glossary that explains it anywhere.  Maybe you can point me to one.