### PR TITLE
chore(docs): Fix Markdownlint failures in nested list

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
@@ -26,7 +26,7 @@ One of the following:
   - : Medium quality.
 - `"high"`
   - : High quality.
-The default value is `"low"`.
+    The default value is `"low"`.
 
 ## Examples
 


### PR DESCRIPTION
We have some failing CI, see: https://github.com/mdn/content/actions/runs/6720658928/job/18264714512?pr=29958

This PR formats the file to get CI green