### PR TITLE
Add Navigator.clipboard property

### DIFF
--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -17,8 +17,10 @@ _Doesn't inherit any properties._
 
 ### Standard properties
 
+- {{domxref("Navigator.clipboard")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("Clipboard")}} object that provides read and write access to the system clipboard.
 - {{domxref("Navigator.connection")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Provides a {{domxref("NetworkInformation")}} object containing information about the network connection of a device.
+  - : Returns a {{domxref("NetworkInformation")}} object containing information about the network connection of a device.
 - {{domxref("Navigator.cookieEnabled")}} {{ReadOnlyInline}}
   - : Returns false if setting a cookie will be ignored and true otherwise.
 - {{domxref("Navigator.credentials")}} {{ReadOnlyInline}}


### PR DESCRIPTION
This property is already listed in the side menu, but it was missing from the main page content.

Page: https://developer.mozilla.org/en-US/docs/Web/API/Navigator