### PR TITLE
TextMetrics.emHeightAscent/Descent no longer experimental

### DIFF
--- a/files/en-us/web/api/textmetrics/emheightascent/index.md
+++ b/files/en-us/web/api/textmetrics/emheightascent/index.md
@@ -3,14 +3,16 @@ title: "TextMetrics: emHeightAscent property"
 short-title: emHeightAscent
 slug: Web/API/TextMetrics/emHeightAscent
 page-type: web-api-instance-property
-status:
-  - experimental
 browser-compat: api.TextMetrics.emHeightAscent
 ---
 
-{{APIRef("Canvas API")}}{{SeeCompatTable}}
+{{APIRef("Canvas API")}}
 
-The read-only `emHeightAscent` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the top of the _em_ square in the line box, in CSS pixels.
+The read-only `emHeightAscent` property of the {{domxref("TextMetrics")}} interface returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the top of the _em_ square in the line box, in CSS pixels.
+
+## Value
+
+A number, in CSS pixels.
 
 ## Examples
 

--- a/files/en-us/web/api/textmetrics/emheightdescent/index.md
+++ b/files/en-us/web/api/textmetrics/emheightdescent/index.md
@@ -3,14 +3,16 @@ title: "TextMetrics: emHeightDescent property"
 short-title: emHeightDescent
 slug: Web/API/TextMetrics/emHeightDescent
 page-type: web-api-instance-property
-status:
-  - experimental
 browser-compat: api.TextMetrics.emHeightDescent
 ---
 
-{{APIRef("Canvas API")}}{{SeeCompatTable}}
+{{APIRef("Canvas API")}}
 
-The read-only `emHeightDescent` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the bottom of the _em_ square in the line box, in CSS pixels.
+The read-only `emHeightDescent` property of the {{domxref("TextMetrics")}} interface returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the bottom of the _em_ square in the line box, in CSS pixels.
+
+## Value
+
+A number, in CSS pixels.
 
 ## Examples
 

--- a/files/en-us/web/api/textmetrics/index.md
+++ b/files/en-us/web/api/textmetrics/index.md
@@ -25,9 +25,9 @@ The **`TextMetrics`** interface represents the dimensions of a piece of text in 
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} attribute to the top of the bounding rectangle used to render the text, in CSS pixels.
 - {{domxref("TextMetrics.actualBoundingBoxDescent")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} attribute to the bottom of the bounding rectangle used to render the text, in CSS pixels.
-- {{domxref("TextMetrics.emHeightAscent")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+- {{domxref("TextMetrics.emHeightAscent")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the top of the _em_ square in the line box, in CSS pixels.
-- {{domxref("TextMetrics.emHeightDescent")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+- {{domxref("TextMetrics.emHeightDescent")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the bottom of the _em_ square in the line box, in CSS pixels.
 - {{domxref("TextMetrics.hangingBaseline")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the hanging baseline of the line box, in CSS pixels.


### PR DESCRIPTION
FF118 supports [`TextMetrics.emHeightDescent`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/emHeightDescent) and [`TextMetrics.emHeightDescent`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/emHeightDescent) in https://bugzilla.mozilla.org/show_bug.cgi?id=1841692 which means that there are more than two supporting browsers. As this is no longer experimental removing the experimental tagging.

Related docs work can be tracked in #28852