### PR TITLE
Corrected example snippet to match cited source

### DIFF
--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -40,7 +40,7 @@ elliptical corners; this solution gives you nice square corners that scale with 
 size.
 
 ```js
-const resizeObserver = new ResizeObserver(entries => {
+const resizeObserver = new ResizeObserver((entries) => {
   for (let entry of entries) {
     if (entry.contentBoxSize) {
       // The standard makes contentBoxSize an array...

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -63,7 +63,7 @@ const resizeObserver = new ResizeObserver((entries) => {
   }
 });
 
-resizeObserver.observe(document.querySelector('div'));
+resizeObserver.observe(document.querySelector("div"));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -61,8 +61,11 @@ const resizeObserver = new ResizeObserver((entries) => {
           ) + "px";
       }
     } else {
-      entry.target.style.borderRadius = Math.min(100, (entry.contentRect.width/10) +
-                                                      (entry.contentRect.height/10)) + 'px';
+      entry.target.style.borderRadius =
+        Math.min(
+          100,
+          entry.contentRect.width / 10 + entry.contentRect.height / 10,
+        ) + "px";
     }
   }
 });

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -53,8 +53,12 @@ const resizeObserver = new ResizeObserver((entries) => {
           ) + "px";
       } else {
         // ...but old versions of Firefox treat it as a single item
-        entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +
-                                                        (entry.contentBoxSize.blockSize/10)) + 'px';
+        entry.target.style.borderRadius =
+          Math.min(
+            100,
+            entry.contentBoxSize.inlineSize / 10 +
+              entry.contentBoxSize.blockSize / 10,
+          ) + "px";
       }
     } else {
       entry.target.style.borderRadius = Math.min(100, (entry.contentRect.width/10) +

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -40,26 +40,26 @@ elliptical corners; this solution gives you nice square corners that scale with 
 size.
 
 ```js
-const resizeObserver = new ResizeObserver((entries) => {
-  const calcBorderRadius = (size1, size2) =>
-    `${Math.min(100, size1 / 10 + size2 / 10)}px`;
-
-  for (const entry of entries) {
-    if (entry.borderBoxSize?.length > 0) {
-      entry.target.style.borderRadius = calcBorderRadius(
-        entry.borderBoxSize[0].inlineSize,
-        entry.borderBoxSize[0].blockSize,
-      );
+const resizeObserver = new ResizeObserver(entries => {
+  for (let entry of entries) {
+    if (entry.contentBoxSize) {
+      // The standard makes contentBoxSize an array...
+      if (entry.contentBoxSize[0]) {
+        entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize[0].inlineSize/10) +
+                                                        (entry.contentBoxSize[0].blockSize/10)) + 'px';
+      } else {
+        // ...but old versions of Firefox treat it as a single item
+        entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +
+                                                        (entry.contentBoxSize.blockSize/10)) + 'px';
+      }
     } else {
-      entry.target.style.borderRadius = calcBorderRadius(
-        entry.contentRect.width,
-        entry.contentRect.height,
-      );
+      entry.target.style.borderRadius = Math.min(100, (entry.contentRect.width/10) +
+                                                      (entry.contentRect.height/10)) + 'px';
     }
   }
 });
 
-resizeObserver.observe(document.querySelector("div"));
+resizeObserver.observe(document.querySelector('div'));
 ```
 
 ## Specifications

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -45,8 +45,12 @@ const resizeObserver = new ResizeObserver((entries) => {
     if (entry.contentBoxSize) {
       // The standard makes contentBoxSize an array...
       if (entry.contentBoxSize[0]) {
-        entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize[0].inlineSize/10) +
-                                                        (entry.contentBoxSize[0].blockSize/10)) + 'px';
+        entry.target.style.borderRadius =
+          Math.min(
+            100,
+            entry.contentBoxSize[0].inlineSize / 10 +
+              entry.contentBoxSize[0].blockSize / 10,
+          ) + "px";
       } else {
         // ...but old versions of Firefox treat it as a single item
         entry.target.style.borderRadius = Math.min(100, (entry.contentBoxSize.inlineSize/10) +


### PR DESCRIPTION
The example snippet was taken from the borderBoxSize demo, and didn't contain any reference to the contentBoxSize property

This snippet is taken from the cited source, and should provide the desired code that was mistakenly unreferenced

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Noticed that the example referenced didn't actually have anything to do with the cited example or the property the page as about

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Changed the example to correctly display the desired example
Cited example is now taken from [this source](https://github.com/mdn/dom-examples/blob/main/resize-observer/resize-observer-border-radius.html#L29-L48)

Fix https://github.com/mdn/content/issues/25364

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
