### PR TITLE
Clear up Intl.NumberFormat useGrouping doc

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -181,8 +181,12 @@ The above properties fall into two groups: `minimumIntegerDigits`, `minimumFract
       - : Display grouping separators based on the locale preference, which may also be dependent on the currency.
     - `"min2"`
       - : Display grouping separators when there are at least 2 digits in a group.
+    - `true`
+      - : Same as `"always"`.
+    - `false`
+      - : Display no grouping separators.
 
-    The default is `"min2"` if `notation` is `"compact"`, and `"auto"` otherwise. The boolean values `true` and `false` are accepted, but are always converted to the default value.
+    The default is `"min2"` if `notation` is `"compact"`, and `"auto"` otherwise. The string values `"true"` and `"false"` are accepted, but are always converted to the default value.
 
 - `signDisplay`
   - : When to display the sign for the number. Possible values are:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The handling of boolean values was documented incorrectly and confused with the string values `"true"` and `"false"`.
In fact, `true` and `false` are valid inputs and treated differently to `"true"` and `"false"`, with `false` having no equivalent string representation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current state of the documentation did not seem to align with the practical outcome of changes. This adaptation should avoid future confusion.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Relevant language specification (see steps 25 onward): https://402.ecma-international.org/10.0/index.html?_gl=1*1986v5e*_ga*Nzc5NTA3Nzk3LjE2OTk0MzE5NjM.*_ga_TDCK4DWEPP*MTY5OTQzMTk2My4xLjEuMTY5OTQzMTk4OS4wLjAuMA..&_ga=2.267103758.1881408366.1699431983-779507797.1699431963#sec-initializenumberformat

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
