### PR TITLE
chore(MDN): remove TenthCampaignQuote macro

### DIFF
--- a/files/en-us/mdn/at_ten/index.md
+++ b/files/en-us/mdn/at_ten/index.md
@@ -20,8 +20,6 @@ For ten years, the MDN community has been documenting the open Web. From fixing 
 
 [Learn more about contributing](/en-US/docs/MDN/Contribute)
 
-{{TenthCampaignQuote}}
-
 ## See also
 
 - [The history of MDN](/en-US/docs/MDN/At_ten/History_of_MDN)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes the invocation of the `{{TenthCampaignQuote}}` macro.

### Motivation

We want to remove it from yari, because it causes non-deterministic build results, and the page has very few users.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to:
- https://github.com/mdn/yari/pull/9906
- https://github.com/mdn/translated-content/pull/16768