### PR TITLE
relnote(120): [Nightly] Prefixed CSS transform & transition properties

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -982,7 +982,7 @@ The CSS {{cssxref("offset-path")}} property now supports using [`url()`](/en-US/
 
 ### zoom property
 
-The non-standard CSS {{cssxref("zoom")}} property lets you magnify an element similar to the {{cssxref("transform")}} property, but it affects the layout size of the element.
+The non-standard CSS {{cssxref("zoom")}} property is enabled in the Nightly release and lets you magnify an element similar to the {{cssxref("transform")}} property, but it affects the layout size of the element.
 See ([Firefox bug 1855763](https://bugzil.la/1855763) and [Firefox bug 390936](https://bugzil.la/390936)) for more details.
 
 <table>
@@ -1018,6 +1018,108 @@ See ([Firefox bug 1855763](https://bugzil.la/1855763) and [Firefox bug 390936](h
       <th>Preference name</th>
       <td colspan="2">
       <code>layout.css.zoom.enabled</code>
+    </td>
+    </tr>
+  </tbody>
+</table>
+
+To ensure compatibility with these changes, the [Vendor-prefixed transform properties](#vendor-prefixed-transform-properties) and the [Vendor-prefixed transition properties](#vendor-prefixed-transition-properties) are disabled in the Nightly release.
+These changes are described in the following sections.
+
+#### Vendor-prefixed transform properties
+
+The `-moz-` prefixed [CSS transform](/en-US/docs/Web/CSS/CSS_transforms) properties have been disabled in the Nightly release via the `layout.css.prefixes.transforms` preference being set to `false` ([Firefox bug 1855763](https://bugzil.la/1855763)).
+Specifically, the disabled properties are:
+
+- `-moz-backface-visibility`
+- `-moz-perspective`
+- `-moz-perspective-origin`
+- `-moz-transform`
+- `-moz-transform-origin`
+- `-moz-transform-style`
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>120</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+      <code>layout.css.prefixes.transforms</code>
+    </td>
+    </tr>
+  </tbody>
+</table>
+
+#### Vendor-prefixed transition properties
+
+The `-moz-` prefixed [CSS transitions](/en-US/docs/Web/CSS/CSS_transitions) properties have been disabled in the Nightly release via the `layout.css.prefixes.transitions` preference being set to `false` ([Firefox bug 1855763](https://bugzil.la/1855763)).
+Specifically, the disabled properties are:
+
+- `-moz-transition`
+- `-moz-transition-delay`
+- `-moz-transition-duration`
+- `-moz-transition-property`
+- `-moz-transition-timing-function`
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>120</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>120</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+      <code>layout.css.prefixes.transitions</code>
     </td>
     </tr>
   </tbody>

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -22,16 +22,6 @@ This article provides information about the changes in Firefox 120 that affect d
 
 #### Removals
 
-- The `-moz-` prefixed [CSS transform](/en-US/docs/Web/CSS/CSS_transforms) properties have been disabled via the `layout.css.prefixes.transforms` preference being set to `false` by default ([Firefox bug 1855763](https://bugzil.la/1855763)).
-  Specifically, the disabled properties are:
-
-  - `-moz-backface-visibility`
-  - `-moz-perspective`
-  - `-moz-perspective-origin`
-  - `-moz-transform`
-  - `-moz-transform-origin`
-  - `-moz-transform-style`
-
 ### JavaScript
 
 - {{jsxref("Date.parse()")}} now accepts several additional date formats:

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -51,7 +51,7 @@ Firefox supports a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_,
 
 ### B
 
-- {{CSSxRef("backface-visibility", "-moz-backface-visibility")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("backface-visibility")}})
+- {{CSSxRef("backface-visibility", "-moz-backface-visibility")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("background-clip", "-moz-background-clip")}} {{deprecated_inline}}
 - {{CSSxRef("background-origin", "-moz-background-origin")}} {{deprecated_inline}}
 - {{CSSxRef("box-decoration-break", "-moz-background-inline-policy")}} {{deprecated_inline}} (No longer supported; use the standard {{CSSxRef("box-decoration-break")}})
@@ -102,8 +102,8 @@ Firefox supports a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_,
 
 - {{CSSxRef("padding-inline-end", "-moz-padding-end")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("padding-inline-end")}})
 - {{CSSxRef("padding-inline-start", "-moz-padding-start")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("padding-inline-start")}})
-- {{CSSxRef("perspective", "-moz-perspective")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("perspective")}})
-- {{CSSxRef("perspective-origin", "-moz-perspective-origin")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("perspective-origin")}})
+- {{CSSxRef("perspective", "-moz-perspective")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("perspective-origin", "-moz-perspective-origin")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("pointer-events")}} {{Experimental_Inline}} (Applying to more than SVG)
 
 ### T–U
@@ -114,9 +114,9 @@ Firefox supports a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_,
 - {{CSSxRef("text-decoration-line", "-moz-text-decoration-line")}} {{deprecated_inline}}
 - {{CSSxRef("text-decoration-style", "-moz-text-decoration-style")}} {{deprecated_inline}}
 - {{CSSxRef("text-size-adjust", "-moz-text-size-adjust")}} {{Experimental_Inline}}
-- {{CSSxRef("transform", "-moz-transform")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("transform")}})
-- {{CSSxRef("transform-origin", "-moz-transform-origin")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("transform-origin")}})
-- {{CSSxRef("transform-style", "-moz-transform-style")}} {{Deprecated_Inline}} (No longer supported; use the standard {{CSSxRef("transform-style")}})
+- {{CSSxRef("transform", "-moz-transform")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("transform-origin", "-moz-transform-origin")}} {{Deprecated_Inline}} (Prefixed version still supported)
+- {{CSSxRef("transform-style", "-moz-transform-style")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("transition", "-moz-transition")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("transition-delay", "-moz-transition-delay")}} {{Deprecated_Inline}} (Prefixed version still supported)
 - {{CSSxRef("transition-duration", "-moz-transition-duration")}} {{Deprecated_Inline}} (Prefixed version still supported)


### PR DESCRIPTION
This PR clarifies the status of the vendor-prefixed transform and transition properties.

* For all changes, this is Nightly-only
* Move `-moz-transform*` relnote to experimental features page under `zoom`
* Set prefixed CSS transform props as still supported
* Add experimental features relnote for CSS transition props


__Related issues and pull requests:__

- [x] Parent issue https://github.com/mdn/content/issues/29785
- [x] Initial PR: https://github.com/mdn/content/pull/29911
- [x] Follow-up: https://github.com/mdn/content/pull/29815
- [x] BCD: (`zoom`) https://github.com/mdn/browser-compat-data/pull/21122

