### PR TITLE
Ref #27079 - `[media]` is allowed in any valid `source` context.

### DIFF
--- a/files/en-us/web/html/element/source/index.md
+++ b/files/en-us/web/html/element/source/index.md
@@ -99,9 +99,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - `media`
 
-  - : Allowed if the `source` element's parent is a {{HTMLElement("picture")}} element, but not allowed if the `source` element's parent is an {{HTMLElement("audio")}} or {{HTMLElement("video")}} element.
-
-    [Media query](/en-US/docs/Web/CSS/CSS_media_queries) of the resource's intended media.
+  - : [Media query](/en-US/docs/Web/CSS/CSS_media_queries) of the resource's intended media.
 
 - `height`
 


### PR DESCRIPTION
### Description

Removes text clarifying appropriate contexts for `media` attributes on `source` elements, as any valid use of `source` allows for `media`.

### Motivation

See #27079 for additional details.

### Related issues and pull requests

Fixes #27079
