### PR TITLE
Fix tablist link on ARIA: tabpanel page

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.md
@@ -65,7 +65,7 @@ See the [`tabpanel`, `tab`, and `tablist` example](/en-US/docs/Web/Accessibility
 ## See Also
 
 - [ARIA `tab` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role)
-- [ARIA `tablist` role](/en-US/docs/Web/Accessibility/ARIA/Roles)
+- [ARIA `tablist` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role)
 - [Example: Tabs with Automatic Activation](https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-automatic.html) - W3C
 - [Example: Tabs with Manual Activation](https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-manual.html) -W3C
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the "ARIA tablist role" link on the `ARIA: tabpanel role` page to link to the proper page. It previously linked to the general [WAI-ARIA Roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) page.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
