### PR TITLE
Fix syntax error for a node version manager's name

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/development_environment/index.md
@@ -102,14 +102,14 @@ nvm install --lts
 
 At the time of writing, the LTS version of nodejs is 18.15.0.
 The command `nvm list` shows the downloaded set of version and the current version.
-You can set a particular version as the _current version_ with the command below (the same as for `npm-windows`)
+You can set a particular version as the _current version_ with the command below (the same as for `nvm-windows`)
 
 ```bash
 nvm use 18.15.0
 ```
 
 Use the command `nvm --help` to find out other command line options.
-These are often similar to, or the same as, those offered by `npm-windows`.
+These are often similar to, or the same as, those offered by `nvm-windows`.
 
 ### Testing your Nodejs and npm installation
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- There's no such package as `npm-windows`. I think it's just `nvm-windows` misspelled.

### Motivation

- A simple syntactical fix to clear any confusion about a node version manager's name.

### Additional details

- None.

### Related issues and pull requests

- None.
