### PR TITLE
Rephrase comment on BigInt operators

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -60,7 +60,7 @@ Most operators support BigInts, however most do not permit operands to be of mix
 - [Unary negation (`-`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
 - [Increment/decrement](/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement): `++`, `--`
 
-The boolean-returning operators allow mixing numbers and BigInts as operands: 
+The boolean-returning operators allow mixing numbers and BigInts as operands:
 
 - [Relational operators](/en-US/docs/Web/JavaScript/Reference/Operators#relational_operators) and [equality operators](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators): `>`, `<`, `>=`, `<=`, `==`, `!=`, `===`, `!==`
 - [Logical operators](/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators) only rely on the [truthiness](/en-US/docs/Glossary/Truthy) of operands

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -59,9 +59,9 @@ The following operators may be used with BigInt values or object-wrapped BigInt 
 + * - % **
 ```
 
-[Bitwise operators](/en-US/docs/Web/JavaScript/Reference/Operators) are supported as well, except `>>>` (zero-fill right shift), as every BigInt value is signed.
+However, the unary operator (`+`) cannot be supported on BigInt due to conflicting usage in asm.js, so it has been omitted [in order to not break asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
 
-Also unsupported is the unary operator (`+`), [in order to not break asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
+All of the [Bitwise operators](/en-US/docs/Web/JavaScript/Reference/Operators) are supported as well, except for `>>>` (zero-fill right shift), as every BigInt value is signed.
 
 ```js
 const previousMaxSafe = BigInt(Number.MAX_SAFE_INTEGER);

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -52,16 +52,23 @@ typeof Object(1n) === "object"; // true
 ```
 
 ### Operators
+Most operators support BigInts, however most do not permit operands to be of mixed types—both operands must be BigInt or neither:
+- [Arithmetic Operators](/en-US/docs/Web/JavaScript/Reference/Operators#arithmetic_operators): `+`, `-`, `*`, `/`, `%`, `**`
+- [Bitwise Operators](/en-US/docs/Web/JavaScript/Reference/Operators#bitwise_shift_operators): `>>`, `<<`, `&`, `|`, `^`, `~`
+- [Unary Negation (`-`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Increment/Decrement](/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement): `++`, `--`
 
-The following operators may be used with BigInt values or object-wrapped BigInt values:
+Mixed operand types are allowed by the boolean-returning operators:
+- [Relational operators](/en-US/docs/Web/JavaScript/Reference/Operators#relational_operators) and [Equality operators](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators): `>`, `<`, `>=`, `<=`, `==`, `!=`, `===`, `!==`
+- [Logical Operators](/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators) all coerce operands to Boolean
 
-```plain
-+ * - % **
-```
+A couple of operators do not support BigInt at all:
+- [Unary Plus (`+`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus) cannot be supported due to conflicting usage in asm.js, so it has been omitted [in order to not break asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
+- [Unsigned right shift (`>>>`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift) is the only bitwise operator that's unsupported, as every BigInt value is signed.
 
-However, the unary operator (`+`) cannot be supported on BigInt due to conflicting usage in asm.js, so it has been omitted [in order to not break asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
-
-All of the [Bitwise operators](/en-US/docs/Web/JavaScript/Reference/Operators) are supported as well, except for `>>>` (zero-fill right shift), as every BigInt value is signed.
+Special Cases:
+- Addition (`+`) involving a String and a BigInt coerces to String.
+- Division (`/`) truncates fractional components towards zero, since BigInt is unable to represent fractional quantities.
 
 ```js
 const previousMaxSafe = BigInt(Number.MAX_SAFE_INTEGER);
@@ -87,11 +94,7 @@ const bigN = 2n ** 54n;
 
 bigN * -1n;
 // -18014398509481984n
-```
 
-The `/` operator also works as expected with whole numbers — but operations with a fractional result will be truncated when used with a BigInt value — they won't return any fractional digits.
-
-```js
 const expected = 4n / 2n;
 // 2n
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -53,7 +53,7 @@ typeof Object(1n) === "object"; // true
 
 ### Operators
 
-Most operators support BigInts, however most do not permit operands to be of mixed types—both operands must be BigInt or neither:
+Most operators support BigInts, however most do not permit operands to be of mixed types — both operands must be BigInt or neither:
 
 - [Arithmetic operators](/en-US/docs/Web/JavaScript/Reference/Operators#arithmetic_operators): `+`, `-`, `*`, `/`, `%`, `**`
 - [Bitwise operators](/en-US/docs/Web/JavaScript/Reference/Operators#bitwise_shift_operators): `>>`, `<<`, `&`, `|`, `^`, `~`

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -52,54 +52,40 @@ typeof Object(1n) === "object"; // true
 ```
 
 ### Operators
+
 Most operators support BigInts, however most do not permit operands to be of mixed types—both operands must be BigInt or neither:
-- [Arithmetic Operators](/en-US/docs/Web/JavaScript/Reference/Operators#arithmetic_operators): `+`, `-`, `*`, `/`, `%`, `**`
-- [Bitwise Operators](/en-US/docs/Web/JavaScript/Reference/Operators#bitwise_shift_operators): `>>`, `<<`, `&`, `|`, `^`, `~`
-- [Unary Negation (`-`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
-- [Increment/Decrement](/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement): `++`, `--`
+
+- [Arithmetic operators](/en-US/docs/Web/JavaScript/Reference/Operators#arithmetic_operators): `+`, `-`, `*`, `/`, `%`, `**`
+- [Bitwise operators](/en-US/docs/Web/JavaScript/Reference/Operators#bitwise_shift_operators): `>>`, `<<`, `&`, `|`, `^`, `~`
+- [Unary negation (`-`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
+- [Increment/decrement](/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement): `++`, `--`
 
 Mixed operand types are allowed by the boolean-returning operators:
-- [Relational operators](/en-US/docs/Web/JavaScript/Reference/Operators#relational_operators) and [Equality operators](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators): `>`, `<`, `>=`, `<=`, `==`, `!=`, `===`, `!==`
-- [Logical Operators](/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators) all coerce operands to Boolean
+
+- [Relational operators](/en-US/docs/Web/JavaScript/Reference/Operators#relational_operators) and [equality operators](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators): `>`, `<`, `>=`, `<=`, `==`, `!=`, `===`, `!==`
+- [Logical operators](/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators) only rely on the [truthiness](/en-US/docs/Glossary/Truthy) of operands
 
 A couple of operators do not support BigInt at all:
-- [Unary Plus (`+`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus) cannot be supported due to conflicting usage in asm.js, so it has been omitted [in order to not break asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
+
+- [Unary plus (`+`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus) cannot be supported due to conflicting usage in asm.js, so it has been left out [in order to not break asm.js](https://github.com/tc39/proposal-bigint/blob/master/ADVANCED.md#dont-break-asmjs).
 - [Unsigned right shift (`>>>`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift) is the only bitwise operator that's unsupported, as every BigInt value is signed.
 
-Special Cases:
-- Addition (`+`) involving a String and a BigInt coerces to String.
+Special cases:
+
+- Addition (`+`) involving a string and a BigInt returns a string.
 - Division (`/`) truncates fractional components towards zero, since BigInt is unable to represent fractional quantities.
 
 ```js
-const previousMaxSafe = BigInt(Number.MAX_SAFE_INTEGER);
-// 9007199254740991n
-
-const maxPlusOne = previousMaxSafe + 1n;
-// 9007199254740992n
-
-const theFuture = previousMaxSafe + 2n;
-// 9007199254740993n, this works now!
-
-const multi = previousMaxSafe * 2n;
-// 18014398509481982n
-
-const subtr = multi - 10n;
-// 18014398509481972n
-
-const mod = multi % 10n;
-// 2n
-
-const bigN = 2n ** 54n;
-// 18014398509481984n
-
-bigN * -1n;
-// -18014398509481984n
-
-const expected = 4n / 2n;
-// 2n
-
-const truncated = 5n / 2n;
-// 2n, not 2.5n
+const previousMaxSafe = BigInt(Number.MAX_SAFE_INTEGER); // 9007199254740991n
+const maxPlusOne = previousMaxSafe + 1n; // 9007199254740992n
+const theFuture = previousMaxSafe + 2n; // 9007199254740993n, this works now!
+const multi = previousMaxSafe * 2n; // 18014398509481982n
+const subtr = multi - 10n; // 18014398509481972n
+const mod = multi % 10n; // 2n
+const bigN = 2n ** 54n; // 18014398509481984n
+bigN * -1n; // -18014398509481984n
+const expected = 4n / 2n; // 2n
+const truncated = 5n / 2n; // 2n, not 2.5n
 ```
 
 ### Comparisons

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -60,7 +60,7 @@ Most operators support BigInts, however most do not permit operands to be of mix
 - [Unary negation (`-`)](/en-US/docs/Web/JavaScript/Reference/Operators/Unary_negation)
 - [Increment/decrement](/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement): `++`, `--`
 
-Mixed operand types are allowed by the boolean-returning operators:
+The boolean-returning operators allow mixing numbers and BigInts as operands: 
 
 - [Relational operators](/en-US/docs/Web/JavaScript/Reference/Operators#relational_operators) and [equality operators](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators): `>`, `<`, `>=`, `<=`, `==`, `!=`, `===`, `!==`
 - [Logical operators](/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators) only rely on the [truthiness](/en-US/docs/Glossary/Truthy) of operands


### PR DESCRIPTION
Got rid of the "also unsupported" phrasing and place more emphasis on `unary`