### PR TITLE
download attribute for <a> on <audio> element page

### DIFF
--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -247,7 +247,7 @@ Browsers don't all support the same [file types](/en-US/docs/Web/Media/Formats/C
   <source src="myAudio.ogg" type="audio/ogg" />
   <p>
     Download <a href="myAudio.mp3">MP3</a> or
-    <a href="myAudio.ogg">OGG</a> audio.
+    <a href="myAudio.ogg" download="myAudio.ogg">OGG</a> audio.
   </p>
 </audio>
 ```
@@ -316,7 +316,7 @@ The following example shows simple usage of the `<audio>` element to play an OGG
 ```html
 <!-- Simple audio playback -->
 <audio src="AudioTest.ogg" autoplay>
-  <a href="AudioTest.ogg">Download OGG audio</a>.
+  <a href="AudioTest.ogg" download="AudioTest.ogg">Download OGG audio</a>.
 </audio>
 ```
 
@@ -329,7 +329,7 @@ This example specifies which audio track to embed using the `src` attribute on a
 ```html
 <audio controls>
   <source src="foo.wav" type="audio/wav" />
-  <a href="foo.wav">Download WAV audio</a>.
+  <a href="foo.wav" download="foo.wav">Download WAV audio</a>.
 </audio>
 ```
 
@@ -377,7 +377,7 @@ Also it's a good practice to provide some content (such as the direct download l
   <source src="myAudio.ogg" type="audio/ogg" />
   <p>
     Download <a href="myAudio.mp3">MP3</a> or
-    <a href="myAudio.ogg">OGG</a> audio.
+    <a href="myAudio.ogg" download="myAudio.ogg">OGG</a> audio.
   </p>
 </audio>
 ```

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -33,7 +33,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
   - : The [`controlslist`](https://wicg.github.io/controls-list/explainer.html) attribute, when specified, helps the browser select what controls to show for the `audio` element whenever the browser shows its own set of controls (that is, when the `controls` attribute is specified).
 
-    The allowed values are `nodownload`, `nofullscreen` and `noremoteplayback`.
+    The allowed values are `no`, `nofullscreen` and `noremoteplayback`.
 
 - `crossorigin`
 
@@ -62,14 +62,14 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
     - `none`: Indicates that the audio should not be preloaded.
     - `metadata`: Indicates that only audio metadata (e.g. length) is fetched.
-    - `auto`: Indicates that the whole audio file can be downloaded, even if the user is not expected to use it.
+    - `auto`: Indicates that the whole audio file can be ed, even if the user is not expected to use it.
     - _empty string_: A synonym of the `auto` value.
 
     The default value is different for each browser. The spec advises it to be set to `metadata`.
 
     > **Note:**
     >
-    > - The `autoplay` attribute has precedence over `preload`. If `autoplay` is specified, the browser would obviously need to start downloading the audio for playback.
+    > - The `autoplay` attribute has precedence over `preload`. If `autoplay` is specified, the browser would obviously need to start ing the audio for playback.
     > - The browser is not forced by the specification to follow the value of this attribute; it is a mere hint.
 
 - `src`
@@ -246,7 +246,7 @@ Browsers don't all support the same [file types](/en-US/docs/Web/Media/Formats/C
   <source src="myAudio.mp3" type="audio/mpeg" />
   <source src="myAudio.ogg" type="audio/ogg" />
   <p>
-    Download <a href="myAudio.mp3">MP3</a> or
+    Download <a href="myAudio.mp3" download="myAudio.mp3">MP3</a> or
     <a href="myAudio.ogg" download="myAudio.ogg">OGG</a> audio.
   </p>
 </audio>


### PR DESCRIPTION
Add the download attribute to the &lt;a&gt; element in "Usage notes," "Basic usage," "&lt;audio&gt; element with &lt;source&gt; element," and "Accessibility concerns."

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Adding the download attribute to the &lt;a&gt; element in "Usage notes," "Basic usage," "&lt;audio&gt; element with &lt;source&gt; element," and "Accessibility concerns."  These &lt;a&gt; elements do not have the download attribute and they are being used for file downloads.

<!-- ✍️ Summarize your changes in one or two sentences -->

&lt;a&gt; elements that are used for file downloads need to have the download attribute and the ones in the examples above do not have this attribute.

<!-- ❓ Why are you making these changes and how do they help readers? -->

Readers will be helped because they will learn how to use &lt;a&gt; elements better.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->