### PR TITLE
Correct the description of the default "path" value

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -52,7 +52,7 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
   - `;partitioned`: Indicates that the cookie should be stored using partitioned storage. See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more details.
 
   - `;path=path`: Indicates the path that must exist in the requested URL for the browser to send the {{httpheader("Cookie")}} header (e.g., '`/`',
-    '`/mydir`'). If not specified, it defaults to the current path of the current document location.
+    '`/mydir`'). If not specified, it defaults to the "directory" of the current document URI's path component.
 
   - `;samesite`: [SameSite](/en-US/docs/Web/HTTP/Cookies#samesite_cookies) prevents the browser from sending this cookie along with cross-site
     requests. Possible values are `lax`, `strict` or `none`.


### PR DESCRIPTION
Used the wording of https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.4

The old wording makes it seem like the default value could be the whole path of the current page, although it actually is the "directory" containing the document.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
