### PR TITLE
A small fix to `{{APIRef()}}` of `Keyboard.lock()`

### DIFF
--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Keyboard.lock
 ---
 
-{{APIRef("Keyboard Map API")}}{{SeeCompatTable}}{{securecontext_header}}
+{{APIRef("Keyboard API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **`lock()`** method of the
 {{domxref("Keyboard")}} interface returns a {{jsxref('Promise')}} after enabling the


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

on https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/lock

note that the two standards `Keyboard Map API` and `Keyboard Lock API` are combined as `Keyboard API` in mdn documentation

so replace `{{APIRef("Keyboard Map API")}}` with `{{APIRef("Keyboard API")}}`

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

see https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/unlock and https://github.com/mdn/content/blob/main/files/en-us/web/api/keyboard/unlock/index.md?plain=1

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
