### PR TITLE
Add example showing lack of comma separator between methods

### DIFF
--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -114,7 +114,7 @@ class ClassWithPublicInstanceMethod {
   aSecondPublicMethod() {
     return "goodbye world";
   }
-} 
+}
 
 const instance = new ClassWithPublicInstanceMethod();
 console.log(instance.publicMethod()); // "hello world"

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -111,7 +111,7 @@ class ClassWithPublicInstanceMethod {
   publicMethod() {
     return "hello world";
   }
-  aSecondPublicMethod() {
+  secondPublicMethod() {
     return "goodbye world";
   }
 }

--- a/files/en-us/web/javascript/reference/functions/method_definitions/index.md
+++ b/files/en-us/web/javascript/reference/functions/method_definitions/index.md
@@ -111,7 +111,10 @@ class ClassWithPublicInstanceMethod {
   publicMethod() {
     return "hello world";
   }
-}
+  aSecondPublicMethod() {
+    return "goodbye world";
+  }
+} 
 
 const instance = new ClassWithPublicInstanceMethod();
 console.log(instance.publicMethod()); // "hello world"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add example showing lack of comma separator between methods

### Motivation

[This section said (emphasis mine)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions#method_definitions_in_classes):

> You can use the exact same syntax to define public instance methods that are available on class instances. **In classes, you don't need the comma separator between methods.**
> 
> ```js
> class ClassWithPublicInstanceMethod {
>   publicMethod() {
>     return "hello world";
>   }
> } 
> 
> const instance = new ClassWithPublicInstanceMethod();
> console.log(instance.publicMethod()); // "hello world"
> ```

I added `aSecondPublicMethod` to the example to demonstrate the bold part.

### Additional details

Alternatively, the bold part could be put after the example instead of before it. Between the two, I prefer showing it in the example because it shows what it means.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
