### PR TITLE
`Worker.postMessage` also support passing an `options` param

### DIFF
--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -18,6 +18,7 @@ The `Worker` can send back information to the thread that spawned it using the {
 
 ```js-nolint
 postMessage(message)
+postMessage(message, options)
 postMessage(message, transfer)
 ```
 
@@ -28,6 +29,10 @@ postMessage(message, transfer)
   - : The object to deliver to the worker; this will be in the `data` field in the event delivered to the {{domxref("DedicatedWorkerGlobalScope.message_event")}} event. This may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
 
     If the `message` parameter is _not_ provided, a {{jsxref("SyntaxError")}} will be thrown by the parser. If the data to be passed to the worker is unimportant, `null` or `undefined` can be passed explicitly.
+
+- `options` {{optional_inline}}
+
+  - : An optional object containing a `transfer` field with an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.
 
 - `transfer` {{optional_inline}}
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -32,7 +32,7 @@ postMessage(message, transfer)
 
 - `options` {{optional_inline}}
 
-  - : An optional object containing a `transfer` field with an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and becomes available only to the worker it was sent to.
+  - : An optional object containing a `transfer` field with an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from, and becomes available only to the worker it was sent to.
 
 - `transfer` {{optional_inline}}
 


### PR DESCRIPTION
### Description

`Worker.postMessage` can also support passing an `options` param

### Motivation

Ditto.

### Additional details

https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage-dev

![image](https://github.com/mdn/content/assets/95597335/44681594-d0a3-4171-be36-124c4feb6347)

https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage

### Related issues and pull requests

Related to #25342 

Related to #29187 
