### PR TITLE
relnote(120): nightly disables CSS -moz-prefixed transform properties, enables CSS zoom property

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -938,6 +938,49 @@ The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/
   </tbody>
 </table>
 
+### zoom property
+
+The non-standard CSS {{cssxref("zoom")}} property lets you magnify an element similar to the {{cssxref("transform")}} property, but it affects the layout size of the element.
+See ([Firefox bug 1855763](https://bugzil.la/1855763) and [Firefox bug 390936](https://bugzil.la/390936)) for more details.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>120</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>120</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>120</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+      <code>layout.css.zoom.enabled</code>
+    </td>
+    </tr>
+  </tbody>
+</table>
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -20,6 +20,8 @@ This article provides information about the changes in Firefox 120 that affect d
 
 #### Removals
 
+- The deprecated `-moz-transform` CSS property has been removed. Use the standard `transform` property instead ([Firefox bug 1855763](https://bugzil.la/1855763)).
+
 ### JavaScript
 
 - {{jsxref("Date.parse()")}} now accepts numeric dashed dates which do not meet the formal ISO standard, e.g.


### PR DESCRIPTION
This PR adds a relnote about disabling `-moz-transform` on nightly and enabling CSS `zoom`.

* `layout.css.zoom.enabled` is true on Nightly (https://hg.mozilla.org/integration/autoland/file/tip/modules/libpref/init/StaticPrefList.yaml#l8791)
* `layout.css.prefixes.transforms` disabled on Nightly for now (https://hg.mozilla.org/integration/autoland/file/tip/modules/libpref/init/StaticPrefList.yaml#l8623)

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/29785
- [x] BCD (CSS `zoom`) https://github.com/mdn/browser-compat-data/pull/21122

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1855763
- https://bugzilla.mozilla.org/show_bug.cgi?id=390936
