### PR TITLE
Django - remove link to Django-aware linters

### DIFF
--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -391,8 +391,7 @@ py -3 -m django --version
 
 Experienced Python developers may install additional tools, such as linters (which help detect common errors in code).
 
-Note that you should use a [Django aware linter](https://djangopackages.org/grids/g/linters/) like [pylint-django](https://pypi.org/project/pylint-django/).
-Commonly used Python linters, such as `pylint`, may incorrectly report errors in the standard files generated for Django.
+Note that you should use a Django-aware linter such as [pylint-django](https://pypi.org/project/pylint-django/), because some common Python linters (such as `pylint`) incorrectly report errors in the standard files generated for Django.
 
 ## Testing your installation
 


### PR DESCRIPTION
The link to https://djangopackages.org/grids/g/linters/ is broken. This is likely not permanent - it look more like an accident/server  error. However I don't think it's necessary to provide - you can find links of interest via an Internet search, and this one will show up if it is valid at that point.

Fixes #29272