### PR TITLE
Example to use :fullscreen without javascript

### DIFF
--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -79,7 +79,7 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 
 Just to be clear. Although the `:fullscreen` pseudo class works with Fullscreen API, it doesn't mean the use of it requires JavaScript.
 
-This example styles a different background color to the {{htmlelement("video")}} element, depending on depending on whether or not it is in
+This example styles a different background color to the {{htmlelement("video")}} element, depending on whether or not it is in
 fullscreen mode. It uses your browser's default control, which uses Fullscreen API, to toggle the video fullscreen on and off.
 
 ```html

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -84,7 +84,8 @@ fullscreen mode. It uses your browser's default control, which uses Fullscreen A
 
 ```html
 <video controls loop>
-    <source src="https://yookoala.github.io/fullscreen-video-background-demo/assets/rotating-cube.webm">
+  <source
+    src="https://yookoala.github.io/fullscreen-video-background-demo/assets/rotating-cube.webm" />
 </video>
 ```
 
@@ -96,10 +97,10 @@ demo shows, you can style the background color of the video
  * Demo: CSS background color.
  */
 video {
-    background-color: blue;
+  background-color: blue;
 }
 video:fullscreen {
-    background-color: green;
+  background-color: green;
 }
 ```
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -75,6 +75,38 @@ document.querySelector(".toggle").addEventListener("click", function (event) {
 
 [See the example live](https://jsfiddle.net/yookoala/oLc1uws0/).
 
+### Fullscreen Element without JavaScript
+
+Just to be clear. Although the `:fullscreen` pseudo class works with Fullscreen API, it doesn't mean the use of it requires JavaScript.
+
+This example styles a different background color to the {{htmlelement("video")}} element, depending on depending on whether or not it is in
+fullscreen mode. It uses your browser's default control, which uses Fullscreen API, to toggle the video fullscreen on and off.
+
+```html
+<video controls loop>
+    <source src="https://yookoala.github.io/fullscreen-video-background-demo/assets/rotating-cube.webm">
+</video>
+```
+
+Since the fullscreen video would fill up the whole screen by default, it takes some tricky CSS to show the background color. But as the
+demo shows, you can style the background color of the video
+
+```css
+/**
+ * Demo: CSS background color.
+ */
+video {
+    background-color: blue;
+}
+video:fullscreen {
+    background-color: green;
+}
+```
+
+#### Demo
+
+[See the example live](https://yookoala.github.io/fullscreen-video-background-demo/)
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
### Description

* Added an example to demostrate that it works without JavaScript.

### Motivation

* The current example seems to imply :fullscreen must be used with JavaScript, which is not true.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #29856

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
