### PR TITLE
fix(css): Clarify text and example for complex selectors with general sibling combinator (~)

### DIFF
--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -61,7 +61,7 @@ p ~ span {
 
 ### Using the combinator with complex selectors
 
-In this example, elements represented by the two complex selectors share the same parent in the document tree. The element represented by the first complex selector precedes (not necessarily immediately) the element represented by the target selector.
+In this example, elements represented by the two [complex selectors](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) share the same parent in the document tree. The element represented by the first complex selector precedes (not necessarily immediately) the element represented by the target selector.
 
 The example below shows that the target complex selector must share the same parent of the first complex selector.
 

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -7,11 +7,11 @@ browser-compat: css.selectors.general_sibling
 
 {{CSSRef("Selectors")}}
 
-The **general sibling combinator** (`~`) separates two selectors and matches _all iterations_ of the second element, that are following the first element (though not necessarily immediately), and are children of the same parent {{Glossary("element")}}.
+The **general sibling combinator** (`~`) separates two selectors and matches _all instances_ of the second element that follow the first element (not necessarily immediately) and share the same parent element.
+
+In the following example, the general sibling combinator (`~`) helps to select and style paragraphs that are both siblings of an image and appear after any image.
 
 ```css
-/* Paragraphs that are siblings of and
-   subsequent to any image */
 img ~ p {
   color: red;
 }
@@ -21,20 +21,14 @@ img ~ p {
 
 ```css-nolint
 /* The white space around the ~ combinator is optional but recommended. */
-former_element ~ target_element { style properties }
+compound_selector1 ~ compound_selector2 { style properties }
 ```
 
 ## Examples
 
-### CSS
+### Using the combinator with simple selectors
 
-```css
-p ~ span {
-  color: red;
-}
-```
-
-### HTML
+This example shows the use of the `~` combinator when both the selectors are simple (`p` and `span`).
 
 ```html
 <article>
@@ -43,7 +37,7 @@ p ~ span {
   <code>Here is some code.</code>
   <span>
     This span is red because it appears after the paragraph, even though there
-    are other nodes in between
+    are other nodes in between.
   </span>
   <p>Whatever it may be, keep smiling.</p>
   <h1>Dream big</h1>
@@ -53,13 +47,52 @@ p ~ span {
   </span>
 </article>
 <span>
-  This span is not red because it doesn't share a parent with a paragraph
+  This span is not red because it doesn't share a parent with a paragraph.
 </span>
 ```
 
-### Result
+```css
+p ~ span {
+  color: red;
+}
+```
 
-{{EmbedLiveSample("Examples", "auto", 300)}}
+{{EmbedLiveSample("Using the combinator with simple selectors", "auto", 300)}}
+
+### Using the combinator with compound selectors
+
+Elements represented by the two compound selectors share the same parent in the document tree. The element represented by the first compound selector precedes (not necessarily immediately) the element represented by the second one.
+
+The example below shows that the second compound selector must match the parent of the first compound selector.
+
+```html
+<h1>Dream big</h1>
+<span>And yet again this is a red span!</span>
+<div class="foo">
+  <p>Here is another paragraph.</p>
+  <span>A blue span</span>
+  <div class="foo">
+    <span>A green span</span>
+  </div>
+</div>
+```
+
+```css
+.foo p ~ span {
+  color: blue;
+}
+
+.foo p ~ .foo span {
+  color: green;
+}
+```
+
+{{EmbedLiveSample("Using the combinator with compound selectors", "auto", 200)}}
+
+In the above HTML, the two siblings of `.foo p` are `span` and `.foo span`.
+
+- When the second compound selector is `span`, it selects the `span` element that is a sibling of `p` and both are descendants of `.foo`.
+- When the second compound selector is `.foo span`, it selects the `span` element that's a descendant of `.foo` if that `.foo` is a sibling of `p`; essentially, both are nested in an ancestor of `.foo`.
 
 ## Specifications
 
@@ -72,3 +105,4 @@ p ~ span {
 ## See also
 
 - [Adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinator)
+-

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -61,9 +61,12 @@ p ~ span {
 
 ### Using the combinator with complex selectors
 
-In this example, elements represented by the two [complex selectors](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) share the same parent in the document tree. The element represented by the first complex selector precedes (not necessarily immediately) the element represented by the target selector.
+This example contains two [complex selectors](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector), both using the general sibling combinator: `.foo p ~ span` and `.foo p ~ .foo span`.
 
-The example below shows that the target complex selector must share the same parent of the first complex selector.
+- The first complex selector, `.foo p ~ span`, matches all spans that come after a paragraph _if_ the span and paragraph share the same parent **and** that parent or an ancestor of that parent has the class `.foo`.
+- The second complex selector, `.foo p ~ .foo span`, matches all spans that are a descendant of the element with class `.foo` _if_ that element is a sibling of the previously mentioned paragraph.
+
+The example below shows that the target element in the complex selector must share the same parent as the initial element in the complex selector.
 
 ```html
 <h1>Dream big</h1>
@@ -89,7 +92,7 @@ The example below shows that the target complex selector must share the same par
 
 {{EmbedLiveSample("Using the combinator with complex selectors", "auto", 200)}}
 
-In the above HTML, the two siblings of `.foo p` are `span` and `.foo span`.
+In the above HTML, the two siblings of `.foo p` are `span` and `.foo`. The green `span` is a descendant of `.foo`, which is a sibling of `.foo p`.
 
 - When the target selector is `span`, the `span` element that is a sibling of `p` is selected. The `p` element is a descendant of `.foo`, so are its `span` siblings.
 - In `.foo p ~ .foo span`, the target selector is `span` that is a descendant of `.foo`. In this case, the `span` element that's a descendent of `.foo` is selected if that `.foo` is a sibling of `p`; essentially, both are nested in an ancestor of `.foo`.

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -21,14 +21,14 @@ img ~ p {
 
 ```css-nolint
 /* The white space around the ~ combinator is optional but recommended. */
-compound_selector1 ~ compound_selector2 { style properties }
+former_element ~ target_element { style properties }
 ```
 
 ## Examples
 
 ### Using the combinator with simple selectors
 
-This example shows the use of the `~` combinator when both the selectors are simple (`p` and `span`).
+This example shows the use of the `~` combinator when both the selectors are simple selectors (`p` and `span`).
 
 ```html
 <article>
@@ -59,11 +59,11 @@ p ~ span {
 
 {{EmbedLiveSample("Using the combinator with simple selectors", "auto", 300)}}
 
-### Using the combinator with compound selectors
+### Using the combinator with complex selectors
 
-Elements represented by the two compound selectors share the same parent in the document tree. The element represented by the first compound selector precedes (not necessarily immediately) the element represented by the second one.
+In this example, elements represented by the two complex selectors share the same parent in the document tree. The element represented by the first complex selector precedes (not necessarily immediately) the element represented by the target selector.
 
-The example below shows that the second compound selector must match the parent of the first compound selector.
+The example below shows that the target complex selector must share the same parent of the first complex selector.
 
 ```html
 <h1>Dream big</h1>
@@ -87,12 +87,12 @@ The example below shows that the second compound selector must match the parent 
 }
 ```
 
-{{EmbedLiveSample("Using the combinator with compound selectors", "auto", 200)}}
+{{EmbedLiveSample("Using the combinator with complex selectors", "auto", 200)}}
 
 In the above HTML, the two siblings of `.foo p` are `span` and `.foo span`.
 
-- When the second compound selector is `span`, it selects the `span` element that is a sibling of `p` and both are descendants of `.foo`.
-- When the second compound selector is `.foo span`, it selects the `span` element that's a descendant of `.foo` if that `.foo` is a sibling of `p`; essentially, both are nested in an ancestor of `.foo`.
+- When the target selector is `span`, the `span` element that is a sibling of `p` is selected. The `p` element is a descendant of `.foo`, so are its `span` siblings.
+- In `.foo p ~ .foo span`, the target selector is `span` that is a descendant of `.foo`. In this case, the `span` element that's a descendent of `.foo` is selected if that `.foo` is a sibling of `p`; essentially, both are nested in an ancestor of `.foo`.
 
 ## Specifications
 
@@ -105,4 +105,3 @@ In the above HTML, the two siblings of `.foo p` are `span` and `.foo span`.
 ## See also
 
 - [Adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinator)
--

--- a/files/en-us/web/css/general_sibling_combinator/index.md
+++ b/files/en-us/web/css/general_sibling_combinator/index.md
@@ -92,7 +92,7 @@ The example below shows that the target element in the complex selector must sha
 
 {{EmbedLiveSample("Using the combinator with complex selectors", "auto", 200)}}
 
-In the above HTML, the two siblings of `.foo p` are `span` and `.foo`. The green `span` is a descendant of `.foo`, which is a sibling of `.foo p`.
+In the above HTML, the two siblings of `.foo p` are `span` and `.foo`. The green `span` is a descendant of the `.foo` class, which is a sibling of `p`.
 
 - When the target selector is `span`, the `span` element that is a sibling of `p` is selected. The `p` element is a descendant of `.foo`, so are its `span` siblings.
 - In `.foo p ~ .foo span`, the target selector is `span` that is a descendant of `.foo`. In this case, the `span` element that's a descendent of `.foo` is selected if that `.foo` is a sibling of `p`; essentially, both are nested in an ancestor of `.foo`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The issue and proposed fix was raised in the PR https://github.com/mdn/content/pull/27124, which was closed due to inaction.

I've opened this new one now to incorporate the suggested changes and add clarifying example and accompanying explanations.

