### PR TITLE
CanvasRenderingContext2D/globalCompositeOperation - Remove draft abandoned values mention in BCD specific notes

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -426,20 +426,6 @@ const op_8x8 = createInterlace(8, "#FFF", "#eee");
 
 {{Compat}}
 
-### WebKit/Blink-specific notes
-
-- In WebKit- and Blink-based Browsers, a non-standard and deprecated method
-  `ctx.setCompositeOperation()` is implemented besides this property.
-- Support for `"plus-darker"` and `"darker"` were removed in
-  Chrome 48. Developers looking for a replacement should use `"darken"`.
-
-### Gecko-specific notes
-
-- An early Canvas specification draft specified the value `"darker"`.
-  However, Firefox removed support for `"darker"` in version 4
-  ([Firefox bug 571532](https://bugzil.la/571532)). See also [this blog post](https://dropshado.ws/post/77229081704/firefox-doesnt-support-canvas-composite-darker) that suggests using `"difference"` as a way to achieve a
-  similar affect to `"darker"`.
-
 ## See also
 
 - The interface defining this property: {{domxref("CanvasRenderingContext2D")}}


### PR DESCRIPTION
### Description

While updating this page in French, I noticed those notes about non-standard values removed from old browsers and chose to remove them.

### Motivation

Keeping it simple and up-to-date for newcomers wanting to build something on the Web. Make the docs more agnostic.
