### PR TITLE
Fix type of `timeZone` property

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -42,8 +42,7 @@ The resulting object has the following properties:
     `"nu"` or filled in as default values.
 - `timeZone`
   - : The value provided for this property in the `options` argument;
-    A {{jsxref("String")}} value identifying the runtime's default time
-    zone instead, if none was provided.
+    defaults to the runtime's default time zone. Should never be `undefined`.
 - `hour12`
   - : The value provided for this property in the `options` argument or
     filled in as a default.

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -42,10 +42,8 @@ The resulting object has the following properties:
     `"nu"` or filled in as default values.
 - `timeZone`
   - : The value provided for this property in the `options` argument;
-    {{jsxref("undefined")}} (representing the runtime's default time zone) if none was
-    provided. Warning: Applications should not rely on {{jsxref("undefined")}} being
-    returned, as future versions may return a {{jsxref("String")}} value identifying
-    the runtime's default time zone instead.
+    A {{jsxref("String")}} value identifying the runtime's default time
+    zone instead, if none was provided.
 - `hour12`
   - : The value provided for this property in the `options` argument or
     filled in as a default.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

According to [ECMAScript definition](https://tc39.es/ecma402/#sec-properties-of-intl-datetimeformat-instances), the `timeZone` property should always be of type `string`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

After [trying to fix TypeScript](https://github.com/microsoft/TypeScript/pull/56056), I've learned that TypeScript definition is correctly indicating that this property is always `string` and never `undefined`. Whereas, MDN docs states otherwise, and also Chrome have a bug where it can be `undefined`. Hence, these two issues should be fixed, and this PR addresses it.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://github.com/microsoft/TypeScript/issues/55869

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
