### PR TITLE
beforeinput does not fire on a select element

### DIFF
--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLElement.beforeinput_event
 
 {{APIRef}}
 
-The DOM **`beforeinput`** event fires when the value of an {{HTMLElement("input")}}, or {{HTMLElement("textarea")}} element is about to be modified. The event also applies to elements with {{domxref("HTMLElement.contentEditable", "contenteditable")}} enabled, and to any element when {{domxref("Document.designMode", "designMode")}} is turned on.
+The DOM **`beforeinput`** event fires when the value of an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is about to be modified. But in contrast to the `input` event, it does not fire on the {{HTMLSelect("select")}} element. The event also applies to elements with {{domxref("HTMLElement.contentEditable", "contenteditable")}} enabled, and to any element when {{domxref("Document.designMode", "designMode")}} is turned on.
 
 This allows web apps to override text edit behavior before the browser modifies the DOM tree, and provides more control over input events to improve performance.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- state that in contrast to the input event, the the beforeinput event does not fire on a select element.
- fix punctuation error

### Motivation

failed to notice that in contrast to the `input `event, which lists `input`, `select `and `textarea`, `beforeinput `only lists `input `and `textarea `. This difference is too subtle. Also note that https://github.com/mdn/content/pull/17484 just removed `select` from the list and left the trailing comma (,)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

https://github.com/mdn/content/pull/17484


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
