### PR TITLE
Fix typo in canvas documentation

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/contextlost_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/contextlost_event/index.md
@@ -14,7 +14,7 @@ The **`contextlost`** event of the [Canvas API](/en-US/docs/Web/API/Canvas_API) 
 Contexts can be lost for several reasons like driver crashes or the application runs out of memory, etc.
 
 By default the user agent will attempt to restore the context and then fire the [`contextrestored` event](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event).
-User code can the context from being restored by calling [`Event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault) during event handling.
+User code can prevent the context from being restored by calling [`Event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault) during event handling.
 
 ## Syntax
 


### PR DESCRIPTION
Fix typo in canvas documentation. Sentence is confusing with missing word.
