### PR TITLE
CSS layout cookbook: wrapper page

### DIFF
--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -2,20 +2,20 @@
 title: Grid wrapper
 slug: Web/CSS/Layout_cookbook/Grid_wrapper
 page-type: guide
-browser-compat: css.properties.grid-template-columns
+browser-compat: css.properties.grid
 ---
 
 {{CSSRef}}
 
-The grid wrapper pattern is useful for aligning grid content within a central wrapper, while also allowing items to break out and align to the edge of the containing element or page when desired.
+The grid wrapper pattern is useful for aligning grid content within a central wrapper while also allowing items to break out and align to the edge of the containing element or page.
 
 ## Requirements
 
-Items placed on the grid should be able to align to a horizontally-centered max-width wrapper and/or the outer edges of the grid.
+Items placed on the grid should be able to align to a horizontally-centered max-width wrapper or the outer edges of the grid, or both.
 
 ## Recipe
 
-{{EmbedGHLiveSample("css-examples/css-cookbook/grid-wrapper.html", '100%', 720)}}
+{{EmbedGHLiveSample("css-examples/css-cookbook/grid-wrapper.html", '100%', 1100)}}
 
 > **Callout:**
 >
@@ -23,54 +23,28 @@ Items placed on the grid should be able to align to a horizontally-centered max-
 
 ## Choices made
 
-This recipe uses the CSS Grid {{cssxref("minmax", "minmax()")}} function to define the grid track sizes in the {{cssxref("grid-template-columns")}} property. For the central columns with a maximum width we can set a minimum value of 0 or greater and a maximum value that specifies the maximum size the column tracks will grow to. Using a numeric unit (pixels, ems, rems) will create a fixed maximum size for the central wrapper, whereas using percentage values or viewport units will mean this wrapper grows or shrinks in response to its context.
+This recipe uses the CSS grid {{cssxref("minmax", "minmax()")}} function to define the grid track sizes in the {{cssxref("grid-template-columns")}} property. For the central columns with a maximum width, we can set a minimum value of `0` or greater and a maximum value that specifies the maximum size the column tracks will grow to. Using a [relative](/en-US/docs/Web/CSS/length#relative_length_units_based_on_font) or [absolute](/en-US/docs/Web/CSS/length#absolute_length_units) {{cssxref("length")}} units (pixels, ems, rems) will create a fixed maximum size for the central wrapper, whereas using {{cssxref("percentage")}} values or [viewport units](/en-US/docs/Web/CSS/length#relative_length_units_based_on_viewport) will mean this wrapper grows or shrinks in response to its context.
 
 The outer two columns have a maximum size of `1fr`, meaning that they will each expand to fill the remaining available space in the grid container.
 
 ## Useful fallbacks or alternative methods
 
-When using this recipe at page level it can be useful to set a `max-width` along with left and right `auto` {{cssxref("margin")}}s to center the content horizontally:
+When using this recipe at page level, to center the grid itself on the page you can set a `max-width` along with left and right `auto` {{cssxref("margin")}}s to center the content horizontally:
 
 ```css
 .grid {
-  max-width: 1200px;
+  max-width: 96vw; /* Limits the width to 96% of the width of the viewport */
   margin: 0 auto; /* horizontally centers the container */
 }
-
-/* Remove the max-width and margins if the browser supports Grid */
-@supports (display: grid) {
-  .grid {
-    display: grid;
-    /* Other grid code goes here */
-    max-width: none;
-    margin: 0;
-  }
-}
 ```
-
-To "break out" a full-width item to the edge of the viewport you can then use this trick (courtesy of [Una Kravets](https://una.im/)):
-
-```css
-.item {
-  width: 100vw;
-  margin-left: 50%;
-  transform: translate3d(-50%, 0, 0);
-}
-```
-
-This gives a good approximation of the layout, only without the benefit of being able to align items easily on an exact grid.
 
 ## Accessibility concerns
 
-Although Grid enables us to position items anywhere (within reason), it is important when placing items using CSS Grid that your underlying markup follows a logical order (see [CSS Grid layout and accessibility](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility) for more details).
-
-## Browser compatibility
-
-{{Compat}}
+Although CSS grid enables positioning items anywhere (within reason), ensuring that your underlying markup follows a logical order is important(see [CSS Grid layout and accessibility](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility) for more details).
 
 ## See also
 
-- {{Cssxref("grid-template-columns")}}
-- [CSS Grid Layout on MDN](/en-US/docs/Web/CSS/CSS_grid_layout)
-- Article: [CSS Grid: More flexibility with minmax()](https://css-irl.info/more-flexibility-with-minmax/)
-- Article: [Breaking Out with CSS Grid](https://rachelandrew.co.uk/archives/2017/06/01/breaking-out-with-css-grid-explained/)
+- {{Cssxref("grid-template-columns")}} property
+- [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) module
+- [CSS Grid: More flexibility with minmax()](https://css-irl.info/more-flexibility-with-minmax/) (2018)
+- [Breaking Out with CSS Grid](https://rachelandrew.co.uk/archives/2017/06/01/breaking-out-with-css-grid-explained/) (2017)

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -47,4 +47,4 @@ Although CSS grid enables positioning items anywhere (within reason), ensuring t
 - {{Cssxref("grid-template-columns")}} property
 - [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) module
 - [CSS Grid: More flexibility with minmax()](https://css-irl.info/more-flexibility-with-minmax/) (2018)
-- [Breaking Out with CSS Grid](https://rachelandrew.co.uk/archives/2017/06/01/breaking-out-with-css-grid-explained/) (2017)
+- [Breaking out with CSS grid](https://rachelandrew.co.uk/archives/2017/06/01/breaking-out-with-css-grid-explained/) (2017)

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -23,13 +23,13 @@ Items placed on the grid should be able to align to a horizontally-centered max-
 
 ## Choices made
 
-This recipe uses the CSS grid {{cssxref("minmax", "minmax()")}} function to define the grid track sizes in the {{cssxref("grid-template-columns")}} property. For the central columns with a maximum width, we can set a minimum value of `0` or greater and a maximum value that specifies the maximum size the column tracks will grow to. Using a [relative](/en-US/docs/Web/CSS/length#relative_length_units_based_on_font) or [absolute](/en-US/docs/Web/CSS/length#absolute_length_units) {{cssxref("length")}} units (pixels, ems, rems) will create a fixed maximum size for the central wrapper, whereas using {{cssxref("percentage")}} values or [viewport units](/en-US/docs/Web/CSS/length#relative_length_units_based_on_viewport) will mean this wrapper grows or shrinks in response to its context.
+This recipe uses the CSS grid {{cssxref("minmax", "minmax()")}} function to define the grid track sizes in the {{cssxref("grid-template-columns")}} property. For the central columns with a maximum width, we can set a minimum value of `0` or greater and a maximum value that specifies the maximum size the column tracks will grow to. Using [relative](/en-US/docs/Web/CSS/length#relative_length_units_based_on_font) or [absolute](/en-US/docs/Web/CSS/length#absolute_length_units) {{cssxref("length")}} units (pixels, ems, rems) will create a fixed maximum size for the central wrapper, whereas using {{cssxref("percentage")}} values or [viewport units](/en-US/docs/Web/CSS/length#relative_length_units_based_on_viewport) will cause the wrapper to grow or shrink in response to its context.
 
 The outer two columns have a maximum size of `1fr`, meaning that they will each expand to fill the remaining available space in the grid container.
 
 ## Useful fallbacks or alternative methods
 
-When using this recipe at page level, to center the grid itself on the page you can set a `max-width` along with left and right `auto` {{cssxref("margin")}}s to center the content horizontally:
+To center the grid horizontally on the page you can set a `max-width` along with left and right `auto` {{cssxref("margin")}}s:
 
 ```css
 .grid {
@@ -40,7 +40,7 @@ When using this recipe at page level, to center the grid itself on the page you 
 
 ## Accessibility concerns
 
-Although CSS grid enables positioning items anywhere (within reason), ensuring that your underlying markup follows a logical order is important(see [CSS Grid layout and accessibility](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility) for more details).
+Although CSS grid enables positioning items anywhere (within reason), ensuring that your underlying markup follows a logical order is important (see [CSS Grid layout and accessibility](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility) for more details).
 
 ## See also
 


### PR DESCRIPTION
This is not a useful page, so I didn't spend much time on it.
Grid is supported, so the fallbacks are not necessary.
Optionally, we could get rid of the page altogether.
part of https://github.com/openwebdocs/project/issues/184.