### PR TITLE
fix reversed code logic on Using the imscJS polyfill page

### DIFF
--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
@@ -182,9 +182,9 @@ for (let i = 0; i < timeEvents.length; i++) {
 
   let myCue;
   if (i < timeEvents.length - 1) {
-    myCue = Cue(timeEvents[i], myVideo.duration, "");
-  } else {
     myCue = new Cue(timeEvents[i], timeEvents[i + 1], "");
+  } else {
+    myCue = new Cue(timeEvents[i], myVideo.duration, "");
   }
 
   myCue.onenter = function () {


### PR DESCRIPTION
### Description

Fixed the reversed logic on [Using the imscJS polyfill](https://developer.mozilla.org/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill) code sample

`i < timeEvents.length - 1 === true` means it's not the last time event so the new Cue's end time should be the next time event.

### Motivation

The original example code was wrong and caused confusion
