### PR TITLE
Link navigator.language and Intl

### DIFF
--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -8,35 +8,29 @@ browser-compat: api.Navigator.language
 
 {{APIRef("HTML DOM")}}
 
-The **`Navigator.language`** read-only property returns
-a string representing the preferred language of the user, usually the language of the
-browser UI.
+The **`Navigator.language`** read-only property returns a string representing the preferred language of the user, usually the language of the browser UI.
 
 ## Value
 
-A string representing the language version as defined in
-{{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
-Examples of valid language codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
+A string representing the language version as defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. Examples of valid language codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 
-Note that in Safari on iOS prior to 10.2, the country code returned is lowercase:
-"en-us", "fr-fr" etc.
+Note that in Safari on iOS prior to 10.2, the country code returned is lowercase: "en-us", "fr-fr" etc.
 
 ## Examples
 
 ### Automatically switching a site's interface to the user's preferred language
 
-Assuming your website has a function called, say, `doLanguageSelect()`, to switch the interface to a given language, you can pass `navigator.language` to it and have the site automatically adapt to the user's preferred language:
+Assuming your website has a function called, say, `selectLang()`, to switch the interface to a given language, you can pass `navigator.language` to it and have the site automatically adapt to the user's preferred language:
 
 ```js
 if (/^en\b/.test(navigator.language)) {
-  doLangSelect(navigator.language);
+  selectLang(navigator.language);
 }
 ```
 
-### Using the `Intl` methods to do language-specific formatting
+### Using Intl constructors to do language-specific formatting
 
-The {{jsxref("Intl")}} methods allow formatting content to match the rules of a given locale.
-You can pass `navigator.language` to them to format content in the locale corresponding to the user's preferred language:
+The {{jsxref("Intl")}} constructors allow formatting content to match the rules of a given locale. You can pass `navigator.language` to them to format content in the locale corresponding to the user's preferred language:
 
 ```js
 const date = new Date("2012-05-24");

--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -14,9 +14,9 @@ browser UI.
 
 ## Value
 
-A string representing the
-language version as defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. Examples of valid language
-codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
+A string representing the language version as defined in
+{{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
+Examples of valid language codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 
 Note that in Safari on iOS prior to 10.2, the country code returned is lowercase:
 "en-us", "fr-fr" etc.
@@ -41,3 +41,4 @@ if (/^en\b/.test(navigator.language)) {
 
 - {{domxref("navigator.languages")}}
 - {{domxref("navigator")}}
+- {{jsxref("Intl")}}

--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -23,10 +23,25 @@ Note that in Safari on iOS prior to 10.2, the country code returned is lowercase
 
 ## Examples
 
+### Automatically switching a site's interface to the user's preferred language
+
+Assuming your website has a function called, say, `doLanguageSelect()`, to switch the interface to a given language, you can pass `navigator.language` to it and have the site automatically adapt to the user's preferred language:
+
 ```js
 if (/^en\b/.test(navigator.language)) {
-  doLangSelect(window.navigator.language);
+  doLangSelect(navigator.language);
 }
+```
+
+### Using the `Intl` methods to do language-specific formatting
+
+The {{jsxref("Intl")}} methods allow formatting content to match the rules of a given locale.
+You can pass `navigator.language` to them to format content in the locale corresponding to the user's preferred language:
+
+```js
+const date = new Date("2012-05-24");
+
+const formattedDate = new Intl.DateTimeFormat(navigator.language).format(date);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -18,16 +18,6 @@ Note that in Safari on iOS prior to 10.2, the country code returned is lowercase
 
 ## Examples
 
-### Automatically switching a site's interface to the user's preferred language
-
-Assuming your website has a function called, say, `selectLang()`, to switch the interface to a given language, you can pass `navigator.language` to it and have the site automatically adapt to the user's preferred language:
-
-```js
-if (/^en\b/.test(navigator.language)) {
-  selectLang(navigator.language);
-}
-```
-
 ### Using Intl constructors to do language-specific formatting
 
 The {{jsxref("Intl")}} constructors allow formatting content to match the rules of a given locale. You can pass `navigator.language` to them to format content in the locale corresponding to the user's preferred language:

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -30,7 +30,7 @@ A string.
 
 ## Examples
 
-### Listing the contents of `navigator.language` and `navigator.languages`
+### Listing the contents of navigator.language and navigator.languages
 
 ```js
 navigator.language; //"en-US"

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -60,3 +60,4 @@ const formattedDate = new Intl.DateTimeFormat(navigator.languages).format(date);
 - {{domxref("navigator.language")}}
 - {{domxref("navigator")}}
 - {{domxref("Window.languagechange_event", "languagechange")}} event
+- {{jsxref("Intl")}}

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -30,9 +30,21 @@ A string.
 
 ## Examples
 
+### Listing the contents of `navigator.language` and `navigator.languages`
+
 ```js
 navigator.language; //"en-US"
 navigator.languages; //["en-US", "zh-CN", "ja-JP"]
+```
+
+### Using Intl constructors to do language-specific formatting, with fallback
+
+The array of language identifiers contained in `navigator.languages` can be passed directly to the {{jsxref("Intl")}} constructors to implement preference-based fallback selection of locales, where the first entry in the list that matches a locale supported by `Intl` is used:
+
+```js
+const date = new Date("2012-05-24");
+
+const formattedDate = new Intl.DateTimeFormat(navigator.languages).format(date);
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -157,4 +157,5 @@ const formattedCount = new Intl.NumberFormat(navigator.languages).format(count);
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
 - {{domxref("navigator.language")}}
+- {{domxref("navigator.languages")}}
 - [The ECMAScript Internationalization API](https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html) by Norbert Lindenberg (2012)

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -133,9 +133,7 @@ const date = new Date("2012-05-24");
 const formattedDate = new Intl.DateTimeFormat(navigator.language).format(date);
 ```
 
-### Using the browser's list of preferred languages
-
-The {{domxref("navigator.languages")}} property provides a sorted list of the user's preferred languages. This list can be passed directly to the `Intl` constructors to implement preference-based fallback selection of locales. The [locale negotiation](#locale-identification-and-negotiation) process is used to pick the most appropriate locale available:
+Alternatively, the {{domxref("navigator.languages")}} property provides a sorted list of the user's preferred languages. This list can be passed directly to the `Intl` constructors to implement preference-based fallback selection of locales. The [locale negotiation](#locale_identification_and_negotiation) process is used to pick the most appropriate locale available:
 
 ```js
 const count = 26254.39;

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -123,6 +123,16 @@ log("en-US"); // 5/24/2012 26,254.39
 log("de-DE"); // 24.5.2012 26.254,39
 ```
 
+### Using the browser's preferred language
+
+Instead of passing a hardcoded locale name to the `Intl` methods, you can use the user's preferred language provided by {{domxref("navigator.language")}}:
+
+```js
+const date = new Date("2012-05-24");
+
+const formattedDate = new Intl.DateTimeFormat(navigator.language).format(date);
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -133,6 +133,16 @@ const date = new Date("2012-05-24");
 const formattedDate = new Intl.DateTimeFormat(navigator.language).format(date);
 ```
 
+### Using the browser's list of preferred languages
+
+The {{domxref("navigator.languages")}} property provides a sorted list of the user's preferred languages. This list can be passed directly to the `Intl` constructors to implement preference-based fallback selection of locales. The [locale negotiation](#locale-identification-and-negotiation) process is used to pick the most appropriate locale available:
+
+```js
+const count = 26254.39;
+
+const formattedCount = new Intl.NumberFormat(navigator.languages).format(count);
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -138,4 +138,5 @@ log("de-DE"); // 24.5.2012 26.254,39
 - {{jsxref("Date.prototype.toLocaleString()")}}
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
+- {{domxref("navigator.language")}}
 - [The ECMAScript Internationalization API](https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html) by Norbert Lindenberg (2012)


### PR DESCRIPTION
### Description

Add a link to [`window.navigator.language`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language) in the "See also" section of the [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) page, and vice versa.

### Motivation

These pages cover related content, so it's likely that people reading one of them will be interested in the other.

### Additional details

N/A

### Related issues and pull requests

N/A
