### PR TITLE
Add CSS to glossary identifier page

### DIFF
--- a/files/en-us/glossary/identifier/index.md
+++ b/files/en-us/glossary/identifier/index.md
@@ -6,16 +6,15 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **identifier** is a sequence of characters in the code that identifies a {{glossary("variable")}}, {{glossary("function")}}, or {{glossary("property")}}. Identifiers are case-sensitive and not quoted.
+An **identifier** is a sequence of characters in the code that identifies a {{glossary("variable")}}, {{glossary("function")}}, or {{glossary("property")}}. In most languages, identifiers are case-sensitive and not quoted.
 
 In {{glossary("JavaScript")}}, identifiers can contain {{glossary("Unicode")}} letters, `$`, `_`, and digits (0-9), but may not start with a digit. An identifier differs from a string in that a {{glossary("string")}} is data, while an identifier is part of the code. In JavaScript, there is no way to convert identifiers to strings, but sometimes it is possible to parse strings into identifiers.
 
-In {{glossary("CSS")}}, there are two identifier data types: {{cssxref("custom-ident")}} and {{cssxref("dashed-ident")}}. The CSS {{cssxref("ident")}} can start with a digit and can contain almost any character, but non-letter/digit ascii characters such as `"`, `\`, and `*` need to be escaped. Emojis, which are valid as identifiers, do not.
+In {{glossary("CSS")}}, there are two identifier data types: {{cssxref("custom-ident")}} and {{cssxref("dashed-ident")}}. The CSS {{cssxref("ident")}} can start with a digit and can contain almost any character, but non-letter/digit ASCII characters such as `"`, `\`, and `*` need to be escaped. Emojis, which are valid as identifiers, do not need to be escaped.
 
 ## See also
 
 - [Glossary](/en-US/docs/Glossary)
-  - {{glossary("Identifier")}}
   - {{glossary("Scope")}}
   - {{glossary("string")}}
   - {{glossary("Unicode")}}

--- a/files/en-us/glossary/identifier/index.md
+++ b/files/en-us/glossary/identifier/index.md
@@ -6,18 +6,17 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **identifier** is a sequence of characters in the code that identifies a {{glossary("variable")}}, {{glossary("function")}}, or {{glossary("property")}}.
+An **identifier** is a sequence of characters in the code that identifies a {{glossary("variable")}}, {{glossary("function")}}, or {{glossary("property")}}. Identifiers are case-sensitive and not quoted.
 
-In {{glossary("JavaScript")}}, identifiers are case-sensitive and can contain {{glossary("Unicode")}} letters, `$`, `_`, and digits (0-9), but may not start with a digit.
+In {{glossary("JavaScript")}}, identifiers can contain {{glossary("Unicode")}} letters, `$`, `_`, and digits (0-9), but may not start with a digit. An identifier differs from a string in that a {{glossary("string")}} is data, while an identifier is part of the code. In JavaScript, there is no way to convert identifiers to strings, but sometimes it is possible to parse strings into identifiers.
 
-An identifier differs from a string in that a {{glossary("string")}} is data, while an identifier is part of the code. In JavaScript, there is no way to convert identifiers to strings, but sometimes it is possible to parse strings into identifiers.
+In {{glossary("CSS")}}, there are two identifier data types: {{cssxref("custom-ident")}} and {{cssxref("dashed-ident")}}. The CSS {{cssxref("ident")}} can start with a digit and can contain almost any character, but non-letter/digit ascii characters such as `"`, `\`, and `*` need to be escaped. Emojis, which are valid as identifiers, do not. 
 
 ## See also
 
-- [Identifier](https://en.wikipedia.org/wiki/Identifier#In_computer_science) on Wikipedia
 - [Glossary](/en-US/docs/Glossary)
-
   - {{glossary("Identifier")}}
   - {{glossary("Scope")}}
   - {{glossary("string")}}
   - {{glossary("Unicode")}}
+- [Identifier](https://en.wikipedia.org/wiki/Identifier#In_computer_science) on Wikipedia

--- a/files/en-us/glossary/identifier/index.md
+++ b/files/en-us/glossary/identifier/index.md
@@ -10,7 +10,7 @@ An **identifier** is a sequence of characters in the code that identifies a {{gl
 
 In {{glossary("JavaScript")}}, identifiers can contain {{glossary("Unicode")}} letters, `$`, `_`, and digits (0-9), but may not start with a digit. An identifier differs from a string in that a {{glossary("string")}} is data, while an identifier is part of the code. In JavaScript, there is no way to convert identifiers to strings, but sometimes it is possible to parse strings into identifiers.
 
-In {{glossary("CSS")}}, there are two identifier data types: {{cssxref("custom-ident")}} and {{cssxref("dashed-ident")}}. The CSS {{cssxref("ident")}} can start with a digit and can contain almost any character, but non-letter/digit ascii characters such as `"`, `\`, and `*` need to be escaped. Emojis, which are valid as identifiers, do not. 
+In {{glossary("CSS")}}, there are two identifier data types: {{cssxref("custom-ident")}} and {{cssxref("dashed-ident")}}. The CSS {{cssxref("ident")}} can start with a digit and can contain almost any character, but non-letter/digit ascii characters such as `"`, `\`, and `*` need to be escaped. Emojis, which are valid as identifiers, do not.
 
 ## See also
 


### PR DESCRIPTION
the identifier glossary entry was JS only. Added CSS info. part of https://github.com/openwebdocs/project/issues/181