### PR TITLE
Django: Get user model from settings

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -65,7 +65,7 @@ MIDDLEWARE = [
 You already created your first user when we looked at the [Django admin site](/en-US/docs/Learn/Server-side/Django/Admin_site) in tutorial 4 (this was a superuser, created with the command `python manage.py createsuperuser`).
 Our superuser is already authenticated and has all permissions, so we'll need to create a test user to represent a normal site user. We'll be using the admin site to create our _locallibrary_ groups and website logins, as it is one of the quickest ways to do so.
 
-> **Note:** You can also create users programmatically, as shown below.
+> **Note:** You can also create users programmatically as shown below.
 > You would have to do this, for example, if developing an interface to allow "ordinary" users to create their own logins (you shouldn't give most users access to the admin site).
 >
 > ```python
@@ -80,7 +80,24 @@ Our superuser is already authenticated and has all permissions, so we'll need to
 > user.save()
 > ```
 >
-> It is highly recommended to set up a custom user model when starting an actual project. You'll be able to easily customize it in the future if the need arises. For more information, see [Using a custom user model when starting a project](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project) (Django docs).
+> Note however that it is highly recommended to set up a _custom user model_ when starting a project, as you'll be able to easily customize it in the future if the need arises.
+> If using a custom user model the code to create the same user would look like this:
+>
+> ```python
+> # Get current user model from settings
+> from django.contrib.auth import get_user_model
+> UserModel = get_user_model()
+>
+> # Create user from model and save to the database
+> user = UserModel.objects.create_user('myusername', 'myemail@crazymail.com', 'mypassword')
+>
+> # Update fields and then save again
+> user.first_name = 'Tyrone'
+> user.last_name = 'Citizen'
+> user.save()
+> ```
+>
+> For more information, see [Using a custom user model when starting a project](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project) (Django docs).
 
 Below we'll first create a group and then a user. Even though we don't have any permissions to add for our library members yet, if we need to later, it will be much easier to add them once to the group than individually to each member.
 
@@ -466,19 +483,31 @@ Unfortunately, we don't yet have any way for users to borrow books! So before we
 
 ### Models
 
-First, we're going to have to make it possible for users to have a `BookInstance` on loan (we already have a `status` and a `due_back` date, but we don't yet have any association between this model and a User. We'll create one using a `ForeignKey` (one-to-many) field. We also need an easy mechanism to test whether a loaned book is overdue.
+First, we're going to have to make it possible for users to have a `BookInstance` on loan (we already have a `status` and a `due_back` date, but we don't yet have any association between this model and a particular user. We'll create one using a `ForeignKey` (one-to-many) field. We also need an easy mechanism to test whether a loaned book is overdue.
 
-Open **catalog/models.py**, and import the `User` model from `django.contrib.auth.models` (add this just below the previous import line at the top of the file, so `User` is available to subsequent code that makes use of it):
-
-```python
-from django.contrib.auth.models import User
-```
-
-Next, add the `borrower` field to the `BookInstance` model:
+Open **catalog/models.py**, and import the `settings` from `django.conf` (add this just below the previous import line at the top of the file, so the settings are available to subsequent code that makes use of them):
 
 ```python
-borrower = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True)
+from django.conf import settings
 ```
+
+Next, add the `borrower` field to the `BookInstance` model, setting the user model for the key as the value of the setting `AUTH_USER_MODEL`.
+Since we have not overridden the setting with a [custom user model](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/) this maps to the default `User` model from `django.contrib.auth.models`.
+
+```python
+borrower = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True)
+```
+
+> **Note:** Importing the model in this way reduces the work required if you later discover that you need a custom user model.
+> This tutorial uses the default model, so you could instead import the `User` model directly with the following lines:
+>
+> ```python
+> from django.contrib.auth.models import User
+> ```
+>
+> ```python
+> borrower = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True)
+> ```
 
 While we're here, let's add a property that we can call from our templates to tell if a particular book instance is overdue.
 While we could calculate this in the template itself, using a [property](https://docs.python.org/3/library/functions.html#property) as shown below will be much more efficient.

--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -86,10 +86,10 @@ Our superuser is already authenticated and has all permissions, so we'll need to
 > ```python
 > # Get current user model from settings
 > from django.contrib.auth import get_user_model
-> UserModel = get_user_model()
+> User = get_user_model()
 >
 > # Create user from model and save to the database
-> user = UserModel.objects.create_user('myusername', 'myemail@crazymail.com', 'mypassword')
+> user = User.objects.create_user('myusername', 'myemail@crazymail.com', 'mypassword')
 >
 > # Update fields and then save again
 > user.first_name = 'Tyrone'

--- a/files/en-us/learn/server-side/django/testing/index.md
+++ b/files/en-us/learn/server-side/django/testing/index.md
@@ -582,15 +582,18 @@ Add the following test code to **/catalog/tests/test_views.py**. Here we first u
 import datetime
 
 from django.utils import timezone
-from django.contrib.auth.models import User # Required to assign User as a borrower
+
+# Get user model from settings
+from django.contrib.auth import get_user_model
+UserModel = get_user_model()
 
 from catalog.models import BookInstance, Book, Genre, Language
 
 class LoanedBookInstancesByUserListViewTest(TestCase):
     def setUp(self):
         # Create two users
-        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
-        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user1 = UserModel.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
+        test_user2 = UserModel.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
 
         test_user1.save()
         test_user2.save()
@@ -765,8 +768,8 @@ from django.contrib.auth.models import Permission # Required to grant the permis
 class RenewBookInstancesViewTest(TestCase):
     def setUp(self):
         # Create a user
-        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
-        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user1 = UserModel.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
+        test_user2 = UserModel.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
 
         test_user1.save()
         test_user2.save()

--- a/files/en-us/learn/server-side/django/testing/index.md
+++ b/files/en-us/learn/server-side/django/testing/index.md
@@ -585,15 +585,15 @@ from django.utils import timezone
 
 # Get user model from settings
 from django.contrib.auth import get_user_model
-UserModel = get_user_model()
+User = get_user_model()
 
 from catalog.models import BookInstance, Book, Genre, Language
 
 class LoanedBookInstancesByUserListViewTest(TestCase):
     def setUp(self):
         # Create two users
-        test_user1 = UserModel.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
-        test_user2 = UserModel.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
+        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
 
         test_user1.save()
         test_user2.save()
@@ -768,8 +768,8 @@ from django.contrib.auth.models import Permission # Required to grant the permis
 class RenewBookInstancesViewTest(TestCase):
     def setUp(self):
         # Create a user
-        test_user1 = UserModel.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
-        test_user2 = UserModel.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
+        test_user1 = User.objects.create_user(username='testuser1', password='1X<ISRUkw+tuK')
+        test_user2 = User.objects.create_user(username='testuser2', password='2HJ1vRV0Z&3iD')
 
         test_user1.save()
         test_user2.save()


### PR DESCRIPTION
This is an optimisation of the code to get a user model for creating a user, and also for adding an association between a borrowed bookinstance and a User.

I say optimisation because the current code works. However, as noted in https://github.com/mdn/django-locallibrary-tutorial/pull/127, in some places Django appears to recommend that you create a custom user and reference that instead (in others it just says "there are cases you will need to do this". 

This is a compromise. It shows how to reference a custom user model, but since we don't need one for this project, it defaults to the original. I think this is better because it is no more work for a user, and makes later adding a custom user model a lot easier.

Associated code is https://github.com/mdn/django-locallibrary-tutorial/pull/127 - which I will merge when this goes in.