### PR TITLE
fix:27887 innerWidth includes scrollbar

### DIFF
--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -8,14 +8,9 @@ browser-compat: api.Window.innerWidth
 
 {{APIRef}}
 
-The read-only {{domxref("Window")}} property
-**`innerWidth`** returns the interior width of the window in
-pixels. This includes the width of the vertical scroll bar, if one is present.
+The read-only {{domxref("Window")}} property **`innerWidth`** returns the interior width of the window (a.k.a. width of the window's {{Glossary("layout viewport")}}) in pixels. This includes the width of the vertical scroll bar, if one is present.
 
-More precisely, `innerWidth` returns the width of the window's
-{{Glossary("layout viewport")}}. The interior height of the window—the height of the
-layout viewport—can be obtained from the {{domxref("Window.innerHeight",
-  "innerHeight")}} property.
+Similarly, the interior height of the window (a.k.a. height of the layout viewport) can be obtained using the {{domxref("Window.innerHeight", "innerHeight")}} property. This measurement also accounts for the height of the horizontal scroll bar, if it is visible.
 
 ## Value
 

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -8,9 +8,9 @@ browser-compat: api.Window.innerWidth
 
 {{APIRef}}
 
-The read-only {{domxref("Window")}} property **`innerWidth`** returns the interior width of the window (a.k.a. width of the window's {{Glossary("layout viewport")}}) in pixels. This includes the width of the vertical scroll bar, if one is present.
+The read-only {{domxref("Window")}} property **`innerWidth`** returns the interior width of the window in pixels (that is, the width of the window's {{Glossary("layout viewport")}}). That includes the width of the vertical scroll bar, if one is present.
 
-Similarly, the interior height of the window (a.k.a. height of the layout viewport) can be obtained using the {{domxref("Window.innerHeight", "innerHeight")}} property. This measurement also accounts for the height of the horizontal scroll bar, if it is visible.
+Similarly, the interior height of the window (that is, the height of the layout viewport) can be obtained using the {{domxref("Window.innerHeight", "innerHeight")}} property. That measurement also accounts for the height of the horizontal scroll bar, if it is visible.
 
 ## Value
 


### PR DESCRIPTION
### Description
I have updated the first two paragraphs of the [innerWidth page](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth)

### Motivation
The first paragraph says innerWidth includes the scrollbar. The second paragraph says that innerWidth returns the width of the layout viewport.

These two statements are contradictory because the layout viewport does not include the scrollbar.

### Related issues and pull requests

Fixes #27887