### PR TITLE
Correct EXSLT namespaces

### DIFF
--- a/files/en-us/web/exslt/regexp/index.md
+++ b/files/en-us/web/exslt/regexp/index.md
@@ -6,6 +6,6 @@ page-type: landing-page
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}
 
-The EXSLT Regular Expressions package provides functions that allow testing, matching, and replacing text using JavaScript style regular expressions. The namespace for the Regular Expressions package is `http://exslt.org/regexp`.
+The EXSLT Regular Expressions package provides functions that allow testing, matching, and replacing text using JavaScript style regular expressions. The namespace for the Regular Expressions package is `http://exslt.org/regular-expressions`.
 
 {{SubpagesWithSummaries}}

--- a/files/en-us/web/exslt/set/index.md
+++ b/files/en-us/web/exslt/set/index.md
@@ -6,6 +6,6 @@ page-type: landing-page
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}
 
-The EXSLT Sets package offers functions that let you perform set manipulation. The namespace for these functions is `http://exslt.org/set`.
+The EXSLT Sets package offers functions that let you perform set manipulation. The namespace for these functions is `http://exslt.org/sets`.
 
 {{SubpagesWithSummaries}}

--- a/files/en-us/web/exslt/str/index.md
+++ b/files/en-us/web/exslt/str/index.md
@@ -6,6 +6,6 @@ page-type: landing-page
 
 {{XSLTRef}}{{QuickLinksWithSubpages("/en-US/docs/Web/EXSLT")}}
 
-The EXSLT Strings package provides functions that allow the manipulation of strings. The namespace for the Strings package is `http://exslt.org/str`.
+The EXSLT Strings package provides functions that allow the manipulation of strings. The namespace for the Strings package is `http://exslt.org/strings`.
 
 {{SubpagesWithSummaries}}


### PR DESCRIPTION
### Description

These namespaces are incorrect.  Fix them.  (In fact, <https://developer.mozilla.org/en-US/docs/Web/EXSLT> is self-contradictory.)

### Motivation

This is simply incorrect.

### Additional details

See <https://exslt.github.io/regexp/index.html>, <https://exslt.github.io/set/index.html>, and <https://exslt.github.io/str/index.html> as sources of truth.  Firefox's behavior matches these.

### Related issues and pull requests

(none)