### PR TITLE
Add reference to pointer-events property

### DIFF
--- a/files/en-us/web/css/opacity/index.md
+++ b/files/en-us/web/css/opacity/index.md
@@ -43,6 +43,8 @@ opacity: unset;
 
 Using `opacity` with a value other than `1` places the element in a new [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context).
 
+When `opacity` value is set to `0`, the element and all of its children are not visible; however, they still register [pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). This behavior can be controlled by [pointer-events](/en-US/docs/Web/CSS/pointer-events) property.
+
 To change the opacity of a background only, use the {{cssxref("background")}} property with a {{cssxref("color_value", "color value")}} that allows for an alpha channel. For example:
 
 ```css

--- a/files/en-us/web/css/opacity/index.md
+++ b/files/en-us/web/css/opacity/index.md
@@ -43,7 +43,7 @@ opacity: unset;
 
 Using `opacity` with a value other than `1` places the element in a new [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context).
 
-When `opacity` value is set to `0`, the element and all of its children are not visible; however, they still register [pointer events](/en-US/docs/Web/API/Pointer_events). This behavior can be controlled by [pointer-events](/en-US/docs/Web/CSS/pointer-events) property.
+When `opacity` value is set to `0`, the element and all of its children are not visible; however, they still register [pointer events](/en-US/docs/Web/API/Pointer_events). This can be controlled with the CSS [`pointer-events`](/en-US/docs/Web/CSS/pointer-events) property.
 
 To change the opacity of a background only, use the {{cssxref("background")}} property with a {{cssxref("color_value", "color value")}} that allows for an alpha channel. For example:
 

--- a/files/en-us/web/css/opacity/index.md
+++ b/files/en-us/web/css/opacity/index.md
@@ -43,7 +43,7 @@ opacity: unset;
 
 Using `opacity` with a value other than `1` places the element in a new [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context).
 
-When `opacity` value is set to `0`, the element and all of its children are not visible; however, they still register [pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). This behavior can be controlled by [pointer-events](/en-US/docs/Web/CSS/pointer-events) property.
+When `opacity` value is set to `0`, the element and all of its children are not visible; however, they still register [pointer events](/en-US/docs/Web/API/Pointer_events). This behavior can be controlled by [pointer-events](/en-US/docs/Web/CSS/pointer-events) property.
 
 To change the opacity of a background only, use the {{cssxref("background")}} property with a {{cssxref("color_value", "color value")}} that allows for an alpha channel. For example:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

A reference to pointer-events property added

### Motivation

I had already run into this issue with pointer events at `opacity: 0`, at that time I did not know about `pointer-events` and had to switch to using `display: none` to avoid buggy keyboard interactions. After that I learned about `pointer-events`. But I had almost forgotten about it and today run into the same issue when reviewing someone else's code. Hopefully having this right here on MDN will help raise awareness and prevent bugs. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
