### PR TITLE
fix: grammar "they are", not "there"

### DIFF
--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -139,7 +139,7 @@ As with HTML, the browser needs to convert the received CSS rules into something
 
 The CSSOM tree includes styles from the user agent style sheet. The browser begins with the most general rule applicable to a node and recursively refines the computed styles by applying more specific rules. In other words, it cascades the property values.
 
-Building the CSSOM is very, very fast and is not displayed in a unique color in current developer tools. Rather, the "Recalculate Style" in developer tools shows the total time it takes to parse CSS, construct the CSSOM tree, and recursively calculate computed styles. In terms of web performance optimization, there are lower hanging fruit, as the total time to create the CSSOM is generally less than the time it takes for one DNS lookup.
+Building the CSSOM is very, very fast and is not displayed in a unique color in current developer tools. Rather, the "Recalculate Style" in developer tools shows the total time it takes to parse CSS, construct the CSSOM tree, and recursively calculate computed styles. In terms of web performance optimization, they are lower hanging fruit, as the total time to create the CSSOM is generally less than the time it takes for one DNS lookup.
 
 ### Other processes
 


### PR DESCRIPTION
### Description

Propose a potential grammatical improvement about the pronoun used to address the CSSOM in **Building the CSSOM tree** section.

### Motivation

Improve the readability with the direct pronoun removed a bit of ambiguity.
