### PR TITLE
FF119 SubtleCrypto.deriveKey() supports HKDF as a derivedKeyAlgorithm

### DIFF
--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -30,8 +30,7 @@ deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
   - : An object defining the [derivation algorithm](#supported_algorithms) to use.
     - To use [ECDH](#ecdh), pass an
       [`EcdhKeyDeriveParams`](/en-US/docs/Web/API/EcdhKeyDeriveParams) object.
-    - To use [HKDF](#hkdf), pass
-      an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
+    - To use [HKDF](#hkdf), pass an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
     - To use [PBKDF2](#pbkdf2), pass
       a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params) object.
 - `baseKey`
@@ -48,6 +47,7 @@ deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
     - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
       [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw): pass an
       [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams) object.
+    - For [HKDF](#hkdf), pass an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
 - `extractable`
   - : A boolean value indicating whether it
     will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -41,13 +41,13 @@ deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
     `CryptoKey` using
     [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
 - `derivedKeyAlgorithm`
-  - : An object defining the algorithm the derived key will be used for.
-    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): pass an
-      [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object.
+  - : An object defining the algorithm the derived key will be used for:
+    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) pass an [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object.
     - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
-      [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw): pass an
+      [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw), pass an
       [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams) object.
     - For [HKDF](#hkdf), pass an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
+    - For [PBKDF2](#pbkdf2), pass a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params) object.
 - `extractable`
   - : A boolean value indicating whether it
     will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or


### PR DESCRIPTION
This adds information that it is possible for [`SubtleCrypto.deriveKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey) to support  HKDF as a `derivedKeyAlgorithm`. This support has been added in FF119.

It is also possible to support  `PBKDF2` as a `derivedKeyAlgorithm` - that was missing so I added that too.

There may be other possible `derivedKeyAlgorithm` options but these are the ones mentioned by the developer I have been talking to.

Related docs work can be tracked in #29411