### PR TITLE
Add a diagram for string.slice()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -34,7 +34,19 @@ A new string containing the extracted section of the string.
 
 `slice()` extracts the text from one string and returns a new string. Changes to the text in one string do not affect the other string.
 
-`slice()` extracts up to but not including `indexEnd`. For example, `str.slice(1, 4)` extracts the second character through the fourth character (characters indexed `1`, `2`, and `3`).
+`slice()` extracts up to but not including `indexEnd`. For example, `str.slice(4, 8)` extracts the fifth character through the eighth character (characters indexed `4`, `5`, `6`, and `7`):
+
+```plain
+              indexStart        indexEnd
+                  ↓               ↓
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+| T | h | e |   | m | i | r | r | o | r |
+
+                  m   i   r   r
+                 _______________
+                      ↑
+                    Result
+```
 
 - If `indexStart >= str.length`, an empty string is returned.
 - If `indexStart < 0`, the index is counted from the end of the string. More formally, in this case, the substring starts at `max(indexStart + str.length, 0)`.


### PR DESCRIPTION
In https://github.com/mdn/content/pull/29020#issuecomment-1714941718 I suggested adding a diagram to help clarify the `indexEnd` argument to [`string.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice).

This PR adds it. There was some grumbling about the use of ASCII art in the other PR, but I have kept it rather than a separate image because:
- it seems adequate for the purpose
- it's smaller, easier to edit, and gives us fewer files to mess around with
- because it's so much more limited in design options, there's much less scope for problems (for example, contrast issues with different themes)

On the other hand maybe accessibility would be better with a separate image? Happy to have a go if we would prefer that.