### PR TITLE
Link to Date.toLocaleString instead of Date.toUTCString

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tostring/index.md
@@ -36,7 +36,7 @@ The {{jsxref("Date")}} object overrides the {{jsxref("Object/toString", "toStrin
 - If you only want to get the _date_ part, use {{jsxref("Date/toDateString", "toDateString()")}}.
 - If you only want to get the _time_ part, use {{jsxref("Date/toTimeString", "toTimeString()")}}.
 - If you want to make the date interpreted as UTC instead of local timezone, use {{jsxref("Date/toUTCString", "toUTCString()")}}.
-- If you want to format the date in a more user-friendly format (e.g. localization), use {{jsxref("Date/toUTCString", "toUTCString()")}}.
+- If you want to format the date in a more user-friendly format (e.g. localization), use {{jsxref("Date/toLocaleString", "toLocaleString()")}}.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Change _see also_ type of recommendation link in `Date.prototype.toString` from `Date.prototype.toUTCString` to `Date.prototype.toLocaleString`.

### Motivation

`Date.prototype.toLocaleString` would seem like a better fit when a user-friendly representation of a Date object is needed.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
