### PR TITLE
Improve document of `FileSystemWritableFileStream.truncate()`

### DIFF
--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -10,7 +10,7 @@ browser-compat: api.FileSystemWritableFileStream.truncate
 
 The **`truncate()`** method of the {{domxref("FileSystemWritableFileStream")}} interface resizes the file associated with the stream to the specified size in bytes.
 
-If the size specified is larger than the current file size the file is padded with `null` bytes.
+If the size specified is larger than the current file size the file is padded with null bytes.
 
 The file cursor is also updated when `truncate()` is called.
 If the offset is smaller than the size, it remains unchanged.
@@ -28,7 +28,7 @@ truncate(size)
 
 ### Parameters
 
-- size
+- `size`
   - : A number specifying the number of bytes to resize the stream to.
 
 ### Return value

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -10,7 +10,7 @@ browser-compat: api.FileSystemWritableFileStream.truncate
 
 The **`truncate()`** method of the {{domxref("FileSystemWritableFileStream")}} interface resizes the file associated with the stream to the specified size in bytes.
 
-If the size specified is larger than the current file size the file is padded with null bytes.
+If the size specified is larger than the current file size the file is padded with `0x00` bytes.
 
 The file cursor is also updated when `truncate()` is called.
 If the offset is smaller than the size, it remains unchanged.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Change parameter name size to &#96;size&#96;.
~~'&#96;null&#96; bytes' should be 'null bytes', it means `0x00`, not the `null` value.~~
Change &#96;null&#96; bytes to &#96;0x00&#96; bytes.

### Related issues and pull requests

Relates to [mdn/translated-content#16864](https://github.com/mdn/translated-content/pull/16864)