### PR TITLE
Fix types for Touch.clientX/clientY/pageX/PageY

### DIFF
--- a/files/en-us/web/api/touch/clientx/index.md
+++ b/files/en-us/web/api/touch/clientx/index.md
@@ -13,8 +13,8 @@ point relative to the viewport, not including any scroll offset.
 
 ## Value
 
-A `long` representing the X coordinate of the touch point relative to the
-viewport, not including any scroll offset.
+A `double` floating point value representing the X coordinate of the touch point
+relative to the viewport, not including any scroll offset.
 
 ## Examples
 

--- a/files/en-us/web/api/touch/clienty/index.md
+++ b/files/en-us/web/api/touch/clienty/index.md
@@ -14,8 +14,8 @@ scroll offset.
 
 ## Value
 
-A `long` value representing the Y coordinate of the touch point relative to
-the viewport, not including any scroll offset.
+A `double` floating point value representing the Y coordinate of the touch point
+relative to the viewport, not including any scroll offset.
 
 ## Examples
 

--- a/files/en-us/web/api/touch/pagex/index.md
+++ b/files/en-us/web/api/touch/pagex/index.md
@@ -13,8 +13,8 @@ coordinate of the touch point relative to the viewport, including any scroll off
 
 ## Value
 
-A `long` representing the X coordinate of the touch point relative to the
-viewport, including any scroll offset.
+A `double` floating point value representing the X coordinate of the touch point
+relative to the viewport, including any scroll offset.
 
 ## Examples
 

--- a/files/en-us/web/api/touch/pagey/index.md
+++ b/files/en-us/web/api/touch/pagey/index.md
@@ -13,8 +13,8 @@ coordinate of the touch point relative to the viewport, including any scroll off
 
 ## Value
 
-A `long` value that represents the Y coordinate of the touch point relative
-to the viewport, including any scroll offset.
+A `double` floating point value representing the Y coordinate of the touch point
+relative to the viewport, including any scroll offset.
 
 ## Examples
 


### PR DESCRIPTION
IIUC these were updated here but not reflected in MND: 
https://github.com/w3c/touch-events/commit/006274ffada14de504f731afdb5ec1581ff327ca