### PR TITLE
Add a note about animated clock's FPS and a suggestion for sweeping second hand

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -169,7 +169,7 @@ function clock() {
   ctx.restore();
 
   const sec = now.getSeconds();
-  // For a sweeping second hand, use:
+  // To display a clock with a sweeping second hand, use:
   // const sec = now.getSeconds() + now.getMilliseconds() / 1000;
   const min = now.getMinutes();
   const hr = now.getHours() % 12;
@@ -238,7 +238,8 @@ window.requestAnimationFrame(clock);
 
 ### Result
 
-> **Note:** Though the image appears to change only once every second, it is updated at 60 frames per second or at the display refresh rate of your web browser. For a sweeping second hand, use the alternative version of `const sec`.
+> **Note:** Although the clock updates only once every second, the animated image is updated at 60 frames per second (or at the display refresh rate of your web browser).
+> To display the clock with a sweeping second hand, replace the definition of `const sec` above with the version that has been commented out.
 
 {{EmbedLiveSample("An_animated_clock", "180", "200")}}
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -169,6 +169,8 @@ function clock() {
   ctx.restore();
 
   const sec = now.getSeconds();
+  // For a sweeping second hand, use:
+  // const sec = now.getSeconds() + now.getMilliseconds() / 1000;
   const min = now.getMinutes();
   const hr = now.getHours() % 12;
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -236,6 +236,8 @@ window.requestAnimationFrame(clock);
 
 ### Result
 
+> **Note:** Though the image appears to change only once every second, it is updated at 60 frames per second or at the display refresh rate of your web browser. See {{domxref("window.requestAnimationFrame()")}} for more information.
+
 {{EmbedLiveSample("An_animated_clock", "180", "200")}}
 
 ## A looping panorama

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -238,7 +238,7 @@ window.requestAnimationFrame(clock);
 
 ### Result
 
-> **Note:** Though the image appears to change only once every second, it is updated at 60 frames per second or at the display refresh rate of your web browser. See {{domxref("window.requestAnimationFrame()")}} for more information.
+> **Note:** Though the image appears to change only once every second, it is updated at 60 frames per second or at the display refresh rate of your web browser.
 
 {{EmbedLiveSample("An_animated_clock", "180", "200")}}
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -238,7 +238,7 @@ window.requestAnimationFrame(clock);
 
 ### Result
 
-> **Note:** Though the image appears to change only once every second, it is updated at 60 frames per second or at the display refresh rate of your web browser.
+> **Note:** Though the image appears to change only once every second, it is updated at 60 frames per second or at the display refresh rate of your web browser. For a sweeping second hand, use the alternative version of `const sec`.
 
 {{EmbedLiveSample("An_animated_clock", "180", "200")}}
 


### PR DESCRIPTION
### Description

Add a note about animated clock's FPS and a suggestion for sweeping second hand.

### Motivation

The animated clock appears to update only once every second, giving a false impression that the FPS is `1`. This note makes it clear that the FPS is actually `60` (usually). It also gives an alternative code suggestion to have a sweeping second hand in the clock.

### Additional details

* Applies to: [Basic_animations#an_animated_clock](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations#an_animated_clock)
* Tested using local deployment.

### Related issues and pull requests

Supersedes #28990