### PR TITLE
Indicate non-universal compatibility

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Error
 
 Runtime errors result in new `Error` objects being created and thrown.
 
-`Error` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker/postMessage()", "postMessage()")}}.
+`Error` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker/postMessage()", "postMessage()")}} (where supported by the browser).
 
 ### Error types
 


### PR DESCRIPTION
### Description
Tiny change that just makes the current wording a little bit more clear.

### Motivation

Just makes the existing wording a little bit clearer.

Upon first reading it, I was under the impression that `Error` would always be Serializable because it uses fairly strong language, but the Browser Compat table shows that's not the case for Safari, etc.

I feel like I'm probably not alone in assuming that it will always be Serializable based on the copy either.
