### PR TITLE
FF118 meta windows key changes

### DIFF
--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
@@ -29,9 +29,9 @@ getModifierState(key)
 
 A boolean.
 
-## Modifier keys on Gecko
+## Modifier keys on Firefox
 
-When `getModifierState()` returns true on Gecko?
+When `getModifierState()` returns true on Firefox?
 
 <table class="standard-table">
   <thead>
@@ -181,10 +181,8 @@ When `getModifierState()` returns true on Gecko?
 </table>
 
 - On the other platforms, "Alt", "Control" and "Shift" may be supported.
-- All modifiers (except `"FnLock"`, `"Hyper"`,
-  `"Super"` and `"Symbol"` which are defined after Gecko
-  implements this) are always supported for untrusted events on Gecko. This doesn't
-  depend on the platform.
+- All modifiers (except `"FnLock"`, `"Hyper"`, `"Super"` and `"Symbol"` which are defined after Firefox implements this) are always supported for untrusted events on Firefox.
+  This doesn't depend on the platform.
 
 ## `"Accel"` virtual modifier
 
@@ -259,21 +257,21 @@ function handleKeyboardEvent(event) {
   ) {
     switch (event.key) {
       case "ArrowDown":
-      case "Down": // hack for IE and old Gecko
+      case "Down": // hack for IE and old Firefox
         event.preventDefault(); // consume the key event
         break;
       case "ArrowLeft":
-      case "Left": // hack for IE and old Gecko
+      case "Left": // hack for IE and old Firefox
         // Do something different if ScrollLock is locked.
         event.preventDefault(); // consume the key event
         break;
       case "ArrowRight":
-      case "Right": // hack for IE and old Gecko
+      case "Right": // hack for IE and old Firefox
         // Do something different if ScrollLock is locked.
         event.preventDefault(); // consume the key event
         break;
       case "ArrowUp":
-      case "Up": // hack for IE and old Gecko
+      case "Up": // hack for IE and old Firefox
         // Do something different if ScrollLock is locked.
         event.preventDefault(); // consume the key event
         break;

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
@@ -41,7 +41,7 @@ When `getModifierState()` returns true on Firefox?
       <th scope="col">Linux (GTK)</th>
       <th scope="col">Mac</th>
       <th scope="col">Android 2.3</th>
-      <th scope="col">Android 3.0 or latter</th>
+      <th scope="col">Android 3.0 or later</th>
     </tr>
   </thead>
   <tbody>
@@ -114,7 +114,7 @@ When `getModifierState()` returns true on Firefox?
     </tr>
     <tr>
       <th scope="row"><code>"Meta"</code></th>
-      <td>❌ <em>Not supported</em></td>
+      <td><kbd>⊞ Windows Logo</kbd> key pressed (from Firefox 118)</td>
       <td><kbd>Meta</kbd> key pressed</td>
       <td><kbd>⌘ Command</kbd> key pressed</td>
       <td>❌ <em>Not supported</em></td>
@@ -129,7 +129,7 @@ When `getModifierState()` returns true on Firefox?
     </tr>
     <tr>
       <th scope="row"><code>"OS"</code></th>
-      <td><kbd>⊞ Windows Logo</kbd> key pressed</td>
+      <td><kbd>⊞ Windows Logo</kbd> key pressed (before Firefox 118)</td>
       <td>
         <kbd>Super</kbd> key or <kbd>Hyper</kbd> key pressed (typically, mapped
         to <kbd>⊞ Windows Logo</kbd> key)

--- a/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
@@ -1054,7 +1054,8 @@ when using it.
 
 ## Code values on Mac
 
-On macOS, it's hard to get scancode or something which can distinguish a physical key from a key event. Therefore, Gecko always maps `code` value from the virtual keycode.
+On macOS, it's hard to get scancode or something which can distinguish a physical key from a key event.
+Therefore, Firefox always maps `code` value from the virtual keycode.
 
 In the cells,
 
@@ -1068,7 +1069,7 @@ In the cells,
   <thead>
     <tr>
       <th scope="row">Virtual keycode</th>
-      <th scope="col">Gecko</th>
+      <th scope="col">Firefox</th>
       <th scope="col">Chromium</th>
     </tr>
   </thead>
@@ -1346,12 +1347,12 @@ In the cells,
     <tr>
       <th scope="row">right-command key (<code>0x36</code>)</th>
       <td><code>"OSRight"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52) (⚠️ Not the same on Gecko)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>kVK_Command (0x37)</code></th>
       <td><code>"OSLeft"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52) (⚠️ Not the same on Gecko)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>kVK_Shift (0x38)</code></th>
@@ -1423,7 +1424,7 @@ In the cells,
       <td><code>"VolumeUp"</code> (⚠️ Not the same on Chromium)</td>
       <td>
         <code>"AudioVolumeUp" </code>(was <code>"VolumeUp"</code> prior to Chromium
-        1) (⚠️ Not the same on Gecko)
+        1) (⚠️ Not the same on Firefox)
       </td>
     </tr>
     <tr>
@@ -1431,7 +1432,7 @@ In the cells,
       <td><code>"VolumeDown"</code> (⚠️ Not the same on Chromium)</td>
       <td>
         <code>"AudioVolumeDown"</code> (was <code>"VolumeDown"</code> prior to
-        Chromium 52) (⚠️ Not the same on Gecko)
+        Chromium 52) (⚠️ Not the same on Firefox)
       </td>
     </tr>
     <tr>
@@ -1439,7 +1440,7 @@ In the cells,
       <td><code>"VolumeMute"</code> (⚠️ Not the same on Chromium)</td>
       <td>
         <code>"AudioVolumeMute"</code> (was <code>"VolumeMute"</code> prior to
-        Chromium 52) (⚠️ Not the same on Gecko)
+        Chromium 52) (⚠️ Not the same on Firefox)
       </td>
     </tr>
     <tr>
@@ -1625,7 +1626,7 @@ In the cells,
     <tr>
       <th scope="row"><code>kVK_Help (0x72)</code></th>
       <td><code>"Help"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"Insert"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"Insert"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>kVK_Home (0x73)</code></th>
@@ -1700,7 +1701,7 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
   <thead>
     <tr>
       <th scope="row">scancode (hardware_keycode)</th>
-      <th scope="col">Gecko</th>
+      <th scope="col">Firefox</th>
       <th scope="col">Chromium</th>
     </tr>
   </thead>
@@ -2128,7 +2129,7 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     <tr>
       <th scope="row"><code>0x005D</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"Lang5"</code> (was <code>""</code> prior to Chromium 48) (⚠️ Not the same on Gecko)</td>
+      <td><code>"Lang5"</code> (was <code>""</code> prior to Chromium 48) (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x005E</code></th>
@@ -2153,12 +2154,12 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     <tr>
       <th scope="row"><code>0x0062</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"Lang3"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"Lang3"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0063</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"Lang4"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"Lang4"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0064</code></th>
@@ -2270,7 +2271,7 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
       <td><code>"VolumeMute"</code> (⚠️ Not the same on Chromium)</td>
       <td>
         <code>"AudioVolumeMute"</code> (was <code>"VolumeMute"</code> prior to
-        Chromium 52) (⚠️ Not the same on Gecko)
+        Chromium 52) (⚠️ Not the same on Firefox)
       </td>
     </tr>
     <tr>
@@ -2278,7 +2279,7 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
       <td><code>"VolumeDown"</code> (⚠️ Not the same on Chromium)</td>
       <td>
         <code>"AudioVolumeDown"</code> (was <code>"VolumeDown"</code> prior to
-        Chromium 52) (⚠️ Not the same on Gecko)
+        Chromium 52) (⚠️ Not the same on Firefox)
       </td>
     </tr>
     <tr>
@@ -2286,13 +2287,13 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
       <td><code>"VolumeUp"</code> (⚠️ Not the same on Chromium)</td>
       <td>
         <code>"AudioVolumeUp"</code> (was <code>"VolumeUp"</code> prior to Chromium
-        52) (⚠️ Not the same on Gecko)
+        52) (⚠️ Not the same on Firefox)
       </td>
     </tr>
     <tr>
       <th scope="row"><code>0x007C</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"Power"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"Power"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x007D</code></th>
@@ -2337,12 +2338,12 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     <tr>
       <th scope="row"><code>0x0085</code></th>
       <td><code>"OSLeft"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52) (⚠️ Not the same on Gecko)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0086</code></th>
       <td><code>"OSRight"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52) (⚠️ Not the same on Gecko)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0087</code></th>
@@ -2422,7 +2423,7 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     <tr>
       <th scope="row"><code>0x0096</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"Sleep"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"Sleep"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0097</code></th>
@@ -2527,12 +2528,12 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     <tr>
       <th scope="row"><code>0x00BB</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"NumpadParenLeft"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"NumpadParenLeft"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x00BC</code></th>
       <td><code>"Unidentified"</code> (❌ Missing)</td>
-      <td><code>"NumpadParenRight"</code> (⚠️ Not the same on Gecko)</td>
+      <td><code>"NumpadParenRight"</code> (⚠️ Not the same on Firefox)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x00BD</code>, <code>0x00BE</code></th>
@@ -2620,7 +2621,7 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
   <thead>
     <tr>
       <th scope="row">scancode</th>
-      <th scope="col">Gecko</th>
+      <th scope="col">Firefox</th>
     </tr>
   </thead>
   <tbody>

--- a/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
@@ -946,13 +946,13 @@ when using it.
     </tr>
     <tr>
       <th scope="row"><code>0xE05B</code></th>
-      <td><code>"OSLeft"</code> (⚠️ Not the same on Chrome)</td>
-      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chrome 52) (⚠️ Not the same on Firefox)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Firefox 118)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chrome 52)</td>
     </tr>
     <tr>
       <th scope="row"><code>0xE05C</code></th>
-      <td><code>"OSRight"</code> (⚠️ Not the same on Chrome)</td>
-      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chrome 52) (⚠️ Not the same on Firefox)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Firefox 118)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chrome 52)</td>
     </tr>
     <tr>
       <th scope="row"><code>0xE05D</code></th>
@@ -1346,13 +1346,13 @@ In the cells,
     </tr>
     <tr>
       <th scope="row">right-command key (<code>0x36</code>)</th>
-      <td><code>"OSRight"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Firefox 118)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52)</td>
     </tr>
     <tr>
       <th scope="row"><code>kVK_Command (0x37)</code></th>
-      <td><code>"OSLeft"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Firefox 118)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52)</td>
     </tr>
     <tr>
       <th scope="row"><code>kVK_Shift (0x38)</code></th>
@@ -2337,13 +2337,13 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     </tr>
     <tr>
       <th scope="row"><code>0x0085</code></th>
-      <td><code>"OSLeft"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Firefox 118)</td>
+      <td><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Chromium 52)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0086</code></th>
-      <td><code>"OSRight"</code> (⚠️ Not the same on Chromium)</td>
-      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52) (⚠️ Not the same on Firefox)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Firefox 118)</td>
+      <td><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Chromium 52)</td>
     </tr>
     <tr>
       <th scope="row"><code>0x0087</code></th>
@@ -3136,13 +3136,13 @@ In the cells, "(❌ Missing)" means that this code value cannot be detected on t
     <tr>
       <th scope="row"><code>0x007D</code></th>
       <td>
-        <p><code>"OSLeft"</code></p>
+        <p><code>"MetaLeft"</code> (was <code>"OSLeft"</code> prior to Firefox 118)</p>
       </td>
     </tr>
     <tr>
       <th scope="row"><code>0x007E</code></th>
       <td>
-        <p><code>"OSRight"</code></p>
+        <p><code>"MetaRight"</code> (was <code>"OSRight"</code> prior to Firefox 118)</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
FF118 has been updated in https://bugzilla.mozilla.org/show_bug.cgi?id=1232918 so that `KeyboardEvent.key` has a value for the Windows Logo key of `Meta` rather than `OS`. The `KeyboardEvent.code` for Windows Logo keys in Win/Linux and Command keys in macOS were declared as `OSLeft`/`OSRight`, but now the spec declares them as `MetaLeft`/`MetaRight`.

I also took the time to rename Gecko to Firefox in these docs, in line with the fact this is effectively an internal name.

This was looked at partially before in https://github.com/mdn/content/issues/27459

Related docs work can be tracked in #28844