### PR TITLE
Fix sidebar on this guide page

### DIFF
--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -4,7 +4,7 @@ slug: Web/API/File_API/Using_files_from_web_applications
 page-type: guide
 ---
 
-{{APIRef("File API")}}
+{{DefaultAPISidebar("File API")}}
 
 Using the File API, web content can ask the user to select local files and then read the contents of those files. This selection can be done by either using an HTML `{{HTMLElement("input/file", '&lt;input type="file"&gt;')}}` element or by drag and drop.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Guide pages should use `{{DefaultAPISidebar}}` instead of `{{APIRef}}`. This PR fixes it.
