### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
@@ -15,7 +15,7 @@ The `aria-describedby` attribute lists the [`id`](/en-US/docs/Web/HTML/Global_at
 
 The `aria-describedby` attribute is not limited to form controls. It can also be used to associate static text with widgets, groups of elements, regions that have a heading, definitions, and more. The `aria-describedby` attribute can be used with semantic HTML elements and with elements that have an ARIA [`role`](/en-US/docs/Web/Accessibility/ARIA/Roles).
 
-The `aria-describedby` attribute is very similar to [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attribute. While the `aria-labelledby` lists the `id`s of the labels or elements that describe the essence of an object, the `aria-describedby` lists the `id`s of the descriptions or elements providing more information that the user might need. Both `aria-labelledby` and `aria-describedby` reference other elements to calculate a text alternative, but a label should be concise, while a description is intended to provide more verbose information; a label describes the essence of an object, while a description provides more information that the user might need.
+The `aria-describedby` attribute is very similar to [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attribute. While `aria-labelledby` lists the `id`s of the labels or elements that describe the essence of an object, `aria-describedby` lists the `id`s of the descriptions or elements providing more information that the user might need. Both `aria-labelledby` and `aria-describedby` reference other elements to calculate a text alternative, but a label should be concise, while a description is intended to provide more verbose information; a label describes the essence of an object, while a description provides more information that the user might need.
 
 The elements linked via `aria-describedby` don't need to be visible. It is possible to reference an element even if that element is hidden. For example, a form control can have a description that is hidden by default that is revealed on request using a disclosure widget like a "more information" icon. The sighted user clicks on the icon; for assistive technology users the description is referenced from that form field directly with `aria-describedby`.
 
@@ -33,16 +33,16 @@ The `aria-describedby` property is appropriate when the associated content conta
 </p>
 ```
 
-> **Note:** The `aria-describedby` attributed is not designed to reference descriptions on an external resource. As its value is one or a space-separated list of more than one `id`, it must reference elements in the same DOM document.
+> **Note:** The `aria-describedby` attribute is not designed to reference descriptions from external resources. As its value is one or more `id`s (space-separated if multiple), it must reference elements in the same DOM document.
 
 ## Values
 
 - ID reference list
-  - : The `id` or space-separated list of element IDs that describe the current element.
+  - : The `id` or space-separated list of element `id`s that describe the current element.
 
 ## Associated roles
 
-Used in **ALL** roles. Usable in all HTML elements as well.
+Used in **all** roles. Usable in all HTML elements as well.
 
 ## Specifications
 


### PR DESCRIPTION
Correct typos, improve clarity.

### Description

#### "the" → ø (2×)
When shifting from using `aria-describedby` and `aria-labelledby` as alternative adjectives for "attribute" to using them as nouns, the null article is preferred over the definite article.

#### "attributed" → "attribute"
Context strongly suggests the noun "attribute" is intended here.

#### "descriptions on an external resource" → "descriptions from external resources"
There are a few prepositions possible here. "In" is used immediately afterwards in "in the same DOM document" (which is arguably redundant, incidentally), but "reference [...] from" feels the most natural to me.

#### "one or a space-separated list of more than one `id`" → "one or more `id`s (space-separated if multiple)"
The key point is that IDs are used. While both technically correct and grammatical, interjecting more information before that point makes the statement more difficult to parse and follow. The proposed parenthetical could also be omitted entirely, as the case of multiple IDs is given in detail immediately thereafter.

#### "IDs" → "`id`s"
This is mainly for consistency since this was the only instance of "IDs".

#### "ALL" → "all"
Using capital letters for emphasis is not ideal, especially not for short words where they are more easily confused for acronyms (especially by screen readers).

### Motivation

I believe my edits will make the content of the page more clear to future readers.