### PR TITLE
Reflect :has() being enabled in Nightly by default

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -526,7 +526,7 @@ For more information, see [Firefox bug 1807685](https://bugzil.la/1807685), [Fir
 ### :has() pseudo-class
 
 The [`:has()`](/en-US/docs/Web/CSS/:has) pseudo-class selects elements that contain the selectors passed as parameters.
-(See [Firefox bug 1771896](https://bugzil.la/1771896) for more details.)
+(See [Firefox bug 418039](https://bugzil.la/418039) for more details.)
 
 <table>
   <thead>
@@ -540,7 +540,7 @@ The [`:has()`](/en-US/docs/Web/CSS/:has) pseudo-class selects elements that cont
     <tr>
       <th>Nightly</th>
       <td>103</td>
-      <td>No</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th>Developer Edition</th>


### PR DESCRIPTION
### Description

`:has()` is [enabled by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1853701) starting Nightly 119. This change reflects that in Experimental features in Firefox.

### Motivation

`:has()` has been a highly requested feature, so getting the words out.

### Additional details

Linked above - [Bug 1853701](https://bugzilla.mozilla.org/show_bug.cgi?id=1853701)
[Inner selectors](https://bugzilla.mozilla.org/show_bug.cgi?id=1852965) (e.g. `:has(:is(.a .b))`) weren't supported in 119, but will be in 120 

### Related issues and pull requests

N/A
