### PR TITLE
reorganize subtitles in 'Keyboard-navigable JavaScript widgets'

### DIFF
--- a/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.md
+++ b/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.md
@@ -8,11 +8,9 @@ page-type: guide
   {{ListSubpagesForSidebar("Web/Accessibility", 1)}}
 </section>
 
-### Overview
-
 Web applications often use JavaScript to mimic desktop widgets such as menus, tree views, rich text fields, and tab panels. These widgets are typically composed of {{ HTMLElement("div") }} and {{ HTMLElement("span") }} elements that do not, by nature, offer the same keyboard functionality that their desktop counterparts do. This document describes techniques to make JavaScript widgets accessible with the keyboard.
 
-### Using tabindex
+## Using tabindex
 
 By default, when people use the tab key to browse a webpage, only interactive elements (like links, form controls) get focused. With the `tabindex` [global attribute](/en-US/docs/Web/HTML/Global_attributes), authors can make other elements focusable, too. When set to `0`, the element becomes focusable by keyboard and script. When set to `-1`, the element becomes focusable by script, but it does not become part of the keyboard focus order.
 
@@ -54,13 +52,13 @@ The following table describes `tabindex` behavior in modern browsers:
   </tbody>
 </table>
 
-#### Non-native controls
+### Non-native controls
 
 Native HTML elements that are interactive, like {{ HTMLElement("a") }}, {{ HTMLElement("input") }} and {{ HTMLElement("select") }}, are already accessible by keyboards, so to use one of them is the fastest path to make components work with keyboards.
 
 Authors can also make a {{ HTMLElement("div") }} or {{ HTMLElement("span") }} keyboard accessible by adding a `tabindex` of `0`. This is particularly useful for components that use interactive elements that do not exist in HTML.
 
-#### Grouping controls
+### Grouping controls
 
 For grouping widgets such as menus, tablists, grids, or tree views, the parent element should be in the tab order (`tabindex="0"`), and each descendant choice/tab/cell/row should be removed from the tab order (`tabindex="-1"`). Users should be able to navigate the descendant elements using arrow keys. (For a full description of the keyboard support that is normally expected for typical widgets, see the [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.1/).)
 
@@ -101,14 +99,14 @@ The example below shows this technique used with a nested menu control. Once key
 
 When a custom control becomes disabled, remove it from the tab order by setting `tabindex="-1"`. Note that disabled items within a grouped widget (such as menu items in a menu) should remain navigable using arrow keys.
 
-### Managing focus inside groups
+## Managing focus inside groups
 
 When a user tabs away from a widget and returns, focus should return to the specific element that had focus, for example, the tree item or grid cell. There are two techniques for accomplishing this:
 
 1. Roving `tabindex`: programmatically moving focus
 2. `aria-activedescendant`: managing a 'virtual' focus
 
-#### Technique 1: Roving tabindex
+### Technique 1: Roving tabindex
 
 Setting the `tabindex` of the focused element to "0" ensures that if the user tabs away from the widget and then returns, the selected item within the group retains focus. Note that updating the `tabindex` to "0" requires also updating the previously selected item to `tabindex="-1"`. This technique involves programmatically moving focus in response to key events and updating the `tabindex` to reflect the currently focused item. To do this:
 
@@ -138,25 +136,25 @@ This technique involves binding a single event handler to the container widget a
 
 The `aria-activedescendant` property identifies the ID of the descendant element that currently has the virtual focus. The event handler on the container must respond to key and mouse events by updating the value of `aria-activedescendant` and ensuring that the current item is styled appropriately (for example, with a border or background color).
 
-### General Guidelines
+## General Guidelines
 
-#### Use onkeydown to trap key events, not onkeypress
+### Use onkeydown to trap key events, not onkeypress
 
 IE will not fire `keypress` events for non-alphanumeric keys. Use `onkeydown` instead.
 
-#### Ensure that keyboard and mouse produce the same experience
+### Ensure that keyboard and mouse produce the same experience
 
 To ensure that the user experience is consistent regardless of input device, keyboard and mouse event handlers should share code where appropriate. For example, the code that updates the `tabindex` or the styling when users navigate using the arrow keys should also be used by mouse click handlers to produce the same changes.
 
-#### Ensure that the keyboard can be used to activate element
+### Ensure that the keyboard can be used to activate element
 
 To ensure that the keyboard can be used to activate elements, any handlers bound to mouse events should also be bound to keyboard events. For example, to ensure that the Enter key will activate an element, if you have an `onclick="doSomething()"`, you should bind `doSomething()` to the key down event as well: `onkeydown="return event.keyCode !== 13 || doSomething();"`.
 
-#### Always draw the focus for tabindex="-1" items and elements that receive focus programmatically
+### Always draw the focus for tabindex="-1" items and elements that receive focus programmatically
 
 IE will not automatically draw the focus outline for items that programmatically receive focus. Choose between changing the background color via something like `this.style.backgroundColor = "gray";` or add a dotted border via `this.style.border = "1px dotted invert"`. In the dotted border case you will need to make sure those elements have an invisible 1px border to start with, so that the element doesn't grow when the border style is applied (borders take up space, and IE doesn't implement CSS outlines).
 
-#### Prevent used key events from performing browser functions
+### Prevent used key events from performing browser functions
 
 If your widget handles a key event, prevent the browser from also handling it (for example, scrolling in response to the arrow keys) by using your event handler's return code. If your event handler returns `false`, the event will not be propagated beyond your handler.
 
@@ -168,6 +166,6 @@ For example:
 
 If `handleKeyDown()` returns `false`, the event will be consumed, preventing the browser from performing any action based on the keystroke.
 
-#### Don't rely on consistent behavior for key repeat, at this point
+### Don't rely on consistent behavior for key repeat, at this point
 
 Unfortunately `onkeydown` may or may not repeat depending on what browser and OS you're running on.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

current document starts heading from h3, which is bad for navigation because 'In this article' is not generated properly

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
