### PR TITLE
CSS cross-fade tabular alignment tweak

### DIFF
--- a/files/en-us/web/css/cross-fade/index.md
+++ b/files/en-us/web/css/cross-fade/index.md
@@ -49,7 +49,7 @@ cross-fade(url(white.png) 25%,  url(black.png)); /* 25% white, 75% black */
 cross-fade(url(white.png),      url(black.png)); /* 50% white, 50% black */
 cross-fade(url(white.png) 75%,  url(black.png)); /* 75% white, 25% black */
 cross-fade(url(white.png) 100%, url(black.png)); /* fully white */
-cross-fade(url(green.png) 75%, url(red.png) 75%); /* both green and red at 75% */
+cross-fade(url(green.png) 75%,  url(red.png) 75%); /* both green and red at 75% */
 ```
 
 If no percentages are declared, both the images will be 50% opaque, with a cross-fade rendering as an even merge of both images.


### PR DESCRIPTION
The tiniest of changes in the 2nd CSS example.  It aligns the final example's `url()` with the others.  All the others above it are already aligned.  Best viewed in the preview.

You might well decide that Prettier should reformat all the CSS examples and remove this tabular alignment instead.  If you prefer to remove the tabular formatting, close this PR and merge #29036.