### PR TITLE
Remove quotes around todo object in Ember interactivity tutorial

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_conditional_footer/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_conditional_footer/index.md
@@ -213,8 +213,8 @@ Finally, we will edit the `todo.hbs` template such that the checkbox's value is 
 
    And replace it with this — you'll notice that here we're using some more conditional content to add the class value if appropriate:
 
-   ```hbs
-   <li class="\{{ if @todo.isCompleted 'completed' }}">
+   ```hbs-nolint
+   <li class=\{{ if @todo.isCompleted 'completed' }}>
    ```
 
 2. Next, find the following line:

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.md
@@ -266,7 +266,7 @@ Now we can access the data using `this.todos.all`, which is much more intuitive.
 
 With a dynamic `#each` block (which is basically syntactic sugar over the top of JavaScript's [`forEach()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach)) that creates a `<Todo />` component for each todo available in the list of todos returned by the service's `all()` getter:
 
-```hbs
+```hbs-nolint
 \{{#each this.todos.all as |todo|}}
 <Todo @todo=\{{todo}} />
 \{{/each}}

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_interactivity_events_state/index.md
@@ -268,7 +268,7 @@ With a dynamic `#each` block (which is basically syntactic sugar over the top of
 
 ```hbs
 \{{#each this.todos.all as |todo|}}
-<Todo @todo="\{{todo}}" />
+<Todo @todo=\{{todo}} />
 \{{/each}}
 ```
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_resources/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/ember_resources/index.md
@@ -140,8 +140,8 @@ export default class Example extends Component {
 
 Which would then be called in the template like so:
 
-```hbs
-<Checkbox @data="\{{this.someData}}" @onChange="\{{this.setData}}" />
+```hbs-nolint
+<Checkbox @data=\{{this.someData}} @onChange=\{{this.setData}} />
 ```
 
 Due to the conciseness of using `mut`, it may be desirable to reach for it. However, `mut` has unnatural semantics and has caused much confusion over the term of its existence.


### PR DESCRIPTION
### Description

@Junaid-1993 discovered a bug in the ["Ember interactivity: Events, classes and state" article](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Ember_interactivity_events_state#displaying_our_todos) and helpfully provided a quick solution. 

### Motivation

To fix a bug preventing the Ember tutorial from working :)

### Related issues and pull requests

Resolves https://github.com/mdn/content/issues/28751