### PR TITLE
FF120 iframe lazy loading requires JavaScript to be enabled

### DIFF
--- a/files/en-us/web/api/htmliframeelement/loading/index.md
+++ b/files/en-us/web/api/htmliframeelement/loading/index.md
@@ -25,6 +25,12 @@ The possible values are:
 
 ## Usage notes
 
+### JavaScript must be enabled
+
+Loading is only deferred when JavaScript is enabled, irrespective of the value of this property.
+
+This is an anti-tracking measure, because if a user agent supported lazy loading when scripting is disabled, it would still be possible for a site to track a user's approximate scroll position throughout a session, by strategically placing iframes in a page's markup such that a server can track how many are requested and when.
+
 ### Timing of the load event
 
 The {{domxref("Window.load_event", "load")}} event is fired when the document has been fully processed.

--- a/files/en-us/web/api/htmlimageelement/loading/index.md
+++ b/files/en-us/web/api/htmlimageelement/loading/index.md
@@ -27,6 +27,11 @@ The possible values are:
 
 > **Note:** In Firefox, the `loading` attribute must be defined before the `src` attribute, otherwise it has no effect ([Firefox bug 1647077](https://bugzil.la/1647077)).
 
+### JavaScript must be enabled
+
+Loading is only deferred when JavaScript is enabled.
+This is an anti-tracking measure, because if a user agent supported lazy loading when scripting is disabled, it would still be possible for a site to track a user's approximate scroll position throughout a session, by strategically placing images in a page's markup such that a server can track how many images are requested and when.
+
 ### Timing of the load event
 
 The {{domxref("Window.load_event", "load")}} event is fired when the document has been fully processed.

--- a/files/en-us/web/api/htmlimageelement/loading/index.md
+++ b/files/en-us/web/api/htmlimageelement/loading/index.md
@@ -8,28 +8,20 @@ browser-compat: api.HTMLImageElement.loading
 
 {{APIRef("HTML DOM")}}
 
-The {{domxref("HTMLImageElement")}}
-property **`loading`** is a string whose value provides a hint
-to the {{Glossary("user agent")}} on how to handle the loading of the image which
-is currently outside the window's {{Glossary("visual viewport")}}.
+The {{domxref("HTMLImageElement")}} property **`loading`** is a string whose value provides a hint to the {{Glossary("user agent")}} on how to handle the loading of the image which is currently outside the window's {{Glossary("visual viewport")}}.
 
-This helps
-to optimize the loading of the document's contents by postponing loading the image until
-it's expected to be needed, rather than immediately during the initial page load.
+This helps to optimize the loading of the document's contents by postponing loading the image until it's expected to be needed, rather than immediately during the initial page load.
 
 ## Value
 
-A string providing a hint to the user agent as to how to best
-schedule the loading of the image to optimize page performance. The possible values are:
+A string providing a hint to the user agent as to how to best schedule the loading of the image to optimize page performance.
+The possible values are:
 
 - `eager`
-  - : The default behavior, `eager` tells the browser to load the image as soon
-    as the `<img>` element is processed.
+  - : The default behavior, `eager` tells the browser to load the image as soon as the `<img>` element is processed.
 - `lazy`
-  - : Tells the user agent to hold off on loading the image until the browser estimates
-    that it will be needed imminently. For instance, if the user is scrolling through the
-    document, a value of `lazy` will cause the image to only be loaded shortly
-    before it will appear in the window's {{Glossary("visual viewport")}}.
+  - : Tells the user agent to hold off on loading the image until the browser estimates that it will be needed imminently.
+    For instance, if the user is scrolling through the document, a value of `lazy` will cause the image to only be loaded shortly before it will appear in the window's {{Glossary("visual viewport")}}.
 
 ## Usage notes
 
@@ -37,44 +29,28 @@ schedule the loading of the image to optimize page performance. The possible val
 
 ### Timing of the load event
 
-The {{domxref("Window.load_event", "load")}} event is fired when the document has been
-fully processed. When images are loaded eagerly (which is the default), every image in
-the document must be fetched before the `load` event can fire.
+The {{domxref("Window.load_event", "load")}} event is fired when the document has been fully processed.
+When images are loaded eagerly (which is the default), every image in the document must be fetched before the `load` event can fire.
 
-By specifying the value `lazy` for `loading`, you prevent the
-image from delaying the `load` attribute by the amount of time it takes to
-request, fetch, and process the image.
+By specifying the value `lazy` for `loading`, you prevent the image from delaying the `load` attribute by the amount of time it takes to request, fetch, and process the image.
 
-Images whose `loading` attribute is set to `lazy` but are located
-within the visual viewport immediately upon initial page load are loaded as soon as the
-layout is known, but their loads do not delay the firing of the `load` event.
-In other words, these images aren't loaded immediately when processing
-the `<img>` element, but are still loaded as part of the initial page
-load. They just don't affect the timing of the `load` event.
+Images whose `loading` attribute is set to `lazy` but are located within the visual viewport immediately upon initial page load are loaded as soon as the layout is known, but their loads do not delay the firing of the `load` event.
+In other words, these images aren't loaded immediately when processing the `<img>` element, but are still loaded as part of the initial page load.
+They just don't affect the timing of the `load` event.
 
-That means that when `load` fires, it's possible that any lazy-loaded images
-located in the visual viewport may not yet be visible.
+That means that when `load` fires, it's possible that any lazy-loaded images located in the visual viewport may not yet be visible.
 
 ### Preventing element shift during image lazy loads
 
-When an image whose loading has been delayed by the `loading` attribute
-being set to `lazy` is finally loaded, the browser will determine the final
-size of the {{HTMLElement("img")}} element based on the style and intrinsic size of the
-image, then reflow the document as needed to update the positions of elements based on
-any size change made to the element to fit the image.
+When an image whose loading has been delayed by the `loading` attribute being set to `lazy` is finally loaded, the browser will determine the final size of the {{HTMLElement("img")}} element based on the style and intrinsic size of the image, then reflow the document as needed to update the positions of elements based on any size change made to the element to fit the image.
 
-To prevent this reflow from occurring, you should explicitly specify the size of the
-image's presentation using the image element's [`width`](/en-US/docs/Web/HTML/Element/img#width) and
-[`height`](/en-US/docs/Web/HTML/Element/img#height) attributes. By establishing the intrinsic aspect ratio
-in this manner, you prevent elements from shifting around while the document loads,
-which can be disconcerting or off-putting at best and can cause users to click the wrong
-thing at worst, depending on the exact timing of the deferred loads and reflows.
+To prevent this reflow from occurring, you should explicitly specify the size of the image's presentation using the image element's [`width`](/en-US/docs/Web/HTML/Element/img#width) and
+[`height`](/en-US/docs/Web/HTML/Element/img#height) attributes.
+By establishing the intrinsic aspect ratio in this manner, you prevent elements from shifting around while the document loads, which can be disconcerting or off-putting at best and can cause users to click the wrong thing at worst, depending on the exact timing of the deferred loads and reflows.
 
 ## Examples
 
-The `addImageToList()` function shown below adds a photo thumbnail to a list
-of items, using lazy-loading to avoid loading the image from the network until it's
-actually needed.
+The `addImageToList()` function shown below adds a photo thumbnail to a list of items, using lazy-loading to avoid loading the image from the network until it's actually needed.
 
 ```js
 function addImageToList(url) {

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -54,9 +54,13 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `eager`
       - : Load the iframe immediately, regardless if it is outside the visible viewport (this is the default value).
     - `lazy`
+
       - : Defer loading of the iframe until it reaches a calculated distance from the viewport, as defined by the browser.
         The intent is to avoid the network and storage bandwidth needed until its reasonably certain that it will be needed.
         This improves the performance and cost in most typical use cases.
+
+        > **Note:** Loading is only deferred when JavaScript is enabled.
+        > This is an anti-tracking measure.
 
 - `name`
   - : A targetable name for the embedded browsing context. This can be used in the `target` attribute of the {{HTMLElement("a")}}, {{HTMLElement("form")}}, or {{HTMLElement("base")}} elements; the `formtarget` attribute of the {{HTMLElement("input")}} or {{HTMLElement("button")}} elements; or the `windowName` parameter in the {{domxref("Window.open()","window.open()")}} method.


### PR DESCRIPTION
FF120 supports lazy loading of iframes in preview in https://bugzilla.mozilla.org/show_bug.cgi?id=1622090. 

This adds a note about the requirement for JavaScript to be enabled for lazy loading to work. This is copied from img docs to the `HTMLImageElement.loading` and the two iframe docs. Note that the first commit in this PR is a pure layout change.

Requirement was confirmed in https://bugzilla.mozilla.org/show_bug.cgi?id=1622090#c26

Related work can be tracked in #29780