### PR TITLE
Update “Element: removeAttribute()” example that used obsolete attribute

### DIFF
--- a/files/en-us/web/api/element/removeattribute/index.md
+++ b/files/en-us/web/api/element/removeattribute/index.md
@@ -41,8 +41,8 @@ You should use `removeAttribute()` instead of setting the attribute value to
 ## Examples
 
 ```js
-// Given: <div id="div1" align="left" width="200px">
-document.getElementById("div1").removeAttribute("align");
+// Given: <div id="div1" disabled width="200px">
+document.getElementById("div1").removeAttribute("disabled");
 // Now: <div id="div1" width="200px">
 ```
 


### PR DESCRIPTION
The attribute used in the example has been deprecated so it should be changed.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I add a more appropriate attribute ("disabled") to the example and removed the deprecated ("align") attribute.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It might be misleading for readers to see a deprecated attribute on an example from mdn.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
