### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/css/scroll-snap-type/index.md
+++ b/files/en-us/web/css/scroll-snap-type/index.md
@@ -172,11 +172,11 @@ scroll-snap-type: unset;
 .x.mandatory-scroll-snapping {
   scroll-snap-type: x mandatory;
 }
-.y.mandatory-scroll-snapping {
-  scroll-snap-type: y mandatory;
-}
 .x.proximity-scroll-snapping {
   scroll-snap-type: x proximity;
+}
+.y.mandatory-scroll-snapping {
+  scroll-snap-type: y mandatory;
 }
 .y.proximity-scroll-snapping {
   scroll-snap-type: y proximity;


### PR DESCRIPTION
reorder css classes to match the html order and results preview of generated code

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The css order to describe the scrolls does not match the html order nor the images making it a little confusing.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

confused me for a sec, this will help other readers that might get confused with this
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Docs link https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type#examples
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fix #29217


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
