### PR TITLE
A little numerical correction

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -50,7 +50,7 @@ The mantissa (also called _significand_) is the part of the number representing 
 
 The mantissa is stored with 52 bits, interpreted as digits after `1.…` in a binary fractional number. Therefore, the mantissa's precision is 2<sup>-52</sup> (obtainable via {{jsxref("Number.EPSILON")}}), or about 15 to 17 decimal places; arithmetic above that level of precision is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding).
 
-The largest value a number can hold is 2<sup>1024</sup> - 1 (with the exponent being 1023 and the mantissa being 0.1111… in base 2), which is obtainable via {{jsxref("Number.MAX_VALUE")}}. Values higher than that are replaced with the special number constant {{jsxref("Infinity")}}.
+The largest value a number can hold is 2<sup>1024</sup> - 2<sup>971</sup> (with the exponent being 1023 and the mantissa being 0.1111… in base 2, i.e. 1-2<sup>-52</sup>), which is obtainable via {{jsxref("Number.MAX_VALUE")}}. Values higher than that are replaced with the special number constant {{jsxref("Infinity")}}.
 
 Integers can only be represented without loss of precision in the range -2<sup>53</sup> + 1 to 2<sup>53</sup> - 1, inclusive (obtainable via {{jsxref("Number.MIN_SAFE_INTEGER")}} and {{jsxref("Number.MAX_SAFE_INTEGER")}}), because the mantissa can only hold 53 bits (including the leading 1).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
### Description
The largest value the [mantissa] can hold is, as the article mentions: 0.111... in binary,
that is,
1 - (0.000...01) in binary,
that is,
1 minus [the mantissa's precision] , which is 2**(-52), as the article mentions. So the largest integer in JS:
 (1+mantissa) * 2<sup>1023</sup>
that is,
(1+1-2<sup>-52</sup>) * 2<sup>1023</sup>
that is,
2<sup>1024</sup> - 2<sup>971</sup>
Check my code snippet max_value.js

<!-- ✍️ Summarize your changes in one or two sentences -->
### Summary
Numerical precision

<!-- ❓ Why are you making these changes and how do they help readers? -->
### Reason
Accuracy is nice
