### PR TITLE
Add legacy support to beforeunload examples

### DIFF
--- a/files/en-us/web/api/beforeunloadevent/index.md
+++ b/files/en-us/web/api/beforeunloadevent/index.md
@@ -18,7 +18,7 @@ See the {{domxref("Window/beforeunload_event", "beforeunload")}} event reference
 _Inherits properties from its parent, {{DOMxRef("Event")}}._
 
 - {{domxref("BeforeUnloadEvent.returnValue", "returnValue")}} {{Deprecated_Inline}}
-  - : When set to a [truthy](/en-US/docs/Glossary/Truthy) value, triggers a browser-controlled confirmation dialog asking users to confirm if they want to leave the page when they try to close or reload it. This is a legacy feature, and best practice is to trigger the dialog by invoking `event.preventDefault()` instead, as shown in the example.
+  - : When set to a [truthy](/en-US/docs/Glossary/Truthy) value, triggers a browser-controlled confirmation dialog asking users to confirm if they want to leave the page when they try to close or reload it. This is a legacy feature, and best practice is to trigger the dialog by invoking `event.preventDefault()`, while also setting `returnValue` to support legacy cases.
 
 ## Instance methods
 
@@ -36,13 +36,17 @@ In the following example we have an HTML text {{htmlelement("input")}} to repres
 
 Our JavaScript attaches an {{domxref("HTMLElement.input_event", "input")}} event listener to the `<input>` element that listens for changes in the inputted value. When the value is updated to a non-empty value, a {{domxref("Window.beforeunload_event", "beforeunload")}} event listener is attached to the {{domxref("Window")}} object.
 
-If the value becomes an empty string again (i.e. the value is deleted), the `beforeunload` event listener is removed again. It would be more efficient to just add the `beforeunload` listener once, and conditionally call `preventDefault()` based on the value of the target input. Best practice however is to add the listener when needed (i.e. when there is unsaved data that could be lost) and remove it again when it is not needed, for reasons outlined in the [`beforeunload` event usage notes](/en-US/docs/Web/API/Window/beforeunload_event#usage_notes).
+If the value becomes an empty string again (i.e. the value is deleted), the `beforeunload` event listener is removed again — as mentioned above in the [Usage notes](#usage_notes), the listener should be removed when there is no unsaved data to warn about.
 
-The `beforeunload` event handler function invokes `preventDefault()` to trigger the warning dialog when the user closes or navigates the tab.
+The `beforeunload` event handler function invokes `event.preventDefault()` to trigger the warning dialog when the user closes or navigates the tab. We have also included `event.returnValue = true` in the handler function so that any browsers that don't support the `event.preventDefault()` mechanism will still run the demo correctly.
 
 ```js
 const beforeUnloadHandler = (event) => {
+  // Recommended
   event.preventDefault();
+
+  // Included for legacy support, e.g. Chrome/Edge < 119
+  event.returnValue = true;
 };
 
 const nameInput = document.querySelector("#name");
@@ -59,8 +63,6 @@ nameInput.addEventListener("input", (event) => {
 When the `<input>` value is non-empty, if you try to close, navigate, or reload the page the browser displays the warning dialog. Try it out:
 
 {{EmbedLiveSample("Examples", "100%", 50)}}
-
-> **Note:** The browser-generated confirmation dialog can also be triggered by setting the {{domxref("BeforeUnloadEvent.returnValue", "event.returnValue")}} property to a truthy value on the `beforeunload` event object, or by returning a truthy value from the event handler function. However, these are legacy mechanisms, and best practice is to trigger the dialog by invoking `event.preventDefault()` as shown in the example above.
 
 ## Specifications
 

--- a/files/en-us/web/api/beforeunloadevent/returnvalue/index.md
+++ b/files/en-us/web/api/beforeunloadevent/returnvalue/index.md
@@ -13,7 +13,7 @@ browser-compat: api.BeforeUnloadEvent.returnValue
 The **`returnValue`** property of the
 {{domxref("BeforeUnloadEvent")}} interface, when set to a truthy value, triggers a browser-generated confirmation dialog asking users to confirm if they _really_ want to leave the page when they try to close or reload it, or navigate somewhere else. This is intended to help prevent loss of unsaved data.
 
-> **Note:** `returnValue` is a legacy feature, and best practice is to trigger the dialog by invoking {{domxref("Event.preventDefault()")}} on the `BeforeUnloadEvent` object instead. See the {{domxref("Window/beforeunload_event", "beforeunload")}} event reference for detailed up-to-date guidance.
+> **Note:** `returnValue` is a legacy feature, and best practice is to trigger the dialog by invoking {{domxref("Event.preventDefault()")}} on the `BeforeUnloadEvent` object, while also setting `returnValue` to support legacy cases. See the {{domxref("Window/beforeunload_event", "beforeunload")}} event reference for detailed up-to-date guidance.
 
 ## Value
 

--- a/files/en-us/web/api/window/beforeunload_event/index.md
+++ b/files/en-us/web/api/window/beforeunload_event/index.md
@@ -18,7 +18,7 @@ The dialog can be triggered in the following ways:
 - Setting the event object's {{domxref("BeforeUnloadEvent.returnValue", "returnValue")}} property to a non-empty string value or any other [truthy](/en-US/docs/Glossary/Truthy) value.
 - Returning any truthy value from the event handler function, e.g. `return "string"`. Note that this only works when the function is attached via the `onbeforeunload` property, not the {{domxref("EventTarget.addEventListener", "addEventListener()")}} method. This behavior is consistent across modern versions of Firefox, Safari, and Chrome.
 
-The last two machanisms are legacy features; best practice is to trigger the dialog by invoking `preventDefault()` on the event object.
+The last two machanisms are legacy features; best practice is to trigger the dialog by invoking `preventDefault()` on the event object, while also setting `returnValue` to support legacy cases.
 
 ## Syntax
 
@@ -76,14 +76,15 @@ Our JavaScript attaches an {{domxref("HTMLElement.input_event", "input")}} event
 
 If the value becomes an empty string again (i.e. the value is deleted), the `beforeunload` event listener is removed again — as mentioned above in the [Usage notes](#usage_notes), the listener should be removed when there is no unsaved data to warn about.
 
-The `beforeunload` event handler function invokes `preventDefault()` to trigger the warning dialog when the user closes or navigates the tab.
+The `beforeunload` event handler function invokes `event.preventDefault()` to trigger the warning dialog when the user closes or navigates the tab. We have also included `event.returnValue = true` in the handler function so that any browsers that don't support the `event.preventDefault()` mechanism will still run the demo correctly.
 
 ```js
 const beforeUnloadHandler = (event) => {
+  // Recommended
   event.preventDefault();
-  // Equivalent to the following legacy mechanisms
-  //   event.returnValue = "string";
-  //   return "string"; (only works with onbeforeunload)
+
+  // Included for legacy support, e.g. Chrome/Edge < 119
+  event.returnValue = true;
 };
 
 const nameInput = document.querySelector("#name");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I created https://github.com/mdn/content/pull/29595 to modernize the `beforeunload` event information on MDN and update the Chromium support information.

This seemed OK, but https://github.com/mdn/content/issues/29655 was then filed — the new demos created confusion for users of Chromium < 119 browsers.

As suggested by @caugner, I am raising this PR to fix this by adding legacy support to the examples.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
