### PR TITLE
Update link to Discord server across content

### DIFF
--- a/files/en-us/mdn/community/communication_channels/index.md
+++ b/files/en-us/mdn/community/communication_channels/index.md
@@ -19,7 +19,7 @@ The MDN Web Docs community Discord server is open to the public.
 This server is a great place to see what staff and members of the community are doing on a daily basis.
 You can ask questions, seek clarifications, find out how to get involved, and join specific channels based on your areas of interest.
 
-Join the MDN Web Docs community via our [Discord invite](https://discord.gg/Gt4Qf6q67h).
+Join the MDN Web Docs community via our [Discord invite](/discord).
 
 ### Matrix chat rooms
 

--- a/files/en-us/mdn/community/communication_channels/index.md
+++ b/files/en-us/mdn/community/communication_channels/index.md
@@ -19,7 +19,7 @@ The MDN Web Docs community Discord server is open to the public.
 This server is a great place to see what staff and members of the community are doing on a daily basis.
 You can ask questions, seek clarifications, find out how to get involved, and join specific channels based on your areas of interest.
 
-Join the MDN Web Docs community via our [Discord invite](https://discord.gg/hkGN8VKvvD).
+Join the MDN Web Docs community via our [Discord invite](https://discord.gg/Gt4Qf6q67h).
 
 ### Matrix chat rooms
 

--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -40,7 +40,7 @@ If you need help or have any questions, feel free to get in touch with one of th
 
 ### Korea (ko)
 
-- Discussions: [Discord (#korean channel)](https://discord.gg/hkGN8VKvvD), [Kakao Talk (#MDN Korea)](https://open.kakao.com/o/gdfG288c)
+- Discussions: [Discord (#korean channel)](https://discord.gg/Gt4Qf6q67h), [Kakao Talk (#MDN Korea)](https://open.kakao.com/o/gdfG288c)
 - Current contributors: [hochan222](https://github.com/hochan222), [yechoi42](https://github.com/yechoi42), [cos18](https://github.com/cos18), [GwangYeol-Im](https://github.com/GwangYeol-Im), [pje1740](https://github.com/pje1740), [yujo11](https://github.com/yujo11), [wisedog](https://github.com/wisedog), [swimjiy](https://github.com/swimjiy), [jho2301](https://github.com/jho2301), [sunhpark42](https://github.com/sunhpark42)
 
 ### Russian (ru)

--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -40,7 +40,7 @@ If you need help or have any questions, feel free to get in touch with one of th
 
 ### Korea (ko)
 
-- Discussions: [Discord (#korean channel)](https://discord.gg/Gt4Qf6q67h), [Kakao Talk (#MDN Korea)](https://open.kakao.com/o/gdfG288c)
+- Discussions: [Discord (#korean channel)](/discord), [Kakao Talk (#MDN Korea)](https://open.kakao.com/o/gdfG288c)
 - Current contributors: [hochan222](https://github.com/hochan222), [yechoi42](https://github.com/yechoi42), [cos18](https://github.com/cos18), [GwangYeol-Im](https://github.com/GwangYeol-Im), [pje1740](https://github.com/pje1740), [yujo11](https://github.com/yujo11), [wisedog](https://github.com/wisedog), [swimjiy](https://github.com/swimjiy), [jho2301](https://github.com/jho2301), [sunhpark42](https://github.com/sunhpark42)
 
 ### Russian (ru)

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -52,7 +52,7 @@ When looking to contribute to the MDN project, you will find yourself in one of 
 
 - **If you want to suggest new content or a new feature**, submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
 
-If you're not sure where to start, reach out to us on [the Discord server](https://discord.gg/Gt4Qf6q67h) and ask for feedback.
+If you're not sure where to start, reach out to us on [the Discord server](/discord) and ask for feedback.
 
 ### Open a pull request
 

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -52,7 +52,7 @@ When looking to contribute to the MDN project, you will find yourself in one of 
 
 - **If you want to suggest new content or a new feature**, submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
 
-If you're not sure where to start, reach out to us on [the Discord server](/en-US/docs/MDN/Community/Communication_channels#discord_server) and ask for feedback.
+If you're not sure where to start, reach out to us on [the Discord server](https://discord.gg/Gt4Qf6q67h) and ask for feedback.
 
 ### Open a pull request
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Thanks to Claas, https://developer.mozilla.org/discord/ will shortly redirect to our most up-to-date Discord server invite link. This PR updates the content to that URL.

### Motivation

Working Discord community invite link, yay!
