### PR TITLE
Update DNR manifest version req

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/declarative_net_request/index.md
@@ -19,7 +19,7 @@ browser-compat: webextensions.manifest.declarative_net_request
     </tr>
     <tr>
       <th scope="row">Manifest version</th>
-      <td>2</td>
+      <td>2 or higher</td>
     </tr>
     <tr>
       <th scope="row">Example</th>


### PR DESCRIPTION
### Description

Update the manifest version requirements for the declarative_net_request manifest key to reflect that it is available in manifest version 2 and higher.

### Motivation

The currently published version requiremnt is inaccurate.

### Additional details

N/A

### Related issues and pull requests

Fixes #29604