### PR TITLE
Fix incorrect link of `URLSearchParams.toString()`

### DIFF
--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -12,10 +12,7 @@ The **`toString()`** method of the
 {{domxref("URLSearchParams")}} interface returns a query string suitable for use in a
 URL.
 
-> **Note:** This method returns the query string without the question
-> mark. This is different from [`Location.search`](/en-US/docs/Web/API/Location/search),
-> [`HTMLAnchorElement.search`](/en-US/docs/Web/API/HTMLAnchorElement/search) and
-> [`URL.search`](/en-US/docs/Web/API/URL/search), which both include the question mark.
+> **Note:** This method returns the query string without the question mark. This is different from [`Location.search`](/en-US/docs/Web/API/Location/search), [`HTMLAnchorElement.search`](/en-US/docs/Web/API/HTMLAnchorElement/search), and [`URL.search`](/en-US/docs/Web/API/URL/search), which all include the question mark.
 
 {{availableinworkers}}
 

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -13,7 +13,8 @@ The **`toString()`** method of the
 URL.
 
 > **Note:** This method returns the query string without the question
-> mark. This is different from [window.location.search](/en-US/docs/Web/API/HTMLAnchorElement/search),
+> mark. This is different from [Location.search](/en-US/docs/Web/API/Location/search)
+> and [HTMLAnchorElement.search](/en-US/docs/Web/API/HTMLAnchorElement/search),
 > which includes it.
 
 {{availableinworkers}}

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -13,9 +13,9 @@ The **`toString()`** method of the
 URL.
 
 > **Note:** This method returns the query string without the question
-> mark. This is different from [`Location.search`](/en-US/docs/Web/API/Location/search)
-> and [`HTMLAnchorElement.search`](/en-US/docs/Web/API/HTMLAnchorElement/search),
-> which both include the question mark.
+> mark. This is different from [`Location.search`](/en-US/docs/Web/API/Location/search),
+> [`HTMLAnchorElement.search`](/en-US/docs/Web/API/HTMLAnchorElement/search) and
+> [`URL.search`](/en-US/docs/Web/API/URL/search), which both include the question mark.
 
 {{availableinworkers}}
 

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -15,7 +15,7 @@ URL.
 > **Note:** This method returns the query string without the question
 > mark. This is different from [Location.search](/en-US/docs/Web/API/Location/search)
 > and [HTMLAnchorElement.search](/en-US/docs/Web/API/HTMLAnchorElement/search),
-> which includes it.
+> which both include the question mark.
 
 {{availableinworkers}}
 

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -13,8 +13,8 @@ The **`toString()`** method of the
 URL.
 
 > **Note:** This method returns the query string without the question
-> mark. This is different from [Location.search](/en-US/docs/Web/API/Location/search)
-> and [HTMLAnchorElement.search](/en-US/docs/Web/API/HTMLAnchorElement/search),
+> mark. This is different from [`Location.search`](/en-US/docs/Web/API/Location/search)
+> and [`HTMLAnchorElement.search`](/en-US/docs/Web/API/HTMLAnchorElement/search),
 > which both include the question mark.
 
 {{availableinworkers}}


### PR DESCRIPTION
### Description

the `window.location.search` was incorrectly linked to `HTMLAnchorElement.search`

though, both `Location.search` and `HTMLAnchorElement.search` contains a '?' while the return value of `URLSearchParams.toString()` does not

so, the fix corrected the link and added both two examples

### Motivation

Ditto.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString

https://developer.mozilla.org/en-US/docs/Web/API/Location/search

https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/search

### Related issues and pull requests
