### PR TITLE
Add missing {{GlossarySidebar}} in two Glossary pages

### DIFF
--- a/files/en-us/glossary/accessible_name/index.md
+++ b/files/en-us/glossary/accessible_name/index.md
@@ -4,6 +4,8 @@ slug: Glossary/Accessible_name
 page-type: glossary-definition
 ---
 
+{{GlossarySidebar}}
+
 An **accessible name** is the name of a user interface element; it is the text associated with an HTML element that provides users of assistive technology with a label for the element.
 
 Accessible names convey the purpose or intent of the element. This helps users understand what the element is for and how they can interact with it. In general, accessible names for elements should be unique to a page. This helps users distinguish an element from other elements and helps users identify the element they want to interact with.

--- a/files/en-us/glossary/binding/index.md
+++ b/files/en-us/glossary/binding/index.md
@@ -4,6 +4,8 @@ slug: Glossary/Binding
 page-type: glossary-definition
 ---
 
+{{GlossarySidebar}}
+
 In programming, a **binding** is an association of an {{glossary("identifier")}} with a value. Not all bindings are {{glossary("variable", "variables")}} — for example, function {{glossary("parameter", "parameters")}} and the binding created by the {{jsxref("Statements/try...catch", "catch (e)")}} block are not "variables" in the strict sense. In addition, some bindings are implicitly created by the language — for example, {{jsxref("Operators/this", "this")}} and [`new.target`](/en-US/docs/Web/JavaScript/Reference/Operators/new.target) in JavaScript.
 
 A binding is {{glossary("mutable")}} if it can be re-assigned, and {{glossary("immutable")}} otherwise; this does _not_ mean that the value it holds is immutable.


### PR DESCRIPTION
### Description

Two of the Glossary pages were missing the `{{GlossarySidebar}}` "macro". This PR adds it to them.

### Motivation

Without the sidebar, it's not possible to navigate from those pages to other pages in the Glossary.
Also, this change restores consistency in how the Glossary pages are rendered.

### Additional details

N/A

### Related issues and pull requests

N/A
