### PR TITLE
Fix a typo in index.md

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -199,7 +199,7 @@ Instead of allowing `'unsafe-inline'`, you can use the `'unsafe-hashes'` source 
 Given a HTML page that includes the following inline event handler:
 
 ```html
-<!-- I wan't to use addEventListener, but I can't :( -->
+<!-- I want to use addEventListener, but I can't :( -->
 <button onclick="myScript()">Submit</button>
 ```
 


### PR DESCRIPTION
Fixes a typo ("wan't") in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_hashes

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

One of the code blocks said "wan't" where it should have said "want", this fixes that.

### Motivation

It's a typo!

### Additional details

N/A

### Related issues and pull requests

N/A