### PR TITLE
replace BigInt() input description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
@@ -20,7 +20,7 @@ BigInt(value)
 ### Parameters
 
 - `value`
-  - : The value to be parsed as BigInt. It may be a string, an integer, a boolean, or another `BigInt`.
+  - : The value to be converted to a BigInt value. It may be a string, an integer, a boolean, or another `BigInt`.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
@@ -20,7 +20,7 @@ BigInt(value)
 ### Parameters
 
 - `value`
-  - : The numeric value of the object being created. It may be a string, an integer, a boolean, or another `BigInt`.
+  - : The value to be parsed as BigInt. It may be a string, an integer, a boolean, or another `BigInt`.
 
 ### Return value
 


### PR DESCRIPTION
It's better to remove "object" since we can only call this method as a regular function and it won't create an object 