### PR TITLE
Update `DataTransferItem.webkitGetAsEntry()` Specifications section

### DIFF
--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -181,7 +181,7 @@ You can see how this works by trying it out below. Find some files and directori
 
 ## Specifications
 
-This API has no official W3C or WHATWG specification.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.DataTransferItem.webkitGetAsEntry
 ---
 
-{{APIRef("HTML Drag and Drop API")}}{{Non-standard_Header}}
+{{APIRef("HTML Drag and Drop API")}}
 
 If the item described by the {{domxref("DataTransferItem")}} is a file, `webkitGetAsEntry()` returns a {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file, `null` is returned.
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.DataTransferItem.webkitGetAsEntry
 ---
 
-{{APIRef("HTML Drag and Drop API")}}
+{{APIRef("HTML Drag and Drop API")}}{{Non-standard_Header}}
 
 If the item described by the {{domxref("DataTransferItem")}} is a file, `webkitGetAsEntry()` returns a {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file, `null` is returned.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

update DataTransferItem.webkitGetAsEntry() Specifications section

*As the discussion above, it seems that DataTransferItem.webkitGetAsEntry() is a method already in standard track, see https://wicg.github.io/entries-api/#html-data*

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry

https://wicg.github.io/entries-api/#html-data

also see methods in the same standard tarck with it:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitEntries

https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
