### PR TITLE
Use consistent formatting for all macros

### DIFF
--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -336,7 +336,7 @@ setX(6);
 console.log(getX()); // 6
 ```
 
-Closures can close over imported values as well, which are regarded as _live {{glossary("binding", "bindings")}}_, because when the original value changes, the imported one changes accordingly.
+Closures can close over imported values as well, which are regarded as _live {{Glossary("binding", "bindings")}}_, because when the original value changes, the imported one changes accordingly.
 
 ```js
 // myModule.js

--- a/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.md
+++ b/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Enumerability_and_ownership_of_properties
 page-type: guide
 ---
 
-{{JsSidebar("More")}}
+{{jsSidebar("More")}}
 
 Every property in JavaScript objects can be classified by three factors:
 

--- a/files/en-us/web/javascript/event_loop/index.md
+++ b/files/en-us/web/javascript/event_loop/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Event_loop
 page-type: guide
 ---
 
-{{JsSidebar("Advanced")}}
+{{jsSidebar("Advanced")}}
 
 JavaScript has a runtime model based on an **event loop**, which is responsible for executing the code, collecting and processing events, and executing queued sub-tasks. This model is quite different from models in other languages like C and Java.
 

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -5,8 +5,7 @@ page-type: guide
 ---
 
 {{jsSidebar("JavaScript Guide")}}
-{{PreviousNext("Web/JavaScript/Guide/Grammar_and_types",
-  "Web/JavaScript/Guide/Loops_and_iteration")}}
+{{PreviousNext("Web/JavaScript/Guide/Grammar_and_types", "Web/JavaScript/Guide/Loops_and_iteration")}}
 
 JavaScript supports a compact set of statements, specifically
 control flow statements, that you can use to incorporate a great deal of interactivity
@@ -534,5 +533,4 @@ try {
 }
 ```
 
-{{PreviousNext("Web/JavaScript/Guide/Grammar_and_types",
-  "Web/JavaScript/Guide/Loops_and_iteration")}}
+{{PreviousNext("Web/JavaScript/Guide/Grammar_and_types", "Web/JavaScript/Guide/Loops_and_iteration")}}

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -721,9 +721,9 @@ JavaScript has several top-level, built-in functions:
   - : The **`encodeURI()`** method encodes a Uniform Resource Identifier (URI) by replacing each instance of certain characters by one, two, three, or four escape sequences representing the UTF-8 encoding of the character (will only be four escape sequences for characters composed of two "surrogate" characters).
 - {{jsxref("Global_Objects/encodeURIComponent", "encodeURIComponent()")}}
   - : The **`encodeURIComponent()`** method encodes a Uniform Resource Identifier (URI) component by replacing each instance of certain characters by one, two, three, or four escape sequences representing the UTF-8 encoding of the character (will only be four escape sequences for characters composed of two "surrogate" characters).
-- {{jsxref("Global_Objects/escape", "escape()")}} {{Deprecated_Inline}}
+- {{jsxref("Global_Objects/escape", "escape()")}} {{deprecated_inline}}
   - : The **`escape()`** method computes a new string in which certain characters have been replaced by a hexadecimal escape sequence. It's deprecated and you should use {{jsxref("Global_Objects/encodeURI", "encodeURI()")}} or {{jsxref("Global_Objects/encodeURIComponent", "encodeURIComponent()")}} instead.
-- {{jsxref("Global_Objects/unescape", "unescape()")}} {{Deprecated_Inline}}
+- {{jsxref("Global_Objects/unescape", "unescape()")}} {{deprecated_inline}}
   - : The **`unescape()`** method computes a new string in which hexadecimal escape sequences are replaced with the character that it represents. The escape sequences might be introduced by a function like {{jsxref("Global_Objects/escape", "escape()")}}. It's deprecated and you should use {{jsxref("Global_Objects/decodeURI", "decodeURI()")}} or {{jsxref("Global_Objects/decodeURIComponent", "decodeURIComponent()")}} instead.
 
 {{PreviousNext("Web/JavaScript/Guide/Loops_and_iteration", "Web/JavaScript/Guide/Expressions_and_operators")}}

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -28,7 +28,7 @@ A semicolon is not necessary after a statement if it is written on its own line.
 
 It is considered best practice, however, to always write a semicolon after a statement, even when it is not strictly needed. This practice reduces the chances of bugs getting into the code.
 
-The source text of JavaScript script gets scanned from left to right, and is converted into a sequence of input elements which are _tokens_, _control characters_, _line terminators_, _comments_, or {{glossary("whitespace")}}. (Spaces, tabs, and newline characters are considered whitespace.)
+The source text of JavaScript script gets scanned from left to right, and is converted into a sequence of input elements which are _tokens_, _control characters_, _line terminators_, _comments_, or {{Glossary("whitespace")}}. (Spaces, tabs, and newline characters are considered whitespace.)
 
 ## Comments
 
@@ -115,7 +115,7 @@ A variable may belong to one of the following [scopes](/en-US/docs/Glossary/Scop
 
 - Global scope: The default scope for all code running in script mode.
 - Module scope: The scope for code running in module mode.
-- Function scope: The scope created with a {{glossary("function")}}.
+- Function scope: The scope created with a {{Glossary("function")}}.
 
 In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) can belong to an additional scope:
 
@@ -482,7 +482,7 @@ console.log(car.manyCars.b); // Jeep
 console.log(car[7]); // Mazda
 ```
 
-Object property names can be any string, including the empty string. If the property name would not be a valid JavaScript {{Glossary("Identifier","identifier")}} or number, it must be enclosed in quotes.
+Object property names can be any string, including the empty string. If the property name would not be a valid JavaScript {{Glossary("Identifier", "identifier")}} or number, it must be enclosed in quotes.
 
 Property names that are not valid identifiers cannot be accessed as a dot (`.`) property.
 

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -44,7 +44,7 @@ const arr3 = [];
 arr3.length = arrayLength;
 ```
 
-> **Note:** In the above code, `arrayLength` must be a `Number`. Otherwise, an array with a single element (the provided value) will be created. Calling `arr.length` will return `arrayLength`, but the array doesn't contain any elements. A {{jsxref("Statements/for...in","for...in")}} loop will not find any property on the array.
+> **Note:** In the above code, `arrayLength` must be a `Number`. Otherwise, an array with a single element (the provided value) will be created. Calling `arr.length` will return `arrayLength`, but the array doesn't contain any elements. A {{jsxref("Statements/for...in", "for...in")}} loop will not find any property on the array.
 
 In addition to a newly defined variable as shown above, arrays can also be assigned as a property of a new or an existing object:
 
@@ -233,7 +233,7 @@ nonsparseArray.forEach((element) => {
 // fourth
 ```
 
-Since JavaScript array elements are saved as standard object properties, it is not advisable to iterate through JavaScript arrays using {{jsxref("Statements/for...in","for...in")}} loops, because normal elements and all enumerable properties will be listed.
+Since JavaScript array elements are saved as standard object properties, it is not advisable to iterate through JavaScript arrays using {{jsxref("Statements/for...in", "for...in")}} loops, because normal elements and all enumerable properties will be listed.
 
 ### Array methods
 
@@ -527,7 +527,7 @@ console.log(result.vegetables);
 // [{ name: "asparagus", type: "vegetables" }]
 ```
 
-Note that the returned object references the _same_ elements as the original array (not {{glossary("deep copy","deep copies")}}). Changing the internal structure of these elements will be reflected in both the original array and the returned object.
+Note that the returned object references the _same_ elements as the original array (not {{Glossary("deep copy", "deep copies")}}). Changing the internal structure of these elements will be reflected in both the original array and the returned object.
 
 If you can't use a string as the key, for example, if the information to group is associated with an object that might change, then you can instead use {{jsxref("Map.groupBy()")}}. This is very similar to `Object.groupBy()` except that it groups the elements of the array into a {{jsxref("Map")}} that can use an arbitrary value ({{Glossary("object")}} or {{Glossary("primitive")}}) as a key.
 
@@ -632,7 +632,7 @@ For example, when an array is the result of a match between a regular expression
 
 ## Working with array-like objects
 
-Some JavaScript objects, such as the [`NodeList`](/en-US/docs/Web/API/NodeList) returned by [`document.getElementsByTagName()`](/en-US/docs/Web/API/Document/getElementsByTagName) or the {{jsxref("Functions/arguments","arguments")}} object made available within the body of a function, look and behave like arrays on the surface but do not share all of their methods. The `arguments` object provides a {{jsxref("Global_Objects/Function/length","length")}} attribute but does not implement array methods like [`forEach()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach).
+Some JavaScript objects, such as the [`NodeList`](/en-US/docs/Web/API/NodeList) returned by [`document.getElementsByTagName()`](/en-US/docs/Web/API/Document/getElementsByTagName) or the {{jsxref("Functions/arguments", "arguments")}} object made available within the body of a function, look and behave like arrays on the surface but do not share all of their methods. The `arguments` object provides a {{jsxref("Function/length", "length")}} attribute but does not implement array methods like [`forEach()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach).
 
 Array methods cannot be called directly on array-like objects.
 
@@ -644,7 +644,7 @@ function printArguments() {
 }
 ```
 
-But you can call them indirectly using {{jsxref("Global_Objects/Function/call","Function.prototype.call()")}}.
+But you can call them indirectly using {{jsxref("Function.prototype.call()")}}.
 
 ```js example-good
 function printArguments() {

--- a/files/en-us/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/en-us/web/javascript/guide/iterators_and_generators/index.md
@@ -6,14 +6,14 @@ page-type: guide
 
 {{jsSidebar("JavaScript Guide")}} {{PreviousNext("Web/JavaScript/Guide/Typed_arrays", "Web/JavaScript/Guide/Meta_programming")}}
 
-Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of {{jsxref("Statements/for...of","for...of")}} loops.
+Iterators and Generators bring the concept of iteration directly into the core language and provide a mechanism for customizing the behavior of {{jsxref("Statements/for...of", "for...of")}} loops.
 
 For details, see also:
 
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
-- {{jsxref("Statements/for...of","for...of")}}
-- {{jsxref("Statements/function*","function*")}} and {{jsxref("Generator")}}
-- {{jsxref("Operators/yield","yield")}} and {{jsxref("Operators/yield*","yield*")}}
+- {{jsxref("Statements/for...of", "for...of")}}
+- {{jsxref("Statements/function*", "function*")}} and {{jsxref("Generator")}}
+- {{jsxref("Operators/yield", "yield")}} and {{jsxref("Operators/yield*", "yield*")}}
 
 ## Iterators
 
@@ -73,7 +73,7 @@ console.log("Iterated over sequence of size:", result.value); // [5 numbers retu
 
 ## Generator functions
 
-While custom iterators are a useful tool, their creation requires careful programming due to the need to explicitly maintain their internal state. **Generator functions** provide a powerful alternative: they allow you to define an iterative algorithm by writing a single function whose execution is not continuous. Generator functions are written using the {{jsxref("Statements/function*","function*")}} syntax.
+While custom iterators are a useful tool, their creation requires careful programming due to the need to explicitly maintain their internal state. **Generator functions** provide a powerful alternative: they allow you to define an iterative algorithm by writing a single function whose execution is not continuous. Generator functions are written using the {{jsxref("Statements/function*", "function*")}} syntax.
 
 When called, generator functions do not initially execute their code. Instead, they return a special type of iterator, called a **Generator**. When a value is consumed by calling the generator's `next` method, the Generator function executes until it encounters the `yield` keyword.
 
@@ -163,7 +163,7 @@ for (const value of myIterable) {
 
 ### Syntaxes expecting iterables
 
-Some statements and expressions expect iterables. For example: the {{jsxref("Statements/for...of","for-of")}} loops, {{jsxref("Operators/yield*","yield*")}}.
+Some statements and expressions expect iterables. For example: the {{jsxref("Statements/for...of", "for...of")}} loops, {{jsxref("Operators/yield*", "yield*")}}.
 
 ```js
 for (const value of ["a", "b", "c"]) {
@@ -192,7 +192,7 @@ a;
 
 Generators compute their `yield`ed values _on demand_, which allows them to efficiently represent sequences that are expensive to compute (or even infinite sequences, as demonstrated above).
 
-The {{jsxref("Global_Objects/Generator/next","next()")}} method also accepts a value, which can be used to modify the internal state of the generator. A value passed to `next()` will be received by `yield` .
+The {{jsxref("Generator/next", "next()")}} method also accepts a value, which can be used to modify the internal state of the generator. A value passed to `next()` will be received by `yield` .
 
 > **Note:** A value passed to the _first_ invocation of `next()` is always ignored.
 
@@ -226,10 +226,10 @@ console.log(sequence.next().value); // 1
 console.log(sequence.next().value); // 2
 ```
 
-You can force a generator to throw an exception by calling its {{jsxref("Global_Objects/Generator/throw","throw()")}} method and passing the exception value it should throw. This exception will be thrown from the current suspended context of the generator, as if the `yield` that is currently suspended were instead a `throw value` statement.
+You can force a generator to throw an exception by calling its {{jsxref("Generator/throw", "throw()")}} method and passing the exception value it should throw. This exception will be thrown from the current suspended context of the generator, as if the `yield` that is currently suspended were instead a `throw value` statement.
 
 If the exception is not caught from within the generator, it will propagate up through the call to `throw()`, and subsequent calls to `next()` will result in the `done` property being `true`.
 
-Generators have a {{jsxref("Global_Objects/Generator/return","return(value)")}} method that returns the given value and finishes the generator itself.
+Generators have a {{jsxref("Generator/return", "return()")}} method that returns the given value and finishes the generator itself.
 
 {{PreviousNext("Web/JavaScript/Guide/Typed_arrays", "Web/JavaScript/Guide/Meta_programming")}}

--- a/files/en-us/web/javascript/guide/keyed_collections/index.md
+++ b/files/en-us/web/javascript/guide/keyed_collections/index.md
@@ -14,7 +14,7 @@ This chapter introduces collections of data which are indexed by a key; `Map` an
 
 A {{jsxref("Map")}} object is a simple key/value map and can iterate its elements in insertion order.
 
-The following code shows some basic operations with a `Map`. See also the {{jsxref("Map")}} reference page for more examples and the complete API. You can use a {{jsxref("Statements/for...of","for...of")}} loop to return an array of `[key, value]` for each iteration.
+The following code shows some basic operations with a `Map`. See also the {{jsxref("Map")}} reference page for more examples and the complete API. You can use a {{jsxref("Statements/for...of", "for...of")}} loop to return an array of `[key, value]` for each iteration.
 
 ```js
 const sayings = new Map();
@@ -42,7 +42,7 @@ sayings.size; // 0
 
 Traditionally, {{jsxref("Object", "objects", "", 1)}} have been used to map strings to values. Objects allow you to set keys to values, retrieve those values, delete keys, and detect whether something is stored at a key. `Map` objects, however, have a few more advantages that make them better maps.
 
-- The keys of an `Object` are {{jsxref("Global_Objects/String","Strings")}} or {{jsxref("Global_Objects/Symbol","Symbols")}}, where they can be of any value for a `Map`.
+- The keys of an `Object` are [strings](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) or [symbols](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol), where they can be of any value for a `Map`.
 - You can get the `size` of a `Map` easily, while you have to manually keep track of size for an `Object`.
 - The iteration of maps is in insertion order of the elements.
 - An `Object` has a prototype, so there are default keys in the map. (This can be bypassed using `map = Object.create(null)`.)

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -5,8 +5,7 @@ page-type: guide
 ---
 
 {{jsSidebar("JavaScript Guide")}}
-{{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling",
-  "Web/JavaScript/Guide/Functions")}}
+{{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling", "Web/JavaScript/Guide/Functions")}}
 
 Loops offer a quick and easy way to do something repeatedly. This
 chapter of the [JavaScript Guide](/en-US/docs/Web/JavaScript/Guide)
@@ -44,7 +43,7 @@ The statements for loops provided in JavaScript are:
 
 ## for statement
 
-A {{jsxref("statements/for","for")}} loop repeats until a specified condition evaluates to false. The JavaScript `for` loop is similar to the Java and C `for` loop.
+A {{jsxref("Statements/for", "for")}} loop repeats until a specified condition evaluates to false. The JavaScript `for` loop is similar to the Java and C `for` loop.
 
 A `for` statement looks as follows:
 
@@ -146,7 +145,7 @@ do {
 
 ## while statement
 
-A {{jsxref("statements/while","while")}} statement executes its statements as long as a
+A {{jsxref("Statements/while", "while")}} statement executes its statements as long as a
 specified condition evaluates to `true`. A `while` statement looks
 as follows:
 
@@ -212,7 +211,7 @@ while (true) {
 
 ## labeled statement
 
-A {{jsxref("statements/label","label")}} provides a statement with an identifier that
+A {{jsxref("Statements/label", "label")}} provides a statement with an identifier that
 lets you refer to it elsewhere in your program. For example, you can use a label to
 identify a loop, and then use the `break` or `continue` statements
 to indicate whether a program should interrupt the loop or continue its execution.
@@ -230,7 +229,7 @@ any statement. For examples of using labeled statements, see the examples of `br
 
 ## break statement
 
-Use the {{jsxref("statements/break","break")}} statement to terminate a loop,
+Use the {{jsxref("Statements/break", "break")}} statement to terminate a loop,
 `switch`, or in conjunction with a labeled statement.
 
 - When you use `break` without a label, it terminates the innermost
@@ -285,7 +284,7 @@ labelCancelLoops: while (true) {
 
 ## continue statement
 
-The {{jsxref("statements/continue","continue")}} statement can be used to restart a
+The {{jsxref("Statements/continue", "continue")}} statement can be used to restart a
 `while`, `do-while`, `for`, or `label`
 statement.
 
@@ -366,7 +365,7 @@ checkiandj: while (i < 4) {
 
 ## for...in statement
 
-The {{jsxref("statements/for...in","for...in")}} statement iterates a specified
+The {{jsxref("Statements/for...in", "for...in")}} statement iterates a specified
 variable over all the enumerable properties of an object. For each distinct property,
 JavaScript executes the specified statements. A `for...in` statement looks as
 follows:
@@ -406,17 +405,17 @@ Although it may be tempting to use this as a way to iterate over {{jsxref("Array
 elements, the `for...in` statement will return the name of your user-defined
 properties in addition to the numeric indexes.
 
-Therefore, it is better to use a traditional {{jsxref("statements/for","for")}} loop
+Therefore, it is better to use a traditional {{jsxref("Statements/for", "for")}} loop
 with a numeric index when iterating over arrays, because the `for...in`
 statement iterates over user-defined properties in addition to the array elements, if
 you modify the Array object (such as adding custom properties or methods).
 
 ## for...of statement
 
-The {{jsxref("statements/for...of","for...of")}} statement creates a loop Iterating
+The {{jsxref("Statements/for...of", "for...of")}} statement creates a loop Iterating
 over [iterable objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) (including
 {{jsxref("Array")}}, {{jsxref("Map")}}, {{jsxref("Set")}},
-{{jsxref("functions/arguments","arguments")}} object and so on), invoking a custom
+{{jsxref("Functions/arguments", "arguments")}} object and so on), invoking a custom
 iteration hook with statements to be executed for the value of each distinct property.
 
 ```js-nolint
@@ -425,7 +424,7 @@ for (variable of object)
 ```
 
 The following example shows the difference between a `for...of` loop and a
-{{jsxref("statements/for...in","for...in")}} loop. While `for...in` iterates
+{{jsxref("Statements/for...in", "for...in")}} loop. While `for...in` iterates
 over property names, `for...of` iterates over property values:
 
 ```js
@@ -455,5 +454,4 @@ for (const [key, val] of Object.entries(obj)) {
 // "bar" 2
 ```
 
-{{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling",
-  "Web/JavaScript/Guide/Functions")}}
+{{PreviousNext("Web/JavaScript/Guide/Control_flow_and_error_handling", "Web/JavaScript/Guide/Functions")}}

--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -34,7 +34,7 @@ Additional examples are available on the {{jsxref("Proxy")}} reference page.
 
 The following terms are used when talking about the functionality of proxies.
 
-- {{jsxref("Global_Objects/Proxy/Proxy","handler","","true")}}
+- {{jsxref("Proxy/Proxy", "handler", "", "true")}}
   - : Placeholder object which contains traps.
 - traps
   - : The methods that provide property access. (This is analogous to the concept of _traps_ in operating systems.)
@@ -412,7 +412,7 @@ console.log(typeof proxy); // "object", typeof doesn't trigger any trap
 
 ## Reflection
 
-{{jsxref("Reflect")}} is a built-in object that provides methods for interceptable JavaScript operations. The methods are the same as those of the {{jsxref("Global_Objects/Proxy/Proxy","proxy handlers","","true")}}.
+{{jsxref("Reflect")}} is a built-in object that provides methods for interceptable JavaScript operations. The methods are the same as those of the [proxy handler's](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy).
 
 `Reflect` is not a function object.
 
@@ -450,7 +450,7 @@ Reflect.apply("".charAt, "ponies", [3]);
 
 ### Checking if property definition has been successful
 
-With {{jsxref("Object.defineProperty")}}, which returns an object if successful, or throws a {{jsxref("TypeError")}} otherwise, you would use a {{jsxref("Statements/try...catch","try...catch")}} block to catch any error that occurred while defining a property. Because {{jsxref("Reflect.defineProperty")}} returns a Boolean success status, you can just use an {{jsxref("Statements/if...else","if...else")}} block here:
+With {{jsxref("Object.defineProperty")}}, which returns an object if successful, or throws a {{jsxref("TypeError")}} otherwise, you would use a {{jsxref("Statements/try...catch", "try...catch")}} block to catch any error that occurred while defining a property. Because {{jsxref("Reflect.defineProperty()")}} returns a Boolean success status, you can just use an {{jsxref("Statements/if...else", "if...else")}} block here:
 
 ```js
 if (Reflect.defineProperty(target, property, attributes)) {

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -7,7 +7,7 @@ browser-compat:
   - javascript.statements.export
 ---
 
-{{JSSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Meta_programming")}}
+{{jsSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Meta_programming")}}
 
 This guide gives you all you need to get started with JavaScript module syntax.
 
@@ -19,7 +19,7 @@ It has therefore made sense in recent years to start thinking about providing me
 
 The good news is that modern browsers have started to support module functionality natively, and this is what this article is all about. This can only be a good thing — browsers can optimize loading of modules, making it more efficient than having to use a library and do all of that extra client-side processing and extra round trips.
 
-Use of native JavaScript modules is dependent on the {{JSxRef("Statements/import", "import")}} and {{JSxRef("Statements/export", "export")}} statements; these are supported in browsers as shown in the compatibility table below.
+Use of native JavaScript modules is dependent on the {{jsxref("Statements/import", "import")}} and {{jsxref("Statements/export", "export")}} statements; these are supported in browsers as shown in the compatibility table below.
 
 ## Browser compatibility
 
@@ -83,7 +83,7 @@ It is also worth noting that:
 
 ## Exporting module features
 
-The first thing you do to get access to module features is export them. This is done using the {{JSxRef("Statements/export", "export")}} statement.
+The first thing you do to get access to module features is export them. This is done using the {{jsxref("Statements/export", "export")}} statement.
 
 The easiest way to use it is to place it in front of any items you want exported out of the module, for example:
 
@@ -114,7 +114,7 @@ Once you've exported some features out of your module, you need to import them i
 import { name, draw, reportArea, reportPerimeter } from "./modules/square.js";
 ```
 
-You use the {{JSxRef("Statements/import", "import")}} statement, followed by a comma-separated list of the features you want to import wrapped in curly braces, followed by the keyword `from`, followed by the _module specifier_.
+You use the {{jsxref("Statements/import", "import")}} statement, followed by a comma-separated list of the features you want to import wrapped in curly braces, followed by the keyword `from`, followed by the _module specifier_.
 
 The _module specifier_ provides a string that the JavaScript environment can resolve to a path to the module file.
 In a browser, this could be a path relative to the site root, which for our `basic-modules` example would be `/js-examples/module-examples/basic-modules`.
@@ -385,7 +385,7 @@ You can only use `import` and `export` statements inside modules, not regular sc
 ## Other differences between modules and standard scripts
 
 - You need to pay attention to local testing — if you try to load the HTML file locally (i.e. with a `file://` URL), you'll run into CORS errors due to JavaScript module security requirements. You need to do your testing through a server.
-- Also, note that you might get different behavior from sections of script defined inside modules as opposed to in standard scripts. This is because modules use {{JSxRef("Strict_mode", "strict mode", "", 1)}} automatically.
+- Also, note that you might get different behavior from sections of script defined inside modules as opposed to in standard scripts. This is because modules use {{jsxref("Strict_mode", "strict mode", "", 1)}} automatically.
 - There is no need to use the `defer` attribute (see [`<script>` attributes](/en-US/docs/Web/HTML/Element/script#attributes)) when loading a module script; modules are deferred automatically.
 - Modules are only executed once, even if they have been referenced in multiple `<script>` tags.
 - Last but not least, let's make this clear — module features are imported into the scope of a single script — they aren't available in the global scope. Therefore, you will only be able to access imported features in the script they are imported into, and you won't be able to access them from the JavaScript console, for example. You'll still get syntax errors shown in the DevTools, but you'll not be able to use some of the debugging techniques you might have expected to use.
@@ -691,7 +691,7 @@ import { Square, Circle, Triangle } from "./modules/shapes.js";
 
 A recent addition to JavaScript modules functionality is dynamic module loading. This allows you to dynamically load modules only when they are needed, rather than having to load everything up front. This has some obvious performance advantages; let's read on and see how it works.
 
-This new functionality allows you to call [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import) as a function, passing it the path to the module as a parameter. It returns a {{JSxRef("Promise")}}, which fulfills with a module object (see [Creating a module object](#creating_a_module_object)) giving you access to that object's exports. For example:
+This new functionality allows you to call [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import) as a function, passing it the path to the module as a parameter. It returns a {{jsxref("Promise")}}, which fulfills with a module object (see [Creating a module object](#creating_a_module_object)) giving you access to that object's exports. For example:
 
 ```js
 import("./modules/myModule.js").then((module) => {

--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Guide/Regular_expressions/Character_classes
 page-type: guide
 ---
 
-{{JSSidebar("JavaScript Guide")}}
+{{jsSidebar("JavaScript Guide")}}
 
 Character classes distinguish kinds of characters such as, for example, distinguishing between letters and digits.
 

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -159,7 +159,7 @@ For instance, to match the string "C:\\" where "C" can be any letter, you'd use 
 If using the `RegExp` constructor with a string literal, remember that the backslash is an escape in string literals, so to use it in the regular expression, you need to escape it at the string literal level.
 `/a\*b/` and `new RegExp("a\\*b")` create the same expression, which searches for "a" followed by a literal "\*" followed by "b".
 
-If escape strings are not already part of your pattern you can add them using {{jsxref('String.prototype.replace()')}}:
+If escape strings are not already part of your pattern you can add them using {{jsxref("String.prototype.replace()")}}:
 
 ```js
 function escapeRegExp(string) {
@@ -453,7 +453,7 @@ form.addEventListener("submit", (event) => {
 
 #### Result
 
-{{ EmbedLiveSample('Using_special_characters_to_verify_input') }}
+{{EmbedLiveSample("Using_special_characters_to_verify_input")}}
 
 ## Tools
 

--- a/files/en-us/web/javascript/index.md
+++ b/files/en-us/web/javascript/index.md
@@ -4,13 +4,13 @@ slug: Web/JavaScript
 page-type: landing-page
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 **JavaScript** (**JS**) is a lightweight interpreted (or [just-in-time](https://en.wikipedia.org/wiki/Just-in-time_compilation) compiled) programming language with {{Glossary("First-class Function", "first-class functions")}}. While it is most well-known as the scripting language for Web pages, [many non-browser environments](https://en.wikipedia.org/wiki/JavaScript#Other_usage) also use it, such as {{Glossary("Node.js")}}, [Apache CouchDB](https://couchdb.apache.org/) and [Adobe Acrobat](https://opensource.adobe.com/dc-acrobat-sdk-docs/acrobatsdk/). JavaScript is a [prototype-based](/en-US/docs/Glossary/Prototype-based_programming), multi-paradigm, [single-threaded](/en-US/docs/Glossary/Thread), [dynamic](/en-US/docs/Glossary/Dynamic_typing) language, supporting object-oriented, imperative, and declarative (e.g. functional programming) styles.
 
 JavaScript's dynamic capabilities include runtime object construction, variable parameter lists, function variables, dynamic script creation (via [`eval`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)), object introspection (via [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) and [`Object` utilities](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#static_methods)), and source-code recovery (JavaScript functions store their source text and can be retrieved through [`toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString)).
 
-This section is dedicated to the JavaScript language itself, and not the parts that are specific to Web pages or other host environments. For information about {{Glossary("API","APIs")}} that are specific to Web pages, please see [Web APIs](/en-US/docs/Web/API) and {{Glossary("DOM")}}.
+This section is dedicated to the JavaScript language itself, and not the parts that are specific to Web pages or other host environments. For information about {{Glossary("API", "APIs")}} that are specific to Web pages, please see [Web APIs](/en-US/docs/Web/API) and {{Glossary("DOM")}}.
 
 The standards for JavaScript are the [ECMAScript Language Specification](https://tc39.es/ecma262/) (ECMA-262) and the [ECMAScript Internationalization API specification](https://tc39.es/ecma402/) (ECMA-402). As soon as one browser implements a feature, we try to document it. This means that cases where some [proposals for new ECMAScript features](https://github.com/tc39/proposals) have already been implemented in browsers, documentation and examples in MDN articles may use some of those new features. Most of the time, this happens between the [stages](https://tc39.es/process-document/) 3 and 4, and is usually before the spec is officially published.
 

--- a/files/en-us/web/javascript/javascript_technologies_overview/index.md
+++ b/files/en-us/web/javascript/javascript_technologies_overview/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/JavaScript_technologies_overview
 page-type: guide
 ---
 
-{{JsSidebar("Introductory")}}
+{{jsSidebar("Introductory")}}
 
 Whereas [HTML](/en-US/docs/Web/HTML) defines a webpage's structure and content and [CSS](/en-US/docs/Web/CSS) sets the formatting and appearance, [JavaScript](/en-US/docs/Web/JavaScript) adds interactivity to a webpage and creates rich web applications.
 

--- a/files/en-us/web/javascript/memory_management/index.md
+++ b/files/en-us/web/javascript/memory_management/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Memory_management
 page-type: guide
 ---
 
-{{JsSidebar("Advanced")}}
+{{jsSidebar("Advanced")}}
 
 Low-level languages like C, have manual memory management primitives such as [`malloc()`](https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html) and [`free()`](https://en.wikipedia.org/wiki/C_dynamic_memory_allocation#Overview_of_functions). In contrast, JavaScript automatically allocates memory when objects are created and frees it when they are not used anymore (_garbage collection_). This automaticity is a potential source of confusion: it can give developers the false impression that they don't need to worry about memory management.
 

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -5,7 +5,7 @@ page-type: guide
 browser-compat: javascript.classes
 ---
 
-{{JsSidebar("Classes")}}
+{{jsSidebar("Classes")}}
 
 Classes are a template for creating objects. They encapsulate data with code to work on that data. Classes in JS are built on [prototypes](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) but also have some syntax and semantics that are unique to classes.
 

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.classes.private_class_fields
 ---
 
-{{JsSidebar("Classes")}}
+{{jsSidebar("Classes")}}
 
 Class fields are [public](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) by default, but **private class members** can be created by using a hash `#` prefix. The privacy encapsulation of these class features is enforced by JavaScript itself.
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.classes.public_class_fields
 ---
 
-{{JsSidebar("Classes")}}
+{{jsSidebar("Classes")}}
 
 **Public fields** are writable, enumerable, and configurable properties. As such, unlike their private counterparts, they participate in prototype inheritance.
 

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -155,7 +155,7 @@ StaticMethodCall.anotherStaticMethod();
 
 ### Calling static members from a class constructor and other methods
 
-Static members are not directly accessible using the {{JSxRef("Operators/this", "this")}} keyword from
+Static members are not directly accessible using the {{jsxref("Operators/this", "this")}} keyword from
 non-static methods. You need to call them using the class name:
 `CLASSNAME.STATIC_METHOD_NAME()` /
 `CLASSNAME.STATIC_PROPERTY_NAME` or by calling the method as a property of

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Deprecated_and_obsolete_features
 page-type: guide
 ---
 
-{{JsSidebar("More")}}
+{{jsSidebar("More")}}
 
 This page lists features of JavaScript that are deprecated (that is, still available but planned for removal) and obsolete (that is, no longer usable).
 

--- a/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/identifier_after_number/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Errors/Identifier_after_number
 page-type: javascript-error
 ---
 
-{{JSSidebar("Errors")}}
+{{jsSidebar("Errors")}}
 
 The JavaScript exception "identifier starts immediately after numeric literal" occurs
 when an identifier started with a digit. Identifiers can only start with a letter,

--- a/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference/Errors/No_non-null_object
 page-type: javascript-error
 ---
 
-{{JSSidebar("Errors")}}
+{{jsSidebar("Errors")}}
 
 The JavaScript exception "is not a non-null object" occurs when an object is expected
 somewhere and wasn't provided. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is not an object and won't work.

--- a/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
+++ b/files/en-us/web/javascript/reference/errors/unnamed_function_statement/index.md
@@ -137,5 +137,5 @@ promise.then(
 - [Functions](/en-US/docs/Web/JavaScript/Guide/Functions) guide
 - [`function`](/en-US/docs/Web/JavaScript/Reference/Statements/function)
 - [`function` expression](/en-US/docs/Web/JavaScript/Reference/Operators/function)
-- {{glossary("IIFE")}}
+- {{Glossary("IIFE")}}
 - [Labeled statement](/en-US/docs/Web/JavaScript/Reference/Statements/label)

--- a/files/en-us/web/javascript/reference/functions/arguments/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.functions.arguments
 ---
 
-{{JSSidebar("Functions")}}
+{{jsSidebar("Functions")}}
 
 **`arguments`** is an array-like object accessible inside [functions](/en-US/docs/Web/JavaScript/Guide/Functions) that contains the values of the arguments passed to that function.
 
@@ -94,7 +94,7 @@ This is the same behavior exhibited by all [strict-mode functions](/en-US/docs/W
 
 ### arguments is an array-like object
 
-`arguments` is an array-like object, which means that `arguments` has a {{jsxref("Functions/arguments/length", "length")}} property and properties indexed from zero, but it doesn't have {{JSxRef("Array")}}'s built-in methods like {{jsxref("Array/forEach", "forEach()")}} or {{jsxref("Array/map", "map()")}}. However, it can be converted to a real `Array`, using one of [`slice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice), {{jsxref("Array.from()")}}, or [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).
+`arguments` is an array-like object, which means that `arguments` has a {{jsxref("Functions/arguments/length", "length")}} property and properties indexed from zero, but it doesn't have {{jsxref("Array")}}'s built-in methods like {{jsxref("Array/forEach", "forEach()")}} or {{jsxref("Array/map", "map()")}}. However, it can be converted to a real `Array`, using one of [`slice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice), {{jsxref("Array.from()")}}, or [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).
 
 ```js
 const args = Array.prototype.slice.call(arguments);
@@ -118,7 +118,7 @@ console.log(midpoint(3, 1, 4, 1, 5)); // 3
 
 ## Properties
 
-- {{jsxref("Functions/arguments/callee", "arguments.callee")}} {{Deprecated_Inline}}
+- {{jsxref("Functions/arguments/callee", "arguments.callee")}} {{deprecated_inline}}
   - : Reference to the currently executing function that the arguments belong to. Forbidden in strict mode.
 - {{jsxref("Functions/arguments/length", "arguments.length")}}
   - : The number of arguments that were passed to the function.

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.functions.arrow_functions
 
 An **arrow function expression** is a compact alternative to a traditional [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function), with some semantic differences and deliberate limitations in usage:
 
-- Arrow functions don't have their own {{glossary("binding", "bindings")}} to [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this), [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments), or [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super), and should not be used as [methods](/en-US/docs/Glossary/Method).
+- Arrow functions don't have their own {{Glossary("binding", "bindings")}} to [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this), [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments), or [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super), and should not be used as [methods](/en-US/docs/Glossary/Method).
 - Arrow functions cannot be used as [constructors](/en-US/docs/Glossary/Constructor). Calling them with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) throws a {{jsxref("TypeError")}}. They also don't have access to the [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) keyword.
 - Arrow functions cannot use [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield) within their body and cannot be created as generator functions.
 

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -103,7 +103,7 @@ f(5); // 5
 
 ### Passing undefined vs. other falsy values
 
-In the second call in this example, even if the first argument is set explicitly to `undefined` (though not `null` or other {{glossary("falsy")}} values), the value of the `num` argument is still the default.
+In the second call in this example, even if the first argument is set explicitly to `undefined` (though not `null` or other {{Glossary("falsy")}} values), the value of the `num` argument is still the default.
 
 ```js
 function test(num = 1) {

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.functions.method_definitions
 ---
 
-{{JsSidebar("Functions")}}
+{{jsSidebar("Functions")}}
 
 **Method definition** is a shorter syntax for defining a function property in an object initializer. It can also be used in [classes](/en-US/docs/Web/JavaScript/Reference/Classes).
 

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -4,7 +4,7 @@ slug: Web/JavaScript/Reference
 page-type: landing-page
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 The JavaScript reference serves as a repository of facts about the JavaScript language. The entire language is described here in detail. As you write JavaScript code, you'll refer to these pages often (thus the title "JavaScript reference").
 
@@ -18,120 +18,120 @@ If you are new to JavaScript, start with the [guide](/en-US/docs/Web/JavaScript/
 
 ### Value properties
 
-- {{JSxRef("globalThis")}}
-- {{JSxRef("Infinity")}}
-- {{JSxRef("NaN")}}
-- {{JSxRef("undefined")}}
+- {{jsxref("globalThis")}}
+- {{jsxref("Infinity")}}
+- {{jsxref("NaN")}}
+- {{jsxref("undefined")}}
 
 ### Function properties
 
-- {{JSxRef("Global_Objects/eval", "eval()")}}
-- {{JSxRef("Global_Objects/isFinite", "isFinite()")}}
-- {{JSxRef("Global_Objects/isNaN", "isNaN()")}}
-- {{JSxRef("Global_Objects/parseFloat", "parseFloat()")}}
-- {{JSxRef("Global_Objects/parseInt", "parseInt()")}}
-- {{JSxRef("Global_Objects/decodeURI", "decodeURI()")}}
-- {{JSxRef("Global_Objects/decodeURIComponent", "decodeURIComponent()")}}
-- {{JSxRef("Global_Objects/encodeURI", "encodeURI()")}}
-- {{JSxRef("Global_Objects/encodeURIComponent", "encodeURIComponent()")}}
-- {{JSxRef("Global_Objects/escape", "escape()")}} {{Deprecated_Inline}}
-- {{JSxRef("Global_Objects/unescape", "unescape()")}} {{Deprecated_Inline}}
+- {{jsxref("Global_Objects/eval", "eval()")}}
+- {{jsxref("Global_Objects/isFinite", "isFinite()")}}
+- {{jsxref("Global_Objects/isNaN", "isNaN()")}}
+- {{jsxref("Global_Objects/parseFloat", "parseFloat()")}}
+- {{jsxref("Global_Objects/parseInt", "parseInt()")}}
+- {{jsxref("Global_Objects/decodeURI", "decodeURI()")}}
+- {{jsxref("Global_Objects/decodeURIComponent", "decodeURIComponent()")}}
+- {{jsxref("Global_Objects/encodeURI", "encodeURI()")}}
+- {{jsxref("Global_Objects/encodeURIComponent", "encodeURIComponent()")}}
+- {{jsxref("Global_Objects/escape", "escape()")}} {{deprecated_inline}}
+- {{jsxref("Global_Objects/unescape", "unescape()")}} {{deprecated_inline}}
 
 ### Fundamental objects
 
-- {{JSxRef("Object")}}
-- {{JSxRef("Function")}}
-- {{JSxRef("Boolean")}}
-- {{JSxRef("Symbol")}}
+- {{jsxref("Object")}}
+- {{jsxref("Function")}}
+- {{jsxref("Boolean")}}
+- {{jsxref("Symbol")}}
 
 ### Error objects
 
-- {{JSxRef("Error")}}
-- {{JSxRef("AggregateError")}}
-- {{JSxRef("EvalError")}}
-- {{JSxRef("RangeError")}}
-- {{JSxRef("ReferenceError")}}
-- {{JSxRef("SyntaxError")}}
-- {{JSxRef("TypeError")}}
-- {{JSxRef("URIError")}}
-- {{JSxRef("InternalError")}} {{Non-Standard_Inline}}
+- {{jsxref("Error")}}
+- {{jsxref("AggregateError")}}
+- {{jsxref("EvalError")}}
+- {{jsxref("RangeError")}}
+- {{jsxref("ReferenceError")}}
+- {{jsxref("SyntaxError")}}
+- {{jsxref("TypeError")}}
+- {{jsxref("URIError")}}
+- {{jsxref("InternalError")}} {{non-standard_inline}}
 
 ### Numbers and dates
 
-- {{JSxRef("Number")}}
-- {{JSxRef("BigInt")}}
-- {{JSxRef("Math")}}
-- {{JSxRef("Date")}}
+- {{jsxref("Number")}}
+- {{jsxref("BigInt")}}
+- {{jsxref("Math")}}
+- {{jsxref("Date")}}
 
 ### Text processing
 
-- {{JSxRef("String")}}
-- {{JSxRef("RegExp")}}
+- {{jsxref("String")}}
+- {{jsxref("RegExp")}}
 
 ### Indexed collections
 
-- {{JSxRef("Array")}}
-- {{JSxRef("Int8Array")}}
-- {{JSxRef("Uint8Array")}}
-- {{JSxRef("Uint8ClampedArray")}}
-- {{JSxRef("Int16Array")}}
-- {{JSxRef("Uint16Array")}}
-- {{JSxRef("Int32Array")}}
-- {{JSxRef("Uint32Array")}}
-- {{JSxRef("BigInt64Array")}}
-- {{JSxRef("BigUint64Array")}}
-- {{JSxRef("Float32Array")}}
-- {{JSxRef("Float64Array")}}
+- {{jsxref("Array")}}
+- {{jsxref("Int8Array")}}
+- {{jsxref("Uint8Array")}}
+- {{jsxref("Uint8ClampedArray")}}
+- {{jsxref("Int16Array")}}
+- {{jsxref("Uint16Array")}}
+- {{jsxref("Int32Array")}}
+- {{jsxref("Uint32Array")}}
+- {{jsxref("BigInt64Array")}}
+- {{jsxref("BigUint64Array")}}
+- {{jsxref("Float32Array")}}
+- {{jsxref("Float64Array")}}
 
 ### Keyed collections
 
-- {{JSxRef("Map")}}
-- {{JSxRef("Set")}}
-- {{JSxRef("WeakMap")}}
-- {{JSxRef("WeakSet")}}
+- {{jsxref("Map")}}
+- {{jsxref("Set")}}
+- {{jsxref("WeakMap")}}
+- {{jsxref("WeakSet")}}
 
 ### Structured data
 
-- {{JSxRef("ArrayBuffer")}}
-- {{JSxRef("SharedArrayBuffer")}}
-- {{JSxRef("DataView")}}
-- {{JSxRef("Atomics")}}
-- {{JSxRef("JSON")}}
+- {{jsxref("ArrayBuffer")}}
+- {{jsxref("SharedArrayBuffer")}}
+- {{jsxref("DataView")}}
+- {{jsxref("Atomics")}}
+- {{jsxref("JSON")}}
 
 ### Managing memory
 
-- {{JSxRef("WeakRef")}}
-- {{JSxRef("FinalizationRegistry")}}
+- {{jsxref("WeakRef")}}
+- {{jsxref("FinalizationRegistry")}}
 
 ### Control abstraction objects
 
-- {{JSxRef("Iterator")}}
-- {{JSxRef("AsyncIterator")}}
-- {{JSxRef("Promise")}}
-- {{JSxRef("GeneratorFunction")}}
-- {{JSxRef("AsyncGeneratorFunction")}}
-- {{JSxRef("Generator")}}
-- {{JSxRef("AsyncGenerator")}}
-- {{JSxRef("AsyncFunction")}}
+- {{jsxref("Iterator")}}
+- {{jsxref("AsyncIterator")}}
+- {{jsxref("Promise")}}
+- {{jsxref("GeneratorFunction")}}
+- {{jsxref("AsyncGeneratorFunction")}}
+- {{jsxref("Generator")}}
+- {{jsxref("AsyncGenerator")}}
+- {{jsxref("AsyncFunction")}}
 
 ### Reflection
 
-- {{JSxRef("Reflect")}}
-- {{JSxRef("Proxy")}}
+- {{jsxref("Reflect")}}
+- {{jsxref("Proxy")}}
 
 ### Internationalization
 
-- {{JSxRef("Intl")}}
-- {{JSxRef("Intl.Collator")}}
-- {{JSxRef("Intl.DateTimeFormat")}}
-- {{JSxRef("Intl.DisplayNames")}}
-- {{JSxRef("Intl.DurationFormat")}}
-- {{JSxRef("Intl.ListFormat")}}
-- {{JSxRef("Intl.Locale")}}
-- {{JSxRef("Intl.NumberFormat")}}
-- {{JSxRef("Intl.PluralRules")}}
-- {{JSxRef("Intl.RelativeTimeFormat")}}
-- {{JSxRef("Intl.Segmenter")}}
+- {{jsxref("Intl")}}
+- {{jsxref("Intl.Collator")}}
+- {{jsxref("Intl.DateTimeFormat")}}
+- {{jsxref("Intl.DisplayNames")}}
+- {{jsxref("Intl.DurationFormat")}}
+- {{jsxref("Intl.ListFormat")}}
+- {{jsxref("Intl.Locale")}}
+- {{jsxref("Intl.NumberFormat")}}
+- {{jsxref("Intl.PluralRules")}}
+- {{jsxref("Intl.RelativeTimeFormat")}}
+- {{jsxref("Intl.Segmenter")}}
 
 ## Statements
 
@@ -179,7 +179,7 @@ If you are new to JavaScript, start with the [guide](/en-US/docs/Web/JavaScript/
 - {{jsxref("Statements/export", "export")}}
 - {{jsxref("Statements/import", "import")}}
 - {{jsxref("Statements/label", "label", "", 1)}}
-- {{jsxref("Statements/with", "with")}} {{Deprecated_Inline}}
+- {{jsxref("Statements/with", "with")}} {{deprecated_inline}}
 
 ## Expressions and operators
 
@@ -187,156 +187,156 @@ If you are new to JavaScript, start with the [guide](/en-US/docs/Web/JavaScript/
 
 ### Primary expressions
 
-- {{JSxRef("Operators/this", "this")}}
+- {{jsxref("Operators/this", "this")}}
 - [Literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#literals)
-- {{JSxRef("Global_Objects/Array", "[]")}}
-- {{JSxRef("Operators/Object_initializer", "{}")}}
-- {{JSxRef("Operators/function", "function")}}
-- {{JSxRef("Operators/class", "class")}}
-- {{JSxRef("Operators/function*", "function*")}}
-- {{JSxRef("Operators/async_function", "async function")}}
-- {{JSxRef("Operators/async_function*", "async function*")}}
-- {{JSxRef("Global_Objects/RegExp", "/ab+c/i")}}
-- {{JSxRef("Template_literals", "`string`")}}
-- {{JSxRef("Operators/Grouping", "( )")}}
+- {{jsxref("Global_Objects/Array", "[]")}}
+- {{jsxref("Operators/Object_initializer", "{}")}}
+- {{jsxref("Operators/function", "function")}}
+- {{jsxref("Operators/class", "class")}}
+- {{jsxref("Operators/function*", "function*")}}
+- {{jsxref("Operators/async_function", "async function")}}
+- {{jsxref("Operators/async_function*", "async function*")}}
+- {{jsxref("Global_Objects/RegExp", "/ab+c/i")}}
+- {{jsxref("Template_literals", "`string`")}}
+- {{jsxref("Operators/Grouping", "( )")}}
 
 ### Left-hand-side expressions
 
-- {{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}
-- {{JSxRef("Operators/Optional_chaining", "?.")}}
-- {{JSxRef("Operators/new", "new")}}
-- {{JSxRef("Operators/new%2Etarget", "new.target")}}
-- {{JSxRef("Operators/import%2Emeta", "import.meta")}}
-- {{JSxRef("Operators/super", "super")}}
-- {{JSxRef("Operators/import", "import()")}}
+- {{jsxref("Operators/Property_accessors", "Property accessors", "", 1)}}
+- {{jsxref("Operators/Optional_chaining", "?.")}}
+- {{jsxref("Operators/new", "new")}}
+- {{jsxref("Operators/new%2Etarget", "new.target")}}
+- {{jsxref("Operators/import%2Emeta", "import.meta")}}
+- {{jsxref("Operators/super", "super")}}
+- {{jsxref("Operators/import", "import()")}}
 
 ### Increment and decrement
 
-- {{JSxRef("Operators/Increment", "A++")}}
-- {{JSxRef("Operators/Decrement", "A--")}}
-- {{JSxRef("Operators/Increment", "++A")}}
-- {{JSxRef("Operators/Decrement", "--A")}}
+- {{jsxref("Operators/Increment", "A++")}}
+- {{jsxref("Operators/Decrement", "A--")}}
+- {{jsxref("Operators/Increment", "++A")}}
+- {{jsxref("Operators/Decrement", "--A")}}
 
 ### Unary operators
 
-- {{JSxRef("Operators/delete", "delete")}}
-- {{JSxRef("Operators/void", "void")}}
-- {{JSxRef("Operators/typeof", "typeof")}}
-- {{JSxRef("Operators/Unary_plus", "+")}}
-- {{JSxRef("Operators/Unary_negation", "-")}}
-- {{JSxRef("Operators/Bitwise_NOT", "~")}}
-- {{JSxRef("Operators/Logical_NOT", "!")}}
-- {{JSxRef("Operators/await", "await")}}
+- {{jsxref("Operators/delete", "delete")}}
+- {{jsxref("Operators/void", "void")}}
+- {{jsxref("Operators/typeof", "typeof")}}
+- {{jsxref("Operators/Unary_plus", "+")}}
+- {{jsxref("Operators/Unary_negation", "-")}}
+- {{jsxref("Operators/Bitwise_NOT", "~")}}
+- {{jsxref("Operators/Logical_NOT", "!")}}
+- {{jsxref("Operators/await", "await")}}
 
 ### Arithmetic operators
 
-- {{JSxRef("Operators/Exponentiation", "**")}}
-- {{JSxRef("Operators/Multiplication", "*")}}
-- {{JSxRef("Operators/Division", "/")}}
-- {{JSxRef("Operators/Remainder", "%")}}
-- {{JSxRef("Operators/Addition", "+")}} (Plus)
-- {{JSxRef("Operators/Subtraction", "-")}}
+- {{jsxref("Operators/Exponentiation", "**")}}
+- {{jsxref("Operators/Multiplication", "*")}}
+- {{jsxref("Operators/Division", "/")}}
+- {{jsxref("Operators/Remainder", "%")}}
+- {{jsxref("Operators/Addition", "+")}} (Plus)
+- {{jsxref("Operators/Subtraction", "-")}}
 
 ### Relational operators
 
-- {{JSxRef("Operators/Less_than", "&lt;")}} (Less than)
-- {{JSxRef("Operators/Greater_than", "&gt;")}} (Greater than)
-- {{JSxRef("Operators/Less_than_or_equal", "&lt;=")}}
-- {{JSxRef("Operators/Greater_than_or_equal", "&gt;=")}}
-- {{JSxRef("Operators/instanceof", "instanceof")}}
-- {{JSxRef("Operators/in", "in")}}
+- {{jsxref("Operators/Less_than", "&lt;")}} (Less than)
+- {{jsxref("Operators/Greater_than", "&gt;")}} (Greater than)
+- {{jsxref("Operators/Less_than_or_equal", "&lt;=")}}
+- {{jsxref("Operators/Greater_than_or_equal", "&gt;=")}}
+- {{jsxref("Operators/instanceof", "instanceof")}}
+- {{jsxref("Operators/in", "in")}}
 
 ### Equality operators
 
-- {{JSxRef("Operators/Equality", "==")}}
-- {{JSxRef("Operators/Inequality", "!=")}}
-- {{JSxRef("Operators/Strict_equality", "===")}}
-- {{JSxRef("Operators/Strict_inequality", "!==")}}
+- {{jsxref("Operators/Equality", "==")}}
+- {{jsxref("Operators/Inequality", "!=")}}
+- {{jsxref("Operators/Strict_equality", "===")}}
+- {{jsxref("Operators/Strict_inequality", "!==")}}
 
 ### Bitwise shift operators
 
-- {{JSxRef("Operators/Left_shift", "&lt;&lt;")}}
-- {{JSxRef("Operators/Right_shift", "&gt;&gt;")}}
-- {{JSxRef("Operators/Unsigned_right_shift", "&gt;&gt;&gt;")}}
+- {{jsxref("Operators/Left_shift", "&lt;&lt;")}}
+- {{jsxref("Operators/Right_shift", "&gt;&gt;")}}
+- {{jsxref("Operators/Unsigned_right_shift", "&gt;&gt;&gt;")}}
 
 ### Binary bitwise operators
 
-- {{JSxRef("Operators/Bitwise_AND", "&amp;")}}
-- {{JSxRef("Operators/Bitwise_OR", "|")}}
-- {{JSxRef("Operators/Bitwise_XOR", "^")}}
+- {{jsxref("Operators/Bitwise_AND", "&amp;")}}
+- {{jsxref("Operators/Bitwise_OR", "|")}}
+- {{jsxref("Operators/Bitwise_XOR", "^")}}
 
 ### Binary logical operators
 
-- {{JSxRef("Operators/Logical_AND", "&amp;&amp;")}}
-- {{JSxRef("Operators/Logical_OR", "||")}}
-- {{JSxRef("Operators/Nullish_coalescing", "??")}}
+- {{jsxref("Operators/Logical_AND", "&amp;&amp;")}}
+- {{jsxref("Operators/Logical_OR", "||")}}
+- {{jsxref("Operators/Nullish_coalescing", "??")}}
 
 ### Conditional (ternary) operator
 
-- {{JSxRef("Operators/Conditional_operator", "(condition ? ifTrue : ifFalse)")}}
+- {{jsxref("Operators/Conditional_operator", "(condition ? ifTrue : ifFalse)")}}
 
 ### Assignment operators
 
-- {{JSxRef("Operators/Assignment", "=")}}
-- {{JSxRef("Operators/Multiplication_assignment", "*=")}}
-- {{JSxRef("Operators/Division_assignment", "/=")}}
-- {{JSxRef("Operators/Remainder_assignment", "%=")}}
-- {{JSxRef("Operators/Addition_assignment", "+=")}}
-- {{JSxRef("Operators/Subtraction_assignment", "-=")}}
-- {{JSxRef("Operators/Left_shift_assignment", "&lt;&lt;=")}}
-- {{JSxRef("Operators/Right_shift_assignment", "&gt;&gt;=")}}
-- {{JSxRef("Operators/Unsigned_right_shift_assignment", "&gt;&gt;&gt;=")}}
-- {{JSxRef("Operators/Bitwise_AND_assignment", "&amp;=")}}
-- {{JSxRef("Operators/Bitwise_XOR_assignment", "^=")}}
-- {{JSxRef("Operators/Bitwise_OR_assignment", "|=")}}
-- {{JSxRef("Operators/Exponentiation_assignment", "**=")}}
-- {{JSxRef("Operators/Logical_AND_assignment", "&amp;&amp;=")}}
-- {{JSxRef("Operators/Logical_OR_assignment", "||=")}}
-- {{JSxRef("Operators/Nullish_coalescing_assignment", "??=")}}
+- {{jsxref("Operators/Assignment", "=")}}
+- {{jsxref("Operators/Multiplication_assignment", "*=")}}
+- {{jsxref("Operators/Division_assignment", "/=")}}
+- {{jsxref("Operators/Remainder_assignment", "%=")}}
+- {{jsxref("Operators/Addition_assignment", "+=")}}
+- {{jsxref("Operators/Subtraction_assignment", "-=")}}
+- {{jsxref("Operators/Left_shift_assignment", "&lt;&lt;=")}}
+- {{jsxref("Operators/Right_shift_assignment", "&gt;&gt;=")}}
+- {{jsxref("Operators/Unsigned_right_shift_assignment", "&gt;&gt;&gt;=")}}
+- {{jsxref("Operators/Bitwise_AND_assignment", "&amp;=")}}
+- {{jsxref("Operators/Bitwise_XOR_assignment", "^=")}}
+- {{jsxref("Operators/Bitwise_OR_assignment", "|=")}}
+- {{jsxref("Operators/Exponentiation_assignment", "**=")}}
+- {{jsxref("Operators/Logical_AND_assignment", "&amp;&amp;=")}}
+- {{jsxref("Operators/Logical_OR_assignment", "||=")}}
+- {{jsxref("Operators/Nullish_coalescing_assignment", "??=")}}
 - [`[a, b] = arr`, `{ a, b } = obj`](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
 
 ### Yield operators
 
-- {{JSxRef("Operators/yield", "yield")}}
-- {{JSxRef("Operators/yield*", "yield*")}}
+- {{jsxref("Operators/yield", "yield")}}
+- {{jsxref("Operators/yield*", "yield*")}}
 
 ### Spread syntax
 
-- {{JSxRef("Operators/Spread_syntax", "...obj")}}
+- {{jsxref("Operators/Spread_syntax", "...obj")}}
 
 ### Comma operator
 
-- {{JSxRef("Operators/Comma_operator", ",")}}
+- {{jsxref("Operators/Comma_operator", ",")}}
 
 ## Functions
 
 [JavaScript functions.](/en-US/docs/Web/JavaScript/Reference/Functions)
 
-- {{JSXRef("Functions/Arrow_functions", "Arrow Functions", "", 1)}}
-- {{JSxRef("Functions/Default_parameters", "Default parameters", "", 1)}}
-- {{JSxRef("Functions/rest_parameters", "Rest parameters", "", 1)}}
-- {{JSxRef("Functions/arguments", "arguments")}}
-- {{JSxRef("Functions/Method_definitions", "Method definitions", "", 1)}}
-- {{JSxRef("Functions/get", "getter", "", 1)}}
-- {{JSxRef("Functions/set", "setter", "", 1)}}
+- {{jsxref("Functions/Arrow_functions", "Arrow Functions", "", 1)}}
+- {{jsxref("Functions/Default_parameters", "Default parameters", "", 1)}}
+- {{jsxref("Functions/rest_parameters", "Rest parameters", "", 1)}}
+- {{jsxref("Functions/arguments", "arguments")}}
+- {{jsxref("Functions/Method_definitions", "Method definitions", "", 1)}}
+- {{jsxref("Functions/get", "getter", "", 1)}}
+- {{jsxref("Functions/set", "setter", "", 1)}}
 
 ## Classes
 
 [JavaScript classes.](/en-US/docs/Web/JavaScript/Reference/Classes)
 
-- {{JSxRef("Classes/Constructor", "constructor")}}
-- {{JSxRef("Classes/extends", "extends")}}
+- {{jsxref("Classes/Constructor", "constructor")}}
+- {{jsxref("Classes/extends", "extends")}}
 - [Private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
 - [Public class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)
-- {{JSxRef("Classes/static", "static")}}
+- {{jsxref("Classes/static", "static")}}
 - [Static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks)
 
 ## Additional reference pages
 
-- {{JSxRef("Lexical_grammar", "Lexical grammar", "", 1)}}
+- {{jsxref("Lexical_grammar", "Lexical grammar", "", 1)}}
 - [Data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
 - [Trailing commas](/en-US/docs/Web/JavaScript/Reference/Trailing_commas)
 - [Errors](/en-US/docs/Web/JavaScript/Reference/Errors)
-- {{JSxRef("Strict_mode", "Strict mode", "", 1)}}
-- {{JSxRef("Deprecated_and_obsolete_features", "Deprecated features", "", 1)}}
+- {{jsxref("Strict_mode", "Strict mode", "", 1)}}
+- {{jsxref("Deprecated_and_obsolete_features", "Deprecated features", "", 1)}}

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -6,7 +6,7 @@ browser-compat: javascript.grammar
 spec-urls: https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html
 ---
 
-{{JsSidebar("More")}}
+{{jsSidebar("More")}}
 
 This page describes JavaScript's lexical grammar. JavaScript source text is just a sequence of characters — in order for the interpreter to understand it, the string has to be _parsed_ to a more structured representation. The initial step of parsing is called [lexical analysis](https://en.wikipedia.org/wiki/Lexical_analysis), in which the text gets scanned from left to right and is converted into a sequence of individual, atomic input elements. Some input elements are insignificant to the interpreter, and will be stripped after this step — they include [white space](#white_space) and [comments](#comments). The others, including [identifiers](#identifiers), [keywords](#keywords), [literals](#literals), and punctuators (mostly [operators](/en-US/docs/Web/JavaScript/Reference/Operators)), will be used for further syntax analysis. [Line terminators](#line_terminators) and multiline comments are also syntactically insignificant, but they guide the process for [automatic semicolons insertion](#automatic_semicolon_insertion) to make certain invalid token sequences become valid.
 
@@ -155,7 +155,7 @@ class C {
 lbl: console.log(1); // Label
 ```
 
-In JavaScript, identifiers are commonly made of alphanumeric characters, underscores (`_`), and dollar signs (`$`). Identifiers are not allowed to start with numbers. However, JavaScript identifiers are not only limited to {{glossary("ASCII")}} — many Unicode code points are allowed as well. Namely, any character in the [ID_Start](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Start%7D) category can start an identifier, while any character in the [ID_Continue](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Continue%7D) category can appear after the first character.
+In JavaScript, identifiers are commonly made of alphanumeric characters, underscores (`_`), and dollar signs (`$`). Identifiers are not allowed to start with numbers. However, JavaScript identifiers are not only limited to {{Glossary("ASCII")}} — many Unicode code points are allowed as well. Namely, any character in the [ID_Start](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Start%7D) category can start an identifier, while any character in the [ID_Continue](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Continue%7D) category can appear after the first character.
 
 > **Note:** If, for some reason, you need to parse some JavaScript source yourself, do not assume all identifiers follow the pattern `/[A-Za-z_$][\w$]*/` (i.e. ASCII-only)! The range of identifiers can be described by the regex `/[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*/u` (excluding unicode escape sequences).
 

--- a/files/en-us/web/javascript/reference/operators/comma_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/comma_operator/index.md
@@ -36,7 +36,7 @@ The comma operator is completely different from commas used as syntactic separat
 - Properties in [object initializers](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) (`{ a: 1, b: 2 }`)
 - Parameters in [function declarations](/en-US/docs/Web/JavaScript/Reference/Statements/function)/expressions (`function f(a, b) { … }`)
 - Arguments in function calls (`f(1, 2)`)
-- {{glossary("Binding")}} lists in [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let), [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const), or [`var`](/en-US/docs/Web/JavaScript/Reference/Statements/var) declarations (`const a = 1, b = 2;`)
+- {{Glossary("Binding")}} lists in [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let), [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const), or [`var`](/en-US/docs/Web/JavaScript/Reference/Statements/var) declarations (`const a = 1, b = 2;`)
 - Import lists in [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) declarations (`import { a, b } from "c";`)
 - Export lists in [`export`](/en-US/docs/Web/JavaScript/Reference/Statements/export) declarations (`export { a, b };`)
 

--- a/files/en-us/web/javascript/reference/operators/delete/index.md
+++ b/files/en-us/web/javascript/reference/operators/delete/index.md
@@ -65,7 +65,7 @@ It is important to consider the following scenarios:
 - Non-configurable properties cannot be removed. This includes properties of built-in objects like {{jsxref("Math")}}, {{jsxref("Array")}}, {{jsxref("Object")}} and properties that are created as non-configurable with methods like {{jsxref("Object.defineProperty()")}}.
 - Deleting variables, including function parameters, never works. `delete variable` will throw a {{jsxref("SyntaxError")}} in strict mode, and will have no effect in non-strict mode.
   - Any variable declared with {{jsxref("Statements/var", "var")}} cannot be deleted from the global scope or from a function's scope, because while they may be attached to the [global object](/en-US/docs/Glossary/Global_object), they are not configurable.
-  - Any variable declared with {{jsxref("Statements/let","let")}} or {{jsxref("Statements/const","const")}} cannot be deleted from the scope within which they were defined, because they are not attached to an object.
+  - Any variable declared with {{jsxref("Statements/let", "let")}} or {{jsxref("Statements/const", "const")}} cannot be deleted from the scope within which they were defined, because they are not attached to an object.
 
 ## Examples
 
@@ -184,7 +184,7 @@ Object.defineProperty(Employee, "name", { configurable: false });
 console.log(delete Employee.name); // returns false
 ```
 
-{{jsxref("Statements/var","var")}} creates non-configurable properties that cannot be deleted with the `delete` operator:
+{{jsxref("Statements/var", "var")}} creates non-configurable properties that cannot be deleted with the `delete` operator:
 
 ```js
 // Since "nameOther" is added using with the

--- a/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring_assignment/index.md
@@ -78,7 +78,7 @@ For features specific to array or object destructuring, refer to the individual 
 
 ### Binding and assignment
 
-For both object and array destructuring, there are two kinds of destructuring patterns: _{{glossary("binding")}} pattern_ and _assignment pattern_, with slightly different syntaxes.
+For both object and array destructuring, there are two kinds of destructuring patterns: _{{Glossary("binding")}} pattern_ and _assignment pattern_, with slightly different syntaxes.
 
 In binding patterns, the pattern starts with a declaration keyword (`var`, `let`, or `const`). Then, each individual property must either be bound to a variable or further destructured.
 
@@ -569,7 +569,7 @@ console.log(foo); // "bar"
 
 #### Invalid JavaScript identifier as a property name
 
-Destructuring can be used with property names that are not valid JavaScript {{glossary("Identifier", "identifiers")}} by providing an alternative identifier that is valid.
+Destructuring can be used with property names that are not valid JavaScript {{Glossary("Identifier", "identifiers")}} by providing an alternative identifier that is valid.
 
 ```js
 const foo = { "fizz-buzz": true };

--- a/files/en-us/web/javascript/reference/operators/import.meta/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.operators.import_meta
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 The **`import.meta`** meta-property exposes context-specific metadata to a JavaScript module. It contains information about the module, such as the module's URL.
 
@@ -94,5 +94,5 @@ fs.readFile(fileURL, "utf8").then(console.log);
 
 ## See also
 
-- {{JSxRef("Statements/import", "import")}}
-- {{JSxRef("Statements/export", "export")}}
+- {{jsxref("Statements/import", "import")}}
+- {{jsxref("Statements/export", "export")}}

--- a/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.operators.import_meta.resolve
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 **`import.meta.resolve()`** is a built-in function defined on the [`import.meta`](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta) object of a JavaScript module that resolves a module specifier to a URL using the current module's URL as base.
 

--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -5,7 +5,7 @@ page-type: landing-page
 browser-compat: javascript.operators
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 This chapter documents all the JavaScript language operators, expressions and keywords.
 
@@ -17,116 +17,116 @@ For an alphabetical listing see the sidebar on the left.
 
 Basic keywords and general expressions in JavaScript. These expressions have the highest precedence (higher than [operators](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence)).
 
-- {{JSxRef("Operators/this", "this")}}
+- {{jsxref("Operators/this", "this")}}
   - : The `this` keyword refers to a special property of an execution context.
 - [Literals](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#literals)
   - : Basic `null`, boolean, number, and string literals.
-- {{JSxRef("Global_Objects/Array", "[]")}}
+- {{jsxref("Global_Objects/Array", "[]")}}
   - : Array initializer/literal syntax.
-- {{JSxRef("Operators/Object_initializer", "{}")}}
+- {{jsxref("Operators/Object_initializer", "{}")}}
   - : Object initializer/literal syntax.
-- {{JSxRef("Operators/function", "function")}}
+- {{jsxref("Operators/function", "function")}}
   - : The `function` keyword defines a function expression.
-- {{JSxRef("Operators/class", "class")}}
+- {{jsxref("Operators/class", "class")}}
   - : The `class` keyword defines a class expression.
-- {{JSxRef("Operators/function*", "function*")}}
+- {{jsxref("Operators/function*", "function*")}}
   - : The `function*` keyword defines a generator function expression.
-- {{JSxRef("Operators/async_function", "async function")}}
+- {{jsxref("Operators/async_function", "async function")}}
   - : The `async function` defines an async function expression.
-- {{JSxRef("Operators/async_function*", "async function*")}}
+- {{jsxref("Operators/async_function*", "async function*")}}
   - : The `async function*` keywords define an async generator function expression.
-- {{JSxRef("Global_Objects/RegExp", "/ab+c/i")}}
+- {{jsxref("Global_Objects/RegExp", "/ab+c/i")}}
   - : Regular expression literal syntax.
-- {{JSxRef("Template_literals", "`string`")}}
+- {{jsxref("Template_literals", "`string`")}}
   - : Template literal syntax.
-- {{JSxRef("Operators/Grouping", "( )")}}
+- {{jsxref("Operators/Grouping", "( )")}}
   - : Grouping operator.
 
 ### Left-hand-side expressions
 
 Left values are the destination of an assignment.
 
-- {{JSxRef("Operators/Property_accessors", "Property accessors", "", 1)}}
+- {{jsxref("Operators/Property_accessors", "Property accessors", "", 1)}}
   - : Member operators provide access to a property or method of an object (`object.property` and `object["property"]`).
-- {{JSxRef("Operators/Optional_chaining", "?.")}}
+- {{jsxref("Operators/Optional_chaining", "?.")}}
   - : The optional chaining operator returns `undefined` instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
-- {{JSxRef("Operators/new", "new")}}
+- {{jsxref("Operators/new", "new")}}
   - : The `new` operator creates an instance of a constructor.
-- {{JSxRef("Operators/new%2Etarget", "new.target")}}
-  - : In constructors, `new.target` refers to the constructor that was invoked by {{JSxRef("Operators/new", "new")}}.
-- {{JSxRef("Operators/import%2Emeta", "import.meta")}}
+- {{jsxref("Operators/new%2Etarget", "new.target")}}
+  - : In constructors, `new.target` refers to the constructor that was invoked by {{jsxref("Operators/new", "new")}}.
+- {{jsxref("Operators/import%2Emeta", "import.meta")}}
   - : An object exposing context-specific metadata to a JavaScript module.
-- {{JSxRef("Operators/super", "super")}}
+- {{jsxref("Operators/super", "super")}}
   - : The `super` keyword calls the parent constructor or allows accessing properties of the parent object.
-- {{JSxRef("Operators/import", "import()")}}
+- {{jsxref("Operators/import", "import()")}}
   - : The `import()` syntax allows loading a module asynchronously and dynamically into a potentially non-module environment.
 
 ### Increment and decrement
 
 Postfix/prefix increment and postfix/prefix decrement operators.
 
-- {{JSxRef("Operators/Increment", "A++")}}
+- {{jsxref("Operators/Increment", "A++")}}
   - : Postfix increment operator.
-- {{JSxRef("Operators/Decrement", "A--")}}
+- {{jsxref("Operators/Decrement", "A--")}}
   - : Postfix decrement operator.
-- {{JSxRef("Operators/Increment", "++A")}}
+- {{jsxref("Operators/Increment", "++A")}}
   - : Prefix increment operator.
-- {{JSxRef("Operators/Decrement", "--A")}}
+- {{jsxref("Operators/Decrement", "--A")}}
   - : Prefix decrement operator.
 
 ### Unary operators
 
 A unary operation is an operation with only one operand.
 
-- {{JSxRef("Operators/delete", "delete")}}
+- {{jsxref("Operators/delete", "delete")}}
   - : The `delete` operator deletes a property from an object.
-- {{JSxRef("Operators/void", "void")}}
+- {{jsxref("Operators/void", "void")}}
   - : The `void` operator evaluates an expression and discards its return value.
-- {{JSxRef("Operators/typeof", "typeof")}}
+- {{jsxref("Operators/typeof", "typeof")}}
   - : The `typeof` operator determines the type of a given object.
-- {{JSxRef("Operators/Unary_plus", "+")}}
+- {{jsxref("Operators/Unary_plus", "+")}}
   - : The unary plus operator converts its operand to Number type.
-- {{JSxRef("Operators/Unary_negation", "-")}}
+- {{jsxref("Operators/Unary_negation", "-")}}
   - : The unary negation operator converts its operand to Number type and then negates it.
-- {{JSxRef("Operators/Bitwise_NOT", "~")}}
+- {{jsxref("Operators/Bitwise_NOT", "~")}}
   - : Bitwise NOT operator.
-- {{JSxRef("Operators/Logical_NOT", "!")}}
+- {{jsxref("Operators/Logical_NOT", "!")}}
   - : Logical NOT operator.
-- {{JSxRef("Operators/await", "await")}}
+- {{jsxref("Operators/await", "await")}}
   - : Pause and resume an async function and wait for the promise's fulfillment/rejection.
 
 ### Arithmetic operators
 
 Arithmetic operators take numerical values (either literals or variables) as their operands and return a single numerical value.
 
-- {{JSxRef("Operators/Exponentiation", "**")}}
+- {{jsxref("Operators/Exponentiation", "**")}}
   - : Exponentiation operator.
-- {{JSxRef("Operators/Multiplication", "*")}}
+- {{jsxref("Operators/Multiplication", "*")}}
   - : Multiplication operator.
-- {{JSxRef("Operators/Division", "/")}}
+- {{jsxref("Operators/Division", "/")}}
   - : Division operator.
-- {{JSxRef("Operators/Remainder", "%")}}
+- {{jsxref("Operators/Remainder", "%")}}
   - : Remainder operator.
-- {{JSxRef("Operators/Addition", "+")}} (Plus)
+- {{jsxref("Operators/Addition", "+")}} (Plus)
   - : Addition operator.
-- {{JSxRef("Operators/Subtraction", "-")}}
+- {{jsxref("Operators/Subtraction", "-")}}
   - : Subtraction operator.
 
 ### Relational operators
 
 A comparison operator compares its operands and returns a boolean value based on whether the comparison is true.
 
-- {{JSxRef("Operators/Less_than", "&lt;")}} (Less than)
+- {{jsxref("Operators/Less_than", "&lt;")}} (Less than)
   - : Less than operator.
-- {{JSxRef("Operators/Greater_than", "&gt;")}} (Greater than)
+- {{jsxref("Operators/Greater_than", "&gt;")}} (Greater than)
   - : Greater than operator.
-- {{JSxRef("Operators/Less_than_or_equal", "&lt;=")}}
+- {{jsxref("Operators/Less_than_or_equal", "&lt;=")}}
   - : Less than or equal operator.
-- {{JSxRef("Operators/Greater_than_or_equal", "&gt;=")}}
+- {{jsxref("Operators/Greater_than_or_equal", "&gt;=")}}
   - : Greater than or equal operator.
-- {{JSxRef("Operators/instanceof", "instanceof")}}
+- {{jsxref("Operators/instanceof", "instanceof")}}
   - : The `instanceof` operator determines whether an object is an instance of another object.
-- {{JSxRef("Operators/in", "in")}}
+- {{jsxref("Operators/in", "in")}}
   - : The `in` operator determines whether an object has a given property.
 
 > **Note:** `=>` is not an operator, but the notation for [Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
@@ -135,107 +135,107 @@ A comparison operator compares its operands and returns a boolean value based on
 
 The result of evaluating an equality operator is always of type boolean based on whether the comparison is true.
 
-- {{JSxRef("Operators/Equality", "==")}}
+- {{jsxref("Operators/Equality", "==")}}
   - : Equality operator.
-- {{JSxRef("Operators/Inequality", "!=")}}
+- {{jsxref("Operators/Inequality", "!=")}}
   - : Inequality operator.
-- {{JSxRef("Operators/Strict_equality", "===")}}
+- {{jsxref("Operators/Strict_equality", "===")}}
   - : Strict equality operator.
-- {{JSxRef("Operators/Strict_inequality", "!==")}}
+- {{jsxref("Operators/Strict_inequality", "!==")}}
   - : Strict inequality operator.
 
 ### Bitwise shift operators
 
 Operations to shift all bits of the operand.
 
-- {{JSxRef("Operators/Left_shift", "&lt;&lt;")}}
+- {{jsxref("Operators/Left_shift", "&lt;&lt;")}}
   - : Bitwise left shift operator.
-- {{JSxRef("Operators/Right_shift", "&gt;&gt;")}}
+- {{jsxref("Operators/Right_shift", "&gt;&gt;")}}
   - : Bitwise right shift operator.
-- {{JSxRef("Operators/Unsigned_right_shift", "&gt;&gt;&gt;")}}
+- {{jsxref("Operators/Unsigned_right_shift", "&gt;&gt;&gt;")}}
   - : Bitwise unsigned right shift operator.
 
 ### Binary bitwise operators
 
 Bitwise operators treat their operands as a set of 32 bits (zeros and ones) and return standard JavaScript numerical values.
 
-- {{JSxRef("Operators/Bitwise_AND", "&amp;")}}
+- {{jsxref("Operators/Bitwise_AND", "&amp;")}}
   - : Bitwise AND.
-- {{JSxRef("Operators/Bitwise_OR", "|")}}
+- {{jsxref("Operators/Bitwise_OR", "|")}}
   - : Bitwise OR.
-- {{JSxRef("Operators/Bitwise_XOR", "^")}}
+- {{jsxref("Operators/Bitwise_XOR", "^")}}
   - : Bitwise XOR.
 
 ### Binary logical operators
 
 Logical operators implement boolean (logical) values and have [short-circuiting](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#short-circuiting) behavior.
 
-- {{JSxRef("Operators/Logical_AND", "&amp;&amp;")}}
+- {{jsxref("Operators/Logical_AND", "&amp;&amp;")}}
   - : Logical AND.
-- {{JSxRef("Operators/Logical_OR", "||")}}
+- {{jsxref("Operators/Logical_OR", "||")}}
   - : Logical OR.
-- {{JSxRef("Operators/Nullish_coalescing", "??")}}
+- {{jsxref("Operators/Nullish_coalescing", "??")}}
   - : Nullish Coalescing Operator.
 
 ### Conditional (ternary) operator
 
-- {{JSxRef("Operators/Conditional_operator", "(condition ? ifTrue : ifFalse)")}}
+- {{jsxref("Operators/Conditional_operator", "(condition ? ifTrue : ifFalse)")}}
   - : The conditional operator returns one of two values based on the logical value of the condition.
 
 ### Assignment operators
 
 An assignment operator assigns a value to its left operand based on the value of its right operand.
 
-- {{JSxRef("Operators/Assignment", "=")}}
+- {{jsxref("Operators/Assignment", "=")}}
   - : Assignment operator.
-- {{JSxRef("Operators/Multiplication_assignment", "*=")}}
+- {{jsxref("Operators/Multiplication_assignment", "*=")}}
   - : Multiplication assignment.
-- {{JSxRef("Operators/Division_assignment", "/=")}}
+- {{jsxref("Operators/Division_assignment", "/=")}}
   - : Division assignment.
-- {{JSxRef("Operators/Remainder_assignment", "%=")}}
+- {{jsxref("Operators/Remainder_assignment", "%=")}}
   - : Remainder assignment.
-- {{JSxRef("Operators/Addition_assignment", "+=")}}
+- {{jsxref("Operators/Addition_assignment", "+=")}}
   - : Addition assignment.
-- {{JSxRef("Operators/Subtraction_assignment", "-=")}}
+- {{jsxref("Operators/Subtraction_assignment", "-=")}}
   - : Subtraction assignment
-- {{JSxRef("Operators/Left_shift_assignment", "&lt;&lt;=")}}
+- {{jsxref("Operators/Left_shift_assignment", "&lt;&lt;=")}}
   - : Left shift assignment.
-- {{JSxRef("Operators/Right_shift_assignment", "&gt;&gt;=")}}
+- {{jsxref("Operators/Right_shift_assignment", "&gt;&gt;=")}}
   - : Right shift assignment.
-- {{JSxRef("Operators/Unsigned_right_shift_assignment", "&gt;&gt;&gt;=")}}
+- {{jsxref("Operators/Unsigned_right_shift_assignment", "&gt;&gt;&gt;=")}}
   - : Unsigned right shift assignment.
-- {{JSxRef("Operators/Bitwise_AND_assignment", "&amp;=")}}
+- {{jsxref("Operators/Bitwise_AND_assignment", "&amp;=")}}
   - : Bitwise AND assignment.
-- {{JSxRef("Operators/Bitwise_XOR_assignment", "^=")}}
+- {{jsxref("Operators/Bitwise_XOR_assignment", "^=")}}
   - : Bitwise XOR assignment.
-- {{JSxRef("Operators/Bitwise_OR_assignment", "|=")}}
+- {{jsxref("Operators/Bitwise_OR_assignment", "|=")}}
   - : Bitwise OR assignment.
-- {{JSxRef("Operators/Exponentiation_assignment", "**=")}}
+- {{jsxref("Operators/Exponentiation_assignment", "**=")}}
   - : Exponentiation assignment.
-- {{JSxRef("Operators/Logical_AND_assignment", "&amp;&amp;=")}}
+- {{jsxref("Operators/Logical_AND_assignment", "&amp;&amp;=")}}
   - : Logical AND assignment.
-- {{JSxRef("Operators/Logical_OR_assignment", "||=")}}
+- {{jsxref("Operators/Logical_OR_assignment", "||=")}}
   - : Logical OR assignment.
-- {{JSxRef("Operators/Nullish_coalescing_assignment", "??=")}}
+- {{jsxref("Operators/Nullish_coalescing_assignment", "??=")}}
   - : Nullish coalescing assignment.
 - [`[a, b] = arr`, `{ a, b } = obj`](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
   - : Destructuring assignment allows you to assign the properties of an array or object to variables using syntax that looks similar to array or object literals.
 
 ### Yield operators
 
-- {{JSxRef("Operators/yield", "yield")}}
+- {{jsxref("Operators/yield", "yield")}}
   - : Pause and resume a generator function.
-- {{JSxRef("Operators/yield*", "yield*")}}
+- {{jsxref("Operators/yield*", "yield*")}}
   - : Delegate to another generator function or iterable object.
 
 ### Spread syntax
 
-- {{JSxRef("Operators/Spread_syntax", "...obj")}}
+- {{jsxref("Operators/Spread_syntax", "...obj")}}
   - : Spread syntax allows an iterable, such as an array or string, to be expanded in places where zero or more arguments (for function calls) or elements (for array literals) are expected. In an object literal, the spread syntax enumerates the properties of an object and adds the key-value pairs to the object being created.
 
 ### Comma operator
 
-- {{JSxRef("Operators/Comma_operator", ",")}}
+- {{jsxref("Operators/Comma_operator", ",")}}
   - : The comma operator allows multiple expressions to be evaluated in a single statement and returns the result of the last expression.
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/logical_not/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_not/index.md
@@ -59,8 +59,7 @@ conversion of any value to the corresponding [boolean primitive](/en-US/docs/Web
 The conversion is based on the "truthyness" or "falsyness" of the value (see
 {{Glossary("truthy")}} and {{Glossary("falsy")}}).
 
-The same conversion can be done through the {{jsxref("Global_Objects/Boolean/Boolean",
-  "Boolean")}} function.
+The same conversion can be done through the {{jsxref("Boolean/Boolean", "Boolean()")}} function.
 
 ```js
 !!true; // !!truthy returns true

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.md
@@ -43,7 +43,7 @@ Even though the `||` operator can be used with operands that are not Boolean
 values, it can still be considered a boolean operator since its return value can always
 be converted to a [boolean primitive](/en-US/docs/Web/JavaScript/Data_structures#boolean_type).
 To explicitly convert its return value (or any expression in general) to the
-corresponding boolean value, use a double [{{JSxRef("Operators/Logical_NOT", "NOT operator", "", 1)}}] or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean")}}
+corresponding boolean value, use a double {{jsxref("Operators/Logical_NOT", "NOT operator", "", 1)}} or the {{jsxref("Global_Objects/Boolean/Boolean", "Boolean()")}}
 constructor.
 
 ### Short-circuit evaluation

--- a/files/en-us/web/javascript/reference/operators/new.target/index.md
+++ b/files/en-us/web/javascript/reference/operators/new.target/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.operators.new_target
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 The **`new.target`** meta-property lets you detect whether a function or constructor was called using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator. In constructors and functions invoked using the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator, `new.target` returns a reference to the constructor or function that `new` was called upon. In normal function calls, `new.target` is {{jsxref("undefined")}}.
 
@@ -24,7 +24,7 @@ new.target
 - In class constructors, it refers to the class that `new` was called upon, which may be a subclass of the current constructor, because subclasses transitively call the superclass's constructor through [`super()`](/en-US/docs/Web/JavaScript/Reference/Operators/super).
 - In ordinary functions, if the function is constructed directly with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new), `new.target` refers to the function itself. If the function is called without `new`, `new.target` is {{jsxref("undefined")}}. Functions can be used as the base class for [`extends`](/en-US/docs/Web/JavaScript/Reference/Classes/extends), in which case `new.target` may refer to the subclass.
 - If a constructor (class or function) is called via {{jsxref("Reflect.construct()")}}, then `new.target` refers to the value passed as `newTarget` (which defaults to `target`).
-- In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), `new.target` is inherited from the surrounding scope. If the arrow function is not defined within another class or function which has a `new.target` {{glossary("binding")}}, then a syntax error is thrown.
+- In [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), `new.target` is inherited from the surrounding scope. If the arrow function is not defined within another class or function which has a `new.target` {{Glossary("binding")}}, then a syntax error is thrown.
 - In [static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks), `new.target` is {{jsxref("undefined")}}.
 
 ## Description

--- a/files/en-us/web/javascript/reference/operators/null/index.md
+++ b/files/en-us/web/javascript/reference/operators/null/index.md
@@ -23,7 +23,7 @@ null
 
 The value `null` is written with a literal: `null`.
 `null` is not an identifier for a property of the global object, like
-{{jsxref("Global_Objects/undefined","undefined")}} can be. Instead,
+{{jsxref("Global_Objects/undefined", "undefined")}} can be. Instead,
 `null` expresses a lack of identification, indicating that a variable points
 to no object. In APIs, `null` is often retrieved in a place where an object
 can be expected but no object is relevant.

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -5,7 +5,7 @@ page-type: javascript-operator
 browser-compat: javascript.operators.nullish_coalescing
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 The **nullish coalescing (`??`)** operator is a logical
 operator that returns its right-hand side operand when its left-hand side operand is

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.operators.object_initializer
 ---
 
-{{JsSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 An **object initializer** is a comma-delimited list of zero or more pairs of property names and associated values of an object, enclosed in curly braces (`{}`). Objects can also be initialized using [`Object.create()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) or [by invoking a constructor function](/en-US/docs/Web/JavaScript/Guide/Working_with_objects#using_a_constructor_function) with the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -5,7 +5,7 @@ page-type: javascript-operator
 browser-compat: javascript.operators.optional_chaining
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 The **optional chaining (`?.`)** operator accesses an object's property or calls a function. If the object accessed or function called using this operator is {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), the expression short circuits and evaluates to {{jsxref("undefined")}} instead of throwing an error.
 
@@ -21,7 +21,7 @@ obj.func?.(args)
 
 ## Description
 
-The `?.` operator is like the `.` chaining operator, except that instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{JSxRef("undefined")}}), the expression short-circuits with a return value of `undefined`. When used with function calls, it returns `undefined` if the given function does not exist.
+The `?.` operator is like the `.` chaining operator, except that instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}), the expression short-circuits with a return value of `undefined`. When used with function calls, it returns `undefined` if the given function does not exist.
 
 This results in shorter and simpler expressions when accessing chained properties when the possibility exists that a reference may be missing. It can also be helpful while exploring the content of an object when there's no known guarantee as to which properties are required.
 
@@ -38,7 +38,7 @@ non-`undefined`) before accessing the value of
 `obj.first.second`. This prevents the error that would occur if you accessed
 `obj.first.second` directly without testing `obj.first`.
 
-This is an idiomatic pattern in JavaScript, but it gets verbose when the chain is long, and it's not safe. For example, if `obj.first` is a {{glossary("Falsy")}} value that's not `null` or `undefined`, such as `0`, it would still short-circuit and make `nestedProp` become `0`, which may not be desirable.
+This is an idiomatic pattern in JavaScript, but it gets verbose when the chain is long, and it's not safe. For example, if `obj.first` is a {{Glossary("Falsy")}} value that's not `null` or `undefined`, such as `0`, it would still short-circuit and make `nestedProp` become `0`, which may not be desirable.
 
 With the optional chaining operator (`?.`), however, you don't have to
 explicitly test and short-circuit based on the state of `obj.first` before
@@ -84,10 +84,10 @@ found:
 const result = someInterface.customMethod?.();
 ```
 
-However, if there is a property with such a name which is not a function, using `?.` will still raise a {{JSxRef("TypeError")}} exception "someInterface.customMethod is not a function".
+However, if there is a property with such a name which is not a function, using `?.` will still raise a {{jsxref("TypeError")}} exception "someInterface.customMethod is not a function".
 
 > **Note:** If `someInterface` itself is `null` or
-> `undefined`, a {{JSxRef("TypeError")}} exception will still be
+> `undefined`, a {{jsxref("TypeError")}} exception will still be
 > raised ("someInterface is null"). If you expect that
 > `someInterface` itself may be `null` or `undefined`,
 > you have to use `?.` at this position as

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.this
 
 A function's **`this`** keyword behaves a little differently in JavaScript compared to other languages. It also has some differences between [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) and non-strict mode.
 
-In most cases, the value of `this` is determined by how a function is called (runtime {{glossary("binding")}}). It can't be set by assignment during execution, and it may be different each time the function is called. The {{jsxref("Function.prototype.bind()", "bind()")}} method can [set the value of a function's `this` regardless of how it's called](#the_bind_method), and [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) don't provide their own `this` binding (it retains the `this` value of the enclosing lexical context).
+In most cases, the value of `this` is determined by how a function is called (runtime {{Glossary("binding")}}). It can't be set by assignment during execution, and it may be different each time the function is called. The {{jsxref("Function.prototype.bind()", "bind()")}} method can [set the value of a function's `this` regardless of how it's called](#the_bind_method), and [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) don't provide their own `this` binding (it retains the `this` value of the enclosing lexical context).
 
 {{EmbedInteractiveExample("pages/js/expressions-this.html")}}
 

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -5,7 +5,7 @@ page-type: javascript-operator
 browser-compat: javascript.operators.typeof
 ---
 
-{{JSSidebar("Operators")}}
+{{jsSidebar("Operators")}}
 
 The **`typeof`** operator returns a string indicating the type of the operand's value.
 
@@ -149,7 +149,7 @@ typeof (someData + " Wisen"); // "string"
 typeof undeclaredVariable; // "undefined"
 ```
 
-However, using `typeof` on lexical declarations ({{JSxRef("Statements/let", "let")}} {{JSxRef("Statements/const", "const")}}, and [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)) in the same block before the place of declaration will throw a {{JSxRef("ReferenceError")}}. Block scoped variables are in a _[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)_ from the start of the block until the initialization is processed, during which it will throw an error if accessed.
+However, using `typeof` on lexical declarations ({{jsxref("Statements/let", "let")}} {{jsxref("Statements/const", "const")}}, and [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class)) in the same block before the place of declaration will throw a {{jsxref("ReferenceError")}}. Block scoped variables are in a _[temporal dead zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)_ from the start of the block until the initialization is processed, during which it will throw an error if accessed.
 
 ```js example-bad
 typeof newLetVariable; // ReferenceError
@@ -216,7 +216,7 @@ function type(value) {
 }
 ```
 
-For checking potentially non-existent variables that would otherwise throw a {{JSxRef("ReferenceError")}}, use `typeof nonExistentVar === "undefined"` because this behavior cannot be mimicked with custom code.
+For checking potentially non-existent variables that would otherwise throw a {{jsxref("ReferenceError")}}, use `typeof nonExistentVar === "undefined"` because this behavior cannot be mimicked with custom code.
 
 ## Specifications
 
@@ -228,5 +228,5 @@ For checking potentially non-existent variables that would otherwise throw a {{J
 
 ## See also
 
-- {{JSxRef("Operators/instanceof", "instanceof")}}
+- {{jsxref("Operators/instanceof", "instanceof")}}
 - [`document.all` willful violation of the standard](https://github.com/tc39/ecma262/issues/668)

--- a/files/en-us/web/javascript/reference/regular_expressions/backreference/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/backreference/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.backreference
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **backreference** refers to the submatch of a previous [capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) and matches the same text as that group. For [named capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group), you may prefer to use the [named backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_backreference) syntax.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/capturing_group/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.capturing_group
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **capturing group** groups a subpattern, allowing you to apply a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) to the entire group or use [disjunctions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) within it. It memorizes information about the subpattern match, so that you can refer back to it later with a [backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference), or access the information through the [match results](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#return_value).
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.character_class
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **character class** matches any character in or not in a custom set of characters. When the [`v`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) flag is enabled, it can also be used to match finite-length strings.
 
@@ -69,7 +69,7 @@ In [Unicode-unaware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Re
 /[😄-😛]/u.test("😑"); // true
 ```
 
-Even if the pattern [ignores case](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase), the case of the two ends of a range is significant in determining which characters belong to the range. For example, the pattern `/[E-F]/i` only matches `E`, `F`, `e`, and `f`, while the pattern `/[E-f]/i` matches all uppercase and lowercase {{glossary("ASCII")}} letters (because it spans over `E–Z` and `a–f`), as well as `[`, `\`, `]`, `^`, `_`, and `` ` ``.
+Even if the pattern [ignores case](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase), the case of the two ends of a range is significant in determining which characters belong to the range. For example, the pattern `/[E-F]/i` only matches `E`, `F`, `e`, and `f`, while the pattern `/[E-f]/i` matches all uppercase and lowercase {{Glossary("ASCII")}} letters (because it spans over `E–Z` and `a–f`), as well as `[`, `\`, `]`, `^`, `_`, and `` ` ``.
 
 ### Non-v-mode character class
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_class_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class_escape/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.character_class_escape
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **character class escape** is an escape sequence that represents a set of characters.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_escape/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.character_escape
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **character escape** represents a character that may not be able to be conveniently represented in its literal form.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/disjunction/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/disjunction/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.disjunction
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **disjunction** specifies multiple alternatives. Any alternative matching the input causes the entire disjunction to be matched.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/index.md
@@ -5,7 +5,7 @@ page-type: landing-page
 browser-compat: javascript.regular_expressions
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **regular expression** (_regex_ for short) allow developers to match strings against a pattern, extract submatch information, or simply test if the string conforms to that pattern. Regular expressions are used in many programming languages, and JavaScript's syntax is inspired by [Perl](https://www.perl.org/).
 
@@ -150,7 +150,7 @@ In addition, `\` can be followed by some non-letter-or-digit characters, in whic
 - `\-`: only valid inside [character classes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class)
 - `\!`, `\#`, `\%`, `\&`, `\,`, `\:`, `\;`, `\<`, `\=`, `\>`, `\@`, `` \` ``, `\~`: only valid inside [`v`-mode character classes](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class)
 
-The other {{glossary("ASCII")}} characters, namely space character, `"`, `'`, `_`, and any letter character not mentioned above, are not valid escape sequences. In [Unicode-unaware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode), escape sequences that are not one of the above become _identity escapes_: they represent the character that follows the backslash. For example, `\a` represents the character `a`. This behavior limits the ability to introduce new escape sequences without causing backward compatibility issues, and is therefore forbidden in Unicode-aware mode.
+The other {{Glossary("ASCII")}} characters, namely space character, `"`, `'`, `_`, and any letter character not mentioned above, are not valid escape sequences. In [Unicode-unaware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode), escape sequences that are not one of the above become _identity escapes_: they represent the character that follows the backslash. For example, `\a` represents the character `a`. This behavior limits the ability to introduce new escape sequences without causing backward compatibility issues, and is therefore forbidden in Unicode-aware mode.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/regular_expressions/input_boundary_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/input_boundary_assertion/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.input_boundary_assertion
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 An **input boundary assertion** checks if the current position in the string is an input boundary. An input boundary is the start or end of the string; or, if the `m` flag is set, the start or end of a line.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/literal_character/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/literal_character/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.literal_character
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **literal character** specifies exactly itself to be matched in the input text.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.lookahead_assertion
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **lookahead assertion** "looks ahead": it attempts to match the subsequent input with the given pattern, but it does not consume any of the input — if the match is successful, the current position in the input stays the same.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/lookbehind_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookbehind_assertion/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.lookbehind_assertion
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **lookbehind assertion** "looks behind": it attempts to match the previous input with the given pattern, but it does not consume any of the input — if the match is successful, the current position in the input stays the same. It matches each atom in its pattern in the reverse order.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/named_backreference/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/named_backreference/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.named_backreference
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **named backreference** refers to the submatch of a previous [named capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) and matches the same text as that group. For [unnamed capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group), you need to use the normal [backreference](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference) syntax.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/named_capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/named_capturing_group/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.named_capturing_group
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **named capturing group** is a particular kind of [capturing group](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) that allows to give a name to the group. The group's matching result can later be identified by this name instead of by its index in the pattern.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/non-capturing_group/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/non-capturing_group/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.non_capturing_group
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **non-capturing group** groups a subpattern, allowing you to apply a [quantifier](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier) to the entire group or use [disjunctions](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) within it. It acts like the [grouping operator](/en-US/docs/Web/JavaScript/Reference/Operators/Grouping) in JavaScript expressions, and unlike [capturing groups](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group), it does not memorize the matched text, allowing for better performance and avoiding confusion when the pattern also contains useful capturing groups.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/quantifier/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/quantifier/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.quantifier
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **quantifier** repeats an [atom](/en-US/docs/Web/JavaScript/Reference/Regular_expressions#atoms) a certain number of times. The quantifier is placed after the atom it applies to.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/unicode_character_class_escape/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.unicode_character_class_escape
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **unicode character class escape** is a kind of [character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape) that matches a set of characters specified by a Unicode property. It's only supported in [Unicode-aware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode). When the [`v`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) flag is enabled, it can also be used to match finite-length strings.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/wildcard/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/wildcard/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.wildcard
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **wildcard** matches all characters except line terminators. It also matches line terminators if the `s` flag is set.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/word_boundary_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/word_boundary_assertion/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.regular_expressions.word_boundary_assertion
 ---
 
-{{JsSidebar}}
+{{jsSidebar}}
 
 A **word boundary assertion** checks if the current position in the string is a word boundary. A word boundary is where the next character is a word character and the previous character is not a word character, or vice versa.
 

--- a/files/en-us/web/javascript/reference/statements/async_function/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.statements.async_function
 
 {{jsSidebar("Statements")}}
 
-The **`async function`** declaration creates a {{glossary("binding")}} of a new async function to a given name. The `await` keyword is permitted within the function body, enabling asynchronous, promise-based behavior to be written in a cleaner style and avoiding the need to explicitly configure promise chains.
+The **`async function`** declaration creates a {{Glossary("binding")}} of a new async function to a given name. The `await` keyword is permitted within the function body, enabling asynchronous, promise-based behavior to be written in a cleaner style and avoiding the need to explicitly configure promise chains.
 
 You can also define async functions using the [`async function` expression](/en-US/docs/Web/JavaScript/Reference/Operators/async_function).
 

--- a/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/async_function_star_/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.statements.async_generator_function
 
 {{jsSidebar("Statements")}}
 
-The **`async function*`** declaration creates a {{glossary("binding")}} of a new async generator function to a given name.
+The **`async function*`** declaration creates a {{Glossary("binding")}} of a new async generator function to a given name.
 
 You can also define async generator functions using the [`async function*` expression](/en-US/docs/Web/JavaScript/Reference/Operators/async_function*).
 

--- a/files/en-us/web/javascript/reference/statements/class/index.md
+++ b/files/en-us/web/javascript/reference/statements/class/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.statements.class
 
 {{jsSidebar("Statements")}}
 
-The **`class`** declaration creates a {{glossary("binding")}} of a new [class](/en-US/docs/Web/JavaScript/Reference/Classes) to a given name.
+The **`class`** declaration creates a {{Glossary("binding")}} of a new [class](/en-US/docs/Web/JavaScript/Reference/Classes) to a given name.
 
 You can also define classes using the [`class` expression](/en-US/docs/Web/JavaScript/Reference/Operators/class).
 

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -44,11 +44,11 @@ An initializer for a constant is required. You must specify its value in the sam
 const FOO; // SyntaxError: Missing initializer in const declaration
 ```
 
-The `const` declaration creates an immutable reference to a value. It does _not_ mean the value it holds is immutable — just that the variable identifier cannot be reassigned. For instance, in the case where the content is an object, this means the object's contents (e.g., its properties) can be altered. You should understand `const` declarations as "create a variable whose _identity_ remains constant", not "whose _value_ remains constant" — or, "create immutable {{glossary("binding", "bindings")}}", not "immutable values".
+The `const` declaration creates an immutable reference to a value. It does _not_ mean the value it holds is immutable — just that the variable identifier cannot be reassigned. For instance, in the case where the content is an object, this means the object's contents (e.g., its properties) can be altered. You should understand `const` declarations as "create a variable whose _identity_ remains constant", not "whose _value_ remains constant" — or, "create immutable {{Glossary("binding", "bindings")}}", not "immutable values".
 
 Many style guides (including [MDN's](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript#variable_declarations)) recommend using `const` over {{jsxref("Statements/let", "let")}} whenever a variable is not reassigned in its scope. This makes the intent clear that a variable's type (or value, in the case of a primitive) can never change. Others may prefer `let` for non-primitives that are mutated.
 
-The list that follows the `const` keyword is called a _{{glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list.
+The list that follows the `const` keyword is called a _{{Glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -256,7 +256,7 @@ console.log(foo); // 4.555806215962888
 
 It is important to note the following:
 
-- You need to include this script in your HTML with a {{htmlelement("script")}} element of `type="module"`, so that it gets recognized as a module and dealt with appropriately.
+- You need to include this script in your HTML with a {{HTMLElement("script")}} element of `type="module"`, so that it gets recognized as a module and dealt with appropriately.
 - You can't run JS modules via a `file://` URL — you'll get [CORS](/en-US/docs/Web/HTTP/CORS) errors. You need to run it via an HTTP server.
 
 ### Using the default export

--- a/files/en-us/web/javascript/reference/statements/function/index.md
+++ b/files/en-us/web/javascript/reference/statements/function/index.md
@@ -7,11 +7,11 @@ browser-compat: javascript.statements.function
 
 {{jsSidebar("Statements")}}
 
-The **`function`** declaration creates a {{glossary("binding")}} of a new function to a given name.
+The **`function`** declaration creates a {{Glossary("binding")}} of a new function to a given name.
 
 You can also define functions using the [`function` expression](/en-US/docs/Web/JavaScript/Reference/Operators/function).
 
-{{EmbedInteractiveExample("pages/js/statement-function.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/statement-function.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/statements/function_star_/index.md
+++ b/files/en-us/web/javascript/reference/statements/function_star_/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.statements.generator_function
 
 {{jsSidebar("Statements")}}
 
-The **`function*`** declaration creates a {{glossary("binding")}} of a new generator function to a given name. A generator function can be exited and later re-entered, with its context (variable {{glossary("binding", "bindings")}}) saved across re-entrances.
+The **`function*`** declaration creates a {{Glossary("binding")}} of a new generator function to a given name. A generator function can be exited and later re-entered, with its context (variable {{Glossary("binding", "bindings")}}) saved across re-entrances.
 
 You can also define generator functions using the [`function*` expression](/en-US/docs/Web/JavaScript/Reference/Operators/function*).
 

--- a/files/en-us/web/javascript/reference/statements/import/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.statements.import
 
 {{jsSidebar("Statements")}}
 
-The static **`import`** declaration is used to import read-only live {{glossary("binding", "bindings")}} which are [exported](/en-US/docs/Web/JavaScript/Reference/Statements/export) by another module. The imported bindings are called _live bindings_ because they are updated by the module that exported the binding, but cannot be re-assigned by the importing module.
+The static **`import`** declaration is used to import read-only live {{Glossary("binding", "bindings")}} which are [exported](/en-US/docs/Web/JavaScript/Reference/Statements/export) by another module. The imported bindings are called _live bindings_ because they are updated by the module that exported the binding, but cannot be re-assigned by the importing module.
 
 In order to use the `import` declaration in a source file, the file must be interpreted by the runtime as a [module](/en-US/docs/Web/JavaScript/Guide/Modules). In HTML, this is done by adding `type="module"` to the {{HTMLElement("script")}} tag. Modules are automatically interpreted in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode).
 
@@ -234,7 +234,7 @@ setTimeout(() => {
 
 ## See also
 
-- {{JSxRef("Statements/export", "export")}}
+- {{jsxref("Statements/export", "export")}}
 - [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import)
 - [`import.meta`](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta)
 - [Previewing ES6 Modules and more from ES2015, ES2016 and beyond](https://blogs.windows.com/msedgedev/2016/05/17/es6-modules-and-beyond/) on blogs.windows.com (2016)

--- a/files/en-us/web/javascript/reference/statements/index.md
+++ b/files/en-us/web/javascript/reference/statements/index.md
@@ -61,7 +61,7 @@ For an alphabetical listing see the sidebar on the left.
 - {{jsxref("Statements/for...in", "for...in")}}
   - : Iterates over the enumerable properties of an object, in arbitrary order. For each distinct property, statements can be executed.
 - {{jsxref("Statements/for...of", "for...of")}}
-  - : Iterates over iterable objects (including {{jsxref("Global_Objects/Array","arrays","","true")}}, array-like objects, [iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators)), invoking a custom iteration hook with statements to be executed for the value of each distinct property.
+  - : Iterates over iterable objects (including {{jsxref("Global_Objects/Array", "arrays", "", "true")}}, array-like objects, [iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators)), invoking a custom iteration hook with statements to be executed for the value of each distinct property.
 - {{jsxref("Statements/for-await...of", "for await...of")}}
   - : Iterates over async iterable objects, array-like objects, [iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators), invoking a custom iteration hook with statements to be executed for the value of each distinct property.
 - {{jsxref("Statements/while", "while")}}
@@ -83,7 +83,7 @@ For an alphabetical listing see the sidebar on the left.
   - : Used to import functions exported from an external module, another script.
 - {{jsxref("Statements/label", "label", "", 1)}}
   - : Provides a statement with an identifier that you can refer to using a `break` or `continue` statement.
-- {{jsxref("Statements/with", "with")}} {{Deprecated_Inline}}
+- {{jsxref("Statements/with", "with")}} {{deprecated_inline}}
   - : Extends the scope chain for a statement.
 
 ## Difference between statements and declarations
@@ -125,7 +125,7 @@ if (condition)
   var i = 0;
 ```
 
-You can see declarations as "{{glossary("binding")}} identifiers to values", and statements as "carrying out actions". The fact that `var` is a statement instead of a declaration is a special case, because it doesn't follow normal lexical scoping rules and may create side effects — in the form of creating global variables, mutating existing `var`-defined variables, and defining variables that are visible outside of its block (because `var`-defined variables aren't block-scoped).
+You can see declarations as "{{Glossary("binding")}} identifiers to values", and statements as "carrying out actions". The fact that `var` is a statement instead of a declaration is a special case, because it doesn't follow normal lexical scoping rules and may create side effects — in the form of creating global variables, mutating existing `var`-defined variables, and defining variables that are visible outside of its block (because `var`-defined variables aren't block-scoped).
 
 As another example, [labels](/en-US/docs/Web/JavaScript/Reference/Statements/label) can only be attached to statements.
 

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -57,7 +57,7 @@ Note that `let` is allowed as an identifier name when declared with `var` or `fu
 
 Many style guides (including [MDN's](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide/JavaScript#variable_declarations)) recommend using {{jsxref("Statements/const", "const")}} over `let` whenever a variable is not reassigned in its scope. This makes the intent clear that a variable's type (or value, in the case of a primitive) can never change. Others may prefer `let` for non-primitives that are mutated.
 
-The list that follows the `let` keyword is called a _{{glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list.
+The list that follows the `let` keyword is called a _{{Glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list.
 
 ### Temporal dead zone (TDZ)
 

--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -57,7 +57,7 @@ You can also use the `try` statement to handle JavaScript exceptions. See the [J
 
 ### Catch binding
 
-When an exception is thrown in the `try` block, `exceptionVar` (i.e., the `e` in `catch (e)`) holds the exception value. You can use this {{glossary("binding")}} to get information about the exception that was thrown. This {{glossary("binding")}} is only available in the `catch` block's {{Glossary("Scope", "scope")}}.
+When an exception is thrown in the `try` block, `exceptionVar` (i.e., the `e` in `catch (e)`) holds the exception value. You can use this {{Glossary("binding")}} to get information about the exception that was thrown. This {{Glossary("binding")}} is only available in the `catch` block's {{Glossary("Scope", "scope")}}.
 
 It needs not be a single identifier. You can use a [destructuring pattern](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to assign multiple identifiers at once.
 

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -61,7 +61,7 @@ for (var a of [1, 2, 3]);
 console.log(a); // 3
 ```
 
-In a script, a variable declared using `var` is added as a non-configurable property of the global object. This means its property descriptor cannot be changed and it cannot be deleted using {{JSxRef("Operators/delete", "delete")}}. JavaScript has automatic memory management, and it would make no sense to be able to use the `delete` operator on a global variable.
+In a script, a variable declared using `var` is added as a non-configurable property of the global object. This means its property descriptor cannot be changed and it cannot be deleted using {{jsxref("Operators/delete", "delete")}}. JavaScript has automatic memory management, and it would make no sense to be able to use the `delete` operator on a global variable.
 
 ```js-nolint example-bad
 "use strict";
@@ -73,7 +73,7 @@ delete x; // SyntaxError in strict mode. Fails silently otherwise.
 
 In both NodeJS [CommonJS](https://www.commonjs.org/) modules and native [ECMAScript modules](/en-US/docs/Web/JavaScript/Guide/Modules), top-level variable declarations are scoped to the module, and are not added as properties to the global object.
 
-The list that follows the `var` keyword is called a _{{glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list and get the initialized value.
+The list that follows the `var` keyword is called a _{{Glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list and get the initialized value.
 
 ### Hoisting
 

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -5,7 +5,7 @@ page-type: guide
 spec-urls: https://tc39.es/ecma262/multipage/strict-mode-of-ecmascript.html
 ---
 
-{{JsSidebar("More")}}
+{{jsSidebar("More")}}
 
 > **Note:** Sometimes you'll see the default, non-strict mode referred to as _[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)_. This isn't an official term, but be aware of it, just in case.
 

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.grammar.template_literals
 ---
 
-{{JsSidebar("More")}}
+{{jsSidebar("More")}}
 
 **Template literals** are literals delimited with backtick (`` ` ``) characters, allowing for [multi-line strings](#multi-line_strings), [string interpolation](#string_interpolation) with embedded expressions, and special constructs called [tagged templates](#tagged_templates).
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.md
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.md
@@ -5,7 +5,7 @@ page-type: javascript-language-feature
 browser-compat: javascript.grammar.trailing_commas
 ---
 
-{{JsSidebar("More")}}
+{{jsSidebar("More")}}
 
 **Trailing commas** (sometimes called "final commas") can be useful when adding new elements, parameters, or properties to JavaScript code. If you want to add a new property, you can add a new line without modifying the previously last line if that line already uses a trailing comma. This makes version-control diffs cleaner and editing code might be less troublesome.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As part of my see-also checker work, I have found a way to parse macros so I can check for consistent macro text. In this process I found it better to make all macros uniform. This PR makes macro text conform to Prettier style as well, and uses consistent casing for all macros.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
