### PR TITLE
Update tag omission for HTMLPElement

### DIFF
--- a/files/en-us/web/html/element/p/index.md
+++ b/files/en-us/web/html/element/p/index.md
@@ -55,9 +55,9 @@ Paragraphs are [block-level elements](/en-US/docs/Glossary/Block-level_content),
         {{HTMLElement("section")}}, {{HTMLElement("table")}},
         {{HTMLElement("ul")}} or another {{HTMLElement("p")}}
         element, or if there is no more content in the parent element and the
-        parent element is not an {{HTMLElement("a")}}, {{HTMLElement("audio")}}, 
-        {{HTMLElement("del")}}, {{HTMLElement("ins")}}, {{HTMLElement("map")}}, 
-        {{HTMLElement("noscript")}} or {{HTMLElement("video")}} element, 
+        parent element is not an {{HTMLElement("a")}}, {{HTMLElement("audio")}},
+        {{HTMLElement("del")}}, {{HTMLElement("ins")}}, {{HTMLElement("map")}},
+        {{HTMLElement("noscript")}} or {{HTMLElement("video")}} element,
         or an autonomous custom element.
       </td>
     </tr>

--- a/files/en-us/web/html/element/p/index.md
+++ b/files/en-us/web/html/element/p/index.md
@@ -42,19 +42,23 @@ Paragraphs are [block-level elements](/en-US/docs/Glossary/Block-level_content),
         {{HTMLElement("p")}} element is immediately followed by an
         {{HTMLElement("address")}},
         {{HTMLElement("article")}}, {{HTMLElement("aside")}},
-        {{HTMLElement("blockquote")}}, {{HTMLElement("div")}},
+        {{HTMLElement("blockquote")}}, {{HTMLElement("details")}}, {{HTMLElement("div")}},
         {{HTMLElement("dl")}}, {{HTMLElement("fieldset")}},
+        {{HTMLElement("figcaption")}}, {{HTMLElement("figure")}},
         {{HTMLElement("footer")}}, {{HTMLElement("form")}},
         {{HTMLElement("Heading_Elements", "h1")}}, {{HTMLElement("Heading_Elements", "h2")}},
         {{HTMLElement("Heading_Elements", "h3")}}, {{HTMLElement("Heading_Elements", "h4")}},
         {{HTMLElement("Heading_Elements", "h5")}}, {{HTMLElement("Heading_Elements", "h6")}},
-        {{HTMLElement("header")}}, {{HTMLElement("hr")}},
-        {{HTMLElement("menu")}}, {{HTMLElement("nav")}},
-        {{HTMLElement("ol")}}, {{HTMLElement("pre")}},
+        {{HTMLElement("header")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("hr")}},
+        {{HTMLElement("main")}}, {{HTMLElement("menu")}}, {{HTMLElement("nav")}},
+        {{HTMLElement("ol")}}, {{HTMLElement("pre")}}, {{HTMLElement("search")}},
         {{HTMLElement("section")}}, {{HTMLElement("table")}},
         {{HTMLElement("ul")}} or another {{HTMLElement("p")}}
         element, or if there is no more content in the parent element and the
-        parent element is not an {{HTMLElement("a")}} element.
+        parent element is not an {{HTMLElement("a")}}, {{HTMLElement("audio")}}, 
+        {{HTMLElement("del")}}, {{HTMLElement("ins")}}, {{HTMLElement("map")}}, 
+        {{HTMLElement("noscript")}} or {{HTMLElement("video")}} element, 
+        or an autonomous custom element.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The tag omission details for the `p` element have not been updated with the specification changes, I have added missing elements.

### Motivation

This way the documentation stays closer to the HTML5 specification

### Additional details

https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
