### PR TITLE
Removed the phrase, ", enabling the first mistake."

### DIFF
--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -223,7 +223,7 @@ doSomething()
 
 The first mistake is to not chain things together properly. This happens when we create a new promise but forget to return it. As a consequence, the chain is broken — or rather, we have two independent chains racing. This means `doFourthThing()` won't wait for `doSomethingElse()` or `doThirdThing()` to finish, and will run concurrently with them — which is likely unintended. Separate chains also have separate error handling, leading to uncaught errors.
 
-The second mistake is to nest unnecessarily, enabling the first mistake. Nesting also limits the scope of inner error handlers, which—if unintended—can lead to uncaught errors. A variant of this is the [promise constructor anti-pattern](https://stackoverflow.com/questions/23803743/what-is-the-explicit-promise-construction-antipattern-and-how-do-i-avoid-it), which combines nesting with redundant use of the promise constructor to wrap code that already uses promises.
+The second mistake is to nest unnecessarily. Nesting also limits the scope of inner error handlers, which—if unintended—can lead to uncaught errors. A variant of this is the [promise constructor anti-pattern](https://stackoverflow.com/questions/23803743/what-is-the-explicit-promise-construction-antipattern-and-how-do-i-avoid-it), which combines nesting with redundant use of the promise constructor to wrap code that already uses promises.
 
 The third mistake is forgetting to terminate chains with `catch`. Unterminated promise chains lead to uncaught promise rejections in most browsers. See [error handling](#error_handling) below.
 


### PR DESCRIPTION
- The full sentence was, `The second mistake is to nest unnecessarily, enabling the first mistake.`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed "The second mistake is to nest unnecessarily, enabling the first mistake." to "The second mistake is to nest unnecessarily."

### Motivation

IMHO, this phrase doesn't improve the reader's understanding of the concepts, and I am not 100% sure what it means. Here's the preceding paragraph (emphasis mine):

> _The first mistake is to not chain things together properly. This happens when we create a new promise but forget to return it. As a consequence, the chain is broken_ — or rather, **we have two independent chains racing. This means doFourthThing() won't wait for doSomethingElse() or doThirdThing() to finish, and will run concurrently with them — which is likely unintended. Separate chains also have separate error handling, leading to uncaught errors.**

I *think* "the first mistake" refers bold, not the italic? Because I don't think you need nesting chains to forget to return a promise, right? You could write `.then((newResult) => { doThirdThing(newResult) })`, whether or not it's part of a nested chain or a flat one. 

Regardless, I don't think I learn anything by knowing exactly what that removed part referred to, so I removed it. Let me know if I'm misunderstanding. Thanks.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
