### PR TITLE
Add LBRY scheme to allowlist

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
@@ -52,7 +52,7 @@ Each protocol handler has three properties, all mandatory:
 
   - : A string defining the protocol. This must be either:
 
-    - one of the following: "bitcoin", "dat", "dweb", "ftp", "geo", "gopher", "im", "ipfs", "ipns", "irc", "ircs", "magnet", "mailto", "matrix", "mms", "news", "nntp", "sip", "sms", "smsto", "ssb", "ssh", "tel", "urn", "webcal", "wtai", "xmpp".
+    - one of the following: "bitcoin", "dat", "dweb", "ftp", "geo", "gopher", "im", "ipfs", "ipns", "irc", "ircs", "lbry", "magnet", "mailto", "matrix", "mms", "news", "nntp", "sip", "sms", "smsto", "ssb", "ssh", "tel", "urn", "webcal", "wtai", "xmpp".
     - a string consisting of a custom name prefixed with "web+" or "ext+". For example: "web+foo" or "ext+foo". The custom name must consist only of lower-case {{Glossary("ASCII")}} characters. It's recommended that extensions use the "ext+" form.
 
 - `name`

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.md
@@ -72,6 +72,7 @@ Otherwise, the scheme must be one of the following:
 - `im`
 - `irc`
 - `ircs`
+- `lbry`
 - `magnet`
 - `mailto`
 - `matrix`

--- a/files/en-us/web/api/navigator/unregisterprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/unregisterprotocolhandler/index.md
@@ -64,6 +64,7 @@ Otherwise, the scheme must be one of the following:
 - `im`
 - `irc`
 - `ircs`
+- `lbry`
 - `magnet`
 - `mailto`
 - `matrix`


### PR DESCRIPTION
### Description

This pull request adds the `lbry` protocol scheme to the MDN documentation.

### Motivation

Adding support for LBRY in browsers.

### Additional details

None

### Related issues and pull requests

**Fixes:** https://github.com/mdn/mdn/issues/472
**Relates to:** https://github.com/whatwg/html/issues/9016
**Depends on:** https://github.com/whatwg/html/pull/9017