### PR TITLE
Add frameAncestors to OnBeforeSendHeaders.details

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -84,6 +84,12 @@ Events have three functions:
   - : `string`. If the request is from a tab open in a contextual identity, the cookie store ID of the contextual identity. See [Work with contextual identities](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) for more information.
 - `documentUrl`
   - : `string`. URL of the document in which the resource will be loaded. For example, if the web page at "https\://example.com" contains an image or an iframe, then the `documentUrl` for the image or iframe will be "https\://example.com". For a top-level document, `documentUrl` is undefined.
+- `frameAncestors`
+  - : `array`. Contains information for each document in the frame hierarchy up to the top-level document. The first element in the array contains information about the immediate parent of the document being requested, and the last element contains information about the top-level document. If the load is actually for the top-level document, then this array is empty.
+    - `url`
+      - : `string`. The URL that the document was loaded from.
+    - `frameId`
+      - : `integer`. The `frameId` of the document. `details.frameAncestors[0].frameId` is the same as `details.parentFrameId`.
 - `frameId`
   - : `integer`. Zero if the request happens in the main frame; a positive value is the ID of a subframe in which the request happens. If the document of a (sub-)frame is loaded (`type` is `main_frame` or `sub_frame`), `frameId` indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique within a tab.
 - `incognito`


### PR DESCRIPTION
It can be observed in Firefox that the details in the OnBeforeSendHeaders callback have the frameAncestors field. This was previously not documented on MDN.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Add frameAncestors to OnBeforeSendHeaders details field list.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The field exists and might be useful for others to know about.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

I can't find any evidence of the field existing except that I exists in code that I need to maintain which was written by at-the-time Firefox contributors and that that code successfully returns the expected value just like in onBeforeRequest.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
