### PR TITLE
camelCase, not camel-case

### DIFF
--- a/files/en-us/web/api/cssstyledeclaration/removeproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/removeproperty/index.md
@@ -20,7 +20,7 @@ removeProperty(property)
 ### Parameters
 
 - `property`
-  - A string representing the property name to be removed. Multi-word property names are hyphenated and not camel-cased.
+  - A string representing the property name to be removed. Multi-word property names are snake-case, not camelCase.
 
 ### Return value
 


### PR DESCRIPTION
"camel-case" is just wrong, and if you're going to use the term, "snake-case" is a better counterpart than "hyphenated".