### PR TITLE
Fix links to Map/Set-like object

### DIFF
--- a/files/en-us/web/api/audioparammap/index.md
+++ b/files/en-us/web/api/audioparammap/index.md
@@ -9,7 +9,7 @@ browser-compat: api.AudioParamMap
 
 The **`AudioParamMap`** interface of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) represents an iterable and read-only set of multiple audio parameters.
 
-An `AudioParamMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is the name string for a parameter, and the corresponding value is an {{domxref("AudioParam")}} containing the value of that parameter.
+An `AudioParamMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the name string for a parameter, and the corresponding value is an {{domxref("AudioParam")}} containing the value of that parameter.
 
 ## Instance properties
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -17,7 +17,7 @@ An HTML form element, such as a checkbox has different _states_, "checked" and "
 
 An instance of `CustomStateList` is returned by {{domxref("ElementInternals.states")}}.
 
-A `CustomStateList` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) that can hold an ordered set of state values.
+A `CustomStateList` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
 Each value stored in a `CustomStateList` is a `<dashed-ident>`, in the format `--mystate`.
 
 ### Interaction with CSS

--- a/files/en-us/web/api/eventcounts/index.md
+++ b/files/en-us/web/api/eventcounts/index.md
@@ -9,7 +9,7 @@ browser-compat: api.EventCounts
 
 The **`EventCounts`** interface of the [Performance API](/en-US/docs/Web/API/Performance_API) provides the number of events that have been dispatched for each event type.
 
-An `EventCounts` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is the name string for an event type, and the corresponding value is an integer indicating the number of events that have been dispatched for that event type.
+An `EventCounts` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the name string for an event type, and the corresponding value is an integer indicating the number of events that have been dispatched for that event type.
 
 ## Constructor
 

--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -9,7 +9,7 @@ browser-compat: api.FontFaceSet
 
 The **`FontFaceSet`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) manages the loading of font-faces and querying of their download status.
 
-A `FontFaceSet` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) that can hold an ordered set of {{domxref("FontFace")}} objects.
+A `FontFaceSet` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of {{domxref("FontFace")}} objects.
 
 This property is available as {{domxref("Document.fonts")}}, or `self.fonts` in [web workers](/en-US/docs/Web/API/Web_Workers_API).
 

--- a/files/en-us/web/api/gpusupportedfeatures/index.md
+++ b/files/en-us/web/api/gpusupportedfeatures/index.md
@@ -9,7 +9,7 @@ browser-compat: api.GPUSupportedFeatures
 
 {{APIRef("WebGPU API")}}{{SeeCompatTable}}
 
-The **`GPUSupportedFeatures`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) that describes additional functionality supported by a {{domxref("GPUAdapter")}}.
+The **`GPUSupportedFeatures`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that describes additional functionality supported by a {{domxref("GPUAdapter")}}.
 
 The `GPUSupportedFeatures` object for the current adapter is accessed via the {{domxref("GPUAdapter.features")}} property.
 
@@ -28,14 +28,14 @@ We have not listed the exact set of additional features available to be used in 
 
 ## Instance properties
 
-The following properties are available to all read-only [`Set`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) (the links below are to the {{jsxref("Set")}} global object reference page).
+The following properties are available to all read-only [`Set`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) (the links below are to the {{jsxref("Set")}} global object reference page).
 
 - {{jsxref("Set.prototype.size", "size")}} {{Experimental_Inline}}
   - : Returns the number of values in the set.
 
 ## Instance methods
 
-The following methods are available to all read-only [`Set`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) (the below links are to the {{jsxref("Set")}} global object reference page).
+The following methods are available to all read-only [`Set`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) (the below links are to the {{jsxref("Set")}} global object reference page).
 
 - {{jsxref("Set.prototype.has()", "has()")}} {{Experimental_Inline}}
   - : Returns a boolean asserting whether an element is present with the given value in the set or not.

--- a/files/en-us/web/api/highlight/index.md
+++ b/files/en-us/web/api/highlight/index.md
@@ -13,7 +13,7 @@ The **`Highlight`** interface of the [CSS Custom Highlight API](/en-US/docs/Web/
 
 To style arbitrary ranges in a page, instantiate a new `Highlight` object, add one or more `Range` objects to it, and register it using the {{domxref("HighlightRegistry")}}.
 
-A `Highlight` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) that can hold one or more `Range` objects.
+A `Highlight` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold one or more `Range` objects.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/highlightregistry/index.md
+++ b/files/en-us/web/api/highlightregistry/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HighlightRegistry
 The **`HighlightRegistry`** interface of the [CSS Custom Highlight API](/en-US/docs/Web/API/CSS_Custom_Highlight_API) is used to register {{domxref("Highlight")}} objects to be styled using the API.
 It is accessed via {{domxref("CSS.highlights_static", "CSS.highlights")}}.
 
-A `HighlightRegistry` instance is a [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is the name string for a custom highlight, and the corresponding value is the associated {{domxref("Highlight")}} object.
+A `HighlightRegistry` instance is a [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the name string for a custom highlight, and the corresponding value is the associated {{domxref("Highlight")}} object.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/keyboardlayoutmap/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/index.md
@@ -11,7 +11,7 @@ browser-compat: api.KeyboardLayoutMap
 
 The **`KeyboardLayoutMap`** interface of the [Keyboard API](/en-US/docs/Web/API/Keyboard_API) is a read-only object with functions for retrieving the string associated with specific physical keys.
 
-A `KeyboardLayoutMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is a string identifying the unique physical key on the keyboard (a "key code"), and the corresponding value is the associated key attribute value (which may be affected by the keyboard layout, and so on).
+A `KeyboardLayoutMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is a string identifying the unique physical key on the keyboard (a "key code"), and the corresponding value is the associated key attribute value (which may be affected by the keyboard layout, and so on).
 
 A list of valid keys is found in the [UI Events KeyboardEvent code Values](https://www.w3.org/TR/uievents-code/#key-alphanumeric-writing-system) specification.
 

--- a/files/en-us/web/api/midiinputmap/index.md
+++ b/files/en-us/web/api/midiinputmap/index.md
@@ -9,7 +9,7 @@ browser-compat: api.MIDIInputMap
 
 The **`MIDIInputMap`** read-only interface of the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API) provides the set of MIDI input ports that are currently available.
 
-A `MIDIInputMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is the ID string for MIDI input, and the associated value is the corresponding {{domxref("MIDIInput")}} object.
+A `MIDIInputMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the ID string for MIDI input, and the associated value is the corresponding {{domxref("MIDIInput")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/midioutputmap/index.md
+++ b/files/en-us/web/api/midioutputmap/index.md
@@ -9,7 +9,7 @@ browser-compat: api.MIDIOutputMap
 
 The **`MIDIOutputMap`** read-only interface of the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API) provides the set of MIDI output ports that are currently available.
 
-A `MIDIOutputMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is the ID string for MIDI output, and the associated value is the corresponding {{domxref("MIDIOutput")}} object.
+A `MIDIOutputMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the ID string for MIDI output, and the associated value is the corresponding {{domxref("MIDIOutput")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcstatsreport/index.md
+++ b/files/en-us/web/api/rtcstatsreport/index.md
@@ -9,7 +9,7 @@ browser-compat: api.RTCStatsReport
 
 The **`RTCStatsReport`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides a statistics report for a {{domxref("RTCPeerConnection")}}, {{domxref("RTCRtpSender")}}, or {{domxref("RTCRtpReceiver")}}.
 
-An `RTCStatsReport` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects), in which each key is an identifier for an object for which statistics are being reported, and the corresponding value is a dictionary object providing the statistics.
+An `RTCStatsReport` instance is a read-only [`Map`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is an identifier for an object for which statistics are being reported, and the corresponding value is a dictionary object providing the statistics.
 
 ## Instance properties
 

--- a/files/en-us/web/api/xranchorset/index.md
+++ b/files/en-us/web/api/xranchorset/index.md
@@ -9,7 +9,7 @@ browser-compat: api.XRAnchorSet
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
-The **`XRAnchorSet`** interface exposes a collection of anchors. Its instances are returned by {{domxref("XRFrame.trackedAnchors")}} and are [`Set`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects).
+The **`XRAnchorSet`** interface exposes a collection of anchors. Its instances are returned by {{domxref("XRFrame.trackedAnchors")}} and are [`Set`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis).
 
 ## Instance properties
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Replace links to

```
/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_objects
```

(the anchor didn't exist)

to

```
/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis
```

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
