### PR TITLE
FF120 Relnote: Global Privacy Control

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2337,51 +2337,6 @@ The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP respo
   </tbody>
 </table>
 
-### Global Privacy Control
-
-[Global Privacy Control](https://globalprivacycontrol.org/) is a mechanism that allows a user to indicate that they do not consent to a website or service selling or sharing their personal information with third parties.
-Firefox implements the {{HTTPHeader("Sec-GPC")}} header to indicate that consent is not granted, and the {{domxref("Navigator.globalPrivacyControl")}} and {{domxref("WorkerNavigator.globalPrivacyControl")}} properties that allow JavaScript to check the user consent preference.
-
-Note that the `about:config` preference `privacy.globalprivacycontrol.enabled` must be set `true` to indicate the user preference to not grant consent ([Firefox bug 1830623](https://bugzil.la/1830623)).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>118</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>95</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>95</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>95</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">
-        <code>privacy.globalprivacycontrol.functionality.enabled</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## HTTP
 
 ### SameSite=Lax by default

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -54,6 +54,9 @@ This article provides information about the changes in Firefox 120 that affect d
 
 - The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code is enabled for [preconnecting](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to a particular origin (that the page is likely to need resources from).
   For more details see [Firefox bug 1858712](https://bugzil.la/1858712).
+- Firefox supports the [Global Privacy Control](https://globalprivacycontrol.org/) {{HTTPHeader("Sec-GPC")}} request header, which may be sent to indicate that the user does not consent to a website or service selling or sharing their personal information with third parties.
+  Users can enable the header, in both normal and private browsing modes, by setting the preference `privacy.globalprivacycontrol.enabled` to `true` (in `about:config`).
+  The {{domxref("Navigator.globalPrivacyControl")}} and {{domxref("WorkerNavigator.globalPrivacyControl")}} properties allow JavaScript to check the user consent preference ([Firefox bug 1856029](https://bugzil.la/1856029)).
 
 #### Removals
 

--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Navigator.globalPrivacyControl
 
 {{APIRef("DOM")}}{{SeeCompatTable}}
 
-The **`Navigator.globalPrivacyControl`** read-only property returns the user's Global Privacy Control setting for the current website.
+The **`Navigator.globalPrivacyControl`** read-only property returns the user's [Global Privacy Control](globalprivacycontrol.org) setting for the current website.
 This setting indicates whether the user consents to the website or service selling or sharing their personal information with third parties.
 
 The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP header.

--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -9,7 +9,7 @@ browser-compat: http.headers.Sec-GPC
 
 {{HTTPSidebar}}{{SeeCompatTable}}
 
-The **`Sec-GPC`** (**G**lobal **P**rivacy **C**ontrol) request header indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
+The **`Sec-GPC`** ([**G**lobal **P**rivacy **C**ontrol](https://globalprivacycontrol.org/)) request header indicates whether the user consents to a website or service selling or sharing their personal information with third parties.
 
 The specification does not define how the user can withdraw or grant consent for website.
 Where possible the mechanism will be indicated in the [browser compatibility](#browser_compatibility) section below.


### PR DESCRIPTION
FF120 enables GPS (global privacy control) in https://bugzilla.mozilla.org/show_bug.cgi?id=1856029. This is essentially an HTTP header that can be sent in requests to deny consent for private data to be sold/shared with third parties, and a Navigator property to check this setting.

The header is sent based on a `about:config` preference that users will have to enable. 

This adds a release note, removes the experimental features, and adds better linking to the GPC website in the affected pages.

For related docs work see #30003