### PR TITLE
Fix: `Content.delete()` should accept an `id` parameter

### DIFF
--- a/files/en-us/web/api/contentindex/delete/index.md
+++ b/files/en-us/web/api/contentindex/delete/index.md
@@ -25,7 +25,8 @@ ContentIndex.delete(id).then(/* … */)
 
 ### Parameters
 
-This method receives no parameters.
+- `id`
+  - : The unique identifier of the indexed content you want the {{domxref("ContentIndex")}} object to remove.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`Content.delete()` should accept an `id` parameter

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Ditto.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://wicg.github.io/content-index/spec/#content-index

![image](https://github.com/mdn/content/assets/95597335/634478d4-94de-4308-a061-6070c2f5c498)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
