### PR TITLE
 docs(relnotes): FX118 release notes for offset-path: url()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -938,7 +938,7 @@ For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `
 
 ### url() function in offset-path property
 
-The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/docs/Web/CSS/offset-path#url) to specify the ID of an SVG shape element. The referenced shape is used to define the shape of the path that an element will follow ([Firefox bug 1598158](https://bugzil.la/1598158)).
+The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/docs/Web/CSS/offset-path#url) to specify the ID of an SVG shape element. The referenced shape defines the shape of the path that an element will follow ([Firefox bug 1598158](https://bugzil.la/1598158)).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -936,6 +936,48 @@ For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `
   </tbody>
 </table>
 
+### url() function in offset-path property
+
+The CSS {{cssxref("offset-path")}} property can be used to specify the ID of an SVG shape element using `<url()>` to create the path shape. For more details, see [Firefox bug 1598158](https://bugzil.la/1598158).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>118</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>118</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>118</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>118</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference names</th>
+      <td colspan="2">
+      <code>layout.css.motion-path-url.enabled</code>
+    </td>
+    </tr>
+  </tbody>
+</table>
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -970,7 +970,7 @@ The CSS {{cssxref("offset-path")}} property can be used to specify the ID of an 
       <td>No</td>
     </tr>
     <tr>
-      <th>Preference names</th>
+      <th>Preference name</th>
       <td colspan="2">
       <code>layout.css.motion-path-url.enabled</code>
     </td>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -938,7 +938,7 @@ For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `
 
 ### url() function in offset-path property
 
-The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/docs/Web/CSS/offset-path#url) to specify the ID of an SVG shape element to define the shape of the path that an element will follow ([Firefox bug 1598158](https://bugzil.la/1598158)).
+The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/docs/Web/CSS/offset-path#url) to specify the ID of an SVG shape element. The referenced shape is used to define the shape of the path that an element will follow ([Firefox bug 1598158](https://bugzil.la/1598158)).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -938,7 +938,7 @@ For more details, see [Firefox bug 1786161](https://bugzil.la/1786161) for the `
 
 ### url() function in offset-path property
 
-The CSS {{cssxref("offset-path")}} property can be used to specify the ID of an SVG shape element using `<url()>` to create the path shape. For more details, see [Firefox bug 1598158](https://bugzil.la/1598158).
+The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/docs/Web/CSS/offset-path#url) to specify the ID of an SVG shape element to define the shape of the path that an element will follow ([Firefox bug 1598158](https://bugzil.la/1598158)).
 
 <table>
   <thead>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fx118 adds support for `url()` in [`offset-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path).
Preference to be enabled (on by default in Nightly): `layout.css.motion-path-url.enabled`

Spec: https://drafts.fxtf.org/motion-1/#valdef-offset-path-url

### Related issues and pull requests

Doc issue tracker: https://github.com/mdn/content/issues/28846
BCD update: https://github.com/mdn/browser-compat-data/pull/20710


