### PR TITLE
fix: link to Set constructor instead of Object constructor

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -73,7 +73,7 @@ The following are examples of writable `Set`-like browser objects:
 
 These properties are defined on `Set.prototype` and shared by all `Set` instances.
 
-- {{jsxref("Object/constructor", "Set.prototype.constructor")}}
+- {{jsxref("Set/Set", "Set.prototype.constructor")}}
   - : The constructor function that created the instance object. For `Set` instances, the initial value is the {{jsxref("Set/Set", "Set")}} constructor.
 - {{jsxref("Set.prototype.size")}}
   - : Returns the number of values in the `Set` object.


### PR DESCRIPTION
### Description

The text `Set.prototype.constructor` incorrectly links to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor.

I've changed it to link to the same page that `Set()` does.

### Motivation

Link went to the wrong article.

### Additional details

N/A

### Related issues and pull requests

N/A