### PR TITLE
bookmarks.getChildren() includes separators

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.bookmarks.getChildren
 
 {{AddonSidebar()}}
 
-**`bookmarks.getChildren()`** retrieves all the immediate children of a given bookmark folder, identified as a {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} ID.
+**`bookmarks.getChildren()`** retrieves all the immediate children of a bookmark folder, identified as a {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} ID.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
@@ -22,11 +22,11 @@ let gettingChildren = browser.bookmarks.getChildren(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} which specifies the ID of the folder whose children are to be retrieved.
+  - : A {{jsxref("string")}} that specifies the ID of the folder whose children are to be retrieved.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with an array of [`BookmarkTreeNode`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode) objects. Each entry represents a single child node. The list is ordered in the same order in which the bookmarks appear in the user interface. Separators are currently not included in the results. The list includes subfolders, but does not include any children contained in subfolders.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is fulfilled with an array of [`BookmarkTreeNode`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode) objects. Each entry represents a child node. The list is in the same order as the bookmarks appear in the user interface. Separators are included in the results. The list includes subfolders but does not include any children contained in subfolders.
 
 If the specified node has no children, the array is empty.
 


### PR DESCRIPTION
### Description

Fixes #14366. Checked and confirmed that separated details were included in bookmarks.getChildren().

<img width="548" alt="image" src="https://github.com/mdn/content/assets/7352080/30c6aa8b-3089-4412-b603-a72668f89869">
