### PR TITLE
Fix issue 28260: clarify event.currentTarget

### DIFF
--- a/files/en-us/web/api/event/currenttarget/index.md
+++ b/files/en-us/web/api/event/currenttarget/index.md
@@ -8,11 +8,9 @@ browser-compat: api.Event.currentTarget
 
 {{APIRef("DOM")}}
 
-The **`currentTarget`** read-only property of the
-{{domxref("Event")}} interface identifies the current target for the event, as the event
-traverses the DOM. It always refers to the element to which the event handler has been
-attached, as opposed to {{domxref("Event.target")}}, which identifies the element on
-which the event occurred and which may be its descendant.
+The **`currentTarget`** read-only property of the {{domxref("Event")}} interface identifies the element to which the event handler has been attached.
+
+This will not always be the same as the element on which the event was fired, because the event may have fired on a descendant of the element with the handler, and then [bubbled](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling) up to the element with the handler. The element on which the event was fired is given by {{domxref("Event.target")}}.
 
 ## Value
 
@@ -20,34 +18,64 @@ An {{domxref("EventTarget")}} representing the object to which the current event
 
 ## Examples
 
-`Event.currentTarget` is interesting to use when attaching the same event
-handler to several elements.
+### currentTarget versus target
 
-```js
-function hide(e) {
-  e.currentTarget.style.visibility = "hidden";
-  console.log(e.currentTarget);
-  // When this function is used as an event handler: this === e.currentTarget
-}
+This example illustrates the difference between `currentTarget` and `target`.
 
-const ps = document.getElementsByTagName("p");
+#### HTML
 
-for (const p of ps) {
-  // Hide the clicked <p> element
-  p.addEventListener("click", hide, false);
-}
+The page has a "parent" {{htmlelement("div")}} containing a "child" `<div>`.
 
-document.body.addEventListener("click", hide, false);
+```html
+<div id="parent">
+  Click parent
+  <div id="child">Click child</div>
+</div>
 
-// Click around and make paragraphs disappear
+<button id="reset">Reset</button>
+<pre id="output"></pre>
 ```
 
-> **Note:** The value of `event.currentTarget` is _only_ available while the event is being handled.
-> If you {{DOMxRef("console.log()")}} the `event` object, storing it in a variable,
-> and _then_ look for the `currentTarget` key in the console, its value will be `null`.<br/>
-> Instead, you should either use `console.log(event.currentTarget)` to be
-> able to view it in the console or use the [`debugger`](/en-US/docs/Web/JavaScript/Reference/Statements/debugger) statement,
-> which will pause the execution of your code thus showing you the value of `event.currentTarget`.
+```css hidden
+button,
+div,
+pre {
+  margin: 0.5rem;
+}
+
+div {
+  padding: 1rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+The event handler is attached to the parent. It logs the value of `event.currentTarget` and `event.target`.
+
+We also have a "Reset" button that just reloads the example.
+
+```js
+const output = document.querySelector("#output");
+const parent = document.querySelector("#parent");
+parent.addEventListener("click", (event) => {
+  const currentTarget = event.currentTarget.getAttribute("id");
+  const target = event.target.getAttribute("id");
+  output.textContent = `Current target: ${currentTarget}\n`;
+  output.textContent += `Target: ${target}`;
+});
+
+const reset = document.querySelector("#reset");
+reset.addEventListener("click", () => document.location.reload());
+```
+
+#### Result
+
+If you click inside the child `<div>`, then `target` identifies the child. If you click inside the parent `<div>`, then `target` identifies the parent.
+
+In both cases, `currentTarget` identifies the parent, because that's the element that the handler is attached to.
+
+{{EmbedLiveSample("currentTarget versus target", 100, 250)}}
 
 ## Specifications
 
@@ -60,3 +88,4 @@ document.body.addEventListener("click", hide, false);
 ## See also
 
 - [Comparison of Event Targets](/en-US/docs/Web/API/Event/Comparison_of_Event_Targets)
+- [Event bubbling](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling)


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/28260, although it is hard to explain this in a simple way. I didn't manage to add a diagram but did add an example that (I hope) is more helpful than the current one.