### PR TITLE
Fix Event Bubbing Link

### DIFF
--- a/files/en-us/web/api/event/bubbles/index.md
+++ b/files/en-us/web/api/event/bubbles/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Event.bubbles
 
 The **`bubbles`** read-only property of the {{domxref("Event")}} interface indicates whether the event bubbles up through the DOM tree or not.
 
-> **Note:** See [Event bubbling and capture](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture) for more information on bubbling.
+> **Note:** See [Event bubbling and capture](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling) for more information on bubbling.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This fixes the link on Event Bubbles page to correctly point to the right part on the "Introduction to Events" page
<!-- ✍️ Summarize your changes in one or two sentences -->

<!-- ❓ Why are you making these changes and how do they help readers? -->


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
