### PR TITLE
Make both occurrences of "ASCII" linked

### DIFF
--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -60,7 +60,7 @@ a[class~="logo"] {
 - `[attr operator value i]`
   - : Adding an `i` (or `I`) before the closing bracket causes the value to be compared case-insensitively (for characters within the {{Glossary("ASCII")}} range).
 - `[attr operator value s]` {{Experimental_Inline}}
-  - : Adding an `s` (or `S`) before the closing bracket causes the value to be compared case-sensitively (for characters within the ASCII range).
+  - : Adding an `s` (or `S`) before the closing bracket causes the value to be compared case-sensitively (for characters within the {{Glossary("ASCII")}} range).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
On the section [attr_operator_value_i](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#attr_operator_value_i), "ASCII" is linked. However on the section that follows it ([attr_operator_value_s](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#attr_operator_value_s)), it isn't. This PR fixes that.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->


### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
