### PR TITLE
relnote(120): `Date.parse` accepts non-ISO numeric dashed dates

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -22,6 +22,16 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### JavaScript
 
+- {{jsxref("Date.parse()")}} now accepts numeric dashed dates which do not meet the formal ISO standard, e.g.
+
+  - `"01-12-1999"` (month first)
+  - `"1999-1-5"` (single-digit month or day)
+  - `"10000-01-12"` (year > 9999)
+  - `"99-01-05"` or `"01-05-99"` (2-digit year, year must be >31 if it comes first)
+  - `"1999-01-05 10:00:00"` (space between date and time).
+
+  These dates will be parsed with behavior typical of other non-ISO dates, such as local time zone and month rollover (April 31 rolls over to May 1 since April 31 doesn't exist).
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
**Entry**

`Date.parse` now accepts numeric dashed dates which do not meet the formal ISO standard, e.g.

  - `"01-12-1999"` (month first)
  - `"1999-1-5"` (single-digit month or day)
  - `"10000-01-12"` (year > 9999)
  - `"99-01-05"` or `"01-05-99"` (2-digit year, year must be >31 if it comes first)
  - `"1999-01-05 10:00:00"` (space between date and time).

These dates will be parsed with behavior typical of other non-ISO dates, such as local time zone and month rollover (April 31 rolls over to May 1 since April 31 doesn't exist).

**Bugzilla**

https://bugzilla.mozilla.org/show_bug.cgi?id=1557650