### PR TITLE
Add word read-only to `History.state`

### DIFF
--- a/files/en-us/web/api/history/state/index.md
+++ b/files/en-us/web/api/history/state/index.md
@@ -8,7 +8,7 @@ browser-compat: api.History.state
 
 {{APIRef("History API")}}
 
-The **`History.state`** property
+The **`History.state`** read-only property
 returns a value representing the state at the top of the history stack. This is
 a way to look at the state without having to wait for a {{domxref("Window/popstate_event", "popstate")}} event.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`History.state` is a read-only property, see https://html.spec.whatwg.org/multipage/nav-history-apis.html#history-3

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
