### PR TITLE
FF119 relnote: Window.sidebar removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -39,7 +39,7 @@ No notable changes.
 
 #### DOM
 
-- The Firefox-only property {{domxref("Window.sidebar")}} has been moved behind a preference and is planned for removal ([Firefox bug 1768486](https://bugzil.la/1768486)).
+- The Firefox-only property {{domxref("Window.sidebar")}} has been moved behind a preference (and permanently removed in version 119) ([Firefox bug 1768486](https://bugzil.la/1768486)).
 
 ### WebDriver conformance
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -42,8 +42,6 @@ This article provides information about the changes in Firefox 119 that affect d
 
 #### DOM
 
-- The deprecated Firefox-only property {{domxref("Window.sidebar")}}, which was disabled by default in version 102, has been removed ([Firefox bug 1768486](https://bugzil.la/1768486)).
-
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -42,6 +42,8 @@ This article provides information about the changes in Firefox 119 that affect d
 
 #### DOM
 
+- The deprecated Firefox-only property {{domxref("Window.sidebar")}}, which was disabled by default in version 102, has been removed ([Firefox bug 1768486](https://bugzil.la/1768486)).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/window/sidebar/index.md
+++ b/files/en-us/web/api/window/sidebar/index.md
@@ -99,5 +99,5 @@ Mozilla-specific. Not part of any standard.
 
 ## Browser compatibility
 
-Moved behind preference in Firefox 102.
+Removed in Firefox 102.
 For more information see Firefox compatibility information in [`window.external`](/en-US/docs/Web/API/Window/external#browser_compatibility).


### PR DESCRIPTION
FF119 removes support for [`Window.sidebar`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sidebar), which is a Mozilla-specific version of `Windows.external` in https://bugzilla.mozilla.org/show_bug.cgi?id=1768486

Support was disabled in 102, behind a pref. Never quite sure how to handle these cases. Decided to record the change in 102, for consistency with the BCD and also explain what happened.

Related docs work can be tracked in #29306