### PR TITLE
Document which `then` handler is called after a `catch` is handled

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
@@ -83,7 +83,7 @@ p1.then((value) => {
     console.error(e.message); // "oh, no!"
   })
   .then(
-    () => console.log("after a catch the chain is restored"),
+    () => console.log("after a catch the chain is restored"), // "after a catch the chain is restored"
     () => console.log("Not fired due to the catch"),
   );
 
@@ -96,7 +96,7 @@ p1.then((value) => {
     console.error(e); // "oh, no!"
   })
   .then(
-    () => console.log("after a catch the chain is restored"),
+    () => console.log("after a catch the chain is restored"), // "after a catch the chain is restored"
     () => console.log("Not fired due to the catch"),
   );
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Document which `then` handler is called after a `catch` is handled

### Motivation

I've added an additional comment to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch#using_and_chaining_the_catch_method for these reasons: 

1. This change is consistent with the rest of the example
2. This documents the last output of the example
3. This shows that, after a `catch` handler, the next `then` in the promise chain calls the `onFulfilled` handler (so long as it doesn't throw its own error?). 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
