### PR TITLE
enhance Object examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -274,7 +274,7 @@ const o3 = new Object(null);
 
 ### Using Object() constructor to create a specific type of object
 
-You can use the [`Object()`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/Object#return_value) constructor to create an Object of a specific type.
+You can use the {{jsxref("Object/Object", "Object()")}} constructor to create an object wrapper of a primitive value.
 
 The following examples store {{jsxref("Boolean")}} objects in `o`:
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -272,7 +272,7 @@ const o2 = new Object(undefined);
 const o3 = new Object(null);
 ```
 
-### Using Object() constructor to create a specific type of object
+### Using Object() constructor to turn primitives into an Object of their respective type
 
 You can use the {{jsxref("Object/Object", "Object()")}} constructor to create an object wrapper of a primitive value.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -279,7 +279,7 @@ You can use the {{jsxref("Object/Object", "Object()")}} constructor to create an
 The following examples create variables `o1` and `o2` which are objects storing {{jsxref("Boolean")}} and {{jsxref("BigInt")}} values:
 
 ```js
-// Equivalent to const o = new Boolean(true)
+// Equivalent to const o1 = new Boolean(true)
 const o1 = new Object(true);
 
 // No equivalent because BigInt() can't be called as a constructor,

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -272,18 +272,15 @@ const o2 = new Object(undefined);
 const o3 = new Object(null);
 ```
 
-### Using Object to create Boolean objects
+### Using Object() constructor to create a specific type of object
+
+You can use the [`Object()`](http://en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/Object#return_value) constructor to create an Object of a specific type.
 
 The following examples store {{jsxref("Boolean")}} objects in `o`:
 
 ```js
 // equivalent to const o = new Boolean(true)
 const o = new Object(true);
-```
-
-```js
-// equivalent to const o = new Boolean(false)
-const o = new Object(Boolean());
 ```
 
 ### Object prototypes

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -274,7 +274,7 @@ const o3 = new Object(null);
 
 ### Using Object() constructor to create a specific type of object
 
-You can use the [`Object()`](http://en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/Object#return_value) constructor to create an Object of a specific type.
+You can use the [`Object()`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Object/Object#return_value) constructor to create an Object of a specific type.
 
 The following examples store {{jsxref("Boolean")}} objects in `o`:
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -279,7 +279,7 @@ You can use the {{jsxref("Object/Object", "Object()")}} constructor to create an
 The following examples create variables `o1` and `o2` which are objects storing {{jsxref("Boolean")}} and {{jsxref("BigInt")}} values:
 
 ```js
-// equivalent to const o = new Boolean(true)
+// Equivalent to const o = new Boolean(true)
 const o1 = new Object(true);
 
 // No equivalent because BigInt() can't be called as a constructor,

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -276,7 +276,7 @@ const o3 = new Object(null);
 
 You can use the {{jsxref("Object/Object", "Object()")}} constructor to create an object wrapper of a primitive value.
 
-The following examples store {{jsxref("Boolean")}} objects in `o`:
+The following examples create variables `o1` and `o2` which are objects storing {{jsxref("Boolean")}} and {{jsxref("BigInt")}} values:
 
 ```js
 // equivalent to const o = new Boolean(true)

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -280,7 +280,11 @@ The following examples create variables `o1` and `o2` which are objects storing 
 
 ```js
 // equivalent to const o = new Boolean(true)
-const o = new Object(true);
+const o1 = new Object(true);
+
+// No equivalent because BigInt() can't be called as a constructor,
+// and calling it as a regular function won't create an object
+const o2 = new Object(1n);
 ```
 
 ### Object prototypes


### PR DESCRIPTION
I think it's better to make this section generic to include creating other types of objects like numbers.

also, I think the second example has 2 things

1. calling Boolean() already created an Object of number type ..... so the object constructor just returning it as it is = I mean it doesn't create any object .....so it doesn't fit the context here.... we are talking about how you can create object of boolean or whatever type using Object constructor so it is not suitable giving people an example of creating an object of an already created object of a specific type 

2. the default value returned by Boolean is already false, so no need to pass it 