### PR TITLE
Fix misleading sample MyCustomizedElement vs. MyCustomizedBuiltInElement

### DIFF
--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -123,9 +123,13 @@ This element extends the built-in {{htmlelement("p")}} element.
 In this minimal example the element doesn't implement any customization, so it will behave just like a normal `<p>` element. However, it does satisfy the requirements of `define()`, so we can define it like this:
 
 ```js
-customElements.define("my-customized-built-in-element", MyCustomizedBuiltInElement, {
-  extends: "p",
-});
+customElements.define(
+  "my-customized-built-in-element",
+  MyCustomizedBuiltInElement,
+  {
+    extends: "p",
+  },
+);
 ```
 
 We could then use it in an HTML page like this:

--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -123,7 +123,7 @@ This element extends the built-in {{htmlelement("p")}} element.
 In this minimal example the element doesn't implement any customization, so it will behave just like a normal `<p>` element. However, it does satisfy the requirements of `define()`, so we can define it like this:
 
 ```js
-customElements.define("my-customized-element", MyCustomizedElement, {
+customElements.define("my-customized-built-in-element", MyCustomizedBuiltInElement, {
   extends: "p",
 });
 ```
@@ -131,7 +131,7 @@ customElements.define("my-customized-element", MyCustomizedElement, {
 We could then use it in an HTML page like this:
 
 ```html
-<p is="my-customized-element"></p>
+<p is="my-customized-built-in-element"></p>
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The sample code was not aligned. The sample class was not used when created this can be irritating to beginners.

### Motivation

Just copying the sample would not work. This could be a source of frustration.

> Uncaught ReferenceError: MyCustomizedElement is not defined