### PR TITLE
Smoothly animate seconds hand in the clock

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -168,7 +168,7 @@ function clock() {
   }
   ctx.restore();
 
-  const sec = now.getSeconds() + (now.getMilliseconds() / 1000);
+  const sec = now.getSeconds() + now.getMilliseconds() / 1000;
   const min = now.getMinutes();
   const hr = now.getHours() % 12;
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -168,7 +168,7 @@ function clock() {
   }
   ctx.restore();
 
-  const sec = now.getSeconds();
+  const sec = now.getSeconds() + (now.getMilliseconds() / 1000);
   const min = now.getMinutes();
   const hr = now.getHours() % 12;
 


### PR DESCRIPTION
### Description

Smoothly animate seconds hand in the clock in the Animated Clock example for `canvas`. Sample video below:

https://github.com/mdn/content/assets/6047296/5506aad9-9cf5-4de0-aec5-13abe6cea799

### Motivation

To properly showcase the fact that the canvas is drawn 60 times per second, the second hand in the clock now smoothly moves instead of jumping from tick to tick (once per second).

### Additional details

* Applies to: [Basic_animations#an_animated_clock](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations#an_animated_clock)
* Tested using MDN Playground.

### Related issues and pull requests

Superseded by #29534

**PS: Please use "Squash and Merge"; thank you.**