### PR TITLE
FF118 Updates for global privacy control

### DIFF
--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Navigator.globalPrivacyControl
 
 {{APIRef("DOM")}}{{SeeCompatTable}}{{Non-standard_header}}
 
-The **`Navigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting. This setting indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+The **`Navigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting for the current website.
+This setting indicates whether the user consents to the website or service selling or sharing their personal information with third parties.
 
 The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP header.
 
@@ -28,7 +29,6 @@ The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP he
 console.log(navigator.globalPrivacyControl);
 // prints "1" indicating user does not want their data shared or sold.
 // prints "0" if the user consents to their data being shared or sold.
-// prints "unspecified" if Sec-GPC header is not present.
 ```
 
 ## Specifications
@@ -43,5 +43,5 @@ console.log(navigator.globalPrivacyControl);
 
 - {{HTTPHeader("Sec-GPC")}} header
 - [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Global Privacy Control Spec](https://globalprivacycontrol.github.io/gpc-spec/)
+- [Global Privacy Control Spec](https://privacycg.github.io/gpc-spec/)
 - [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)

--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -18,17 +18,14 @@ The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP he
 
 ## Value
 
-- `1`
-  - : User _does not_ provide consent to sell or share their data.
-- `0`
-  - : User either _does_ provide consent to sell or share their data, or has not indicated a preference.
+`true` if the user explicitly _does not_ provide consent to sell or share their data.
+`false` if the user either grants consent, or has not indicated a preference.
 
 ## Example
 
 ```js
 console.log(navigator.globalPrivacyControl);
-// prints "1" indicating user does not want their data shared or sold.
-// prints "0" if the user consents to their data being shared or sold.
+// "true" if the user has specifically indicated they do not want their data shared or sold, otherwise "false".
 ```
 
 ## Specifications

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -92,7 +92,7 @@ _Doesn't inherit any properties._
   - : Returns the build identifier of the browser. In modern browsers this property now returns a fixed timestamp as a privacy measure, e.g. `20181001000000` in Firefox 64 onwards.
 - {{domxref("Navigator.contacts")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('ContactsManager')}} interface which allows users to select entries from their contact list and share limited details of the selected entries with a website or application.
-- {{domxref("Navigator.globalPrivacyControl")}} {{Non-standard_Inline}} {{Experimental_Inline}}
+- {{domxref("Navigator.globalPrivacyControl")}} {{ReadOnlyInline}}{{Non-standard_Inline}} {{Experimental_Inline}}
   - : Returns a boolean indicating a user's consent to their information being shared or sold.
 - {{domxref("Navigator.securitypolicy")}} {{Non-standard_Inline}}
   - : Returns an empty string. In Netscape 4.7x, returns "US & CA domestic policy" or "Export policy".

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -92,7 +92,7 @@ _Doesn't inherit any properties._
   - : Returns the build identifier of the browser. In modern browsers this property now returns a fixed timestamp as a privacy measure, e.g. `20181001000000` in Firefox 64 onwards.
 - {{domxref("Navigator.contacts")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref('ContactsManager')}} interface which allows users to select entries from their contact list and share limited details of the selected entries with a website or application.
-- {{domxref("Navigator.globalPrivacyControl")}} {{ReadOnlyInline}}{{Non-standard_Inline}} {{Experimental_Inline}}
+- {{domxref("Navigator.globalPrivacyControl")}} {{ReadOnlyInline}} {{Non-standard_Inline}} {{Experimental_Inline}}
   - : Returns a boolean indicating a user's consent to their information being shared or sold.
 - {{domxref("Navigator.securitypolicy")}} {{Non-standard_Inline}}
   - : Returns an empty string. In Netscape 4.7x, returns "US & CA domestic policy" or "Export policy".

--- a/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
@@ -1,17 +1,17 @@
 ---
-title: "Navigator: globalPrivacyControl property"
+title: "WorkerNavigator: globalPrivacyControl property"
 short-title: globalPrivacyControl
-slug: Web/API/Navigator/globalPrivacyControl
+slug: Web/API/WorkerNavigator/globalPrivacyControl
 page-type: web-api-instance-property
 status:
   - experimental
   - non-standard
-browser-compat: api.Navigator.globalPrivacyControl
+browser-compat: api.WorkerNavigator.globalPrivacyControl
 ---
 
 {{APIRef("DOM")}}{{SeeCompatTable}}{{Non-standard_header}}
 
-The **`Navigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting. This setting indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+The **`WorkerNavigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting. This setting indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
 
 The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP header.
 

--- a/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
@@ -18,17 +18,14 @@ The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP he
 
 ## Value
 
-- `1`
-  - : User _does not_ provide consent to sell or share their data.
-- `0`
-  - : User either _does_ provide consent to sell or share their data, or has not indicated a preference.
+`true` if the user explicitly _does not_ grant consent to sell or share their data.
+`false` if the user either grants consent, or has not indicated a preference.
 
 ## Example
 
 ```js
 console.log(navigator.globalPrivacyControl);
-// prints "1" indicating user does not want their data shared or sold.
-// prints "0" if the user either consents or has not indicated a preference.
+// "true" if the user has specifically indicated they do not want their data shared or sold, otherwise "false".
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/workernavigator/globalprivacycontrol/index.md
@@ -11,7 +11,8 @@ browser-compat: api.WorkerNavigator.globalPrivacyControl
 
 {{APIRef("DOM")}}{{SeeCompatTable}}{{Non-standard_header}}
 
-The **`WorkerNavigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting. This setting indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+The **`WorkerNavigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting for the current website.
+This setting indicates whether the user consents to the website or service selling or sharing their personal information with third parties.
 
 The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP header.
 
@@ -27,8 +28,7 @@ The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP he
 ```js
 console.log(navigator.globalPrivacyControl);
 // prints "1" indicating user does not want their data shared or sold.
-// prints "0" if the user consents to their data being shared or sold.
-// prints "unspecified" if Sec-GPC header is not present.
+// prints "0" if the user either consents or has not indicated a preference.
 ```
 
 ## Specifications
@@ -43,5 +43,5 @@ console.log(navigator.globalPrivacyControl);
 
 - {{HTTPHeader("Sec-GPC")}} header
 - [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Global Privacy Control Spec](https://globalprivacycontrol.github.io/gpc-spec/)
+- [Global Privacy Control Spec](https://privacycg.github.io/gpc-spec/)
 - [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)

--- a/files/en-us/web/api/workernavigator/index.md
+++ b/files/en-us/web/api/workernavigator/index.md
@@ -21,6 +21,8 @@ _The `WorkerNavigator` interface doesn't inherit any property._
   - : Returns the version of the browser as a string. Do not rely on this property to return the correct value.
 - {{DOMxRef("WorkerNavigator.connection")}} {{ReadOnlyInline}}
   - : Provides a {{DOMxRef("NetworkInformation")}} object containing information about the network connection of a device.
+- {{domxref("WorkerNavigator.globalPrivacyControl")}} {{ReadOnlyInline}} {{Non-standard_Inline}} {{Experimental_Inline}}
+  - : Returns a boolean indicating a user's consent to their information being shared or sold.
 - {{domxref("WorkerNavigator.gpu")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the {{domxref("GPU")}} object for the current worker context. The entry point for the {{domxref("WebGPU_API", "WebGPU API", "", "nocode")}}.
 - {{DOMxRef("WorkerNavigator.hardwareConcurrency")}} {{ReadOnlyInline}}

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -234,6 +234,11 @@ _Learn more about CORS [here](/en-US/docs/Glossary/CORS)._
 - {{HTTPHeader("Via")}}
   - : Added by proxies, both forward and reverse proxies, and can appear in the request headers and the response headers.
 
+## Privacy
+
+- {{HTTPHeader("Sec-GPC")}} {{non-standard_inline}}{{experimental_inline}}
+  - : Indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+
 ## Redirects
 
 - {{HTTPHeader("Location")}}

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -4,12 +4,16 @@ slug: Web/HTTP/Headers/Sec-GPC
 page-type: http-header
 status:
   - experimental
+  - non-standard
 browser-compat: http.headers.Sec-GPC
 ---
 
-{{HTTPSidebar}}{{SeeCompatTable}}
+{{HTTPSidebar}}{{SeeCompatTable}}{{Non-standard_header}}
 
 The **`Sec-GPC`** (**G**lobal **P**rivacy **C**ontrol) request header indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+
+> **Note:** The specification does not define how the user can withdraw or grant consent.
+> Where possible the mechanism will be indicated in the [browser compatibility](#browser_compatibility) section below.
 
 <table class="properties">
   <tbody>
@@ -32,13 +36,15 @@ Sec-GPC: 1
 
 ## Directives
 
-If `Sec-GPC` is enabled the header is sent with a value of `1` indicating the user prefers their information not be shared with or sold to third parties. Otherwise, the header is not sent to indicate the user has not made a decision or the user is okay with their information being shared with or sold to third parties.
+The `Sec-GPC` is header is sent with a value of `1` if the user has indicated that they prefer their information not be shared with, or sold to, third parties.
+
+Otherwise, the header is not sent, which indicates that either the user has not made a decision or the user is okay with their information being shared with or sold to third parties.
 
 ## Examples
 
 ### Reading Global Privacy Control status from JavaScript
 
-The user's GPC preference can also be read from JavaScript using the {{domxref("Navigator.globalPrivacyControl")}} property:
+The user's GPC preference can also be read from JavaScript using the {{domxref("Navigator.globalPrivacyControl")}} or {{domxref("WorkerNavigator.globalPrivacyControl")}} property:
 
 ```js
 navigator.globalPrivacyControl; // "0" or "1"

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -12,8 +12,8 @@ browser-compat: http.headers.Sec-GPC
 
 The **`Sec-GPC`** (**G**lobal **P**rivacy **C**ontrol) request header indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
 
-> **Note:** The specification does not define how the user can withdraw or grant consent.
-> Where possible the mechanism will be indicated in the [browser compatibility](#browser_compatibility) section below.
+The specification does not define how the user can withdraw or grant consent.
+Where possible the mechanism will be indicated in the [browser compatibility](#browser_compatibility) section below.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -12,7 +12,7 @@ browser-compat: http.headers.Sec-GPC
 
 The **`Sec-GPC`** (**G**lobal **P**rivacy **C**ontrol) request header indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
 
-The specification does not define how the user can withdraw or grant consent.
+The specification does not define how the user can withdraw or grant consent for website.
 Where possible the mechanism will be indicated in the [browser compatibility](#browser_compatibility) section below.
 
 <table class="properties">


### PR DESCRIPTION
This adds the global privacy control API `WorkerNavigator.globalPrivacyControl` and updates `Navigator.globalPrivacyControl` . It also updates the `Sec-GPC` HTTP header.

This is part of work for FF118 in #28854