### PR TITLE
Add deprecated/non-standard badges

### DIFF
--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -18,7 +18,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### A
 
-- {{MathMLElement("maction")}} (Bound actions to sub-expressions)  {{deprecated_inline}}
+- {{MathMLElement("maction")}} (Bound actions to sub-expressions) {{deprecated_inline}}
 - {{MathMLElement("annotation")}} (Data annotations)
 - {{MathMLElement("annotation-xml")}} (XML annotations)
 
@@ -29,7 +29,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### F
 
-- {{MathMLElement("mfenced")}} (Parentheses)  {{non-standard_inline}}{{deprecated_inline}}
+- {{MathMLElement("mfenced")}} (Parentheses) {{non-standard_inline}}{{deprecated_inline}}
 - {{MathMLElement("mfrac")}} (Fraction)
 
 ### I

--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -18,18 +18,18 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### A
 
-- {{MathMLElement("maction")}} (Bound actions to sub-expressions)
+- {{MathMLElement("maction")}} (Bound actions to sub-expressions)  {{deprecated_inline}}
 - {{MathMLElement("annotation")}} (Data annotations)
 - {{MathMLElement("annotation-xml")}} (XML annotations)
 
 ### E
 
-- {{MathMLElement("menclose")}} (Enclosed contents)
+- {{MathMLElement("menclose")}} (Enclosed contents) {{non-standard_inline}}
 - {{MathMLElement("merror")}} (Enclosed syntax error messages)
 
 ### F
 
-- {{MathMLElement("mfenced")}} (Parentheses) {{deprecated_inline}}
+- {{MathMLElement("mfenced")}} (Parentheses)  {{non-standard_inline}}{{deprecated_inline}}
 - {{MathMLElement("mfrac")}} (Fraction)
 
 ### I

--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -29,7 +29,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### F
 
-- {{MathMLElement("mfenced")}} (Parentheses) {{non-standard_inline}}{{deprecated_inline}}
+- {{MathMLElement("mfenced")}} (Parentheses) {{non-standard_inline}} {{deprecated_inline}}
 - {{MathMLElement("mfrac")}} (Fraction)
 
 ### I


### PR DESCRIPTION
# Update MathML element reference page

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

## Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added some inline deprecated and non-standard annotations.

After opening some pages, I noticed that some elements were deprecated and/or non-standard, but it wasn't always mentioned in [this article](https://developer.mozilla.org/en-US/docs/Web/MathML/Element)

## Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

They help developers know deprecated and non-standard elements in [this article](https://developer.mozilla.org/en-US/docs/Web/MathML/Element) with a glance without opening the article of those elements.
