### PR TITLE
Fix typo in storage access api demo

### DIFF
--- a/files/en-us/web/api/storage_access_api/using/index.md
+++ b/files/en-us/web/api/storage_access_api/using/index.md
@@ -45,7 +45,7 @@ function doThingsWithCookies() {
 }
 
 async function handleCookieAccess() {
-  if (document.hasStorageAccess) {
+  if (!document.hasStorageAccess) {
     // This browser doesn't support the Storage Access API
     // so let's just hope we have access!
     doThingsWithCookies();


### PR DESCRIPTION
### Description

Just fixing what appears to be as a typo in the storage access api demo.