### PR TITLE
fix(css): `:blank` and `@page:blank` are not same

### DIFF
--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -153,7 +153,7 @@ Where the `<page-body>` includes:
 
 and `<pseudo-selector>` represents these pseudo-classes:
 
-- {{Cssxref(":blank")}}
+- [`:blank`](https://drafts.csswg.org/css-page/#blank-pseudo)
 - {{Cssxref(":first")}}
 - {{Cssxref(":left")}}
 - {{Cssxref(":right")}}
@@ -389,7 +389,7 @@ Clicking the print button will launch a print dialog with the html sections spli
 
 Please refer to the various [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) of `@page` for examples.
 
-- {{Cssxref(":blank")}}
+- [`:blank`](https://drafts.csswg.org/css-page/#blank-pseudo)
 - {{Cssxref(":first")}}
 - {{Cssxref(":left")}}
 - {{Cssxref(":right")}}


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/28809

They are not the same because they'll be tracked separately in browser compatibility. So on @page, removing association with input related `:blank`. 