### PR TITLE
Fix a newline issue in imagesmoothingquality content

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
@@ -26,7 +26,8 @@ One of the following:
   - : Medium quality.
 - `"high"`
   - : High quality.
-    The default value is `"low"`.
+
+The default value is `"low"`.
 
 ## Examples
 


### PR DESCRIPTION
I merged https://github.com/mdn/content/pull/29959 without making sure that the change made sense in the context of the content. 

Oops, my bad! Fixed here.