### PR TITLE
Edit Iterator.find comparing it to Array.find instead of Array.every

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/iterator/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/find/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Iterator.find
 
 {{JSRef}}{{SeeCompatTable}}
 
-The **`find()`** method of {{jsxref("Iterator")}} instances is similar to {{jsxref("Array.prototype.every()")}}: it returns the first element produced by the iterator that satisfies the provided testing function. If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
+The **`find()`** method of {{jsxref("Iterator")}} instances is similar to {{jsxref("Array.prototype.find()")}}: it returns the first element produced by the iterator that satisfies the provided testing function. If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 ## Syntax
 


### PR DESCRIPTION
The description of Iterator.find includes 
```
The find() method of Iterator instances is similar to Array.prototype.every(): 
```

This two methods are not similar. I have changed it so it likens Iterator.find to Array.find

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
