### PR TITLE
fix wrong explanation about cache-control and authroization header

### DIFF
--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -34,8 +34,6 @@ Cache-Control: private
 
 Personalized contents are usually controlled by cookies, but the presence of a cookie does not always indicate that it is private, and thus a cookie alone does not make the response private.
 
-Note that a response to a request with an `Authorization` header cannot be stored in the shared cache by default, unless public is specified.
-
 ### Shared cache
 
 The shared cache is located between the client and the server and can store responses that can be shared among users. And shared caches can be further sub-classified into **proxy caches** and **managed caches**.

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -34,7 +34,7 @@ Cache-Control: private
 
 Personalized contents are usually controlled by cookies, but the presence of a cookie does not always indicate that it is private, and thus a cookie alone does not make the response private.
 
-Note that if the response has an `Authorization` header, it cannot be stored in the private cache (or a shared cache, unless `public` is specified).
+Note that if the response has an `Authorization` header, it cannot be stored in the shared cache by default unless some other explicit directives (e.g. `public`, `max-age` etc) are specified.
 
 ### Shared cache
 

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -34,7 +34,7 @@ Cache-Control: private
 
 Personalized contents are usually controlled by cookies, but the presence of a cookie does not always indicate that it is private, and thus a cookie alone does not make the response private.
 
-Note that if the response has an `Authorization` header, it cannot be stored in the shared cache by default unless some other explicit directives (e.g. `public`, `max-age` etc) are specified.
+Note that a response to a request with an `Authorization` header cannot be stored in the shared cache by default, unless public is specified.
 
 ### Shared cache
 


### PR DESCRIPTION
### Description

https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#private_caches

has incorrect explanation about cache-control and authorization header.

### Motivation

in Spec (RFC 9111) only mentions that if request contains `Authorization` header, it can't be stored in Shared Cache by default.

https://httpwg.org/specs/rfc9111.html#response.cacheability:~:text=if%20the%20cache%20is%20shared%3A%20the%20authorization%20header%20field%20is%20not%20present%20in%20the%20request%20(see%20section%2011.6.2%20of%20%5Bhttp%5D)

> if the cache is shared: the Authorization header field is not present in the request (see Section 11.6.2 of [HTTP])

But the content mentions like below.

> Note that if the response has an Authorization header, it cannot be stored in the private cache (or a shared cache, unless public is specified).

should remove `private cache` from here.

### Related issues and pull requests

Fixes #29019