### PR TITLE
Window.set/clearImmediate deprecated

### DIFF
--- a/files/en-us/web/api/window/clearimmediate/index.md
+++ b/files/en-us/web/api/window/clearimmediate/index.md
@@ -3,15 +3,15 @@ title: "Window: clearImmediate() method"
 short-title: clearImmediate()
 slug: Web/API/Window/clearImmediate
 page-type: web-api-instance-method
+status:
+  - deprecated
+  - non-standard
 browser-compat: api.Window.clearImmediate
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}} {{deprecated_header}}
 
 This method clears the action specified by {{DOMxRef("window.setImmediate")}}.
-
-> **Note:** This method is not expected to become standard, and is nowadays only implemented
-> by Node.js 0.10+. It meets resistance both from [Gecko](https://bugzil.la/686201) (Firefox) and [Chromium/WebKit](https://crbug.com/146172) (Chrome/Safari).
 
 ## Syntax
 
@@ -43,8 +43,8 @@ document.getElementById("button").addEventListener(() => {
 
 ## Specifications
 
-Not part of any current specifications. The
-[Efficient Script Yielding](https://w3c.github.io/setImmediate/#si-setImmediate)
+Not part of any current specifications.
+The [Efficient Script Yielding](https://w3c.github.io/setImmediate/#si-setImmediate)
 specification is no longer being worked on.
 
 ## Browser compatibility

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -171,7 +171,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Enables you to cancel a callback previously scheduled with {{domxref("Window.requestAnimationFrame")}}.
 - {{domxref("Window.cancelIdleCallback()")}}
   - : Enables you to cancel a callback previously scheduled with {{domxref("Window.requestIdleCallback")}}.
-- {{domxref("Window.clearImmediate()")}}
+- {{domxref("Window.clearImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Cancels the repeated execution set using `setImmediate()`.
 - {{domxref("clearInterval", "Window.clearInterval()")}}
   - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
@@ -237,7 +237,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Scrolls the current document by the specified number of pages.
 - {{domxref("Window.scrollTo()")}}
   - : Scrolls to a particular set of coordinates in the document.
-- {{domxref("Window.setImmediate()")}}
+- {{domxref("Window.setImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Executes a function after the browser has finished other heavy tasks.
 - {{domxref("setInterval", "Window.setInterval()")}}
   - : Schedules a function to execute every time a given number of milliseconds elapses.

--- a/files/en-us/web/api/window/setimmediate/index.md
+++ b/files/en-us/web/api/window/setimmediate/index.md
@@ -3,17 +3,15 @@ title: "Window: setImmediate() method"
 short-title: setImmediate()
 slug: Web/API/Window/setImmediate
 page-type: web-api-instance-method
+status:
+  - deprecated
+  - non-standard
 browser-compat: api.Window.setImmediate
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}} {{deprecated_header}}
 
-This method is used to break up long running operations and run a callback function
-immediately after the browser has completed other operations such as events and display
-updates.
-
-> **Note:** This method is not expected to become standard, and is nowadays only implemented
-> by Node.js 0.10+. It meets resistance both from [Gecko](https://bugzil.la/686201) (Firefox) and [Chromium/WebKit](https://crbug.com/146172) (Chrome/Safari).
+This method is used to break up long running operations and run a callback function immediately after the browser has completed other operations such as events and display updates.
 
 ## Syntax
 
@@ -39,29 +37,23 @@ The ID of the immediate which can be used later with {{DOMxRef("window.clearImme
 
 ## Notes
 
-The {{DOMxRef("Window.clearImmediate", "clearImmediate")}} method can be used to clear
-the immediate actions, just like {{DOMxRef("clearTimeout")}} for
-{{DOMxRef("setTimeout()")}}.
+The {{DOMxRef("Window.clearImmediate", "clearImmediate")}} method can be used to clear the immediate actions, just like {{DOMxRef("clearTimeout")}} for {{DOMxRef("setTimeout()")}}.
 
-This method can be used instead of the `setTimeout(fn, 0)` method to execute
-[heavy operations](https://humanwhocodes.com/blog/2009/08/11/timed-array-processing-in-javascript/).
+This method can be used instead of the `setTimeout(fn, 0)` method to execute [heavy operations](https://humanwhocodes.com/blog/2009/08/11/timed-array-processing-in-javascript/).
 
 The feature can be emulated in a few different ways:
 
 - {{DOMxRef("Window.postMessage", "postMessage")}} can be used to trigger an immediate but yielding callback.
 - {{DOMxRef("MessageChannel")}} can be used reliably inside of Web Workers whereas the
   semantics of postMessage mean it cannot be used there.
-- `setTimeout(fn, 0)` _can_ potentially be used, however as it is
-  clamped to 4ms for timers nested more than 5 levels deep [per the HTML spec](https://html.spec.whatwg.org/multipage/webappapis.html#timers), it does not make for a suitable polyfill for the natural immediacy of
-  `setImmediate`.
+- `setTimeout(fn, 0)` _can_ potentially be used, however as it is clamped to 4ms for timers nested more than 5 levels deep [per the HTML spec](https://html.spec.whatwg.org/multipage/webappapis.html#timers), it does not make for a suitable polyfill for the natural immediacy of `setImmediate`.
 
 All of these techniques are incorporated into a [robust setImmediate polyfill](https://github.com/YuzuJS/setImmediate).
 
 ## Specifications
 
-Not part of any current specifications. The
-[Efficient Script Yielding](https://w3c.github.io/setImmediate/#si-setImmediate)
-specification is no longer being worked on.
+Not part of any current specifications.
+The [Efficient Script Yielding](https://w3c.github.io/setImmediate/#si-setImmediate) specification is no longer being worked on.
 
 ## Browser compatibility
 


### PR DESCRIPTION
Fixes #29540

They are deprecated and non-standard., as resolved by https://github.com/mdn/browser-compat-data/pull/20919