### PR TITLE
Fix issue 29094: request parameter to BackgroundFetchRegistration: ma…

### DIFF
--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
@@ -15,15 +15,16 @@ The **`matchAll()`** method of the {{domxref("BackgroundFetchRegistration")}} in
 ## Syntax
 
 ```js-nolint
+matchAll()
 matchAll(request)
 matchAll(request,options)
 ```
 
 ### Parameters
 
-- `request`
+- `request` {{optional_inline}}
   - : The {{domxref("Request")}} for which you are attempting to find records.
-    This can be a {{domxref("Request")}} object or a URL.
+    This can be a {{domxref("Request")}} object or a URL. If this parameter is omitted, all records are included in the result.
 - `options` {{optional_inline}}
 
   - : An object that sets options for the `match` operation. The available


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/29094.

I could not see where it is specced what happens if `request` is omitted: https://wicg.github.io/background-fetch/#background-fetch-registration-match-all so I guessed.