### PR TITLE
Permissions-Policy: publickey-credentials-get not experimental

### DIFF
--- a/files/en-us/web/http/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/index.md
@@ -165,7 +165,7 @@ You can specify
 
   - : Controls whether the current document is allowed to use the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to create new asymmetric key credentials, i.e., via {{domxref("CredentialsContainer.create", "navigator.credentials.create({publicKey: ..., ...})")}}.
 
-- {{httpheader("Permissions-Policy/publickey-credentials-get", "publickey-credentials-get")}} {{Experimental_Inline}}
+- {{httpheader("Permissions-Policy/publickey-credentials-get", "publickey-credentials-get")}}
 
   - : Controls whether the current document is allowed to use the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to retrieve already stored public-key credentials, i.e., via {{domxref("CredentialsContainer.get", "navigator.credentials.get({publicKey: ..., ...})")}}.
 

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
@@ -2,12 +2,10 @@
 title: "Permissions-Policy: publickey-credentials-get"
 slug: Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get
 page-type: http-permissions-policy-directive
-status:
-  - experimental
 browser-compat: http.headers.Permissions-Policy.publickey-credentials-get
 ---
 
-{{HTTPSidebar}} {{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `publickey-credentials-get` directive controls whether the current document is allowed to access the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to retrieve public-key credentials, i.e., via {{domxref("CredentialsContainer.get","navigator.credentials.get({publicKey})")}}.
 


### PR DESCRIPTION
[`Permissions-Policy: publickey-credentials-get`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) is supported in FF118 in https://bugzilla.mozilla.org/show_bug.cgi?id=1460986. That's 2 main browsers, so not experimental. This just moves the experimental header and metadata.

Associated docs work can be tracked in https://github.com/mdn/content/issues/28848
