### PR TITLE
Genre - remove note about wrong route

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/genre_detail_page/index.md
@@ -96,7 +96,6 @@ Run the application and open your browser to `http://localhost:3000/`. Select th
 > ```
 >
 > The most likely cause is that the ID being passed into the mongoose methods is not actually an ID.
-> This could happen, for example, if your intended route had an ID, but another route without an ID was matched first.
 > [`Mongoose.prototype.isValidObjectId()`](<https://mongoosejs.com/docs/api/mongoose.html#Mongoose.prototype.isValidObjectId()>) can be used to check whether a particular ID is valid.
 
 ## Next steps


### PR DESCRIPTION
Fixes #29340

I don't see how this comment can be true (and I think I added it many years ago). If another route without an ID was matched then the URL will be processed on that route and the ID will/should never be passed to mongo db (at least in this way).

I've removed the reason line. The error can happen while you're developing, so I think the rest of the comment is still a useful starting point to find out what might have gone wrong.