### PR TITLE
Standardize rest parameters for web APIs

### DIFF
--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -13,9 +13,9 @@ The **`add()`** method of the {{domxref("DOMTokenList")}} interface adds the giv
 ## Syntax
 
 ```js-nolint
-add(token0)
-add(token0, token1)
-add(token0, token1, /* …, */ tokenN)
+add(token1)
+add(token1, token2)
+add(token1, token2, /* …, */ tokenN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
@@ -17,19 +17,17 @@ The {{domxref("RTCPeerConnection")}} method **`addTrack()`** adds a new media tr
 
 ```js-nolint
 addTrack(track)
-addTrack(track, stream0)
-addTrack(track, stream0, stream1)
-addTrack(track, stream0, stream1, /* …, */ streamN)
+addTrack(track, stream1)
+addTrack(track, stream1, stream2)
+addTrack(track, stream1, stream2, /* …, */ streamN)
 ```
 
 ### Parameters
 
 - `track`
-  - : A {{domxref("MediaStreamTrack")}} object representing the media track to add to the
-    peer connection.
-- `stream0, …, streamN` {{optional_inline}}
-  - : One or more local {{domxref("MediaStream")}} objects to which the track should be
-    added.
+  - : A {{domxref("MediaStreamTrack")}} object representing the media track to add to the peer connection.
+- `stream1`, …, `streamN` {{optional_inline}}
+  - : One or more local {{domxref("MediaStream")}} objects to which the track should be added.
 
 The specified `track` doesn't necessarily have to already be part of any of
 the specified `stream`s. Instead, the `stream`s are a way to group

--- a/files/en-us/web/api/rtcrtpsender/setstreams/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setstreams/index.md
@@ -14,16 +14,15 @@ The {{domxref("RTCRtpSender")}} method **`setStreams()`** associates the sender'
 
 ```js-nolint
 setStreams()
-setStreams(mediaStream0)
-setStreams(mediaStream0, mediaStream1)
-setStreams(mediaStream0, mediaStream1, /* …, */ mediaStreamN)
+setStreams(mediaStream1)
+setStreams(mediaStream1, mediaStream2)
+setStreams(mediaStream1, mediaStream2, /* …, */ mediaStreamN)
 ```
 
 ### Parameters
 
 - `mediaStreamN` {{optional_inline}}
-  - : An arbitrary number of {{domxref("MediaStream")}} objects specified as arguments, that identify the streams to which the
-    `RTCRtpSender`'s {{domxref("RTCRtpSender.track", "track")}} belongs.
+  - : An arbitrary number of {{domxref("MediaStream")}} objects specified as arguments, that identify the streams to which the `RTCRtpSender`'s {{domxref("RTCRtpSender.track", "track")}} belongs.
     If this parameter isn't specified, no new streams will be associated with the track.
 
 ### Return value

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -8,14 +8,9 @@ browser-compat: api.setInterval
 
 {{APIRef("HTML DOM")}}
 
-The **`setInterval()`** method,
-offered on the {{domxref("Window")}} and {{domxref("Worker")}} interfaces, repeatedly
-calls a function or executes a code snippet, with a fixed time delay between each
-call.
+The **`setInterval()`** method, offered on the {{domxref("Window")}} and {{domxref("Worker")}} interfaces, repeatedly calls a function or executes a code snippet, with a fixed time delay between each call.
 
-This method returns an interval ID which uniquely identifies the interval, so you
-can remove it later by calling {{domxref("clearInterval",
-  "clearInterval()")}}.
+This method returns an interval ID which uniquely identifies the interval, so you can remove it later by calling {{domxref("clearInterval", "clearInterval()")}}.
 
 ## Syntax
 
@@ -25,9 +20,9 @@ setInterval(code, delay)
 
 setInterval(func)
 setInterval(func, delay)
-setInterval(func, delay, arg0)
-setInterval(func, delay, arg0, arg1)
-setInterval(func, delay, arg0, arg1, /* …, */ argN)
+setInterval(func, delay, arg1)
+setInterval(func, delay, arg1, arg2)
+setInterval(func, delay, arg1, arg2, /* …, */ argN)
 ```
 
 ### Parameters
@@ -35,34 +30,23 @@ setInterval(func, delay, arg0, arg1, /* …, */ argN)
 - `func`
   - : A {{jsxref("function")}} to be executed every `delay` milliseconds. The first execution happens after `delay` milliseconds.
 - `code`
-  - : An optional syntax allows you to include a string instead of a function, which is
-    compiled and executed every `delay` milliseconds. This syntax is _not
-    recommended_ for the same reasons that make using {{jsxref("Global_Objects/eval", "eval()")}} a
-    security risk.
+  - : An optional syntax allows you to include a string instead of a function, which is compiled and executed every `delay` milliseconds.
+    This syntax is _not recommended_ for the same reasons that make using {{jsxref("Global_Objects/eval", "eval()")}} a security risk.
 - `delay` {{optional_inline}}
-  - : The time, in milliseconds (thousandths of a second), the timer should delay in
-    between executions of the specified function or code. Defaults to 0 if not specified. See [Delay restrictions](#delay_restrictions)
-    below for details on the permitted range of `delay` values.
-- `arg0, …, argN` {{optional_inline}}
-  - : Additional arguments which are passed through to the function specified by
-    _func_ once the timer expires.
+  - : The time, in milliseconds (thousandths of a second), the timer should delay in between executions of the specified function or code. Defaults to 0 if not specified.
+    See [Delay restrictions](#delay_restrictions) below for details on the permitted range of `delay` values.
+- `arg1`, …,`argN` {{optional_inline}}
+  - : Additional arguments which are passed through to the function specified by _func_ once the timer expires.
 
 ### Return value
 
-The returned `intervalID` is a numeric, non-zero value which identifies the
-timer created by the call to `setInterval()`; this value can be passed to
-{{domxref("clearInterval()")}} to cancel the interval.
+The returned `intervalID` is a numeric, non-zero value which identifies the timer created by the call to `setInterval()`; this value can be passed to {{domxref("clearInterval()")}} to cancel the interval.
 
-It may be helpful to be aware that `setInterval()` and
-{{domxref("setTimeout()")}} share the same pool
-of IDs, and that `clearInterval()` and
-{{domxref("clearTimeout", "clearTimeout()")}} can technically
-be used interchangeably. For clarity, however, you should try to always match them to
-avoid confusion when maintaining your code.
+It may be helpful to be aware that `setInterval()` and {{domxref("setTimeout()")}} share the same pool of IDs, and that `clearInterval()` and {{domxref("clearTimeout", "clearTimeout()")}} can technically be used interchangeably.
+For clarity, however, you should try to always match them to avoid confusion when maintaining your code.
 
-> **Note:** The `delay` argument is converted to a
-> signed 32-bit integer. This effectively limits `delay` to 2147483647 ms,
-> since it's specified as a signed integer in the IDL.
+> **Note:** The `delay` argument is converted to a signed 32-bit integer.
+> This effectively limits `delay` to 2147483647 ms, since it's specified as a signed integer in the IDL.
 
 ## Examples
 
@@ -143,9 +127,8 @@ See also: [`clearInterval()`](/en-US/docs/Web/API/clearInterval).
 
 ## The "this" problem
 
-When you pass a method to `setInterval()` or any other function, it is
-invoked with the wrong [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)
-value. This problem is explained in detail in the [JavaScript reference](/en-US/docs/Web/JavaScript/Reference/Operators/this#callbacks).
+When you pass a method to `setInterval()` or any other function, it is invoked with the wrong [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) value.
+This problem is explained in detail in the [JavaScript reference](/en-US/docs/Web/JavaScript/Reference/Operators/this#callbacks).
 
 ### Explanation
 

--- a/files/en-us/web/api/window/setimmediate/index.md
+++ b/files/en-us/web/api/window/setimmediate/index.md
@@ -19,9 +19,9 @@ updates.
 
 ```js-nolint
 setImmediate(func)
-setImmediate(func, param0)
-setImmediate(func, param0, param1)
-setImmediate(func, param0, param1, /* …, */ paramN)
+setImmediate(func, param1)
+setImmediate(func, param1, param2)
+setImmediate(func, param1, param2, /* …, */ paramN)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ setImmediate(func, param0, param1, /* …, */ paramN)
 
   - : The function you wish to call.
 
-- `param0`, …, `paramN`
+- `param1`, …, `paramN`
   - : All parameters will be passed directly to your function.
 
 ### Return value


### PR DESCRIPTION
This follows on from #28651, updating Web API to match page structure for rest parameter names to start from 1.

For example `unshift(element0, element1, /* …, */ elementN)` changes to `unshift(element1, element2, /* …, */ elementN)`.

These found by searching for some common names, and then for `/* …, */`. Majority were already matching new format. 

