### PR TITLE
fix(formatting): relnotes have some accidentally-committed whitespace

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -52,7 +52,6 @@ This article provides information about the changes in Firefox 120 that affect d
 
 - The {{domxref("PublicKeyCredential.authenticatorAttachment", "authenticatorAttachment")}} property of the {{domxref("PublicKeyCredential")}} interface is now supported.
   This allows web application client and server code to configure itself based on whether the authenticator is part of the device running web authentication, or can roam between devices (see [Firefox bug 1810851](https://bugzil.la/1810851)).
-  
 - The [Minimum PIN Length Extension (`minPinLength`)](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) is supported, allowing a relying party server to request the authenticator's minimum PIN length during creation/registration ([Firefox bug 1844450](https://bugzil.la/1844450)).
 
 #### DOM


### PR DESCRIPTION
Stray newline is causing builds to be wobbly. See:

- [x] https://github.com/mdn/content/pull/29908
- [CI logs](https://github.com/mdn/content/actions/runs/6694264749/job/18187166574?pr=29908)
