### PR TITLE
Fix casing of argument to WindowControlsOverlayGeometryChangeEvent ctor

### DIFF
--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
@@ -29,8 +29,8 @@ _The `WindowControlsOverlayGeometryChangeEvent()` constructor also inherits argu
 - `options`
   - : An object with the following properties:
     - `visible`
-      - : A boolean flag that's true when the `titleBarAreaRect` object's values are not 0.
-    - `titleBarAreaRect`
+      - : A boolean flag that's true when the `titlebarAreaRect` object's values are not 0.
+    - `titlebarAreaRect`
       - : A {{domxref("DOMRect")}} representing the position and size of the title bar area.
 
 ## Specifications


### PR DESCRIPTION
While looking at https://github.com/mdn/content/pull/29441 I found that the casing of one of the arguments was wrong, so it wasn't possible to construct this event using the page as a reference.