### PR TITLE
fix fetch parameter

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -207,7 +207,7 @@ button.addEventListener("click", () => aborter.abort());
 logChunks("http://example.com/somefile.txt", { signal: aborter.signal });
 
 async function logChunks(url, { signal }) {
-  const response = await fetch(url, signal);
+  const response = await fetch(url, { signal });
   for await (const chunk of response.body) {
     // Do something with the chunk
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The second parameter of `fetch` must be an object
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Fix a non-working example
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Source

https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal