### PR TITLE
No prefetch attribute in link element

### DIFF
--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -222,10 +222,6 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     > - In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., [media types and groups](/en-US/docs/Web/CSS/@media), where defined and allowed as values for this attribute, such as `print`, `screen`, `aural`, `braille`.
     >   HTML5 extended this to any kind of [media queries](/en-US/docs/Web/CSS/CSS_media_queries), which are a superset of the allowed values of HTML 4.
     > - Browsers not supporting [CSS Media Queries](/en-US/docs/Web/CSS/CSS_media_queries) won't necessarily recognize the adequate link; do not forget to set fallback links, the restricted set of media queries defined in HTML 4.
-
-- `prefetch` {{secureContext_inline}} {{experimental_inline}}
-  - : Identifies a resource that might be required by the next navigation and that the user agent should retrieve it.
-    This allows the user agent to respond faster when the resource is requested in the future.
 - `referrerpolicy`
 
   - : A string indicating which referrer to use when fetching the resource:

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -222,6 +222,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     > - In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., [media types and groups](/en-US/docs/Web/CSS/@media), where defined and allowed as values for this attribute, such as `print`, `screen`, `aural`, `braille`.
     >   HTML5 extended this to any kind of [media queries](/en-US/docs/Web/CSS/CSS_media_queries), which are a superset of the allowed values of HTML 4.
     > - Browsers not supporting [CSS Media Queries](/en-US/docs/Web/CSS/CSS_media_queries) won't necessarily recognize the adequate link; do not forget to set fallback links, the restricted set of media queries defined in HTML 4.
+
 - `referrerpolicy`
 
   - : A string indicating which referrer to use when fetching the resource:


### PR DESCRIPTION
### Description

no prefetch attribute in link element

### Motivation

link element does not has a attribute named prefetch

though prefetch can be an attribute value of rel attribute

### Additional details

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link

https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement

### Related issues and pull requests
