### PR TITLE
Update realm restrictions

### DIFF
--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -84,7 +84,7 @@ WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
 - **realm=**\<realm> {{optional_inline}}
   - : A string describing a protected area.
     A realm allows a server to partition up the areas it protects (if supported by a scheme that allows such partitioning).
-    Some clients show this value to the user to inform them about which particular credentials are required though most browsers stopped doing so to counter phishing.
+    Some clients show this value to the user to inform them about which particular credentials are required — though most browsers stopped doing so to counter phishing.
     The only reliably supported character set for this value is `us-ascii`.
     If no realm is specified, clients often display a formatted hostname instead.
 - `<token68>` {{optional_inline}}

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -83,7 +83,9 @@ WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
 
 - **realm=**\<realm> {{optional_inline}}
   - : A string describing a protected area.
-    A realm allows a server to partition up the areas it protects (if supported by a scheme that allows such partitioning), and informs users about which particular username/password are required.
+    A realm allows a server to partition up the areas it protects (if supported by a scheme that allows such partitioning).
+    Some clients show this value to the user to inform them about which particular credentials are required though most browsers stopped doing so to counter phishing.
+    The only reliably supported character set for this value is `us-ascii`.
     If no realm is specified, clients often display a formatted hostname instead.
 - `<token68>` {{optional_inline}}
   - : A token that may be useful for some schemes. The token allows the 66 unreserved URI characters plus a few others.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The charset for the `realm` directive is undefined and thus only `us-ascii` is really reliably supported.

### Motivation

I accidentally set the `realm` value to a UTF-8 encoded value and was surprised by the result. While debugging this I noticed that at least Firefox and Chromium do not show this value anymore at all.

### Additional details

https://www.rfc-editor.org/rfc/rfc7617#section-3
https://www.rfc-editor.org/rfc/rfc9110#section-11.5

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
