### PR TITLE
Node/removeChild example throws an error

### DIFF
--- a/files/en-us/web/api/node/removechild/index.md
+++ b/files/en-us/web/api/node/removechild/index.md
@@ -84,11 +84,11 @@ while (element.firstChild) {
 ```
 
 ```js
-let top = document.getElementById("top");
-let nested = document.getElementById("nested");
+let d = document.getElementById("top");
+let d_nested = document.getElementById("nested");
 
 // Throws Uncaught TypeError
-let garbage = top.removeChild(nested);
+let garbage = d.removeChild(d_nested);
 ```
 
 ### Causing a NotFoundError
@@ -101,14 +101,14 @@ let garbage = top.removeChild(nested);
 ```
 
 ```js
-let top = document.getElementById("top");
-let nested = document.getElementById("nested");
+let d = document.getElementById("top");
+let d_nested = document.getElementById("nested");
 
 // This first call correctly removes the node
-let garbage = top.removeChild(nested);
+let garbage = d.removeChild(d_nested);
 
 // Throws NotFoundError
-garbage = top.removeChild(nested);
+garbage = d.removeChild(d_nested);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/node/removechild/index.md
+++ b/files/en-us/web/api/node/removechild/index.md
@@ -88,7 +88,7 @@ let parent = document.getElementById("parent");
 let child = document.getElementById("child");
 
 // Throws Uncaught TypeError
-let garbage = d.removeChild(child);
+let garbage = parent.removeChild(child);
 ```
 
 ### Causing a NotFoundError

--- a/files/en-us/web/api/node/removechild/index.md
+++ b/files/en-us/web/api/node/removechild/index.md
@@ -45,23 +45,23 @@ removeChild(child)
 Given this HTML:
 
 ```html
-<div id="top">
-  <div id="nested"></div>
+<div id="parent">
+  <div id="child"></div>
 </div>
 ```
 
 To remove a specified element when knowing its parent node:
 
 ```js
-let d = document.getElementById("top");
-let d_nested = document.getElementById("nested");
-let throwawayNode = d.removeChild(d_nested);
+let parent = document.getElementById("parent");
+let child = document.getElementById("child");
+let throwawayNode = parent.removeChild(child);
 ```
 
 To remove a specified element without having to specify its parent node:
 
 ```js
-let node = document.getElementById("nested");
+let node = document.getElementById("child");
 if (node.parentNode) {
   node.parentNode.removeChild(node);
 }
@@ -80,35 +80,35 @@ while (element.firstChild) {
 
 ```html
 <!--Sample HTML code-->
-<div id="top"></div>
+<div id="parent"></div>
 ```
 
 ```js
-let d = document.getElementById("top");
-let d_nested = document.getElementById("nested");
+let parent = document.getElementById("parent");
+let child = document.getElementById("child");
 
 // Throws Uncaught TypeError
-let garbage = d.removeChild(d_nested);
+let garbage = d.removeChild(child);
 ```
 
 ### Causing a NotFoundError
 
 ```html
 <!--Sample HTML code-->
-<div id="top">
-  <div id="nested"></div>
+<div id="parent">
+  <div id="child"></div>
 </div>
 ```
 
 ```js
-let d = document.getElementById("top");
-let d_nested = document.getElementById("nested");
+let parent = document.getElementById("parent");
+let child = document.getElementById("child");
 
 // This first call correctly removes the node
-let garbage = d.removeChild(d_nested);
+let garbage = parent.removeChild(child);
 
 // Throws NotFoundError
-garbage = d.removeChild(d_nested);
+garbage = parent.removeChild(child);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/node/removechild/index.md
+++ b/files/en-us/web/api/node/removechild/index.md
@@ -53,15 +53,15 @@ Given this HTML:
 To remove a specified element when knowing its parent node:
 
 ```js
-let parent = document.getElementById("parent");
-let child = document.getElementById("child");
-let throwawayNode = parent.removeChild(child);
+const parent = document.getElementById("parent");
+const child = document.getElementById("child");
+const throwawayNode = parent.removeChild(child);
 ```
 
 To remove a specified element without having to specify its parent node:
 
 ```js
-let node = document.getElementById("child");
+const node = document.getElementById("child");
 if (node.parentNode) {
   node.parentNode.removeChild(node);
 }
@@ -70,7 +70,7 @@ if (node.parentNode) {
 To remove all children from an element:
 
 ```js
-let element = document.getElementById("idOfParent");
+const element = document.getElementById("idOfParent");
 while (element.firstChild) {
   element.removeChild(element.firstChild);
 }
@@ -84,11 +84,11 @@ while (element.firstChild) {
 ```
 
 ```js
-let parent = document.getElementById("parent");
-let child = document.getElementById("child");
+const parent = document.getElementById("parent");
+const child = document.getElementById("child");
 
 // Throws Uncaught TypeError
-let garbage = parent.removeChild(child);
+const garbage = parent.removeChild(child);
 ```
 
 ### Causing a NotFoundError
@@ -101,11 +101,11 @@ let garbage = parent.removeChild(child);
 ```
 
 ```js
-let parent = document.getElementById("parent");
-let child = document.getElementById("child");
+const parent = document.getElementById("parent");
+const child = document.getElementById("child");
 
 // This first call correctly removes the node
-let garbage = parent.removeChild(child);
+const garbage = parent.removeChild(child);
 
 // Throws NotFoundError
 garbage = parent.removeChild(child);


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

You cannot redeclare global "top" variable

I changed to the first example names

### Motivation

When someone try to use the code it throws an error

### Additional details

Firefox error:
```
Uncaught SyntaxError: redeclaration of non-configurable global property top
```

Brave error:
```
Uncaught SyntaxError: Identifier 'top' has already been declared
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
