### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.md
@@ -27,7 +27,7 @@ To place an item into the center of another box horizontally and vertically.
 
 ## Using flexbox
 
-To center a box within another box, first turn the containing box into a [flex container](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox#the_flex_container) by settings its {{cssxref("display")}} property to `flex`. Then set {{cssxref("align-items")}} to `center` for vertical centering (on the block axis) and {{cssxref("justify-content")}} to `center` for horizontal centering (on the inline axis). And that's all it takes to center one box inside another!
+To center a box within another box, first turn the containing box into a [flex container](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox#the_flex_container) by setting its {{cssxref("display")}} property to `flex`. Then set {{cssxref("align-items")}} to `center` for vertical centering (on the block axis) and {{cssxref("justify-content")}} to `center` for horizontal centering (on the inline axis). And that's all it takes to center one box inside another!
 
 ### HTML
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed an extraneous "s" in the sentence "To center a box within another box, first turn the containing box into a flex container by setting**s** its display property to flex.

### Motivation

Just saw the issue and wanted to fix it.

### Additional details

From [this section](https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Center_an_element#using_flexbox), first sentence in the Using Flexbox section.

### Related issues and pull requests

None
