### PR TITLE
Fix link to HLS.js

### DIFF
--- a/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -90,7 +90,7 @@ DASH stands for Dynamic Adaptive Streaming over HTTP. It is supported via Media 
 
 HLS or HTTP Live Streaming is a protocol invented by Apple Inc and supported on iOS, Safari and the latest versions of Android browser / Chrome. HLS is also adaptive.
 
-HLS can also be decoded using JavaScript, which means we can support the latest versions of Firefox, Chrome and Safari. See this [HTTP Live Streaming JavaScript player](https://github.com/dailymotion/hls.js).
+HLS can also be decoded using JavaScript, which means we can support the latest versions of Firefox, Chrome and Safari. See this [HTTP Live Streaming JavaScript player](https://github.com/video-dev/hls.js).
 
 At the start of the streaming session, an [extended M3U (m3u8) playlist](https://en.wikipedia.org/wiki/M3U8#Extended_M3U_directives) is downloaded. This contains the metadata for the various sub-streams that are provided.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The link for HLS.js pointed to the former parent repository but the project has since been moved to *video-dev* 