### PR TITLE
Add new chrome properties to runtime.MessageSender

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -23,8 +23,6 @@ Values of this type are objects. They contain the following properties:
   - : `integer`. The frame that opened the connection. Zero for top-level frames, positive for child frames. This is only set when `tab` is set.
 - `id` {{optional_inline}}
   - : `string`. The ID of the extension that sent the message, if the message was sent by an extension. If the sender has an ID explicitly set using the [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `id` has this value. Otherwise, it has the ID that was generated for the sender.
-- `nativeApplication` {{optional_inline}}
-  - : `string`. The name of the native application that opened the connection, if any.
 - `origin` {{optional_inline}}
   - : `string`. The origin of the page or frame that opened the connection. It can differ from the `url` property (e.g., about:blank) or be opaque (e.g., sandboxed iframes). This is useful for identifying if the origin can be trusted if it isn't apparent from the URL.
 - `tab` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.runtime.MessageSender
 
 {{AddonSidebar()}}
 
-An object containing information about the sender of a message or connection request; this is passed to the {{WebExtAPIRef("runtime.onMessage()")}} listener.
+An object containing information about the sender of a message or connection request that is passed to the {{WebExtAPIRef("runtime.onMessage()")}} listener.
 
 It is also a property of {{WebExtAPIRef("runtime.Port")}}, but only in the `Port` instance passed into the {{WebExtAPIRef("runtime.onConnect()")}} or {{WebExtAPIRef("runtime.onConnectExternal()")}} listeners.
 
@@ -15,30 +15,35 @@ It is also a property of {{WebExtAPIRef("runtime.Port")}}, but only in the `Port
 
 Values of this type are objects. They contain the following properties:
 
-- `tab` {{optional_inline}}
-  - : {{WebExtAPIRef('tabs.Tab')}}. The {{WebExtAPIRef('tabs.Tab')}} which opened the connection. This property will only be present when the connection was opened from a tab (including content scripts).
+- `documentId` {{optional_inline}}
+  - : `string`. A UUID of the document that opened the connection.
+- `documentLifecycle` {{optional_inline}}
+  - : `string`. The lifecycle state the document that opened the connection was in when the port was created. Note that the lifecycle state of the document may have changed since the port was created.
 - `frameId` {{optional_inline}}
-  - : `integer`. The frame that opened the connection. Zero for top-level frames, positive for child frames. This will only be set when `tab` is set.
+  - : `integer`. The frame that opened the connection. Zero for top-level frames, positive for child frames. This is only set when `tab` is set.
 - `id` {{optional_inline}}
-
-  - : `string`. The ID of the extension that sent the message, if the message was sent by an extension. If the sender set an ID explicitly using the [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `id` will have this value. Otherwise it will have the ID that was generated for the sender.
-
+  - : `string`. The ID of the extension that sent the message, if the message was sent by an extension. If the sender has an ID explicitly set using the [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `id` has this value. Otherwise, it has the ID that was generated for the sender.
+- `nativeApplication` {{optional_inline}}
+  - : `string`. The name of the native application that opened the connection, if any.
+- `origin` {{optional_inline}}
+  - : `string`. The origin of the page or frame that opened the connection. It can differ from the `url` property (e.g., about:blank) or be opaque (e.g., sandboxed iframes). This is useful for identifying if the origin can be trusted if it isn't apparent from the URL.
+- `tab` {{optional_inline}}
+  - : {{WebExtAPIRef('tabs.Tab')}}. The {{WebExtAPIRef('tabs.Tab')}} which opened the connection. This property is only present when the connection was opened from a tab (including content scripts).
+- `tlsChannelId` {{optional_inline}}
+  - : `string`. The TLS channel ID of the page or frame that opened the connection, if requested by the extension and available.
 - `url` {{optional_inline}}
 
   - : `string`. The URL of the page or frame hosting the script that sent the message.
 
-    If the sender is a script running in an extension page (such as a [background page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts), an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#options_pages), or a [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#browser_actions_2) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#page_actions) popup), the URL will be in the form `"moz-extension://<extension-internal-id>/path/to/page.html"`. If the sender is a background script and you haven't included a background page, it will be `"moz-extension://<extension-internal-id>/_generated_background_page.html"`.
+    If the sender is a script running in an extension page (such as a [background page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts), an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#options_pages), or a [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#browser_actions_2) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#page_actions) popup), the URL is in the form `"moz-extension://<extension-internal-id>/path/to/page.html"`. If the sender is a background script and you haven't included a background page, it is `"moz-extension://<extension-internal-id>/_generated_background_page.html"`.
 
-    \>If the sender is a script running in a web page (including content scripts as well as normal page scripts), then `url` will be the web page URL. If the script is running in an iframe, `url` will be the iframe's URL.
+    If the sender is a script running in a web page (including content and normal page scripts), then `url` is the web page URL. If the script is running in an iframe, `url` is the iframe's URL.
 
-- `tlsChannelId` {{optional_inline}}
-  - : `string`. The TLS channel ID of the page or frame that opened the connection, if requested by the extension, and if available.
+{{WebExtExamples}}
 
 ## Browser compatibility
 
 {{Compat}}
-
-{{WebExtExamples}}
 
 > **Note:** This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-MessageSender) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 


### PR DESCRIPTION
### Description

Fixes #12041 by adding documentation for `origin` and `nativeApplication` properties and also capturing the more recently added `documentId` and `documentLifecycle`.

Complementary BCD update in https://github.com/mdn/browser-compat-data/pull/20970.