### PR TITLE
fix(RTCRtpSender): link to own method, not RTCRtpReceiver

### DIFF
--- a/files/en-us/web/api/rtcrtpsender/index.md
+++ b/files/en-us/web/api/rtcrtpsender/index.md
@@ -19,7 +19,7 @@ With it, you can configure the encoding used for the corresponding track, get in
   - : The {{domxref("MediaStreamTrack")}} which is being handled by the `RTCRtpSender`. If `track` is `null`, the `RTCRtpSender` doesn't transmit anything.
 - {{domxref("RTCRtpSender.transport")}} {{ReadOnlyInline}}
   - : The {{domxref("RTCDtlsTransport")}} over which the sender is exchanging the RTP and RTCP packets used to manage transmission of media and control data. This value is `null` until the transport is established. When bundling is in use, more than transceiver may be sharing the same transport object.
-- {{domxref("RTCRtpReceiver.transform")}}
+- {{domxref("RTCRtpSender.transform")}}
   - : An {{domxref("RTCRtpScriptTransform")}}<!-- or {{domxref("SFrameTransform")}} --> is used to insert a transform stream ({{domxref("TransformStream")}}) running in a worker thread into the sender pipeline, allowing stream transforms to be applied to encoded video and audio frames after they are output by a codec, and before they are sent.
 
 ### Obsolete properties


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes an inconsistency on the [RTCRtpSender](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender#instance_properties) page, where the `transform` property links to RTCRtp**Receiver**.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

- fixes https://github.com/mdn/content/issues/29640


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
