### PR TITLE
WebGL: Fix description of vertexAttrib

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -57,7 +57,7 @@ This value will be used if a bound array buffer has not been enabled with
 Attributes may be matrices, in which case columns of the matrix must be loaded into
 successive vertex attribute slots.
 
-The values set with `vertexAttrib` are context-global; this is, they aren't part of the shader state
+The values set with `vertexAttrib` are context-global; that is, they aren't part of the shader state
 (like generic vertex attribute indexes to shader variable bindings) and aren't part of
 the vertex array object state (like enabled vertex attribute arrays). The only way to
 change the values is by calling this function again.

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -57,7 +57,7 @@ This value will be used if a bound array buffer has not been enabled with
 Attributes may be matrices, in which case columns of the matrix must be loaded into
 successive vertex attribute slots.
 
-The values set with `vertexAttrib` are context-global, i.e. they aren't part of the shader state
+The values set with `vertexAttrib` are context-global; this is, they aren't part of the shader state
 (like generic vertex attribute indexes to shader variable bindings) and aren't part of
 the vertex array object state (like enabled vertex attribute arrays). The only way to
 change the values is by calling this function again.

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -57,9 +57,8 @@ This value will be used if a bound array buffer has not been enabled with
 Attributes may be matrices, in which case columns of the matrix must be loaded into
 successive vertex attribute slots.
 
-The values set with {{domxref("WebGLRenderingContext.vertexAttribPointer()",
-  "vertexAttribPointer")}} are context-global, i.e. they aren't part of the shader state
-(like generix vertex attribute indexes to shader variable bindings) and aren't part of
+The values set with `vertexAttrib` are context-global, i.e. they aren't part of the shader state
+(like generic vertex attribute indexes to shader variable bindings) and aren't part of
 the vertex array object state (like enabled vertex attribute arrays). The only way to
 change the values is by calling this function again.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It looks like "vertexAttribPointer" in the description of vertexAttrib should be replaced with "vertexAttrib".

The original page says:
> The values set with [vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer) are context-global, i.e. they aren't part of the shader state (like generix vertex attribute indexes to shader variable bindings) and aren't part of the vertex array object state (like enabled vertex attribute arrays). The only way to change the values is by calling this function again.

However, the values set with vertexAttribPointer are not context-global. They are stored in a vertex array object. [OpenGL ES reference page says](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glVertexAttribPointer.xhtml#description):
> When a generic vertex attribute array is specified, size, type, normalized, stride, and pointer are saved as vertex array state.

The values set with vertexAttrib are context-global as described. And it doesn't make sense to mention vertexAttribPointer in the vertexAttrib description.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change may help readers avoid confusion.