### PR TITLE
HTML base element: data and javascript URLs disallowed

### DIFF
--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -15,9 +15,7 @@ A document's used base URL can be accessed by scripts with {{domxref('Node.baseU
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>Metadata content.</td>
     </tr>
@@ -32,16 +30,13 @@ A document's used base URL can be accessed by scripts with {{domxref('Node.baseU
     <tr>
       <th scope="row">Permitted parents</th>
       <td>
-        A {{HTMLElement("head")}} that doesn't contain another
-        {{HTMLElement("base")}} element.
+        A {{HTMLElement("head")}} that doesn't contain another {{HTMLElement("base")}} element.
       </td>
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >No corresponding role</a
-        >
+        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">No corresponding role</a>
       </td>
     </tr>
     <tr>
@@ -62,7 +57,9 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 > **Warning:** If either of the following attributes are specified, this element **must** come before other elements with attribute values of URLs, such as {{HTMLElement("link")}}'s `href` attribute.
 
 - `href`
-  - : The base URL to be used throughout the document for relative URLs. Absolute and relative URLs are allowed.
+  - : The base URL to be used throughout the document for relative URLs.
+    Absolute and relative URLs are allowed.
+    [`data:`](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) and `javascript:` URLs are not allowed.
 - `target`
 
   - : A **keyword** or **author-defined name** of the default {{Glossary("browsing context")}} to show the results of navigation from {{HTMLElement("a")}}, {{HTMLElement("area")}}, or {{HTMLElement("form")}} elements without explicit `target` attributes. The following keywords have special meanings:


### PR DESCRIPTION
Fixes #28865

The `href` in the [`<base>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) element disallows `data:` and `javascript:` URLs in a recent spec change. BCD for this fixed in https://github.com/mdn/browser-compat-data/pull/20646

Note that this only applies to the HTML element. The Web API for setting the base URL does not follow this yet.