### PR TITLE
Background page load fail bug fix release note

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -34,7 +34,7 @@ browser-compat: webextensions.manifest.background
   </tbody>
 </table>
 
-Use the `background` key to include one or more background scripts or a background page in your extension.
+Use the `background` key to include one or more background scripts, a background page, or a Service worker in your extension.
 
 Background scripts are the place to put code that needs to maintain a long-term state, or perform long-term operations, independently of the lifetime of any particular web pages or browser windows.
 
@@ -46,6 +46,22 @@ The `background` key is an object that must have one of these properties:
 
 <table class="standard-table">
   <tbody>
+    <tr>
+      <td><code>page</code></td>
+      <td>
+        <p>
+          If you need specific content in the background page, you can define a
+          page using the <code>page</code> property. This is a
+          <code>String</code> representing a path, relative to the manifest.json
+          file, to an HTML document included in your extension bundle.
+        </p>
+        <p>
+          If you use this property, you can not specify background scripts using
+          <code>scripts</code>, but you can include scripts from the
+          page, just like a normal web page.
+        </p>
+      </td>
+    </tr>
     <tr>
       <td><code>scripts</code></td>
       <td>
@@ -78,26 +94,36 @@ The `background` key is an object that must have one of these properties:
             key in the manifest.json file of your extension.
           </p>
         </div>
+        <p>
+          See the note following the table regarding browser support.
+        </p>
       </td>
     </tr>
     <tr>
-      <td><code>page</code></td>
+      <td><code>service_worker</code></td>
       <td>
         <p>
-          If you need specific content in the background page, you can define a
-          page using the <code>page</code> property. This is a
-          <code>String</code> representing a path, relative to the manifest.json
-          file, to an HTML document included in your extension bundle.
+          Specify a JavaScript file as the extension service worker. A service worker is a background script that acts as the extension's main event handler.
         </p>
         <p>
-          If you use this property, you can not specify background scripts using
-          <code>scripts</code>, but you can include scripts from the
-          page, just like a normal web page.
+          See the note following the table regarding browser support.
         </p>
       </td>
     </tr>
   </tbody>
 </table>
+
+> **Note:** Support for the `scripts` and `service_workers` properties varies between browsers like this.
+>
+> - Chrome:
+>   - supports `background.service_worker`.
+>   - before Chrome 121, Chrome refuses to load an extension that has `background.scripts` present. From Chrome 121, Chrome loads these extensions and ignores `background.scripts`.
+> - Safari:
+>   - supports `background.service_worker`.
+>   - supports `background.scripts`, if `service_worker` is not specified.
+> - Firefox:
+>   - supports `background.service_worker` if the service worker feature is enabled. However, this feature is affected by [a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1775618#c1).
+>   - supports `background.scripts`, if `service_worker` is not specified or the service worker feature is disabled.
 
 The `background` key can also contain this optional property:
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -36,13 +36,13 @@ browser-compat: webextensions.manifest.background
 
 Use the `background` key to include one or more background scripts, a background page, or a Service worker in your extension.
 
-Background scripts are the place to put code that needs to maintain a long-term state, or perform long-term operations, independently of the lifetime of any particular web pages or browser windows.
+Background scripts are the place to put code that needs to maintain a long-term state or perform long-term operations independently of the lifetime of any particular web pages or browser windows.
 
-Background scripts are loaded as soon as the extension is loaded and stay loaded until the extension is disabled or uninstalled unless `persistent` is specified as `false`. You can use any WebExtension APIs in the script as long as you have requested the necessary [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
+Background scripts are loaded as soon as the extension is loaded and stay loaded until the extension is disabled or uninstalled unless `persistent` is specified as `false`. You can use any WebExtension APIs in the script if you have requested the necessary [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
 
 See [Background scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts) for some more details.
 
-The `background` key is an object that must have one of these properties:
+The `background` key is an object that must have one of these properties (for more information on how these properties are supported, see [Browser support](#browser_support)):
 
 <table class="standard-table">
   <tbody>
@@ -52,8 +52,8 @@ The `background` key is an object that must have one of these properties:
         <p>
           If you need specific content in the background page, you can define a
           page using the <code>page</code> property. This is a
-          <code>String</code> representing a path, relative to the manifest.json
-          file, to an HTML document included in your extension bundle.
+          <code>String</code> representing a path relative to the manifest.json
+          file to an HTML document included in your extension bundle.
         </p>
         <p>
           If you use this property, you can not specify background scripts using
@@ -94,9 +94,6 @@ The `background` key is an object that must have one of these properties:
             key in the manifest.json file of your extension.
           </p>
         </div>
-        <p>
-          See the note following the table regarding browser support.
-        </p>
       </td>
     </tr>
     <tr>
@@ -105,26 +102,10 @@ The `background` key is an object that must have one of these properties:
         <p>
           Specify a JavaScript file as the extension [service worker](/en-US/docs/Web/API/Service_Worker_API). A service worker is a background script that acts as the extension's main event handler.
         </p>
-        <p>
-          See the note following the table regarding browser support.
-        </p>
       </td>
     </tr>
   </tbody>
 </table>
-
-> **Note:** Support for the `scripts`, `page` and `service_worker` properties varies between browsers like this.
->
-> - Chrome:
->   - supports `background.service_worker`.
->   - supports `background.scripts` (and `background.page`) in Manifest V2 extensions only.
->   - before Chrome 121, Chrome refuses to load a Manifest V3 extension that has `background.scripts` or `background.page` present. From Chrome 121, their presence in a Manifest V3 extension is ignored.
-> - Safari:
->   - supports `background.service_worker`.
->   - supports `background.scripts`, if `service_worker` is not specified.
-> - Firefox:
->   - `background.service_worker` is not supported ([bug 1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659).
->   - supports `background.scripts`, if `service_worker` is not specified or the service worker feature is disabled. Before Firefox 120, Firefox did not start the background page if `service_worker` was present ([Firefox bug 1860304](https://bugzil.la/1860304)). From Firefox 121, the background page starts as expected regardless of the presence of `service_worker`.
 
 The `background` key can also contain this optional property:
 
@@ -134,7 +115,7 @@ The `background` key can also contain this optional property:
       <td><code>persistent</code></td>
       <td>
         <p>A <code>Boolean</code> value.</p>
-        <p>If omitted, this property default to <code>true</code> in Manifest V2 and <code>false</code> in Manifest V3. Setting to <code>true</code> in Manifest V3 results in an error.</p>
+        <p>If omitted, this property defaults to <code>true</code> in Manifest V2 and <code>false</code> in Manifest V3. Setting to <code>true</code> in Manifest V3 results in an error.</p>
         <ul>
           <li>
             <code>true</code> indicates the background page is to be kept in
@@ -177,7 +158,54 @@ The `background` key can also contain this optional property:
   </tbody>
 </table>
 
-## Example
+## Browser support
+
+Support for the `scripts`, `page`, and `service_worker` properties varies between browsers like this:
+
+- Chrome:
+  - supports `background.service_worker`.
+  - supports `background.scripts` (and `background.page`) in Manifest V2 extensions only.
+  - before Chrome 121, Chrome refuses to load a Manifest V3 extension with `background.scripts` or `background.page` present. From Chrome 121, their presence in a Manifest V3 extension is ignored.
+- Firefox:
+  - `background.service_worker` is not supported (see [Firefox bug 1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659)).
+  - supports `background.scripts` if `service_worker` is not specified or the service worker feature is disabled. Before Firefox 120, Firefox did not start the background page if `service_worker` was present (see [Firefox bug 1860304](https://bugzil.la/1860304)). From Firefox 121, the background page starts as expected, regardless of the presence of `service_worker`.
+- Safari:
+  - supports `background.service_worker`.
+  - supports `background.scripts` if `service_worker` is not specified.
+
+To illustrate, this is a simple example of a cross-browser extension that supports `scripts` and `service_worker`. The example has this manifest.json file:
+
+```json
+{
+  "name": "Demo of service worker + event page",
+  "version": "1",
+  "manifest_version": 3,
+  "background": {
+    "scripts": ["background.js"],
+    "service_worker": "background.js"
+  }
+}
+```
+
+And, background.js contains:
+
+```javascript
+if (typeof browser == "undefined") {
+  // Chrome does not support the browser namespace yet.
+  globalThis.browser = chrome;
+}
+browser.runtime.onInstalled.addListener(() => {
+  browser.tabs.create({ url: "http://example.com/firstrun.html" });
+});
+```
+
+When the extension is executed, this happens:
+
+- in Chrome, the `service_worker` property is used, and a service worker starts that opens the tab because, in a Manifest V3 extension, Chrome only supports service workers for background scripts.
+- in Firefox, the `scripts` property is used, and a script starts that opens the tab because Firefox only supports scripts for background scripts.
+- in Safari, the `service_worker` property is used, and a service worker starts that opens the tab because Safari gives priority to using service workers for background scripts.
+
+## Examples
 
 ```json
   "background": {

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -168,10 +168,10 @@ Support for the `scripts`, `page`, and `service_worker` properties varies betwee
   - before Chrome 121, Chrome refuses to load a Manifest V3 extension with `background.scripts` or `background.page` present. From Chrome 121, their presence in a Manifest V3 extension is ignored.
 - Firefox:
   - `background.service_worker` is not supported (see [Firefox bug 1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659)).
-  - supports `background.scripts` if `service_worker` is not specified or the service worker feature is disabled. Before Firefox 120, Firefox did not start the background page if `service_worker` was present (see [Firefox bug 1860304](https://bugzil.la/1860304)). From Firefox 121, the background page starts as expected, regardless of the presence of `service_worker`.
+  - supports `background.scripts` (or `background.page`) if `service_worker` is not specified or the service worker feature is disabled. Before Firefox 120, Firefox did not start the background page if `service_worker` was present (see [Firefox bug 1860304](https://bugzil.la/1860304)). From Firefox 121, the background page starts as expected, regardless of the presence of `service_worker`.
 - Safari:
   - supports `background.service_worker`.
-  - supports `background.scripts` if `service_worker` is not specified.
+  - supports `background.scripts` (or `background.page`) if `service_worker` is not specified.
 
 To illustrate, this is a simple example of a cross-browser extension that supports `scripts` and `service_worker`. The example has this manifest.json file:
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -103,7 +103,7 @@ The `background` key is an object that must have one of these properties:
       <td><code>service_worker</code></td>
       <td>
         <p>
-          Specify a JavaScript file as the extension service worker. A service worker is a background script that acts as the extension's main event handler.
+          Specify a JavaScript file as the extension [service worker](/en-US/docs/Web/API/Service_Worker_API). A service worker is a background script that acts as the extension's main event handler.
         </p>
         <p>
           See the note following the table regarding browser support.
@@ -113,17 +113,18 @@ The `background` key is an object that must have one of these properties:
   </tbody>
 </table>
 
-> **Note:** Support for the `scripts` and `service_workers` properties varies between browsers like this.
+> **Note:** Support for the `scripts`, `page` and `service_worker` properties varies between browsers like this.
 >
 > - Chrome:
 >   - supports `background.service_worker`.
->   - before Chrome 121, Chrome refuses to load an extension that has `background.scripts` present. From Chrome 121, Chrome loads these extensions and ignores `background.scripts`.
+>   - supports `background.scripts` (and `background.page`) in Manifest V2 extensions only.
+>   - before Chrome 121, Chrome refuses to load a Manifest V3 extension that has `background.scripts` or `background.page` present. From Chrome 121, their presence in a Manifest V3 extension is ignored.
 > - Safari:
 >   - supports `background.service_worker`.
 >   - supports `background.scripts`, if `service_worker` is not specified.
 > - Firefox:
->   - supports `background.service_worker` if the service worker feature is enabled. However, this feature is affected by [a bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1775618#c1).
->   - supports `background.scripts`, if `service_worker` is not specified or the service worker feature is disabled.
+>   - `background.service_worker` is not supported ([bug 1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659).
+>   - supports `background.scripts`, if `service_worker` is not specified or the service worker feature is disabled. Before Firefox 120, Firefox did not start the background page if `service_worker` was present ([Firefox bug 1860304](https://bugzil.la/1860304)). From Firefox 121, the background page starts as expected regardless of the presence of `service_worker`.
 
 The `background` key can also contain this optional property:
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -62,6 +62,10 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### Other
 
+- Fixed a bug that caused background pages to fail to start when a manifest.json `background` key contained `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
+
+  > This fix doesn't resolve the issue where the service worker fails to load when the configuration preference `extensions.backgroundServiceWorker.enabled` is `true`, see ([Firefox bug 1775618](https://bugzil.la/1775618#c1)).
+
 ## Older versions
 
 {{Firefox_for_developers(120)}}

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -65,7 +65,7 @@ This article provides information about the changes in Firefox 121 that affect d
 - Fixed a bug that resulted in background pages not starting when a manifest.json `background` key contains `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
 
   > **Note:** Incidentally, a change in Chrome 121 sees the `scripts` property ignored when specified with the `service_worker` property. Previously, Chrome refused to load extensions containing both properties ([Chromium bug 1418934](https://crbug.com/1418934)).
-  > For more information, see [Browser support of the `background` manifest key](en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support).
+  > For more information, see [Browser support of the `background` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -64,7 +64,7 @@ This article provides information about the changes in Firefox 121 that affect d
 
 - Fixed a bug that caused background pages to fail to start when a manifest.json `background` key contained `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
 
-  > This fix doesn't resolve the issue where the service worker fails to load when the configuration preference `extensions.backgroundServiceWorker.enabled` is `true`, see ([Firefox bug 1775618](https://bugzil.la/1775618#c1)).
+  > NOTE: Incidentally, Chrome 121 now ignores the `scripts` key when specified along with the `service_worker` key, instead of refusing to load the extension ([Chromium bug 1418934](https://crbug.com/1418934)).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -64,7 +64,7 @@ This article provides information about the changes in Firefox 121 that affect d
 
 - Fixed a bug that caused background pages to fail to start when a manifest.json `background` key contained `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
 
-  > NOTE: Incidentally, Chrome 121 now ignores the `scripts` key when specified along with the `service_worker` key, instead of refusing to load the extension ([Chromium bug 1418934](https://crbug.com/1418934)).
+  > NOTE: Incidentally, Chrome 121 ignores the `scripts` key when specified with the `service_worker` key, instead of refusing to load the extension ([Chromium bug 1418934](https://crbug.com/1418934)).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -65,6 +65,7 @@ This article provides information about the changes in Firefox 121 that affect d
 - Fixed a bug that resulted in background pages not starting when a manifest.json `background` key contains `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
 
   > **Note:** Incidentally, a change in Chrome 121 sees the `scripts` property ignored when specified with the `service_worker` property. Previously, Chrome refused to load extensions containing both properties ([Chromium bug 1418934](https://crbug.com/1418934)).
+  > For more information, see [Browser support of the `background` manifest key](en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support).
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -62,9 +62,9 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### Other
 
-- Fixed a bug that caused background pages to fail to start when a manifest.json `background` key contained `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
+- Fixed a bug that resulted in background pages not starting when a manifest.json `background` key contains `service_worker` and `scripts` declarations ([Firefox bug 1860304](https://bugzil.la/1860304)).
 
-  > NOTE: Incidentally, Chrome 121 ignores the `scripts` key when specified with the `service_worker` key, instead of refusing to load the extension ([Chromium bug 1418934](https://crbug.com/1418934)).
+  > **Note:** Incidentally, a change in Chrome 121 sees the `scripts` property ignored when specified with the `service_worker` property. Previously, Chrome refused to load extensions containing both properties ([Chromium bug 1418934](https://crbug.com/1418934)).
 
 ## Older versions
 


### PR DESCRIPTION
### Description

Adds a release note describing the fix of a bug that resulted in background pages failing to load. Addresses the dev–doc–needed request for [Bug 1860304](https://bugzilla.mozilla.org/show_bug.cgi?id=1860304) Background page fails to load if background.service_worker and background.scripts are both present.
