### PR TITLE
counter descriptor: speak as

### DIFF
--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -49,7 +49,7 @@ speak-as: <counter-style-name>;
 
 Assistive technology support is very limited for the `speak-as` property. Do not rely on it to convey information critical to understanding the page's purpose.
 
-[Let's Talk About Speech CSS | CSS Tricks](https://css-tricks.com/lets-talk-speech-css/)
+[Let's Talk About Speech CSS | CSS Tricks](https://css-tricks.com/lets-talk-speech-css/) (2017)
 
 ## Formal definition
 
@@ -63,15 +63,17 @@ Assistive technology support is very limited for the `speak-as` property. Do not
 
 ### Setting the spoken form for a counter
 
+In this example, the counter system is fixed with unintelligible symbols used for the markers. To experience the result of the `speak-as` descriptor, use assistive technology such as VoiceOver or other screen reader or view the [accessibility panel](https://firefox-source-docs.mozilla.org/devtools-user/index.html#accessibility-inspector) in the developer tools of a browser that supports the `speak-as` counter feature.
+
 #### HTML
 
 ```html
 <ul class="list">
-  <li>One</li>
-  <li>Two</li>
-  <li>Three</li>
-  <li>Four</li>
-  <li>Five</li>
+  <li>I had one apple</li>
+  <li>I ate two bananas</li>
+  <li>I devoured three oranges</li>
+  <li>I am not hungry for dinner</li>
+  <li>But I'll have five scopps of ice cream for desert</li>
 </ul>
 ```
 
@@ -104,5 +106,6 @@ Assistive technology support is very limited for the `speak-as` property. Do not
 
 ## See also
 
+- Other {{cssxref("@counter-style")}} descriptors, including, {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - {{cssxref("symbols", "symbols()")}}, the functional notation creating anonymous counter styles.

--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -63,7 +63,7 @@ Assistive technology support is very limited for the `speak-as` property. Do not
 
 ### Setting the spoken form for a counter
 
-In this example, the counter system is fixed with unintelligible symbols used for the markers. To experience the result of the `speak-as` descriptor, use assistive technology such as VoiceOver or other screen reader or view the [accessibility panel](https://firefox-source-docs.mozilla.org/devtools-user/index.html#accessibility-inspector) in the developer tools of a browser that supports the `speak-as` counter feature.
+In this example, the counter system is fixed with unintelligible symbols used for the markers. To experience the result of the `speak-as` descriptor, use assistive technology such as VoiceOver or another screen reader or view the [accessibility panel](https://firefox-source-docs.mozilla.org/devtools-user/index.html#accessibility-inspector) in the developer tools of a browser that supports `speak-as`.
 
 #### HTML
 
@@ -106,6 +106,6 @@ In this example, the counter system is fixed with unintelligible symbols used fo
 
 ## See also
 
-- Other {{cssxref("@counter-style")}} descriptors, including, {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
+- Other {{cssxref("@counter-style")}} descriptors: {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
-- {{cssxref("symbols", "symbols()")}}, the functional notation creating anonymous counter styles.
+- {{cssxref("symbols", "symbols()")}}: the functional notation for creating anonymous counter styles.

--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -63,7 +63,9 @@ Assistive technology support is very limited for the `speak-as` property. Do not
 
 ### Setting the spoken form for a counter
 
-In this example, the counter system is fixed with unintelligible symbols used for the markers. To experience the result of the `speak-as` descriptor, use assistive technology such as VoiceOver or another screen reader or view the [accessibility panel](https://firefox-source-docs.mozilla.org/devtools-user/index.html#accessibility-inspector) in the developer tools of a browser that supports `speak-as`.
+In this example, the counter system is fixed with unintelligible symbols used for the visual markers. However, the `speak-as` descriptor is used to set the list item markers as numbers in the accessibility tree. When supported, numbers rather than visual markers will be read out by screen readers.
+
+To experience the result of the `speak-as` descriptor, use assistive technology such as VoiceOver or another screen reader or view the [accessibility panel](https://firefox-source-docs.mozilla.org/devtools-user/index.html#accessibility-inspector) in the developer tools of a browser that supports `speak-as`.
 
 #### HTML
 


### PR DESCRIPTION
Not much has changed with this descriptor. It's only supported in FF. I altered the example so walking thru it with a screen reader is more ovbvious if supported and a little more entertaining.