### PR TITLE
Added await to get processor node

### DIFF
--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -207,7 +207,7 @@ In order to ensure the context is usable, this starts by creating the context if
 You can then create a new audio processor node by doing this:
 
 ```js
-let newProcessorNode = createMyAudioProcessor();
+let newProcessorNode = await createMyAudioProcessor();
 ```
 
 If the returned value, `newProcessorNode`, is non-`null`, we have a valid audio context with its hiss processor node in place and ready to use.


### PR DESCRIPTION
### Description
Added an await so that newProcessorNode will get the intended value.

### Motivation
If the await is not there, then newProcessorNode is a Promise and checking for null (as suggested in the below comments) will not detect if something went wrong.
