### PR TITLE
bug: Wait to image’s `load` event, rather the `window` one in example

### DIFF
--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -79,10 +79,10 @@ image will be drawn in is 200px wide, and the image will be drawn to fill its wi
 ### JavaScript
 
 ```js
-let output = document.querySelector(".output");
-let image = document.querySelector("img");
+const output = document.querySelector(".output");
+const image = document.querySelector("img");
 
-window.addEventListener("load", (event) => {
+image.addEventListener("load", (event) => {
   output.innerHTML +=
     `Natural size: ${image.naturalWidth} x ` +
     `${image.naturalHeight} pixels<br>`;
@@ -93,7 +93,7 @@ window.addEventListener("load", (event) => {
 
 The JavaScript code dumps the natural and as-displayed sizes into the
 {{HTMLElement("div")}} with the class `output`. This is done in response to
-the window's {{domxref("Window.load_event", "load")}} event handler, in order to ensure
+the images's {{domxref("HTMLElement.load_event", "load")}} event handler, in order to ensure
 that the image is available before attempting to examine its width and height.
 
 ### Result

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -79,7 +79,7 @@ const output = document.querySelector("pre");
 const image = document.querySelector("img");
 
 image.addEventListener("load", (event) => {
-  const { naturalWidth, naturalHeight, width, height }= image;
+  const { naturalWidth, naturalHeight, width, height } = image;
   output.textContent = `
 Natural size: ${naturalWidth} x ${naturalHeight} pixels
 Displayed size: ${width} x ${height} pixels

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -49,7 +49,7 @@ its rendered size as altered by the page's CSS and other factors.
     class="image"
     alt="A round wall clock with a white dial and black numbers" />
 </div>
-<div class="output"></div>
+<pre></pre>
 ```
 
 The HTML features a 400x398 pixel image which is placed inside a
@@ -66,10 +66,6 @@ The HTML features a 400x398 pixel image which is placed inside a
 .image {
   width: 100%;
 }
-
-.output {
-  padding-top: 2em;
-}
 ```
 
 The main thing of note in the CSS above is that the style used for the container the
@@ -79,20 +75,20 @@ image will be drawn in is 200px wide, and the image will be drawn to fill its wi
 ### JavaScript
 
 ```js
-const output = document.querySelector(".output");
+const output = document.querySelector("pre");
 const image = document.querySelector("img");
 
 image.addEventListener("load", (event) => {
-  output.innerHTML +=
-    `Natural size: ${image.naturalWidth} x ` +
-    `${image.naturalHeight} pixels<br>`;
-  output.innerHTML +=
-    `Displayed size: ${image.width} x ` + `${image.height} pixels`;
+  const { naturalWidth, naturalHeight, width, height }= image;
+  output.textContent = `
+Natural size: ${naturalWidth} x ${naturalHeight} pixels
+Displayed size: ${width} x ${height} pixels
+`;
 });
 ```
 
 The JavaScript code dumps the natural and as-displayed sizes into the
-{{HTMLElement("div")}} with the class `output`. This is done in response to
+{{HTMLElement("pre")}}. This is done in response to
 the images's {{domxref("HTMLElement.load_event", "load")}} event handler, in order to ensure
 that the image is available before attempting to examine its width and height.
 


### PR DESCRIPTION
### Description

In the given example, we should probably wait for the image `load` event. As the example currently returns¹:
![obrazek](https://github.com/mdn/content/assets/8017233/7744a117-8fb2-40cb-89a5-30e3ef704d53)

[1] Tested on Firefox 118.0.1 and Chromium 117.0.5938.149 (both on Ubuntu)