### PR TITLE
Cache.match: change "URL" to "URL string"

### DIFF
--- a/files/en-us/web/api/cache/match/index.md
+++ b/files/en-us/web/api/cache/match/index.md
@@ -22,7 +22,7 @@ match(request, options)
 
 - `request`
   - : The {{domxref("Request")}} for which you are attempting to find responses in the
-    {{domxref("Cache")}}. This can be a {{domxref("Request")}} object or a URL.
+    {{domxref("Cache")}}. This can be a {{domxref("Request")}} object or a URL string.
 - `options` {{optional_inline}}
 
   - : An object that sets options for the `match` operation.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The `Cache.match()` method takes as its first parameter a `Request` object or a URL string (but not a `URL` object). This edit clarifies that.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Because I was confused whether `Cache.match()` accepts a `URL` object as its first parameter, and with this edit my confusion will be a thing of the past.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The same language is already used in [the documentation for `CacheStorage.match`](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match#specifications)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
