### PR TITLE
`DedicatedWorkerGlobalScope.postMessage` also support passing an options param

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -38,7 +38,7 @@ postMessage(message, transfer)
 
   - : An optional object containing a `transfer` field with an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.
 
-- `transferList` {{optional_inline}}
+- `transfer` {{optional_inline}}
 
   - : An optional ordered [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of.
     If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -22,14 +22,22 @@ The main scope that spawned the worker can send back information to the thread t
 ## Syntax
 
 ```js-nolint
-postMessage(message, transferList)
+postMessage(message)
+postMessage(options)
+postMessage(message, transfer)
 ```
 
 ### Parameters
 
 - `message`
+
   - : The object to deliver to the main thread; this will be in the data field in the event delivered to the {{domxref("Worker.message_event")}}.
     This may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
+
+- `options` {{optional_inline}}
+
+  - : An optional object containing a `transfer` field with an [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of. If the ownership of an object is transferred, it becomes unusable in the context it was sent from and it becomes available only to the main thread it was sent to.
+
 - `transferList` {{optional_inline}}
 
   - : An optional ordered [array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of.


### PR DESCRIPTION
### Description

`DedicatedWorkerGlobalScope.postMessage` can also support passing an `options` param

### Motivation

Ditto.

### Additional details

https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-postmessage-dev

![image](https://github.com/mdn/content/assets/95597335/9b52f9c9-1e88-4f64-82d0-50bf58f4c8b9)

https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/postMessage

https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage

### Related issues and pull requests

Related to #25342

Related to #29187 
