### PR TITLE
Update index.md  indexEnd is not the end since we actually end before it

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -15,16 +15,16 @@ returns it as a new string, without modifying the original string.
 ## Syntax
 
 ```js-nolint
-slice(indexStart)
-slice(indexStart, indexEnd)
+slice(ignoreIndexBefore)
+slice(ignoreIndexBefore, ignoreIndexFrom)
 ```
 
 ### Parameters
 
-- `indexStart`
-  - : The index of the first character to include in the returned substring.
-- `indexEnd` {{optional_inline}}
-  - : The index of the first character to exclude from the returned substring.
+- `ignoreIndexBefore`
+  - : The index of the first character to include in the returned substring.Ignore indexes before it.
+- `ignoreIndexFrom` {{optional_inline}}
+  - : The index of the first character to exclude from the returned substring.Ignore this index and those after it.
 
 ### Return value
 
@@ -34,14 +34,14 @@ A new string containing the extracted section of the string.
 
 `slice()` extracts the text from one string and returns a new string. Changes to the text in one string do not affect the other string.
 
-`slice()` extracts up to but not including `indexEnd`. For example, `str.slice(1, 4)` extracts the second character through the fourth character (characters indexed `1`, `2`, and `3`).
+`slice()` extracts and returns indexvalues from `ignoreIndexBefore` until the index before `ignoreIndexFrom`. For example, `str.slice(1, 4)` extracts the second character through the fourth character (characters indexed `1`, `2`, and `3`).
 
-- If `indexStart >= str.length`, an empty string is returned.
-- If `indexStart < 0`, the index is counted from the end of the string. More formally, in this case, the substring starts at `max(indexStart + str.length, 0)`.
-- If `indexStart` is omitted, undefined, or cannot be converted to a number (using {{jsxref('Number', 'Number(indexStart)')}}), it's treated as `0`.
-- If `indexEnd` is omitted, undefined, or cannot be converted to a number (using {{jsxref('Number', 'Number(indexEnd)')}}), or if `indexEnd >= str.length`, `slice()` extracts to the end of the string.
-- If `indexEnd < 0`, the index is counted from the end of the string. More formally, in this case, the substring ends at `max(indexEnd + str.length, 0)`.
-- If `indexEnd <= indexStart` after normalizing negative values (i.e. `indexEnd` represents a character that's before `indexStart`), an empty string is returned.
+- If `ignoreIndexBefore >= str.length`, an empty string is returned.
+- If `ignoreIndexBefore < 0`, the index is counted from the end of the string. More formally, in this case, the substring starts at `max(ignoreIndexBefore + str.length, 0)`.
+- If `ignoreIndexBefore` is omitted, undefined, or cannot be converted to a number (using {{jsxref('Number', 'Number(ignoreIndexBefore)')}}), it's treated as `0`.
+- If `ignoreIndexFrom` is omitted, undefined, or cannot be converted to a number (using {{jsxref('Number', 'Number(ignoreIndexFrom)')}}), or if `indexEnd >= str.length`, `slice()` extracts to the end of the string.
+- If `ignoreIndexFrom < 0`, the index is counted from the end of the string. More formally, in this case, the substring ends at `max(ignoreIndexFrom + str.length, 0)`.
+- If `ignoreIndexFrom <= ignoreIndexBefore` after normalizing negative values (i.e. `ignoreIndexFrom` represents a character that's before `ignoreIndexBefore`), an empty string is returned.
 
 ## Examples
 
@@ -63,34 +63,85 @@ console.log(str5); // ""
 
 ### Using slice() with negative indexes
 
-The following example uses `slice()` with negative indexes.
+The slice method with negative indexes counts backwards from left to right.The following example uses `slice()` with negative indexes.
+
+## Syntax
+
+```js-nolint
+slice(showIndexBefore)
+slice(ignoreIndexFrom,ignoreIndexBefore)
+```
+
+## Single negative index
+
+when dealing with a single negative index argument,it extracts and returns the index before the specified index while counting from the end of the string or from right to left,but instead of chopping it off,in this case it returns it as can be seen `slice(showIndexBefore)`
 
 ```js
 const str = "The morning is upon us.";
 str.slice(-3); // 'us.'
+str.slice(-10) // 's upon us.'
+```
+
+## Two negative indexes
+
+The two negative index arguments actually share the same extract and return pattern with postive index arguments except that this time around we count from end of the string (right to left) and then our first parameter becomes second and vice versa.
+
+```js
+const str = "The morning is upon us.";
 str.slice(-3, -1); // 'us'
+```
+
+### Using slice() with positive and negative indexes
+
+occasionally we see that our slice has positive and negative index arguments
+
+## positive first,negative second
+
+In this scenario, we count from both ends. More like ignore the indexes before the first index argument while counting from left to right and ignore indexes before the second index argument while counting from right to left.
+
+## Syntax
+
+```js-nolint
+slice(ignoreIndexBefore,ignoreIndexBefore)
+```
+
+```js
+const str = "The morning is upon us.";
 str.slice(0, -1); // 'The morning is upon us'
 str.slice(4, -1); // 'morning is upon us'
 ```
 
-This example counts backwards from the end of the string by `11` to find the
-start index and forwards from the start of the string by `16` to find the end
-index.
+## negative first,positive second
+
+In this scenario, our first index argument is negative which means we are counting right to left in reference to it.The second index is positive which means we count normally, left to right in reference to it
+
+## Syntax
+
+```js-nolint
+slice(ignoreIndexFrom,ignoreIndexFrom)
+```
+
+```js
+const str = "The morning is upon us.";
+str.slice(-11, 16); // "is u"
+```
+
+This example counts backwards from the end of the string by `11` and cuts off index `11` and any index that comes after and forwards from the start of the string by `16` and cuts off index `16` and anything that comes after.
 
 ```js
 console.log(str.slice(-11, 16)); // "is u"
 ```
 
-Here it counts forwards from the start by `11` to find the start index and
-backwards from the end by `7` to find the end index.
+Here it counts forwards from the start by `11` and cuts off index `11` and any index that comes after  and
+backwards from the end by `7` and cuts off index `7` and anything that comes after .
 
 ```js
 console.log(str.slice(11, -7)); // " is u"
 ```
 
-These arguments count backwards from the end by `5` to find the start index
-and backwards from the end by `1` to find the end index.
-
+These arguments count backwards from the end by `5` and cuts off index `11` and any index that comes after
+and backwards from the end by `1` and cuts off index `1` and anything that comes after .
+ 
 ```js
 console.log(str.slice(-5, -1)); // "n us"
 ```


### PR DESCRIPTION
For long the slice has been a source of confusion among developers. Apart from it's similarity with the splice in terms of name , I feel the naming of the parameters has also contributed. Also I had to specify what happens when we have negative arguments because clearly what happens with single negative arguments is different from what happens generally with the slice. Also naming our second parameter indexEnd is confusing because that particular index is not a part of it , as long as we counting from 0.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Had to change parameter names and threw more light on negative indexes.

### Motivation

The slice has been a source of confusion for so long and I think the parameter names and negative indexes contributed.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
