### PR TITLE
Fix longOffset example in DateTimeFormat

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -121,7 +121,7 @@ Intl.DateTimeFormat(locales, options)
     - `"shortOffset"`
       - : Short localized GMT format (e.g., `GMT-8`)
     - `"longOffset"`
-      - : Long localized GMT format (e.g., `GMT-0800`)
+      - : Long localized GMT format (e.g., `GMT-08:00`)
     - `"shortGeneric"`
       - : Short generic non-location format (e.g.: `PT`, `Los Angeles Zeit`).
     - `"longGeneric"`


### PR DESCRIPTION
### Description

Fix the `longOffset` example for the `timeZoneName` option in `Intl.DateTimeFormat`

### Motivation

This is what it looks like in current engines.