### PR TITLE
Follow-up to PR 29267

### DIFF
--- a/files/en-us/web/api/document/adoptedstylesheets/index.md
+++ b/files/en-us/web/api/document/adoptedstylesheets/index.md
@@ -22,10 +22,11 @@ Only stylesheets created using the [`CSSStyleSheet()` constructor](/en-US/docs/W
 
 ## Value
 
-The value is an array of {{domxref("CSSStyleSheet()")}} instances that must have been created using the {{domxref("CSSStyleSheet.CSSStyleSheet()", "CSSStyleSheet()")}} constructor within the context of the same {{domxref("Document")}}.
+The value is an array of {{domxref("CSSStyleSheet")}} instances that must have been created using the {{domxref("CSSStyleSheet.CSSStyleSheet()", "CSSStyleSheet()")}} constructor within the context of the same {{domxref("Document")}}.
 
-If the array needs to be modified, then a new array must be assigned (in-place mutations like `push()` will throw an exception).
-Note however that the {{domxref("CSSStyleSheet()")}} instances themselves can be modified, and these changes will apply wherever the stylesheet is adopted.
+If the array needs to be modified, use in-place mutations like `push()`. The {{domxref("CSSStyleSheet")}} instances themselves can also be modified, and these changes will apply wherever the stylesheet is adopted.
+
+In an earlier version of the specification, the array was not modifiable, so the only way to add new stylesheets was to assign a new array to `adoptedStyleSheets`.
 
 ### Exceptions
 

--- a/files/en-us/web/api/shadowroot/adoptedstylesheets/index.md
+++ b/files/en-us/web/api/shadowroot/adoptedstylesheets/index.md
@@ -22,10 +22,11 @@ Only stylesheets created using the [`CSSStyleSheet()` constructor](/en-US/docs/W
 
 ## Value
 
-The value is an array of {{domxref("CSSStyleSheet()")}} instances that must have been created using the {{domxref("CSSStyleSheet.CSSStyleSheet()", "CSSStyleSheet()")}} constructor within the context of the shadow root's parent {{domxref("Document")}}.
+The value is an array of {{domxref("CSSStyleSheet")}} instances that must have been created using the {{domxref("CSSStyleSheet.CSSStyleSheet()", "CSSStyleSheet()")}} constructor within the context of the shadow root's parent {{domxref("Document")}}.
 
-If the array needs to be modified, use in-place mutations like `push()`.
-Note, the {{domxref("CSSStyleSheet()")}} instances themselves can also be modified, and these changes will apply wherever the stylesheet is adopted.
+If the array needs to be modified, use in-place mutations like `push()`. The {{domxref("CSSStyleSheet")}} instances themselves can also be modified, and these changes will apply wherever the stylesheet is adopted.
+
+In an earlier version of the specification, the array was not modifiable, so the only way to add new stylesheets was to assign a new array to `adoptedStyleSheets`.
 
 ## Examples
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/content/pull/29267.

- document the new behavior in `Document` as well as `ShadowRoot`
- document the old behavior too