### PR TITLE
fix: WebAssembly runs inside the JavaScript engine

### DIFF
--- a/files/en-us/webassembly/concepts/index.md
+++ b/files/en-us/webassembly/concepts/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{WebAssemblySidebar}}
 
-This article explains the concepts behind how WebAssembly works including its goals, the problems it solves, and how it runs inside the web browser's rendering engine.
+This article explains the concepts behind how WebAssembly works including its goals, the problems it solves, and how it runs inside the web browser's JavaScript engine.
 
 ## What is WebAssembly?
 


### PR DESCRIPTION
### Description

WebAssembly runs inside the JavaScript engine (e.g. [V8](https://v8.dev/blog/webassembly-experimental), [SpiderMonkey](https://spidermonkey.dev/)) not rendering engine.
