### PR TITLE
Renamed `method` because it is not a real method

### DIFF
--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -82,7 +82,7 @@ const obj = {
   __proto__: {
     prop: "foo",
   },
-  method: function () {
+  b: function () {
     console.log(super.prop); // SyntaxError: 'super' keyword unexpected here
   },
 };

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -82,7 +82,7 @@ const obj = {
   __proto__: {
     prop: "foo",
   },
-  b: function () {
+  notAMethod: function () {
     console.log(super.prop); // SyntaxError: 'super' keyword unexpected here
   },
 };


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Renamed `method` to `b` because it is not a real method.

### Motivation

[This section said](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions#using_super_in_method_definitions):

> Only functions defined as methods have access to the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) keyword. `super.prop` looks up the property on the prototype of the object that the method was initialized on.
> 
> ```js
> const obj = {
>   __proto__: {
>     prop: "foo",
>   },
>   method: function () {
>     console.log(super.prop); // SyntaxError: 'super' keyword unexpected here
>   },
> };
> ```

The function is named `method` even through, as the previous sentence says, this is _not_ a function defined as a method. I renamed `method` to `b` to reduce a bit of cognitive load.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
