### PR TITLE
Update example code: remove unnecessary condition

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
@@ -218,10 +218,9 @@ self.addEventListener("fetch", (event) => {
       if (cachedResponse) {
         // Return the cached response if it's available.
         return cachedResponse;
-      } else {
-        // Respond with a HTTP 404 response status.
-        return new Response(null, { status: 404 });
       }
+      // Respond with a HTTP 404 response status.
+      return new Response(null, { status: 404 });
     })(),
   );
 });
@@ -291,10 +290,9 @@ self.addEventListener("fetch", (event) => {
       if (cachedResponse) {
         // Return the cached response if it's available.
         return cachedResponse;
-      } else {
-        // If resource isn't in the cache, return a 404.
-        return new Response(null, { status: 404 });
       }
+      // If resource isn't in the cache, return a 404.
+      return new Response(null, { status: 404 });
     })(),
   );
 });


### PR DESCRIPTION
Remove unnecessary `else` condition following `return early return often` from an example code provided in this great tutorial.

### Motivation

If an if block contains a return statement, the else block becomes unnecessary. Its contents can be placed outside of the block.

### Additional details

https://eslint.org/docs/latest/rules/no-else-return
