### PR TITLE
No quotes or square brackets around IPv6 address in `X-Forwarded-For`

### DIFF
--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -83,13 +83,13 @@ Forwarded: for=192.0.2.43, for=198.51.100.17
 ### Transitioning from `X-Forwarded-For` to `Forwarded`
 
 If your application, server, or proxy supports the standardized `Forwarded` header, the {{HTTPHeader("X-Forwarded-For")}} header can be replaced.
-Note that IPv6 address is quoted and enclosed in square brackets in `Forwarded`.
+Note that an IPv6 address is quoted and enclosed in square brackets in `Forwarded` (unlike in the {{HTTPHeader("X-Forwarded-For")}} header).
 
 ```http
 X-Forwarded-For: 192.0.2.172
 Forwarded: for=192.0.2.172
 
-X-Forwarded-For: 192.0.2.43, "[2001:db8:cafe::17]"
+X-Forwarded-For: 192.0.2.43, 2001:db8:cafe::17
 Forwarded: for=192.0.2.43, for="[2001:db8:cafe::17]"
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- The examples on the description page for the `X-Forwarded-For` header do not show quotes or square brackets around IPv6 addresses, nor does the description itself mention them. 
- The explicit mentioning of quotes and square brackets around IPv6 addresses in the `Forwarded` header in the description of how to transition from `X-Forwarded-For` to `Forwarded` headers (on the description page for the `Forwarded` header) suggests this is intended to highlight the difference in use of quotes and square brackets between the two headers.
- Thus the example in the "Transitioning from `X-Forwarded-For` to `Forwarded`" section on the description page for the `Forwarded` header seems to have a bug.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Fix buggy example on `Forwarded` header description page, more explicit phrasing.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
