### PR TITLE
Add Number to the list of types for structured clone algorithm

### DIFF
--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -33,6 +33,7 @@ It clones by recursing through the input object while maintaining a map of previ
 - {{jsxref("Date")}}
 - {{jsxref("Error")}} types (but see [Error types](#error_types) below).
 - {{jsxref("Map")}}
+- {{jsxref("Number")}}
 - {{jsxref("Object")}} objects: but only plain objects (e.g. from object literals).
 - [Primitive types](/en-US/docs/Web/JavaScript/Data_structures#primitive_values), except `symbol`.
 - {{jsxref("RegExp")}}: but note that `lastIndex` is not preserved.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add `Number`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

`Number` objects are cloneable and the other built-in wrappers, `String` and `Boolean`, are already included.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

See https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal for cloneability.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
