### PR TITLE
fix(css): device_smyk() add spec URL

### DIFF
--- a/files/en-us/web/css/color_value/device-cmyk/index.md
+++ b/files/en-us/web/css/color_value/device-cmyk/index.md
@@ -3,6 +3,7 @@ title: device-cmyk()
 slug: Web/CSS/color_value/device-cmyk
 page-type: css-function
 browser-compat: css.types.color.device-cmyk
+spec-urls: https://drafts.csswg.org/css-color-5/#device-cmyk
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/29962

As no browser has implemented this there is no entry in BCD yet so resorting to `spec-urls` front-matter.