### PR TITLE
Fix a typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/small/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/small/index.md
@@ -38,7 +38,7 @@ const worldString = "Hello, world";
 
 console.log(worldString.small()); // <small>Hello, world</small>
 console.log(worldString.big()); // <big>Hello, world</big>
-console.log(worldString.fontsize(7)); // <font size="7">Hello, world</fontsize>
+console.log(worldString.fontsize(7)); // <font size="7">Hello, world</font>
 ```
 
 With the {{domxref("HTMLElement/style", "element.style")}} object you can get the element's `style` attribute and manipulate it more generically, for example:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replacing the wrong closing tag `</fontsize>` with `</font>`.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Correcting minor typo.

### Additional details

### Related issues and pull requests
