### PR TITLE
Fix: update to `Element.requestPointerLock()` due to "Pointer Lock 2.0"

### DIFF
--- a/files/en-us/web/api/element/requestpointerlock/index.md
+++ b/files/en-us/web/api/element/requestpointerlock/index.md
@@ -19,21 +19,15 @@ To track the success or failure of the request, it is necessary to listen for th
 
 ```js-nolint
 requestPointerLock()
-requestPointerLock(options)
 ```
 
 ### Parameters
 
-- `options` {{optional_inline}}
-  - : An options object that can contain the following properties:
-    - `unadjustedMovement` {{optional_inline}}
-      - : Disables OS-level adjustment for mouse acceleration, and accesses raw mouse input instead. The default value is `false`; setting it to `true` will disable mouse acceleration.
+None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}}.
-
-> **Note:** Some browsers do not yet support the promise version of `requestPointerLock()`, just the older synchronous version.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Update to `Element.requestPointerLock()` due to "Pointer Lock 2.0"

### Motivation

Since "Pointer Lock 2.0", `Element.requestPointerLock()` no longer return a promise and does not support passing an param; though some browsers still work as older ways

![image](https://github.com/mdn/content/assets/95597335/5a41b04d-ceee-490d-be05-caa51e4b4e80)

So, update thise description to standard way and add note to those not standard behavior

### Additional details

https://w3c.github.io/pointerlock/#extensions-to-the-element-interface

### Related issues and pull requests

For #11327 , it seems that Paragraph I has be updated and Paragraph II will never be updated.
