### PR TITLE
FF120 Relnote/Expr: HTTP103 preconnect

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2428,7 +2428,8 @@ For more details see [Firefox bug 1617609](https://bugzil.la/1617609).
 
 ### HTTP Status 103
 
-The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code may be sent by a server to allow a user agent to start preloading resources while the server is still preparing the full response.
+The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code may be sent by a server to allow a user agent to start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources while the server is still preparing the full response.
+Note that using the header to [preconnect](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to sites is already supported.
 For more details see [Firefox bug 1813035](https://bugzil.la/1813035).
 
 <table>
@@ -2462,7 +2463,7 @@ For more details see [Firefox bug 1813035](https://bugzil.la/1813035).
     </tr>
     <tr>
       <th>Preference name</th>
-      <td colspan="2"><code>network.early-hints.enabled</code> and <code>network.early-hints.preconnect.enabled</code></td>
+      <td colspan="2"><code>network.early-hints.enabled</code></td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -50,6 +50,9 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### HTTP
 
+- The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code is enabled for [preconnecting](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to a particular origin (that the page is likely to need resources from).
+  For more details see [Firefox bug 1858712](https://bugzil.la/1858712).
+
 #### Removals
 
 ### Security

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -2,12 +2,10 @@
 title: 103 Early Hints
 slug: Web/HTTP/Status/103
 page-type: http-status-code
-status:
-  - experimental
 browser-compat: http.status.103
 ---
 
-{{HTTPSidebar}}{{SeeCompatTable}}
+{{HTTPSidebar}}
 
 The HTTP **`103 Early Hints`** [information response](/en-US/docs/Web/HTTP/Status#information_responses) may be sent by a server while it is still preparing a response, with hints about the sites and resources that the server is expecting the final response will link.
 This allows a browser to [preconnect](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to sites or start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources even before the server has prepared and sent that final response.

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -28,8 +28,8 @@ The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs
   - : This code is sent in response to an {{HTTPHeader("Upgrade")}} request header from the client and indicates the protocol the server is switching to.
 - {{HTTPStatus(102, "102 Processing")}} ({{Glossary("WebDAV")}})
   - : This code indicates that the server has received and is processing the request, but no response is available yet.
-- {{HTTPStatus(103, "103 Early Hints")}} {{experimental_inline}}
-  - : This status code is primarily intended to be used with the {{HTTPHeader("Link")}} header, letting the user agent start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources while the server prepares a response.
+- {{HTTPStatus(103, "103 Early Hints")}}
+  - : This status code is primarily intended to be used with the {{HTTPHeader("Link")}} header, letting the user agent start [preloading](/en-US/docs/Web/HTML/Attributes/rel/preload) resources while the server prepares a response or [preconnect](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to an origin from which the page will need resources.
 
 ## Successful responses
 


### PR DESCRIPTION
FF120 supports [HTTP Status 103](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/103) for preconnect, but not preload. 

This updates the docs to:
- Update experimental features to remove preconnect case (preload still exists)
- Update release not to indicate preconnect case is supported
- Remove experimental status from page (the status now supported)

Related docs work done in #29779