### PR TITLE
FF118Relnote: TextMetrics.emHeightDescent/Ascent supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -40,6 +40,8 @@ This article provides information about the changes in Firefox 118 that affect d
 
 ### APIs
 
+- The [`TextMetrics.emHeightDescent`](/en-US/docs/Web/API/TextMetrics/emHeightDescent) and [`TextMetrics.emHeightAscent`](/en-US/docs/Web/API/TextMetrics/emHeightAscent) properties are now supported (Firefox bug [1841692](https://bugzil.la/1841692)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF118 supports [`TextMetrics.emHeightDescent`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/emHeightDescent) and [`TextMetrics.emHeightAscent`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/emHeightAscent) in https://bugzilla.mozilla.org/show_bug.cgi?id=1841692

This just adds a release note.

Other docs work can be tracked in #28852