### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -721,7 +721,7 @@ input.invalid {
   background-color: #fdd;
 }
 
-input:focus.invalid {
+input:focus:invalid {
   outline: none;
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

There was a typo on one of the examples of CSS where the pseudoclass `:focus.invalid` was used, the pseudoclass should be instead `:focus:invalid` (as used on other examples).

