### PR TITLE
Fix mistake on Warning for Deep Clone section

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -94,7 +94,7 @@ console.log(obj1); // { a: 1, b: { c: 0 } }
 console.log(obj2); // { a: 2, b: { c: 0 } }
 
 obj2.b.c = 3;
-console.log(obj1); // { a: 1, b: { c: 3 } }
+console.log(obj1); // { a: 1, b: { c: 0 } }
 console.log(obj2); // { a: 2, b: { c: 3 } }
 
 // Deep Clone


### PR DESCRIPTION
### Description

There was a mistake on "[Warning for Deep Clone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#warning_for_deep_clone)" section.

obj1.b.c should be **0**.

### Motivation

Fix the mistake to the others don't get confused.

### Additional details

### Related issues and pull requests
