### PR TITLE
FF120Relnote: UserActivation

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 120 that affect d
 - The {{domxref("PublicKeyCredential.authenticatorAttachment", "authenticatorAttachment")}} property of the {{domxref("PublicKeyCredential")}} interface is now supported.
   This allows web application client and server code to configure itself based on whether the authenticator is part of the device running web authentication, or can roam between devices (see [Firefox bug 1810851](https://bugzil.la/1810851)).
 - The [Minimum PIN Length Extension (`minPinLength`)](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) is supported, allowing a relying party server to request the authenticator's minimum PIN length during creation/registration ([Firefox bug 1844450](https://bugzil.la/1844450)).
+- The {{domxref("Navigator.userActivation")}} property and {{domxref("UserActivation")}} interface are now supported.
+  These can be used to check whether the user is interacting with the page, or has interacted with it since page load (see [Firefox bug 1791079](https://bugzil.la/1791079)).
 
 #### DOM
 


### PR DESCRIPTION
FF120 supports [`UserActivation`](https://developer.mozilla.org/en-US/docs/Web/API/UserActivation) in https://bugzilla.mozilla.org/show_bug.cgi?id=1791079. This adds a release note.

This is part of docs work for #29778