### PR TITLE
relnote(120): removal of -moz-transform props

### DIFF
--- a/files/en-us/glossary/vendor_prefix/index.md
+++ b/files/en-us/glossary/vendor_prefix/index.md
@@ -78,4 +78,6 @@ requestAnimationFrame(callback);
 
 ## See also
 
+- [Mozilla vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)
+- [WebKit vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/WebKit_Extensions)
 - [Browser prefixes](https://en.wikipedia.org/wiki/CSS_hack#Browser_prefixes) on Wikipedia

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -20,8 +20,15 @@ This article provides information about the changes in Firefox 120 that affect d
 
 #### Removals
 
-- The `-moz` prefixed properties for CSS transforms have been disabled with the `layout.css.prefixes.transforms` set to `false`.
-  The standard `transform` properties should be used instead ([Firefox bug 1855763](https://bugzil.la/1855763)).
+- The `-moz-` prefixed [CSS transform](/en-US/docs/Web/CSS/CSS_transforms) properties have been disabled via the `layout.css.prefixes.transforms` preference being set to `false` by default ([Firefox bug 1855763](https://bugzil.la/1855763)).
+  Specifically, the disabled properties are:
+
+  - `-moz-backface-visibility`
+  - `-moz-perspective`
+  - `-moz-perspective-origin`
+  - `-moz-transform`
+  - `-moz-transform-origin`
+  - `-moz-transform-style`
 
 ### JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -20,7 +20,8 @@ This article provides information about the changes in Firefox 120 that affect d
 
 #### Removals
 
-- The deprecated `-moz-transform` CSS property has been removed. Use the standard `transform` property instead ([Firefox bug 1855763](https://bugzil.la/1855763)).
+- The `-moz` prefixed properties for CSS transforms have been disabled with the `layout.css.prefixes.transforms` set to `false`.
+  The standard `transform` properties should be used instead ([Firefox bug 1855763](https://bugzil.la/1855763)).
 
 ### JavaScript
 
@@ -49,11 +50,6 @@ This article provides information about the changes in Firefox 120 that affect d
 #### Removals
 
 ### APIs
-
-- The {{domxref("PublicKeyCredential.authenticatorAttachment", "authenticatorAttachment")}} property of the {{domxref("PublicKeyCredential")}} interface is now supported.
-  This allows web application client and server code to configure itself based on whether the authenticator is part of the device running web authentication, or can roam between devices (see [Firefox bug 1810851](https://bugzil.la/1810851)).
-  
-- The [Minimum PIN Length Extension (`minPinLength`)](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) is supported, allowing a relying party server to request the authenticator's minimum PIN length during creation/registration ([Firefox bug 1844450](https://bugzil.la/1844450)).
 
 #### DOM
 

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -51,6 +51,11 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### APIs
 
+- The {{domxref("PublicKeyCredential.authenticatorAttachment", "authenticatorAttachment")}} property of the {{domxref("PublicKeyCredential")}} interface is now supported.
+  This allows web application client and server code to configure itself based on whether the authenticator is part of the device running web authentication, or can roam between devices (see [Firefox bug 1810851](https://bugzil.la/1810851)).
+
+- The [Minimum PIN Length Extension (`minPinLength`)](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) is supported, allowing a relying party server to request the authenticator's minimum PIN length during creation/registration ([Firefox bug 1844450](https://bugzil.la/1844450)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -8,7 +8,7 @@ status:
 
 {{CSSRef}}
 
-Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, including properties, values, pseudo-elements and pseudo-classes, at-rules, and media queries. These extensions are prefixed with `-moz-`.
+Firefox supports a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, including properties, values, pseudo-elements and pseudo-classes, at-rules, and media queries. These extensions are prefixed with `-moz-`.
 
 > **Note:** These extensions are mostly experimental or deprecated but kept for backward compatibility. Avoid using them on production websites.
 
@@ -38,56 +38,56 @@ Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, 
 
 ### A
 
-- {{CSSxRef("animation", "-moz-animation")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-delay", "-moz-animation-delay")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-direction", "-moz-animation-direction")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-duration", "-moz-animation-duration")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-fill-mode", "-moz-animation-fill-mode")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-iteration-count", "-moz-animation-iteration-count")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-name", "-moz-animation-name")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-play-state", "-moz-animation-play-state")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("animation-timing-function","-moz-animation-timing-function")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("animation", "-moz-animation")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-delay", "-moz-animation-delay")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-direction", "-moz-animation-direction")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-duration", "-moz-animation-duration")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-fill-mode", "-moz-animation-fill-mode")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-iteration-count", "-moz-animation-iteration-count")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-name", "-moz-animation-name")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-play-state", "-moz-animation-play-state")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("animation-timing-function","-moz-animation-timing-function")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("appearance","-moz-appearance")}} {{Experimental_Inline}}
 
 ### B
 
-- {{CSSxRef("backface-visibility", "-moz-backface-visibility")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("backface-visibility")}}]
+- {{CSSxRef("backface-visibility", "-moz-backface-visibility")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("backface-visibility")}})
 - {{CSSxRef("background-clip", "-moz-background-clip")}} {{deprecated_inline}}
 - {{CSSxRef("background-origin", "-moz-background-origin")}} {{deprecated_inline}}
-- {{CSSxRef("box-decoration-break", "-moz-background-inline-policy")}} {{deprecated_inline}} \[Superseded by the standard version {{CSSxRef("box-decoration-break")}}]
+- {{CSSxRef("box-decoration-break", "-moz-background-inline-policy")}} {{deprecated_inline}} (No longer supported; use the standard {{CSSxRef("box-decoration-break")}})
 - {{CSSxRef("background-size", "-moz-background-size")}} {{deprecated_inline}}
-- {{CSSxRef("border-inline-end", "-moz-border-end")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-end")}}]
-- {{CSSxRef("border-inline-color", "-moz-border-end-color")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-end-color")}}]
-- {{CSSxRef("border-inline-style", "-moz-border-end-style")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-end-style")}}]
-- {{CSSxRef("border-inline-width", "-moz-border-end-width")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-end-width")}}]
+- {{CSSxRef("border-inline-end", "-moz-border-end")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-end")}})
+- {{CSSxRef("border-inline-color", "-moz-border-end-color")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-end-color")}})
+- {{CSSxRef("border-inline-style", "-moz-border-end-style")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-end-style")}})
+- {{CSSxRef("border-inline-width", "-moz-border-end-width")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-end-width")}})
 - {{CSSxRef("border-image", "-moz-border-image")}} {{Deprecated_Inline}}
-- {{CSSxRef("border-inline-start", "-moz-border-start")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-start")}}]
-- {{CSSxRef("border-inline-start-color", "-moz-border-start-color")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-start-color")}}]
-- {{CSSxRef("border-inline-start-style", "-moz-border-start-style")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-start-style")}}]
-- {{CSSxRef("border-inline-start-width", "-moz-border-start-width")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("border-inline-start-width")}}]
-- {{CSSxRef("box-sizing", "-moz-box-sizing")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("border-inline-start", "-moz-border-start")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-start")}})
+- {{CSSxRef("border-inline-start-color", "-moz-border-start-color")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-start-color")}})
+- {{CSSxRef("border-inline-start-style", "-moz-border-start-style")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-start-style")}})
+- {{CSSxRef("border-inline-start-width", "-moz-border-start-width")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("border-inline-start-width")}})
+- {{CSSxRef("box-sizing", "-moz-box-sizing")}} {{Deprecated_Inline}} (Prefixed version still supported)
 
 ### C
 
-- {{CSSxRef("clip-path")}} {{Experimental_Inline}} \[Applying to more than SVG]
-- {{CSSxRef("column-count", "-moz-column-count")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-fill", "-moz-column-fill")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-gap", "-moz-column-gap")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-width", "-moz-column-width")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-rule", "-moz-column-rule")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-rule-width", "-moz-column-rule-width")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-rule-style", "-moz-column-rule-style")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("column-rule-color", "-moz-column-rule-color")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("clip-path")}} {{Experimental_Inline}} (Applying to more than SVG)
+- {{CSSxRef("column-count", "-moz-column-count")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-fill", "-moz-column-fill")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-gap", "-moz-column-gap")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-width", "-moz-column-width")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-rule", "-moz-column-rule")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-rule-width", "-moz-column-rule-width")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-rule-style", "-moz-column-rule-style")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("column-rule-color", "-moz-column-rule-color")}} {{Deprecated_Inline}} (Prefixed version still supported)
 
 ### F–M
 
-- {{CSSxRef("filter")}} {{Experimental_Inline}} \[Applying to more than SVG]
-- {{CSSxRef("font-feature-settings", "-moz-font-feature-settings")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("font-language-override", "-moz-font-language-override")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("hyphens", "-moz-hyphens")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("margin-inline-end", "-moz-margin-end")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("margin-inline-end")}}]
-- {{CSSxRef("margin-inline-start", "-moz-margin-start")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("margin-inline-start")}}]
-- {{CSSxRef("mask")}} {{Experimental_Inline}} \[Applying to more than SVG]
+- {{CSSxRef("filter")}} {{Experimental_Inline}} (Applying to more than SVG)
+- {{CSSxRef("font-feature-settings", "-moz-font-feature-settings")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("font-language-override", "-moz-font-language-override")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("hyphens", "-moz-hyphens")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("margin-inline-end", "-moz-margin-end")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("margin-inline-end")}})
+- {{CSSxRef("margin-inline-start", "-moz-margin-start")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("margin-inline-start")}})
+- {{CSSxRef("mask")}} {{Experimental_Inline}} (Applying to more than SVG)
 
 ### O
 
@@ -100,11 +100,11 @@ Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, 
 
 ### P
 
-- {{CSSxRef("padding-inline-end", "-moz-padding-end")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("padding-inline-end")}}]
-- {{CSSxRef("padding-inline-start", "-moz-padding-start")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("padding-inline-start")}}]
-- {{CSSxRef("perspective", "-moz-perspective")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("perspective")}}]
-- {{CSSxRef("perspective-origin", "-moz-perspective-origin")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("perspective-origin")}}]
-- {{CSSxRef("pointer-events")}} {{Experimental_Inline}} \[Applying to more than SVG]
+- {{CSSxRef("padding-inline-end", "-moz-padding-end")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("padding-inline-end")}})
+- {{CSSxRef("padding-inline-start", "-moz-padding-start")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("padding-inline-start")}})
+- {{CSSxRef("perspective", "-moz-perspective")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("perspective")}})
+- {{CSSxRef("perspective-origin", "-moz-perspective-origin")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("perspective-origin")}})
+- {{CSSxRef("pointer-events")}} {{Experimental_Inline}} (Applying to more than SVG)
 
 ### T–U
 
@@ -114,14 +114,14 @@ Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, 
 - {{CSSxRef("text-decoration-line", "-moz-text-decoration-line")}} {{deprecated_inline}}
 - {{CSSxRef("text-decoration-style", "-moz-text-decoration-style")}} {{deprecated_inline}}
 - {{CSSxRef("text-size-adjust", "-moz-text-size-adjust")}} {{Experimental_Inline}}
-- {{CSSxRef("transform", "-moz-transform")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("transform")}}]
-- {{CSSxRef("transform-origin", "-moz-transform-origin")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("transform-origin")}}]
-- {{CSSxRef("transform-style", "-moz-transform-style")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("transform-style")}}]
-- {{CSSxRef("transition", "-moz-transition")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("transition-delay", "-moz-transition-delay")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("transition-duration", "-moz-transition-duration")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("transition-property", "-moz-transition-property")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("transition-timing-function", "-moz-transition-timing-function")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("transform", "-moz-transform")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("transform")}})
+- {{CSSxRef("transform-origin", "-moz-transform-origin")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("transform-origin")}})
+- {{CSSxRef("transform-style", "-moz-transform-style")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("transform-style")}})
+- {{CSSxRef("transition", "-moz-transition")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("transition-delay", "-moz-transition-delay")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("transition-duration", "-moz-transition-duration")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("transition-property", "-moz-transition-property")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("transition-timing-function", "-moz-transition-timing-function")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("user-select", "-moz-user-select")}} {{Experimental_Inline}}
 
 ## Values
@@ -514,5 +514,4 @@ Properties: {{CSSxRef("width")}}, {{CSSxRef("min-width")}}, and {{CSSxRef("max-w
 ## See also
 
 - [Vendor Prefix](/en-US/docs/Glossary/Vendor_Prefix) glossary entry
-- [Mozilla vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)
 - [WebKit vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/WebKit_Extensions)

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -1,5 +1,5 @@
 ---
-title: Mozilla CSS extensions
+title: Mozilla vendor-prefixed CSS extensions
 slug: Web/CSS/Mozilla_Extensions
 page-type: landing-page
 status:
@@ -513,4 +513,6 @@ Properties: {{CSSxRef("width")}}, {{CSSxRef("min-width")}}, and {{CSSxRef("max-w
 
 ## See also
 
-- [WebKit CSS extensions](/en-US/docs/Web/CSS/WebKit_Extensions)
+- [Vendor Prefix](/en-US/docs/Glossary/Vendor_Prefix) glossary entry
+- [Mozilla vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)
+- [WebKit vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/WebKit_Extensions)

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -51,7 +51,7 @@ Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, 
 
 ### B
 
-- {{CSSxRef("backface-visibility", "-moz-backface-visibility")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("backface-visibility", "-moz-backface-visibility")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("backface-visibility")}}]
 - {{CSSxRef("background-clip", "-moz-background-clip")}} {{deprecated_inline}}
 - {{CSSxRef("background-origin", "-moz-background-origin")}} {{deprecated_inline}}
 - {{CSSxRef("box-decoration-break", "-moz-background-inline-policy")}} {{deprecated_inline}} \[Superseded by the standard version {{CSSxRef("box-decoration-break")}}]
@@ -102,8 +102,8 @@ Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, 
 
 - {{CSSxRef("padding-inline-end", "-moz-padding-end")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("padding-inline-end")}}]
 - {{CSSxRef("padding-inline-start", "-moz-padding-start")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("padding-inline-start")}}]
-- {{CSSxRef("perspective", "-moz-perspective")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("perspective-origin", "-moz-perspective-origin")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("perspective", "-moz-perspective")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("perspective")}}]
+- {{CSSxRef("perspective-origin", "-moz-perspective-origin")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("perspective-origin")}}]
 - {{CSSxRef("pointer-events")}} {{Experimental_Inline}} \[Applying to more than SVG]
 
 ### T–U
@@ -114,9 +114,9 @@ Firefox support a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_, 
 - {{CSSxRef("text-decoration-line", "-moz-text-decoration-line")}} {{deprecated_inline}}
 - {{CSSxRef("text-decoration-style", "-moz-text-decoration-style")}} {{deprecated_inline}}
 - {{CSSxRef("text-size-adjust", "-moz-text-size-adjust")}} {{Experimental_Inline}}
-- {{CSSxRef("transform", "-moz-transform")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("transform-origin", "-moz-transform-origin")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
-- {{CSSxRef("transform-style", "-moz-transform-style")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
+- {{CSSxRef("transform", "-moz-transform")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("transform")}}]
+- {{CSSxRef("transform-origin", "-moz-transform-origin")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("transform-origin")}}]
+- {{CSSxRef("transform-style", "-moz-transform-style")}} {{Deprecated_Inline}} \[Superseded by the standard version {{CSSxRef("transform-style")}}]
 - {{CSSxRef("transition", "-moz-transition")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
 - {{CSSxRef("transition-delay", "-moz-transition-delay")}} {{Deprecated_Inline}} \[Prefixed version still accepted]
 - {{CSSxRef("transition-duration", "-moz-transition-duration")}} {{Deprecated_Inline}} \[Prefixed version still accepted]

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -1,5 +1,5 @@
 ---
-title: WebKit CSS extensions
+title: WebKit vendor-prefixed CSS extensions
 slug: Web/CSS/WebKit_Extensions
 page-type: landing-page
 status:
@@ -520,5 +520,6 @@ For web-compatibility reasons, Blink, WebKit, and Gecko browsers treat all pseud
 
 ## See also
 
+- [Vendor Prefix](/en-US/docs/Glossary/Vendor_Prefix) glossary entry
+- [Mozilla vendor-prefixed CSS extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)
 - [Styling Form Controls on the WebKit Trac](https://trac.webkit.org/wiki/Styling%20Form%20Controls)
-- [Mozilla CSS Extensions](/en-US/docs/Web/CSS/Mozilla_Extensions)


### PR DESCRIPTION
The `layout.css.prefixes.transforms` pref covers more props than just `-moz-transform`, there are others, see https://hg.mozilla.org/mozilla-central/rev/a0041460ad93 and https://github.com/mdn/content/issues/29785#issuecomment-1785152204

__changes:__
- Mozilla CSS extensions page has details of which props should be used instead of the vendor prefixed versions
- Add "vendor-prefixed" to page titles, link to glossary

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/29785
- [x] content https://github.com/mdn/content/pull/29815
- [x] BCD https://github.com/mdn/browser-compat-data/pull/21122

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1855763
- https://bugzilla.mozilla.org/show_bug.cgi?id=390936