### PR TITLE
Marked realm as required

### DIFF
--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -94,7 +94,8 @@ Generally you will need to check the relevant specifications for these (keys for
 ### Basic
 
 - `<realm>`
-  - : As above.
+  - : As [above](#realm).
+    Note that the realm is mandatory for basic authentication.
 - `charset="UTF-8"` {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.
     The only allowed value is the case-insensitive string "UTF-8".

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -65,10 +65,9 @@ WWW-Authenticate: <auth-scheme> realm=<realm> auth-param1=auth-param1-token, ...
 WWW-Authenticate: <auth-scheme> token68 auth-param1=auth-param1-token, ..., auth-paramN=auth-paramN-token
 ```
 
-For example, [Basic authentication](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) allows for optional `realm` and `charset` keys, but does not support `token68`.
+For example, [Basic authentication](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) requires `realm` and allows for optional use of `charset` key, but does not support `token68`.
 
 ```http
-WWW-Authenticate: Basic
 WWW-Authenticate: Basic realm=<realm>
 WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
 ```
@@ -94,7 +93,7 @@ Generally you will need to check the relevant specifications for these (keys for
 
 ### Basic
 
-- `<realm>` {{optional_inline}}
+- `<realm>` {{required_inline}}
   - : As above.
 - `charset="UTF-8"` {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -93,7 +93,7 @@ Generally you will need to check the relevant specifications for these (keys for
 
 ### Basic
 
-- `<realm>` {{required_inline}}
+- `<realm>`
   - : As above.
 - `charset="UTF-8"` {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.


### PR DESCRIPTION
Fixes: #28531 

Resolving the contradiction to RFC(As per [RFC 7617, Section 2](https://datatracker.ietf.org/doc/html/rfc7617#section-2)), marked realm as a required parameter in the basic authentication scheme. Also removed one example that omitted realm as a parameter from basic authentication.



