### PR TITLE
Add a reference to the missing `showPicker()` method of HTMLInputElement.

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -740,6 +740,8 @@ The following methods are provided by the {{domxref("HTMLInputElement")}} interf
   - : Sets the contents of the specified range of characters in the input element to a given string. A `selectMode` parameter is available to allow controlling how the existing content is affected.
 - {{domxref("HTMLInputElement.setSelectionRange", "setSelectionRange()")}}
   - : Selects the specified range of characters within a textual input element. Does nothing for inputs which aren't presented as text input fields.
+- {{domxref("HTMLInputElement.showPicker", "showPicker()")}}
+  - : Displays the browser picker for the input element that would normally be displayed when the element is selected, but triggered from a button press or other user interaction.
 - {{domxref("HTMLInputElement.stepDown", "stepDown()")}}
   - : Decrements the value of a numeric input by one, by default, or by the specified number of units.
 - {{domxref("HTMLInputElement.stepUp", "stepUp()")}}


### PR DESCRIPTION
Add a reference to the missing `showPicker()` method of HTMLInputElement.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The [Methods section](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#methods) of the HTML element `input` doesn't have a reference to the `showPicker()` method. It's the only one (for input elements) missing from that list that is on the [HTMLInputElement API instance methods](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#instance_methods).

This PR simply adds in a link and short description to match the other methods. The text was taken from the `showPicker()` page and edited to fit the same style as the rest of the list.

### Motivation

I only recently learned this method exists, despite using the Input page often. Having the method listed here will help bring the docs into alignment with the other methods and help surface this relatively new API to other devs.

