### PR TITLE
docs(games): Fix link to game developer resources

### DIFF
--- a/files/en-us/games/techniques/3d_collision_detection/index.md
+++ b/files/en-us/games/techniques/3d_collision_detection/index.md
@@ -165,5 +165,5 @@ Related articles on MDN:
 
 External resources:
 
-- [Simple intersection tests for games](https://www.gamasutra.com/view/feature/3383/simple_intersection_tests_for_games.php) on Gamasutra
+- [Simple intersection tests for games](https://www.gamedeveloper.com/disciplines/simple-intersection-tests-for-games) on Game Developer
 - [Bounding volume](https://en.wikipedia.org/wiki/Bounding_volume) on Wikipedia


### PR DESCRIPTION
The Gamasutra link at the bottom of the page was broken, I fixed it.
