### PR TITLE
Add the last page-type values

### DIFF
--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to build custom form controls
 slug: Learn/Forms/How_to_build_custom_form_controls
+page-type: learn-module-chapter
 ---
 
 {{LearnSidebar}}

--- a/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_javascript_deno/index.md
+++ b/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_javascript_deno/index.md
@@ -1,6 +1,7 @@
 ---
 title: Writing a WebSocket server in JavaScript (Deno)
 slug: Web/API/WebSockets_API/Writing_a_WebSocket_server_in_JavaScript_Deno
+page-type: guide
 ---
 
 {{DefaultAPISidebar("Websockets API")}}

--- a/files/en-us/web/http/headers/sec-ch-prefers-color-scheme/index.md
+++ b/files/en-us/web/http/headers/sec-ch-prefers-color-scheme/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sec-CH-Prefers-Color-Scheme
 slug: Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme
+page-type: http-header
 status:
   - experimental
 browser-compat: http.headers.Sec-CH-Prefers-Color-Scheme

--- a/files/en-us/web/xslt/index.md
+++ b/files/en-us/web/xslt/index.md
@@ -1,6 +1,7 @@
 ---
 title: "XSLT: Extensible Stylesheet Language Transformations"
 slug: Web/XSLT
+page-type: landing-page
 ---
 
 {{XsltSidebar}}

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -4,7 +4,7 @@
     "title": "Front matter schema",
     "type": "object",
     "additionalProperties": false,
-    "required": ["title", "slug"],
+    "required": ["title", "slug", "page-type"],
     "properties": {
       "title": {
         "title": "Title",


### PR DESCRIPTION
This PR adds `page-type` values for the four pages which didn't have one, and makes `page-type` a mandatory front matter key (I think, if I understand the schema properly).

Fixes https://github.com/openwebdocs/project/issues/91.