### PR TITLE
docs: remove closing slash from example

### DIFF
--- a/files/en-us/web/html/element/br/index.md
+++ b/files/en-us/web/html/element/br/index.md
@@ -37,11 +37,11 @@ You can set a {{cssxref("margin")}} on `<br>` elements themselves to increase th
 In the following example we use `<br>` elements to create line breaks between the different lines of a postal address:
 
 ```html
-Mozilla<br />
-331 E. Evelyn Avenue<br />
-Mountain View, CA<br />
-94041<br />
-USA<br />
+Mozilla<br>
+331 E. Evelyn Avenue<br>
+Mountain View, CA<br>
+94041<br>
+USA<br>
 ```
 
 #### Result


### PR DESCRIPTION

### Description
removal of  U+002F character (/), in example

### Motivation
I don't think it is a good practice to share XHTML syntax by default in those examples.
