### PR TITLE
Emphasize that `every` returns true for empty arrays

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -35,7 +35,7 @@ every(callbackFn, thisArg)
 
 ### Return value
 
-`true` if `callbackFn` returns a {{Glossary("truthy")}} value for every array element. Otherwise, `false`.
+`true` if the array is empty, or if `callbackFn` returns a {{Glossary("truthy")}} value for every array element. Otherwise, `false`.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`every` returns `true` for empty arrays. For example, this returns `true`:

```js
[].every(() => false)
// true
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This gotcha was mentioned later in the description, but it deserves more emphasis, because many users of `every` will find this behavior counterintuitive.