### PR TITLE
Improved the reliability of cache.match by using an url instead of a request

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
@@ -287,7 +287,7 @@ self.addEventListener("fetch", (event) => {
   event.respondWith(
     (async () => {
       const cache = await caches.open(CACHE_NAME);
-      const cachedResponse = await cache.match(event.request);
+      const cachedResponse = await cache.match(event.request.url);
       if (cachedResponse) {
         // Return the cached response if it's available.
         return cachedResponse;

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
@@ -214,7 +214,7 @@ self.addEventListener("fetch", (event) => {
   event.respondWith(
     (async () => {
       const cache = await caches.open(CACHE_NAME);
-      const cachedResponse = await cache.match(event.request);
+      const cachedResponse = await cache.match(event.request.url);
       if (cachedResponse) {
         // Return the cached response if it's available.
         return cachedResponse;


### PR DESCRIPTION
### Description
The match would sometimes fail due to the VARY header.

### Motivation
For a tutorial, it's very important to be as safe as possible, so `request.url` should be used instead of `request`.

### Additional details
https://stackoverflow.com/questions/42813582/service-worker-cache-matchrequest-returns-undefined
