### PR TITLE
Fix small mistake in js snippet in MDN docs

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -99,7 +99,7 @@ class C {
     this.#x = x;
   }
   static getX(obj) {
-    if (#x in obj) return obj.#x;
+    if ("#x" in obj) return obj.#x;
 
     return "obj must be an instance of C";
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Link the the MDN web docs page:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#:~:text=if%20(%23x%20in%20obj)%20return%20obj.%23x%3B

<!-- ✍️ Summarize your changes in one or two sentences -->
Fix a small mistake in the following js snippet:
```js
class C {
  #x;
  constructor(x) {
    this.#x = x;
  }
  static getX(obj) {
    if (#x in obj) return obj.#x;

    return "obj must be an instance of C";
  }
}
console.log(C.getX(new C("foo"))); // "foo"
console.log(C.getX(new C(0.196))); // 0.196
console.log(C.getX(new C(new Date()))); // the current date and time
console.log(C.getX({})); // "obj must be an instance of C"
```
```js
if (#x in obj) return obj.#x;
```
should be
```js
if ("#x" in obj) return obj.#x;
```

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
