### PR TITLE
fix: replace the documentation of "tag" yaml header

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/json_structured_data/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/json_structured_data/index.md
@@ -56,20 +56,20 @@ An entry in `GroupData.json` has the following structure:
   - : This key is both an ID used by sidebar macros like `\{{APIRef("Name_of_the_API")}}` and the name displayed in the sidebar itself. Choose it wisely.
     > **Warning:** If you want to change the name displayed in the sidebar, you must edit all the pages displaying it.
 - `"overview"`
-  - : This is a list containing one page: the overview page, used as the link for the `"Name_of_the_API"` text. The value is the _title of the page_, and the page must be in the `web/api/`directory.
+  - : This is a list containing one page: the overview page, used as the link for the `"Name_of_the_API"` text. The value is the _title of the page_, and the page must be in the `web/api/` directory.
 - `"guides"`
   - : This is a list of guides to display in the sidebar, in the given order. The values are _paths to the page_, starting with `/docs/`.
 - `"interfaces"`
   - : This lists the interfaces that are part of the API.
 - `"methods"`
   - : This lists the methods that are part of the API.
-    > **Note:** The methods of the interfaces listed in `"interfaces"` **must** not be listed there. They are automatically added to the sidebar if the tag `Method` is in the YAML header on that page.
+    > **Note:** The methods of the interfaces listed in `"interfaces"` **must** not be listed there. They are automatically added to the sidebar if the `page-type` key for that page is `web-api-static-method` or `web-api-instance-method`.
 - `"properties"`
   - : This lists the methods on other interfaces that are part of the API, like `navigator.xr` (a property that the WebXR API adds to the `navigator` object)
-    > **Note:** The properties of the interfaces listed in `"interfaces"` **must** not be listed there. They are automatically added to the sidebar if the tag `Property` is in the YAML header on that page.
+    > **Note:** The properties of the interfaces listed in `"interfaces"` **must** not be listed there. They are automatically added to the sidebar if the `page-type` key for that page is `web-api-static-property` or `web-api-instance-property`.
 - `"events"`
   - : This lists events of other interfaces that are part of the API. The values are the _title of the pages_ (that must reside under `Web/Events`)
-    > **Note:** The events targeting the interfaces listed in `"interfaces"` **must** not be listed there. They are automatically added to the sidebar if the tag `Event` (singular!) is in the YAML header on that page.
+    > **Note:** The events targeting the interfaces listed in `"interfaces"` **must** not be listed there. They are automatically added to the sidebar if the `page-type` key for that page is `web-api-event`.
 
 There are two other keys, `"dictionaries"` and `"callbacks"`, operating on the same principle. As we no longer document these entities in their own pages, their use is deprecated, and no new entry should be added to them (and we remove them little by little).
 


### PR DESCRIPTION
### Description

replace the documentation of "tag" yaml header.

### Motivation

We've removed the `tag` front-matter key. And now [use `page-type` to collect methods, properties, and events](https://github.com/mdn/yari/blob/b996e3648c16f9b36f87e4af570dfffbf400c27c/kumascript/macros/APIRef.ejs#L79-L103).
