### PR TITLE
Fix :fullscreen documentation

### DIFF
--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -23,41 +23,59 @@ The `:fullscreen` pseudo-class lets you configure your stylesheets to automatica
 
 ## Examples
 
-In this example, the color of a button is changed depending on whether or not the document is in fullscreen mode. This is done without needing to specifically apply style changes using JavaScript.
+In this example, the color of a button is changed depending on whether or not it's parent div is in fullscreen mode. This is done without needing to specifically apply style changes using JavaScript.
 
 ### HTML
 
 The page's HTML looks like this:
 
 ```html
-<h1>MDN Web Docs Demo: :fullscreen pseudo-class</h1>
+<div style="background-color: lightyellow">
+  <h1>MDN Web Docs Demo: :fullscreen pseudo-class</h1>
 
-<p>
-  This demo uses the <code>:fullscreen</code> pseudo-class to automatically
-  change the style of a button used to toggle fullscreen mode on and off,
-  entirely using CSS.
-</p>
+  <p>
+    This demo uses the <code>:fullscreen</code> pseudo-class to automatically
+    change the style of a button used to toggle fullscreen mode on and off,
+    entirely using CSS.
+  </p>
 
-<button id="fs-toggle">Toggle Fullscreen</button>
+  <button id="fs-toggle">Toggle Fullscreen</button>
+</div>
 ```
 
-The {{HTMLElement("button")}} with the ID `"fs-toggle"` will change between pale red and pale green depending on whether or not the document is in fullscreen mode.
+The {{HTMLElement("button")}} with the ID `"fs-toggle"` will change between light pink and light green depending on whether or not the parent div is in fullscreen mode.
+
+### Javascript
+
+For this example, we need the button click to toggle parent div to and from fullscreen mode:
+
+```js
+document.querySelector('#fs-toggle').addEventListener('click', function (event) {
+    if (document.fullscreenElement) {
+        // If there is a fullscreen element, exit full screen.
+        document.exitFullscreen();
+        return;
+    }
+    // Make the parent div fullscreen.
+    event.target.parentElement.requestFullscreen();
+});f
+```
 
 ### CSS
 
 The magic happens in the CSS. There are two rules here. The first establishes the background color of the "Toggle Fullscreen Mode" button when the element is not in a fullscreen state. The key is the use of the `:not(:fullscreen)`, which looks for the element to not have the `:fullscreen` pseudo-class applied to it.
 
 ```css
-#fs-toggle:not(:fullscreen) {
-  background-color: #afa;
+div:not(:fullscreen) #fs-toggle {
+  background-color: lightgreen;
 }
 ```
 
-When the document _is_ in fullscreen mode, the following CSS applies instead, setting the background color to a pale shade of red.
+When the parent div _is_ in fullscreen mode, the following CSS applies instead, setting the background color to light pink.
 
 ```css
-#fs-toggle:fullscreen {
-  background-color: #faa;
+div:fullscreen #fs-toggle {
+  background-color: lightpink;
 }
 ```
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -80,7 +80,6 @@ div:fullscreen #fs-toggle {
 }
 ```
 
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -41,7 +41,7 @@ This example styles an element in different background color depending on whethe
     is light pink.
   </p>
 
-    <button class="toggle">Toggle Fullscreen</button>
+  <button class="toggle">Toggle Fullscreen</button>
 </div>
 ```
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -71,9 +71,9 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 });
 ```
 
-#### Result
+### Demo
 
-{{EmbedLiveSample("Styling a Fullscreen Element", "100%", 300)}}
+See the demo live on [JSFiddle](https://jsfiddle.net/yookoala/oLc1uws0/).
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.fullscreen
 
 {{CSSRef}}
 
-The **`:fullscreen`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches every element which is currently in fullscreen mode. If multiple elements have been put into fullscreen mode, this selects them all.
+The **`:fullscreen`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches every element that is currently in fullscreen mode. If multiple elements have been put into fullscreen mode, this selects them all.
 
 ## Syntax
 
@@ -25,7 +25,7 @@ The `:fullscreen` pseudo-class lets you configure your stylesheets to automatica
 
 ### Styling a Fullscreen Element
 
-This example styles an element in different background color depending on whether or not it is in fullscreen state.
+This example applies a different background color to a {{htmlelement("div")}} element, depending on whether or not it is in fullscreen mode. It includes a {{htmlelement("button")}} to toggle fullscreen on and off.
 
 ```html
 <div class="element">
@@ -45,7 +45,7 @@ This example styles an element in different background color depending on whethe
 </div>
 ```
 
-The `:fullscreen` pseudo-class is used to override the background color of the `<div>` when it is in fullscreen mode.
+The `:fullscreen` pseudo-class is used to override the [`background-color`](/en-US/docs/Web/CSS/background-color) of the `<div>` when it is in fullscreen mode.
 
 ```css
 .element {
@@ -57,7 +57,7 @@ The `:fullscreen` pseudo-class is used to override the background color of the `
 }
 ```
 
-The following JavaScript provides an event handler function that toggles fullscreen when the button is clicked.
+The following JavaScript provides an event handler function that toggles fullscreen when the `<button>` is clicked.
 
 ```js
 document.querySelector(".toggle").addEventListener("click", function (event) {
@@ -71,9 +71,9 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 });
 ```
 
-### Demo
+#### Demo
 
-See the demo live on [JSFiddle](https://jsfiddle.net/yookoala/oLc1uws0/).
+[See the example live](https://jsfiddle.net/yookoala/oLc1uws0/).
 
 ## Specifications
 
@@ -87,7 +87,6 @@ See the demo live on [JSFiddle](https://jsfiddle.net/yookoala/oLc1uws0/).
 
 - [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API)
 - [Guide to the Fullscreen API](/en-US/docs/Web/API/Fullscreen_API/Guide)
-- {{cssxref(":not")}}
 - {{cssxref("::backdrop")}}
 - DOM API: {{ domxref("Element.requestFullscreen()") }}, {{ domxref("Document.exitFullscreen()") }}, {{ domxref("Document.fullscreenElement") }}
 - [`allowfullscreen`](/en-US/docs/Web/HTML/Element/iframe#allowfullscreen) attribute

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -71,7 +71,6 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 
 {{EmbedLiveSample("Styling a Fullscreen Element", "100%", 300)}}
 
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -45,6 +45,8 @@ This example styles an element in different background color depending on whethe
 </div>
 ```
 
+The `:fullscreen` pseudo-class is used to override the background color of the `<div>` when it is in fullscreen mode.
+
 ```css
 .element {
   background-color: lightyellow;
@@ -54,6 +56,8 @@ This example styles an element in different background color depending on whethe
   background-color: lightpink;
 }
 ```
+
+The following JavaScript provides an event handler function that toggles fullscreen when the button is clicked.
 
 ```js
 document.querySelector(".toggle").addEventListener("click", function (event) {

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -50,7 +50,9 @@ The {{HTMLElement("button")}} with the ID `"fs-toggle"` will change between ligh
 For this example, we need the button click to toggle parent div to and from fullscreen mode:
 
 ```js
-document.querySelector('#fs-toggle').addEventListener('click', function (event) {
+document
+  .querySelector("#fs-toggle")
+  .addEventListener("click", function (event) {
     if (document.fullscreenElement) {
         // If there is a fullscreen element, exit full screen.
         document.exitFullscreen();

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -56,14 +56,14 @@ This example styles an element in different background color depending on whethe
 ```
 
 ```js
-document.querySelector('.toggle').addEventListener('click', function (event) {
-    if (document.fullscreenElement) {
-        // If there is a fullscreen element, exit full screen.
-        document.exitFullscreen();
-        return;
-    }
-    // Make the parent div fullscreen.
-    document.querySelector('.element').requestFullscreen();
+document.querySelector(".toggle").addEventListener("click", function (event) {
+  if (document.fullscreenElement) {
+    // If there is a fullscreen element, exit full screen.
+    document.exitFullscreen();
+    return;
+  }
+  // Make the parent div fullscreen.
+  document.querySelector(".element").requestFullscreen();
 });
 ```
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -71,7 +71,7 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 });
 ```
 
-### Result
+#### Result
 
 {{EmbedLiveSample("Styling a Fullscreen Element", "100%", 300)}}
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -60,7 +60,8 @@ document
     }
     // Make the parent div fullscreen.
     event.target.parentElement.requestFullscreen();
-});f
+  });
+f;
 ```
 
 ### CSS

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -36,10 +36,10 @@ This example styles an element in different background color depending on whethe
     change the background color of the <code>.element</code> div.
   </p>
 
-    <p>
-        Normally, the background is light yellow. In fullscreen mode, the background
-        is light pink.
-    </p>
+  <p>
+    Normally, the background is light yellow. In fullscreen mode, the background
+    is light pink.
+  </p>
 
     <button class="toggle">Toggle Fullscreen</button>
 </div>

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -31,10 +31,10 @@ This example styles an element in different background color depending on whethe
 <div class="element">
   <h1>MDN :fullscreen pseudo-class demo</h1>
 
-    <p>
-        This demo uses the <code>:fullscreen</code> pseudo-class to automatically
-        change the background color of the <code>.element</code> div.
-    </p>
+  <p>
+    This demo uses the <code>:fullscreen</code> pseudo-class to automatically
+    change the background color of the <code>.element</code> div.
+  </p>
 
     <p>
         Normally, the background is light yellow. In fullscreen mode, the background

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -29,7 +29,7 @@ This example styles an element in different background color depending on whethe
 
 ```html
 <div class="element">
-    <h1>MDN :fullscreen pseudo-class demo</h1>
+  <h1>MDN :fullscreen pseudo-class demo</h1>
 
     <p>
         This demo uses the <code>:fullscreen</code> pseudo-class to automatically

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -66,21 +66,19 @@ f;
 
 ### CSS
 
-The magic happens in the CSS. There are two rules here. The first establishes the background color of the "Toggle Fullscreen Mode" button when the element is not in a fullscreen state. The key is the use of the `:not(:fullscreen)`, which looks for the element to not have the `:fullscreen` pseudo-class applied to it.
+The magic happens in the CSS. There are two rules here:
+1. Normally, the background color of the "Toggle Fullscreen Mode" button is light green.
+2. Within a div which _is_ in fullscreen state, background color of the same button is light pink.
 
 ```css
-div:not(:fullscreen) #fs-toggle {
+#fs-toggle {
   background-color: lightgreen;
 }
-```
-
-When the parent div _is_ in fullscreen mode, the following CSS applies instead, setting the background color to light pink.
-
-```css
 div:fullscreen #fs-toggle {
   background-color: lightpink;
 }
 ```
+
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -67,6 +67,7 @@ f;
 ### CSS
 
 The magic happens in the CSS. There are two rules here:
+
 1. Normally, the background color of the "Toggle Fullscreen Mode" button is light green.
 2. Within a div which _is_ in fullscreen state, background color of the same button is light pink.
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -23,62 +23,54 @@ The `:fullscreen` pseudo-class lets you configure your stylesheets to automatica
 
 ## Examples
 
-In this example, the color of a button is changed depending on whether or not it's parent div is in fullscreen mode. This is done without needing to specifically apply style changes using JavaScript.
+### Styling a Fullscreen Element
 
-### HTML
-
-The page's HTML looks like this:
+This example styles an element in different background color depending on whether or not it is in fullscreen state.
 
 ```html
-<div style="background-color: lightyellow">
-  <h1>MDN Web Docs Demo: :fullscreen pseudo-class</h1>
+<div class="element">
+    <h1>MDN :fullscreen pseudo-class demo</h1>
 
-  <p>
-    This demo uses the <code>:fullscreen</code> pseudo-class to automatically
-    change the style of a button used to toggle fullscreen mode on and off,
-    entirely using CSS.
-  </p>
+    <p>
+        This demo uses the <code>:fullscreen</code> pseudo-class to automatically
+        change the background color of the <code>.element</code> div.
+    </p>
 
-  <button id="fs-toggle">Toggle Fullscreen</button>
+    <p>
+        Normally, the background is light yellow. In fullscreen mode, the background
+        is light pink.
+    </p>
+
+    <button class="toggle">Toggle Fullscreen</button>
 </div>
 ```
 
-The {{HTMLElement("button")}} with the ID `"fs-toggle"` will change between light pink and light green depending on whether or not the parent div is in fullscreen mode.
+```css
+.element {
+  background-color: lightyellow;
+}
 
-### Javascript
-
-For this example, we need the button click to toggle parent div to and from fullscreen mode:
+.element:fullscreen {
+    background-color: lightpink;
+}
+```
 
 ```js
-document
-  .querySelector("#fs-toggle")
-  .addEventListener("click", function (event) {
+document.querySelector('.toggle').addEventListener('click', function (event) {
     if (document.fullscreenElement) {
-      // If there is a fullscreen element, exit full screen.
-      document.exitFullscreen();
-      return;
+        // If there is a fullscreen element, exit full screen.
+        document.exitFullscreen();
+        return;
     }
     // Make the parent div fullscreen.
-    event.target.parentElement.requestFullscreen();
-  });
-f;
+    document.querySelector('.element').requestFullscreen();
+});
 ```
 
-### CSS
+### Result
 
-The magic happens in the CSS. There are two rules here:
+{{EmbedLiveSample("Styling a Fullscreen Element", "100%", 300)}}
 
-1. Normally, the background color of the "Toggle Fullscreen Mode" button is light green.
-2. Within a div which _is_ in fullscreen state, background color of the same button is light pink.
-
-```css
-#fs-toggle {
-  background-color: lightgreen;
-}
-div:fullscreen #fs-toggle {
-  background-color: lightpink;
-}
-```
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -51,7 +51,7 @@ This example styles an element in different background color depending on whethe
 }
 
 .element:fullscreen {
-    background-color: lightpink;
+  background-color: lightpink;
 }
 ```
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -62,7 +62,7 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
     document.exitFullscreen();
     return;
   }
-  // Make the parent div fullscreen.
+  // Make the .element div fullscreen.
   document.querySelector(".element").requestFullscreen();
 });
 ```

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -54,9 +54,9 @@ document
   .querySelector("#fs-toggle")
   .addEventListener("click", function (event) {
     if (document.fullscreenElement) {
-        // If there is a fullscreen element, exit full screen.
-        document.exitFullscreen();
-        return;
+      // If there is a fullscreen element, exit full screen.
+      document.exitFullscreen();
+      return;
     }
     // Make the parent div fullscreen.
     event.target.parentElement.requestFullscreen();


### PR DESCRIPTION
### Description
Fix both the example and description of the :fullscreen pseudo class page.

### Motivation

Problems:
* The example doesn't work without Javascript but the script is not provided.
* The description of :fullscreen pseudo class is wrong. The pseudo class does not activate when the browser or document is in fullscreen mode at all. It matches **element** that is fullscreen.

Fixes:
* Add javascript and a parent element for the Fullscreen API to work with. Parent element is not required but it better demonstrates the nature of the whole API set.
* Correct the descriptions.
* Use color name instead of rgb to improve readability of the example.


### Additional details

From the specification of :fullscreen, [5.1](https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class):

<blockquote>
The :fullscreen pseudo-class must match any [element](https://dom.spec.whatwg.org/#concept-element) for which one of the following conditions is true:

*  element’s [fullscreen flag](https://fullscreen.spec.whatwg.org/#fullscreen-flag) is set.

* element is a [shadow host](https://dom.spec.whatwg.org/#element-shadow-host) and the result of [retargeting](https://dom.spec.whatwg.org/#retarget) its [node document](https://dom.spec.whatwg.org/#concept-node-document)’s [fullscreen element](https://fullscreen.spec.whatwg.org/#fullscreen-element) against element is element.
</blockquote>

A JSFiddle example showing the working example: https://jsfiddle.net/yookoala/veu1n3rt/

### Related issues and pull requests

Fixes #29950

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
