### PR TITLE
Accessibility Update

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -151,7 +151,7 @@ p {
 }
 
 a {
-  outline: none;
+  outline-color: transparent;
 }
 
 a:link {
@@ -301,7 +301,7 @@ solution.addEventListener("click", () => {
 }
 
 a {
-  outline: none;
+  outline-color: transparent;
   text-decoration: none;
   padding: 2px 1px 0;
 }
@@ -368,7 +368,7 @@ p {
 }
 
 a {
-  outline: none;
+  outline-color: transparent;
   text-decoration: none;
   padding: 2px 1px 0;
 }
@@ -448,7 +448,7 @@ html {
 a {
   flex: 1;
   text-decoration: none;
-  outline: none;
+  outline-color: transparent;
   text-align: center;
   line-height: 3;
   color: black;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Small accessibility defect in CSS when using "outline: none". Made simple change to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc.

### Motivation

It makes the app more accessible to people with different contrast settings.

### Additional details

Reference: https://www.youtube.com/shorts/4B_4WLpbyp8

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
