### PR TITLE
docs(js): change height params for EmbedInteractiveExample calls

### DIFF
--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.classes.extends
 
 The **`extends`** keyword is used in [class declarations](/en-US/docs/Web/JavaScript/Reference/Statements/class) or [class expressions](/en-US/docs/Web/JavaScript/Reference/Operators/class) to create a class that is a child of another class.
 
-{{EmbedInteractiveExample("pages/js/classes-extends.html")}}
+{{EmbedInteractiveExample("pages/js/classes-extends.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -13,7 +13,7 @@ value.
 
 See also {{jsxref("Array.prototype.reduce()")}} for left-to-right.
 
-{{EmbedInteractiveExample("pages/js/array-reduce-right.html", "shorter")}}
+{{EmbedInteractiveExample("pages/js/array-reduce-right.html")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.BigInt.asIntN
 
 The **`BigInt.asIntN()`** static method truncates a `BigInt` value to the given number of least significant bits and returns that value as a signed integer.
 
-{{EmbedInteractiveExample("pages/js/bigint-asintn.html", "taller")}}
+{{EmbedInteractiveExample("pages/js/bigint-asintn.html")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaledatestring/index.md
@@ -11,7 +11,7 @@ The **`toLocaleDateString()`** method of {{jsxref("Date")}} instances returns a 
 
 When formatting large numbers of dates, it is better to create an {{jsxref("Intl.DateTimeFormat")}} object and use its {{jsxref("Intl/DateTimeFormat/format", "format()")}} method.
 
-{{EmbedInteractiveExample("pages/js/date-tolocaledatestring.html")}}
+{{EmbedInteractiveExample("pages/js/date-tolocaledatestring.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatToParts
 
 The **`formatToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances allows locale-aware formatting of strings produced by this `Intl.DateTimeFormat` object.
 
-{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formattoparts.html")}}
+{{EmbedInteractiveExample("pages/js/intl-datetimeformat-prototype-formattoparts.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/formattoparts/index.md
@@ -11,7 +11,7 @@ The **`formatToParts()`** method of {{jsxref("Intl.ListFormat")}} instances
 returns an {{jsxref("Array")}} of objects representing the different components that
 can be used to format a list of values in a locale-aware fashion.
 
-{{EmbedInteractiveExample("pages/js/intl-listformat-prototype-formattoparts.html")}}
+{{EmbedInteractiveExample("pages/js/intl-listformat-prototype-formattoparts.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/tostring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.Locale.toString
 
 The **`toString()`** method of {{jsxref("Intl.Locale")}} instances returns this Locale's full [locale identifier string](https://www.unicode.org/reports/tr35/#Unicode_locale_identifier).
 
-{{EmbedInteractiveExample("pages/js/intl-locale-prototype-tostring.html")}}
+{{EmbedInteractiveExample("pages/js/intl-locale-prototype-tostring.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.NumberFormat
 
 The **`Intl.NumberFormat()`** constructor creates {{jsxref("Intl.NumberFormat")}} objects.
 
-{{EmbedInteractiveExample("pages/js/intl-numberformat.html")}}
+{{EmbedInteractiveExample("pages/js/intl-numberformat.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.JSON.stringify
 
 The **`JSON.stringify()`** static method converts a JavaScript value to a JSON string, optionally replacing values if a replacer function is specified or optionally including only the specified properties if a replacer array is specified.
 
-{{EmbedInteractiveExample("pages/js/json-stringify.html")}}
+{{EmbedInteractiveExample("pages/js/json-stringify.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
@@ -13,7 +13,7 @@ The **`Map.groupBy()`** static method groups the elements of a given iterable us
 
 The method is primarily useful when grouping elements that are associated with an object, and in particular when that object might change over time. If the object is invariant, you might instead represent it using a string, and group elements with {{jsxref("Object.groupBy()")}}.
 
-{{EmbedInteractiveExample("pages/js/map-groupby.html", "shorter")}}
+{{EmbedInteractiveExample("pages/js/map-groupby.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Promise.allSettled
 
 The **`Promise.allSettled()`** static method takes an iterable of promises as input and returns a single {{jsxref("Promise")}}. This returned promise fulfills when all of the input's promises settle (including when an empty iterable is passed), with an array of objects that describe the outcome of each promise.
 
-{{EmbedInteractiveExample("pages/js/promise-allsettled.html")}}
+{{EmbedInteractiveExample("pages/js/promise-allsettled.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/apply/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Reflect.apply
 
 The **`Reflect.apply()`** static method calls a target function with arguments as specified.
 
-{{EmbedInteractiveExample("pages/js/reflect-apply.html")}}
+{{EmbedInteractiveExample("pages/js/reflect-apply.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.indexOf
 
 The **`indexOf()`** method of {{jsxref("String")}} values searches this string and returns the index of the first occurrence of the specified substring. It takes an optional starting position and returns the first occurrence of the specified substring at an index greater than or equal to the specified number.
 
-{{EmbedInteractiveExample("pages/js/string-indexof.html")}}
+{{EmbedInteractiveExample("pages/js/string-indexof.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/lastindexof/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.String.lastIndexOf
 
 The **`lastIndexOf()`** method of {{jsxref("String")}} values searches this string and returns the index of the last occurrence of the specified substring. It takes an optional starting position and returns the last occurrence of the specified substring at an index less than or equal to the specified number.
 
-{{EmbedInteractiveExample("pages/js/string-lastindexof.html", "shorter")}}
+{{EmbedInteractiveExample("pages/js/string-lastindexof.html")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -11,7 +11,7 @@ The **`Symbol.split`** static data property represents the [well-known symbol](/
 
 For more information, see[`RegExp.prototype[@@split]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split) and {{jsxref("String.prototype.split()")}}.
 
-{{EmbedInteractiveExample("pages/js/symbol-split.html")}}
+{{EmbedInteractiveExample("pages/js/symbol-split.html", "taller")}}
 
 ## Value
 


### PR DESCRIPTION
Some improvements to interactive examples following changes in https://github.com/mdn/interactive-examples/pull/2648

<details>

These have additional vertical lines, and need the taller editor

```plain
live-examples/js-examples/bigint/bigint-asintn.js -> example needs to be shortened, remove taller in content
live-examples/js-examples/string/string-indexof.js -> content needs taller editor, example needs to be shortened (horizonatally)
live-examples/js-examples/array/array-reduce-right.js -> content needs standard editor
live-examples/js-examples/classes/classes-extends.js -> content needs taller editor
live-examples/js-examples/date/date-tolocaledatestring.js -> content needs taller editor
live-examples/js-examples/intl/intl-datetimeformat-prototype-formattoparts.js -> content needs taller editor
live-examples/js-examples/intl/intl-listformat-prototype-formattoparts.js -> content needs taller editor
live-examples/js-examples/intl/intl-locale-prototype-tostring.js -> content needs taller editor
live-examples/js-examples/intl/intl-numberformat.js -> content needs taller editor
live-examples/js-examples/json/json-stringify.js -> content needs taller editor
live-examples/js-examples/map/map-groupby.js -> content needs taller editor
live-examples/js-examples/promise/promise-allsettled.js -> content needs taller editor
live-examples/js-examples/reflect/reflect-apply.js -> content needs taller editor
live-examples/js-examples/symbol/symbol-split.js -> -> content needs taller editor
```

</details>


__Depends on:__

- [x] https://github.com/mdn/interactive-examples/pull/2649