### PR TITLE
Fix link to `AbortController()`

### DIFF
--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -13,7 +13,7 @@ You can create a new `AbortController` object using the {{domxref("AbortControll
 
 ## Constructor
 
-- {{domxref("AbortController()")}}
+- {{domxref("AbortController.AbortController()", "AbortController()")}}
   - : Creates a new `AbortController` object instance.
 
 ## Instance properties


### PR DESCRIPTION
### Description

This PR fixes the link to the `AbortController()` constructor.

### Motivation

### Additional details

### Related issues and pull requests