### PR TITLE
Fix typo in text_fragments/index.md

### DIFF
--- a/files/en-us/web/text_fragments/index.md
+++ b/files/en-us/web/text_fragments/index.md
@@ -8,7 +8,7 @@ browser-compat:
   - css.selectors.target-text
 ---
 
-**Text fragments** allow you linking directly to a specific portion of text in a web document, without requiring the author to annotate it with an ID, using particular syntax in the URL fragment. Supporting browsers are free to choose how to draw attention to the linked text, e.g. with a color highlight and/or scrolling to the content on the page. This is useful because it allows web content authors to deep-link to other content they don't control, without relying on the presence of IDs to make that possible. Building on top of that, it could be used to generate more effective content-sharing links for users to pass to one another.
+**Text fragments** allow linking directly to a specific portion of text in a web document, without requiring the author to annotate it with an ID, using particular syntax in the URL fragment. Supporting browsers are free to choose how to draw attention to the linked text, e.g. with a color highlight and/or scrolling to the content on the page. This is useful because it allows web content authors to deep-link to other content they don't control, without relying on the presence of IDs to make that possible. Building on top of that, it could be used to generate more effective content-sharing links for users to pass to one another.
 
 ## Concepts and usage
 


### PR DESCRIPTION
### Description

Removes an unnecessary (and ungrammatical) "you" from the description of the text fragments feature.

### Motivation

Fixes a typo.
