### PR TITLE
Remove "or refreshes" example language from `overscroll-behavior: contain` docs

### DIFF
--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-block` property is specified as a keyword chosen from t
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-block` property is specified as a keyword chosen from t
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects or refreshes), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-inline` property is specified as a keyword chosen from 
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-inline` property is specified as a keyword chosen from 
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects or refreshes), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-x` property is specified as a keyword chosen from the l
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects or refreshes), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-x` property is specified as a keyword chosen from the l
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-y/index.md
+++ b/files/en-us/web/css/overscroll-behavior-y/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-y` property is specified as a keyword chosen from the l
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects or refreshes), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-y/index.md
+++ b/files/en-us/web/css/overscroll-behavior-y/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-y` property is specified as a keyword chosen from the l
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -46,7 +46,7 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects or refreshes), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -46,7 +46,7 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects), but no scroll chaining occurs to neighboring scrolling areas, e.g. underlying elements will not scroll.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 


### PR DESCRIPTION
### Description

The current doc says:
> Default scroll overflow behavior is observed inside the element this value is set on (e.g. "bounce" effects **or refreshes**)...

The "or refreshes" part shouldn't be there, because native browser navigation isn't allowed when `overscroll-behavior: contain` is set.

### Motivation

This removes misleading information from `overscroll-behavior` documentation.

### Related issues and pull requests

Resolves: https://github.com/mdn/content/issues/29473 (there are more details in that issue)

