### PR TITLE
Improve nesting selector example by noting cross-browser limitations

### DIFF
--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -238,7 +238,7 @@ In this example the `&` nesting selector is used to create compound selectors to
     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
   </div>
   <div class="notice success">
-    <h2>Success</h2>
+    <h2 class="check">Success</h2>
     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
   </div>
 </div>
@@ -269,8 +269,9 @@ This CSS uses nesting to create compound selectors. The top-level selector defin
   background-color: #ffc107;
   color: black;
   padding: 1rem;
-  h2:before {
-    /* same as `.notice h2:before` */
+  & h2:before {
+    /* equivalent to `.notice h2:before` */
+    /* adding `& ` to this selector improves cross-browser compatibility */
     content: "ℹ︎ ";
   }
   &.warning {
@@ -280,6 +281,8 @@ This CSS uses nesting to create compound selectors. The top-level selector defin
     color: white;
     h2:before {
       /* equivalent to `.notice.warning h2:before` */
+      /* note the lack of explicit `& ` in this selector */
+      /* this selector is the same as `& h2:before` in some browsers */
       content: "! ";
     }
   }
@@ -288,8 +291,10 @@ This CSS uses nesting to create compound selectors. The top-level selector defin
     background-color: #004d40;
     border-color: #004d40;
     color: white;
-    h2:before {
-      /* equivalent to `.notice.success h2:before` */
+    .check:before {
+      /* equivalent to `.notice.success .check:before` */
+      /* not all browsers support implicitly-nested rules that start with a type selector */
+      /* we overcome this limitation by explicitly adding a class to this `h2` element in the HTML */
       content: "✓ ";
     }
   }

--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -230,15 +230,15 @@ In this example the `&` nesting selector is used to create compound selectors to
 ```html
 <div class="notices">
   <div class="notice">
-    <h2>Notice</h2>
+    <h2 class="notice-heading">Notice</h2>
     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
   </div>
   <div class="notice warning">
-    <h2>Warning</h2>
+    <h2 class="warning-heading">Warning</h2>
     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
   </div>
   <div class="notice success">
-    <h2 class="check">Success</h2>
+    <h2 class="success-heading">Success</h2>
     <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
   </div>
 </div>
@@ -258,7 +258,7 @@ Styles for the `.notices` to create a column using {{cssxref('CSS_flexible_box_l
 }
 ```
 
-This CSS uses nesting to create compound selectors. The top-level selector defines the basic styles for an element with `class="notice"`. The `&` nesting selector is then used to create compound selectors for elements with either `class="notice warning"` or `class="notice success"`.
+This CSS uses nesting to create compound selectors. The top-level selector defines the basic styles for an element with `class="notice"`. The `&` nesting selector is then used to create compound selectors for elements with either `class="notice warning"` or `class="notice success"`. In this example, we also create compound selectors with nesting without explicitly using `&`, such as the selector `.notice .notice-heading:before`.
 
 ```css
 .notice {
@@ -269,9 +269,8 @@ This CSS uses nesting to create compound selectors. The top-level selector defin
   background-color: #ffc107;
   color: black;
   padding: 1rem;
-  & h2:before {
-    /* equivalent to `.notice h2:before` */
-    /* adding `& ` to this selector improves cross-browser compatibility */
+  .notice-heading:before {
+    /* equivalent to `.notice .notice-heading:before` */
     content: "ℹ︎ ";
   }
   &.warning {
@@ -279,10 +278,8 @@ This CSS uses nesting to create compound selectors. The top-level selector defin
     background-color: #d81b60;
     border-color: #d81b60;
     color: white;
-    h2:before {
-      /* equivalent to `.notice.warning h2:before` */
-      /* note the lack of explicit `& ` in this selector */
-      /* this selector is the same as `& h2:before` in some browsers */
+    .warning-heading:before {
+      /* equivalent to `.notice.warning .warning-heading:before` */
       content: "! ";
     }
   }
@@ -291,10 +288,8 @@ This CSS uses nesting to create compound selectors. The top-level selector defin
     background-color: #004d40;
     border-color: #004d40;
     color: white;
-    .check:before {
-      /* equivalent to `.notice.success .check:before` */
-      /* not all browsers support implicitly-nested rules that start with a type selector */
-      /* we overcome this limitation by explicitly adding a class to this `h2` element in the HTML */
+    .success-heading:before {
+      /* equivalent to `.notice.success .success-heading:before` */
       content: "✓ ";
     }
   }

--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -258,7 +258,7 @@ Styles for the `.notices` to create a column using {{cssxref('CSS_flexible_box_l
 }
 ```
 
-This CSS uses nesting to create compound selectors. The top-level selector defines the basic styles for an element with `class="notice"`. The `&` nesting selector is then used to create compound selectors for elements with either `class="notice warning"` or `class="notice success"`. In this example, we also create compound selectors with nesting without explicitly using `&`, such as the selector `.notice .notice-heading:before`.
+In the CSS code below, nesting is used to create compound selectors both with and without `&`. The top-level selector defines the basic styles for elements with `class="notice"`. The `&` nesting selector is then used to create compound selectors for elements with either `class="notice warning"` or `class="notice success"`. Additionally, the use of nesting to create compound selectors without explicitly using `&` can be seen in the selector `.notice .notice-heading:before`.
 
 ```css
 .notice {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Improve [the "Using CSS nesting > Nesting and compound selectors" reference documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting/Using_CSS_nesting#compound_selectors) by including information about cross-browser support in the example code itself.

### Motivation

@mirthmgr called out this lack of clarity in https://github.com/mdn/content/issues/29458

### Additional details

[This resource](https://developer.chrome.com/articles/css-nesting/), in addition to the MDN CSS nesting doc, helped me grok CSS nesting.

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/29458


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
