### PR TITLE
Update document.hidden and document.visibilityState

### DIFF
--- a/files/en-us/web/api/document/hidden/index.md
+++ b/files/en-us/web/api/document/hidden/index.md
@@ -11,14 +11,11 @@ browser-compat: api.Document.hidden
 The **`Document.hidden`** read-only property returns a Boolean
 value indicating if the page is considered hidden or not.
 
-> **Note:** This property is described as "historical" in the [Page Visibility Level 2 specification](https://www.w3.org/TR/page-visibility-2/). Consider using the {{domxref("Document.visibilityState")}}
-> property instead.
+The {{domxref("Document.visibilityState")}} property provides an alternative way to determine whether the page is hidden.
 
-## Syntax
+## Value
 
-```js-nolint
-document.hidden
-```
+A Boolean value, `true` if the page is hidden, and `false` otherwise.
 
 ## Examples
 
@@ -29,16 +26,6 @@ document.addEventListener("visibilitychange", () => {
 });
 ```
 
-## Usage notes
-
-> **Warning:** Due to prerendering, it may happen that `document.hidden` is
-> `true`, even if the page is actually visible to the user. In such scenario
-> the page load starts with
-> `document.visibilityState = "prerender"`
-> and transitions to `document.visibilityState = "visible"` after some delay.
-> This scenario can be reproduced by opening a new browser tab in Safari, pasting a URL
-> in the URL bar, and navigating to that URL.
-
 ## Specifications
 
 {{Specifications}}
@@ -46,3 +33,7 @@ document.addEventListener("visibilitychange", () => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Document.visibilityState")}}

--- a/files/en-us/web/api/document/visibilitystate/index.md
+++ b/files/en-us/web/api/document/visibilitystate/index.md
@@ -9,12 +9,15 @@ browser-compat: api.Document.visibilityState
 {{ApiRef("DOM")}}
 
 The **`Document.visibilityState`**
-read-only property returns the visibility of the {{domxref('document')}}, that is in
-which context this element is now visible. It is useful to know if the document is in
-the background or an invisible tab, or only loaded for pre-rendering.
+read-only property returns the visibility of the document. It can be used to check whether the document is in the background or in a minimized window, or is otherwise not visible to the user.
 
-Possible
-values are:
+When the value of this property changes, the {{domxref("Document/visibilitychange_event", "visibilitychange")}} event is sent to the {{domxref("Document")}}.
+
+The {{domxref("Document.hidden")}} property provides an alternative way to determine whether the page is hidden.
+
+## Value
+
+A string with one of the following values:
 
 - `visible`
   - : The page content may be at least partially visible. In practice this means that the
@@ -23,20 +26,6 @@ values are:
   - : The page content is not visible to the user. In practice this means that the
     document is either a background tab or part of a minimized window, or the OS screen
     lock is active.
-
-When the value of this property changes, the
-{{domxref("Document/visibilitychange_event", "visibilitychange")}} event is sent to the
-{{domxref("Document")}}.
-
-Typical use of this can be to prevent the download of some assets when the document is
-solely prerendered, or stop some activities when the document is in the background or
-minimized.
-
-## Syntax
-
-```js-nolint
-document.visibilityState
-```
 
 ## Examples
 
@@ -54,3 +43,7 @@ document.addEventListener("visibilitychange", () => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Document.hidden")}}


### PR DESCRIPTION
This is an attempt to finish https://github.com/mdn/content/pull/26418, which seems to have stalled.

Discussion in https://github.com/mdn/content/pull/26418 suggests that we should recommend `visibilityState` over `hidden` - while I'm happy to do so, I could not find a concrete reason to prefer it, and in the thread that removed the note from the specification noone advanced one either: https://github.com/w3c/page-visibility/pull/64.

I also removed some bits about `prerender` which I guess were leftovers from https://github.com/mdn/content/pull/20285, and rewrote both articles to match [our template](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_property_subpage_template).