### PR TITLE
Fix broken link to Array.at within Array.with

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/with/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/with/index.md
@@ -37,7 +37,7 @@ A new array with the element at `index` replaced with `value`.
 
 The `with()` method changes the value of a given index in the array, returning a new array with the element at the given index replaced with the given value. The original array is not modified. This allows you to chain array methods while doing manipulations.
 
-By combining `with()` with {{jsxref("Arra/at", "at()")}}, you can both write and read (respectively) an array using negative indices.
+By combining `with()` with {{jsxref("Array/at", "at()")}}, you can both write and read (respectively) an array using negative indices.
 
 The `with()` method never produces a [sparse array](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays). If the source array is sparse, the empty slots will be replaced with `undefined` in the new array.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
<!-- ✍️ Summarize your changes in one or two sentences -->

Small fix for a broken link to `Array.prototype.at` on the `Array.prototype.with` page that was added in #29099. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Link already exists and passed review, just fixing the link here.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
