### PR TITLE
Express BookInstance update - better option select markup

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
@@ -115,7 +115,7 @@ block content
       select#book.form-control(type='select' placeholder='Select book' name='book' required='true')
         - book_list.sort(function(a, b) {let textA = a.title.toUpperCase(); let textB = b.title.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
         for book in book_list
-          option(value=book._id, selected=(selected_book==book._id.toString() ? 'selected' : false) ) #{book.title}
+          option(value=book._id, selected=(selected_book==book._id.toString() ? '' : false) ) #{book.title}
 
     div.form-group
       label(for='imprint') Imprint:


### PR DESCRIPTION
 This improves the pug form for the BookInstance update template so that the selected book has `<option selected>` rather than `<option selected="selected">`. Note that both are valid, and both work. It's just that the changed version is more familiar and easier to read.

note that setting the value to `false` is somewhat arbitrary - any value other than `selected` or the null string is taken as false.

Corresponding worked example update: https://github.com/mdn/express-locallibrary-tutorial/pull/238

Fixes #29859
