### PR TITLE
FF119RelNote: WebTransport supports sendorder

### DIFF
--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -40,6 +40,8 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### APIs
 
+- The relative priority for send streams can now be specified in an options argument passed to [`WebTransport.createBidirectionalStream()`](/en-US/docs/Web/API/WebTransport/createBidirectionalStream) and [`WebTransport.createUnidirectionalStream()`](/en-US/docs/Web/API/WebTransport/createUnidirectionalStream) ([Firefox bug 1816925](https://bugzil.la/1816925)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -40,7 +40,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### APIs
 
-- The relative priority for send streams can now be specified in an options argument passed to [`WebTransport.createBidirectionalStream()`](/en-US/docs/Web/API/WebTransport/createBidirectionalStream) and [`WebTransport.createUnidirectionalStream()`](/en-US/docs/Web/API/WebTransport/createUnidirectionalStream) ([Firefox bug 1816925](https://bugzil.la/1816925)).
+- The relative priority for send streams can now be specified by including the `sendOrder` property inside an options argument passed to [`WebTransport.createBidirectionalStream()`](/en-US/docs/Web/API/WebTransport/createBidirectionalStream) and [`WebTransport.createUnidirectionalStream()`](/en-US/docs/Web/API/WebTransport/createUnidirectionalStream) ([Firefox bug 1816925](https://bugzil.la/1816925)).
 
 #### DOM
 


### PR DESCRIPTION
FF119 supports `options.sendOrder` as an option to the `WebTransport.createBidirectionalStream()` and  `WebTransport.createUnidirectionalStream()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1816925

This adds a  release note. 

Related docs work can be tracked in https://github.com/mdn/content/issues/29300