### PR TITLE
Rephrasing the use of async with module scripts

### DIFF
--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -61,7 +61,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
   - : For classic scripts, if the `async` attribute is present, then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available.
 
-    For [module scripts](/en-US/docs/Web/JavaScript/Guide/Modules), if the `async` attribute is present then the scripts and all their dependencies will be executed in the defer queue, therefore they will get fetched in parallel to parsing and evaluated as soon as they are available.
+    For [module scripts](/en-US/docs/Web/JavaScript/Guide/Modules), if the `async` attribute is present then the scripts and all their dependencies will be fetched in parallel to parsing and evaluated as soon as they are available.
 
     This attribute allows the elimination of **parser-blocking JavaScript** where the browser would have to load and evaluate scripts before continuing to parse. `defer` has a similar effect in this case.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
A rephrase of the text regarding the use of the async attribute in a script tag. 

**Old Text**: 
For module scripts, if the async attribute is present, then the scripts and all their dependencies will be executed in the defer queue. Therefore, they will get fetched in parallel to parsing and evaluated as soon as they are available.

**Proposed Text**:
For module scripts, if the `async` attribute is present, then the scripts and all their dependencies will be fetched in parallel to parsing and evaluated as soon as they are available.

### Motivation
<!-- ❓ Why are you making these changes, and how do they help readers? -->
The text has more clarity, as the user understands that async allows for resources to be fetched in parallel.

### Additional details
Source for proposed text: [HTML Docs](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-async)

### Related issues and pull requests
Fixes #24754  😀

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
