### PR TITLE
Fixed 'Uncaught TypeError: oscList[octave][dataset.note] is undefined…' for simple synth keyboard

### DIFF
--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -542,8 +542,10 @@ function notePressed(event) {
 
     if (!dataset["pressed"]) {
       const octave = Number(dataset["octave"]);
-      oscList[octave][dataset["note"]] = playTone(dataset["frequency"]);
-      dataset["pressed"] = "yes";
+      if (!oscList[octave][dataset["note"]]) {
+        oscList[octave][dataset["note"]] = playTone(dataset["frequency"]);
+        dataset["pressed"] = "yes";
+      }
     }
   }
 }
@@ -563,9 +565,11 @@ function noteReleased(event) {
 
   if (dataset && dataset["pressed"]) {
     const octave = Number(dataset["octave"]);
-    oscList[octave][dataset["note"]].stop();
-    delete oscList[octave][dataset["note"]];
-    delete dataset["pressed"];
+    if (oscList[octave] && oscList[octave][dataset["note"]]) {
+      oscList[octave][dataset["note"]].stop();
+      delete oscList[octave][dataset["note"]];
+      delete dataset["pressed"];
+    }
   }
 }
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
I added a nested if-statement to check if "oscList" exists before trying to access "note."
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I'm currently learning the Web Audio API, and I wanted to contribute to the docs after seeing the error. This change would result in less confusion following along with the tutorial.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
If I'm missing anything from this contribution, please let me know.
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
