### PR TITLE
Update description of HTMLAudioElement behavior on garbage collection

### DIFF
--- a/files/en-us/web/api/htmlaudioelement/audio/index.md
+++ b/files/en-us/web/api/htmlaudioelement/audio/index.md
@@ -74,8 +74,7 @@ If all references to an audio element created using
 the `Audio()` constructor are deleted, the element itself won't be removed
 from memory by the JavaScript runtime's garbage collection mechanism if playback is
 currently underway. Instead, the audio will keep playing and the object will remain in
-memory until playback ends or is paused (such as by calling
-{{domxref("HTMLMediaElement.pause", "pause()")}}). At that time, the object becomes
+memory until playback ends. At that time, the object becomes
 subject to garbage collection.
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It's not possible for the user to call .pause() if there is no longer a reference to the object.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This part of the documentation describes an impossible case.
It's unnecessary and might confuse the reader.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
