### PR TITLE
"sited" > "sighted" on accessibility focused text

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -89,7 +89,7 @@ The `aria-keyshortcuts` attribute is very similar to the [problematic](https://w
 <button accesskey="s">Stress reliever</button>
 ```
 
-In this example, we ensured the presence of the shortcut was known to sited users a well by highlighting the non-modifier character.
+In this example, we ensured the presence of the shortcut was known to sighted users a well by highlighting the non-modifier character.
 
 While the goal of the `accesskey` attribute matches the intention of `aria-keyshortcuts` and to do so natively, `accesskey` is rife with issues. Because of these issues, it is generally advised not to use accesskeys for most general-purpose websites and web apps.
 


### PR DESCRIPTION
### Description

Fixing a typo where the intended meaning was "people with the ability to see", but the word was "sited" instead of "sighted".

```diff
- the shortcut was known to sited users
+ the shortcut was known to sighted users
```

### Motivation

The intent is to keep the documentation high quality by fixing a very minor typo.

