### PR TITLE
CSS module: generated content

### DIFF
--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -75,7 +75,7 @@ The value can be one of two keywords — `none` or `normal` — or either `<cont
 
 - `contents` {{Experimental_Inline}}
 
-  - : When supported, the contents of the element itself.
+  - : Adds the contents of the element itself to the generated content value.
 
 - {{cssxref("&lt;string&gt;")}}
 
@@ -285,8 +285,7 @@ The generated content is the value of the `href` attribute, prepended by "URL: "
 
 ### Adding an image with alternative text
 
-This example inserts an image before the link. Alternative text that a screen reader can output as speech is included,
-which some browsers may display. To indicate if alternative text after a content list is supported or not, a fallback `content`, the CSS includes the message " - no alt text - ".
+This example inserts an image before all links. Two `content` values are provided. The later `content` value includes an image with alternative text that a screen reader can output as speech. If a browser does not support alternative text, this declaration will be considered invalid, with the previous `content` value displaying. This fallback content list include an image and the message " - alt text is not supported - ".
 
 #### HTML
 
@@ -304,7 +303,7 @@ This will be used on browsers that _display_ the alternative text and in browser
 a::before {
   /* fallback content */
   content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico")
-    " - no alt text - ";
+    " - alt text is not supported - ";
   /* content with alternative text */
   content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico") /
     " MOZILLA: ";
@@ -319,10 +318,9 @@ a::before {
 
 {{EmbedLiveSample('Adding_an_image_with_alternative_text', '100%', 60)}}
 
-If using a screen reader, it should speak the word "MOZILLA" when it reaches the image. If supported (if the "no alt text" is not showing), you can select the `::before` pseudo-element with your developer tools selection tool, and view the {{glossary("accessible name")}} in the accessibility panel.
+If using a screen reader, it should speak the word "MOZILLA" when it reaches the image. If supported (if the "alt text is not supported" is not showing), you can select the `::before` pseudo-element with your developer tools selection tool, and view the {{glossary("accessible name")}} in the accessibility panel.
 
-Note that on a browser that does not support the alternative text syntax, the whole line is invalid.
-In this case, the previous `content` value, if supported, will be used.
+In browsers that don't support the alternative text syntax the whole declaration containing the alt text is invalid. In this case, the previous `content` value will be used, showing the image and "alt text is not supported" text.
 
 ### Element replacement with `url()`
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -44,8 +44,8 @@ content: close-quote;
 content: no-open-quote;
 content: no-close-quote;
 
-/* list of content values */
-/* Except for normal and none, several values can be used simultaneously */
+/* <content-list>: a list of content values. 
+Several values can be used simultaneously */
 content: "prefix" url(http://www.example.com/test.png);
 content: "prefix" url("/img/test.png") "suffix" / "Alt text";
 content: open-quote counter(chapter_counter);
@@ -60,17 +60,16 @@ content: unset;
 
 ### Values
 
+The value is `none` or `normal`, or a `<content-list>`, a list of anonymous inline boxes that will replace the content of the selected element (in the specified order). Each `<content-list>` item is either content or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader), with an optional alternative text value of a `<string>` or `<counter>`:
+
 - `none`
 
-  - : When applied to a pseudo-element, the pseudo-element is not generated. If applied to an element, the value has no effect.
+  - : When applied to a pseudo-element, the pseudo-element is not generated.
+    When applied to an element, the value has no effect.
 
 - `normal`
 
-  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, `normal` the content will be the initial, or normal, content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}.
-
-- `<content-list>`
-
-  - : A list of anonymous inline boxes that will replace the content of the selected element (in the specified order). Each `<content-list>` item is either content or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
+  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, `normal` the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}.
 
 - {{cssxref("&lt;string&gt;")}}
 
@@ -108,19 +107,8 @@ content: unset;
 
   - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element or pseudo-element's originating element. The value of the element's attribute `x` as an unparsed string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute name parameter depends on the document language.
 
-- `<content-list> / "<string> or <counter>"`
-  - : Alternative text may be specified for an image , or any of the `<content-list>` items, by appending a forward slash and then the string text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} specifies the "alt text" for the element.
-
-## Accessibility concerns
-
-CSS-generated content is not included in the [DOM](/en-US/docs/Web/API/Document_Object_Model/Introduction). Because of this, it will not be represented in the [accessibility tree](/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis) and certain assistive technology/browser combinations will not announce it. If the content conveys information that is critical to understanding the page's purpose, it is better to include it in the main document.
-
-If inserted content is not decorative, check that the information is provided to assistive technologies and is also available when CSS is turned off.
-
-- [Accessibility support for CSS generated content – Tink](https://tink.uk/accessibility-support-for-css-generated-content/) (2015)
-- [WCAG, Guideline 1.3: Create content that can be presented in different ways](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.3_—_create_content_that_can_be_presented_in_different_ways)
-- [Understanding Success Criterion 1.3.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
-- [Failure of Success Criterion 1.3.1: inserting non-decorative generated content](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F87) Techniques for WCAG 2.0
+- alternative text `/ <string> <counter>`
+  - : Alternative text may be specified for an image or any `<content-list>` items, by appending a forward slash and then a string of text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} specifies the "alt text" for the element.
 
 ## Formal definition
 
@@ -149,6 +137,7 @@ This example combines the counters function and text to prepend all list items w
       <li>Ducks</li>
       <li>Flightless</li>
     </ol>
+  <li>Marsupials</li>
   </li>
 </ol>
 ```
@@ -158,6 +147,7 @@ This example combines the counters function and text to prepend all list items w
 ```css
 ol {
   counter-reset: items;
+  margin-left: 2em;
 }
 li {
   counter-increment: items;
@@ -171,11 +161,11 @@ li::marker {
 
 {{EmbedLiveSample('Adding_text_to_list_item_counters', '100%', 200)}}
 
-The `counter()` function created a numeric `items` counter in which nested numbers are separated with a period (`.`).
+The generated content on the marker adds the text "item ", with a space, followed by a counter, followed by a colon and an additional space. The `counter()` function created a numeric `items` counter in which nested numbers are separated with a period (`.`) in most browsers.
 
 ### Strings with attribute values
 
-This example adds a string of text after every fully qualified secure link. The text is the value of the `href` attribute, prepended by "URL:", followed by a space, all in parentheses.
+This example uses an [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors) to select every fully qualified secure link, adding the value of the `href` attribute after the link text as the content of the {{cssxref("::after")}} pseudo-element.
 
 #### HTML
 
@@ -199,6 +189,8 @@ a[href^="https://"]::after
 #### Result
 
 {{EmbedLiveSample('Strings_with_attribute_values', '100%', 200)}}
+
+The generated content is the value of the `href` attribute, prepended by "URL:", followed by a space, all in parentheses.
 
 ### Quotes
 
@@ -418,6 +410,17 @@ div {
 #### Result
 
 {{EmbedLiveSample('Element_replacement_with_image-set', '100%', 110)}}
+
+## Accessibility concerns
+
+CSS-generated content is not included in the [DOM](/en-US/docs/Web/API/Document_Object_Model/Introduction). Because of this, it will not be represented in the [accessibility tree](/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis) and certain assistive technology/browser combinations will not announce it. If the content conveys information that is critical to understanding the page's purpose, it is better to include it in the main document.
+
+If inserted content is not decorative, check that the information is provided to assistive technologies and is also available when CSS is turned off.
+
+- [Accessibility support for CSS generated content – Tink](https://tink.uk/accessibility-support-for-css-generated-content/) (2015)
+- [WCAG, Guideline 1.3: Create content that can be presented in different ways](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.3_—_create_content_that_can_be_presented_in_different_ways)
+- [Understanding Success Criterion 1.3.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
+- [Failure of Success Criterion 1.3.1: inserting non-decorative generated content](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F87) Techniques for WCAG 2.0
 
 ## Specifications
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -285,7 +285,7 @@ The generated content is the value of the `href` attribute, prepended by "URL: "
 
 ### Adding an image with alternative text
 
-This example inserts an image before all links. Two `content` values are provided. The later `content` value includes an image with alternative text that a screen reader can output as speech. If a browser does not support alternative text, this declaration will be considered invalid, with the previous `content` value displaying. This fallback content list include an image and the message " - alt text is not supported - ".
+This example inserts an image before all links. Two `content` values are provided. The later `content` value includes an image with alternative text that a screen reader can output as speech. If a browser does not support alternative text, this declaration will be considered invalid, with the previous `content` value displaying. This fallback content list includes an image and the message " - alt text is not supported - ".
 
 #### HTML
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -18,13 +18,13 @@ The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element with a
 content: normal;
 content: none;
 
-/* <image> values */
+/* <content-replacement> / <image> values */
 content: url("http://www.example.com/test.png");
 content: linear-gradient(#e66465, #9198e5);
 content: image-set("image1x.png" 1x, "image2x.png" 2x);
 
-/* alt text for generated content, added in the Level 3 specification */
-content: url("http://www.example.com/test.png") / "This is the alt text";
+/* speech output: alternative text after a "/"  */
+content: url("../img/test.png") / "This is the alt text";
 
 /* <string> value */
 content: "prefix";
@@ -43,7 +43,7 @@ content: counters(section_counter, ".", decimal-leading-zero);
 /* attr() value linked to the HTML attribute value */
 content: attr(value string);
 
-/* Language- and position-dependent keywords */
+/* <quote> values */
 content: open-quote;
 content: close-quote;
 content: no-open-quote;
@@ -63,42 +63,70 @@ content: unset;
 ### Values
 
 - `none`
+
   - : When applied to a pseudo-element, the pseudo-element is not generated. If applied to an element, the value has no effect.
+
 - `normal`
-  - : Computes to `none` for the `::before` and `::after` pseudo-elements.
-- {{cssxref("&lt;string&gt;")}}
-  - : Specifies the "alt text" for the element. This value can be any number of text characters. Non-Latin characters must be encoded using their Unicode escape sequences: for example, `\000A9` represents the copyright symbol.
+
+  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, `normal` the content will be the initial, or normal, content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}.
+
 - `<content-list>`
-  - : A list of anonymous inline boxes that will replace the content of the selected element (in the specified order).
-    This list can include strings, images, counters, and so on.
+
+  - : A list of anonymous inline boxes that will replace the content of the selected element (in the specified order). Each `<content-list>` item is either content or of type `<string>`, `<image>`, `<counter>`, `<quote>`, `<target>`, or `<leader()>`.
+
+- {{cssxref("&lt;string&gt;")}}
+
+  - : A sequence of characters enclosed in matching single or double quotes. Multiple string values will be concatenated (there is no concatenation operator in CSS).
+
 - {{cssxref("&lt;image&gt;")}}
+
   - : An {{cssxref("&lt;image&gt;")}}, denoted by the {{cssxref("url", "url()")}} or {{cssxref("image/image-set", "image-set()")}} or {{cssxref("&lt;gradient&gt;")}} data type, or part of the webpage, defined by the {{cssxref("element", "element()")}} function, denoting the content to display.
-- {{cssxref("counter", "counter()")}}
 
-  - : The value of a [CSS counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters), generally a number produced by computations defined by {{cssxref("&lt;counter-reset&gt;")}} and {{cssxref("&lt;counter-increment&gt;")}} properties. It can be displayed using either the {{cssxref("counter", "counter()")}} or {{cssxref("counters", "counters()")}} function.
+- `<counter>`
 
-    The {{cssxref("counter", "counter()")}} function has two forms: 'counter(_name_)' or 'counter(_name_, style)'. The generated text is the value of the innermost counter of the given name in scope at the given pseudo-element. It is formatted in the specified {{cssxref("&lt;list-style-type&gt;")}} (`decimal` by default).
+  - : The `<counter>` value is a [CSS counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters), generally a number produced by computations defined by {{cssxref("&lt;counter-reset&gt;")}} and {{cssxref("&lt;counter-increment&gt;")}} properties. It can be displayed using either the {{cssxref("counter", "counter()")}} or {{cssxref("counters", "counters()")}} function.
+    - {{cssxref("counter", "counter()")}}
+      - : The {{cssxref("counter", "counter()")}} function has two forms: 'counter(_name_)' or 'counter(_name_, style)'. The generated text is the value of the innermost counter of the given name in scope at the given pseudo-element. It is formatted in the specified {{cssxref("&lt;list-style-type&gt;")}} (`decimal` by default).
+    - {{cssxref("counters", "counters()")}}
+      - : The {{cssxref("counters", "counters()")}} function also has two forms: 'counters(_name_, _string_)' or 'counters(_name_, _string_, _style_)'. The generated text is the value of all counters with the given name in scope at the given pseudo-element, from outermost to innermost, separated by the specified string. The counters are rendered in the indicated {{cssxref("&lt;list-style-type&gt;")}} (`decimal` by default).
 
-    The {{cssxref("counters", "counters()")}} function also has two forms: 'counters(_name_, _string_)' or 'counters(_name_, _string_, _style_)'. The generated text is the value of all counters with the given name in scope at the given pseudo-element, from outermost to innermost, separated by the specified string. The counters are rendered in the indicated {{cssxref("&lt;list-style-type&gt;")}} (`decimal` by default).
+- `<quote>`
+
+  - : The `<quote>` data type includes language- and position-dependent keywords:
+    - `open-quote` and `close-quote`
+      - : These values are replaced by the appropriate string from the {{cssxref("quotes")}} property.
+    - `no-open-quote` | `no-close-quote`
+      - : Introduces no content, but increments (decrements) the level of nesting for quotes.
+
+- `<target>` {{Experimental_Inline}}
+
+  - : The `<target>` data type includes three target functions, `<target-counter()>`, `<target-counters()>`, and `<target-text()>` that create cross-reference obtained from the target end of a link. See [Formal syntax](#formal_syntax).
+
+- `<leader>` {{Experimental_Inline}}
+
+  - : stuff
 
 - `attr(x)`
-  - : The value of the element's attribute `x` as a string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute names depends on the document language.
-- `open-quote` | `close-quote`
-  - : These values are replaced by the appropriate string from the {{cssxref("quotes")}} property.
-- `no-open-quote` | `no-close-quote`
-  - : Introduces no content, but increments (decrements) the level of nesting for quotes.
-- `<content-list> / "Alternative text"`
-  - : Alternative text may be specified for an image (or list of content items) by appending a forward slash and then the text.
-    The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers.
-    Note that if the browser does not support alternative text, neither the content or alternative text will be used.
+
+  - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element or pseudo-element's originating element. The value of the element's attribute `x` as an unparsed string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute names depends on the document language.
+
+- `<content-list> / "<string> or <counter>"`
+
+  - : Alternative text may be specified for an image , or any of the `<content-list>` items, by appending a forward slash and then the string text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, neither the content or alternative text will be used.
+
+    - {{cssxref("string", "/ &lt;string>")}}
+      - : Specifies the "alt text" for the element. This value can be any number of text characters. Non-Latin characters must be encoded using their Unicode escape sequences: for example, `\000A9` represents the copyright symbol.
 
 ## Accessibility concerns
 
 CSS-generated content is not included in the [DOM](/en-US/docs/Web/API/Document_Object_Model/Introduction). Because of this, it will not be represented in the [accessibility tree](/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis) and certain assistive technology/browser combinations will not announce it. If the content conveys information that is critical to understanding the page's purpose, it is better to include it in the main document.
 
-- [Accessibility support for CSS generated content – Tink](https://tink.uk/accessibility-support-for-css-generated-content/)
-- [Explanation of WCAG, Guideline 1.3 – MDN](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.3_%e2%80%94_create_content_that_can_be_presented_in_different_ways)
+If inserted content is not decorative, check that the information is provided to assistive technologies and is also available when CSS is turned off.
+
+- [Accessibility support for CSS generated content – Tink](https://tink.uk/accessibility-support-for-css-generated-content/) (2015)
+- [WCAG, Guideline 1.3: Create content that can be presented in different ways](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.3_—_create_content_that_can_be_presented_in_different_ways)
 - [Understanding Success Criterion 1.3.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
+- [Failure of Success Criterion 1.3.1: inserting non-decorative generated content](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F87) Techniques for WCAG 2.0
 
 ## Formal definition
 
@@ -110,14 +138,81 @@ CSS-generated content is not included in the [DOM](/en-US/docs/Web/API/Document_
 
 ## Examples
 
-### Headings and quotes
+### Adding text to list item counters
 
-This example inserts quotation marks around quotes, and adds the word "Chapter" before headings.
+This example combines the counters function and text to prepend all list items with a more detailed counter. We set the content of the the list marker to be a concatenated content-list containing a counter between two strings.
 
 #### HTML
 
 ```html
-<h1>5</h1>
+<ol>
+  <li>Dogs</li>
+  <li>Cats</li>
+  <li>
+    Birds
+    <ol>
+      <li>Owls</li>
+      <li>Ducks</li>
+      <li>Flightless</li>
+    </ol>
+  </li>
+</ol>
+```
+
+#### CSS
+
+```css
+ol {
+  counter-reset: items;
+}
+li {
+  counter-increment: items;
+}
+li::marker {
+  content: "item " counters(items, ".", numeric) ": ";
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Adding_text_to_list_item_counters', '100%', 200)}}
+
+The `counter()` function created a numeric `items` counter in which nested numbers are separated with a period (`.`).
+
+### Strings with attribute values
+
+This example adds a string of text after every fully qualified secure link. The text is the value of the `href` attribute, prepended by "URL:", followed by a space, all in parentheses.
+
+#### HTML
+
+```html
+<ul>
+  <li><a href="https://mozilla.com">Mozilla</a></li>
+  <li><a href="/">MDN</a></li>
+  <li><a href="https://openwebdocs.org">OpenWebDocs</a></li>
+</ul>
+```
+
+#### CSS
+
+```css
+a[href^="https://"]::after
+{
+  content: " (URL: " attr(href) ")";
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Strings_with_attribute_values', '100%', 200)}}
+
+### Quotes
+
+This example inserts quotation marks around quotes.
+
+#### HTML
+
+```html
 <p>
   According to Sir Tim Berners-Lee,
   <q cite="http://www.w3.org/People/Berners-Lee/FAQ.html#Internet">
@@ -127,16 +222,9 @@ This example inserts quotation marks around quotes, and adds the word "Chapter" 
   We must understand that there is nothing fundamentally wrong with building on
   the contributions of others.
 </p>
-
-<h1>6</h1>
-<p>
-  According to the Mozilla Manifesto,
-  <q cite="http://www.mozilla.org/en-US/about/manifesto/">
-    Individuals must have the ability to shape the Internet and their own
-    experiences on the Internet.
-  </q>
-  Therefore, we can infer that contributing to the open web can protect our own
-  individual experiences on it.
+<p lang="fr-fr">
+  Mais c'est Magritte qui a dit,
+  <q lang="fr-fr"> Ceci n'est pas une pipe. </q>.
 </p>
 ```
 
@@ -154,17 +242,13 @@ q::before {
 q::after {
   content: close-quote;
 }
-
-h1::before {
-  content: "Chapter "; /* The trailing space creates separation
-                          between the added content and the
-                          rest of the content */
-}
 ```
 
 #### Result
 
-{{EmbedLiveSample('Headings_and_quotes', '100%', 200)}}
+{{EmbedLiveSample('Quotes', '100%', 200)}}
+
+Note the type of quotes generated is language dependent.
 
 ### Image combined with alternative text
 
@@ -236,108 +320,76 @@ This example inserts additional text after special items in a list.
 
 {{EmbedLiveSample('Targeting_classes', '100%', 160)}}
 
-### Images and element attributes
-
-This example inserts an image before each link, and adds its `id` attribute after.
-
-#### HTML
-
-```html
-<ul>
-  <li><a id="moz" href="https://www.mozilla.org/">Mozilla Home Page</a></li>
-  <li>
-    <a id="mdn" href="https://developer.mozilla.org/">
-      Mozilla Developer Network
-    </a>
-  </li>
-</ul>
-```
-
-#### CSS
-
-```css
-a {
-  text-decoration: none;
-  border-bottom: 3px dotted navy;
-}
-
-a::after {
-  content: " (" attr(id) ")";
-}
-
-#moz::before {
-  content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico");
-}
-
-#mdn::before {
-  content: url("mdn-favicon16.png");
-}
-
-li {
-  margin: 1em;
-}
-```
-
-#### Result
-
-{{EmbedLiveSample('Images_and_element_attributes', '100%', 160)}}
-
 ### Element replacement with `url()`
 
-This example replaces an element's content with an image {{cssxref("url", "url()")}}. Content added with `::before` or `::after` will not be generated as the contents of the element have been replaced.
+This example replaces a regular element's contents with an image {{cssxref("url", "url()")}}. The `id` of the element, generated on `::after`, is not displayed if the element is replaced.
 
 #### HTML
 
 ```html
-<div id="replaced">Mozilla</div>
+<div id="replaced">I disappear</div>
+<hr />
+<div id="notReplaced">I am not replaced</div>
 ```
 
 #### CSS
 
 ```css
+div {
+  min-height: 50px;
+  background: palegoldenrod;
+}
+
 #replaced {
   content: url("mdn.svg");
 }
 
-/* will not show if element replacement is supported */
-#replaced::after {
+/* will not show if element is replaced */
+div::after {
   content: " (" attr(id) ")";
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample('Element_replacement_with_url', '100%', 200)}}
+{{EmbedLiveSample('Element_replacement_with_url', '100%',400)}}
+
+When generating content on regular elements (rather than just on pseudo-elements), the entire element is replaced; `::before` or `::after` pseudo-elements are not generated on replaced elements. In other words, only of the two CSS declarations is applied to each `<div>`.
 
 ### Element replacement with `<gradient>`
 
-This example replaces an element's content with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}}.
+This example replaces an element's content with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}} if supported.
 
 #### HTML
 
 ```html
-<div id="replaced">Mozilla</div>
+<div id="replaced">I disappear</div>
+<hr />
+<div id="notReplaced">I am not replaced</div>
 ```
 
 #### CSS
 
-```css hidden
+```css
 div {
-  width: 100px;
-  height: 100px;
+  min-width: 100px;
+  min-height: 50px;
   border: 1px solid lightgrey;
 }
-```
 
-```css
 #replaced {
   content: linear-gradient(purple, yellow);
+}
+/* will not show if the element is replaced */
+div::after {
+  content: " (Gradients may be supported, but not as a value for <content>)";
+  background: linear-gradient(to right, yellow, pink);
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample('Element_replacement_with_gradient', '100%', 110)}}
+{{EmbedLiveSample('Element_replacement_with_gradient', '100%', 200)}}
 
 ### Element replacement with `image-set()`
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.content
 
 {{CSSRef}}
 
-The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element's content with a generated value. The `content` property is used to define what is rendered inside an element or pseudo-element. For elements, the `content` property specifies whether the element renders normally (`normal` or `none`) or is replaced with an image (and associated "alt" text). For pseudo-elements and margin boxes, `content` controls whether the element renders at all, replacing the element with an image, text, or both.
+The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces content with a generated value. It can be used to define what is rendered inside an element or pseudo-element. For elements, the `content` property specifies whether the element renders normally (`normal` or `none`) or is replaced with an image (and associated "alt" text). For pseudo-elements and margin boxes, `content` defines the content as images, text, both, or none, which determines whether the element renders at all.
 
 Objects inserted using the `content` property are **anonymous [replaced elements](/en-US/docs/Web/CSS/Replaced_element)**.
 
@@ -62,7 +62,7 @@ content: unset;
 
 ### Values
 
-The value can be one of two keywords — `none` or `normal` — or, for DOM nodes, the content replacement can be an `<image>`, otherwise a list of of one or more anonymous inline boxes, called a `<content-list>`, that will replace the content of the selected element in the specified order. Each content-list item is either `contents` or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader), with an optional alternative text value of a `<string>` or `<counter>`:
+The value can be one of two keywords — `none` or `normal` — or either `<content-replacement>` when replacing a DOM node or a `<content-list>` for pseudo-elements and margin boxes, with optional alternative text value of a `<string>` or `<counter>`. Content replacement is always an `<image>`. A content-list is a list of of one or more anonymous inline boxes appearing in the order specified. Each content-list item is either `contents` or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader):
 
 - `none`
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -7,7 +7,9 @@ browser-compat: css.properties.content
 
 {{CSSRef}}
 
-The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element with a generated value. Objects inserted using the `content` property are **anonymous [replaced elements](/en-US/docs/Web/CSS/Replaced_element)**.
+The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element with a generated value. The `content` property is used to define what is rendered inside an element or pseudo-element. For elements, the `content` property specifies whether the element renders normally (`normal` or `none`) or is replaced with an image (and associated "alt" text). For pseudo-elements and margin boxes, `content` controls whether the element renders at all, replacing the element with an image, text, or both.
+
+Objects inserted using the `content` property are **anonymous [replaced elements](/en-US/docs/Web/CSS/Replaced_element)**.
 
 {{EmbedInteractiveExample("pages/tabbed/content.html", "tabbed-shorter")}}
 
@@ -60,7 +62,7 @@ content: unset;
 
 ### Values
 
-The value is `none` or `normal`, or a `<content-list>`, a list of anonymous inline boxes that will replace the content of the selected element (in the specified order). Each `<content-list>` item is either content or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader), with an optional alternative text value of a `<string>` or `<counter>`:
+The value can be one of two keywords — `none` or `normal` — or, for DOM nodes, the content replacement can be an `<image>`, otherwise a list of of one or more anonymous inline boxes, called a `<content-list>`, that will replace the content of the selected element in the specified order. Each content-list item is either `contents` or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader), with an optional alternative text value of a `<string>` or `<counter>`:
 
 - `none`
 
@@ -69,7 +71,11 @@ The value is `none` or `normal`, or a `<content-list>`, a list of anonymous inli
 
 - `normal`
 
-  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, `normal` the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}.
+  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, `normal` the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin box, this computes to `contents`.
+
+- `contents` {{Experimental_Inline}}
+
+  - : When supported, the contents of the element itself.
 
 - {{cssxref("&lt;string&gt;")}}
 
@@ -101,13 +107,13 @@ The value is `none` or `normal`, or a `<content-list>`, a list of anonymous inli
 
 - `<leader()>` {{Experimental_Inline}}
 
-  - : The `<leader()>` data type inclues a leader function: `leader( <leader-type> )`. This function accepts the keyword values `dotted`, `solid`, or `space` (equal to `leader(".")`, `leader("_")`, and `leader(" ")`, respectively), or a `<string>` as a parameter. When used as a value for `content`, the leader-type provided will be inserted as a repeating pattern visually connecting content across a horizontal line.
+  - : The `<leader()>` data type inclues a leader function: `leader( <leader-type> )`. This function accepts the keyword values `dotted`, `solid`, or `space` (equal to `leader(".")`, `leader("_")`, and `leader(" ")`, respectively), or a `<string>` as a parameter. When supported and used as a value for `content`, the leader-type provided will be inserted as a repeating pattern visually connecting content across a horizontal line.
 
 - `attr(x)`
 
   - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element or pseudo-element's originating element. The value of the element's attribute `x` as an unparsed string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute name parameter depends on the document language.
 
-- alternative text `/ <string> <counter>`
+- alternative text `/ <string> | <counter>`
   - : Alternative text may be specified for an image or any `<content-list>` items, by appending a forward slash and then a string of text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} specifies the "alt text" for the element.
 
 ## Formal definition
@@ -120,9 +126,93 @@ The value is `none` or `normal`, or a `<content-list>`, a list of anonymous inli
 
 ## Examples
 
+The first examples created generated content on pseudo-elements. The last three are [examples of element replacement](#element-replacement-with-url).
+
+### Appending strings based on an element's class
+
+This example inserts generated text, coloring it red, after the text based on an element's class name.
+
+#### HTML
+
+```html
+<h2>Paperback Best Sellers</h2>
+<ol>
+  <li>Political Thriller</li>
+  <li class="new-entry">Halloween Stories</li>
+  <li>My Biography</li>
+  <li class="new-entry">Vampire Romance</li>
+</ol>
+```
+
+#### CSS
+
+```css
+.new-entry::after {
+  content: " New!"; /* The leading space creates separation
+                       between the DOM node's content and the generated content
+                       being added. */
+  color: red;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Appending_strings_based_on_an_elements_class', '100%', 160)}}
+
+### Quotes
+
+This example inserts differently colored quotation marks around quotes.
+
+#### HTML
+
+```html
+<p>
+  According to Sir Tim Berners-Lee,
+  <q cite="http://www.w3.org/People/Berners-Lee/FAQ.html#Internet">
+    I was lucky enough to invent the Web at the time when the Internet already
+    existed - and had for a decade and a half.
+  </q>
+  We must understand that there is nothing fundamentally wrong with building on
+  the contributions of others.
+</p>
+<p lang="fr-fr">
+  Mais c'est Magritte qui a dit,
+  <q lang="fr-fr"> Ceci n'est pas une pipe. </q>.
+</p>
+```
+
+#### CSS
+
+```css
+q {
+  color: #00f;
+}
+
+q::before,
+q::after {
+  font-size: larger;
+  color: #f00;
+  background: #ccc;
+}
+
+q::before {
+  content: open-quote;
+}
+
+q::after {
+  content: close-quote;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Quotes', '100%', 200)}}
+
+Note the [type of quotes generated](/en-US/docs/Web/CSS/quotes#auto_quotes) is based on the language. Browsers add open- and close-quotes before and after {{HTMLElement("q")}} elements by default, so the quotes in this example would appear without them being explicitly set. They could have been turned off by setting `no-open-quote` and `no-close-quote`, or `none` value. They can also be turned off by setting the {{cssxref("quotes")}} property to `none` instead.
+
 ### Adding text to list item counters
 
-This example combines the counters function and text to prepend all list items with a more detailed counter. We set the content of the the list marker to be a concatenated content-list containing a counter between two strings.
+This example combines a counter sandwiched between two `<string>`s prepended to all list items, creating a more detailed marker for list items ({{HTMLElement("li")}}) within unordered lists ({{HTMLElement("ol")}}).
 
 #### HTML
 
@@ -161,11 +251,11 @@ li::marker {
 
 {{EmbedLiveSample('Adding_text_to_list_item_counters', '100%', 200)}}
 
-The generated content on the marker adds the text "item ", with a space, followed by a counter, followed by a colon and an additional space. The `counter()` function created a numeric `items` counter in which nested numbers are separated with a period (`.`) in most browsers.
+The generated content on each list item's marker adds the text "item " as a prefix, including a space to separate the prefix from the counter, which is followed by ": ", a colon and an additional space. The {{cssxref("counters()")}} function defines a numeric `items` counter, in which the numbers of nested ordered lists have their numbers separated with a period (`.`) in most browsers.
 
 ### Strings with attribute values
 
-This example uses an [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors) to select every fully qualified secure link, adding the value of the `href` attribute after the link text as the content of the {{cssxref("::after")}} pseudo-element.
+This example is useful for print stylesheets. It uses an [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors) to select every fully qualified secure link, adding the value of the `href` attribute after the link text as the content of the {{cssxref("::after")}} pseudo-element.
 
 #### HTML
 
@@ -183,6 +273,7 @@ This example uses an [attribute selector](/en-US/docs/Web/CSS/Attribute_selector
 a[href^="https://"]::after
 {
   content: " (URL: " attr(href) ")";
+  color: darkgreen;
 }
 ```
 
@@ -190,56 +281,12 @@ a[href^="https://"]::after
 
 {{EmbedLiveSample('Strings_with_attribute_values', '100%', 200)}}
 
-The generated content is the value of the `href` attribute, prepended by "URL:", followed by a space, all in parentheses.
+The generated content is the value of the `href` attribute, prepended by "URL: ", with a space, all in parentheses.
 
-### Quotes
+### Adding an image with alternative text
 
-This example inserts quotation marks around quotes.
-
-#### HTML
-
-```html
-<p>
-  According to Sir Tim Berners-Lee,
-  <q cite="http://www.w3.org/People/Berners-Lee/FAQ.html#Internet">
-    I was lucky enough to invent the Web at the time when the Internet already
-    existed - and had for a decade and a half.
-  </q>
-  We must understand that there is nothing fundamentally wrong with building on
-  the contributions of others.
-</p>
-<p lang="fr-fr">
-  Mais c'est Magritte qui a dit,
-  <q lang="fr-fr"> Ceci n'est pas une pipe. </q>.
-</p>
-```
-
-#### CSS
-
-```css
-q {
-  color: blue;
-}
-
-q::before {
-  content: open-quote;
-}
-
-q::after {
-  content: close-quote;
-}
-```
-
-#### Result
-
-{{EmbedLiveSample('Quotes', '100%', 200)}}
-
-Note the type of quotes generated is language dependent.
-
-### Image combined with alternative text
-
-This example inserts an image before the link and provides alternative text that a screen reader can output as speech.
-Some browsers may also display the alternative text.
+This example inserts an image before the link. Alternative text that a screen reader can output as speech in included,
+which some browsers may display. To indicate if alternative text after a content list is supported or not, a fallback `content`, the CSS includes the message " - no alt text - ".
 
 #### HTML
 
@@ -251,10 +298,14 @@ Some browsers may also display the alternative text.
 
 The CSS to show the image and set the alternative text is shown below.
 This also sets the font and color for the content.
-This will only be used on browsers that _display_ the alternative text.
+This will be used on browsers that _display_ the alternative text and in browsers that don't support alternative text and show the the fallback `content` value.
 
 ```css
 a::before {
+  /* fallback content */
+  content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico")
+    " - no alt text - ";
+  /* content with alternative text */
   content: url("https://mozorg.cdn.mozilla.net/media/img/favicon.ico") /
     " MOZILLA: ";
   font:
@@ -266,71 +317,31 @@ a::before {
 
 #### Result
 
-The browser should display the icon before the link below.
-If using a screen reader, it should speak the word "MOZILLA" when it reaches the image.
+{{EmbedLiveSample('Adding_an_image_with_alternative_text', '100%', 60)}}
 
-{{EmbedLiveSample('Image_combined_with_text', '100%', 60)}}
+If using a screen reader, it should speak the word "MOZILLA" when it reaches the image. If supported (if the "no alt text" is not showing), you can select the `::before` pseudo-element with your developer tools selection tool, and view the {{glossary("accessible name")}} in the accessibility panel.
 
 Note that on a browser that does not support the alternative text syntax, the whole line is invalid.
-In this case neither the image or alternative text will be used!
-You could partially address this issue by including CSS that adds the image before the line with them both.
-
-### Targeting classes
-
-This example inserts additional text after special items in a list.
-
-#### HTML
-
-```html
-<h2>Paperback Best Sellers</h2>
-<ol>
-  <li>Political Thriller</li>
-  <li class="new-entry">Halloween Stories</li>
-  <li>My Biography</li>
-  <li class="new-entry">Vampire Romance</li>
-</ol>
-```
-
-#### CSS
-
-```css
-.new-entry::after {
-  content: " New!"; /* The leading space creates separation
-                       between the added content and the
-                       rest of the content */
-  color: red;
-}
-```
-
-#### Result
-
-{{EmbedLiveSample('Targeting_classes', '100%', 160)}}
+In this case, the previous `content` value, if supported, will be used.
 
 ### Element replacement with `url()`
 
-This example replaces a regular element's contents with an image {{cssxref("url", "url()")}}. The `id` of the element, generated on `::after`, is not displayed if the element is replaced.
+This example replaces a regular element! The element's contents are replaced with an SVG using the {{cssxref("url", "url()")}} image function. We include generated content, attempting to add the `id` of the element generated on `::after`. This pseudo-element is not generated in browsers that support content replacement as the element is replaced.
 
 #### HTML
 
 ```html
-<div id="replaced">I disappear</div>
-<hr />
-<div id="notReplaced">I am not replaced</div>
+<div id="replaced">This content is replaced!</div>
 ```
 
 #### CSS
 
 ```css
-div {
-  min-height: 50px;
-  background: palegoldenrod;
-}
-
 #replaced {
   content: url("mdn.svg");
 }
 
-/* will not show if element is replaced */
+/* will not show if element replacement is supported */
 div::after {
   content: " (" attr(id) ")";
 }
@@ -340,36 +351,37 @@ div::after {
 
 {{EmbedLiveSample('Element_replacement_with_url', '100%',400)}}
 
-When generating content on regular elements (rather than just on pseudo-elements), the entire element is replaced; `::before` or `::after` pseudo-elements are not generated on replaced elements. In other words, only of the two CSS declarations is applied to each `<div>`.
+When generating content on regular elements (rather than just on pseudo-elements), the entire element is replaced. This means that `::before` and `::after` pseudo-elements are not generated.
 
 ### Element replacement with `<gradient>`
 
-This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The first element's contents are replaced with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}}. The second element, which is not replaced, includes generated text set on `::after`. This generated text includes a gradient image as a background.
+This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The element's contents are replaced with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}}. With {{cssxref("@supports")}}, we provide alt text support and a {{cssxref("gradient/repeating-linear-gradient" ,"repeating-linear-gradient()")}} for browsers that support alt text with element content replacement.
 
 #### HTML
 
 ```html
 <div id="replaced">I disappear</div>
-<hr />
-<div id="notReplaced">I am not replaced</div>
 ```
 
 #### CSS
 
 ```css
 div {
-  width: 75%;
-  height: 75px;
-  border: 1px solid lightgrey;
+  border: 1px solid;
+  background-color: #ccc;
+  min-height: 100px;
+  min-width: 100px;
 }
 
 #replaced {
-  content: linear-gradient(purple, yellow);
+  content: linear-gradient(#639f, #c96a);
 }
-/* will not show if the element is replaced */
-div::after {
-  content: " (Check the browser compatibility. A browser may support CSS gradients, but not as a `content` value)";
-  background: linear-gradient(to right, yellow, pink);
+
+@supports (content: linear-gradient(#000, #fff) / "alt text") {
+  #replaced {
+    content: repeating-linear-gradient(blue 0, orange 10%) /
+      "Gradients and alt text are supported";
+  }
 }
 ```
 
@@ -377,7 +389,7 @@ div::after {
 
 {{EmbedLiveSample('Element_replacement_with_gradient', '100%', 200)}}
 
-Check the [browser compatibility chart](#browser-compatibility). All browsers support gradients and all browsers support replacing elements with images, but not all browsers correctly render gradients when set as a `content` value.
+Check the [browser compatibility chart](#browser-compatibility). All browsers support gradients and all browsers support replacing elements with images, but not all browsers support gradients as a `content` value and not all browsers support alt text on replacements. If the browser displays a box with no gradient, replacing elements is supported, but gradients are not supported as a content replacement value. If the element is replaced with a striped gradient, the browser supports both.
 
 ### Element replacement with `image-set()`
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -324,7 +324,9 @@ In browsers that don't support the alternative text syntax the whole declaration
 
 ### Element replacement with `url()`
 
-This example replaces a regular element! The element's contents are replaced with an SVG using the {{cssxref("url", "url()")}} image function. We include generated content, attempting to add the `id` of the element generated on `::after`. This pseudo-element is not generated in browsers that support content replacement as the element is replaced.
+This example replaces a regular element! The element's contents are replaced with an SVG using the {{cssxref("url", "url()")}} image function.
+
+Pseudo-elements aren't rendered on replaced elements. As this element is replaced, any matching `::after` or `::before` are not generated or applied. To demonstrate this, we include an `::after` declaration block, attempting to add the `id` as generated content. This pseudo-element will not be generated as the element is replaced.
 
 #### HTML
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -62,7 +62,14 @@ content: unset;
 
 ### Values
 
-The value can be one of two keywords — `none` or `normal` — or either `<content-replacement>` when replacing a DOM node or a `<content-list>` for pseudo-elements and margin boxes, with optional alternative text value of a `<string>` or `<counter>`. Content replacement is always an `<image>`. A content-list is a list of of one or more anonymous inline boxes appearing in the order specified. Each content-list item is either `contents` or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader):
+The value can be:
+
+- One of two keywords — `none` or `normal`
+- `<content-replacement>` when replacing a DOM node. `<content-replacement>` is always an `<image>`.
+- A `<content-list>` when replacing pseudo-elements and margin boxes. A content-list is a list of one or more anonymous inline boxes appearing in the order specified. Each `<content-list>` item is either `contents` or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
+- An optional alternative text value of a `<string>` or `<counter>`, preceded by a slash (`/`).
+
+The keywords and data types mentioned above are described in more detail below:
 
 - `none`
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.content
 
 {{CSSRef}}
 
-The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element with a generated value. The `content` property is used to define what is rendered inside an element or pseudo-element. For elements, the `content` property specifies whether the element renders normally (`normal` or `none`) or is replaced with an image (and associated "alt" text). For pseudo-elements and margin boxes, `content` controls whether the element renders at all, replacing the element with an image, text, or both.
+The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element's content with a generated value. The `content` property is used to define what is rendered inside an element or pseudo-element. For elements, the `content` property specifies whether the element renders normally (`normal` or `none`) or is replaced with an image (and associated "alt" text). For pseudo-elements and margin boxes, `content` controls whether the element renders at all, replacing the element with an image, text, or both.
 
 Objects inserted using the `content` property are **anonymous [replaced elements](/en-US/docs/Web/CSS/Replaced_element)**.
 
@@ -71,7 +71,7 @@ The value can be one of two keywords — `none` or `normal` — or, for DOM node
 
 - `normal`
 
-  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, `normal` the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin box, this computes to `contents`.
+  - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to `contents`.
 
 - `contents` {{Experimental_Inline}}
 
@@ -83,7 +83,7 @@ The value can be one of two keywords — `none` or `normal` — or, for DOM node
 
 - {{cssxref("&lt;image&gt;")}}
 
-  - : An {{cssxref("&lt;image&gt;")}}, denoted by the {{cssxref("url", "url()")}} or {{cssxref("image/image-set", "image-set()")}} or {{cssxref("&lt;gradient&gt;")}} data type, or part of the webpage, defined by the {{cssxref("element", "element()")}} function, denoting the content to display.
+  - : An {{cssxref("&lt;image&gt;")}}, representing an image to display. This can be equal to a {{cssxref("url", "url()")}}, {{cssxref("image/image-set", "image-set()")}}, or {{cssxref("&lt;gradient&gt;")}} data type, or a part of the webpage itself, defined by the {{cssxref("element", "element()")}} function.
 
 - `<counter>`
 
@@ -98,23 +98,23 @@ The value can be one of two keywords — `none` or `normal` — or, for DOM node
   - : The `<quote>` data type includes language- and position-dependent keywords:
     - `open-quote` and `close-quote`
       - : These values are replaced by the appropriate string from the {{cssxref("quotes")}} property.
-    - `no-open-quote` | `no-close-quote`
+    - `no-open-quote` and `no-close-quote`
       - : Introduces no content, but increments (decrements) the level of nesting for quotes.
 
 - `<target>` {{Experimental_Inline}}
 
-  - : The `<target>` data type includes three target functions, `<target-counter()>`, `<target-counters()>`, and `<target-text()>` that create cross-reference obtained from the target end of a link. See [Formal syntax](#formal_syntax).
+  - : The `<target>` data type includes three target functions, `<target-counter()>`, `<target-counters()>`, and `<target-text()>` that create cross-references obtained from the target end of a link. See [Formal syntax](#formal_syntax).
 
 - `<leader()>` {{Experimental_Inline}}
 
-  - : The `<leader()>` data type inclues a leader function: `leader( <leader-type> )`. This function accepts the keyword values `dotted`, `solid`, or `space` (equal to `leader(".")`, `leader("_")`, and `leader(" ")`, respectively), or a `<string>` as a parameter. When supported and used as a value for `content`, the leader-type provided will be inserted as a repeating pattern visually connecting content across a horizontal line.
+  - : The `<leader()>` data type inclues a leader function: `leader( <leader-type> )`. This function accepts the keyword values `dotted`, `solid`, or `space` (equal to `leader(".")`, `leader("_")`, and `leader(" ")`, respectively), or a `<string>` as a parameter. When supported and used as a value for `content`, the leader-type provided will be inserted as a repeating pattern, visually connecting content across a horizontal line.
 
 - `attr(x)`
 
-  - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element or pseudo-element's originating element. The value of the element's attribute `x` as an unparsed string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute name parameter depends on the document language.
+  - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element, or the pseudo-element's originating element. The value of the element's attribute `x` is an unparsed string representing the attribute name. If there is no attribute `x`, an empty string is returned. The case sensitivity of the attribute name parameter depends on the document language.
 
-- alternative text `/ <string> | <counter>`
-  - : Alternative text may be specified for an image or any `<content-list>` items, by appending a forward slash and then a string of text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} specifies the "alt text" for the element.
+- alternative text: `/ <string> | <counter>`
+  - : Alternative text may be specified for an image or any `<content-list>` items, by appending a forward slash and then a string of text or a counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} data types specify the "alt text" for the element.
 
 ## Formal definition
 
@@ -126,11 +126,11 @@ The value can be one of two keywords — `none` or `normal` — or, for DOM node
 
 ## Examples
 
-The first examples created generated content on pseudo-elements. The last three are [examples of element replacement](#element-replacement-with-url).
+The first five examples create generated content on pseudo-elements. The last three are [examples of element replacement](#element-replacement-with-url).
 
 ### Appending strings based on an element's class
 
-This example inserts generated text, coloring it red, after the text based on an element's class name.
+This example inserts generated text after the text of elements that have a particular class name. The text is colored red.
 
 #### HTML
 
@@ -208,7 +208,7 @@ q::after {
 
 {{EmbedLiveSample('Quotes', '100%', 200)}}
 
-Note the [type of quotes generated](/en-US/docs/Web/CSS/quotes#auto_quotes) is based on the language. Browsers add open- and close-quotes before and after {{HTMLElement("q")}} elements by default, so the quotes in this example would appear without them being explicitly set. They could have been turned off by setting `no-open-quote` and `no-close-quote`, or `none` value. They can also be turned off by setting the {{cssxref("quotes")}} property to `none` instead.
+Note the [type of quotes generated](/en-US/docs/Web/CSS/quotes#auto_quotes) is based on the language. Browsers add open- and close-quotes before and after {{HTMLElement("q")}} elements by default, so the quotes in this example would appear without them being explicitly set. They could have been turned off by setting the respective `content` property values to `no-open-quote` and `no-close-quote`, or by setting them both to `none`. They can also be turned off by setting the {{cssxref("quotes")}} property to `none` instead.
 
 ### Adding text to list item counters
 
@@ -285,7 +285,7 @@ The generated content is the value of the `href` attribute, prepended by "URL: "
 
 ### Adding an image with alternative text
 
-This example inserts an image before the link. Alternative text that a screen reader can output as speech in included,
+This example inserts an image before the link. Alternative text that a screen reader can output as speech is included,
 which some browsers may display. To indicate if alternative text after a content list is supported or not, a fallback `content`, the CSS includes the message " - no alt text - ".
 
 #### HTML

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -18,7 +18,7 @@ The **`content`** [CSS](/en-US/docs/Web/CSS) property replaces an element with a
 content: normal;
 content: none;
 
-/* <content-replacement> / <image> values */
+/* <content-replacement>: <image> values */
 content: url("http://www.example.com/test.png");
 content: linear-gradient(#e66465, #9198e5);
 content: image-set("image1x.png" 1x, "image2x.png" 2x);
@@ -27,12 +27,7 @@ content: image-set("image1x.png" 1x, "image2x.png" 2x);
 content: url("../img/test.png") / "This is the alt text";
 
 /* <string> value */
-content: "prefix";
-
-/* list of content values */
-content: "prefix" url("http://www.example.com/test.png");
-content: "prefix" url("http://www.example.com/test.png") "suffix" /
-  "This is some alt text";
+content: "unparsed text";
 
 /* <counter> values, optionally with <list-style-type> */
 content: counter(chapter_counter);
@@ -41,7 +36,7 @@ content: counters(section_counter, ".");
 content: counters(section_counter, ".", decimal-leading-zero);
 
 /* attr() value linked to the HTML attribute value */
-content: attr(value string);
+content: attr(href);
 
 /* <quote> values */
 content: open-quote;
@@ -49,7 +44,10 @@ content: close-quote;
 content: no-open-quote;
 content: no-close-quote;
 
+/* list of content values */
 /* Except for normal and none, several values can be used simultaneously */
+content: "prefix" url(http://www.example.com/test.png);
+content: "prefix" url("/img/test.png") "suffix" / "Alt text";
 content: open-quote counter(chapter_counter);
 
 /* Global values */
@@ -72,7 +70,7 @@ content: unset;
 
 - `<content-list>`
 
-  - : A list of anonymous inline boxes that will replace the content of the selected element (in the specified order). Each `<content-list>` item is either content or of type `<string>`, `<image>`, `<counter>`, `<quote>`, `<target>`, or `<leader()>`.
+  - : A list of anonymous inline boxes that will replace the content of the selected element (in the specified order). Each `<content-list>` item is either content or of type [`<string>`](#string), [`<image>`](#image), [`<counter>`](#counter), [`<quote>`](#quote), [`<target>`](#target), or [`<leader()>`](#leader).
 
 - {{cssxref("&lt;string&gt;")}}
 
@@ -102,20 +100,16 @@ content: unset;
 
   - : The `<target>` data type includes three target functions, `<target-counter()>`, `<target-counters()>`, and `<target-text()>` that create cross-reference obtained from the target end of a link. See [Formal syntax](#formal_syntax).
 
-- `<leader>` {{Experimental_Inline}}
+- `<leader()>` {{Experimental_Inline}}
 
-  - : stuff
+  - : The `<leader()>` data type inclues a leader function: `leader( <leader-type> )`. This function accepts the keyword values `dotted`, `solid`, or `space` (equal to `leader(".")`, `leader("_")`, and `leader(" ")`, respectively), or a `<string>` as a parameter. When used as a value for `content`, the leader-type provided will be inserted as a repeating pattern visually connecting content across a horizontal line.
 
 - `attr(x)`
 
-  - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element or pseudo-element's originating element. The value of the element's attribute `x` as an unparsed string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute names depends on the document language.
+  - : The `attr(x)` CSS function retrieves the value of an attribute of the selected element or pseudo-element's originating element. The value of the element's attribute `x` as an unparsed string. If there is no attribute `x`, an empty string is returned. The case-sensitivity of attribute name parameter depends on the document language.
 
 - `<content-list> / "<string> or <counter>"`
-
-  - : Alternative text may be specified for an image , or any of the `<content-list>` items, by appending a forward slash and then the string text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, neither the content or alternative text will be used.
-
-    - {{cssxref("string", "/ &lt;string>")}}
-      - : Specifies the "alt text" for the element. This value can be any number of text characters. Non-Latin characters must be encoded using their Unicode escape sequences: for example, `\000A9` represents the copyright symbol.
+  - : Alternative text may be specified for an image , or any of the `<content-list>` items, by appending a forward slash and then the string text or counter. The alternative text is intended for speech output by screen-readers, but may also be displayed in some browsers. Note that if the browser does not support alternative text, the `content` declaration will be considered invalid and will be ignored. The {{cssxref("string", "/ &lt;string>")}} or {{cssxref("counter", "/ &lt;counter>")}} specifies the "alt text" for the element.
 
 ## Accessibility concerns
 
@@ -358,7 +352,7 @@ When generating content on regular elements (rather than just on pseudo-elements
 
 ### Element replacement with `<gradient>`
 
-This example replaces an element's content with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}} if supported.
+This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The first element's contents are replaced with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}}. The second element, which is not replaced, includes generated text set on `::after`. This generated text includes a gradient image as a background.
 
 #### HTML
 
@@ -372,8 +366,8 @@ This example replaces an element's content with a {{cssxref("gradient/linear-gra
 
 ```css
 div {
-  min-width: 100px;
-  min-height: 50px;
+  width: 75%;
+  height: 75px;
   border: 1px solid lightgrey;
 }
 
@@ -382,7 +376,7 @@ div {
 }
 /* will not show if the element is replaced */
 div::after {
-  content: " (Gradients may be supported, but not as a value for <content>)";
+  content: " (Check the browser compatibility. A browser may support CSS gradients, but not as a `content` value)";
   background: linear-gradient(to right, yellow, pink);
 }
 ```
@@ -390,6 +384,8 @@ div::after {
 #### Result
 
 {{EmbedLiveSample('Element_replacement_with_gradient', '100%', 200)}}
+
+Check the [browser compatibility chart](#browser-compatibility). All browsers support gradients and all browsers support replacing elements with images, but not all browsers correctly render gradients when set as a `content` value.
 
 ### Element replacement with `image-set()`
 
@@ -433,6 +429,7 @@ div {
 
 ## See also
 
+- [CSS generated content](/en-US/docs/Web/CSS/CSS_generated_content) module
 - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)
 - {{Cssxref("::after")}}
 - {{Cssxref("::before")}}

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -7,15 +7,15 @@ spec-urls: https://drafts.csswg.org/css-content/
 
 {{CSSRef}}
 
-The **CSS generated content** module defines an element' content can be replaced and content can be added to a document with CSS.
+The **CSS generated content** module defines how an element's content can be replaced and content can be added to a document with CSS.
 
-Generated content can be used for content replacement, in which case the content of a DOM node is replaced with a CSS `<image>`. The CSS generated content also enables generating language-specific quotes, create custom list item numbers and bullets, and visually adding content by generating content on select pseudo-elements as anonymous replaced elements.
+Generated content can be used for content replacement, in which case the content of a DOM node is replaced with a CSS `<image>`. The CSS generated content also enables generating language-specific quotes, creating custom list item numbers and bullets, and visually adding content by generating content on select pseudo-elements as anonymous replaced elements.
 
 ### Generated content in action
 
 {{EmbedGHLiveSample("css-examples/modules/generated_content.html", '100%', 720)}}
 
-The HTML for this sample is a single, empty {{HTMLElement("div")}} inside an otherwise empty {{HTMLElement("body")}}. The snowman was created with [CSS images](/en-US/docs/Web/CSS/CSS_images) and [CSS background and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders). The carrot nose was added by genarating content: the empty box with a wide orange {{cssxref("border-left", "left border")}} added to the {{cssxref("::before")}} pseudo-element. The text is also generated content: the "only one &lt;div>" was generated with the {{cssxref("content")}} property applied to the {{cssxref("::after")}} pseudo-element.
+The HTML for this sample is a single, empty {{HTMLElement("div")}} inside an otherwise empty {{HTMLElement("body")}}. The snowman was created with [CSS images](/en-US/docs/Web/CSS/CSS_images) and [CSS backgrounds and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders). The carrot nose was added using generated content: an empty box with a wide orange {{cssxref("border-left", "left border")}} added to the {{cssxref("::before")}} pseudo-element. The text is also generated content: "only one &lt;div>" was generated with the {{cssxref("content")}} property applied to the {{cssxref("::after")}} pseudo-element.
 
 To see the code for this animation, [view the source on GitHub](https://github.com/mdn/css-examples/blob/main/modules/generated_content.html).
 
@@ -26,11 +26,11 @@ To see the code for this animation, [view the source on GitHub](https://github.c
 - {{cssxref("content")}}
 - {{cssxref("quotes")}}
 
-> **Note:** The CSS generated content module introduces four at-risk properties that have not been implented, including `string-set`, `bookmark-label`, `bookmark-level`, and `bookmark-state`.
+> **Note:** The CSS generated content module introduces four at-risk properties that have not been implemented: `string-set`, `bookmark-label`, `bookmark-level`, and `bookmark-state`.
 
 ### Functions
 
-The CSS generated content module introduces six yet-to-be implemented CSS functions including `content()`, `string()`, and `leader()` functions, and the three [`<target>`](/en-US/docs/Web/CSS/content#target) functions: `target-counter()`, `target-counters()`, and `target-text()`.
+The CSS generated content module introduces six yet-to-be implemented CSS functions including `content()`, `string()`, and `leader()`, and the three [`<target>`](/en-US/docs/Web/CSS/content#target) functions `target-counter()`, `target-counters()`, and `target-text()`.
 
 ### Data types
 
@@ -43,7 +43,7 @@ The CSS generated content module introduces six yet-to-be implemented CSS functi
 
 ## Guides
 
-- [How to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
+- ["How to" guide for generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
 
   - : Learn how to add text or image content to a document using the {{cssxref("content")}} property.
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -7,7 +7,9 @@ spec-urls: https://drafts.csswg.org/css-content/
 
 {{CSSRef}}
 
-The **CSS generated content** module defines how content can be added to a document with CSS. Generated content can be used to add content to anonymous replaced elements or replace the content of a DOM node with a CSS generated value.
+The **CSS generated content** module defines an element' content can be replaced and content can be added to a document with CSS.
+
+Generated content can be used for content replacement, in which case the content of a DOM node is replaced with a CSS `<image>`. The CSS generated content also enables generating language-specific quotes, create custom list item numbers and bullets, and visually adding content by generating content on select pseudo-elements as anonymous replaced elements.
 
 ### Generated content in action
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -68,7 +68,7 @@ The CSS generated content module introduces six yet-to-be implemented CSS functi
 
 [CSS values and units](/en-US/docs/Web/CSS/CSS_values_and_units) module
 
-- {{cssxref("attr()")}} function
+- {{cssxref("attr", "attr()")}} function
 - {{cssxref("string")}} data type
 - {{cssxref("image")}} data type
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -23,28 +23,26 @@ The **CSS generated content** module defines how content can be added to a docum
 - `<content()>`
 - `<string()>`
 - `<leader()>`
-- `<target-counter()>`
-- `<target-counters()>`
-- `<target-text()>`
+
+> **Note:** The CSS generated content module introduces three experimental [`<target>`](/en-US/docs/Web/CSS/content#target) functions that have not been implented, including `<target-counter()>`, `<target-counters()>`, and `<target-text()>`.
 
 ### Data types
 
-- `<content-list>`
-- `<content-replacement>`
-- `<image>`
-- `<counter>`
-- `<quote>`
-- `<target>`
-- `<quote>`
+- [`<content-list>`](/en-US/docs/Web/CSS/content#content-list)
+- `<content-replacement>` (see {{cssxref("image")}})
+- {{cssxref("image")}}
+- {{cssxref("counter")}}
+- [`<quote>`](/en-US/docs/Web/CSS/content#quote)
+- [`<target>`](/en-US/docs/Web/CSS/content#target)
 
 ## Guides
 
-- [How to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generated_content) to l
+- [How to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
 
-  - : Learn how to generated content with CSS, including the {{cssxref("content")}} and {{cssxref("quotes")}} properties.
+  - : Learn how to add text or image content to a document using the {{cssxref("content")}} property.
 
 - [Using CSS generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
-  - :
+  - : How to
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -51,26 +51,24 @@ The CSS generated content module introduces six CSS functions including the not 
 
 ## Related concepts
 
-- [CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
+[CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
 
-  - {{cssxref("::before")}} pseudo-element
-  - {{cssxref("::after")}} pseudo-element
-  - {{cssxref("::marker")}} pseudo-element
+- {{cssxref("::before")}} pseudo-element
+- {{cssxref("::after")}} pseudo-element
+- {{cssxref("::marker")}} pseudo-element
 
-- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+[CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
 
-  - {{cssxref("counter", "counter()")}} function
-  - {{cssxref("counters", "counters()")}} function
-  - {{cssxref("counter-increment")}} property
-  - {{cssxref("counter-reset")}} property
+- {{cssxref("counter", "counter()")}} function
+- {{cssxref("counters", "counters()")}} function
+- {{cssxref("counter-increment")}} property
+- {{cssxref("counter-reset")}} property
 
-- [CSS values and units](/en-US/docs/Web/CSS/CSS_values_and_units) module
+[CSS values and units](/en-US/docs/Web/CSS/CSS_values_and_units) module
 
-  - {{cssxref("string")}} data type
-  - {{cssxref("attr()")}} function
-  - {{cssxref("image")}} data type
-
-- [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)
+- {{cssxref("attr()")}} function
+- {{cssxref("string")}} data type
+- {{cssxref("image")}} data type
 
 ## Specifications
 
@@ -80,3 +78,4 @@ The CSS generated content module introduces six CSS functions including the not 
 
 - [CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
 - [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+- [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -9,6 +9,14 @@ spec-urls: https://drafts.csswg.org/css-content/
 
 The **CSS generated content** module defines how content can be added to a document with CSS. Generated content can be used to add content to anonymous replaced elements or replace the content of a DOM node in very limited circumstances with a generated value.
 
+### Generated content in action
+
+{{EmbedGHLiveSample("css-examples/modules/generated_content.html", '100%', 650)}}
+
+The HTML for this sample is a single, empty {{HTMLElement("div")}} inside an otherwise empty {{HTMLElement("body")}}. The snowman was created with [CSS images](/en-US/docs/Web/CSS/CSS_images) and [CSS background and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders). The carrot nose was added by genarating content: the empty box with a wide orange {{cssxref("border-left", "left border")}} added to the {{cssxref("::before")}} pseudo-element. The text is also generated content: the "only one &lt;div>" was generated with the {{cssxref("content")}} property applied to the {{cssxref("::after")}} pseudo-element.
+
+To see the code for this animation, [view the source on GitHub](https://github.com/mdn/css-examples/blob/main/modules/generated_content.html).
+
 ## Reference
 
 ### Properties
@@ -20,18 +28,14 @@ The **CSS generated content** module defines how content can be added to a docum
 
 ### Functions
 
-- `<content()>`
-- `<string()>`
-- `<leader()>`
-
-> **Note:** The CSS generated content module introduces three experimental [`<target>`](/en-US/docs/Web/CSS/content#target) functions that have not been implented, including `<target-counter()>`, `<target-counters()>`, and `<target-text()>`.
+The CSS generated content module introduces six CSS functions including the not yet implented `content()`, `string()`, and `leader()` functions, and the three experimental [`<target>`](/en-US/docs/Web/CSS/content#target) functions, including `target-counter()`, `target-counters()`, and `target-text()`.
 
 ### Data types
 
 - [`<content-list>`](/en-US/docs/Web/CSS/content#content-list)
 - `<content-replacement>` (see {{cssxref("image")}})
 - {{cssxref("image")}}
-- {{cssxref("counter")}}
+- [`<counter>`](/en-US/docs/Web/CSS/content#counter)
 - [`<quote>`](/en-US/docs/Web/CSS/content#quote)
 - [`<target>`](/en-US/docs/Web/CSS/content#target)
 
@@ -41,17 +45,32 @@ The **CSS generated content** module defines how content can be added to a docum
 
   - : Learn how to add text or image content to a document using the {{cssxref("content")}} property.
 
-- [Using CSS generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
-  - : How to
+- [Create fancy boxes with generated content](/en-US/docs/Learn/CSS/Howto/Create_fancy_boxes)
+
+  - : Example of styling generated content for visual effects.
 
 ## Related concepts
 
-- {{cssxref("::before")}} pseudo-element
-- {{cssxref("::after")}} pseudo-element
-- {{cssxref("::marker")}} pseudo-element
+- [CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
 
-- {{cssxref("counter-increment")}} property
-- {{cssxref("counter-reset")}} property
+  - {{cssxref("::before")}} pseudo-element
+  - {{cssxref("::after")}} pseudo-element
+  - {{cssxref("::marker")}} pseudo-element
+
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+
+  - {{cssxref("counter", "counter()")}} function
+  - {{cssxref("counters", "counters()")}} function
+  - {{cssxref("counter-increment")}} property
+  - {{cssxref("counter-reset")}} property
+
+- [CSS values and units](/en-US/docs/Web/CSS/CSS_values_and_units) module
+
+  - {{cssxref("string")}} data type
+  - {{cssxref("attr()")}} function
+  - {{cssxref("image")}} data type
+
+- [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)
 
 ## Specifications
 
@@ -60,3 +79,4 @@ The **CSS generated content** module defines how content can be added to a docum
 ## See also
 
 - [CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -13,7 +13,7 @@ Generated content can be used for content replacement, in which case the content
 
 ### Generated content in action
 
-{{EmbedGHLiveSample("css-examples/modules/generated_content.html", '100%', 720)}}
+{{EmbedGHLiveSample("css-examples/modules/generated_content.html", '100%',420)}}
 
 The HTML for this sample is a single, empty {{HTMLElement("div")}} inside an otherwise empty {{HTMLElement("body")}}. The snowman was created with [CSS images](/en-US/docs/Web/CSS/CSS_images) and [CSS backgrounds and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders). The carrot nose was added using generated content: an empty box with a wide orange {{cssxref("border-left", "left border")}} added to the {{cssxref("::before")}} pseudo-element. The text is also generated content: "only one &lt;div>" was generated with the {{cssxref("content")}} property applied to the {{cssxref("::after")}} pseudo-element.
 
@@ -53,24 +53,24 @@ The CSS generated content module introduces six yet-to-be implemented CSS functi
 
 ## Related concepts
 
-[CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
+- [CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module
 
-- {{cssxref("::before")}} pseudo-element
-- {{cssxref("::after")}} pseudo-element
-- {{cssxref("::marker")}} pseudo-element
+  - {{cssxref("::before")}} pseudo-element
+  - {{cssxref("::after")}} pseudo-element
+  - {{cssxref("::marker")}} pseudo-element
 
-[CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
 
-- {{cssxref("counter", "counter()")}} function
-- {{cssxref("counters", "counters()")}} function
-- {{cssxref("counter-increment")}} property
-- {{cssxref("counter-reset")}} property
+  - {{cssxref("counter", "counter()")}} function
+  - {{cssxref("counters", "counters()")}} function
+  - {{cssxref("counter-increment")}} property
+  - {{cssxref("counter-reset")}} property
 
-[CSS values and units](/en-US/docs/Web/CSS/CSS_values_and_units) module
+- [CSS values and units](/en-US/docs/Web/CSS/CSS_values_and_units) module
 
-- {{cssxref("attr", "attr()")}} function
-- {{cssxref("string")}} data type
-- {{cssxref("image")}} data type
+  - {{cssxref("attr", "attr()")}} function
+  - {{cssxref("string")}} data type
+  - {{cssxref("image")}} data type
 
 ## Specifications
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -7,11 +7,11 @@ spec-urls: https://drafts.csswg.org/css-content/
 
 {{CSSRef}}
 
-The **CSS generated content** module defines how content can be added to a document with CSS. Generated content can be used to add content to anonymous replaced elements or replace the content of a DOM node in very limited circumstances with a generated value.
+The **CSS generated content** module defines how content can be added to a document with CSS. Generated content can be used to add content to anonymous replaced elements or replace the content of a DOM node with a CSS generated value.
 
 ### Generated content in action
 
-{{EmbedGHLiveSample("css-examples/modules/generated_content.html", '100%', 650)}}
+{{EmbedGHLiveSample("css-examples/modules/generated_content.html", '100%', 720)}}
 
 The HTML for this sample is a single, empty {{HTMLElement("div")}} inside an otherwise empty {{HTMLElement("body")}}. The snowman was created with [CSS images](/en-US/docs/Web/CSS/CSS_images) and [CSS background and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders). The carrot nose was added by genarating content: the empty box with a wide orange {{cssxref("border-left", "left border")}} added to the {{cssxref("::before")}} pseudo-element. The text is also generated content: the "only one &lt;div>" was generated with the {{cssxref("content")}} property applied to the {{cssxref("::after")}} pseudo-element.
 
@@ -28,7 +28,7 @@ To see the code for this animation, [view the source on GitHub](https://github.c
 
 ### Functions
 
-The CSS generated content module introduces six CSS functions including the not yet implented `content()`, `string()`, and `leader()` functions, and the three experimental [`<target>`](/en-US/docs/Web/CSS/content#target) functions, including `target-counter()`, `target-counters()`, and `target-text()`.
+The CSS generated content module introduces six yet-to-be implemented CSS functions including `content()`, `string()`, and `leader()` functions, and the three [`<target>`](/en-US/docs/Web/CSS/content#target) functions: `target-counter()`, `target-counters()`, and `target-text()`.
 
 ### Data types
 

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -7,9 +7,7 @@ spec-urls: https://drafts.csswg.org/css-content/
 
 {{CSSRef}}
 
-**CSS Generated Content** is a module of CSS that defines how to add content to an element. Generated content can be used to add content to anonymous replaced elements or replace the content of a DOM node in very limited circumstances with a generated value.
-
-See the [how to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generated_content) to learn more, and the {{cssxref("content")}} and {{cssxref("quotes")}} properties for implementation information.
+The **CSS generated content** module defines how content can be added to a document with CSS. Generated content can be used to add content to anonymous replaced elements or replace the content of a DOM node in very limited circumstances with a generated value.
 
 ## Reference
 
@@ -18,11 +16,49 @@ See the [how to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generat
 - {{cssxref("content")}}
 - {{cssxref("quotes")}}
 
+> **Note:** The CSS generated content module introduces four at-risk properties that have not been implented, including `string-set`, `bookmark-label`, `bookmark-level`, and `bookmark-state`.
+
+### Functions
+
+- `<content()>`
+- `<string()>`
+- `<leader()>`
+- `<target-counter()>`
+- `<target-counters()>`
+- `<target-text()>`
+
+### Data types
+
+- `<content-list>`
+- `<content-replacement>`
+- `<image>`
+- `<counter>`
+- `<quote>`
+- `<target>`
+- `<quote>`
+
+## Guides
+
+- [How to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generated_content) to l
+
+  - : Learn how to generated content with CSS, including the {{cssxref("content")}} and {{cssxref("quotes")}} properties.
+
+- [Using CSS generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
+  - :
+
+## Related concepts
+
+- {{cssxref("::before")}} pseudo-element
+- {{cssxref("::after")}} pseudo-element
+- {{cssxref("::marker")}} pseudo-element
+
+- {{cssxref("counter-increment")}} property
+- {{cssxref("counter-reset")}} property
+
 ## Specifications
 
 {{Specifications}}
 
 ## See also
 
-- [Using CSS generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
-- Pseudo-elements: {{cssxref("::before")}}, {{cssxref("::after")}}, {{cssxref("::marker")}}
+- [CSS pseudo-elements](/en-US/docs/Web/CSS/CSS_pseudo-elements) module


### PR DESCRIPTION
Rewrote the two pages.

The module page now follows our new module structure.
the content page needed a rewrite: the values and browser support have changed a lot since this was originally written.