### PR TITLE
fetch: use bullet points for “credentials” argument for consistency

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -86,10 +86,13 @@ fetch(resource, options)
 
       - : How to handle a `redirect` response:
 
-        - `follow`: Automatically follow redirects. Unless otherwise stated the redirect mode is set to `follow`.
-        - `error`: Abort with an error if a redirect occurs.
-        - `manual`: Caller intends to process the response in another context.
-          See [WHATWG fetch standard](https://fetch.spec.whatwg.org/#concept-request-redirect-mode) for more information.
+        - `follow`
+          - : Automatically follow redirects. Unless otherwise stated the redirect mode is set to `follow`.
+        - `error`
+          - : Abort with an error if a redirect occurs.
+        - `manual`
+          - : Caller intends to process the response in another context.
+            See [WHATWG fetch standard](https://fetch.spec.whatwg.org/#concept-request-redirect-mode) for more information.
 
     - `referrer`
       - : A string specifying the referrer of the request. This can be a
@@ -111,9 +114,12 @@ fetch(resource, options)
         fetch request and abort it if desired via an {{domxref("AbortController")}}.
     - `priority`
       - : Specifies the priority of the fetch request relative to other requests of the same type. Must be one of the following strings:
-        - `high`: A high priority fetch request relative to other requests of the same type.
-        - `low`: A low priority fetch request relative to other requests of the same type.
-        - `auto`: Automatically determine the priority of the fetch request relative to other requests of the same type (default).
+        - `high`
+          - : A high priority fetch request relative to other requests of the same type.
+        - `low`
+          - : A low priority fetch request relative to other requests of the same type.
+        - `auto`
+          - : Automatically determine the priority of the fetch request relative to other requests of the same type (default).
 
 ### Return value
 


### PR DESCRIPTION
### Description

The “credentials” argument now lists its possible values using bullet points, as the other options do.

### Motivation

Other arguments, such as “redirect”, use bullet points. Currently, “credentials” is the only one without bullet points, which makes me wonder if I'm misreading something.

Before:

![2023-09-03-17-27-37](https://github.com/mdn/content/assets/291640/39b020b3-6f20-46ac-9ecd-b9770e255bd9)

After:

![2023-09-03-17-27-43](https://github.com/mdn/content/assets/291640/3204e4c4-418d-4e4c-9ef2-f2f34b718662)