### PR TITLE
See also: add CSS module links

### DIFF
--- a/files/en-us/web/api/csscounterstylerule/index.md
+++ b/files/en-us/web/api/csscounterstylerule/index.md
@@ -53,3 +53,4 @@ _This interface doesn't implement any specific method but inherits methods from 
 ## See also
 
 - {{CSSxRef("@counter-style")}}
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module

--- a/files/en-us/web/css/@counter-style/pad/index.md
+++ b/files/en-us/web/css/@counter-style/pad/index.md
@@ -94,3 +94,4 @@ ul {
 - List style properties: {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - {{cssxref("symbols", "symbols()")}} function to create anonymous counter styles
 - [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/@counter-style/prefix/index.md
+++ b/files/en-us/web/css/@counter-style/prefix/index.md
@@ -86,3 +86,5 @@ In this example, each counter number is prefixed by "Book " (with a space) and f
 - Other {{cssxref("@counter-style")}} descriptors: {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, {{cssxref("@counter-style/speak-as", "speak-as")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - {{cssxref("symbols", "symbols()")}}: the functional notation for creating anonymous counter styles
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/@counter-style/range/index.md
+++ b/files/en-us/web/css/@counter-style/range/index.md
@@ -130,3 +130,5 @@ The first range is the list of ranges includes 2, 3, and 4. The second includes 
 - Other {{cssxref("@counter-style")}} descriptors: {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/pad", "pad")}}, {{cssxref("@counter-style/speak-as", "speak-as")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - {{cssxref("symbols", "symbols()")}}: the functional notation for creating anonymous counter styles.
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -111,3 +111,5 @@ To experience the result of the `speak-as` descriptor, use assistive technology 
 - Other {{cssxref("@counter-style")}} descriptors: {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - {{cssxref("symbols", "symbols()")}}: the functional notation for creating anonymous counter styles.
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/@counter-style/suffix/index.md
+++ b/files/en-us/web/css/@counter-style/suffix/index.md
@@ -79,3 +79,5 @@ The **`suffix`** descriptor takes as its value a single `<symbol>`:
 - Other {{cssxref("@counter-style")}} descriptors: {{cssxref("@counter-style/system","system")}}, {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, {{cssxref("@counter-style/speak-as", "speak-as")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - {{cssxref("symbols", "symbols()")}}: the functional notation for creating anonymous counter styles
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/_doublecolon_marker/index.md
+++ b/files/en-us/web/css/_doublecolon_marker/index.md
@@ -68,3 +68,6 @@ ul li::marker {
 ## See also
 
 - HTML elements that have marker boxes by default: {{HTMLElement("ol")}}, {{HTMLElement("li")}}, {{HTMLElement("summary")}}
+- [CSS generated content](/en-US/docs/Web/CSS/CSS_generated_content) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module

--- a/files/en-us/web/css/counter-increment/index.md
+++ b/files/en-us/web/css/counter-increment/index.md
@@ -128,5 +128,5 @@ i {
 - Counter at-rule: {{cssxref("@counter-style")}}
 - Counter functions: {{cssxref("counter", "counter()")}}, {{cssxref("counters", "counters()")}}
 - [Using CSS counters](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) guide
-- [CSS lists](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
 - [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module

--- a/files/en-us/web/css/counter-reset/index.md
+++ b/files/en-us/web/css/counter-reset/index.md
@@ -122,3 +122,5 @@ h1 {
 - {{cssxref("@counter-style")}}
 - {{cssxref("counter", "counter()")}} and {{cssxref("counters", "counters()")}} functions
 - {{cssxref("content")}} property
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/counter-set/index.md
+++ b/files/en-us/web/css/counter-set/index.md
@@ -86,3 +86,5 @@ h1 {
 - {{cssxref("@counter-style")}}
 - {{cssxref("counter", "counter()")}} and {{cssxref("counters", "counters()")}} functions
 - {{cssxref("content")}} property
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/counter/index.md
+++ b/files/en-us/web/css/counter/index.md
@@ -119,3 +119,6 @@ li::after {
 - {{cssxref("counter-increment")}}
 - {{cssxref("@counter-style")}}
 - CSS [`counters()`](/en-US/docs/Web/CSS/counters) function
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS generated content](/en-US/docs/Web/CSS/CSS_generated_content) module

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -165,3 +165,6 @@ li::before {
 - {{cssxref("@counter-style")}}
 - CSS [`counter()`](/en-US/docs/Web/CSS/counter) function
 - {{cssxref("::marker")}}
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS generated content](/en-US/docs/Web/CSS/CSS_generated_content) module

--- a/files/en-us/web/css/css_counter_styles/index.md
+++ b/files/en-us/web/css/css_counter_styles/index.md
@@ -54,7 +54,7 @@ No properties are defined in this module
 
 ## Related concepts
 
-[CSS lists](/en-US/docs/Web/CSS/CSS_lists) module:
+[CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module:
 
 - {{cssxref("counter-increment")}} property
 - {{cssxref("counter-reset")}} property

--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -311,3 +311,5 @@ li::before {
 - {{cssxref("counter-set")}}
 - {{cssxref("counter-increment")}}
 - {{cssxref("@counter-style")}}
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module

--- a/files/en-us/web/css/css_lists/index.md
+++ b/files/en-us/web/css/css_lists/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS lists
+title: CSS lists and counters
 slug: Web/CSS/CSS_lists
 page-type: css-module
 spec-urls: https://drafts.csswg.org/css-lists/
@@ -7,7 +7,7 @@ spec-urls: https://drafts.csswg.org/css-lists/
 
 {{CSSRef}}
 
-The **CSS lists** module defines how lists can be laid out and styled.
+The **CSS lists and counters** module enables styling list counters, including styling, positioning, and manipulating their values.
 
 ## Reference
 

--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -709,3 +709,5 @@ container.addEventListener("change", (event) => {
 
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}
 - [Counter styles converter](https://r12a.github.io/app-counters/)
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module

--- a/files/en-us/web/css/list-style/index.md
+++ b/files/en-us/web/css/list-style/index.md
@@ -155,5 +155,5 @@ These CSS workarounds should only be used when an HTML solution is unavailable, 
 
 - {{Cssxref("list-style-type")}}, {{Cssxref("list-style-image")}}, and {{Cssxref("list-style-position")}} properties
 - {{Cssxref("::marker")}} pseudo-element
-- [CSS lists](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
 - [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module

--- a/files/en-us/web/css/visual_formatting_model/index.md
+++ b/files/en-us/web/css/visual_formatting_model/index.md
@@ -108,7 +108,7 @@ In addition, the references for specific values of display explain how these for
 - [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout)
 - [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout)
 - [CSS table](/en-US/docs/Web/CSS/CSS_table) module
-- [CSS lists](/en-US/docs/Web/CSS/CSS_lists) module
+- [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
 
 ### Independent formatting contexts
 


### PR DESCRIPTION
Added the lists and counters, counter styles, and generated content modules to the see also sections of the various pages that needed it.

Note that css_lists is updated here. This is a temporary fix. I am currently working on an overhaul of that page. This is NOT that. However, the name and definition of the module really needed to be corrected.