### PR TITLE
Fix issue 30014: pushState is not asynchronous

### DIFF
--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -12,8 +12,6 @@ In an [HTML](/en-US/docs/Web/HTML) document, the
 **`history.pushState()`** method adds an entry to the browser's
 session history stack.
 
-This method is {{glossary("asynchronous")}}. Add a listener for the {{domxref("Window/popstate_event", "popstate")}} event in order to determine when the navigation has completed. The `state` parameter will be available in it.
-
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/30168, fixes https://github.com/mdn/content/issues/25785, fixes https://github.com/mdn/content/issues/30014.

Reverts the change in https://github.com/mdn/content/pull/25702 which added this paragraph, incorrectly I think.

The History API docs are still quite confusing and could do with further improvements, but this is worth doing now anyway.