### PR TITLE
fix: typofix (s/IndexDB/IndexedDB) + headings structure

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -119,7 +119,7 @@ We are using the [Web Storage API](/en-US/docs/Web/API/Web_Storage_API), specifi
 
 [LocalStorage](/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage#storing_simple_data_—_web_storage) has several limitations, but suffices for our apps needs. We're using localStorage to make this simple and client-side only. This means the data will only be stored on one browser on a single device. Clearing the browser data will also lose all locally stored periods. What may seem like a limitation for many applications may be an asset in the case of this application, as menstrual cycle data is personal, and the user of such an app may very rightly be concerned about privacy.
 
-For a more robust application, other [client side storage](/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage) options like [IndexDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) (IDB) and, discussed later, service workers, have better performance.
+For a more robust application, other [client side storage](/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage) options like [IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) (IDB) and, discussed later, service workers, have better performance.
 
 Limitations of `localStorage` include:
 

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -128,7 +128,7 @@ Limitations of `localStorage` include:
 - Can cause poor performance: Getting and setting from and to local storage is done synchronously on the main thread. When the main thread is occupied, apps are not responsive and appear frozen. With the limited nature of this app, this blip of bad user experience is negligible.
 - Only available to the main thread: In addition to the performance issues of occupying the main thread, service workers do not have access to the main thread, meaning the service worker can't directly set or get the local storage data.
 
-#### Retrieve, append, sort, and re-store data
+### Retrieve, append, sort, and re-store data
 
 Because we're using localStorage, which comprises of a single string, we retrieve the JSON string of data from local storage, parse the JSON data (if any), push the new pair of dates to the existing array, sort the dates, parse the JSON object back into a string, and save that string back to `localStorage`.
 
@@ -167,7 +167,7 @@ function getAllStoredPeriods() {
 }
 ```
 
-### Render data to screen
+## Render data to screen
 
 The last step of our application is to render the list of past periods to the screen along with a heading.
 
@@ -222,7 +222,7 @@ function formatDate(dateString) {
 }
 ```
 
-## Render past periods on load
+### Render past periods on load
 
 When the deferred JavaScript runs on page load, we render past periods, if any.
 


### PR DESCRIPTION
Trivial typofix
Edit: also added a fix for headings as VS Code warned me about jumping from ## to #### 