### PR TITLE
Remove mention of "type" attribute of area element

### DIFF
--- a/files/en-us/web/html/element/area/index.md
+++ b/files/en-us/web/html/element/area/index.md
@@ -96,9 +96,6 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
     > **Note:** The `nohref` attribute is not necessary, as omitting the `href` attribute is sufficient.
 
-- `type` {{deprecated_inline}}
-  - : Hint for the type of the referenced resource. Ignored by browsers.
-
 ## Examples
 
 ```html


### PR DESCRIPTION
This PR removes mention of the `type` attribute of the `<area>` element from MDN.  The feature is irrelevant and may be removed according to the BCD guideliens.

BCD PR: https://github.com/mdn/browser-compat-data/pull/20543
