### PR TITLE
Fix using readable byte streams

### DIFF
--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -448,7 +448,7 @@ class MockUnderlyingFileHandle {
       for (let i = 0; i < length; i++) {
         myview[i] = this.filedata[position + i];
         resultobj["bytesRead"] = i + 1;
-        if (position + i >= this.maxdata) {
+        if (position + i + 1 >= this.maxdata) {
           break;
         }
       }
@@ -698,7 +698,7 @@ class MockUnderlyingFileHandle {
       for (let i = 0; i < length; i++) {
         myview[i] = this.filedata[position + i];
         resultobj["bytesRead"] = i + 1;
-        if (position + i >= this.maxdata) {
+        if (position + i + 1 >= this.maxdata) {
           break;
         }
       }
@@ -924,7 +924,7 @@ class MockUnderlyingFileHandle {
       for (let i = 0; i < length; i++) {
         myview[i] = this.filedata[position + i];
         resultobj["bytesRead"] = i + 1;
-        if (position + i >= this.maxdata) {
+        if (position + i + 1 >= this.maxdata) {
           break;
         }
       }

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -423,7 +423,7 @@ The `close()` method does nothing: it is only provided to show where you might c
 ```js
 class MockUnderlyingFileHandle {
   constructor() {
-    this.maxdata = 1300; // "file size"
+    this.maxdata = 100; // "file size"
     this.filedata = this.randomByteArray(this.maxdata);
     this.position = 0;
   }
@@ -573,8 +573,8 @@ function makeReadableByteFileStream(filename) {
       const theView = controller.byobRequest.view;
       const { bytesRead, buffer } = await fileHandle.read(
         theView.buffer,
-        theView.offset,
-        theView.length,
+        theView.byteOffset,
+        theView.byteLength,
         position,
       );
       if (bytesRead === 0) {
@@ -608,7 +608,7 @@ When the underlying source signals that it has no more data, the `reader.read()`
 
 ```js
 const reader = stream.getReader({ mode: "byob" });
-let buffer = new ArrayBuffer(4000);
+let buffer = new ArrayBuffer(200);
 readStream(reader);
 
 function readStream(reader) {
@@ -809,8 +809,8 @@ function makeReadableByteFileStream(filename) {
       const theView = controller.byobRequest.view;
       const { bytesRead, buffer } = await fileHandle.read(
         theView.buffer,
-        theView.offset,
-        theView.length,
+        theView.byteOffset,
+        theView.byteLength,
         position,
       );
       if (bytesRead === 0) {
@@ -1038,8 +1038,8 @@ function makeReadableByteFileStream(filename) {
         const theView = controller.byobRequest.view;
         const { bytesRead, buffer } = await fileHandle.read(
           theView.buffer,
-          theView.offset,
-          theView.length,
+          theView.byteOffset,
+          theView.byteLength,
           position,
         );
         if (bytesRead === 0) {
@@ -1060,8 +1060,8 @@ function makeReadableByteFileStream(filename) {
         const mynewBuffer = new Uint8Array(DEFAULT_CHUNK_SIZE);
         const { bytesRead, buffer } = await fileHandle.read(
           mynewBuffer.buffer,
-          mynewBuffer.offset,
-          mynewBuffer.length,
+          mynewBuffer.byteOffset,
+          mynewBuffer.byteLength,
           position,
         );
         if (bytesRead === 0) {

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -615,33 +615,31 @@ function readStream(reader) {
   let bytesReceived = 0;
   let offset = 0;
 
-  while (offset < buffer.byteLength) {
-    // read() returns a promise that resolves when a value has been received
-    reader
-      .read(new Uint8Array(buffer, offset, buffer.byteLength - offset))
-      .then(function processText({ done, value }) {
-        // Result objects contain two properties:
-        // done  - true if the stream has already given all its data.
-        // value - some data. Always undefined when done is true.
+  // read() returns a promise that resolves when a value has been received
+  reader
+    .read(new Uint8Array(buffer, offset, buffer.byteLength - offset))
+    .then(function processText({ done, value }) {
+      // Result objects contain two properties:
+      // done  - true if the stream has already given all its data.
+      // value - some data. Always undefined when done is true.
 
-        if (done) {
-          logConsumer(`readStream() complete. Total bytes: ${bytesReceived}`);
-          return;
-        }
+      if (done) {
+        logConsumer(`readStream() complete. Total bytes: ${bytesReceived}`);
+        return;
+      }
 
-        buffer = value.buffer;
-        offset += value.byteLength;
-        bytesReceived += value.byteLength;
+      buffer = value.buffer;
+      offset += value.byteLength;
+      bytesReceived += value.byteLength;
 
-        logConsumer(`Read ${bytesReceived} bytes: ${value}`);
-        result += value;
+      logConsumer(`Read ${bytesReceived} bytes: ${value}`);
+      result += value;
 
-        // Read some more, and call this function again
-        return reader
-          .read(new Uint8Array(buffer, offset, buffer.byteLength - offset))
-          .then(processText);
-      });
-  }
+      // Read some more, and call this function again
+      return reader
+        .read(new Uint8Array(buffer, offset, buffer.byteLength - offset))
+        .then(processText);
+    });
 }
 ```
 

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -447,7 +447,7 @@ class MockUnderlyingFileHandle {
       // Write the length of data specified
       for (let i = 0; i < length; i++) {
         myview[i] = this.filedata[position + i];
-        resultobj["bytesRead"] = i;
+        resultobj["bytesRead"] = i + 1;
         if (position + i >= this.maxdata) {
           break;
         }
@@ -697,7 +697,7 @@ class MockUnderlyingFileHandle {
       // Write the length of data specified
       for (let i = 0; i < length; i++) {
         myview[i] = this.filedata[position + i];
-        resultobj["bytesRead"] = i;
+        resultobj["bytesRead"] = i + 1;
         if (position + i >= this.maxdata) {
           break;
         }
@@ -923,7 +923,7 @@ class MockUnderlyingFileHandle {
       // Write the length of data specified
       for (let i = 0; i < length; i++) {
         myview[i] = this.filedata[position + i];
-        resultobj["bytesRead"] = i;
+        resultobj["bytesRead"] = i + 1;
         if (position + i >= this.maxdata) {
           break;
         }


### PR DESCRIPTION
Fixes #28954

This fixes errors in the live example
- mocked source was reporting one value less than it was sending
- The readable byte stream was passing the wrong variables for buffer size and offsets. It only worked because everything gets copied in one buffer, and for the first calculation this all evaluates as undefined and then to zero.
- The consumer had a sync while loop around promise based code, that would have blocked the promises. It only worked by luck and isn't needed. 

In addition I changed the mocked source so that it can't magically fill whatever buffer is supplied - but will fill with some random size of data. That's a bit more realistic and means that it tests the examples end to end (they weren't assuming fixed size source data, but nor were they tested for it).

Lastly, I have copied the now-tested source into `ReadableStreamBYOBReader`. I think we're goo. 
