### PR TITLE
Remove the incorrect event of Worker interface

### DIFF
--- a/files/en-us/web/api/worker/index.md
+++ b/files/en-us/web/api/worker/index.md
@@ -43,10 +43,6 @@ _Inherits methods from its parent, {{domxref("EventTarget")}}._
   - : Fires when the worker's parent receives a message from that worker.
 - [`messageerror`](/en-US/docs/Web/API/Worker/messageerror_event)
   - : Fires when a `Worker` object receives a message that can't be [deserialized](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
-- [`rejectionhandled`](/en-US/docs/Web/API/Window/rejectionhandled_event)
-  - : Fires every time a {{jsxref("Promise")}} rejects, regardless of whether or not there is a handler to catch the rejection.
-- [`unhandledrejection`](/en-US/docs/Web/API/Window/unhandledrejection_event)
-  - : Fires when a {{jsxref("Promise")}} rejects with no handler to catch the rejection.
 
 ## Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

remove the incorrect event (`rejectionhandled` and `unhandledrejection`) of `Worker` interface

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

the `Worker` interface does not has a event handler of `rejectionhandled` and `unhandledrejection`
the only available event handler of `Worker` interface is `error` from `AbstractWorker` mixin and `message` and `messageerror` from `Worker` itself

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

See the standard of [AbstractWorker](https://html.spec.whatwg.org/multipage/workers.html#abstractworker)
and [Worker](https://html.spec.whatwg.org/multipage/workers.html#worker)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
