### PR TITLE
fix(css): add 'auto' value outline-color

### DIFF
--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -37,7 +37,7 @@ The `outline-color` property is specified as any one of the values listed below.
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the outline, specified as a `<color>`.
 - `auto` {{Experimental_Inline}}
-  - : Computes to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword). However, when [`outline-style`](/en-US/docs/Web/CSS/outline-style) is `auto`, `outline-color: auto` computes to the [accent color](/en-US/docs/Web/CSS/accent-color).
+  - : Computes to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) unless [`outline-style`](/en-US/docs/Web/CSS/outline-style) is set to `auto` then it computes to the [accent color](/en-US/docs/Web/CSS/accent-color).
 
 ## Description
 

--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -20,7 +20,7 @@ outline-color: rgb(30, 222, 121);
 outline-color: blue;
 
 /* Keyword value */
-outline-color: invert;
+outline-color: auto;
 
 /* Global values */
 outline-color: inherit;
@@ -36,8 +36,8 @@ The `outline-color` property is specified as any one of the values listed below.
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the outline, specified as a `<color>`.
-- `invert`
-  - : To ensure the outline is visible, performs a color inversion of the background. Note that browsers are not required to support this value; if they don't, this keyword is considered invalid.
+- `auto` {{Experimental_Inline}}
+  - : Computes to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword). However, when [`outline-style`](/en-US/docs/Web/CSS/outline-style) is `auto`, `outline-color: auto` computes to the [accent color](/en-US/docs/Web/CSS/accent-color).
 
 ## Description
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/29723

The value `invert` has been [changed to `auto`](https://github.com/w3c/csswg-drafts/commit/17e16ba259d6774af368f4d19b190d8d6d6e7afc) 3 months ago.

No browser implements `invert` or `auto` values yet.