### PR TITLE
WebDriver conformance changes for Firefox 118

### DIFF
--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -67,9 +67,21 @@ This article provides information about the changes in Firefox 118 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
+#### General
+
+- Fixed an internal race condition for Android which caused the returned user prompt text to be empty for both WebDriver BiDi and Marionette ([Firefox bug 1848167](https://bugzil.la/1848167)).
+- Both the `WebDriver:PerformActions` command in Marionette and the `browsingContext.performActions` command in WebDriver BiDi failed to correctly scroll for a `wheel` input source in environments that have a high-resolution display connected ([Firefox bug 1849229](https://bugzil.la/1849229)).
+
 #### WebDriver BiDi
 
+- Added the [`browsingContext.activate`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-activate) command that allows users to bring the given background tab into foreground ([Firefox bug 1841004](https://bugzil.la/1841004)).
+- Added the [`browsingContext.handleUserPrompt`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-handleUserPrompt) command that allows users to accept or dismiss an open user prompt of type `alert`, `confirm`, or `prompt` ([Firefox bug 1824197](https://bugzil.la/1824197)).
+- Added the [`browsingContext.userPromptOpened`](https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptOpened) event which is emitted when a user prompt of type `alert`, `confirm`, or `prompt` was opened ([Firefox bug 1824224](https://bugzil.la/1824224)).
+- Added a `type` field to the JSON payload that is returned to clients to identify `event` messages, or the success state of a command, which can be one of `success` or `error` ([Firefox bug 1844009](https://bugzil.la/1844009)).
+
 #### Marionette
+
+- Added support for all the [`Web Authentication extension commands`](https://www.w3.org/TR/webauthn-2/#sctn-automation), which allow users to authenticate themselves by Public Key Credentials ([Firefox bug 1846574](https://bugzil.la/1846574))
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -81,7 +81,7 @@ This article provides information about the changes in Firefox 118 that affect d
 
 #### Marionette
 
-- Added support for all the [`Web Authentication extension commands`](https://www.w3.org/TR/webauthn-2/#sctn-automation), which allow users to authenticate themselves by Public Key Credentials ([Firefox bug 1846574](https://bugzil.la/1846574))
+- Added support for all the [Web Authentication extension commands](https://www.w3.org/TR/webauthn-2/#sctn-automation), which allow users to authenticate themselves by Public Key Credentials ([Firefox bug 1846574](https://bugzil.la/1846574))
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
These are [all the changes for WebDriver and Marionette](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox117&query_format=advanced&o1=equals&f1=cf_status_firefox118&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=16730451) for the upcoming Firefox 118 release.

@juliandescottes and @lutien can you please have a look? Thanks!