### PR TITLE
webRequest StreamFilter ondata object property clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.webRequest.StreamFilter.ondata
 
 {{AddonSidebar()}}
 
-An event handler called repeatedly when response data is available. The handler is passed an [`event` interface object](/en-US/docs/web/api/event). However, the only reliable content in that object is the `data` property, which includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
+An event handler called repeatedly when response data is available. The handler is passed an [`Event` object](/en-US/docs/web/api/event) with a `data` property, which includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
 
 To decode the data, use either {{domxref("TextDecoder")}} or {{domxref("Blob")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.webRequest.StreamFilter.ondata
 
 {{AddonSidebar()}}
 
-An event handler called repeatedly when response data is available. The handler is passed an [`Event` object](/en-US/docs/web/api/event) with a `data` property, which includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
+An event handler called repeatedly when response data is available. The handler is passed an [`Event` object](/en-US/docs/web/api/event) with a `data` property. The `data` property includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
 
 To decode the data, use either {{domxref("TextDecoder")}} or {{domxref("Blob")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/streamfilter/ondata/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.webRequest.StreamFilter.ondata
 
 {{AddonSidebar()}}
 
-An event handler that is called repeatedly when response data is available. The handler is passed an `event` object containing a `data` property, which includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
+An event handler called repeatedly when response data is available. The handler is passed an [`event` interface object](/en-US/docs/web/api/event). However, the only reliable content in that object is the `data` property, which includes a chunk of the response data as an {{jsxref("ArrayBuffer")}}.
 
 To decode the data, use either {{domxref("TextDecoder")}} or {{domxref("Blob")}}.
 


### PR DESCRIPTION
### Description

Fixes [#18601](https://github.com/mdn/content/issues/18601) by providing clarification about the content of the `event` object.
