### PR TITLE
mark readonly property for Navigator interface

### DIFF
--- a/files/en-us/web/api/navigator/pdfviewerenabled/index.md
+++ b/files/en-us/web/api/navigator/pdfviewerenabled/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.pdfViewerEnabled
 
 {{APIRef("HTML DOM")}}
 
-The **`pdfViewerEnabled`** property of the {{domxref("Navigator")}} interface indicates whether the browser supports inline display of PDF files when navigating to them.
+The **`pdfViewerEnabled`** read-only property of the {{domxref("Navigator")}} interface indicates whether the browser supports inline display of PDF files when navigating to them.
 
 If inline viewing is not supported the PDF is downloaded and may then be handled by some external application.
 

--- a/files/en-us/web/api/navigator/presentation/index.md
+++ b/files/en-us/web/api/navigator/presentation/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.presentation
 
 {{securecontext_header}}{{APIRef("Presentation API")}}
 
-The `presentation` property of {{DOMxRef("Navigator")}} serves as the entry
+The `presentation` read-only property of {{DOMxRef("Navigator")}} serves as the entry
 point for the [Presentation API](/en-US/docs/Web/API/Presentation_API) and
 returns a reference to {{DOMxRef("Presentation")}} object.
 

--- a/files/en-us/web/api/navigator/windowcontrolsoverlay/index.md
+++ b/files/en-us/web/api/navigator/windowcontrolsoverlay/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Navigator.windowControlsOverlay
 
 {{SecureContext_Header}}{{APIRef("")}}
 
-The **`windowControlsOverlay`** property of the {{domxref("Navigator")}}
+The **`windowControlsOverlay`** read-only property of the {{domxref("Navigator")}}
 interface returns the {{domxref("WindowControlsOverlay")}} interface, which exposes
 information about the title bar geometry in desktop Progressive Web Apps that use the [Window Controls Overlay API](/en-US/docs/Web/API/Window_Controls_Overlay_API).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

to mark those property that is read-only in Navigator interface to be read-only

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://wicg.github.io/window-controls-overlay/#extensions-to-the-navigator-interface

```ts
partial interface Navigator {
  [SameObject] readonly attribute WindowControlsOverlay windowControlsOverlay;
};
```

https://w3c.github.io/presentation-api/#interface-presentation

```ts
partial interface Navigator {
  [SecureContext, SameObject] readonly attribute Presentation presentation;
};
```

https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-pdfviewerenabled

```ts
interface mixin NavigatorPlugins {
  // ...
  readonly attribute boolean pdfViewerEnabled;
}
```

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
