### PR TITLE
FF119 Relnote: Object.groupBy and Map.groupBy

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1024,48 +1024,6 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ## JavaScript
 
-### Array (iterable) grouping methods
-
-The {{jsxref("Object.groupBy()")}} and {{jsxref("Map.groupBy()")}} static methods are used to group the elements of an iterable using a string or value returned by a test function (respectively).
-The first method should be used when strings can be used to represent element groups, while the method in `Map` might be used when elements are associated with a particular object.
-(See [Firefox bug 1841518](https://bugzil.la/1841518) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version removed</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>117</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>NA</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>NA</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>NA</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>javascript.options.experimental.array_grouping</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Array transfer
 
 The {{jsxref("ArrayBuffer.prototype.transfer()")}} and {{jsxref("ArrayBuffer.prototype.transferToFixedLength()")}} methods are used to [transfer ownership](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer#transferring_arraybuffers) of memory from one {{jsxref("ArrayBuffer")}} to another.

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -22,6 +22,8 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### JavaScript
 
+- The {{jsxref("Object.groupBy()")}} and {{jsxref("Map.groupBy()")}} static methods for grouping the elements of an iterable are now supported (See [Firefox bug 1792650](https://bugzil.la/1792650) for more details.)
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
FF119 now supports Object.groupBy and Map.groupBy 

This adds the release note and removes from experimental features.

Related docs work can be tracked in #29303