### PR TITLE
relnote(118): maction semantics mathml pref removed

### DIFF
--- a/.vscode/project-words.txt
+++ b/.vscode/project-words.txt
@@ -23,6 +23,7 @@ hulki
 i'gyu
 Kazotetsu
 Letorey
+mathml
 mdnplay
 menclose
 mfenced

--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -18,7 +18,7 @@ This article provides information about the changes in Firefox 118 that affect d
 
 ### MathML
 
-- The `mathml.legacy_maction_and_semantics_implementations.disabled` preference is now removed, which means that the [`<semantics>`](/en-US/docs/Web/MathML/Element/semantics) and [`<maction>`](/en-US/docs/Web/MathML/Element/maction) elements render the first child element by default (Firefox bug [1788223](https://bugzil.la/1788223)).
+- The `mathml.legacy_maction_and_semantics_implementations.disabled` preference is now removed, which means that the [`<semantics>`](/en-US/docs/Web/MathML/Element/semantics) and [`<maction>`](/en-US/docs/Web/MathML/Element/maction) elements only render the first child element by default (Firefox bug [1788223](https://bugzil.la/1788223)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -16,6 +16,10 @@ This article provides information about the changes in Firefox 118 that affect d
 
 - The {{HTMLElement('search')}} element is now supported. The `<search>` element is a group element that serves to contain all the elements used in a search or filtering operation ([Firefox bug 1824121](https://bugzil.la/1824121)).
 
+### MathML
+
+- The `mathml.legacy_maction_and_semantics_implementations.disabled` preference is now removed, which means that the [`<semantics>`](/en-US/docs/Web/MathML/Element/semantics) and [`<maction>`](/en-US/docs/Web/MathML/Element/maction) elements render the first child element by default (Firefox bug [1788223](https://bugzil.la/1788223)).
+
 #### Removals
 
 ### CSS


### PR DESCRIPTION
This PR adds a relnote about removal of the mathml pref `mathml.legacy_maction_and_semantics_implementations.disabled`.

>By default, only the first child of the element is rendered 

This is documented in admonitions in the respective MathML element pages.

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/28850
- [x] https://github.com/mdn/content/pull/21627

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1788223
