### PR TITLE
Expand on the payload of the subscription change

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -60,7 +60,7 @@ self.addEventListener(
             "Content-type": "application/json",
           },
           body: JSON.stringify({
-            old: getPayload(oldSubscription),
+            old: getPayload(event.oldSubscription),
             new: getPayload(subscription
           }),
         }),

--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -61,7 +61,7 @@ self.addEventListener(
           },
           body: JSON.stringify({
             old: getPayload(event.oldSubscription),
-            new: getPayload(subscription
+            new: getPayload(subscription)
           }),
         }),
       );

--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -47,8 +47,8 @@ self.addEventListener(
     const conv = (val) => btoa(String.fromCharCode.apply(null, new Uint8Array(val)));
     const getPayload = (subscription) => ({
       endpoint: subscription.endpoint,
-      p256dh: conv(subscription.getKey('p256dh')),
-      auth: conv(subscription.getKey('auth'))
+      publicKey: conv(subscription.getKey('p256dh')),
+      authToken: conv(subscription.getKey('auth'))
     });
 
     const subscription = self.registration.pushManager

--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -44,7 +44,14 @@ This example, run in the context of a service worker, listens for a `pushsubscri
 self.addEventListener(
   "pushsubscriptionchange",
   (event) => {
-    const subscription = swRegistration.pushManager
+    const conv = (val) => btoa(String.fromCharCode.apply(null, new Uint8Array(val)));
+    const getPayload = (subscription) => ({
+      endpoint: subscription.endpoint,
+      p256dh: conv(subscription.getKey('p256dh')),
+      auth: conv(subscription.getKey('auth'))
+    });
+
+    const subscription = self.registration.pushManager
       .subscribe(event.oldSubscription.options)
       .then((subscription) =>
         fetch("register", {
@@ -53,7 +60,8 @@ self.addEventListener(
             "Content-type": "application/json",
           },
           body: JSON.stringify({
-            endpoint: subscription.endpoint,
+            old: getPayload(oldSubscription),
+            new: getPayload(subscription
           }),
         }),
       );
@@ -70,7 +78,7 @@ You can also use the `onpushsubscriptionchange` event handler property to set up
 ```js
 self.onpushsubscriptionchange = (event) => {
   event.waitUntil(
-    swRegistration.pushManager
+    self.registration.pushManager
       .subscribe(event.oldSubscription.options)
       .then((subscription) => {
         /* ... */

--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -44,11 +44,12 @@ This example, run in the context of a service worker, listens for a `pushsubscri
 self.addEventListener(
   "pushsubscriptionchange",
   (event) => {
-    const conv = (val) => btoa(String.fromCharCode.apply(null, new Uint8Array(val)));
+    const conv = (val) =>
+      btoa(String.fromCharCode.apply(null, new Uint8Array(val)));
     const getPayload = (subscription) => ({
       endpoint: subscription.endpoint,
-      publicKey: conv(subscription.getKey('p256dh')),
-      authToken: conv(subscription.getKey('auth'))
+      publicKey: conv(subscription.getKey("p256dh")),
+      authToken: conv(subscription.getKey("auth")),
     });
 
     const subscription = self.registration.pushManager
@@ -61,7 +62,7 @@ self.addEventListener(
           },
           body: JSON.stringify({
             old: getPayload(event.oldSubscription),
-            new: getPayload(subscription)
+            new: getPayload(subscription),
           }),
         }),
       );


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Currently the example to change a push subscription is confusing and missing important steps.
You will need to relate the current subscription to the new one. So the old one get's disregarded / updated.

### Motivation

I am integrating push subscriptions in my clients project and want to share what I learned.

### Open questions

You find a lot of incomplete examples in the internet.
One is https://pushpad.xyz/blog/web-push-error-410-the-push-subscription-has-expired-or-the-user-has-unsubscribed
where they are using `event.newSubscription.toJSON().keys.p256dh` to get the publicKey.
But for me this seemed not to work and I had to use this snippet: `btoa(String.fromCharCode.apply(null, new Uint8Array(subscription.getKey('p256dh'))))`

Both result in slightely different values:
`BOU-zIjojGv41ekvvFK26dYqu-BXRPRdWbUMGYyHbqzoRI9__BKMB_ukIHw8utVwljGKb5zIfA-uxgagYxekYMY`
vs
`BOU+zIjojGv41ekvvFK26dYqu+BXRPRdWbUMGYyHbqzoRI9//BKMB/ukIHw8utVwljGKb5zIfA+uxgagYxekYMY=`

are both approaches working for the mozilla push notification servers?