### PR TITLE
FF120Relnote minPinLength WebAuthn extension

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -48,6 +48,8 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### APIs
 
+- The [Minimum PIN Length Extension (`minPinLength`)](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) is supported, allowing a relying party server to request the authenticator's minimum PIN length during creation/registration ([Firefox bug 1844450](https://bugzil.la/1844450)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF120 supports the [minPinLength](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) WebAuth extension in https://bugzilla.mozilla.org/show_bug.cgi?id=1844450.

This adds the release note.

Related docs work can be tracked in #29783