### PR TITLE
Fix 28835: Update order of dispatch for focus events

### DIFF
--- a/files/en-us/web/api/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/index.md
@@ -29,14 +29,7 @@ _This interface has no specific methods. It inherits methods from its parent {{d
 
 ## Order of events
 
-The _UI Events_ specification states that focus events [occur in a set order](https://w3c.github.io/uievents/#events-focusevent-event-order) relative to one another, and goes on to describe the typical sequence of events that fire when the focus is shifted from element A to element B:
-
-1. `focusout`: sent before element A loses focus.
-2. `focusin`: sent before element B receives focus.
-3. `blur`: sent after element A loses focus.
-4. `focus`: sent after element B receives focus.
-
-However, current browser implementations fire these four events in a different order:
+When focus is shifted from element A to element B, focus events are dispatched in the following order:
 
 1. `blur`: sent after element A loses focus.
 2. `focusout`: sent after the `blur` event.


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28835.

See also https://github.com/w3c/uievents/issues/88 and its resolution in https://github.com/w3c/uievents/pull/290.