### PR TITLE
fix: image is not readable in dark theme

### DIFF
--- a/files/en-us/glossary/decryption/index.md
+++ b/files/en-us/glossary/decryption/index.md
@@ -10,7 +10,7 @@ In {{glossary("cryptography")}}, **decryption** is the conversion of {{glossary(
 
 Decryption is a cryptographic primitive: it transforms a ciphertext message into plaintext using a cryptographic algorithm called a {{glossary("cipher")}}. Like encryption, decryption in modern ciphers is performed using a specific algorithm and a secret, called the {{glossary("key")}}. Since the algorithm is often public, the key must stay secret if the encryption stays secure.
 
-![The decryption primitive.](decryption.png)
+<img src="decryption.png" style="background-color: white;" alt="The decryption primitive.">
 
 Decryption is the reverse of {{glossary("encryption")}} and if the key stays secret, decryption without knowing the specific secret, decryption is mathematically hard to perform. How hard depends on the security of the cryptographic algorithm chosen and evolves with the progress of {{glossary("cryptanalysis")}}.
 

--- a/files/en-us/glossary/encryption/index.md
+++ b/files/en-us/glossary/encryption/index.md
@@ -10,6 +10,6 @@ In {{glossary("cryptography")}}, **encryption** is the conversion of {{glossary(
 
 Encryption is a cryptographic primitive: it transforms a plaintext message into a ciphertext using a cryptographic algorithm called a {{glossary("cipher")}}. Encryption in modern ciphers is performed using a specific algorithm and a secret, called the {{glossary("key")}}. Since the algorithm is often public, the key must stay secret if the encryption stays secure.
 
-![How encryption works.](encryption.png)
+<img src="encryption.png" style="background-color: white;" alt="How encryption works.">
 
 Without knowing the secret, the reverse operation, {{glossary("decryption")}}, is mathematically hard to perform. How hard depends on the security of the cryptographic algorithm chosen and evolves with the progress of {{glossary("cryptanalysis")}}.

--- a/files/en-us/glossary/mvc/index.md
+++ b/files/en-us/glossary/mvc/index.md
@@ -18,7 +18,7 @@ The three parts of the MVC software-design pattern can be described as follows:
 
 Imagine a simple shopping list app. All we want is a list of the name, quantity and price of each item we need to buy this week. Below we'll describe how we could implement some of this functionality using MVC.
 
-![Diagram to show the different parts of the mvc architecture.](model-view-controller-light-blue.png)
+<img src="model-view-controller-light-blue.png" style="background-color: white" alt="Diagram to show the different parts of the mvc architecture.">
 
 ### The Model
 

--- a/files/en-us/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
+++ b/files/en-us/learn/common_questions/web_mechanics/what_is_a_domain_name/index.md
@@ -46,7 +46,7 @@ To solve all those problems we use human-readable addresses called domain names.
 
 A domain name has a simple structure made of several parts (it might be one part only, two, three…), separated by dots and **read from right to left**:
 
-![Anatomy of the MDN domain name](structure.png)
+<img src="structure.png" style="background-color:white;" alt="Anatomy of the MDN domain name">
 
 Each of those parts provides specific information about the whole domain name.
 

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -14,7 +14,7 @@ This theory is not essential to writing web code in the short term, but before l
 
 Computers connected to the internet are called **clients** and **servers**. A simplified diagram of how they interact might look like this:
 
-![Two circles representing client and server. An arrow labelled request is going from client to server, and an arrow labelled responses is going from server to client](simple-client-server.png)
+<img src="simple-client-server.png" style="background-color:white;" alt="Two circles representing client and server. An arrow labelled request is going from client to server, and an arrow labelled responses is going from server to client">
 
 - Clients are the typical web user's internet-connected devices (for example, your computer connected to your Wi-Fi, or your phone connected to your mobile network) and web-accessing software available on those devices (usually a web browser like Firefox or Chrome).
 - Servers are computers that store webpages, sites, or apps. When a client device wants to access a webpage, a copy of the webpage is downloaded from the server onto the client machine to be displayed in the user's web browser.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Images were not readable in dark theme, so changed the background color to white.

### Motivation

The png images on the website are unreadable in dark theme. So I changed their background colour to white which makes them much more readable.

### Additional details
Before, it was unreadable in dark mode, screenshot for reference:
<img src="https://github.com/mdn/content/assets/95935183/36ba29d5-3274-49f9-b20b-bae22c092367" width="100%" alt="decryption">

Now the image is readable.
<img src="https://github.com/mdn/content/assets/95935183/2072b909-d2b5-47d7-a7b3-e486e2077777" alt="decryption">

### Related issues and pull requests

Relates to #29840 
