### PR TITLE
DedicatedWorkerGlobalScope.postMessage() - fix syntax

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -23,7 +23,7 @@ The main scope that spawned the worker can send back information to the thread t
 
 ```js-nolint
 postMessage(message)
-postMessage(options)
+postMessage(message, options)
 postMessage(message, transfer)
 ```
 


### PR DESCRIPTION
One of the syntax options shown was invalid. 

Fixes #29346