### PR TITLE
Remove 'Reflecting ARIA attributes' from experimental FX relnotes; add ARIA reflection to FX119 relnotes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -99,46 +99,6 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
   </tbody>
 </table>
 
-### Reflecting ARIA attributes
-
-[ARIA](/en-US/docs/Web/Accessibility/ARIA) reflection is enabled for non-IDREF attributes which allows authors to get and set ARIA attributes on DOM elements directly via JavaScript APIs, rather than by using `setAttribute` and `getAttribute`, (see [Firefox bug 1824980](https://bugzil.la/1824980) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>114</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>114</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>114</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>114</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>accessibility.ARIAReflection.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## CSS
 
 ### Hex boxes to display stray control characters

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -42,7 +42,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 #### DOM
 
-- [ARIA](/en-US/docs/Web/Accessibility/ARIA) reflection is enabled for attributes that do not reference other elements; only non-IDREF attributes are reflected. This allows developers to get and set ARIA attributes on DOM elements directly via JavaScript APIs, rather than by using `setAttribute` and `getAttribute`. For example, `el.ariaPressed = "true";` is now supported in addition to `el.setAttribute("aria-pressed", "true");`. (See [Firefox bug 1785412](https://bugzil.la/1785412) for more details.)
+- [ARIA](/en-US/docs/Web/Accessibility/ARIA) reflection is now supported by default for attributes that do not reference other elements; only non-IDREF attributes are reflected. You can now get and set ARIA attributes on DOM elements directly via JavaScript APIs, rather than by using `setAttribute` and `getAttribute`. For example, `buttonElement.ariaPressed = "true";` is now supported in addition to `buttonElement.setAttribute("aria-pressed", "true");` ([Firefox bug 1785412](https://bugzil.la/1785412)).
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -42,6 +42,8 @@ This article provides information about the changes in Firefox 119 that affect d
 
 #### DOM
 
+- [ARIA](/en-US/docs/Web/Accessibility/ARIA) reflection is enabled for attributes that do not reference other elements; only non-IDREF attributes are reflected. This allows developers to get and set ARIA attributes on DOM elements directly via JavaScript APIs, rather than by using `setAttribute` and `getAttribute`. For example, `el.ariaPressed = "true";` is now supported in addition to `el.setAttribute("aria-pressed", "true");`. (See [Firefox bug 1785412](https://bugzil.la/1785412) for more details.)
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
### Description

- Removes 'Reflecting ARIA attributes' from experimental Firefox release notes
- Adds ARIA Reflection to FX119 release notes under APIs -> DOM

### Motivation

The browser is changing, and we must keep up!

### Additional details

https://bugzilla.mozilla.org/show_bug.cgi?id=1785412

### Related issues and pull requests

Child of https://github.com/mdn/content/issues/29311
Should be merged along with https://github.com/mdn/browser-compat-data/pull/20911