### PR TITLE
Update `importmap` example

### DIFF
--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -171,8 +171,8 @@ Relative URLs are resolved to absolute URL addresses using the [base URL](/en-US
     "imports": {
       "shapes": "./shapes/square.js",
       "shapes/square": "./modules/shapes/square.js",
-      "https://example.com/shapes/": "/shapes/square/",
       "https://example.com/shapes/square.js": "./shapes/square.js",
+      "https://example.com/shapes/": "/shapes/square/",
       "../shapes/square": "./shapes/square.js"
     }
   }

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -192,7 +192,7 @@ import { name as squareNameOne } from "shapes";
 import { name as squareNameTwo } from "shapes/square";
 
 // Remap a URL to another URL
-import { name as squareNameThree } from "https://example.com/shapes/moduleshapes/square.js";
+import { name as squareNameThree } from "https://example.com/shapes/square.js";
 ```
 
 If the module specifier has a trailing forward slash then the value must have one as well, and the key is matched as a "path prefix".
@@ -200,7 +200,7 @@ This allows remapping of whole classes of URLs.
 
 ```js
 // Remap a URL as a prefix ( https://example.com/shapes/)
-import { name as squareNameFour } from "https://example.com/shapes/square.js";
+import { name as squareNameFour } from "https://example.com/shapes/moduleshapes/square.js";
 ```
 
 It is possible for multiple keys in an import map to be valid matches for a module specifier.


### PR DESCRIPTION
I think these two examples are in the wrong places.  The `"https://example.com/shapes/square.js"` example should be in the block that shows exact matches and the `"https://example.com/shapes/moduleshapes/square.js"` example should be in the trailing forward slash match block.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The examples given look mixed up when trying to convey the difference between an exact `importmap` specifier match and one that matches on the trailing forward slash.  For example, `"https://example.com/shapes/square.js"` is given as an example for a trailing forward slash match even though it has an exact match in the `importmap` example given.

### Motivation

It took me awhile to understand the `importmap` based on the examples given.  I wasn't able to understand what was happening just by reading the documentation.  I had to run the project locally and play around with the examples to get it.  They really don't look right to me.
