### PR TITLE
`FileSystemDirectoryHandle.getDirectoryHandle()` may also throw `TypeError`

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
@@ -45,7 +45,7 @@ A {{jsxref('Promise')}} which resolves with a {{domxref('FileSystemDirectoryHand
   - : Thrown if {{domxref('PermissionStatus')}} is not 'granted'.
 - {{jsxref("TypeError")}}
   - : Thrown if the name specified is not a valid string or contains characters that would
-    interfere with the native file system
+    interfere with the native file system.
 - `TypeMismatchError` {{domxref("DOMException")}}
   - : Thrown if the returned entry is a file and not a directory.
 - `NotFoundError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
@@ -43,6 +43,9 @@ A {{jsxref('Promise')}} which resolves with a {{domxref('FileSystemDirectoryHand
 
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if {{domxref('PermissionStatus')}} is not 'granted'.
+- {{jsxref("TypeError")}}
+  - : Thrown if the name specified is not a valid string or contains characters that would
+    interfere with the native file system
 - `TypeMismatchError` {{domxref("DOMException")}}
   - : Thrown if the returned entry is a file and not a directory.
 - `NotFoundError` {{domxref("DOMException")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle

Step 5.1

![image](https://github.com/mdn/content/assets/95597335/08aec2ad-aaa6-43c9-aad5-a42166928eaa)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
