### PR TITLE
css(padding-block): fix order of properties

### DIFF
--- a/files/en-us/web/css/padding-block/index.md
+++ b/files/en-us/web/css/padding-block/index.md
@@ -15,8 +15,8 @@ The **`padding-block`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/d
 
 This property is a shorthand for the following CSS properties:
 
-- {{cssxref("padding-block-end")}}
 - {{cssxref("padding-block-start")}}
+- {{cssxref("padding-block-end")}}
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The shorthand order seemed like it was `padding-end` then `padding-start` but it's the opposite.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I stumbled upon this one.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
