### PR TITLE
fix(css): scroll chaining can be stopped on iframes

### DIFF
--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -56,7 +56,7 @@ By default, mobile browsers tend to provide a "bounce" effect or even a page ref
 
 In some cases, these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
 
-Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property does not work on iframes. However, the property can be used on [`<html>`](/en-US/docs/Web/HTML/Element/html) and [`<body>`](/en-US/docs/Web/HTML/Element/body) elements inside iframes to stop scroll chaining.
+Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, setting this property on an iframe has no effect. To control scroll chaining from an iframe, set `overscroll-behavior` on both the [`<html>`](/en-US/docs/Web/HTML/Element/html) and the [`<body>`](/en-US/docs/Web/HTML/Element/body) elements of the iframe's document.
 
 ## Formal definition
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -56,7 +56,7 @@ By default, mobile browsers tend to provide a "bounce" effect or even a page ref
 
 In some cases, these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
 
-Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property cannot be used to stop scroll chaining for iframes.
+Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) is not a scroll container, this property does not work on iframes. However, the property can be used on [`<html>`](/en-US/docs/Web/HTML/Element/html) and [`<body>`](/en-US/docs/Web/HTML/Element/body) elements inside iframes to stop scroll chaining.
 
 ## Formal definition
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/28904

As mentioned in [the comment](https://github.com/mdn/content/issues/28904#issuecomment-1704334074)
> to make it work in Safari and Firefox, it needs to be set on `<html>`, and for Chrome it needs to be set on `<body>`.

... does stop scroll chaining for iframe