### PR TITLE
Fix typo in example for returnPathDirectories

### DIFF
--- a/files/en-us/web/api/file_system_api/index.md
+++ b/files/en-us/web/api/file_system_api/index.md
@@ -116,7 +116,7 @@ async function returnPathDirectories(directoryHandle) {
     return;
   }
 
-  // Check if handle exists inside directory our directory handle
+  // Check if handle exists inside our directory handle
   const relativePaths = await directoryHandle.resolve(handle);
 
   if (relativePaths === null) {

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -69,7 +69,7 @@ async function returnPathDirectories(directoryHandle) {
     return;
   }
 
-  // Check if handle exists inside directory our directory handle
+  // Check if handle exists inside our directory handle
   const relativePaths = await directoryHandle.resolve(handle);
 
   if (relativePath === null) {


### PR DESCRIPTION
### Description

Typo fix. 
