### PR TITLE
Arrow functions: Change “concise body” to “expression body”

### DIFF
--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -301,7 +301,7 @@ function doIt() {
   };
   ```
 
-- When using arrow functions, use [implicit return](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#function_body) (also known as _concise body_) when possible:
+- When using arrow functions, use [implicit return](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#function_body) (also known as _expression body_) when possible:
 
   ```js example-good
   arr.map((e) => e.id);

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -136,13 +136,13 @@ const bob2 = (a) => a + 100;
 
 ### Function body
 
-Arrow functions can have either a _concise body_ or the usual _block body_.
+Arrow functions can have either an _expression body_ or the usual _block body_.
 
-In a concise body, only a single expression is specified, which becomes the implicit return value. In a block body, you must use an explicit `return` statement.
+In an expression body, only a single expression is specified, which becomes the implicit return value. In a block body, you must use an explicit `return` statement.
 
 ```js
 const func = (x) => x * x;
-// concise body syntax, implied "return"
+// expression body syntax, implied "return"
 
 const func2 = (x, y) => {
   return x + y;
@@ -150,7 +150,7 @@ const func2 = (x, y) => {
 // with block body, explicit "return" needed
 ```
 
-Returning object literals using the concise body syntax `(params) => { object: literal }` does not work as expected.
+Returning object literals using the expression body syntax `(params) => { object: literal }` does not work as expected.
 
 ```js-nolint example-bad
 const func = () => { foo: 1 };
@@ -163,7 +163,7 @@ const func3 = () => { foo() {} };
 // SyntaxError: Unexpected token '{'
 ```
 
-This is because JavaScript only sees the arrow function as having a concise body if the token following the arrow is not a left brace, so the code inside braces ({}) is parsed as a sequence of statements, where `foo` is a [label](/en-US/docs/Web/JavaScript/Reference/Statements/label), not a key in an object literal.
+This is because JavaScript only sees the arrow function as having an expression body if the token following the arrow is not a left brace, so the code inside braces ({}) is parsed as a sequence of statements, where `foo` is a [label](/en-US/docs/Web/JavaScript/Reference/Statements/label), not a key in an object literal.
 
 To fix this, wrap the object literal in parentheses:
 

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -78,7 +78,7 @@ The grouping operator can be used to eliminate this ambiguity, since when the pa
 
 You may also use the [`void`](/en-US/docs/Web/JavaScript/Reference/Operators/void#immediately_invoked_function_expressions) operator to eliminate ambiguity.
 
-In an [arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) concise body (one that directly returns an expression without the keyword `return`), the grouping operator can be used to return an object literal expression, because otherwise the left curly brace would be interpreted as the start of the function body.
+In an [arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) expression body (one that directly returns an expression without the keyword `return`), the grouping operator can be used to return an object literal expression, because otherwise the left curly brace would be interpreted as the start of the function body.
 
 ```js
 const f = () => ({ a: 1 });


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Arrow functions: Change “concise body” to “expression body”.

### Motivation

In the [ECMAScript grammar](https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-arrow-function-definitions), the `ConciseBody` product is the union of the `ExpressionBody` and `FunctionBody` products – “concise body” is not the opposite of “function body”, but a superset of it; the opposite is “expression body”.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
