### PR TITLE
Clarify the return value of `every()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -35,7 +35,7 @@ every(callbackFn, thisArg)
 
 ### Return value
 
-`true` if `callbackFn` returns a {{Glossary("truthy")}} value for every array element. Otherwise, `false`.
+`true` if the array is empty, or if `callbackFn` returns a {{Glossary("truthy")}} value for every array element. Otherwise, `false`.
 
 ## Description
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarifying the return value of `every()`, demonstrating that it will short circuit, and emphasizing that it will return `true` for the empty array.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Fixes #28981.

<!-- ❓ Why are you making these changes and how do they help readers? -->