### PR TITLE
Update `scroll-snap-type` and "Basic concepts of scroll snap"

### DIFF
--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -17,8 +17,10 @@ Before you can define scroll snapping, you need to enable scrolling on a scroll 
 You can then define scroll snapping on the scroll container by using the following two key properties:
 
 - {{cssxref("scroll-snap-type")}}: Using this property, you can define whether or not the scrollable viewport can be snapped to, whether snapping is required or optional, and the axis on which the snapping should occur.
-- {{cssxref("scroll-snap-align")}}: This property is set on every child of the scroll container and you can use it to define each child's snap position or lack thereof. (Using the {{cssxref("scroll-snap-stop")}} property, you can ensure that a child is snapped to during scrolling and not passed over. You can also set several {{cssxref("scroll-margin")}} properties on child elements that are snapped to during scrolling to create an outset from the defined box.)
-  Optional {{cssxref("scroll-padding")}} properties can be set on the scroll container to create a snapping offset.
+- {{cssxref("scroll-snap-align")}}: This property is set on every child of the scroll container and you can use it to define each child's snap position or lack thereof.
+- {{cssxref("scroll-snap-stop")}}: This property ensures that a child is snapped to during scrolling and not passed over.
+- {{cssxref("scroll-margin")}}: This property can be set on child elements that are snapped to during scrolling to create an outset from the defined box.
+- {{cssxref("scroll-padding")}}: This property can be set on the scroll container to create a snapping offset.
 
 The example below demonstrates scroll snapping along the vertical axis, which is defined by `scroll-snap-type`. Additionally, `scroll-snap-align` applies on all the children of the `<section>` element, dictating the point where the scrolling of each child should stop.
 

--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -59,7 +59,7 @@ scroll-snap-type: unset;
 - `proximity`
   - : The visual viewport of this scroll container may snap to a snap position if it isn't currently scrolled. The user agent decides if it snaps or not based on scroll parameters. This is the default snap strictness if any snap axis is specified.
 
-> **Note:** If the content in the snapport is changed (e.g. added, moved, deleted, or resized) or the value of any scroll snap-related properties (e.g. `scroll-snap-type` or `scroll-margin`) is changed, the scroll container will be [resnapped](https://drafts.csswg.org/css-scroll-snap/#re-snap) according to the latest value of `scroll-snap-type`.
+> **Note:** If the content in the snap port is changed (e.g. added, moved, deleted, or resized) or the value of any scroll snap-related property (e.g. `scroll-snap-type` or `scroll-margin`) is changed, the scroll container will be [resnapped](https://drafts.csswg.org/css-scroll-snap/#re-snap) according to the latest value of `scroll-snap-type`.
 
 ## Formal definition
 

--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -148,9 +148,10 @@ scroll-snap-type: unset;
 }
 .container {
   display: flex;
-  overflow: auto;
+  margin: 1em auto;
   outline: 1px dashed lightgray;
   flex: none;
+  overflow: auto;
 }
 .container.x {
   width: 100%;
@@ -219,7 +220,7 @@ scroll-snap-type: unset;
 
 #### Results
 
-{{EmbedLiveSample("snapping_in_different_axes", "100%", 1630)}}
+{{EmbedLiveSample("snapping_in_different_axes", "100%", 1800)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -16,20 +16,21 @@ Specifying any precise animations or physics used to enforce those snap points i
 ## Syntax
 
 ```css
-/* Keyword values */
+/* No snapping */
 scroll-snap-type: none;
+
+/* Keyword values for snap axes */
 scroll-snap-type: x;
 scroll-snap-type: y;
 scroll-snap-type: block;
 scroll-snap-type: inline;
 scroll-snap-type: both;
 
-/* Optional mandatory | proximity*/
+/* Optional keyword values for snap strictness */
+/* mandatory | proximity */
 scroll-snap-type: x mandatory;
 scroll-snap-type: y proximity;
 scroll-snap-type: both mandatory;
-
-/* … */
 
 /* Global values */
 scroll-snap-type: inherit;
@@ -54,9 +55,11 @@ scroll-snap-type: unset;
 - `both`
   - : The scroll container snaps to snap positions in both of its axes independently (potentially snapping to different elements in each axis).
 - `mandatory`
-  - : The visual viewport of this scroll container will rest on a snap point if it isn't currently scrolled. That means it snaps on that point when the scroll action finished, if possible. If content is added, moved, deleted or resized the scroll offset will be adjusted to maintain the resting on that snap point.
+  - : The visual viewport of this scroll container must snap to a snap position if it isn't currently scrolled.
 - `proximity`
-  - : The visual viewport of this scroll container may come to rest on a snap point if it isn't currently scrolled considering the user agent's scroll parameters. If content is added, moved, deleted or resized the scroll offset may be adjusted to maintain the resting on that snap point.
+  - : The visual viewport of this scroll container may snap to a snap position if it isn't currently scrolled. The user agent decides if it snaps or not based on scroll parameters. This is the default snap strictness if any snap axis is specified.
+
+> **Note:** If the content in the snapport is changed (e.g. added, moved, deleted, or resized) or the value of any scroll snap-related properties (e.g. `scroll-snap-type` or `scroll-margin`) is changed, the scroll container will be [resnapped](https://drafts.csswg.org/css-scroll-snap/#re-snap) according to the latest value of `scroll-snap-type`.
 
 ## Formal definition
 
@@ -81,7 +84,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container x proximity-scroll-snapping" dir="ltr">
     <div>X Prox. LTR</div>
     <div>2</div>
@@ -89,7 +91,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container y mandatory-scroll-snapping" dir="ltr">
     <div>Y Mand. LTR</div>
     <div>2</div>
@@ -97,7 +98,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container y proximity-scroll-snapping" dir="ltr">
     <div>Y Prox. LTR</div>
     <div>2</div>
@@ -105,7 +105,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container x mandatory-scroll-snapping" dir="rtl">
     <div>X Mand. RTL</div>
     <div>2</div>
@@ -113,7 +112,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container x proximity-scroll-snapping" dir="rtl">
     <div>X Prox. RTL</div>
     <div>2</div>
@@ -121,7 +119,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container y mandatory-scroll-snapping" dir="rtl">
     <div>Y Mand. RTL</div>
     <div>2</div>
@@ -129,7 +126,6 @@ scroll-snap-type: unset;
     <div>4</div>
     <div>5</div>
   </div>
-
   <div class="container y proximity-scroll-snapping" dir="rtl">
     <div>Y Prox. RTL</div>
     <div>2</div>
@@ -142,13 +138,7 @@ scroll-snap-type: unset;
 
 #### CSS
 
-```css
-/* setup */
-html,
-body,
-.holster {
-  height: 100%;
-}
+```css hidden
 .holster {
   display: flex;
   align-items: center;
@@ -156,38 +146,37 @@ body,
   flex-flow: column nowrap;
   font-family: monospace;
 }
-
 .container {
   display: flex;
   overflow: auto;
   outline: 1px dashed lightgray;
   flex: none;
 }
-
 .container.x {
   width: 100%;
   height: 128px;
   flex-flow: row nowrap;
+  overflow-y: hidden;
 }
-
 .container.y {
   width: 256px;
   height: 256px;
   flex-flow: column nowrap;
+  overflow-x: hidden;
 }
+```
+
+```css
 /* scroll-snap */
 .x.mandatory-scroll-snapping {
   scroll-snap-type: x mandatory;
 }
-
 .y.mandatory-scroll-snapping {
   scroll-snap-type: y mandatory;
 }
-
 .x.proximity-scroll-snapping {
   scroll-snap-type: x proximity;
 }
-
 .y.proximity-scroll-snapping {
   scroll-snap-type: y proximity;
 }
@@ -197,30 +186,32 @@ body,
   scroll-snap-align: center;
   flex: none;
 }
+```
 
+```css hidden
 .x.container > div {
   line-height: 128px;
   font-size: 64px;
   width: 100%;
   height: 128px;
 }
-
 .y.container > div {
   line-height: 256px;
   font-size: 128px;
   width: 256px;
   height: 100%;
 }
+
 /* appearance fixes */
 .y.container > div:first-child {
   line-height: 1.3;
   font-size: 64px;
 }
+
 /* coloration */
 .container > div:nth-child(even) {
   background-color: #87ea87;
 }
-
 .container > div:nth-child(odd) {
   background-color: #87ccea;
 }
@@ -228,7 +219,7 @@ body,
 
 #### Results
 
-{{EmbedLiveSample("Snapping_in_different_axes", "100%", "1630")}}
+{{EmbedLiveSample("snapping_in_different_axes", "100%", 1630)}}
 
 ## Specifications
 


### PR DESCRIPTION
### Description

This PR:

1. tries to make the description more concise and up to date for `scroll-snap-type`;
2. improves the listing on "Basic concepts of scroll snap".

### Motivation

See the comments below for details. This also blocks the l10n of this page.

### Additional details

Here are references for [resnapping](https://drafts.csswg.org/css-scroll-snap/#re-snap).

Gecko bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1530253

WPT:
https://wpt.fyi/results/css/css-scroll-snap/snap-after-relayout
https://wpt.fyi/results/css/css-scroll-snap/resnap-on-snap-alignment-change.html
https://wpt.fyi/results/css/css-scroll-snap/scroll-snap-type-change.html

### Related issues and pull requests