### PR TITLE
Accessibility Update

### DIFF
--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
@@ -56,7 +56,7 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Small accessibility defect in CSS when using "outline: none". Made simple change to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc.

### Motivation

It makes the app more accessible to people with different contrast settings.

### Additional details

Reference: https://www.youtube.com/shorts/4B_4WLpbyp8

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
