### PR TITLE
WebDriver conformance release notes for Firefox 119

### DIFF
--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -77,7 +77,6 @@ This article provides information about the changes in Firefox 119 that affect d
 
 - When performing a `scroll` action of input type `wheel` with an origin set to `pointer` an `invalid argument` error was inappropriately raised, whereby as per the current WebDriver specification this combination is currently not supported ([Firefox bug 1850166](https://bugzil.la/1850166)).
 
-
 #### WebDriver BiDi
 
 - Added the [`browsingContext.reload`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-reload) command that allows users to reload the page or a frame that is currently displayed within a given browsing context ([Firefox bug 1830859](https://bugzil.la/1830859)).

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -73,7 +73,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 #### General
 
-- When performing a `pointerDown` action with the middle or right mouse button pressed, the  `mousedown` event as emitted by the related HTML element had the value of the `buttons` property swapped ([Firefox bug 1850086](https://bugzil.la/1850086)).
+- When performing a `pointerDown` action with the middle or right mouse button pressed, the `mousedown` event as emitted by the related HTML element had the value of the `buttons` property swapped ([Firefox bug 1850086](https://bugzil.la/1850086)).
 
 - When performing a `scroll` action of input type `wheel` with an origin set to `pointer` an `invalid argument` error was inappropriately raised, whereby as per the current WebDriver specification this combination is currently not supported ([Firefox bug 1850166](https://bugzil.la/1850166)).
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -71,9 +71,30 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
+#### General
+
+- When performing a `pointerDown` action with the middle or right mouse button pressed, the  `mousedown` event as emitted by the related HTML element had the value of the `buttons` property swapped ([Firefox bug 1850086](https://bugzil.la/1850086)).
+
+- When performing a `scroll` action of input type `wheel` with an origin set to `pointer` an `invalid argument` error was inappropriately raised, whereby as per the current WebDriver specification this combination is currently not supported ([Firefox bug 1850166](https://bugzil.la/1850166)).
+
+
 #### WebDriver BiDi
 
+- Added the [`browsingContext.reload`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-reload) command that allows users to reload the page or a frame that is currently displayed within a given browsing context ([Firefox bug 1830859](https://bugzil.la/1830859)).
+
+- Added the [`browsingContext.userPromptClosed`](https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptClosed) event that is emitted when a user prompt of type `alert`, `confirm`, or `prompt` got closed ([Firefox bug 1824221](https://bugzil.la/1824221)).
+
+- Added the [`browsingContext.navigationStarted`](https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationStarted) event that is emitted when a new navigation is started by Firefox ([Firefox bug 1756595](https://bugzil.la/1756595)).
+
+- Added the [`script.realmCreated`](https://w3c.github.io/webdriver-bidi/#event-script-realmCreated) and [`script.realmDestroyed`](https://w3c.github.io/webdriver-bidi/#event-script-realmDestroyed) events that allow users to monitor the lifetime of JavaScript Realms of a given browsing context. Such a Realm is basically an isolated execution environment (`sandbox`) with its own unique global object (window) ([Firefox bug 1788657](https://bugzil.la/1788657), [Firefox bug 1788659](https://bugzil.la/1788659)).
+
+- The `browsingContext.userPromptOpened` event was accidentally sent when a HTTP Authentication dialog was opened ([Firefox bug 1853302](https://bugzil.la/1853302)).
+
+- Unwanted events with the `context` field set to `null` will no longer be emitted. Because the underlying browsing context has been closed such events are no longer valid ([Firefox bug 1847563](https://bugzil.la/1847563)).
+
 #### Marionette
+
+- The list of possible error codes when trying to install a WebExtension by using the `Addon:Install` command has been updated to match the latest error codes of Firefox ([Firefox bug 1852537](https://bugzil.la/1852537)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -75,7 +75,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 - When performing a `pointerDown` action with the middle or right mouse button pressed, the `mousedown` event as emitted by the related HTML element had the value of the `buttons` property swapped ([Firefox bug 1850086](https://bugzil.la/1850086)).
 
-- When performing a `scroll` action of input type `wheel` with an origin set to `pointer` an `invalid argument` error was inappropriately raised, whereby as per the current WebDriver specification this combination is currently not supported ([Firefox bug 1850166](https://bugzil.la/1850166)).
+- When performing a `scroll` action of input type `wheel` with an origin set to `pointer` an `invalid argument` error was inappropriately raised, whereas per the current WebDriver specification this combination is not supported ([Firefox bug 1850166](https://bugzil.la/1850166)).
 
 #### WebDriver BiDi
 

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -50,6 +50,8 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
+#### General
+
 #### WebDriver BiDi
 
 #### Marionette


### PR DESCRIPTION
This PR is based on the [WebDriver conformance changes for Firefox 119](https://bugzilla.mozilla.org/buglist.cgi?component=Agent&component=Marionette&component=WebDriver%20BiDi&v1=fixed&columnlist=component%2Cresolution%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&resolution=FIXED&v2=%5Bwptsync%20downstream%5D&query_format=advanced&o1=equals&product=Remote%20Protocol&f2=status_whiteboard&o2=notsubstring&f1=cf_status_firefox119&list_id=16767067).

@lutien and @juliandescottes can you please review? Thanks