### PR TITLE
add description for `ScreenDetailed.change` event

### DIFF
--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -63,7 +63,7 @@ _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 ## Events
 
 - {{domxref("Screen.change_event", "change")}} {{experimental_inline}} {{securecontext_inline}}
-  - : Fired on a specific screen when it changes in some way — for example, width or height, available width or available height, color depth, or orientation.
+  - : Fired on a specific screen when it changes in some way — width or height, available width or available height, color depth, or orientation.
 - {{DOMxRef("Screen.orientationchange_event", "orientationchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Fires when the screen orientation changes.
 

--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -63,7 +63,7 @@ _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 ## Events
 
 - {{domxref("Screen.change_event", "change")}} {{experimental_inline}} {{securecontext_inline}}
-  - : Fired on a specific screen when it changes in some way — for example, including width or height, available width or available height, color depth, or orientation.
+  - : Fired on a specific screen when it changes in some way — for example, width or height, available width or available height, color depth, or orientation.
 - {{DOMxRef("Screen.orientationchange_event", "orientationchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Fires when the screen orientation changes.
 

--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -63,7 +63,7 @@ _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 ## Events
 
 - {{domxref("Screen.change_event", "change")}} {{experimental_inline}} {{securecontext_inline}}
-  - : Fired on a specific screen when it changes in some way — width or height, available width or available height, color depth, or orientation.
+  - : Fired on a specific screen when it changes in some way — width or height, available width or height, color depth, or orientation.
 - {{DOMxRef("Screen.orientationchange_event", "orientationchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Fires when the screen orientation changes.
 

--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -63,7 +63,7 @@ _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 ## Events
 
 - {{domxref("Screen.change_event", "change")}} {{experimental_inline}} {{securecontext_inline}}
-  - : Fired on a specific screen when it changes in some way — for example available width or height, or orientation.
+  - : Fired on a specific screen when it changes in some way, including width or height, available width or available height, color depth, or orientation.
 - {{DOMxRef("Screen.orientationchange_event", "orientationchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Fires when the screen orientation changes.
 

--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -63,7 +63,7 @@ _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 ## Events
 
 - {{domxref("Screen.change_event", "change")}} {{experimental_inline}} {{securecontext_inline}}
-  - : Fired on a specific screen when it changes in some way, including width or height, available width or available height, color depth, or orientation.
+  - : Fired on a specific screen when it changes in some way — for example, including width or height, available width or available height, color depth, or orientation.
 - {{DOMxRef("Screen.orientationchange_event", "orientationchange")}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Fires when the screen orientation changes.
 

--- a/files/en-us/web/api/screendetailed/index.md
+++ b/files/en-us/web/api/screendetailed/index.md
@@ -42,7 +42,6 @@ _Inherits events from its parent, {{DOMxRef("Screen")}}._
 
 - `change` {{experimental_inline}}
   - : Fired on a specific screen when any property of the screen changes — width or height, available width or available height, color depth, or orientation, screen position and available screen position, device pixel ratio, label or screen's designation.
-    The event is inherited from {{DOMxRef("Screen")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/screendetailed/index.md
+++ b/files/en-us/web/api/screendetailed/index.md
@@ -36,6 +36,13 @@ _Inherits properties from its parent, {{DOMxRef("Screen")}}._
 - {{domxref("ScreenDetailed.top", "top")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A number representing the y-coordinate (top edge) of the total screen area.
 
+## Events
+
+_Inherits events from its parent, {{DOMxRef("Screen")}}._
+
+- `change` {{experimental_inline}}
+  - : Fired on a specific screen when any property of the screen changes — for example, except for including width or height, available width or available height, color depth, or orientation, also including screen position and available screen position, device pixel ratio, label or screen's designation. The event is inherited from {{DOMxRef("Screen")}}.
+
 ## Examples
 
 When {{domxref("Window.getScreenDetails()")}} is invoked, the user will be asked for permission to manage windows on all their displays (the status of this permission can be checked using {{domxref("Permissions.query()")}} to query `window-management`). Provided they grant permission, the resulting {{domxref("ScreenDetails")}} object contains `ScreenDetailed` objects representing all the screens available to the user's system.

--- a/files/en-us/web/api/screendetailed/index.md
+++ b/files/en-us/web/api/screendetailed/index.md
@@ -41,7 +41,7 @@ _Inherits properties from its parent, {{DOMxRef("Screen")}}._
 _Inherits events from its parent, {{DOMxRef("Screen")}}._
 
 - `change` {{experimental_inline}}
-  - : Fired on a specific screen when any property of the screen changes — for example, except for including width or height, available width or available height, color depth, or orientation, also including screen position and available screen position, device pixel ratio, label or screen's designation. The event is inherited from {{DOMxRef("Screen")}}.
+  - : Fired on a specific screen when any property of the screen changes — for example, except for width or height, available width or available height, color depth, or orientation, also screen position and available screen position, device pixel ratio, label or screen's designation. The event is inherited from {{DOMxRef("Screen")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/screendetailed/index.md
+++ b/files/en-us/web/api/screendetailed/index.md
@@ -41,7 +41,8 @@ _Inherits properties from its parent, {{DOMxRef("Screen")}}._
 _Inherits events from its parent, {{DOMxRef("Screen")}}._
 
 - `change` {{experimental_inline}}
-  - : Fired on a specific screen when any property of the screen changes — for example, except for width or height, available width or available height, color depth, or orientation, also screen position and available screen position, device pixel ratio, label or screen's designation. The event is inherited from {{DOMxRef("Screen")}}.
+  - : Fired on a specific screen when any property of the screen changes — width or height, available width or available height, color depth, or orientation, screen position and available screen position, device pixel ratio, label or screen's designation.
+    The event is inherited from {{DOMxRef("Screen")}}.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the `ScreenDetailed.change` event inherit from the `Screen.change` event, and they do behave differently according to standard

the `Screen.change` event, see https://w3c.github.io/window-management/#api-screen-onchange-attribute, only listen to [basic observable property](https://w3c.github.io/window-management/#screen-basic-observable-properties)

the `ScreenDetailed.change` event, see https://w3c.github.io/window-management/#api-screendetailed-onchange-attribute, will listen to [basic observable property](https://w3c.github.io/window-management/#screen-basic-observable-properties) or [advanced observable property](https://w3c.github.io/window-management/#screen-advanced-observable-properties)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
