### PR TITLE
docs(relnotes): Fx118 - Add release note for "from-font" in CSS "font-size-adjust"

### DIFF
--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -19,6 +19,7 @@ This article provides information about the changes in Firefox 118 that affect d
 ### CSS
 
 - Multiple CSS [math functions](/en-US/docs/Web/CSS/CSS_Functions#math_functions) are now supported: [`abs()`](/en-US/docs/Web/CSS/abs), [`sign()`](/en-US/docs/Web/CSS/sign), [`round()`](/en-US/docs/Web/CSS/round), [`mod()`](/en-US/docs/Web/CSS/mod), [`rem()`](/en-US/docs/Web/CSS/rem), [`pow()`](/en-US/docs/Web/CSS/pow), [`sqrt()`](/en-US/docs/Web/CSS/sqrt), [`hypot()`](/en-US/docs/Web/CSS/hypot), [`log()`](/en-US/docs/Web/CSS/log), and [`exp()`](/en-US/docs/Web/CSS/exp) (Firefox bug [1814589](https://bugzil.la/1814589)).
+- A new keyword `from-font` in the CSS property [`font-size-adjust`](/en-US/docs/Web/CSS/font-size-adjust) enables picking the desired `<font-metric>` from the first available font (Firefox bug [1708240](https://bugzil.la/1708240)).
 
 #### Removals
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fx118 introduces support for the `from-font` keyword in CSS [`font-size-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust#browser_compatibility) property.

### Related issues and pull requests

Doc issue tracker: https://github.com/mdn/content/issues/28842
Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1708240
Content PR: https://github.com/mdn/content/pull/29052
