### PR TITLE
docs(css): Add details about subgrid to Grid Learn article

### DIFF
--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -885,6 +885,6 @@ In this overview, we've toured the main features of CSS Grid Layout. You should 
 - [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid) guide
 - [CSS grid inspector: Examine grid layouts](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html) on firefox-source-docs
 - [A complete guide to CSS grid](https://css-tricks.com/snippets/css/complete-guide-grid/), a visual guide on CSS-Tricks (2023)
-- [Grid Garden](https://cssgridgarden.com/), an educational game to learn and better understand the basics of grid  on cssgridgarden.com
+- [Grid Garden](https://cssgridgarden.com/), an educational game to learn and better understand the basics of grid on cssgridgarden.com
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -586,7 +586,7 @@ You can play around with our layout, changing the footer to only sit underneath 
 
 ## Nesting grids and subgrid
 
-It's also possible to nest grids inside each other and create a [Subgrid](/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid).
+It's also possible to nest grids inside each other and create a [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
 You can do this by setting `display: grid` on a grid item.
 
 Let's expand on the example by adding a container for articles and use a nested grid to control how multiple articles are laid out.
@@ -882,7 +882,7 @@ In this overview, we've toured the main features of CSS Grid Layout. You should 
 ## See also
 
 - [CSS Grid guides](/en-US/docs/Web/CSS/CSS_grid_layout#guides)
-- [Subgrid](/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
+- [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
 - [CSS Grid Inspector: Examine grid layouts](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html)
 - [CSS-Tricks Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) — an article explaining everything about Grid in a visually appealing way
 - [Grid Garden](https://cssgridgarden.com/) — an educational game to learn and better understand the basics of Grid

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -6,7 +6,7 @@ page-type: learn-module-chapter
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}
 
-[CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layout) is a two-dimensional layout system for the web. It lets you organize content in rows and columns and has many features that make building complex layouts straightforward. This article will explain all you need to know to get started with grid layout.
+[CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) is a two-dimensional layout system for the web. It lets you organize content into rows and columns and offers many features to simplify the creation of complex layouts. This article will explain all you need to know to get started with grid layout.
 
 <table>
   <tbody>
@@ -48,9 +48,9 @@ The following video provides a nice visual explanation of using CSS Grid:
 
 ### Defining a grid
 
-Let's try out grid layouts with an example. First download and open [the starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/0-starting-point.html) in your text editor and browser (you can also [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/0-starting-point.html)). You will see an example with a container, which has some child items. These display in normal flow by default, so the boxes display one below the other. We'll be working with this file for the first part of this lesson, making changes to see how its grid behaves.
+Let's try out grid layouts with the help of an example. Download and open [the starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/0-starting-point.html) in your text editor and browser (you can also [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/0-starting-point.html)). You will see an example with a container, which has some child items. By default, these items are displayed in a normal flow, causing them to appear one below the other. For the initial part of this lesson, we'll be using this file to see how its grid behaves.
 
-To define a grid we use the `grid` value of the {{cssxref("display")}} property. As with [Flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox), this enables Grid Layout; all of the direct children of the container become grid items. Add this to the CSS inside your file:
+Similar to how you define flexbox, you define a grid layout by setting the value of the {{cssxref("display")}} property to `grid`. As in the case of flexbox, the `display: grid` property transforms all the direct children of the container into grid items. Add the following CSS to your file:
 
 ```css
 .container {
@@ -240,13 +240,13 @@ Change your track listing to the following:
 
 You'll now get three `1fr` tracks just as before. The first value passed to the `repeat()` function specifies the number of times you want the listing to repeat, while the second value is a track listing, which may be one or more tracks that you want to repeat.
 
-### The implicit and explicit grid
+### Implicit and explicit grids
 
-We've only specified column tracks so far, but rows are being created to hold our content. This is an example of _explicit_ versus _implicit_ grid.
-Here's a bit more about the difference:
+Up to this point, we've specified only column tracks, but rows are automatically created to hold the content. This concept highlights the distinction between explicit and implicit grids.
+Here's a bit more about the difference between the two types of grids:
 
 - **Explicit grid** is created using `grid-template-columns` or `grid-template-rows`.
-- **Implicit grid** extends the defined explicit grid when content is placed outside of that grid, such as into our rows by drawing additional grid lines.
+- **Implicit grid** extends the defined explicit grid when content is placed outside of that grid, such as into the rows by drawing additional grid lines.
 
 By default, tracks created in the implicit grid are `auto` sized, which in general means that they're large enough to contain their content. If you wish to give implicit grid tracks a size, you can use the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties. If you add `grid-auto-rows` with a value of `100px` to your CSS, you'll see that those created rows are now 100 pixels tall.
 
@@ -290,7 +290,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('The_implicit_and_explicit_grid', '100%', 400) }}
+{{ EmbedLiveSample('Implicit_and_explicit_grids', '100%', 400) }}
 
 ### The minmax() function
 
@@ -363,20 +363,20 @@ This works because grid is creating as many 200-pixel columns as will fit into t
 
 We now move on from creating a grid to placing things on the grid. Our grid always has lines — these are numbered beginning with 1 and relate to the [writing mode](/en-US/docs/Web/CSS/CSS_writing_modes) of the document. For example, column line 1 in English (written left-to-right) would be on the left-hand side of the grid and row line 1 at the top, while in Arabic (written right-to-left), column line 1 would be on the right-hand side.
 
-We can arrange things along these lines by specifying the start and end line of the grid area we want to use that an item should be placed into. There are four properties that we can use to do this:
+To position items along these lines, we can specify the start and end lines of the grid area where an item should be placed. There are four properties we can use to do this:
 
 - {{cssxref("grid-column-start")}}
 - {{cssxref("grid-column-end")}}
 - {{cssxref("grid-row-start")}}
 - {{cssxref("grid-row-end")}}
 
-These properties can have a line number as their value, so we can specify that an item should start on line 1 and end on line 3, for example.
-You can also use shorthand properties that let you specify the start and end lines at once, separated by a forward slash `/`:
+These properties accept line numbers as their values, so we can specify that an item should start on line 1 and end on line 3, for example.
+Alternatively, you can also use shorthand properties that let you specify the start and end lines simultaneously, separated by a forward slash `/`:
 
 - {{cssxref("grid-column")}} shorthand for `grid-column-start` and `grid-column-end`
 - {{cssxref("grid-row")}} shorthand for `grid-row-start` and `grid-row-end`
 
-To see this in action, download the [line-based placement starting point](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/8-placement-starting-point.html) file or [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/8-placement-starting-point.html). It has a defined grid and a simple article outlined. You can see that _auto-placement_ is placing each item into its own cell on the grid.
+To see this in action, download the [line-based placement starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/8-placement-starting-point.html) or [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/8-placement-starting-point.html). It has a defined grid and a simple article outlined. You can see that _auto-placement_ is placing each item into its own cell in the grid.
 
 Let's arrange all of the elements for our site by using the grid lines. Add the following rules to the bottom of your CSS:
 
@@ -586,12 +586,12 @@ You can play around with our layout, changing the footer to only sit underneath 
 
 ## Nesting grids and subgrid
 
-It's also possible to nest grids inside each other and create a [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
-You can do this by setting `display: grid` on a grid item.
+It's possible to nest a grid within another grid, creating a ["subgrid"](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid).
+You can do this by setting the `display: grid` property on a grid item.
 
-Let's expand on the example by adding a container for articles and use a nested grid to control how multiple articles are laid out.
-We're only using one column in the nested grid, but we can define that the rows should be split into a 2:1:1 ratio using the `grid-template-rows` property.
-This way, we can make a layout where one article at the top of the page has a large display, while others have a smaller, preview-like layout.
+Let's expand on the previous example by adding a container for articles and using a nested grid to control the layout of multiple articles.
+While we're using only one column in the nested grid, we can define the rows to be split in a 2:1:1 ratio by using the `grid-template-rows` property.
+This approach allows us to create a layout where one article at the top of the page has a large display, while the others have a smaller, preview-like layout.
 
 ```html hidden live-sample___nesting-grids
 <div class="container">
@@ -707,10 +707,10 @@ article {
 
 {{EmbedLiveSample('nesting-grids', '100%', 1100)}}
 
-To make it easier to work with layouts in nested grids, you can use `subgrid` on `grid-template-rows` and `grid-template-columns` properties to use the parent grid's tracks.
+To make it easier to work with layouts in nested grids, you can use `subgrid` on `grid-template-rows` and `grid-template-columns` properties. This allows you to leverage the tracks defined in the parent grid.
 
-In the following example, we're using [line-based placement](#line-based_placement) so the nested grid spans multiple columns and rows of the parent grid.
-We've added `subgrid` to use the tracks of the parent's columns, but added a different layout for rows of the nested grid.
+In the following example, we're using [line-based placement](#line-based_placement), enabling the nested grid to span multiple columns and rows of the parent grid.
+We've added `subgrid` to inherit the parent grid's column tracks while adding a different layout for the rows within the nested grid.
 
 ```css hidden live-sample___subgrid
 body {
@@ -768,10 +768,10 @@ body {
 
 {{ EmbedLiveSample('subgrid', '100%', 300) }}
 
-## Grid frameworks in CSS Grid
+## Grid frameworks
 
-There are many grid frameworks available that provide a 12 or 16-column grid to help lay out your content.
-The good news is that you probably don't need any third-party frameworks to help you build grid-based layouts — it's already in the spec and supported in most modern browsers.
+Numerous grid frameworks are available, offering a 12 or 16-column grid, to help with laying out your content.
+The good news is that you probably won't need any third-party frameworks to help you create grid-based layouts — grid functionality is already included in the specification and is supported by most modern browsers.
 
 [Download the starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/11-grid-system-starting-point.html). This has a container with a 12-column grid defined and the same markup we used in the previous two examples. We can now use line-based placement to place our content on the 12-column grid.
 
@@ -881,10 +881,10 @@ In this overview, we've toured the main features of CSS Grid Layout. You should 
 
 ## See also
 
-- [CSS Grid guides](/en-US/docs/Web/CSS/CSS_grid_layout#guides)
-- [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
-- [CSS Grid Inspector: Examine grid layouts](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html)
-- [CSS-Tricks Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) — an article explaining everything about Grid in a visually appealing way
-- [Grid Garden](https://cssgridgarden.com/) — an educational game to learn and better understand the basics of Grid
+- A [list of guides](/en-US/docs/Web/CSS/CSS_grid_layout#guides) related to the CSS grid layout
+- [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid) guide
+- [CSS grid inspector: Examine grid layouts](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html) on firefox-source-docs
+- [A complete guide to CSS grid](https://css-tricks.com/snippets/css/complete-guide-grid/), a visual guide on CSS-Tricks (2023)
+- [Grid Garden](https://cssgridgarden.com/), an educational game to learn and better understand the basics of grid  on cssgridgarden.com
 
 {{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -6,7 +6,7 @@ page-type: learn-module-chapter
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/CSS_layout/Flexbox", "Learn/CSS/CSS_layout/Floats", "Learn/CSS/CSS_layout")}}
 
-CSS Grid Layout is a two-dimensional layout system for the web. It lets you lay content out in rows and columns. It has many features that make building complex layouts straightforward. This article will explain all you need to know to get started with grid layout.
+[CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layout) is a two-dimensional layout system for the web. It lets you organize content in rows and columns and has many features that make building complex layouts straightforward. This article will explain all you need to know to get started with grid layout.
 
 <table>
   <tbody>
@@ -42,16 +42,15 @@ A grid will typically have **columns**, **rows**, and then gaps between each row
 ## Creating your grid in CSS
 
 Having decided on the grid that your design needs, you can use CSS Grid Layout to create it. We'll look at the basic features of Grid Layout first and then explore how to create a simple grid system for your project.
-
 The following video provides a nice visual explanation of using CSS Grid:
 
 {{EmbedYouTube("KOvGeFUHAC0")}}
 
 ### Defining a grid
 
-As a starting point, download and open [the starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/0-starting-point.html) in your text editor and browser (you can also [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/0-starting-point.html)). You will see an example with a container, which has some child items. These display in normal flow by default, so the boxes display one below the other. We'll be working with this file for the first part of this lesson, making changes to see how its grid behaves.
+Let's try out grid layouts with an example. First download and open [the starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/0-starting-point.html) in your text editor and browser (you can also [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/0-starting-point.html)). You will see an example with a container, which has some child items. These display in normal flow by default, so the boxes display one below the other. We'll be working with this file for the first part of this lesson, making changes to see how its grid behaves.
 
-To define a grid we use the `grid` value of the {{cssxref("display")}} property. As with Flexbox, this enables Grid Layout; all of the direct children of the container become grid items. Add this to the CSS inside your file:
+To define a grid we use the `grid` value of the {{cssxref("display")}} property. As with [Flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox), this enables Grid Layout; all of the direct children of the container become grid items. Add this to the CSS inside your file:
 
 ```css
 .container {
@@ -103,11 +102,11 @@ body {
 </div>
 ```
 
-{{ EmbedLiveSample('Defining_a_grid', '100%', 400) }}
+{{ EmbedLiveSample('Defining_a_grid', '100%', 200) }}
 
 ### Flexible grids with the fr unit
 
-In addition to creating grids using lengths and percentages, we can use `fr`. The `fr` unit represents one fraction of the available space in the grid container to flexibly size grid rows and columns.
+In addition to creating grids using lengths and percentages, we can use [`fr`](/en-US/docs/Web/CSS/flex_value). The `fr` unit represents one fraction of the available space in the grid container to flexibly size grid rows and columns.
 
 Change your track listing to the following definition, creating three `1fr` tracks:
 
@@ -160,7 +159,7 @@ body {
 </div>
 ```
 
-{{ EmbedLiveSample('Flexible_grids_with_the_fr_unit', '100%', 400) }}
+{{ EmbedLiveSample('Flexible_grids_with_the_fr_unit', '100%', 200) }}
 
 > **Note:** The `fr` unit distributes _available_ space, not _all_ space. Therefore, if one of your tracks has something large inside it, there will be less free space to share.
 
@@ -213,7 +212,7 @@ body {
 </div>
 ```
 
-{{ EmbedLiveSample('Gaps_between_tracks', '100%', 400) }}
+{{ EmbedLiveSample('Gaps_between_tracks', '100%', 250) }}
 
 > **Note:** The `gap` properties (`column-gap`, `row-gap` and `gap`) used to be prefixed by `grid-`. The spec has changed but the prefixed versions will be maintained as an alias. To be on the safe side and make your code more bulletproof, you can add both properties:
 >
@@ -243,14 +242,13 @@ You'll now get three `1fr` tracks just as before. The first value passed to the 
 
 ### The implicit and explicit grid
 
-We've only specified column tracks so far, yet rows are being created to hold our content. This is an example of the _explicit_ versus the _implicit_ grid.
+We've only specified column tracks so far, but rows are being created to hold our content. This is an example of _explicit_ versus _implicit_ grid.
+Here's a bit more about the difference:
 
-The difference:
+- **Explicit grid** is created using `grid-template-columns` or `grid-template-rows`.
+- **Implicit grid** extends the defined explicit grid when content is placed outside of that grid, such as into our rows by drawing additional grid lines.
 
-- Explicit grid: Created using `grid-template-columns` or `grid-template-rows`.
-- Implicit grid: Extends the defined explicit grid when content is placed outside of that grid, such as into our rows by drawing additional grid lines.
-
-By default, tracks created in the implicit grid are `auto` sized, which in general means that they're large enough to accommodate their content. If you wish to give implicit grid tracks a size, you can use the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties. If you add `grid-auto-rows` with a value of `100px` to your CSS, you'll see that those created rows are now 100 pixels tall.
+By default, tracks created in the implicit grid are `auto` sized, which in general means that they're large enough to contain their content. If you wish to give implicit grid tracks a size, you can use the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties. If you add `grid-auto-rows` with a value of `100px` to your CSS, you'll see that those created rows are now 100 pixels tall.
 
 ```css hidden
 body {
@@ -292,7 +290,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('The_implicit_and_explicit_grid', '100%', 500) }}
+{{ EmbedLiveSample('The_implicit_and_explicit_grid', '100%', 400) }}
 
 ### The minmax() function
 
@@ -365,23 +363,22 @@ This works because grid is creating as many 200-pixel columns as will fit into t
 
 We now move on from creating a grid to placing things on the grid. Our grid always has lines — these are numbered beginning with 1 and relate to the [writing mode](/en-US/docs/Web/CSS/CSS_writing_modes) of the document. For example, column line 1 in English (written left-to-right) would be on the left-hand side of the grid and row line 1 at the top, while in Arabic (written right-to-left), column line 1 would be on the right-hand side.
 
-We can arrange things in accordance with these lines by specifying the start and end line. We do this using the following properties:
+We can arrange things along these lines by specifying the start and end line of the grid area we want to use that an item should be placed into. There are four properties that we can use to do this:
 
 - {{cssxref("grid-column-start")}}
 - {{cssxref("grid-column-end")}}
 - {{cssxref("grid-row-start")}}
 - {{cssxref("grid-row-end")}}
 
-These properties can all have a line number as their value. You can also use the shorthand properties:
+These properties can have a line number as their value, so we can specify that an item should start on line 1 and end on line 3, for example.
+You can also use shorthand properties that let you specify the start and end lines at once, separated by a forward slash `/`:
 
-- {{cssxref("grid-column")}}
-- {{cssxref("grid-row")}}
+- {{cssxref("grid-column")}} shorthand for `grid-column-start` and `grid-column-end`
+- {{cssxref("grid-row")}} shorthand for `grid-row-start` and `grid-row-end`
 
-These let you specify the start and end lines at once, separated by a forward slash `/`.
+To see this in action, download the [line-based placement starting point](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/8-placement-starting-point.html) file or [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/8-placement-starting-point.html). It has a defined grid and a simple article outlined. You can see that _auto-placement_ is placing each item into its own cell on the grid.
 
-[Download this file as a starting point](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/8-placement-starting-point.html) or [see it live here](https://mdn.github.io/learning-area/css/css-layout/grids/8-placement-starting-point.html). It has a defined grid and a simple article outlined. You can see that _auto-placement_ is placing each item into its own cell on the grid.
-
-Let's instead arrange all of the elements for our site by using the grid lines. Add the following rules to the bottom of your CSS:
+Let's arrange all of the elements for our site by using the grid lines. Add the following rules to the bottom of your CSS:
 
 ```css
 header {
@@ -473,7 +470,7 @@ aside {
 </div>
 ```
 
-{{ EmbedLiveSample('Line-based_placement', '100%', 600) }}
+{{ EmbedLiveSample('Line-based_placement', '100%', 550) }}
 
 > **Note:** You can also use the value `-1` to target the end column or row line, then count inwards from the end using negative values. Note also that lines count always from the edges of the explicit grid, not the [implicit grid](/en-US/docs/Glossary/Grid).
 
@@ -575,7 +572,7 @@ aside {
 </div>
 ```
 
-{{ EmbedLiveSample('Positioning_with_grid-template-areas', '100%', 600) }}
+{{ EmbedLiveSample('Positioning_with_grid-template-areas', '100%', 550) }}
 
 The rules for `grid-template-areas` are as follows:
 
@@ -587,9 +584,194 @@ The rules for `grid-template-areas` are as follows:
 
 You can play around with our layout, changing the footer to only sit underneath the article and the sidebar to span all the way down. This is a very nice way to describe a layout because it's clear just from looking at the CSS to know exactly what's happening.
 
+## Nesting grids and subgrid
+
+It's also possible to nest grids inside each other and create a [Subgrid](/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid).
+You can do this by setting `display: grid` on a grid item.
+
+Let's expand on the example by adding a container for articles and use a nested grid to control how multiple articles are laid out.
+We're only using one column in the nested grid, but we can define that the rows should be split into a 2:1:1 ratio using the `grid-template-rows` property.
+This way, we can make a layout where one article at the top of the page has a large display, while others have a smaller, preview-like layout.
+
+```html hidden live-sample___nesting-grids
+<div class="container">
+  <header>This is my lovely blog</header>
+  <div class="articles">
+    <article>
+      <h1>Darmok and Jalad had a picnic at Tanagra</h1>
+
+      <p>
+        Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras
+        porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed
+        auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet
+        orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac
+        ornare ex malesuada et. In vitae convallis lacus. Aliquam erat volutpat.
+        Suspendisse ac imperdiet turpis. Aenean finibus sollicitudin eros
+        pharetra congue. Duis ornare egestas augue ut luctus. Proin blandit quam
+        nec lacus varius commodo et a urna. Ut id ornare felis, eget fermentum
+        sapien.
+      </p>
+
+      <button>Read more</button>
+    </article>
+    <article>
+      <h1>Temba held his arms wide</h1>
+      <p>
+        Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras
+        porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed
+        auctor cursus massa at porta. Integer ligula ipsum, tristique sit amet
+        orci vel, viverra egestas ligula. Curabitur vehicula tellus neque, ac
+        ornare ex malesuada et ...
+      </p>
+      <button>Read more</button>
+    </article>
+    <article>
+      <h1>Gilgamesh, a king, at Uruk</h1>
+      <p>
+        Duis felis orci, pulvinar id metus ut, rutrum luctus orci. Cras
+        porttitor imperdiet nunc, at ultricies tellus laoreet sit amet. Sed
+        auctor cursus massa at porta ...
+      </p>
+      <button>Read more</button>
+    </article>
+  </div>
+  <aside>
+    <h2>Other things</h2>
+    <p>
+      Nam vulputate diam nec tempor bibendum. Donec luctus augue eget malesuada
+      ultrices. Phasellus turpis est, posuere sit amet dapibus ut, facilisis sed
+      est.
+    </p>
+    <button>Read more</button>
+  </aside>
+  <footer>Contact me@example.com</footer>
+</div>
+```
+
+```css hidden live-sample___nesting-grids
+body {
+  width: 90%;
+  max-width: 900px;
+  margin: 2em auto;
+  font:
+    0.9em/1.2 Arial,
+    Helvetica,
+    sans-serif;
+}
+
+header,
+footer {
+  border-radius: 5px;
+  padding: 10px;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
+}
+header {
+  grid-area: header;
+}
+
+aside {
+  border-right: 1px solid #999;
+  grid-area: sidebar;
+  padding-right: 10px;
+  font-size: 0.8em;
+}
+
+footer {
+  grid-area: footer;
+}
+.container {
+  display: grid;
+  grid-template-areas:
+    "header header"
+    "sidebar content"
+    "footer footer";
+  grid-template-columns: 1fr 3fr;
+  gap: 20px;
+}
+```
+
+```css live-sample___nesting-grids
+.articles {
+  display: grid;
+  grid-template-rows: 2fr 1fr 1fr;
+  gap: inherit;
+}
+
+article {
+  padding: 10px;
+  border: 2px solid rgb(79, 185, 227);
+  border-radius: 5px;
+}
+```
+
+{{EmbedLiveSample('nesting-grids', '100%', 1100)}}
+
+To make it easier to work with layouts in nested grids, you can use `subgrid` on `grid-template-rows` and `grid-template-columns` properties to use the parent grid's tracks.
+
+In the following example, we're using [line-based placement](#line-based_placement) so the nested grid spans multiple columns and rows of the parent grid.
+We've added `subgrid` to use the tracks of the parent's columns, but added a different layout for rows of the nested grid.
+
+```css hidden live-sample___subgrid
+body {
+  width: 90%;
+  max-width: 900px;
+  margin: 2em auto;
+  font:
+    0.9em/1.2 Arial,
+    Helvetica,
+    sans-serif;
+}
+
+.container div {
+  border-radius: 5px;
+  padding: 10px;
+  background-color: rgb(207, 232, 220);
+  border: 2px solid rgb(79, 185, 227);
+}
+```
+
+```html live-sample___subgrid
+<div class="container">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+  <div>Four</div>
+  <div id="subgrid">
+    <div>Five</div>
+    <div>Six</div>
+    <div>Seven</div>
+    <div>Eight</div>
+  </div>
+  <div>Nine</div>
+  <div>Ten</div>
+</div>
+```
+
+```css live-sample___subgrid
+.container {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(1fr);
+  gap: 10px;
+}
+
+#subgrid {
+  grid-column: 1 / 4;
+  grid-row: 2 / 4;
+  display: grid;
+  gap: inherit;
+  grid-template-columns: subgrid;
+  grid-template-rows: 2fr 1fr;
+}
+```
+
+{{ EmbedLiveSample('subgrid', '100%', 300) }}
+
 ## Grid frameworks in CSS Grid
 
-Grid "frameworks" tend to be based around 12 or 16-column grids. With CSS Grid, you don't need any third party tool to give you such a framework — it's already there in the spec.
+There are many grid frameworks available that provide a 12 or 16-column grid to help lay out your content.
+The good news is that you probably don't need any third-party frameworks to help you build grid-based layouts — it's already in the spec and supported in most modern browsers.
 
 [Download the starting point file](https://github.com/mdn/learning-area/blob/main/css/css-layout/grids/11-grid-system-starting-point.html). This has a container with a 12-column grid defined and the same markup we used in the previous two examples. We can now use line-based placement to place our content on the 12-column grid.
 
@@ -700,6 +882,7 @@ In this overview, we've toured the main features of CSS Grid Layout. You should 
 ## See also
 
 - [CSS Grid guides](/en-US/docs/Web/CSS/CSS_grid_layout#guides)
+- [Subgrid](/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
 - [CSS Grid Inspector: Examine grid layouts](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html)
 - [CSS-Tricks Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) — an article explaining everything about Grid in a visually appealing way
 - [Grid Garden](https://cssgridgarden.com/) — an educational game to learn and better understand the basics of Grid


### PR DESCRIPTION
We don't mention subgrid or nesting grids in the learn doc, this PR adds some more examples and links to subgrid where possible.

__additions:__
- nested grid example 
- example using `subgrid`
- link to subgrid in See Also
 
__changes:__
- Height of embedded examples to make vertical space a little tighter
- Some flyby tidy up

__follow-ups:__
It might be nice to add the example with nested grids to be available to download in the learning area. Pending review changes on that.