### PR TITLE
Update to `Window.showDirectoryPicker()` and `Window.showSaveFilePicker()` and `Window.showOpenFilePicker()`

### DIFF
--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.showDirectoryPicker
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("File System API")}}{{SeeCompatTable}}
+{{APIRef("File System API")}}{{Securecontext_Header}}{{SeeCompatTable}}
 
 The **`showDirectoryPicker()`** method of the
 {{domxref("Window")}} interface displays a directory picker which allows the user to
@@ -30,7 +30,7 @@ showDirectoryPicker()
       - : By specifying an ID, the browser can remember different directories for different
         IDs. If the same ID is used for another picker, the picker opens in the same
         directory.
-    - `mode`
+    - `mode` {{optional_inline}}
       - : A string that defaults to `"read"` for read-only access or `"readwrite"` for read
         and write access to the directory.
     - `startIn`
@@ -43,9 +43,11 @@ A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref('FileSyst
 
 ### Exceptions
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : Thrown if the user dismisses the prompt without making a selection, or if the user
-    agent deems the selected content to be too sensitive or dangerous
+    agent deems the selected content to be too sensitive or dangerous.
+- `SecurityError` {{domxref("DOMException")}}
+  - : An SecurityError is thrown if it was blocked by Same-Origin policy or it was not called via a user interaction such as a button press.
 
 ## Security
 

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -26,14 +26,14 @@ showDirectoryPicker()
 
   - : An object containing options, which are as follows:
 
-    - `id`
+    - `id` {{optional_inline}}
       - : By specifying an ID, the browser can remember different directories for different
         IDs. If the same ID is used for another picker, the picker opens in the same
         directory.
     - `mode` {{optional_inline}}
       - : A string that defaults to `"read"` for read-only access or `"readwrite"` for read
         and write access to the directory.
-    - `startIn`
+    - `startIn` {{optional_inline}}
       - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
 

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -47,7 +47,7 @@ A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref('FileSyst
   - : Thrown if the user dismisses the prompt without making a selection, or if the user
     agent deems the selected content to be too sensitive or dangerous.
 - `SecurityError` {{domxref("DOMException")}}
-  - : An SecurityError is thrown if it was blocked by Same-Origin policy or it was not called via a user interaction such as a button press.
+  - : Thrown if the call was blocked by the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) or it was not called via a user interaction such as a button press.
 
 ## Security
 

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -26,21 +26,28 @@ showOpenFilePicker()
 
   - : An object containing options, which are as follows:
 
-    - `multiple`
-      - : A boolean value that defaults to `false`. When
-        set to `true` multiple files may be selected.
-    - `excludeAcceptAllOption`
+    - `excludeAcceptAllOption` {{Optional_Inline}}
       - : A boolean value that defaults to
         `false`. By default the picker should include an option to not apply
         any file type filters (instigated with the type option below). Setting this option
         to `true` means that option is _not_ available.
+    - `id`
+      - : By specifying an ID, the browser can remember different directories for different
+        IDs. If the same ID is used for another picker, the picker opens in the same
+        directory.
+    - `multiple` {{Optional_Inline}}
+      - : A boolean value that defaults to `false`. When
+        set to `true` multiple files may be selected.
+    - `startIn`
+      - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
+        `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `types`
 
       - : An {{jsxref('Array')}} of allowed file types to pick. Each
         item is an object with the following options:
 
-        - `description`
-          - : An optional description of the category of files types allowed.
+        - `description` {{Optional_Inline}}
+          - : An optional description of the category of files types allowed. Default to be an empty string.
         - `accept`
           - : An {{jsxref('Object')}} with the keys set to the [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) and the values an {{jsxref('Array')}} of file extensions (see below
             for an example).
@@ -51,9 +58,11 @@ A {{jsxref("Promise")}} whose fulfillment handler receives an {{jsxref('Array')}
 
 ### Exceptions
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : An AbortError is thrown if a user dismisses the prompt without making a selection or
     if a file selected is deemed too sensitive or dangerous to be exposed to the website.
+- `SecurityError` {{domxref("DOMException")}}
+  - : An SecurityError is thrown if it was blocked by Same-Origin policy or it was not called via a user interaction such as a button press.
 
 ## Security
 

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -31,14 +31,14 @@ showOpenFilePicker()
         `false`. By default the picker should include an option to not apply
         any file type filters (instigated with the type option below). Setting this option
         to `true` means that option is _not_ available.
-    - `id`
+    - `id` {{Optional_Inline}}
       - : By specifying an ID, the browser can remember different directories for different
         IDs. If the same ID is used for another picker, the picker opens in the same
         directory.
     - `multiple` {{Optional_Inline}}
       - : A boolean value that defaults to `false`. When
         set to `true` multiple files may be selected.
-    - `startIn`
+    - `startIn` {{Optional_Inline}}
       - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `types`

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -47,7 +47,7 @@ showOpenFilePicker()
         item is an object with the following options:
 
         - `description` {{Optional_Inline}}
-          - : An optional description of the category of files types allowed. Default to be an empty string.
+          - : An optional description of the category of files types allowed. Defaults to an empty string.
         - `accept`
           - : An {{jsxref('Object')}} with the keys set to the [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) and the values an {{jsxref('Array')}} of file extensions (see below
             for an example).
@@ -62,7 +62,7 @@ A {{jsxref("Promise")}} whose fulfillment handler receives an {{jsxref('Array')}
   - : An AbortError is thrown if a user dismisses the prompt without making a selection or
     if a file selected is deemed too sensitive or dangerous to be exposed to the website.
 - `SecurityError` {{domxref("DOMException")}}
-  - : An SecurityError is thrown if it was blocked by Same-Origin policy or it was not called via a user interaction such as a button press.
+  - : Thrown if the call was blocked by the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) or it was not called via a user interaction such as a button press.
 
 ## Security
 

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -31,11 +31,11 @@ showSaveFilePicker()
         `false`. By default, the picker should include an option to not apply
         any file type filters (instigated with the type option below). Setting this option
         to `true` means that option is _not_ available.
-    - `id`
+    - `id` {{Optional_Inline}}
       - : By specifying an ID, the browser can remember different directories for different
         IDs. If the same ID is used for another picker, the picker opens in the same
         directory.
-    - `startIn`
+    - `startIn` {{Optional_Inline}}
       - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `suggestedName` {{Optional_Inline}}

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -40,7 +40,7 @@ showSaveFilePicker()
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `suggestedName` {{Optional_Inline}}
       - : A {{jsxref('String')}}. The suggested file name.
-    - `types`
+    - `types` {{Optional_Inline}}
 
       - : An {{jsxref('Array')}} of allowed file types to save. Each
         item is an object with the following options:

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -26,21 +26,28 @@ showSaveFilePicker()
 
   - : An object containing options, which are as follows:
 
-    - `excludeAcceptAllOption`
+    - `excludeAcceptAllOption` {{Optional_Inline}}
       - : A boolean value that defaults to
         `false`. By default, the picker should include an option to not apply
         any file type filters (instigated with the type option below). Setting this option
         to `true` means that option is _not_ available.
-    - `suggestedName`
+    - `id`
+      - : By specifying an ID, the browser can remember different directories for different
+        IDs. If the same ID is used for another picker, the picker opens in the same
+        directory.
+    - `startIn`
+      - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
+        `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
+    - `suggestedName` {{Optional_Inline}}
       - : A {{jsxref('String')}}. The suggested file name.
     - `types`
 
       - : An {{jsxref('Array')}} of allowed file types to save. Each
         item is an object with the following options:
 
-        - `description`
+        - `description` {{Optional_Inline}}
           - : An optional description of the category of files
-            types allowed.
+            types allowed. Default to be an empty string.
         - `accept`
           - : An {{jsxref('Object')}} with the keys set to the [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) and the values an {{jsxref('Array')}} of file extensions (see below
             for an example).
@@ -51,9 +58,11 @@ A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref('FileSyst
 
 ### Exceptions
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : Thrown if the user dismisses the file picker without selecting or inputting a file,
     or if the user agent deems any selected files too sensitive or dangerous.
+- `SecurityError` {{domxref("DOMException")}}
+  - : An SecurityError is thrown if it was blocked by Same-Origin policy or it was not called via a user interaction such as a button press.
 
 ## Security
 

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -62,7 +62,7 @@ A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref('FileSyst
   - : Thrown if the user dismisses the file picker without selecting or inputting a file,
     or if the user agent deems any selected files too sensitive or dangerous.
 - `SecurityError` {{domxref("DOMException")}}
-  - : An SecurityError is thrown if it was blocked by Same-Origin policy or it was not called via a user interaction such as a button press.
+  - : Thrown if the call was blocked by the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) or it was not called via a user interaction such as a button press.
 
 ## Security
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update to `Window.showDirectoryPicker()` and `Window.showSaveFilePicker()` and `Window.showOpenFilePicker()`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

1. add `{{Optional_Inline}}` to some some optional parameters
2. add the missing `id` and `startIn` parameters for `Window.showSaveFilePicker()` and `Window.showOpenFilePicker()`
3. add the missing `SecurityError` exception, see https://wicg.github.io/file-system-access/#permissions - permission request algorithm

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker

https://developer.mozilla.org/en-US/docs/Web/API/window/showOpenFilePicker

https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker

https://wicg.github.io/file-system-access/#idl-index

![image](https://github.com/mdn/content/assets/95597335/4ef4c922-dbe2-4718-acb2-5c32674e6ffb)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
