### PR TITLE
Some minor keyboard lock api improvements

### DIFF
--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -16,7 +16,7 @@ capture of keypresses for any or all of the keys on the physical keyboard. This 
 can only capture keys that are granted access by the underlying operating
 system.
 
-If `lock()` is called multiple times without an intervening call to {{domxref("Keyboard.unlock()", "unlock()")}}, then only the key codes specified in the last call will be locked.
+If `lock()` is called multiple times, previously locked keys will be unlocked and only the key codes specified in the most recent call will be locked.
 
 ## Syntax
 
@@ -33,7 +33,7 @@ lock(keyCodes)
 
 ### Return value
 
-A {{jsxref('Promise')}}.
+A {{jsxref('Promise')}} that resolves with {{jsxref('undefined')}} when the lock was successful.
 
 ### Exceptions
 

--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -16,7 +16,8 @@ capture of keypresses for any or all of the keys on the physical keyboard. This 
 can only capture keys that are granted access by the underlying operating
 system.
 
-If `lock()` is called multiple times, previously locked keys will be unlocked and only the key codes specified in the most recent call will be locked.
+If `lock()` is called multiple times then only the key codes specified in the most recent call will be locked.
+Any keys locked by a previous call to `lock()` are unlocked.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Clarified how `navigator.keyboard.lock()` works when called multiple times.
- More detailed return value description.

### Motivation

The previous description for calling `lock()` multiple times was a bit unclear to me. It seems to be copied directly from [the spec](https://wicg.github.io/keyboard-lock/#h-keyboard-lock:~:text=is%20called%20multiple%20times%20without%20an%20intervening).
The 'without an intervening call to `unlock()`' part threw me off, because this made it sound like it *will* combine all previous keycodes if you were to call `unlock()` in between.
