### PR TITLE
fix: code result error for set and update syntax for some set/map page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/@@iterator/index.md
@@ -16,7 +16,7 @@ The initial value of this property is the same function object as the initial va
 ## Syntax
 
 ```js-nolint
-map[Symbol.iterator]()
+mapInstance.map[Symbol.iterator]()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/clear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/clear/index.md
@@ -14,7 +14,7 @@ The **`clear()`** method of {{jsxref("Map")}} instances removes all elements fro
 ## Syntax
 
 ```js-nolint
-clear()
+mapInstance.clear()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/entries/index.md
@@ -14,7 +14,7 @@ The **`entries()`** method of {{jsxref("Map")}} instances returns a new _[map it
 ## Syntax
 
 ```js-nolint
-entries()
+mapInstance.entries()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
@@ -15,8 +15,8 @@ pair in this map, in insertion order.
 ## Syntax
 
 ```js-nolint
-forEach(callbackFn)
-forEach(callbackFn, thisArg)
+mapInstance.forEach(callbackFn)
+mapInstance.forEach(callbackFn, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/get/index.md
@@ -17,7 +17,7 @@ modify it inside the `Map` object.
 ## Syntax
 
 ```js-nolint
-get(key)
+mapInstance.get(key)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/has/index.md
@@ -15,7 +15,7 @@ specified key exists in this map or not.
 ## Syntax
 
 ```js-nolint
-has(key)
+mapInstance.has(key)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/keys/index.md
@@ -14,7 +14,7 @@ The **`keys()`** method of {{jsxref("Map")}} instances returns a new _[map itera
 ## Syntax
 
 ```js-nolint
-keys()
+mapInstance.keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/set/index.md
@@ -14,7 +14,7 @@ The **`set()`** method of {{jsxref("Map")}} instances adds or updates an entry i
 ## Syntax
 
 ```js-nolint
-set(key, value)
+mapInstance.set(key, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/map/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/values/index.md
@@ -14,7 +14,7 @@ The **`values()`** method of {{jsxref("Map")}} instances returns a new _[map ite
 ## Syntax
 
 ```js-nolint
-values()
+mapInstance.values()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/@@iterator/index.md
@@ -16,7 +16,7 @@ The initial value of this property is the same function object as the initial va
 ## Syntax
 
 ```js-nolint
-set[Symbol.iterator]()
+setInstance[Symbol.iterator]()
 ```
 
 ### Parameters
@@ -58,7 +58,7 @@ const setIter = mySet[Symbol.iterator]();
 
 console.log(setIter.next().value); // "0"
 console.log(setIter.next().value); // 1
-console.log(setIter.next().value); // Object
+console.log(setIter.next().value); // {}
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/set/add/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/add/index.md
@@ -14,7 +14,7 @@ The **`add()`** method of {{jsxref("Set")}} instances inserts a new element with
 ## Syntax
 
 ```js-nolint
-add(value)
+setInstance.add(value)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/set/clear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/clear/index.md
@@ -14,7 +14,7 @@ The **`clear()`** method of {{jsxref("Set")}} instances removes all elements fro
 ## Syntax
 
 ```js-nolint
-clear()
+setInstance.clear()
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ console.log(mySet.has("foo")); // true
 mySet.clear();
 
 console.log(mySet.size); // 0
-console.log(mySet.has("bar")); // false
+console.log(mySet.has("foo")); // false
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/set/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/entries/index.md
@@ -14,7 +14,7 @@ The **`entries()`** method of {{jsxref("Set")}} instances returns a new _[set it
 ## Syntax
 
 ```js-nolint
-entries()
+setInstance.entries()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
@@ -15,8 +15,8 @@ for each value in this set, in insertion order.
 ## Syntax
 
 ```js-nolint
-forEach(callbackFn)
-forEach(callbackFn, thisArg)
+setInstance.forEach(callbackFn)
+setInstance.forEach(callbackFn, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/set/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/has/index.md
@@ -15,7 +15,7 @@ element with the specified value exists in this set or not.
 ## Syntax
 
 ```js-nolint
-has(value)
+setInstance.has(value)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/set/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/keys/index.md
@@ -13,7 +13,7 @@ The **`keys()`** method of {{jsxref("Set")}} instances is an alias for the [`val
 ## Syntax
 
 ```js-nolint
-keys()
+setInstance.keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/set/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/values/index.md
@@ -14,7 +14,7 @@ The **`values()`** method of {{jsxref("Set")}} instances returns a new _[set ite
 ## Syntax
 
 ```js-nolint
-values()
+setInstance.values()
 ```
 
 ### Parameters


### PR DESCRIPTION
### Description

1. Fix code result error in set.`@@iterator` and improve another code example in set.`clear`, according to preview comments in https://github.com/mdn/translated-content/pull/16466#discussion_r1352353192 and https://github.com/mdn/translated-content/pull/16479#discussion_r1352344963.
2. Update the syntax part of the pages of set&map 's instance methods, to unify @Josh-Cena's recent changes which clear these methods are instances' methods.

### Motivation

Ditto.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
