### PR TITLE
docs(api): add note for getUserMedia calls with facing mode prefs

### DIFF
--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -420,6 +420,8 @@ const constraints = {
 };
 ```
 
+> **Note:** In certain cases, it may be necessary to release the current camera facing mode before you can switch to a different one. To ensure the camera switch, it is advisable to free up the media resources by invoking the "stop()" method on the track before requesting a different facing mode.
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
Added additional notes in switching camera code example. current example does not work on all devices if camera is active.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
When the getUserMedia is called with a preference of the facing mode and you would like to switch to another facing mode, getUserMedia must be called again with the new values. Some devices don't allow you to ask for another facing camera unless you stop the previous one. so a step top stop the video track must be manually call to allow for a transition.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This behaviour was not clear to me util we tested with specific devices. it is not mentioned in the docs so I thought it would be helpful for other readers to be aware of it.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
