### PR TITLE
Small update to `window storage event`

### DIFF
--- a/files/en-us/web/api/window/storage_event/index.md
+++ b/files/en-us/web/api/window/storage_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Window.storage_event
 
 {{APIRef}}
 
-The **`storage`** event of the {{domxref("Window")}} interface fires when a storage area (`localStorage`) has been modified in the context of another document.
+The **`storage`** event of the {{domxref("Window")}} interface fires when a storage area (`localStorage` or `sessionStorage`) has been modified in the context of another document.
 
 > **Note:** This won't work on the same page that is making the changes — it is really a way for other pages on the domain using the storage to sync any changes that are made. Pages on other domains can't access the same storage objects.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

window.storage may fired when `localStorage` or `sessionStorage` modified in the context of another document

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

add `sessionStorage` also

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event

https://developer.mozilla.org/en-US/docs/Web/API/Window#events

https://html.spec.whatwg.org/multipage/indices.html#event-storage

![image](https://github.com/mdn/content/assets/95597335/54ebb246-f5e1-40ce-8974-6a8c1208073c)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
