### PR TITLE
Update “File drag and drop” doc to mention inability to use setDragImage and setData when dragging files into the browser from the OS

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -44,7 +44,7 @@ Lastly, an application may want to style the drop target element to visually ind
 ```
 
 > **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser, use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
-> This means that it is not possible to use [`setDragImage()`](/en-US/docs/Web/API/DataTransfer/setDragImage) to apply a custom drag image/cursor overlay when dragging files from the OS — because the drag data store is read-only in all events other than {{domxref("HTMLElement/dragstart_event", "dragstart")}}. This also applies to {{domxref("DataTransferItem.setData","setData()")}}.
+> This means that it is not possible to use {{domxref("DataTransfer.setDragImage","setDragImage()")}} to apply a custom drag image/cursor overlay when dragging files from the OS — because the drag data store can only be modified in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event. This also applies to {{domxref("DataTransfer.setData","setData()")}}.
 
 ## Process the drop
 

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -44,6 +44,7 @@ Lastly, an application may want to style the drop target element to visually ind
 ```
 
 > **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser, use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
+> This means that it is not possible to use {{domxref("DataTransferItem.setDragImage","setDragImage()")}} to apply a custom drag image/cursor overlay when dragging files from the OS, because the drag data store is read-only in all events other than{{domxref("HTMLElement/dragstart_event", "dragstart")}}. This also applies to {{domxref("DataTransferItem.setData","setData()")}}.
 
 ## Process the drop
 

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -44,7 +44,7 @@ Lastly, an application may want to style the drop target element to visually ind
 ```
 
 > **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser, use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
-> This means that it is not possible to use {{domxref("DataTransferItem.setDragImage","setDragImage()")}} to apply a custom drag image/cursor overlay when dragging files from the OS, because the drag data store is read-only in all events other than {{domxref("HTMLElement/dragstart_event", "dragstart")}}. This also applies to {{domxref("DataTransferItem.setData","setData()")}}.
+> This means that it is not possible to use [`setDragImage()`](/en-US/docs/Web/API/DataTransfer/setDragImage) to apply a custom drag image/cursor overlay when dragging files from the OS — because the drag data store is read-only in all events other than {{domxref("HTMLElement/dragstart_event", "dragstart")}}. This also applies to {{domxref("DataTransferItem.setData","setData()")}}.
 
 ## Process the drop
 

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -44,7 +44,7 @@ Lastly, an application may want to style the drop target element to visually ind
 ```
 
 > **Note:** {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are not fired when dragging a file into the browser from the OS. To detect when OS files are dragged into the browser, use {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragleave_event", "dragleave")}}.
-> This means that it is not possible to use {{domxref("DataTransferItem.setDragImage","setDragImage()")}} to apply a custom drag image/cursor overlay when dragging files from the OS, because the drag data store is read-only in all events other than{{domxref("HTMLElement/dragstart_event", "dragstart")}}. This also applies to {{domxref("DataTransferItem.setData","setData()")}}.
+> This means that it is not possible to use {{domxref("DataTransferItem.setDragImage","setDragImage()")}} to apply a custom drag image/cursor overlay when dragging files from the OS, because the drag data store is read-only in all events other than {{domxref("HTMLElement/dragstart_event", "dragstart")}}. This also applies to {{domxref("DataTransferItem.setData","setData()")}}.
 
 ## Process the drop
 


### PR DESCRIPTION
Add explicit text about the inability to use setDragImage and setData when dragging files into the browser from the OS, as dragstart is never fired.

### Description

The _File drag and drop_ page is a great overview of how to build a barebones file drop handler. But it lacks a specific note about this particular limitation.

### Motivation

I hope to prevent others from having to figure this out the hard/time-consuming way, as I did.

