### PR TITLE
bytesToBase64 example: use String.fromCodePoint.apply

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -52,7 +52,7 @@ function base64ToBytes(base64) {
 }
 
 function bytesToBase64(bytes) {
-  const binString = String.fromCodePoint.apply(undefined, bytes);
+  const binString = String.fromCodePoint(...bytes);
   return btoa(binString);
 }
 

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -52,7 +52,7 @@ function base64ToBytes(base64) {
 }
 
 function bytesToBase64(bytes) {
-  const binString = Array.from(bytes, (x) => String.fromCodePoint(x)).join("");
+  const binString = String.fromCodePoint.apply(undefined, bytes);
   return btoa(binString);
 }
 


### PR DESCRIPTION
### Description

String.fromCodePoint already has rest parameters, so we can just call it with apply and pass the Uint8Array from the TextEncoder.encode.

### Motivation

I believe it looks more straightforward. Could be better for performance as well, but mostly easier to read.

### Additional details

Nothing to add.

### Related issues and pull requests

Nothing to add.