### PR TITLE
remove itunes from platform strings

### DIFF
--- a/files/en-us/web/api/navigator/getinstalledrelatedapps/index.md
+++ b/files/en-us/web/api/navigator/getinstalledrelatedapps/index.md
@@ -56,7 +56,6 @@ A {{JSxRef("Promise")}} that fulfills with an array of objects representing any 
     - `"chrome_web_store"`: A [Google Chrome Web Store](https://chrome.google.com/webstore) app.
     - `"play"`: A [Google Play Store](https://play.google.com/) app.
     - `"chromeos_play"`: A [Chrome OS Play](https://support.google.com/googleplay/answer/7021273) app.
-    - `"itunes"`: An [Apple App Store](https://www.apple.com/app-store/) app.
     - `"webapp"`: A [Progressive Web App](/en-US/docs/Web/Progressive_web_apps).
     - `"windows"`: A [Windows Store](https://www.microsoft.com/store/apps) app.
     - `"f-droid"`: An [F-Droid](https://f-droid.org/) app.


### PR DESCRIPTION
### Description

itunes value associated to the App Store for platform member of related apps has been dropped since it's misleading and currently not supported by safari. The list has been updated as per the W3C wiki.

### Motivation

I am a User Experience Engineer who is keen to learning PWA at a depth (at the moment) to benefit open-source. 

### Additional details

[W3C | Platforms](https://github.com/w3c/manifest/wiki/Platforms)

### Related issues and pull requests

Fixes #29486 
