### PR TITLE
remove ' from last example in charset at-rule for less confusion

### DIFF
--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -48,7 +48,7 @@ As there are several ways to define the character encoding of a style sheet, the
 @charset 'iso-8859-15'; /* Invalid, wrong quoting style used */
 @charset  "UTF-8"; /* Invalid, more than one space */
  @charset "UTF-8"; /* Invalid, there is a character (a space) before the at-rule */
-@charset UTF-8; /* Invalid, without ' or ", the charset is not a CSS {{cssxref("&lt;string&gt;")}} */
+@charset UTF-8; /* Invalid, without ", the charset is not a CSS {{cssxref("&lt;string&gt;")}} */
 ```
 
 ## Specifications

--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -43,12 +43,15 @@ As there are several ways to define the character encoding of a style sheet, the
 
 ### Valid and invalid charset declarations
 
-```css-nolint
+```css example-good
 @charset "UTF-8"; /* Set the encoding of the style sheet to Unicode UTF-8 */
-@charset 'iso-8859-15'; /* Invalid, wrong quoting style used */
+```
+
+```css example-bad
+@charset 'iso-8859-15'; /* Invalid, wrong quotes used */
 @charset  "UTF-8"; /* Invalid, more than one space */
  @charset "UTF-8"; /* Invalid, there is a character (a space) before the at-rule */
-@charset UTF-8; /* Invalid, without ", the charset is not a CSS {{cssxref("&lt;string&gt;")}} */
+@charset UTF-8; /* Invalid, the charset is a CSS <string> and requires double-quotes */
 ```
 
 ## Specifications

--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -43,11 +43,11 @@ As there are several ways to define the character encoding of a style sheet, the
 
 ### Valid and invalid charset declarations
 
-```css example-good
+```css-nolint example-good
 @charset "UTF-8"; /* Set the encoding of the style sheet to Unicode UTF-8 */
 ```
 
-```css example-bad
+```css-nolint example-bad
 @charset 'iso-8859-15'; /* Invalid, wrong quotes used */
 @charset  "UTF-8"; /* Invalid, more than one space */
  @charset "UTF-8"; /* Invalid, there is a character (a space) before the at-rule */


### PR DESCRIPTION
While At-rule @charset must be double-quoted We remove ' from last example for more helping and less confusing

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
