### PR TITLE
FF119 Object.groupBy and Map.groupBy

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
@@ -13,7 +13,7 @@ The **`Map.groupBy()`** static method groups the elements of a given iterable us
 
 The method is primarily useful when grouping elements that are associated with an object, and in particular when that object might change over time. If the object is invariant, you might instead represent it using a string, and group elements with {{jsxref("Object.groupBy()")}}.
 
-{{EmbedInteractiveExample("pages/js/map-groupby.html","shorter")}}
+{{EmbedInteractiveExample("pages/js/map-groupby.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
@@ -2,12 +2,10 @@
 title: Map.groupBy()
 slug: Web/JavaScript/Reference/Global_Objects/Map/groupBy
 page-type: javascript-static-method
-status:
-  - experimental
 browser-compat: javascript.builtins.Map.groupBy
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 > **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.groupToMap()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
 
@@ -15,7 +13,7 @@ The **`Map.groupBy()`** static method groups the elements of a given iterable us
 
 The method is primarily useful when grouping elements that are associated with an object, and in particular when that object might change over time. If the object is invariant, you might instead represent it using a string, and group elements with {{jsxref("Object.groupBy()")}}.
 
-<!-- {{EmbedInteractiveExample("pages/js/map-groupby.html")}} -->
+{{EmbedInteractiveExample("pages/js/map-groupby.html","shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -7,10 +7,8 @@ browser-compat: javascript.builtins.Map
 
 {{JSRef}}
 
-The **`Map`** object holds key-value pairs and remembers the original insertion
-order of the keys. Any value (both objects and
-{{Glossary("Primitive", "primitive values")}}) may be used as
-either a key or a value.
+The **`Map`** object holds key-value pairs and remembers the original insertion order of the keys.
+Any value (both objects and {{Glossary("Primitive", "primitive values")}}) may be used as either a key or a value.
 
 {{EmbedInteractiveExample("pages/js/map.html", "taller")}}
 
@@ -307,7 +305,7 @@ The following are examples of read-only `Map`-like browser objects:
 
 ## Static methods
 
-- {{jsxref("Map.groupBy()")}} {{experimental_inline}}
+- {{jsxref("Map.groupBy()")}}
   - : Groups the elements of a given iterable using the values returned by a provided callback function. The final returned `Map` uses the unique values from the test function as keys, which can be used to get the array of elements in each group.
 
 ## Instance properties

--- a/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
@@ -2,12 +2,10 @@
 title: Object.groupBy()
 slug: Web/JavaScript/Reference/Global_Objects/Object/groupBy
 page-type: javascript-static-method
-status:
-  - experimental
 browser-compat: javascript.builtins.Object.groupBy
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 > **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.group()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -205,7 +205,7 @@ Unlike [conversion to primitives](/en-US/docs/Web/JavaScript/Data_structures#pri
   - : Returns an array of all symbol properties found directly upon a given object.
 - {{jsxref("Object.getPrototypeOf()")}}
   - : Returns the prototype (internal `[[Prototype]]` property) of the specified object.
-- {{jsxref("Object.groupBy()")}} {{experimental_inline}}
+- {{jsxref("Object.groupBy()")}}
   - : Groups the elements of a given iterable according to the string values returned by a provided callback function. The returned object has separate properties for each group, containing arrays with the elements in the group.
 - {{jsxref("Object.hasOwn()")}}
   - : Returns `true` if the specified object has the indicated property as its _own_ property, or `false` if the property is inherited or does not exist.


### PR DESCRIPTION
FF119 supports Object.groupBy and Map.groupBy in https://bugzilla.mozilla.org/show_bug.cgi?id=1792650

This removes the experimental markup and un-hides the interactive example that has already been merged.

Related docs work can be tracked in #29303