### PR TITLE
fix: remove the broken link to the posted message

### DIFF
--- a/files/en-us/mdn/community/contributing/security_vulnerability_response/index.md
+++ b/files/en-us/mdn/community/contributing/security_vulnerability_response/index.md
@@ -31,7 +31,7 @@ This was very effective, judging from the responses the issue received, but we c
 
 With this, we felt rather confident that between us reaching out, and coverage of the issue online by npm and other channels, would ensure that we ensured our users are safe.
 
-As a final step, @schalkneethling posted a message on Twitter which was in turn retweeted by the [MDN Web Docs Twitter account](https://twitter.com/schalkneethling/status/1067436637385179136).
+As a final step, we tweeted from our official Twitter account to raise awareness of the issue.
 
 ### In closing
 


### PR DESCRIPTION
### Description

remove the broken link to the posted message on twitter

### Related issues and pull requests

Fixes: #29268
