### PR TITLE
Correct descriptions of the asynchronous iterator methods on `FileSystemDirectoryHandle`

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileSystemDirectoryHandle.entries
 The **`entries()`** method of the
 {{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
 for the iteration of the key-value pairs of the entries within the `FileSystemDirectoryHandle`
-on which this method is called. The order of iteration is vague. The key-value pairs are
+on which this method is called. The key-value pairs are
 in the form of an array like `[key, value]`.
 
 ## Syntax

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -28,13 +28,14 @@ None.
 
 A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
 an object with the following properties:
-  - `done`
-    - : A boolean value, representing if the iteration has ended.
-  - `value`
-    - : An array, representing a key-value pair of an entry.
-        The first element is a string representing the key of the entry.
-        The second element is the {{domxref("FileSystemHandle")}} of the entry.
-        If the iteration has ended, This property would be `undefined`.
+
+- `done`
+  - : A boolean value, representing if the iteration has ended.
+- `value`
+  - : An array, representing a key-value pair of an entry.
+    The first element is a string representing the key of the entry.
+    The second element is the {{domxref("FileSystemHandle")}} of the entry.
+    If the iteration has ended, This property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileSystemDirectoryHandle.entries
 The **`entries()`** method of the
 {{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
 for the iteration of the key-value pairs of the entries within the `FileSystemDirectoryHandle`
-on which this method is called. The order of iteration is uncertain. The key-value pairs are
+on which this method is called. The order of iteration is vague. The key-value pairs are
 in the form of an array like `[key, value]`.
 
 ## Syntax
@@ -26,13 +26,7 @@ None.
 
 ### Return value
 
-A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
-an object with the following properties:
-
-- `done`
-  - : A boolean value, representing if the iteration has ended.
-- `value`
-  - : An array, representing a key-value pair of an entry. The first element is a string representing the key of the entry. The second element is the {{domxref("FileSystemHandle")}} of the entry. If the iteration has ended, this property would be `undefined`.
+A new asynchronous iterator containing the key-value pairs of each entry within the `FileSystemDirectoryHandle`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -35,7 +35,7 @@ an object with the following properties:
   - : An array, representing a key-value pair of an entry.
     The first element is a string representing the key of the entry.
     The second element is the {{domxref("FileSystemHandle")}} of the entry.
-    If the iteration has ended, This property would be `undefined`.
+    If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -32,10 +32,7 @@ an object with the following properties:
 - `done`
   - : A boolean value, representing if the iteration has ended.
 - `value`
-  - : An array, representing a key-value pair of an entry.
-    The first element is a string representing the key of the entry.
-    The second element is the {{domxref("FileSystemHandle")}} of the entry.
-    If the iteration has ended, this property would be `undefined`.
+  - : An array, representing a key-value pair of an entry. The first element is a string representing the key of the entry. The second element is the {{domxref("FileSystemHandle")}} of the entry. If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -9,10 +9,10 @@ browser-compat: api.FileSystemDirectoryHandle.entries
 {{securecontext_header}}{{APIRef("File System API")}}
 
 The **`entries()`** method of the
-{{domxref("FileSystemDirectoryHandle")}} interface returns an array of a given object's
-own enumerable property `[key, value]` pairs, in the same order as that
-provided by a [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loop (the difference being that a for-in loop
-enumerates properties in the prototype chain as well).
+{{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
+for the iteration of the key-value pairs of the entries within the `FileSystemDirectoryHandle`
+on which this method is called. The order of iteration is uncertain. The key-value pairs are
+in the form of an array like `[key, value]`.
 
 ## Syntax
 
@@ -26,10 +26,19 @@ None.
 
 ### Return value
 
-An array of the given `FileSystemDirectoryHandle` object's own enumerable
-property `[key, value]` pairs.
+A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
+an object with the following properties:
+  - `done`
+    - : A boolean value, representing if the iteration has ended.
+  - `value`
+    - : An array, representing a key-value pair of an entry.
+        The first element is a string representing the key of the entry.
+        The second element is the {{domxref("FileSystemHandle")}} of the entry.
+        If the iteration has ended, This property would be `undefined`.
 
 ## Examples
+
+Use the `for await...of` loop can simplify the iteration process.
 
 ```js
 const dirHandle = await window.showDirectoryPicker();

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileSystemDirectoryHandle.keys
 The **`keys()`** method of the
 {{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
 for the iteration of the key of the entries within the `FileSystemDirectoryHandle`
-on which this method is called. The order of iteration is vague.
+on which this method is called.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileSystemDirectoryHandle.keys
 The **`keys()`** method of the
 {{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
 for the iteration of the key of the entries within the `FileSystemDirectoryHandle`
-on which this method is called. The order of iteration is uncertain.
+on which this method is called. The order of iteration is vague.
 
 ## Syntax
 
@@ -25,13 +25,7 @@ None.
 
 ### Return value
 
-A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
-an object with the following properties:
-
-- `done`
-  - : A boolean value, representing if the iteration has ended.
-- `value`
-  - : A string, representing the key of an entry. If the iteration has ended, this property would be `undefined`.
+A new asynchronous iterator containing the key of each entry within the `FileSystemDirectoryHandle`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -9,8 +9,9 @@ browser-compat: api.FileSystemDirectoryHandle.keys
 {{securecontext_header}}{{APIRef("File System API")}}
 
 The **`keys()`** method of the
-{{domxref("FileSystemDirectoryHandle")}} interface returns a new _array iterator_
-containing the keys for each item in `FileSystemDirectoryHandle`.
+{{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
+for the iteration of the key of the entries within the `FileSystemDirectoryHandle`
+on which this method is called. The order of iteration is uncertain.
 
 ## Syntax
 
@@ -24,9 +25,16 @@ None.
 
 ### Return value
 
-A new {{jsxref('Array')}}
+A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
+an object with the following properties:
+  - `done`
+    - : A boolean value, representing if the iteration has ended.
+  - `value`
+    - : A string, representing the key of an entry. If the iteration has ended, it would be `undefined`.
 
 ## Examples
+
+Use the `for await...of` loop can simplify the iteration process.
 
 ```js
 const dirHandle = await window.showDirectoryPicker();

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -32,7 +32,7 @@ an object with the following properties:
   - : A boolean value, representing if the iteration has ended.
 - `value`
   - : A string, representing the key of an entry.
-      If the iteration has ended, this property would be `undefined`.
+    If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -31,8 +31,7 @@ an object with the following properties:
 - `done`
   - : A boolean value, representing if the iteration has ended.
 - `value`
-  - : A string, representing the key of an entry.
-    If the iteration has ended, this property would be `undefined`.
+  - : A string, representing the key of an entry. If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A new asynchronous iterator containing the key of each entry within the `FileSystemDirectoryHandle`.
+A new asynchronous iterator containing the keys of each entry within the `FileSystemDirectoryHandle`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -27,10 +27,11 @@ None.
 
 A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
 an object with the following properties:
-  - `done`
-    - : A boolean value, representing if the iteration has ended.
-  - `value`
-    - : A string, representing the key of an entry. If the iteration has ended, it would be `undefined`.
+
+- `done`
+  - : A boolean value, representing if the iteration has ended.
+- `value`
+  - : A string, representing the key of an entry. If the iteration has ended, it would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -31,7 +31,8 @@ an object with the following properties:
 - `done`
   - : A boolean value, representing if the iteration has ended.
 - `value`
-  - : A string, representing the key of an entry. If the iteration has ended, it would be `undefined`.
+  - : A string, representing the key of an entry.
+      If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileSystemDirectoryHandle.values
 The **`values()`** method of the
 {{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
 for the iteration of the value of the entries within the `FileSystemDirectoryHandle`
-on which this method is called. The order of iteration is vague.
+on which this method is called.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -32,7 +32,7 @@ an object with the following properties:
   - : A boolean value, representing if the iteration has ended.
 - `value`
   - : A {{domxref("FileSystemHandle")}} object. The handle of the entry.
-    If the iteration has ended, It would be `undefined`.
+    If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -27,11 +27,12 @@ None.
 
 A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
 an object with the following properties:
-  - `done`
-    - : A boolean value, representing if the iteration has ended.
-  - `value`
-    - : A {{domxref("FileSystemHandle")}} object. The handle of the entry.
-        If the iteration has ended, It would be `undefined`.
+
+- `done`
+  - : A boolean value, representing if the iteration has ended.
+- `value`
+  - : A {{domxref("FileSystemHandle")}} object. The handle of the entry.
+    If the iteration has ended, It would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -9,9 +9,9 @@ browser-compat: api.FileSystemDirectoryHandle.values
 {{securecontext_header}}{{APIRef("File System API")}}
 
 The **`values()`** method of the
-{{domxref("FileSystemDirectoryHandle")}} interface returns a new _array iterator_
-containing the values for each index in the `FileSystemDirectoryHandle`
-object.
+{{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
+for the iteration of the value of the entries within the `FileSystemDirectoryHandle`
+on which this method is called. The order of iteration is uncertain.
 
 ## Syntax
 
@@ -25,9 +25,17 @@ None.
 
 ### Return value
 
-A new {{jsxref('Array')}}
+A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
+an object with the following properties:
+  - `done`
+    - : A boolean value, representing if the iteration has ended.
+  - `value`
+    - : A {{domxref("FileSystemHandle")}} object. The handle of the entry.
+        If the iteration has ended, It would be `undefined`.
 
 ## Examples
+
+Use the `for await...of` loop can simplify the iteration process.
 
 ```js
 const dirHandle = await window.showDirectoryPicker();

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -31,8 +31,7 @@ an object with the following properties:
 - `done`
   - : A boolean value, representing if the iteration has ended.
 - `value`
-  - : A {{domxref("FileSystemHandle")}} object. The handle of the entry.
-    If the iteration has ended, this property would be `undefined`.
+  - : A {{domxref("FileSystemHandle")}} object. The handle of the entry. If the iteration has ended, this property would be `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FileSystemDirectoryHandle.values
 The **`values()`** method of the
 {{domxref("FileSystemDirectoryHandle")}} interface returns a new asynchronous iterator
 for the iteration of the value of the entries within the `FileSystemDirectoryHandle`
-on which this method is called. The order of iteration is uncertain.
+on which this method is called. The order of iteration is vague.
 
 ## Syntax
 
@@ -25,13 +25,7 @@ None.
 
 ### Return value
 
-A new asynchronous iterator provides a {{jsxref('Promise')}} which fulfills with
-an object with the following properties:
-
-- `done`
-  - : A boolean value, representing if the iteration has ended.
-- `value`
-  - : A {{domxref("FileSystemHandle")}} object. The handle of the entry. If the iteration has ended, this property would be `undefined`.
+A new asynchronous iterator containing the handles of each entry within the `FileSystemDirectoryHandle`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Correct descriptions of the asynchronous iterator methods on `FileSystemDirectoryHandle`.

### Motivation

`FileSystemDirectoryHandle: keys()`
`FileSystemDirectoryHandle: values()`
`FileSystemDirectoryHandle: entries()`

### Related issues and pull requests

Fixes #25876