### PR TITLE
fix the layout of examples

### DIFF
--- a/files/en-us/web/html/element/sup/index.md
+++ b/files/en-us/web/html/element/sup/index.md
@@ -23,23 +23,9 @@ For example, to style the [wordmark](https://en.wikipedia.org/wiki/Wordmark) of 
 
 Appropriate use cases for `<sup>` include (but aren't necessarily limited to):
 
-- Displaying exponents, such as "x
-
-  <sup>3</sup>
-
-  ." It may be worth considering the use of [MathML](/en-US/docs/Web/MathML) for these, especially in more complex cases. See [Exponents](#exponents) under [Examples](#examples) below.
-
-- Displaying [superior lettering](https://en.wikipedia.org/wiki/Superior_letter), which is used in some languages when rendering certain abbreviations. For example, in French, the word "mademoiselle" can be abbreviated "M
-
-  <sup>lle</sup>
-
-  "); this is an acceptable use case. See [Superior lettering](#superior_lettering) for examples.
-
-- Representing ordinal numbers, such as "4
-
-  <sup>th</sup>
-
-  " instead of "fourth." See [Ordinal numbers](#ordinal_numbers) for examples.
+- Displaying exponents, such as "x<sup>3</sup>". It may be worth considering the use of [MathML](/en-US/docs/Web/MathML) for these, especially in more complex cases. See [Exponents](#exponents) under [Examples](#examples) below.
+- Displaying [superior lettering](https://en.wikipedia.org/wiki/Superior_letter), which is used in some languages when rendering certain abbreviations. For example, in French, the word "mademoiselle" can be abbreviated "M<sup>lle</sup>"; this is an acceptable use case. See [Superior lettering](#superior_lettering) for examples.
+- Representing ordinal numbers, such as "4<sup>th</sup>" instead of "fourth." See [Ordinal numbers](#ordinal_numbers) for examples.
 
 ## Examples
 


### PR DESCRIPTION
### Description

- There are extra spaces within the quotes, combine those lines to fix this.
- remove the extra parenthese
- put the dot outside the wrapping quotes.
