### PR TITLE
FF119 WebTransport supports sendorder

### DIFF
--- a/files/en-us/web/api/webtransport/createbidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createbidirectionalstream/index.md
@@ -14,13 +14,10 @@ The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WebTran
 "Reliable" means that transmission and order of data are guaranteed.
 This provides slower delivery (albeit faster than with WebSockets) than {{domxref("WebTransport.datagrams", "datagrams")}}, but is needed in situations where reliability and ordering are important, like chat applications.
 
-<!-- sendOrder is pending https://bugzilla.mozilla.org/show_bug.cgi?id=1816925
-
-The relative order in which queued bytes are emptied from created streams can be specified using the send-order option.
+The relative order in which queued bytes are emptied from created streams can be specified using the `sendOrder` option.
 If set, queued bytes in streams with a higher send order are guaranteed to be sent before queued bytes for streams with a lower send order.
 If the order number is not set then the order in which bytes are sent is implementation dependent.
 Note however that even though bytes from higher send-order streams are sent first, they may not arrive first.
--->
 
 {{AvailableInWorkers}}
 
@@ -28,15 +25,10 @@ Note however that even though bytes from higher send-order streams are sent firs
 
 ```js-nolint
 createBidirectionalStream()
+createBidirectionalStream(options)
 ```
 
-<!-- createBidirectionalStream({sendOrder: "596996858"}) -->
-
 ### Parameters
-
-None
-
-<!-- sendOrder is pending https://bugzilla.mozilla.org/show_bug.cgi?id=1816925
 
 - `options` {{optional_inline}}
 
@@ -46,7 +38,6 @@ None
       - : A integer value specifying the send priority of this stream relative to other streams for which the value has been set.
         Queued bytes are sent first for streams that have a higher value.
         If not set, the send order depends on the implementation.
--->
 
 ### Return value
 
@@ -63,7 +54,9 @@ An initial function is used to get references to the {{domxref("WebTransportBidi
 
 ```js
 async function setUpBidirectional() {
-  const stream = await transport.createBidirectionalStream();
+  const stream = await transport.createBidirectionalStream({
+    sendOrder: "596996858",
+  });
   // stream is a WebTransportBidirectionalStream
   // stream.readable is a ReadableStream
   const readable = stream.readable;

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -14,13 +14,10 @@ The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("Writabl
 
 "Reliable" means that transmission and order of data are guaranteed. This provides slower delivery (albeit faster than with WebSockets) than {{domxref("WebTransport.datagrams", "datagrams")}}, but is needed in situations where reliability and ordering are important, like chat applications.
 
-<!-- sendOrder is pending https://bugzilla.mozilla.org/show_bug.cgi?id=1816925
-
-The relative order in which queued bytes are emptied from created streams can be specified using the send-order option.
+The relative order in which queued bytes are emptied from created streams can be specified using the `sendOrder` option.
 If set, queued bytes in streams with a higher send order are guaranteed to be sent before queued bytes for streams with a lower send order.
 If the order number is not set then the order in which bytes are sent is implementation dependent.
 Note however that even though bytes from higher send-order streams are sent first, they may not arrive first.
--->
 
 {{AvailableInWorkers}}
 
@@ -28,15 +25,11 @@ Note however that even though bytes from higher send-order streams are sent firs
 
 ```js-nolint
 createUnidirectionalStream()
+createUnidirectionalStream(options)
 ```
-
-<!-- createUnidirectionalStream({sendOrder: "596996858"}) -->
 
 ### Parameters
 
-None
-
-<!--
 - `options` {{optional_inline}}
 
   - : An object that may have the following properties:
@@ -45,11 +38,10 @@ None
       - : A integer value specifying the send priority of this stream relative to other streams for which the value has been set.
         Queued bytes are sent first for streams that have a higher value.
         If not set, the send order depends on the implementation.
--->
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a {{domxref("WritableStream")}} object.
+A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object (this is a {{domxref("WritableStream")}}).
 
 ### Exceptions
 
@@ -64,7 +56,9 @@ Use the {{domxref("WritableStreamDefaultWriter.close", "close()")}} method of th
 
 ```js
 async function writeData() {
-  const stream = await transport.createUnidirectionalStream();
+  const stream = await transport.createUnidirectionalStream({
+    sendOrder: "596996858",
+  });
   const writer = stream.writable.getWriter();
   const data1 = new Uint8Array([65, 66, 67]);
   const data2 = new Uint8Array([68, 69, 70]);

--- a/files/en-us/web/api/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/index.md
@@ -34,7 +34,8 @@ The **`WebTransport`** interface of the {{domxref("WebTransport API", "WebTransp
   - : Returns a promise that resolves when the transport is ready to use.
 - {{domxref("WebTransport.reliability", "reliability")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a string that indicates whether the connection supports reliable transports only, or whether it also supports unreliable transports (such as UDP).
-  <!-- {{domxref("WebTransport.draining", "draining")}} {{ReadOnlyInline}} {{Experimental_Inline}} : Returns a promise that resolves if a server wants the client to gracefully close the connection. -->
+
+<!-- {{domxref("WebTransport.draining", "draining")}} {{ReadOnlyInline}} {{Experimental_Inline}} : Returns a promise that resolves if a server wants the client to gracefully close the connection. -->
 
 ## Instance methods
 


### PR DESCRIPTION
FF119 supports `options.sendOrder` as an option to the [`WebTransport.createBidirectionalStream()`](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport/createBidirectionalStream) and `createUnidirectionalStream`

This documents the option, which I had previously done, but hidden in comments

Related docs work can be tracked in #29300