### PR TITLE
Wrong use for "selector" instead of "combinator".

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -66,7 +66,7 @@ If you remove the `>` that designates this as a child combinator, you end up wit
 
 ## Next-sibling combinator
 
-The next-sibling combinator (`+`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the next sibling element of the first selector. For example, to select all `<img>` elements that are immediately preceded by a `<p>` element:
+The **next-sibling combinator** (`+`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the next sibling element of the first selector. For example, to select all `<img>` elements that are immediately preceded by a `<p>` element:
 
 ```css
 p + img
@@ -82,7 +82,7 @@ If you insert some other element such as a `<h2>` in between the `<h1>` and the 
 
 ## Subsequent-sibling combinator
 
-If you want to select siblings of an element even if they are not directly adjacent, then you can use the subsequent-sibling combinator (`~`). To select all `<img>` elements that come _anywhere_ after `<p>` elements, we'd do this:
+If you want to select siblings of an element even if they are not directly adjacent, then you can use the **subsequent-sibling combinator** (`~`). To select all `<img>` elements that come _anywhere_ after `<p>` elements, we'd do this:
 
 ```css
 p ~ img

--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -66,7 +66,7 @@ If you remove the `>` that designates this as a child combinator, you end up wit
 
 ## Next-sibling combinator
 
-The next-sibling selector (`+`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the next sibling element of the first selector. For example, to select all `<img>` elements that are immediately preceded by a `<p>` element:
+The next-sibling combinator (`+`) is placed between two CSS selectors. It matches only those elements matched by the second selector that are the next sibling element of the first selector. For example, to select all `<img>` elements that are immediately preceded by a `<p>` element:
 
 ```css
 p + img


### PR DESCRIPTION
### Description

Using "Combinator" instead of "selector" for the (+) symbol, while the nex-sibling selector mean the whole selector (first sub selector, +, concerned element)

### Additional details
See the above combinator sections.