### PR TITLE
Simple headers to CORS-safelisted request headers

### DIFF
--- a/files/en-us/web/api/request/mode/index.md
+++ b/files/en-us/web/api/request/mode/index.md
@@ -24,15 +24,10 @@ to determine if cross-origin requests lead to valid responses, and which propert
         set, the result is an error. You could use this to ensure that a request is always
         being made to your origin.
     - `no-cors`
-      - : Prevents the method from being anything other than
-        `HEAD`, `GET` or `POST`, and the headers from
-        being anything other than [simple headers](https://fetch.spec.whatwg.org/#simple-header). If any
-        ServiceWorkers intercept these requests, they may not add or override any headers
-        except for those that are [simple headers](https://fetch.spec.whatwg.org/#simple-header). In
-        addition, JavaScript may not access any properties of the resulting
-        {{domxref("Response")}}. This ensures that ServiceWorkers do not affect the
-        semantics of the Web and prevents security and privacy issues arising from leaking
-        data across domains.
+      - : Prevents the method from being anything other than `HEAD`, `GET` or `POST`, and the headers from being anything other than {{Glossary("CORS-safelisted request header", "CORS-safelisted request headers")}}.
+        If any ServiceWorkers intercept these requests, they may not add or override any headers except for those that are {{Glossary("CORS-safelisted request header", "CORS-safelisted request headers")}}.
+        In addition, JavaScript may not access any properties of the resulting {{domxref("Response")}}.
+        This ensures that ServiceWorkers do not affect the semantics of the Web and prevents security and privacy issues arising from leaking data across domains.
     - `cors`
       - : Allows cross-origin requests, for example to access various
         APIs offered by 3rd party vendors. These are expected to adhere to the [CORS protocol](/en-US/docs/Web/HTTP/CORS). Only a [limited set](https://fetch.spec.whatwg.org/#concept-filtered-response-cors) of headers are exposed in the {{domxref("Response")}}, but the body is


### PR DESCRIPTION
I am pretty sure that the https://fetch.spec.whatwg.org/#simple-header linked in this doc means "CORS-safelisted request headers" link - so changing to use internal glossary link

Fell out of #29413