### PR TITLE
Fix exception section of `Element.releasePointerCapture()`

### DIFF
--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -34,9 +34,8 @@ None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
-| Exception          | Explanation                                          |
-| ------------------ | ---------------------------------------------------- |
-| `InvalidPointerId` | pointerId does not match any of the active pointers. |
+- `NotFoundError` {{domxref("DOMException")}}
+  - : Thrown if `pointerId` does not match any active pointer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -99,5 +99,6 @@ slider.onpointerup = stopSliding;
 
 ## See also
 
+- {{ domxref("Element.hasPointerCapture","Element.hasPointerCapture()") }}
 - {{ domxref("Element.setPointerCapture","Element.setPointerCapture()") }}
 - {{ domxref("Pointer_events","Pointer Events") }}

--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -109,5 +109,6 @@ slider.onpointerup = stopSliding;
 
 ## See also
 
-- {{domxref("Element.releasePointerCapture")}}
+- {{domxref("Element.hasPointerCapture","Element.hasPointerCapture()")}}
+- {{domxref("Element.releasePointerCapture","Element.releasePointerCapture()")}}
 - {{domxref("Pointer_events","Pointer Events")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix exception section of `Element.releasePointerCapture()`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The exception section of `Element.releasePointerCapture()` is not correct enough, it in fact should throw a `NotFoundError`, the the content does not mention this exception, see the exception section of https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture

Also, add a reference to `Element.hasPointerCapture()`

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

See https://w3c.github.io/pointerevents/#extensions-to-the-element-interface

![image](https://github.com/mdn/content/assets/95597335/f0dab294-2ccc-4251-9838-5e720f923356)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
