### PR TITLE
Remove whitespace inside of parentheses

### DIFF
--- a/files/en-us/web/css/css_selectors/selectors_and_combinators/index.md
+++ b/files/en-us/web/css/css_selectors/selectors_and_combinators/index.md
@@ -78,7 +78,7 @@ The [adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinato
 
 ### Column combinator
 
-There is also a [column combinator](/en-US/docs/Web/CSS/Column_combinator), denoted by two pipe characters ( `||`), which, when supported, selects nodes that belong to a column. For example, `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
+There is also a [column combinator](/en-US/docs/Web/CSS/Column_combinator), denoted by two pipe characters (`||`), which, when supported, selects nodes that belong to a column. For example, `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
 
 ### Namespace separator
 


### PR DESCRIPTION
### Description

I have removed unnecessary whitespace inside parentheses in the [MDN Web Docs paragraph](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors/Selectors_and_combinators#column_combinator) related to the "Column combinator." Specifically, I updated the text to read as follows:

Before:
```markdown
There is also a [column combinator](/en-US/docs/Web/CSS/Column_combinator), denoted by two pipe characters ( `||`), which, when supported, selects nodes that belong to a column. For example, `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
```

After:
```markdown
There is also a [column combinator](/en-US/docs/Web/CSS/Column_combinator), denoted by two pipe characters (`||`), which, when supported, selects nodes that belong to a column. For example, `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
```

### Motivation

This change improves readability and consistency in the documentation by removing unnecessary whitespace inside parentheses.

### Additional details

None.

### Related issues and pull requests

None.
