### PR TITLE
Fix invalid CSS property values in examples of `transition-duration`

### DIFF
--- a/files/en-us/web/css/transition-duration/index.md
+++ b/files/en-us/web/css/transition-duration/index.md
@@ -70,7 +70,7 @@ transition-duration: unset;
   height: 100px;
   background-color: red;
   font-size: 18px;
-  transition-property: background-color font-size transform color;
+  transition-property: background-color, font-size, transform, color;
   transition-timing-function: ease-in-out;
 }
 
@@ -79,7 +79,7 @@ transition-duration: unset;
   background-color: blue;
   color: yellow;
   font-size: 12px;
-  transition-property: background-color font-size transform color;
+  transition-property: background-color, font-size, transform, color;
   transition-timing-function: ease-in-out;
 }
 


### PR DESCRIPTION
### Description

The values of `transition-property` properties in the example code is not correct. Values of `transition-property` should be separated by commas instead of just spaces.

### Motivation

Although with the incorrect property values the example would still look fine, because the fallback value for the `transition-property` property is `all`, but it's still incorrect and would confuse people who read the example code.

### Additional details

The property shown as invalid in Firefox dev tools:

![image](https://github.com/mdn/content/assets/9620335/888ebd95-f947-433a-a192-a62ca7ac69c1)

Formal Syntax of `transition-property`: https://developer.mozilla.org/en-US/docs/Web/CSS/transition-property#formal_syntax

![image](https://github.com/mdn/content/assets/9620335/c9de6895-b69f-42a3-92b2-f023a7968b9b)
