### PR TITLE
Fix sidebar for Notifications guide

### DIFF
--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -5,7 +5,7 @@ page-type: guide
 browser-compat: api.Notification
 ---
 
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{DefaultAPISidebar("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
 The [Notifications API](/en-US/docs/Web/API/Notifications_API) lets a web page or app send notifications that are displayed outside the page at the system level; this lets web apps send information to a user even if the application is idle or in the background. This article looks at the basics of using this API in your own apps.
 


### PR DESCRIPTION
The page at https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API was using the wrong macro to generate a sidebar.