### PR TITLE
Fix 28866: Clarify polygon() syntax

### DIFF
--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -35,7 +35,7 @@ clip-path: polygon(0 0, 50% 1rem, 100% 2vw, calc(100% - 20px) 100%, 0 100%);
 
 ### Setting a polygon for shape-outside
 
-In this example a shape is created for text to follow using the {{cssxref("shape-outside")}} property. We've drawn the reference box for the shape, to help understand how the polygon is calculated.
+In this example a shape is created for text to follow using the {{cssxref("shape-outside")}} property.
 
 ```html
 <div class="box">
@@ -56,23 +56,34 @@ In this example a shape is created for text to follow using the {{cssxref("shape
 
 ```css
 .box {
-  width: 300px;
+  width: 250px;
 }
 
 .shape {
   float: left;
-  shape-outside: polygon(0px 0px, 80.67% 17.17%, 200px 150px, 0px 189px) border-box;
-  width: 200px;
-  height: 200px;
-  border: 1px solid red;
+  shape-outside: polygon(
+      0px 10px,
+      15% 12%,
+      30% 15%,
+      40% 26%,
+      45% 35%,
+      45% 45%,
+      40% 55%,
+      10% 90%,
+      10% 98%,
+      8% 100%,
+      0 100%
+    ) border-box;
+  width: 300px;
+  height: 320px;
 }
 
 p {
-  font-size: 0.8rem;
+  font-size: 0.9rem;
 }
 ```
 
-{{EmbedLiveSample("Setting a polygon for shape-outside", '100%', 300)}}
+{{EmbedLiveSample("Setting a polygon for shape-outside", '100%', 400)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.basic-shape.polygon
 
 {{CSSRef}}
 
-The **`polygon()`** [CSS](/en-US/docs/Web/CSS) function is one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types).
+The **`polygon()`** [CSS](/en-US/docs/Web/CSS) function is one of the {{cssxref("&lt;basic-shape&gt;")}} [data types](/en-US/docs/Web/CSS/CSS_Types). It's used to draw a [polygon](https://en.wikipedia.org/wiki/Polygon) by providing one or more pairs of coordinates, each of which represents a vertex of the shape.
 
 {{EmbedInteractiveExample("pages/css/function-polygon.html")}}
 
@@ -15,22 +15,63 @@ The **`polygon()`** [CSS](/en-US/docs/Web/CSS) function is one of the {{cssxref(
 
 ```css
 clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%);
+clip-path: polygon(0px 0px, 200px 100px, 0px 200px);
+clip-path: polygon(0% 0px, 100% 100px, 0px 100%);
 ```
 
 ### Values
 
-- `<fill-rule>`
-  - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the [filling rule](/en-US/docs/Web/SVG/Attribute/fill-rule).
-- `[<length-percentage><length-percentage>]#`
-  - : Three or more pairs of values (a polygon must at least draw a triangle). These values are co-ordinates drawn with reference to the reference box.
+- [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule)
+  - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the filling rule.
+- {{cssxref("length-percentage")}}
+  - : Each vertex of the polygon is represented with a pair of `<length-percentage>` values, which give the coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
+
+### Formal syntax
+
+{{csssyntax}}
 
 ## Examples
 
-### Basic polygon() example
+### Setting a polygon for shape-outside
 
-In this example a shape is created for text to follow using the `polygon()`, you can change any of the values to see how the shape is changed.
+In this example a shape is created for text to follow using the {{cssxref("shape-outside")}} property. We've drawn the reference box for the shape, to help understand how the polygon is calculated.
 
-{{EmbedGHLiveSample("css-examples/shapes/basic-shape/polygon.html", '100%', 800)}}
+```html
+<div class="box">
+  <div class="shape"></div>
+  <p>
+    One November night in the year 1782, so the story runs, two brothers sat
+    over their winter fire in the little French town of Annonay, watching the
+    grey smoke-wreaths from the hearth curl up the wide chimney. Their names
+    were Stephen and Joseph Montgolfier, they were papermakers by trade, and
+    were noted as possessing thoughtful minds and a deep interest in all
+    scientific knowledge and new discovery. Before that night—a memorable night,
+    as it was to prove—hundreds of millions of people had watched the rising
+    smoke-wreaths of their fires without drawing any special inspiration from
+    the fact.
+  </p>
+</div>
+```
+
+```css
+.box {
+  width: 300px;
+}
+
+.shape {
+  float: left;
+  shape-outside: polygon(0px 0px, 80.67% 17.17%, 200px 150px, 0px 189px) border-box;
+  width: 200px;
+  height: 200px;
+  border: 1px solid red;
+}
+
+p {
+  font-size: 0.8rem;
+}
+```
+
+{{EmbedLiveSample("Setting a polygon for shape-outside", '100%', 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -17,6 +17,7 @@ The **`polygon()`** [CSS](/en-US/docs/Web/CSS) function is one of the {{cssxref(
 clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%);
 clip-path: polygon(0px 0px, 200px 100px, 0px 200px);
 clip-path: polygon(0% 0px, 100% 100px, 0px 100%);
+clip-path: polygon(0 0, 50% 1rem, 100% 2vw, calc(100% - 20px) 100%, 0 100%);
 ```
 
 ### Values

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -28,12 +28,16 @@ polygon(nonzero, 0% 0%, 50% 50%, 0% 100%)
 polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 ```
 
-### Values
+### Parameters
 
-- [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule)
+- [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) {{optional_inline}}
   - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the filling rule.
 - {{cssxref("length-percentage")}}
   - : Each vertex of the polygon is represented with a pair of `<length-percentage>` values, which give the coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
+
+### Return value
+
+Returns a {{cssxref("basic-shape")}} value.
 
 ## Formal syntax
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -13,11 +13,19 @@ The **`polygon()`** [CSS](/en-US/docs/Web/CSS) function is one of the {{cssxref(
 
 ## Syntax
 
-```css
-clip-path: polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%);
-clip-path: polygon(0px 0px, 200px 100px, 0px 200px);
-clip-path: polygon(0% 0px, 100% 100px, 0px 100%);
-clip-path: polygon(0 0, 50% 1rem, 100% 2vw, calc(100% - 20px) 100%, 0 100%);
+```css-nolint
+
+/* Specified as coordinate list */
+/* polygon(<length-percentage> <length-percentage>, ... )*/
+polygon(50% 2.4%, 34.5% 33.8%, 0% 38.8%, 25% 63.1%, 19.1% 97.6%)
+polygon(0px 0px, 200px 100px, 0px 200px)
+polygon(0% 0px, 100% 100px, 0px 100%)
+polygon(0 0, 50% 1rem, 100% 2vw, calc(100% - 20px) 100%, 0 100%)
+
+/* Specified as coordinate list and fill rule*/
+/* polygon(<fill-rule> <length-percentage> <length-percentage>, ... )*/
+polygon(nonzero, 0% 0%, 50% 50%, 0% 100%)
+polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 ```
 
 ### Values
@@ -27,7 +35,7 @@ clip-path: polygon(0 0, 50% 1rem, 100% 2vw, calc(100% - 20px) 100%, 0 100%);
 - {{cssxref("length-percentage")}}
   - : Each vertex of the polygon is represented with a pair of `<length-percentage>` values, which give the coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
 
-### Formal syntax
+## Formal syntax
 
 {{csssyntax}}
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -62,7 +62,7 @@ In this example a shape is created for text to follow using the {{cssxref("shape
 .shape {
   float: left;
   shape-outside: polygon(
-    0px 10px,
+    0 5%,
     15% 12%,
     30% 15%,
     40% 26%,

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -62,18 +62,18 @@ In this example a shape is created for text to follow using the {{cssxref("shape
 .shape {
   float: left;
   shape-outside: polygon(
-      0px 10px,
-      15% 12%,
-      30% 15%,
-      40% 26%,
-      45% 35%,
-      45% 45%,
-      40% 55%,
-      10% 90%,
-      10% 98%,
-      8% 100%,
-      0 100%
-    ) border-box;
+    0px 10px,
+    15% 12%,
+    30% 15%,
+    40% 26%,
+    45% 35%,
+    45% 45%,
+    40% 55%,
+    10% 90%,
+    10% 98%,
+    8% 100%,
+    0 100%
+  );
   width: 300px;
   height: 320px;
 }


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28866.

This makes a few changes to the page for [`polygon()`](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/polygon), including:

- more informative summary
- more syntax examples to show you can use more than just percentages
- rewritten "Values" section to add links
- added "Formal syntax"
- turned GH sample into a live sample, which is a lot more readable (wrt this we have expressed a desire to move away from GHLiveSample when we can, and towards EmbedLiveSample)
- made some minor changes to the example to (I hope) make it more understandable

If you like these changes we should do something similar with the other `<basic-shape>` functions.
