### PR TITLE
CSS selector structure: fix CSSxRef macro for :is()

### DIFF
--- a/files/en-us/web/css/css_selectors/selector_structure/index.md
+++ b/files/en-us/web/css/css_selectors/selector_structure/index.md
@@ -88,7 +88,7 @@ If any selector in a [non-forgiving selector](/en-US/docs/Web/CSS/Selector_list#
 }
 ```
 
-The {{cssxref("is", ":is()")}} and {{cssxref(":where", ":where()")}} pseudo-classes can be used to construct [forgiving selector lists](/en-US/docs/Web/CSS/Selector_list#forgiving_selector_list).
+The {{cssxref(":is", ":is()")}} and {{cssxref(":where", ":where()")}} pseudo-classes can be used to construct [forgiving selector lists](/en-US/docs/Web/CSS/Selector_list#forgiving_selector_list).
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description/Motivation

<!-- ✍️ Summarize your changes in one or two sentences -->
Corrects the first parameter of the CSSxRef macro for `:is()`. Currently the macro results in a link that says documentation for `:is()` does not exist yet, but [the page exists](https://developer.mozilla.org/en-US/docs/Web/CSS/:is).

