### PR TITLE
Update web/css/align-items values explanations

### DIFF
--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -74,7 +74,7 @@ align-items: unset;
 - `baseline`, `first baseline`, `last baseline`
   - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
 - `stretch`
-  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the width and height limits.
+  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
 - `safe`
   - : Used alongside an alignment keyword. If the chosen keyword means that the item overflows the alignment container causing data loss, the item is instead aligned as if the alignment mode were `start`.
 - `unsafe`

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -22,13 +22,13 @@ align-items: stretch;
 
 /* Positional alignment */
 /* align-items does not take left and right values */
-align-items: center; /* Pack items around the center */
-align-items: start; /* Pack items from the start */
-align-items: end; /* Pack items from the end */
-align-items: flex-start; /* Pack flex items from the start */
-align-items: flex-end; /* Pack flex items from the end */
-align-items: self-start; /* Pack flex items from the start */
-align-items: self-end; /* Pack flex items from the end */
+align-items: center;
+align-items: start;
+align-items: end;
+align-items: flex-start;
+align-items: flex-end;
+align-items: self-start;
+align-items: self-end;
 
 /* Baseline alignment */
 align-items: baseline;

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -58,9 +58,9 @@ align-items: unset;
     - The property doesn't apply to block-level boxes, and to table cells.
 
 - `flex-start`
-  - : The cross-start margin edges of the flex items are flushed with the cross-start edge of the line.
+  - : Only used in flex layout. Aligns the flex items to be flush with the edge of the alignment container corresponding to the flex container's main-start or cross-start side, as appropriate.
 - `flex-end`
-  - : The cross-end margin edges of the flex items are flushed with the cross-end edge of the line.
+  - : Only used in flex layout. Aligns the flex items to be flush with the edge of the alignment container corresponding to the flex container's main-end or cross-end side, as appropriate.
 - `center`
   - : The flex items' margin boxes are centered within the line on the cross-axis. If the cross-size of an item is larger than the flex container, it will overflow equally in both directions.
 - `start`
@@ -74,7 +74,7 @@ align-items: unset;
 - `baseline`, `first baseline`, `last baseline`
   - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
 - `stretch`
-  - : Flex items are stretched such that the cross-size of the item's margin box is the same as the line while respecting width and height constraints.
+  - : If the combined size of the items is less than the size of the alignment container, any auto-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by `max-height`/`max-width` (or equivalent functionality), so that the combined size exactly fills the alignment container.
 - `safe`
   - : Used alongside an alignment keyword. If the chosen keyword means that the item overflows the alignment container causing data loss, the item is instead aligned as if the alignment mode were `start`.
 - `unsafe`

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -58,9 +58,9 @@ align-items: unset;
     - The property doesn't apply to block-level boxes, and to table cells.
 
 - `flex-start`
-  - : Only used in flex layout. Aligns the flex items to be flush with the edge of the alignment container corresponding to the flex container's main-start or cross-start side, as appropriate.
+  - : Used in flex layout only, aligns the flex items flush against the flex container's main-start or cross-start side.
 - `flex-end`
-  - : Only used in flex layout. Aligns the flex items to be flush with the edge of the alignment container corresponding to the flex container's main-end or cross-end side, as appropriate.
+  - : Used in flex layout only, aligns the flex items flush against the flex container's main-end or cross-end side.
 - `center`
   - : The flex items' margin boxes are centered within the line on the cross-axis. If the cross-size of an item is larger than the flex container, it will overflow equally in both directions.
 - `start`
@@ -74,7 +74,7 @@ align-items: unset;
 - `baseline`, `first baseline`, `last baseline`
   - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
 - `stretch`
-  - : If the combined size of the items is less than the size of the alignment container, any auto-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by `max-height`/`max-width` (or equivalent functionality), so that the combined size exactly fills the alignment container.
+  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the width and height limits.
 - `safe`
   - : Used alongside an alignment keyword. If the chosen keyword means that the item overflows the alignment container causing data loss, the item is instead aligned as if the alignment mode were `start`.
 - `unsafe`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
1. Remove inline comments in **Syntax** section because some of them are incorrect or inaccurate.
2. Update the explanations for `flex-start`, `flex-end`, and `stretch` values in the **Syntax/Values** section according to the information from [W3C](https://www.w3.org/TR/css-align-3/).

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
1. In the **Syntax** section, the inline comments are confusing because they use the same explanation for `flex-start` as they do for `self-start`, and the same goes for `flex-end` and `self-end`. However, these values are different. Since we already have the **Syntax/Values** section for further explanations on values, the inline comments are redundant and can be confusing for readers.
2. It's important to explicitly mention that `flex-start` and `flex-end` are only used in flex layout. On the other hand, the `stretch` value is not limited to flex layout, so this distinction should be made clear in the documentation.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://www.w3.org/TR/css-align-3/
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
