### PR TITLE
Improve wording

### DIFF
--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -111,9 +111,9 @@ function isValidJSON(text) {
 
 The `finally` block contains statements to execute after the `try` block and `catch` block(s) execute, but before the statements following the `try...catch...finally` block. Control flow will always enter the `finally` block, which can proceed in one of the following ways:
 
-- Immediately before the `try` block finishes execution normally (and no exceptions were thrown);
-- Immediately before the `catch` block finishes execution normally;
-- Immediately before a control-flow statement (`return`, `throw`, `break`, `continue`) is executed in the `try` block or `catch` block.
+- Immediately after the `try` block finishes execution normally (and no exceptions were thrown);
+- Immediately after the `catch` block finishes execution normally;
+- Immediately after a control-flow statement (`return`, `throw`, `break`, `continue`) is executed in the `try` block or `catch` block.
 
 If an exception is thrown from the `try` block, even when there's no `catch` block to handle the exception, the `finally` block still executes, in which case the exception is still thrown immediately after the `finally` block finishes executing.
 

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -113,7 +113,7 @@ The `finally` block contains statements to execute after the `try` block and `ca
 
 - Immediately after the `try` block finishes execution normally (and no exceptions were thrown);
 - Immediately after the `catch` block finishes execution normally;
-- Immediately after a control-flow statement (`return`, `throw`, `break`, `continue`) is executed in the `try` block or `catch` block.
+- Immediately before a control-flow statement (`return`, `throw`, `break`, `continue`) is executed in the `try` block or `catch` block.
 
 If an exception is thrown from the `try` block, even when there's no `catch` block to handle the exception, the `finally` block still executes, in which case the exception is still thrown immediately after the `finally` block finishes executing.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The code inside of `finally` block will execute after the execution of the `try` or `catch` block i.e., the control flow has to exit the `try` or `catch` before `finally` is executed.
<!-- ✍️ Summarize your changes in one or two sentences -->


<!-- ❓ Why are you making these changes and how do they help readers? -->


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
