### PR TITLE
update FileSystemSyncAccessHandle for exception section

### DIFF
--- a/files/en-us/web/api/filesystemsyncaccesshandle/flush/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/flush/index.md
@@ -31,7 +31,8 @@ None ({{jsxref('undefined')}}).
 
 ### Exceptions
 
-None.
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the associated access handle is already closed.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/read/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/read/index.md
@@ -36,6 +36,8 @@ A number representing the number of bytes read from the file.
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the associated access handle is already closed.
+- {{jsxref("TypeError")}}
+  - : Thrown if the underlying file system does not support reading the file from the specified file offset.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/truncate/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/truncate/index.md
@@ -31,7 +31,7 @@ None ({{jsxref('undefined')}}).
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the associated access handle is already closed, or if the modification of the file's binary data completely fails.
+  - : Thrown if the associated access handle is already closed, or if the modification of the file's binary data otherwise fails.
 - `QuotaExceededError` {{domxref("DOMException")}}
   - : Thrown if the `newSize` is larger than the original size of the file, and exceeds the browser's [storage quota](/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria).
 - {{jsxref("TypeError")}}

--- a/files/en-us/web/api/filesystemsyncaccesshandle/truncate/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/truncate/index.md
@@ -31,9 +31,11 @@ None ({{jsxref('undefined')}}).
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the associated access handle is already closed, or if the modification of the file's binary data otherwise fails.
+  - : Thrown if the associated access handle is already closed, or if the modification of the file's binary data completely fails.
 - `QuotaExceededError` {{domxref("DOMException")}}
   - : Thrown if the `newSize` is larger than the original size of the file, and exceeds the browser's [storage quota](/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria).
+- {{jsxref("TypeError")}}
+  - : Thrown if the underlying file system does not support setting the file size to the new size.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/write/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/write/index.md
@@ -37,7 +37,11 @@ A number representing the number of bytes written to the file.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the associated access handle is already closed.
+  - : Thrown if the associated access handle is already closed, or if the modification of the file's binary data completely fails.
+- `QuotaExceededError` {{domxref("DOMException")}}
+  - : Thrown if the increased data capacity exceeds the browser's [storage quota](/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria).
+- {{jsxref("TypeError")}}
+  - : Thrown if the underlying file system does not support writing the file from the specified file offset.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

mainly for update exception section of FileSystemSyncAccessHandle interface methods

* read
  * InvalidStateError step1
  * TypeError step6
* write
  * InvalidStateError step1
  * TypeError step3 & stp14.2
  * QuotaExceededError step12
* truncate
  * InvalidStateError step1 & step5.3 & step6.2
  * TypeError step4
  * QuotaExceededError step5.1
* flush
  * InvalidStateError step1

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

for standard:
[FileSystemSyncAccessHandle.read()](https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-read)
[FileSystemSyncAccessHandle.write()](https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-write)
[FileSystemSyncAccessHandle.truncate()](https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-truncate)
[FileSystemSyncAccessHandle.flush()](https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-flush)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
