### PR TITLE
Reword requestAnimationFrame intro phrase

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Window.requestAnimationFrame
 {{APIRef}}
 
 The **`window.requestAnimationFrame()`** method tells the
-browser that you wish to perform an animation. I requests that the browser call a
+browser that you wish to perform an animation. It requests the browser to call a
 user-supplied callback function prior to the next repaint.
 
 The frequency of calls to the callback function will generally match the display


### PR DESCRIPTION
### Description

Rewords second introductory phrase of `requestAnimationFrame` docs in English.

### Motivation

I found structure of the second phrase of the intro a bit odd. It's not very readable:
- Subject is "I"? (Maybe a typo of "It"?)
- Request that the browser call -> requests the browser _to_ call
  - 3rd person if subject is "It" 
  - Use `to` as per [request verb usage](https://www.wordreference.com/definition/request): _request `{object: the browser}` to `{verb: call}`_


### Additional details

N/A

### Related issues and pull requests
Introduced in #28590 afaik

