### PR TITLE
Fix error in `Promise.any()` behavior description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -28,7 +28,7 @@ A {{jsxref("Promise")}} that is:
 
 - **Already rejected**, if the `iterable` passed is empty.
 - **Asynchronously fulfilled**, when any of the promises in the given `iterable` fulfills. The fulfillment value is the fulfillment value of the first promise that was fulfilled.
-- **Asynchronously rejected**, when all of the promises in the given `iterable` reject. The rejection reason is an {{jsxref("AggregateError")}} containing an array of rejection reasons in its `errors` property. The errors are in the order of the promises passed, regardless of completion order. If the `iterable` passed is non-empty but contains no pending promises, the returned promise is still asynchronously (instead of synchronously) rejected.
+- **Asynchronously rejected**, when all of the promises in the given `iterable` reject. The rejection reason is an {{jsxref("AggregateError")}} containing an array of rejection reasons in its `errors` property. The errors are in the order of the promises passed, regardless of completion order. If the `iterable` passed is non-empty but contains no pending promises, the returned promise is still asynchronously (instead of synchronously) settled.
 
 ## Description
 


### PR DESCRIPTION
### Description

If the iterable passed is non-empty but contains no pending promises, the returned promise can also be fulfilled if there is any fulfilled promise in the iterable.

### Additional details

Saying that the returned promise is rejected if the iterable passed is non-empty but contains no pending promises is incorrect since the returned promise can also be fulfilled. The correct term is **settled**.

Consider the following example:

```
Promise.any([Promise.resolve('ok')])
  .then((value) => {
    console.log(`Fulfilled with value ${value}`);
  })
  .catch((reason) => {
    console.log(`Rejected with reason ${reason}`);
  })
// Fulfilled with value ok
```
