### PR TITLE
Add more entries to "See also" section in "Wrapping and breaking text"

### DIFF
--- a/files/en-us/web/css/css_text/wrapping_breaking_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_breaking_text/index.md
@@ -54,9 +54,9 @@ To add hyphens when words are broken, use the CSS {{cssxref("hyphens")}} propert
 
 {{EmbedGHLiveSample("css-examples/css-text/hyphens.html", '100%', 600)}}
 
-You can also use the {{cssxref("hyphenate-character")}} property to use the string of your choice instead of the hyphen character at the end of the line (before the hyphenation line break).
+You can also use the {{cssxref("hyphenate-character")}} property to use the string of your choice instead of the default hyphenation character at the end of the line (before the hyphenation line break) for the language. The `auto` value selects the correct value to mark a mid-word line break according to the typographic conventions of the current content language.
 
-This property also takes the value `auto`, which will select the correct value to mark a mid-word line break according to the typographic conventions of the current content language.
+CSS provides additional hyphenation control: the {{cssxref("hyphenate-limit-chars")}} property can be used to set the minimum word length that allows for hyphenation as well as the minimum number of characters before and after the hyphen.
 
 ## The `<wbr>` element
 

--- a/files/en-us/web/css/css_text/wrapping_breaking_text/index.md
+++ b/files/en-us/web/css/css_text/wrapping_breaking_text/index.md
@@ -72,5 +72,8 @@ In the below example the text breaks in the location of the {{HTMLElement("wbr")
 - The CSS {{cssxref("word-break")}} property
 - The CSS {{cssxref("overflow-wrap")}} property
 - The CSS {{cssxref("white-space")}} property
+- The CSS {{cssxref("text-wrap")}} property
 - The CSS {{cssxref("hyphens")}} property
+- The CSS {{cssxref("hyphenate-character")}} property
+- The CSS {{cssxref("hyphenate-limit-chars")}} property
 - [Overflow and Data Loss in CSS](https://www.smashingmagazine.com/2019/09/overflow-data-loss-css/)


### PR DESCRIPTION
### Description

Add links to the [`text-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap), [`hyphenate-character`](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-character) and [`hyphenate-limit-chars`](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-limit-chars) CSS properties to the "See also" section of the [Wrapping and breaking text](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_text/Wrapping_breaking_text) page.

### Motivation

There properties (especially `text-wrap`) are relevant for text wrapping, so they should be mentioned in this overview page.

### Related issues and pull requests

This PR follows the same logic as #22350, so it could be considered sort of a follow-up to it.

