### PR TITLE
fixing a typo

### DIFF
--- a/files/en-us/web/css/_colon_visited/index.md
+++ b/files/en-us/web/css/_colon_visited/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.visited
 
 {{CSSRef}}
 
-The **`:visited`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) applies once the link has been visited by the user. For privacy reasons, the styles that can be modified using this selector are very limited. The `:visited` pseudo-class applies only {{htmlelement("a")}} and {{htmlelement("area")}} elements that have an `href` attribute.
+The **`:visited`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) applies once the link has been visited by the user. For privacy reasons, the styles that can be modified using this selector are very limited. The `:visited` pseudo-class applies only to {{htmlelement("a")}} and {{htmlelement("area")}} elements that have an `href` attribute.
 
 {{EmbedInteractiveExample("pages/tabbed/pseudo-class-visited.html", "tabbed-shorter")}}
 


### PR DESCRIPTION
### Description

fixed a typo — 'to' is missing after 'only' in "applies only `<a>` and `<area>` elements that have an href attribute"

### Motivation

n/a

### Additional details

n/a

### Related issues and pull requests

n/a