### PR TITLE
Update switch case syntax spec to use the term expression rather than value

### DIFF
--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -15,12 +15,12 @@ The **`switch`** statement evaluates an [expression](/en-US/docs/Web/JavaScript/
 
 ```js-nolint
 switch (expression) {
-  case value1:
+  case caseExpression1:
     statements
-  case value2:
+  case caseExpression2:
     statements
   // …
-  case valueN:
+  case caseExpressionN:
     statements
   default:
     statements
@@ -29,8 +29,8 @@ switch (expression) {
 
 - `expression`
   - : An expression whose result is matched against each `case` clause.
-- `case valueN` {{optional_inline}}
-  - : A `case` clause used to match against `expression`. If the `expression` matches the specified `valueN` (which can be any expression), execution starts from the first statement after that `case` clause until either the end of the `switch` statement or the first encountered `break`.
+- `case expressionN` {{optional_inline}}
+  - : A `case` clause used to match against `expression`. If the `expression` matches the specified `expressionN`, execution starts from the first statement after that `case` clause until either the end of the `switch` statement or the first encountered `break`.
 - `default` {{optional_inline}}
   - : A `default` clause; if provided, this clause is executed if the value of `expression` doesn't match any of the `case` clauses. A `switch` statement can only have one `default` clause.
 

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -29,8 +29,8 @@ switch (expression) {
 
 - `expression`
   - : An expression whose result is matched against each `case` clause.
-- `case expressionN` {{optional_inline}}
-  - : A `case` clause used to match against `expression`. If the `expression` matches the specified `expressionN`, execution starts from the first statement after that `case` clause until either the end of the `switch` statement or the first encountered `break`.
+- `case caseExpressionN` {{optional_inline}}
+  - : A `case` clause used to match against `expression`. If the value of `expression` matches the value of any `caseExpressionN`, execution starts from the first statement after that `case` clause until either the end of the `switch` statement or the first encountered `break`.
 - `default` {{optional_inline}}
   - : A `default` clause; if provided, this clause is executed if the value of `expression` doesn't match any of the `case` clauses. A `switch` statement can only have one `default` clause.
 

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -38,7 +38,7 @@ switch (expression) {
 
 A `switch` statement first evaluates its expression. It then looks for the first `case` clause whose expression evaluates to the same value as the result of the input expression (using the [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) comparison) and transfers control to that clause, executing all statements following that clause.
 
-The clause values are only evaluated when necessary — if a match is already found, subsequent `case` clause values will not be evaluated, even when they will be visited by [fall-through](#breaking_and_fall-through).
+The clause expressions are only evaluated when necessary — if a match is already found, subsequent `case` clause expressions will not be evaluated, even when they will be visited by [fall-through](#breaking_and_fall-through).
 
 ```js
 switch (undefined) {
@@ -54,7 +54,7 @@ If no matching `case` clause is found, the program looks for the optional `defau
 
 You can use the [`break`](/en-US/docs/Web/JavaScript/Reference/Statements/break) statement within a `switch` statement's body to break out early, often when all statements between two `case` clauses have been executed. Execution will continue at the first statement following `switch`.
 
-If `break` is omitted, execution will proceed to the next `case` clause, even to the `default` clause, regardless of whether the value of that clause matches. This behavior is called "fall-through".
+If `break` is omitted, execution will proceed to the next `case` clause, even to the `default` clause, regardless of whether the expression of that clause matches. This behavior is called "fall-through".
 
 ```js
 const foo = 0;
@@ -179,7 +179,7 @@ It also works when you put `default` before all other `case` clauses.
 
 This method takes advantage of the fact that if there is no `break` below a `case` clause, execution will continue to the next `case` clause regardless if that `case` meets the criteria.
 
-The following is an example of a single operation sequential `case` statement, where four different values perform exactly the same.
+The following is an example of a single operation sequential `case` statement, where four different s perform exactly the same.
 
 ```js
 const Animal = "Giraffe";

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -54,7 +54,7 @@ If no matching `case` clause is found, the program looks for the optional `defau
 
 You can use the [`break`](/en-US/docs/Web/JavaScript/Reference/Statements/break) statement within a `switch` statement's body to break out early, often when all statements between two `case` clauses have been executed. Execution will continue at the first statement following `switch`.
 
-If `break` is omitted, execution will proceed to the next `case` clause, even to the `default` clause, regardless of whether the expression of that clause matches. This behavior is called "fall-through".
+If `break` is omitted, execution will proceed to the next `case` clause, even to the `default` clause, regardless of whether the value of that clause's expression matches. This behavior is called "fall-through".
 
 ```js
 const foo = 0;
@@ -179,7 +179,7 @@ It also works when you put `default` before all other `case` clauses.
 
 This method takes advantage of the fact that if there is no `break` below a `case` clause, execution will continue to the next `case` clause regardless if that `case` meets the criteria.
 
-The following is an example of a single operation sequential `case` statement, where four different s perform exactly the same.
+The following is an example of a single operation sequential `case` statement, where four different values perform exactly the same.
 
 ```js
 const Animal = "Giraffe";


### PR DESCRIPTION
Rename valueN to expressionN as value is misleading and tends to reinforce the misconception that only values are allowed due to examples in how it's usually taught.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Despite the parentheses saying "which can be any expression", I was mislead by the syntax spec using "value".  Despite being technically correct, parentheses like these probably get missed as people usually skim docs instead of reading them.  Only further down with the switch(true) example was it clear to me that value could be any expression. 

I understand that anywhere a value is expected, an expression can be used, but this makes the difference in naming more misleading.  I feel like this could be interpreted as pedantic, but I believe it would make a practical difference for some readers.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It helps readers understand that case clauses don't have to be literals or values, they can be any expression.  The renaming makes this clear.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
