### PR TITLE
Fix block code indentation inside dls

### DIFF
--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -65,74 +65,84 @@ The `filter` property is specified as `none` or one or more of the functions lis
 When the `filter` property values contains multiple functions, the filters are applied in order.
 
 - {{cssxref("filter-function/blur", "blur()")}}
+
   - : Applies a Gaussian blur to the input image.
 
-```css
-filter: blur(5px);
-```
+    ```css
+    filter: blur(5px);
+    ```
 
 - {{cssxref("filter-function/brightness", "brightness()")}}
+
   - : Applies a linear multiplier to the input image, making it appear more or less bright. Values are linear multipliers on the effect, with `0%` creating a completely black image, `100%` having no effect, and values over `100%` brightening the image.
 
-```css
-filter: brightness(2);
-```
+    ```css
+    filter: brightness(2);
+    ```
 
 - {{cssxref("filter-function/contrast", "contrast()")}}
+
   - : Adjusts the contrast of the input image. A value of `0%` makes the image grey, `100%` has no effect, and values over `100%` create a contrast.
 
-```css
-filter: contrast(200%);
-```
+    ```css
+    filter: contrast(200%);
+    ```
 
 - {{cssxref("filter-function/drop-shadow", "drop-shadow()")}}
+
   - : Applies the parameter `<shadow>` as a drop shadow, following the contours of the image. The shadow syntax is similar to `<box-shadow>` (defined in the [CSS backgrounds and borders module](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders)), with the exception that the `inset` keyword and `spread` parameter are not allowed. As with all `filter` property values, any filters after the `drop-shadow()` are applied to the shadow.
 
-```css
-filter: drop-shadow(16px 16px 10px black);
-```
+    ```css
+    filter: drop-shadow(16px 16px 10px black);
+    ```
 
 - {{cssxref("filter-function/grayscale", "grayscale()")}}
+
   - : Converts the image to grayscale. A value of `100%` is completely grayscale. The initial value of `0%` leaves the input unchanged. Values between `0%` and `100%` produce linear multipliers on the effect.
 
-```css
-filter: grayscale(100%);
-```
+    ```css
+    filter: grayscale(100%);
+    ```
 
 - {{cssxref("filter-function/hue-rotate", "hue-rotate()")}}
+
   - : Applies a hue rotation. The `<angle>` value defines the number of degrees around the hue color circle at which the input samples will be adjusted. A value of `0deg` leaves the input unchanged.
 
-```css
-filter: hue-rotate(90deg);
-```
+    ```css
+    filter: hue-rotate(90deg);
+    ```
 
 - {{cssxref("filter-function/invert", "invert()")}}
+
   - : Inverts the samples in the input image. A value of `100%` completely inverts the image. A value of `0%` leaves the input unchanged. Values between `0%` and `100%` have linear multipliers on the effect.
 
-```css
-filter: invert(100%);
-```
+    ```css
+    filter: invert(100%);
+    ```
 
 - {{cssxref("filter-function/opacity", "opacity()")}}
+
   - : Applies transparency. `0%` makes the image completely transparent and `100%` leaves the image unchanged.
 
-```css
-filter: opacity(50%);
-```
+    ```css
+    filter: opacity(50%);
+    ```
 
 - {{cssxref("filter-function/saturate", "saturate()")}}
+
   - : Saturates the image, with `0%` being completely unsaturated, `100%` leaving the image unchanged, and values of over `100%` increasing saturation.
 
-```css
-filter: saturate(200%);
-```
+    ```css
+    filter: saturate(200%);
+    ```
 
 - {{cssxref("filter-function/sepia", "sepia()")}}
+
   - : Converts the image to sepia, with a value of `100%` making the image completely sepia and `0%` making no change.
 
-```css
-filter: sepia(100%);
-```
+    ```css
+    filter: sepia(100%);
+    ```
 
 ## Combining functions
 


### PR DESCRIPTION
### Description

When updating the page in `fr`, I noticed the definition list containing the code blocks resulted in an incorrect markup (several dls separated by code blocks rather than one dl where each item contained a code block)

![screenshot of fx devtools where we can see the actual markup](https://github.com/mdn/content/assets/2413436/25151872-1a0b-4a9b-b198-702499d3520a)

### Motivation

Semantic ftw.