### PR TITLE
Fix invalid CSS value for grid-template-row of repeat(1fr)

### DIFF
--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -752,7 +752,7 @@ body {
 .container {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: repeat(1fr);
+  grid-template-rows: repeat(1, 1fr);
   gap: 10px;
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updated value for CSS property `grid-template-row`.

### Motivation

CSS value for `grid-template-row` is invalid. Making it pointless and confusing to readers.

### Additional details


### Related issues and pull requests

