### PR TITLE
Update nesting_selector example

### DIFF
--- a/files/en-us/web/css/nesting_selector/index.md
+++ b/files/en-us/web/css/nesting_selector/index.md
@@ -183,7 +183,7 @@ This example uses nested CSS styling.
 .example {
   font-family: system-ui;
   font-size: 1.2rem;
-  & a {
+  & > a {
     color: tomato;
     &:hover,
     &:focus {


### PR DESCRIPTION
Added missing child combinator to the last example, since the point is to show equivalent rules with and without nesting.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Added missing child combinator to the last example.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
The point of the last two examples is to show equivalent rules with and without nesting. Without this change readers may be mislead into thinking that the nesting selector implies a child combinator.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
