### PR TITLE
Ff119 relnote coep cred

### DIFF
--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -32,7 +32,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### HTTP
 
-- The [`credentialless`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#credentialless) directive of the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} HTTP response header is now supported, allowing `no-cors` requests for resources to be made on cross-origin servers that have not explicitly opted into it, albeit without cookies or other credentials ([Firefox bug 1851467](https://bugzil.la/1851467)).
+- The [`credentialless`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#credentialless) directive of the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} HTTP response header is now supported on desktop platforms (and mobile platforms other than Android), allowing `no-cors` requests for resources to be made on cross-origin servers that have not explicitly opted into it, albeit without cookies or other credentials ([Firefox bug 1851467](https://bugzil.la/1851467)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -32,6 +32,8 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### HTTP
 
+- The [`credentialless`](/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#credentialless) directive of the {{HTTPHeader("Cross-Origin-Embedder-Policy")}} HTTP response header is now supported, allowing `no-cors` requests for resources to be made on cross-origin servers that have not explicitly opted into it, albeit without cookies or other credentials ([Firefox bug 1851467](https://bugzil.la/1851467)).
+
 #### Removals
 
 ### Security


### PR DESCRIPTION
FF119 supports the HTTP [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) header directive `credentialless` in https://bugzilla.mozilla.org/show_bug.cgi?id=1851467 on desktop (all platforms other than Android).

This adds a release note.

This is part of https://github.com/mdn/content/issues/29413