### PR TITLE
Fix missing link to Storage API

### DIFF
--- a/files/en-us/web/api/storagemanager/estimate/index.md
+++ b/files/en-us/web/api/storagemanager/estimate/index.md
@@ -81,7 +81,7 @@ navigator.storage.estimate().then((estimate) => {
 
 ## See also
 
-- Storage API
+- [Storage API](/en-US/docs/Web/API/Storage_API)
 - {{domxref("Storage")}}, the object returned by {{domxref("Window.localStorage")}}
 - {{domxref("StorageManager")}}
 - {{domxref("navigator.storage")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I found a missing link to the "Storage API" page in the "See also" section of [`StorageManager.estimate`](
https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I believe the linking is useful for most people.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
No details.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

No issues or pull requests.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
