### PR TITLE
Update CSS `<position>` data type

### DIFF
--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.position
 
 {{CSSRef}}
 
-The **`<position>`** (or **`<bg-position>`**) [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a two-dimensional coordinate used to set a location relative to an element box. It is used in the {{cssxref("background-position")}}, {{cssxref("object-position")}}, {{cssxref("mask-position")}} {{cssxref("offset-position")}} and {{cssxref("offset-anchor")}} properties.
+The **`<position>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a two-dimensional coordinate used to set a location relative to an element box. It is used in the {{cssxref("background-position")}}, {{cssxref("object-position")}}, {{cssxref("mask-position")}} {{cssxref("offset-position")}} and {{cssxref("offset-anchor")}} properties.
 
 > **Note:** The final position described by the `<position>` value does not need to be inside the element's box.
 

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.position
 
 {{CSSRef}}
 
-The **`<position>`** (or **`<bg-position>`**) [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a two-dimensional coordinate used to set a location relative to an element box. It is used in the {{cssxref("background-position")}} and {{cssxref("offset-anchor")}} properties.
+The **`<position>`** (or **`<bg-position>`**) [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a two-dimensional coordinate used to set a location relative to an element box. It is used in the {{cssxref("background-position")}}, {{cssxref("object-position")}}, {{cssxref("mask-position")}} {{cssxref("offset-position")}} and {{cssxref("offset-anchor")}} properties.
 
 > **Note:** The final position described by the `<position>` value does not need to be inside the element's box.
 

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.position
 
 {{CSSRef}}
 
-The **`<position>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a two-dimensional coordinate used to set a location relative to an element box. It is used in the {{cssxref("background-position")}}, {{cssxref("object-position")}}, {{cssxref("mask-position")}} {{cssxref("offset-position")}} and {{cssxref("offset-anchor")}} properties.
+The **`<position>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a two-dimensional coordinate used to set a location relative to an element box. It is used in the {{cssxref("background-position")}}, {{cssxref("object-position")}}, {{cssxref("mask-position")}} {{cssxref("offset-position")}}, {{cssxref("offset-anchor")}} and {{cssxref("transform-origin")}} properties.
 
 > **Note:** The final position described by the `<position>` value does not need to be inside the element's box.
 


### PR DESCRIPTION
### Description

The current introduction implies that the CSS `<position>` data type is used by 2 properties, mainly by the `background-position` property. This is not correct. I added a list of 6 CSS properties where it is used. This way the reader understands that this data type is widely used.