### PR TITLE
Clarify need for theme permission

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -22,7 +22,7 @@ let getting = browser.theme.getCurrent(
 ### Parameters
 
 - `windowId` {{optional_inline}}
-  - : `integer`. The ID of a window. If this is provided, the theme applied on that window is provided. If it is omitted, the theme applied on the last focused window is provided.
+  - : `integer`. The ID of a window. If this is provided, the theme resolved is the one applied to that window. If it is omitted, the theme resolved is the one applied to the most recently focused window.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.theme.getCurrent
 
 {{AddonSidebar()}}
 
-Gets the currently used theme as a {{WebExtAPIRef("theme.Theme", "Theme")}} object. The arguments available in the color object are listed in the [properties of the color](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#colors).
+Gets the current theme as a {{WebExtAPIRef("theme.Theme", "Theme")}} object.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
@@ -22,19 +22,15 @@ let getting = browser.theme.getCurrent(
 ### Parameters
 
 - `windowId` {{optional_inline}}
-  - : `integer`. The ID of a window. If this is provided, the theme applied on that window will be provided. If it is omitted the theme applied on the last focused window will be provided.
+  - : `integer`. The ID of a window. If this is provided, the theme applied on that window is provided. If it is omitted, the theme applied on the last focused window is provided.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). The promise will be fulfilled with a {{WebExtAPIRef("theme.Theme")}} object representing the theme applied to the given window. If no extension-supplied theme has been applied to the given window, it will be fulfilled with an empty object.
-
-## Browser compatibility
-
-{{Compat}}
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). The promise is fulfilled with a {{WebExtAPIRef("theme.Theme")}} object representing the theme applied to the given window. If no extension-supplied theme has been applied to the given window, it is fulfilled with an empty object.
 
 ## Examples
 
-Gets the properties `frame` and `toolbar` colors of the current theme
+Gets the properties `frame` and `toolbar` colors of the current theme:
 
 ```js
 function getStyle(themeInfo) {
@@ -53,3 +49,7 @@ getCurrentThemeInfo();
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/index.md
@@ -9,6 +9,8 @@ browser-compat: webextensions.api.theme
 
 Enables browser extensions to get details of the browser's theme and update the theme.
 
+You can use this API to include a theme in your extension, which you define as a {{WebExtAPIRef("theme.Theme")}} and apply using {{WebExtAPIRef("theme.update()")}}. You cannot include a static theme in your extension, defined with the ["theme"](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) manifest key. The "theme" manifest key is used to define static themes only. See [Themes](https://extensionworkshop.com/documentation/themes/) on Extension Workshop for more information.
+
 ## Types
 
 - {{WebExtAPIRef("theme.Theme")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/index.md
@@ -7,11 +7,7 @@ browser-compat: webextensions.api.theme
 
 {{AddonSidebar}}
 
-Enables browser extensions to update the browser theme.
-
-To use this API, an extension must request the "theme" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in its [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
-
-> **Note:** When we set up a theme in a background file, we must declare the 'theme' [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and therefore we cannot use the [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) function of the manifest, since it's not compatible.
+Enables browser extensions to get details of the browser's theme and update the theme.
 
 ## Types
 
@@ -30,10 +26,10 @@ To use this API, an extension must request the "theme" [permission](/en-US/docs/
 ## Events
 
 - {{WebExtAPIRef("theme.onUpdated")}}
-  - : Fired when the browser theme has been changed.
+  - : Fired when the browser theme changes.
+
+{{WebExtExamples("h2")}}
 
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
@@ -13,7 +13,7 @@ Fires when a theme supplied as a browser extension is applied or removed. Specif
 - when a [dynamic theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme) calls [`theme.update()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/update) or [`theme.reset()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/theme/reset)
 - when a theme gets uninstalled.
 
-Note that this event is not fired for changes to the built-in themes.
+This event is not fired for changes to the built-in themes.
 
 ## Syntax
 
@@ -45,13 +45,9 @@ Events have three functions:
       - : `object`. An object containing two properties:
 
         - `theme`
-          - : `object`. If the event fired because an extension-supplied theme was removed, this will be an empty object. If it fired because an extension-supplied theme was applied, then it will be a {{WebExtAPIRef("theme.Theme")}} object representing the theme that was applied.
+          - : `object`. If the event fired because an extension-supplied theme was removed, this is an empty object. If it fired because an extension-supplied theme was applied, then it is a {{WebExtAPIRef("theme.Theme")}} object representing the theme that was applied.
         - `windowId` {{optional_inline}}
-          - : `integer`. The ID of the window for which theme has been updated. If this property is not present, it means that the theme was updated globally.
-
-## Browser compatibility
-
-{{Compat}}
+          - : `integer`. The ID of the window in which the theme was updated. If this property is not present, the theme was updated in all windows.
 
 ## Examples
 
@@ -68,3 +64,7 @@ browser.theme.onUpdated.addListener(handleUpdated);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.md
@@ -11,8 +11,6 @@ Resets any theme applied using the {{WebExtAPIRef("theme.update()")}} method.
 
 To use this method, an extension must request the "theme" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in its [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
 
-> **Note:** An extension using the "theme" permission cannot use the manifest [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) key to define a theme.
-
 Note that this always reset the theme back to the original default theme, even if the user selected a different theme before this extension's theme was applied (see [bug 1415267](https://bugzil.la/1415267)).
 
 ## Syntax

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/reset/index.md
@@ -7,9 +7,13 @@ browser-compat: webextensions.api.theme.reset
 
 {{AddonSidebar()}}
 
-Resets any theme that was applied using the {{WebExtAPIRef("theme.update()")}} method.
+Resets any theme applied using the {{WebExtAPIRef("theme.update()")}} method.
 
-Note that this will always reset the theme back to the original default theme, even if the user had selected a different theme before this extension's theme was applied (see [bug 1415267](https://bugzil.la/1415267)).
+To use this method, an extension must request the "theme" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in its [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
+
+> **Note:** An extension using the "theme" permission cannot use the manifest [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) key to define a theme.
+
+Note that this always reset the theme back to the original default theme, even if the user selected a different theme before this extension's theme was applied (see [bug 1415267](https://bugzil.la/1415267)).
 
 ## Syntax
 
@@ -22,11 +26,7 @@ browser.theme.reset(
 ### Parameters
 
 - `windowId` {{optional_inline}}
-  - : `integer`. The ID of a window. If this is provided, the theme applied to that window will be reset. If it is omitted the theme will be reset on all windows.
-
-## Browser compatibility
-
-{{Compat}}
+  - : `integer`. The ID of a window. If this is provided, the theme applied to that window is reset. If it is omitted, the theme is reset on all windows.
 
 ## Examples
 
@@ -41,6 +41,10 @@ browser.browserAction.onClicked.addListener(() => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/theme/index.md
@@ -13,8 +13,8 @@ A Theme object represents the specification of a theme.
 
 A JSON [object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) that takes the same properties as the ["theme"](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) manifest key.
 
+{{WebExtExamples}}
+
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -7,7 +7,11 @@ browser-compat: webextensions.api.theme.update
 
 {{AddonSidebar()}}
 
-Updates the browser theme according to the content of given {{WebExtAPIRef("theme.Theme", "Theme")}} object.
+Updates the browser theme according to the content of the {{WebExtAPIRef("theme.Theme", "Theme")}} object.
+
+To use this method, an extension must request the "theme" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in its [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
+
+> **Note:** An extension using the "theme" permission cannot use the manifest [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) key to define a theme.
 
 ## Syntax
 
@@ -21,17 +25,13 @@ browser.theme.update(
 ### Parameters
 
 - `windowId` {{optional_inline}}
-  - : `integer`. The ID of a window. If this is provided, the theme is applied only to that window. If it is omitted the theme is applied to all windows.
+  - : `integer`. The ID of a window. If this is provided, the theme is applied only to that window. If it is omitted, the theme is applied to all windows.
 - `theme`
   - : `object`. A {{WebExtAPIRef("theme.Theme", "Theme")}} object specifying values for the UI elements you want to modify.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
-Sets the browser theme to use a sun graphic with complementary background color:
+Sets the browser theme to use a sun graphic with a complementary background color:
 
 ```js
 const suntheme = {
@@ -47,7 +47,7 @@ const suntheme = {
 browser.theme.update(suntheme);
 ```
 
-Set the theme for just the currently focused window:
+Set the theme for the focused window only:
 
 ```js
 const day = {
@@ -75,3 +75,7 @@ browser.menus.onClicked.addListener(updateThemeForCurrentWindow);
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/update/index.md
@@ -11,8 +11,6 @@ Updates the browser theme according to the content of the {{WebExtAPIRef("theme.
 
 To use this method, an extension must request the "theme" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in its [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
 
-> **Note:** An extension using the "theme" permission cannot use the manifest [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) key to define a theme.
-
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
### Description

Clarifies that the theme permission is only required for the update and reset methods. In addition to the confirmation mentioned in the issue, I also confirm this by removing the permission from the manifest of the [theme-integrated-sidebar](https://github.com/mdn/webextensions-examples/tree/main/theme-integrated-sidebar), which uses theme.getCurrent and theme.onUpdated, and confirmed it continued to behave as expected.

Also, tidied up a number of style and grammar issues.

### Related issues and pull requests

Fixes #10665
