### PR TITLE
Fix uppercase PopupInfo class name

### DIFF
--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -190,7 +190,7 @@ To begin with, the JavaScript file defines a class called `PopupInfo`, which ext
 
 ```js
 // Create a class for the element
-class PopUpInfo extends HTMLElement {
+class PopupInfo extends HTMLElement {
   constructor() {
     // Always call super first in constructor
     super();
@@ -302,7 +302,7 @@ Here's the class definition:
 
 ```js
 // Create a class for the element
-class PopUpInfo extends HTMLElement {
+class PopupInfo extends HTMLElement {
   constructor() {
     // Always call super first in constructor
     super();


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
When call customElements.define('popup-info', PopupInfo) got error: "Uncaught ReferenceError: PopupInfo is not defined", because class name declared as "PopUpInfo", even in other places it's declared correctly.


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Fix error

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
