### PR TITLE
importmaps do not apply to workers/worklets

### DIFF
--- a/files/en-us/web/html/element/script/type/importmap/index.md
+++ b/files/en-us/web/html/element/script/type/importmap/index.md
@@ -14,7 +14,7 @@ It provides a mapping between the text used as the module specifier in an [`impo
 The JSON object must conform to the [Import map JSON representation format](#import_map_json_representation).
 
 An import map is used to resolve module specifiers in static and dynamic imports, and therefore must be declared and processed before any `<script>` elements that import modules using specifiers declared in the map.
-Note that the import map applies only to module specifiers in the [`import` statement](/en-US/docs/Web/JavaScript/Reference/Statements/import) or [`import()` operator](/en-US/docs/Web/JavaScript/Reference/Operators/import); it does not apply to the path specified in the `src` attribute of a `<script>` element.
+Note that the import map applies only to module specifiers in the [`import` statement](/en-US/docs/Web/JavaScript/Reference/Statements/import) or [`import()` operator](/en-US/docs/Web/JavaScript/Reference/Operators/import) for modules loaded into documents; it does not apply to the path specified in the `src` attribute of a `<script>` element or to modules loaded into workers or worklets.
 
 For more information, see the [Importing modules using import maps](/en-US/docs/Web/JavaScript/Guide/Modules#importing_modules_using_import_maps) section in the JavaScript modules guide.
 

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -181,6 +181,7 @@ Relative URLs are resolved to absolute URL addresses using the [base URL](/en-US
 
 The import map is defined using a [JSON object](/en-US/docs/Web/HTML/Element/script/type/importmap#import_map_json_representation) inside a `<script>` element with the `type` attribute set to [`importmap`](/en-US/docs/Web/HTML/Element/script/type/importmap).
 There can only be one import map in the document, and because it is used to resolve which modules are loaded in both static and dynamic imports, it must be declared before any `<script>` elements that import modules.
+Note that the import map only applies to the document — the specification does not cover how to apply an import map in a worker or worklet context. <!-- https://github.com/WICG/import-maps/issues/2 -->
 
 With this map you can now use the property names above as module specifiers.
 If there is no trailing forward slash on the module specifier key then the whole module specifier key is matched and substituted.


### PR DESCRIPTION
This adds a few notes to make it clear that importmaps apply only to the importing document.
There is no official specification for applying importmaps to workers - though there is a discussion here https://github.com/WICG/import-maps/issues/2

This falls out of the discussion in https://github.com/mdn/browser-compat-data/pull/21157