### PR TITLE
Fixed the missleading syntax for CharacterData.replaceWith

### DIFF
--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -17,7 +17,7 @@ Strings are inserted as {{domxref("Text")}} nodes; the string is being passed as
 ## Syntax
 
 ```js-nolint
-replaceWith(nodes)
+replaceWith(...nodes)
 ```
 
 ### Parameters


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`CharacterData.replaceWith()` was missing `...` in its syntax section, which would indicate, that the parameters are not accepted as an array, but as multiple parameters .

### Motivation

Other methods, that accept arguments in such a way, denote that in their syntax section, this one does not, which could have been misleading. The source for it accepting the arguments in such a manner is [the specification](https://dom.spec.whatwg.org/#ref-for-dom-childnode-replacewith%E2%91%A0)
