### PR TITLE
docs(css-easing-function): Rewrite the "Values" section

### DIFF
--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.easing-function
 
 {{CSSRef}}
 
-The **`<easing-function>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents a mathematical function that describes the rate at which a numerical value changes.
+The **`<easing-function>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents a mathematical function that describes the rate at which a value changes.
 
 This transition between two values may be applied in different situations. It may be used to describe how fast values change during animations. This lets you vary the animation's speed over the course of its duration. You can specify an easing function for CSS [transition](/en-US/docs/Web/CSS/transition-timing-function) and [animation](/en-US/docs/Web/CSS/animation-timing-function) properties.
 
@@ -30,6 +30,7 @@ ease-in-out
 /* steps function and keywords */
 /* steps(<number-of-steps>, <direction>) */
 steps(4, end)
+steps(10, jump-both)
 step-start
 step-end
 ```
@@ -54,7 +55,7 @@ step-end
 
 - `<cubic-bezier-easing-function>`
 
-  - : Specifies a `cubic-bezier()` function using two control points, each with two values, which help shape the curve of the animation or transition progress. The control points can be specified using a custom `cubic-bezier()` function, or one of the four predefined keyword values for the `cubic-bezier()` function can be used. The predefined keywords include:
+  - : Specifies a [Bézier curve](/en-US/docs/Glossary/Bezier_curve) to shape the progress of an animation or a transition. In CSS, Bézier curves are defined by four control points that mathematically describe the curve: a starting point, an ending point, and two control points. The cubic Bézier easing function can be defined in one of these two ways: by creating a custom curve with a four-parameter `cubic-bezier()` function call or by using one of the predefined keyword values, which map to the commonly used Bézier curve parameters. The predefined keyword values include:
 
     `ease`: This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1)`. It indicates that the interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. It is similar to the `ease-in-out` keyword, though it accelerates more sharply at the beginning.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -108,7 +108,7 @@ For example, the `linear(0, 0.25, 1)` function defines the linear stops at `0`, 
 
 ![Graphs of "Input progress" to "Output progress", of which "linear(0, 0.25, 1)" shows a broken line connecting the origin, (0.5, 0.25), and (1, 1); and "linear(0, 0.25 75%, 1)" shows a broken line connecting the origin, (0.75, 0.25), and (1, 1).](linear_function.svg)
 
-By default, the stops are equidistant. So if there are 5 stops, they will be at 0%, 25%, 50%, 75%, and 100% of the duration. However, optional `<linear-stop-length>` percentage values provide finer control, defining the start and/or length of each segment, allowing for a more controlled progression of the transition.
+By default, the stops are equidistant. So if there are 5 stops, they will be at 0%, 25%, 50%, 75%, and 100% of the duration. You can use optional `<linear-stop-length>` percentage values to provide finer control, defining the start and/or length of each segment, allowing for a more controlled progression of the transition.
 
 Let's look at an example where the progress of the animation is specified: `linear(0, 0.25 75%, 1)`. In this case, the animation progresses to `75%` of its total change in the first 25% of the duration (that is, to go from the timeline point `0` to `0.25`). The last 25% of the animation's total change is used during the remaining 75% of the duration (that is, to progress from the timeline point `0.25` to `1`). Consider another example of the `linear()` function: `linear(0.5 25% 75%, 1)`. Here, the animation reaches `25%` of its total change at the halfway point (`0.5`), and then instantly jumps to `75%` of its total change. Over the remaining 50% of the duration (`0.5` to `1`), it progresses from `75%` of its total change to 100%.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -21,7 +21,7 @@ linear
 
 /* cubic-bezier function and keywords */
 /* cubic-bezier(<x1>, <y1>, <x2>, <y2>) */
-cubic-bezier(0.42, 0, 1, 1)
+cubic-bezier(0.25, 0.1, 0.25, 1)
 ease
 ease-in
 ease-out
@@ -38,24 +38,23 @@ step-end
 
 - `linear`
 
-  - : Specifies a constant rate of interpolation, ensuring there is no change in the rate of progress of the animation throughout the duration. This also means that there is no acceleration or deceleration at any point during the animation's duration. It's important to not confuse this keyword value with the [linear() easing function](#linear_easing_function), although they are related: the `linear` keyword produces a `linear()` easing function with two points, `linear(0, 1)`.
-    > **Note:** The `linear` keyword always serializes as `linear`, whereas its function equivalent `linear(0, 1)` serializes as `linear(0 0%, 1 100%)`.
+  - : Specifies a constant rate of interpolation, with no change in the rate of progress throughout the duration (that is, no acceleration or deceleration). This keyword value is equivalent to both [`cubic-bezier(0, 0, 1, 1)`](#cubic_bézier_easing_function) and [`linear(0, 1)`](#linear_easing_function) functions.
 
 ![Graph of "Input progress" to "Output progress" showing a line extending from the origin to (1, 1).](linear.svg)
 
 - `<linear-easing-function>`
 
-  - : Specifies a `linear()` function using multiple points, called linear stops, allowing you to control the movement of an animation at specific points along the path.
+  - : Specifies a `linear()` function with one or more comma-separated _linear stops_, each containing up to two optional _stop lengths_, to control the progress of an animation or transition.
 
-    The `linear()` function specifies a list of points (`<linear-stop-list>`), separated by commas. Each point or linear stop in the list (`<linear-stop>`) is specified as a {{cssxref("&lt;number&gt;")}} and optional one or two {{cssxref("&lt;percentage&gt;")}} values (`<linear-stop-length>`).
+    The `linear()` function specifies a `<linear-stop-list>`, a comma-separated list of points along the animation or transition progress. Each point or `<linear-stop>` in the list is specified as a {{cssxref("&lt;number&gt;")}} between `0` and `1`. By default, each stop in the `<linear-stop-list>` is equidistant. To have more control on the progress of the animation or transition, each point can include up to two optional {{cssxref("&lt;percentage&gt;")}} `<linear-stop-length>` values.
 
-    - `<number>`: Represents a point in time. The value should be between `0` and `1`.
+    - `<number>`: Represents a point in time along the duration of the animation or transition. The value should be between `0` and `1`, where `0` represents the start of the iteration and `1` represents the end.
 
-    - `<percentage>`: Represents the progress of the animation at the specified point in time. If two percentage values are specified, they represent a range for that specific point – the first percentage indicates the starting point and the second percentage indicates the ending point of the progress for that segment in the animation. If no `<percentage>` value is specified, the points are spread evenly along the timeline.
+    - `<percentage>`: Indicates the position of a linear stop along the duration. It can take up to two values. If one value is specified, it defines the start of the associated linear stop. If two percentage values are specified, they define the length of the stop: the first percentage indicates the starting point and the second percentage indicates the ending point for that segment in the animation or transition. If no `<percentage>` value is specified, which is the default, the stops are spread evenly along the timeline.
 
 - `<cubic-bezier-easing-function>`
 
-  - : Specifies a `cubic-bezier()` function using two control points, which help shape the curve of the animation's progress. This parameter accepts one of the following four keyword values that map to predefined `cubic-bezier()` functions or a custom `cubic-bezier()` function to specify the control points:
+  - : Specifies a `cubic-bezier()` function using two control points, each with two values, which help shape the curve of the animation or transition progress. The control points can be specified using a custom `cubic-bezier()` function, or one of the four predefined keyword values for the `cubic-bezier()` function can be used. The predefined keywords include:
 
     `ease`: This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1)`. It indicates that the interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. It is similar to the `ease-in-out` keyword, though it accelerates more sharply at the beginning.
 
@@ -67,30 +66,29 @@ step-end
 
     ![Graphs of "Input progress" to "Output progress", of which "ease" shows a curved line quickly rising from the origin to (1, 1); "ease-in" shows a shallow curved line from the origin that straightens out as it approaches (1, 1); "ease-out" shows a straight diagonal line that slightly curves as it gets close to (1, 1); and "ease-in-out" shows a symmetrical, "S"-shaped line curving from the origin to (1, 1).](ease.svg)
 
-    `cubic-bezier()`: This function accepts four {{cssxref("&lt;number&gt;")}} values.
+    `cubic-bezier()`: This function accepts four {{cssxref("&lt;number&gt;")}} values to shape a curve.
 
-    - `<number>`: Specifies the abscissas and ordinates of the [P1 and P2 points](#cubic_bézier_easing_function) of the curve (as `<x1>`, `<y1>`, `<x2>`, and `<y2>`). `<x1>` and `<x2>` must be in the range `[0, 1]`, otherwise the value is invalid.
+    - {{cssxref("&lt;number&gt;")}}: Specifies the location of [P1 and P2 points](#cubic_bézier_easing_function) on the curve. `<x1>` and `<y1>` are the coordinates for point P1, and `<x2>` and `<y2>` are the coordinates for point P2. `<x1>` and `<x2>` values must be between `0` and `1`, otherwise the function will not work as expected.
 
 - `<step-easing-function>`
 
-  - : Specifies a `steps()` function that divides the animation into a set number of intervals or "steps", causing the animation to jump from one step to the next rather than transitioning smoothly. This parameter accepts one of the following two keyword values that map to predefined `steps()` functions or a custom `steps()` function:
+  - : Specifies a `steps()` function that divides the animation into a set number of equal-length intervals or "steps", causing the animation to jump from one step to the next rather than transitioning smoothly. This parameter accepts one of the following two keyword values that map to predefined `steps()` functions or a custom `steps()` function:
 
     `step-start`: This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`. It indicates that the interpolation jumps immediately to its final state, where it stays until the end.
 
     `step-end`: This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`. It indicates that the interpolation stays in its initial state until the end, at which point it jumps directly to its final state.
 
-    ![Graphs of "Input progress" to "Output progress", of which "step-start" shows a hollow origin and a horizontal line extending from (0, 1) to (1, 1); and "step-end" shows a horizontal line extending from the origin to (1, 0) (hollow) and a point at (1, 1).](step.svg)
+    ![Two graphs of "Input progress" to "Output progress". In the "step-start" graph, an unfilled circle represents the origin point (0,0), with a horizontal line extending from (0, 1) to (1, 1). In the "step-end" graph, a horizontal line extends from the origin to (1, 0), with an unfilled circle at (1,0) and a solid circle at (1, 1).](step.svg)
 
-    `steps()`: This function accepts a strictly positive {{cssxref("&lt;integer&gt;")}} and a second optional `<step-position>`.
+    `steps()`: This function accepts a positive {{cssxref("&lt;integer&gt;")}} and an optional `<step-position>`.
 
-    - `<integer>`: Represents the number of equidistant intervals or 'steps' in the animation. It must be a positive integer greater than `0` unless the second parameter is `jump-none`, in which case, it must be a positive integer greater than `1`.
-    - `<step-position>`: Indicates when the animation jumps from one step to the next. The possible keyword values include:
+    - `<integer>`: Represents the number of equidistant intervals or 'steps'. It must be a positive integer greater than `0` unless the second parameter is `jump-none`, in which case, it must be a positive integer greater than `1`.
+    - `<step-position>`: Specifies the [timing of the jump](#steps_easing_function) to occur either at the start, at the end, at both start and end, or at neither. The possible keyword values include:
 
-      - `jump-start` denotes that the first step or jump happens when the interpolation begins.
-      - `jump-end` denotes that the last step or jump happens when the interpolation ends. This is the default value when no `<step-position>` is specified.
-      - `jump-none` denotes that no jump happens at the beginning or the end, effectively removing a step during the interpolation iteration. Instead, the animation holds steady at both the 0% mark and the 100% mark. The duration of these holds is determined by dividing the total animation duration by the number of steps (1/n).
-      - `jump-both` denotes that jumps occur at both the 0% and 100% marks, effectively adding a step during the interpolation iteration.
-      - `jump-none` denotes no jump on either end, effectively removing a step during the interpolation iteration. Instead, it holds at both the 0% mark and the 100% mark, each for 1/n of the duration.
+      - `jump-start` denotes that the first jump occurs right at the start, essentially at the `0` point. No time is spent at the `0%` mark.
+      - `jump-end` denotes that the last jump occurs right at the end, essentially at the `1` point. No time is spent at the `100%` mark. This is the default value when no `<step-position>` is specified.
+      - `jump-none` denotes that no jump occurs either at the beginning or at the end, effectively removing a step during the duration. Instead, the progress holds steady at both the `0%` mark and `100%` marks. The duration of these holds is determined by dividing the total duration by the number of steps (1/n).
+      - `jump-both` denotes that jumps occur at both the beginning and the end, essentially occurring at both the `0` and `1`. Effectively, a step is added at both the ends. No time is spent at the `0%` and `100%` marks.
       - `start` is the equivalent of `jump-start`.
       - `end` is the equivalent of `jump-end`.
 
@@ -104,15 +102,17 @@ There are three types of easing functions:
 
 ### Linear easing function
 
-The `linear()` function defines a piecewise linear function that interpolates linearly between its points, allowing you to approximate more complex animations like bounce and elastic effects. The interpolation is done at a constant rate from beginning to end. A typical use of the `linear()` function is to provide many points to approximate any curve.
+The `linear()` function creates a piecewise linear easing, allowing the approximation of complex animations and transitions by interpolating linearly between the specified points. The interpolation occurs at a constant rate from beginning to end. A typical use of the `linear()` function is to provide many points to approximate any curve.
 
-When you define the `linear()` function, you specify a list of _linear stops_ like in `linear(0, 0.25, 1)`. In this case, the animation starts at point `0`, goes linearly to point `0.25`, and then continues linearly to the point `1`. Since no `<linear-stop-length>` percentage is specified, the same animation duration (50%) is used to go from `0` to `0.25` and from `0.25` to `1`.
+For example, the `linear(0, 0.25, 1)` function defines the linear stops at `0`, `0.25`, and `1`. The animation or transition starts at point `0`, moves linearly to `0.25`, and then continues linearly to point `1`. Since no `<linear-stop-length>` percentage is specified, the same duration (50%) is used to go from `0` to `0.25` and from `0.25` to `1`.
 
 ![Graphs of "Input progress" to "Output progress", of which "linear(0, 0.25, 1)" shows a broken line connecting the origin, (0.5, 0.25), and (1, 1); and "linear(0, 0.25 75%, 1)" shows a broken line connecting the origin, (0.75, 0.25), and (1, 1).](linear_function.svg)
 
+By default, the stops are equidistant. So if there are 5 stops, they will be at 0%, 25%, 50%, 75%, and 100% of the duration. However, optional `<linear-stop-length>` percentage values provide finer control, defining the start and/or length of each segment, allowing for a more controlled progression of the transition.
+
 Let's look at an example where the progress of the animation is specified: `linear(0, 0.25 75%, 1)`. In this case, the animation progresses to `75%` of its total change in the first 25% of the duration (that is, to go from the timeline point `0` to `0.25`). The last 25% of the animation's total change is used during the remaining 75% of the duration (that is, to progress from the timeline point `0.25` to `1`). Consider another example of the `linear()` function: `linear(0.5 25% 75%, 1)`. Here, the animation reaches `25%` of its total change at the halfway point (`0.5`), and then instantly jumps to `75%` of its total change. Over the remaining 50% of the duration (`0.5` to `1`), it progresses from `75%` of its total change to 100%.
 
-The [`linear`](#linear) keyword is equivalent to the easing function `linear(0, 1)`.
+> **Note:** The [`linear`](#linear) keyword is equivalent to the easing function `linear(0, 1)`. While the `linear` keyword is always interpreted as-is, the function `linear(0, 1)` gets interpreted as `linear(0 0%, 1 100%)`.
 
 ### Cubic Bézier easing function
 
@@ -147,7 +147,7 @@ steps(5, jump-none)
 steps(3, jump-both)
 ```
 
-![Graphs of "Input progress" to "Output progress", of which "steps(2, jump-start)" shows horizontal lines extending 0.5 unit from (0, 0.5) and (0.5, 1), respectively, with hollow points at the origin and (0.5, 0.5); "steps(4, jump-end)" shows horizontal lines extending 0.25 unit from (0, 0), (0.25, 0.25), (0.5, 0.5), and (0.75, 0.75), respectively, with hollow points at (0.25, 0), (0.5, 0.25), and (0.75, 0.5), and a point at (1, 1); "steps(5, jump-none)" shows horizontal lines extending 0.2 unit from (0, 0), (0.2, 0.25), (0.4, 0.5), (0.6, 0.75), and (0.8, 1), respectively, with hollow points at (0.2, 0), (0.4, 0.25), (0.6, 0.5), and (0.8, 0.75); "steps(3, jump-both)" shows horizontal lines extending 1/3 unit from (0, 0.25), (1/3, 0.5), and (2/3, 0.75),respectively , with a point at (1, 1) and hollow points at the origin, (1/3, 0.25), (2/3, 0.5), and (1, 0.75).](jump.svg)
+![Graphs of "Input progress" to "Output progress", of which "steps(2, jump-start)" shows horizontal lines extending 0.5 unit from (0, 0.5) and (0.5, 1), respectively, with empty circles at the origin and (0.5, 0.5); "steps(4, jump-end)" shows horizontal lines extending 0.25 unit from (0, 0), (0.25, 0.25), (0.5, 0.5), and (0.75, 0.75), respectively, with unfilled circles at (0.25, 0), (0.5, 0.25), and (0.75, 0.5), and a solid circle at (1, 1); "steps(5, jump-none)" shows horizontal lines extending 0.2 unit from (0, 0), (0.2, 0.25), (0.4, 0.5), (0.6, 0.75), and (0.8, 1), respectively, with unfilled circles at (0.2, 0), (0.4, 0.25), (0.6, 0.5), and (0.8, 0.75); "steps(3, jump-both)" shows horizontal lines extending 1/3 unit from (0, 0.25), (1/3, 0.5), and (2/3, 0.75),respectively , with a solid circle at (1, 1) and unfilled circles at the origin, (1/3, 0.25), (2/3, 0.5), and (1, 0.75).](jump.svg)
 
 Each of the keywords [`step-start`](#step-start) and [`step-end`](#step-end) is equivalent to a specific `steps()` value.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -100,7 +100,7 @@ There are three types of easing functions:
 
 - [Linear](#linear_easing_function)
 - [Cubic Bézier](#cubic_bézier_easing_function)
-- [Step](#step_easing_function)
+- [Steps](#steps_easing_function)
 
 ### Linear easing function
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -39,7 +39,7 @@ step-end
 - `linear`
 
   - : Specifies a constant rate of interpolation, ensuring there is no change in the rate of progress of the animation throughout the duration. This also means that there is no acceleration or deceleration at any point during the animation's duration. It's important to not confuse this keyword value with the [linear() easing function](#linear_easing_function), although they are related: the `linear` keyword produces a `linear()` easing function with two points, `linear(0, 1)`.
-    > **Note:** The `linear` keyword always serializes as `linear`, whereas its function equivalent `linear(0, 1)` serializes to `linear(0 0%, 1 100%)`.
+    > **Note:** The `linear` keyword always serializes as `linear`, whereas its function equivalent `linear(0, 1)` serializes as `linear(0 0%, 1 100%)`.
 
 ![Graph of "Input progress" to "Output progress" showing a line extending from the origin to (1, 1).](linear.svg)
 
@@ -47,7 +47,7 @@ step-end
 
   - : Specifies a `linear()` function using multiple points, called linear stops, allowing you to control the movement of an animation at specific points along the path.
 
-    The `linear()` function specifies a list of points (`<linear-stop-list>`), separated by commas. Each point or linear stop in the list (`<linear-stop>`) is specified as a {{cssxref("&lt;number&gt;")}} and one or two {{cssxref("&lt;percentage&gt;")}} values (`<linear-stop-length>`).
+    The `linear()` function specifies a list of points (`<linear-stop-list>`), separated by commas. Each point or linear stop in the list (`<linear-stop>`) is specified as a {{cssxref("&lt;number&gt;")}} and optional one or two {{cssxref("&lt;percentage&gt;")}} values (`<linear-stop-length>`).
 
     - `<number>`: Represents a point in time. The value should be between `0` and `1`.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -49,9 +49,9 @@ step-end
 
     The `linear()` function specifies a list of points (`<linear-stop-list>`), separated by commas. Each point or linear stop in the list (`<linear-stop>`) is specified as a {{cssxref("&lt;number&gt;")}} and one or two {{cssxref("&lt;percentage&gt;")}} values (`<linear-stop-length>`).
 
-    `<number>`: Represents a point in time. The value should be between `0` and `1`.
+    - `<number>`: Represents a point in time. The value should be between `0` and `1`.
 
-    `<percentage>`: Represents the progress of the animation at the specified point in time. If two percentage values are specified, they represent a range for that specific point – the first percentage indicates the starting point and the second percentage indicates the ending point of the progress for that segment in the animation. If no `<percentage>` value is specified, the points are spread evenly along the timeline.
+    - `<percentage>`: Represents the progress of the animation at the specified point in time. If two percentage values are specified, they represent a range for that specific point – the first percentage indicates the starting point and the second percentage indicates the ending point of the progress for that segment in the animation. If no `<percentage>` value is specified, the points are spread evenly along the timeline.
 
 - `<cubic-bezier-easing-function>`
 
@@ -67,7 +67,9 @@ step-end
 
     ![Graphs of "Input progress" to "Output progress", of which "ease" shows a curved line quickly rising from the origin to (1, 1); "ease-in" shows a shallow curved line from the origin that straightens out as it approaches (1, 1); "ease-out" shows a straight diagonal line that slightly curves as it gets close to (1, 1); and "ease-in-out" shows a symmetrical, "S"-shaped line curving from the origin to (1, 1).](ease.svg)
 
-    `cubic-bezier()`: This function accepts four {{cssxref("&lt;number&gt;")}} values to specify the abscissas and ordinates of the [P1 and P2 points](#cubic_bézier_easing_function) of the curve (as `<x1>`, `<y1>`, `<x2>`, and `<y2>`). `<x1>` and `<x2>` must be in the range `[0, 1]`, otherwise the value is invalid.
+    `cubic-bezier()`: This function accepts four {{cssxref("&lt;number&gt;")}} values.
+
+    - `<number>`: Specifies the abscissas and ordinates of the [P1 and P2 points](#cubic_bézier_easing_function) of the curve (as `<x1>`, `<y1>`, `<x2>`, and `<y2>`). `<x1>` and `<x2>` must be in the range `[0, 1]`, otherwise the value is invalid.
 
 - `<step-easing-function>`
 
@@ -79,25 +81,18 @@ step-end
 
     ![Graphs of "Input progress" to "Output progress", of which "step-start" shows a hollow origin and a horizontal line extending from (0, 1) to (1, 1); and "step-end" shows a horizontal line extending from the origin to (1, 0) (hollow) and a point at (1, 1).](step.svg)
 
-    `steps()`: This function accepts a strictly positive {{cssxref("&lt;integer&gt;")}} and a second optional `<step-position>`. The `<integer>` value represents the number of equidistant intervals or 'steps' in the animation. It must be a positive integer greater than `0` unless the second parameter is `jump-none`, in which case, it must be a positive integer greater than `1`. The `<step-position>` keyword value indicates when the animation jumps from one step to the next. The possible keyword values include:
+    `steps()`: This function accepts a strictly positive {{cssxref("&lt;integer&gt;")}} and a second optional `<step-position>`.
 
-    - `jump-start` denotes that the first step or jump happens when the interpolation begins.
-    - `jump-end` denotes that the last step or jump happens when the interpolation ends. This is the default.
-    - `jump-none` denotes that no jump happens at the beginning or the end. Instead, the animation holds steady at both the 0% mark and the 100% mark. The duration of these holds is determined by dividing the total animation duration by the number of steps (1/n).
-    - `jump-both` denotes that jumps occur at both the 0% and 100% marks, effectively adding a step during the interpolation iteration.
-    - `jump-none` denotes no jump on either end, effectively removing a step during the interpolation iteration. Instead, it holds at both the 0% mark and the 100% mark, each for 1/n of the duration.
-    - `start` is the equivalent of `jump-start`.
-    - `end` is the equivalent of `jump-end`.
+    - `<integer>`: Represents the number of equidistant intervals or 'steps' in the animation. It must be a positive integer greater than `0` unless the second parameter is `jump-none`, in which case, it must be a positive integer greater than `1`.
+    - `<step-position>`: Indicates when the animation jumps from one step to the next. The possible keyword values include:
 
-- `step-start`
-
-  - : Indicates that the interpolation jumps immediately to its final state, where it stays until the end. This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`.
-
-- `step-end`
-
-  - : Indicates that the interpolation stays in its initial state until the end, at which point it jumps directly to its final state. This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`.
-
-![Graphs of "Input progress" to "Output progress", of which "step-start" shows a hollow origin and a horizontal line extending from (0, 1) to (1, 1); and "step-end" shows a horizontal line extending from the origin to (1, 0) (hollow) and a point at (1, 1).](step.svg)
+      - `jump-start` denotes that the first step or jump happens when the interpolation begins.
+      - `jump-end` denotes that the last step or jump happens when the interpolation ends. This is the default value when no `<step-position>` is specified.
+      - `jump-none` denotes that no jump happens at the beginning or the end, effectively removing a step during the interpolation iteration. Instead, the animation holds steady at both the 0% mark and the 100% mark. The duration of these holds is determined by dividing the total animation duration by the number of steps (1/n).
+      - `jump-both` denotes that jumps occur at both the 0% and 100% marks, effectively adding a step during the interpolation iteration.
+      - `jump-none` denotes no jump on either end, effectively removing a step during the interpolation iteration. Instead, it holds at both the 0% mark and the 100% mark, each for 1/n of the duration.
+      - `start` is the equivalent of `jump-start`.
+      - `end` is the equivalent of `jump-end`.
 
 ## Description
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -7,7 +7,7 @@ browser-compat: css.types.easing-function
 
 {{CSSRef}}
 
-The **`<easing-function>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) denotes a mathematical function that describes the rate at which a numerical value changes.
+The **`<easing-function>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents a mathematical function that describes the rate at which a numerical value changes.
 
 This transition between two values may be applied in different situations. It may be used to describe how fast values change during animations. This lets you vary the animation's speed over the course of its duration. You can specify an easing function for CSS [transition](/en-US/docs/Web/CSS/transition-timing-function) and [animation](/en-US/docs/Web/CSS/animation-timing-function) properties.
 
@@ -21,7 +21,7 @@ linear
 
 /* cubic-bezier function and keywords */
 /* cubic-bezier(<x1>, <y1>, <x2>, <y2>) */
-cubic-bezier(0.42, 0.0, 1.0, 1.0)
+cubic-bezier(0.42, 0, 1, 1)
 ease
 ease-in
 ease-out
@@ -36,47 +36,54 @@ step-end
 
 ### Values
 
-- `<point-list>`
-
-  - : List of linear stops.
-
 - `linear`
 
-  - : Indicates that the interpolation goes linearly. This keyword represents the easing function `linear(0, 1)`.
+  - : Specifies a constant rate of interpolation, ensuring there is no change in the rate of progress of the animation throughout the duration. This also means that there is no acceleration or deceleration at any point during the animation's duration. It's important to not confuse this keyword value with the [linear() easing function](#linear_easing_function), although they are related: the `linear` keyword produces a `linear()` easing function with two points, `linear(0, 1)`.
+    > **Note:** The `linear` keyword always serializes as `linear`, whereas its function equivalent `linear(0, 1)` serializes to `linear(0 0%, 1 100%)`.
 
 ![Graph of "Input progress" to "Output progress" showing a line extending from the origin to (1, 1).](linear.svg)
 
-- `<x1>`, `<y1>`, `<x2>`, `<y2>`
+- `<linear-easing-function>`
 
-  - : {{cssxref("&lt;number&gt;")}} values representing the abscissas and ordinates of the [P1 and P2 points](#cubic_bézier_functions) defining the cubic Bézier curve. `x1` and `x2` must be in the range `[0, 1]`, otherwise the value is invalid.
+  - : Specifies a `linear()` function using multiple points, called linear stops, allowing you to control the movement of an animation at specific points along the path.
 
-- `ease`
+    The `linear()` function specifies a list of points (`<linear-stop-list>`), separated by commas. Each point or linear stop in the list (`<linear-stop>`) is specified as a {{cssxref("&lt;number&gt;")}} and one or two {{cssxref("&lt;percentage&gt;")}} values (`<linear-stop-length>`).
 
-  - : Indicates that the interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1.0)`. It is similar to [`ease-in-out`](#ease-in-out), though it accelerates more sharply at the beginning.
+    `<number>`: Represents a point in time. The value should be between `0` and `1`.
 
-- `ease-in`
+    `<percentage>`: Represents the progress of the animation at the specified point in time. If two percentage values are specified, they represent a range for that specific point – the first percentage indicates the starting point and the second percentage indicates the ending point of the progress for that segment in the animation. If no `<percentage>` value is specified, the points are spread evenly along the timeline.
 
-  - : Indicates that the interpolation starts slowly, then progressively speeds up until the end, at which point it stops abruptly. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 1.0, 1.0)`.
+- `<cubic-bezier-easing-function>`
 
-- `ease-out`
+  - : Specifies a `cubic-bezier()` function using two control points, which help shape the curve of the animation's progress. This parameter accepts one of the following four keyword values that map to predefined `cubic-bezier()` functions or a custom `cubic-bezier()` function to specify the control points:
 
-  - : Indicates that the interpolation starts abruptly and then progressively slows down towards the end. This keyword represents the easing function `cubic-bezier(0.0, 0.0, 0.58, 1.0)`.
+    `ease`: This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1)`. It indicates that the interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. It is similar to the `ease-in-out` keyword, though it accelerates more sharply at the beginning.
 
-- `ease-in-out`
+    `ease-in`: This keyword represents the easing function `cubic-bezier(0.42, 0, 1, 1)`. It indicates that the interpolation starts slowly, then progressively speeds up until the end, at which point it stops abruptly.
 
-  - : Indicates that the interpolation starts slowly, speeds up, and then slows down towards the end. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 0.58, 1.0)`. At the beginning, it behaves like the [`ease-in`](#ease-in) keyword; at the end, it is like the [`ease-out`](#ease-out) keyword.
+    `ease-out`: This keyword represents the easing function `cubic-bezier(0, 0, 0.58, 1)`. It indicates that the interpolation starts abruptly and then progressively slows down towards the end.
 
-![Graphs of "Input progress" to "Output progress", of which "ease" shows a curved line quickly rising from the origin to (1, 1); "ease-in" shows a shallow curved line from the origin that straightens out as it approaches (1, 1); "ease-out" shows a straight diagonal line that slightly curves as it gets close to (1, 1); and "ease-in-out" shows a symmetrical, "S"-shaped line curving from the origin to (1, 1).](ease.svg)
+    `ease-in-out`: This keyword represents the easing function `cubic-bezier(0.42, 0, 0.58, 1)`. It indicates that the interpolation starts slowly, speeds up, and then slows down towards the end. At the beginning, it behaves like the `ease-in` keyword; at the end, it is like the `ease-out` keyword.
 
-- `<number-of-steps>`
+    ![Graphs of "Input progress" to "Output progress", of which "ease" shows a curved line quickly rising from the origin to (1, 1); "ease-in" shows a shallow curved line from the origin that straightens out as it approaches (1, 1); "ease-out" shows a straight diagonal line that slightly curves as it gets close to (1, 1); and "ease-in-out" shows a symmetrical, "S"-shaped line curving from the origin to (1, 1).](ease.svg)
 
-  - : A strictly positive {{cssxref("&lt;integer&gt;")}}, representing the amount of equidistant treads composing the stepping function.
+    `cubic-bezier()`: This function accepts four {{cssxref("&lt;number&gt;")}} values to specify the abscissas and ordinates of the [P1 and P2 points](#cubic_bézier_easing_function) of the curve (as `<x1>`, `<y1>`, `<x2>`, and `<y2>`). `<x1>` and `<x2>` must be in the range `[0, 1]`, otherwise the value is invalid.
 
-- `<direction>`
+- `<step-easing-function>`
 
-  - : One of the following keywords that indicate when the jumps occur:
+  - : Specifies a `steps()` function that divides the animation into a set number of intervals or "steps", causing the animation to jump from one step to the next rather than transitioning smoothly. This parameter accepts one of the following two keyword values that map to predefined `steps()` functions or a custom `steps()` function:
+
+    `step-start`: This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`. It indicates that the interpolation jumps immediately to its final state, where it stays until the end.
+
+    `step-end`: This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`. It indicates that the interpolation stays in its initial state until the end, at which point it jumps directly to its final state.
+
+    ![Graphs of "Input progress" to "Output progress", of which "step-start" shows a hollow origin and a horizontal line extending from (0, 1) to (1, 1); and "step-end" shows a horizontal line extending from the origin to (1, 0) (hollow) and a point at (1, 1).](step.svg)
+
+    `steps()`: This function accepts a strictly positive {{cssxref("&lt;integer&gt;")}} and a second optional `<step-position>`. The `<integer>` value represents the number of equidistant intervals or 'steps' in the animation. It must be a positive integer greater than `0` unless the second parameter is `jump-none`, in which case, it must be a positive integer greater than `1`. The `<step-position>` keyword value indicates when the animation jumps from one step to the next. The possible keyword values include:
+
     - `jump-start` denotes that the first step or jump happens when the interpolation begins.
     - `jump-end` denotes that the last step or jump happens when the interpolation ends. This is the default.
+    - `jump-none` denotes that no jump happens at the beginning or the end. Instead, the animation holds steady at both the 0% mark and the 100% mark. The duration of these holds is determined by dividing the total animation duration by the number of steps (1/n).
     - `jump-both` denotes that jumps occur at both the 0% and 100% marks, effectively adding a step during the interpolation iteration.
     - `jump-none` denotes no jump on either end, effectively removing a step during the interpolation iteration. Instead, it holds at both the 0% mark and the 100% mark, each for 1/n of the duration.
     - `start` is the equivalent of `jump-start`.
@@ -104,11 +111,11 @@ There are three types of easing functions:
 
 The `linear()` function defines a piecewise linear function that interpolates linearly between its points, allowing you to approximate more complex animations like bounce and elastic effects. The interpolation is done at a constant rate from beginning to end. A typical use of the `linear()` function is to provide many points to approximate any curve.
 
-When you define the `linear()` function, you specify the _linear easing points_ as a list, as in, `linear(0, 0.25, 1)`. This `linear()` function produces an easing function that moves linearly from `0`, to `0.25`, then to `1`.
+When you define the `linear()` function, you specify a list of _linear stops_ like in `linear(0, 0.25, 1)`. In this case, the animation starts at point `0`, goes linearly to point `0.25`, and then continues linearly to the point `1`. Since no `<linear-stop-length>` percentage is specified, the same animation duration (50%) is used to go from `0` to `0.25` and from `0.25` to `1`.
 
 ![Graphs of "Input progress" to "Output progress", of which "linear(0, 0.25, 1)" shows a broken line connecting the origin, (0.5, 0.25), and (1, 1); and "linear(0, 0.25 75%, 1)" shows a broken line connecting the origin, (0.75, 0.25), and (1, 1).](linear_function.svg)
 
-Consider another example of the function: `linear(0, 0.25 75%, 1)`. This produces a linear easing function that spends 75% of the time transitioning from `0` to `0.25` and the last 25% transitioning from `0.25` to `1`.
+Let's look at an example where the progress of the animation is specified: `linear(0, 0.25 75%, 1)`. In this case, the animation progresses to `75%` of its total change in the first 25% of the duration (that is, to go from the timeline point `0` to `0.25`). The last 25% of the animation's total change is used during the remaining 75% of the duration (that is, to progress from the timeline point `0.25` to `1`). Consider another example of the `linear()` function: `linear(0.5 25% 75%, 1)`. Here, the animation reaches `25%` of its total change at the halfway point (`0.5`), and then instantly jumps to `75%` of its total change. Over the remaining 50% of the duration (`0.5` to `1`), it progresses from `75%` of its total change to 100%.
 
 The [`linear`](#linear) keyword is equivalent to the easing function `linear(0, 1)`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- This PR updates the descriptions in the "Values" section for consistency in style and format and to better reflect the syntax of `<easing-funcion>`.

    `<easing-function> = linear | <linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>`

- Additionally, values called `<point-list>`, `<number-of-steps>`, and `<direction>` have been removed because they were not referenced in the the [Formal syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function#formal_syntax) section or the [spec](https://drafts.csswg.org/css-easing/#easing-functions).

- Added another example in the "Linear easing function" section under "Description".

### Motivation

To align the "Values" section to match the parameter names and the order in which they appear in the [Formal syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function#formal_syntax) section (Formal syntax on this page is up-to-date with the [spec](https://drafts.csswg.org/css-easing/#easing-functions)).

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/20138
