### PR TITLE
Fix the return type for HTMLCollection.item()

### DIFF
--- a/files/en-us/web/api/htmlcollection/index.md
+++ b/files/en-us/web/api/htmlcollection/index.md
@@ -24,7 +24,7 @@ An `HTMLCollection` in the HTML DOM is live; it is automatically updated when th
 
 - {{domxref("HTMLCollection.item()")}}
 
-  - : Returns the specific node at the given zero-based `index` into the list. Returns `null` if the `index` is out of range.
+  - : Returns the specific element at the given zero-based `index` into the list. Returns `null` if the `index` is out of range.
 
     An alternative to accessing `collection[i]` (which instead returns `undefined` when `i` is out-of-bounds). This is mostly useful for non-JavaScript DOM implementations.
 

--- a/files/en-us/web/api/htmlcollection/item/index.md
+++ b/files/en-us/web/api/htmlcollection/item/index.md
@@ -9,12 +9,12 @@ browser-compat: api.HTMLCollection.item
 {{APIRef("HTML DOM")}}
 
 The {{domxref("HTMLCollection")}} method `item()`
-returns the node located at the specified offset into the collection.
+returns the element located at the specified offset into the collection.
 
 > **Note:** Because the contents of an `HTMLCollection` are
 > live, changes to the underlying DOM can and will cause the position of individual
-> nodes in the collection to change, so the index value will not necessarily remain
-> constant for a given node.
+> elements in the collection to change, so the index value will not necessarily remain
+> constant for a given element.
 
 ## Syntax
 
@@ -25,13 +25,13 @@ item(index)
 ### Parameters
 
 - `index`
-  - : The position of the {{domxref("Node")}} to be returned. Elements appear in an
+  - : The position of the {{domxref("Element")}} to be returned. Elements appear in an
     `HTMLCollection` in the same order in which they appear in the document's
     source.
 
 ### Return value
 
-The {{domxref("Node")}} at the specified index, or `null` if
+The {{domxref("Element")}} at the specified index, or `null` if
 `index` is less than zero or greater than or equal to the length property.
 
 ## Usage notes


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The HTMLCollection.item() used the word "node" and stated its return type as a Node, while it actually returns an Element. I do know, that Element extends the Node type, but it would be more precise to use the Element type, when talking about the method. 

### Motivation

The change fixes a factual error, the source is [the specification provided in the documentation](https://dom.spec.whatwg.org/#interface-htmlcollection).