### PR TITLE
Updated outlines from none to transparent color for accessibility pur…

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -151,7 +151,7 @@ p {
 }
 
 a {
-  outline: none;
+  outline-color: transparent;
 }
 
 a:link {
@@ -301,7 +301,7 @@ solution.addEventListener("click", () => {
 }
 
 a {
-  outline: none;
+  outline-color: transparent;
   text-decoration: none;
   padding: 2px 1px 0;
 }
@@ -368,7 +368,7 @@ p {
 }
 
 a {
-  outline: none;
+  outline-color: transparent;
   text-decoration: none;
   padding: 2px 1px 0;
 }
@@ -448,7 +448,7 @@ html {
 a {
   flex: 1;
   text-decoration: none;
-  outline: none;
+  outline-color: transparent;
   text-align: center;
   line-height: 3;
   color: black;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
@@ -38,7 +38,7 @@ This is the first example of code that explains [how to build a custom form widg
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -174,7 +174,7 @@ This is the first example of code that explains [how to build a custom form widg
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -310,7 +310,7 @@ This is the first example of code that explains [how to build a custom form widg
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
@@ -56,7 +56,7 @@ This is the third example that explain [how to build custom form widgets](/en-US
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
@@ -56,7 +56,7 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
@@ -56,7 +56,7 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -135,7 +135,7 @@ We need an extra class `active` to define the look and feel of our control when 
 ```css
 .select.active,
 .select:focus {
-  outline: none;
+  outline-color: transparent;
 
   /* This box-shadow property is not exactly required, however it's imperative to ensure
      active state is visible, especially to keyboard users, that we use it as a default value. */
@@ -306,7 +306,7 @@ So here's the result with our three states ([check out the source code here](/en
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -428,7 +428,7 @@ So here's the result with our three states ([check out the source code here](/en
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -550,7 +550,7 @@ So here's the result with our three states ([check out the source code here](/en
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -809,7 +809,7 @@ Check out the [full source code](/en-US/docs/Learn/Forms/How_to_build_custom_for
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -1106,7 +1106,7 @@ Check out the [full source code](/en-US/docs/Learn/Forms/How_to_build_custom_for
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -1427,7 +1427,7 @@ Check out the [source code here](/en-US/docs/Learn/Forms/How_to_build_custom_for
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -1752,7 +1752,7 @@ Check out the [full source code here](/en-US/docs/Learn/Forms/How_to_build_custo
 .select.active,
 .select:focus {
   box-shadow: 0 0 3px 1px #227755;
-  outline: none;
+  outline-color: transparent;
 }
 
 .select .optList {
@@ -2036,7 +2036,7 @@ We'll do a little styling of the radio button list (not the legend/fieldset) to 
 }
 .styledSelect:not(:focus-within) input:not(:checked) + label {
   height: 0;
-  outline: none;
+  outline-color: transparent;
   overflow: hidden;
 }
 .styledSelect:not(:focus-within) input:checked + label {

--- a/files/en-us/learn/forms/styling_web_forms/index.md
+++ b/files/en-us/learn/forms/styling_web_forms/index.md
@@ -357,7 +357,6 @@ button:after {
 
 button:hover,
 button:focus {
-  outline-color: transparent;
   background: #000;
   color: #fff;
 }

--- a/files/en-us/learn/forms/styling_web_forms/index.md
+++ b/files/en-us/learn/forms/styling_web_forms/index.md
@@ -357,7 +357,7 @@ button:after {
 
 button:hover,
 button:focus {
-  outline: none;
+  outline-color: transparent;
   background: #000;
   color: #fff;
 }

--- a/files/en-us/web/css/_colon_focus/index.md
+++ b/files/en-us/web/css/_colon_focus/index.md
@@ -54,7 +54,7 @@ Make sure the visual focus indicator can be seen by people with low vision. This
 
 - Accessible Visual Focus Indicators: [Give Your Site Some Focus! Tips for Designing Useful and Usable Focus Indicators](https://www.deque.com/blog/give-site-focus-tips-designing-usable-focus-indicators/)
 
-### `:focus { outline: none; }`
+### `:focus { outline-color: transparent; }`
 
 Never just remove the focus outline (visible focus indicator) without replacing it with a focus outline that will pass [WCAG 2.1 SC 1.4.11 Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).
 

--- a/files/en-us/web/css/_colon_focus/index.md
+++ b/files/en-us/web/css/_colon_focus/index.md
@@ -54,7 +54,7 @@ Make sure the visual focus indicator can be seen by people with low vision. This
 
 - Accessible Visual Focus Indicators: [Give Your Site Some Focus! Tips for Designing Useful and Usable Focus Indicators](https://www.deque.com/blog/give-site-focus-tips-designing-usable-focus-indicators/)
 
-### `:focus { outline-color: transparent; }`
+### `:focus { outline: none; }`
 
 Never just remove the focus outline (visible focus indicator) without replacing it with a focus outline that will pass [WCAG 2.1 SC 1.4.11 Non-Text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).
 


### PR DESCRIPTION
### Description

Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc.

### Motivation

It makes the app more accessible to people with different contrast settings while it also maintains the app's original design.

### Additional details

Reference: https://www.youtube.com/shorts/4B_4WLpbyp8

### Related issues and pull requests

Apologies for submitting the copious amounts of PR's. Thanks to the tips I was able to figure out how to merge all commits into a single PR. Still learning, but thank you for your patience! 😄 Any other advice/criticisms are welcomed.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
