### PR TITLE
Link from CSS `:scope` pseudo-class to `@scope` at-rule

### DIFF
--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -105,6 +105,7 @@ The scope of `context` is the element with the [`id`](/en-US/docs/Web/HTML/Globa
 
 ## See also
 
+- The {{cssxref("@scope")}} [at-rule](/en-US/docs/Web/CSS/At-rule)
 - The {{cssxref(":root")}} [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes)
 - [Locating DOM elements using selectors](/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors)
 - {{domxref("Element.querySelector()")}} and {{domxref("Element.querySelectorAll()")}}


### PR DESCRIPTION
Missed this one on https://github.com/mdn/content/pull/30045