### PR TITLE
Fix syntax error

### DIFF
--- a/files/en-us/web/css/view-timeline-name/index.md
+++ b/files/en-us/web/css/view-timeline-name/index.md
@@ -145,7 +145,7 @@ Last, an animation is specified on the element that animates its opacity and sca
   }
 
   to {
-    opacity: 1,
+    opacity: 1;
     transform: scaleX(1);
   }
 }


### PR DESCRIPTION
### Description
Replaces a `,` with a `;`. This corrects a syntax error in a code example:
https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline-name