### PR TITLE
Glossary:Site - compare to origin

### DIFF
--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -17,7 +17,7 @@ According to this definition, `support.mozilla.org` and `developer.mozilla.org` 
 In some contexts, the scheme is also considered when differentiating sites. This would make `http://vpl.ca` and `https://vpl.ca` different sites. Including the scheme prevents an insecure (HTTP) site from being treated as the same site as a secure (HTTPS) site. A definition that considers the scheme is sometimes called a _schemeful same-site_. This stricter definition is applied in the rules for handling [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookies.
 
 :::note
-For security reasons, browsers sometimes need to may further need to distinguish between requests using the port as well as the site (scheme and domain).
+For security reasons, browsers sometimes need to distinguish between requests using the port as well as the site (scheme and domain).
 The scheme, domain and port together are referred to as an {{Glossary("Origin")}}.
 :::
 

--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -16,6 +16,11 @@ According to this definition, `support.mozilla.org` and `developer.mozilla.org` 
 
 In some contexts, the scheme is also considered when differentiating sites. This would make `http://vpl.ca` and `https://vpl.ca` different sites. Including the scheme prevents an insecure (HTTP) site from being treated as the same site as a secure (HTTPS) site. A definition that considers the scheme is sometimes called a _schemeful same-site_. This stricter definition is applied in the rules for handling [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookies.
 
+:::note 
+For security reasons, browsers sometimes need to may further need to distinguish between requests using the port as well as the site (scheme and domain).
+The scheme, domain and port together are referred to as an {{Glossary("Origin")}}.
+:::
+
 ## Examples
 
 These are the same site because the registrable domain of `mozilla.org` is the same:

--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -16,10 +16,7 @@ According to this definition, `support.mozilla.org` and `developer.mozilla.org` 
 
 In some contexts, the scheme is also considered when differentiating sites. This would make `http://vpl.ca` and `https://vpl.ca` different sites. Including the scheme prevents an insecure (HTTP) site from being treated as the same site as a secure (HTTPS) site. A definition that considers the scheme is sometimes called a _schemeful same-site_. This stricter definition is applied in the rules for handling [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookies.
 
-:::note
-For security reasons, browsers sometimes need to distinguish between requests using the port as well as the site (scheme and domain).
-The scheme, domain and port together are referred to as an {{Glossary("Origin")}}.
-:::
+> **Note:** Browsers sometimes make security decisions (for example, deciding which resources a script can access) based on the {{Glossary("Origin")}} of a resource. This is a more restrictive concept than the site, encompassing the scheme, the whole domain, and the port. See also [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy).
 
 ## Examples
 

--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -16,7 +16,7 @@ According to this definition, `support.mozilla.org` and `developer.mozilla.org` 
 
 In some contexts, the scheme is also considered when differentiating sites. This would make `http://vpl.ca` and `https://vpl.ca` different sites. Including the scheme prevents an insecure (HTTP) site from being treated as the same site as a secure (HTTPS) site. A definition that considers the scheme is sometimes called a _schemeful same-site_. This stricter definition is applied in the rules for handling [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookies.
 
-:::note 
+:::note
 For security reasons, browsers sometimes need to may further need to distinguish between requests using the port as well as the site (scheme and domain).
 The scheme, domain and port together are referred to as an {{Glossary("Origin")}}.
 :::

--- a/files/en-us/glossary/site/index.md
+++ b/files/en-us/glossary/site/index.md
@@ -16,7 +16,7 @@ According to this definition, `support.mozilla.org` and `developer.mozilla.org` 
 
 In some contexts, the scheme is also considered when differentiating sites. This would make `http://vpl.ca` and `https://vpl.ca` different sites. Including the scheme prevents an insecure (HTTP) site from being treated as the same site as a secure (HTTPS) site. A definition that considers the scheme is sometimes called a _schemeful same-site_. This stricter definition is applied in the rules for handling [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookies.
 
-> **Note:** Browsers sometimes make security decisions (for example, deciding which resources a script can access) based on the {{Glossary("Origin")}} of a resource. This is a more restrictive concept than the site, encompassing the scheme, the whole domain, and the port. See also [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy).
+> **Note:** Browsers sometimes make security decisions (for example, deciding which resources a script can access) based on the {{Glossary("Origin")}} of a resource. This is a more restrictive concept than the site, encompassing the scheme, the whole domain, and the port. See also [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
 ## Examples
 


### PR DESCRIPTION
Fixes #5557

We have glossary topics for Site and Origin and in most cases you will only need one or the other. I don't think we need a whole topic to differentiate them, but I think it helps in at least one of these topics to mention the difference.