### PR TITLE
Updates for `DOMRectReadOnly`

### DIFF
--- a/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
@@ -26,18 +26,18 @@ new DOMRectReadOnly(x, y, width, height)
   - : The `y` coordinate of the `DOMRectReadOnly`'s
     origin.
 - `width`
-  - : The width of the `DOMRectReadOnly`.
+  - : The `width` of the `DOMRectReadOnly`.
 - `height`
-  - : The height of the `DOMRectReadOnly`.
+  - : The `height` of the `DOMRectReadOnly`.
 
 ## Examples
 
-To create a new `DOMPoint`, you could run a line of code like so:
+To create a new `DOMRectReadOnly`, you could run a line of code like so:
 
 ```js
 const myDOMRect = new DOMRectReadOnly(0, 0, 100, 100);
 // running 'myDOMRect' in the console would then return
-// DOMRect { x: 0, y: 0, width: 100, height: 100, top: 0, right: 100, bottom: 100, left: 0 }
+// DOMRectReadOnly { x: 0, y: 0, width: 100, height: 100, top: 0, right: 100, bottom: 100, left: 0 }
 ```
 
 ## Specifications

--- a/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
@@ -8,8 +8,7 @@ browser-compat: api.DOMRectReadOnly.DOMRectReadOnly
 
 {{APIRef("Geometry Interfaces")}}
 
-The **`DOMRectReadOnly()`** constructor creates a new
-{{domxref("DOMRectReadOnly")}} object.
+The **`DOMRectReadOnly()`** constructor creates a new {{domxref("DOMRectReadOnly")}} object.
 
 ## Syntax
 

--- a/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
@@ -26,9 +26,9 @@ new DOMRectReadOnly(x, y, width, height)
   - : The `y` coordinate of the `DOMRectReadOnly`'s
     origin.
 - `width`
-  - : The `width` of the `DOMRectReadOnly`.
+  - : The width of the `DOMRectReadOnly`.
 - `height`
-  - : The `height` of the `DOMRectReadOnly`.
+  - : The height of the `DOMRectReadOnly`.
 
 ## Examples
 

--- a/files/en-us/web/api/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/index.md
@@ -17,13 +17,13 @@ The **`DOMRectReadOnly`** interface specifies the standard properties (also used
 ## Instance properties
 
 - {{domxref("DOMRectReadOnly.x")}} {{ReadOnlyInline}}
-  - : The x coordinate of the `DOMRectReadOnly`'s origin.
+  - : Returns the x coordinate of the `DOMRectReadOnly`'s origin.
 - {{domxref("DOMRectReadOnly.y")}} {{ReadOnlyInline}}
-  - : The y coordinate of the `DOMRectReadOnly`'s origin.
+  - : Returns the y coordinate of the `DOMRectReadOnly`'s origin.
 - {{domxref("DOMRectReadOnly.width")}} {{ReadOnlyInline}}
-  - : The width of the `DOMRectReadOnly`.
+  - : Returns the width of the `DOMRectReadOnly`.
 - {{domxref("DOMRectReadOnly.height")}} {{ReadOnlyInline}}
-  - : The height of the `DOMRectReadOnly`.
+  - : Returns the height of the `DOMRectReadOnly`.
 - {{domxref("DOMRectReadOnly.top")}} {{ReadOnlyInline}}
   - : Returns the top coordinate value of the `DOMRectReadOnly` (usually the same as `y`).
 - {{domxref("DOMRectReadOnly.right")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/index.md
@@ -7,36 +7,36 @@ browser-compat: api.DOMRectReadOnly
 
 {{APIRef("Geometry Interfaces")}}
 
-The **`DOMRectReadOnly`** interface specifies the standard properties used by {{domxref("DOMRect")}} to define a rectangle whose properties are immutable.
+The **`DOMRectReadOnly`** interface specifies the standard properties (also used by {{domxref("DOMRect")}}) to define a rectangle whose properties are immutable.
 
 ## Constructor
 
 - {{domxref("DOMRectReadOnly.DOMRectReadOnly","DOMRectReadOnly()")}}
-  - : Defined to create a new `DOMRectReadOnly` object. Note that this constructor cannot be called by 3rd party JavaScript; doing so returns an `"Illegal constructor"` {{jsxref('TypeError')}}.
+  - : Defined to create a new `DOMRectReadOnly` object.
 
 ## Instance properties
 
 - {{domxref("DOMRectReadOnly.x")}} {{ReadOnlyInline}}
-  - : The x coordinate of the `DOMRect`'s origin.
+  - : The x coordinate of the `DOMRectReadOnly`'s origin.
 - {{domxref("DOMRectReadOnly.y")}} {{ReadOnlyInline}}
-  - : The y coordinate of the `DOMRect`'s origin.
+  - : The y coordinate of the `DOMRectReadOnly`'s origin.
 - {{domxref("DOMRectReadOnly.width")}} {{ReadOnlyInline}}
-  - : The width of the `DOMRect`.
+  - : The width of the `DOMRectReadOnly`.
 - {{domxref("DOMRectReadOnly.height")}} {{ReadOnlyInline}}
-  - : The height of the `DOMRect`.
+  - : The height of the `DOMRectReadOnly`.
 - {{domxref("DOMRectReadOnly.top")}} {{ReadOnlyInline}}
-  - : Returns the top coordinate value of the `DOMRect` (usually the same as `y`).
+  - : Returns the top coordinate value of the `DOMRectReadOnly` (usually the same as `y`).
 - {{domxref("DOMRectReadOnly.right")}} {{ReadOnlyInline}}
-  - : Returns the right coordinate value of the `DOMRect` (usually the same as `x + width`).
+  - : Returns the right coordinate value of the `DOMRectReadOnly` (usually the same as `x + width`).
 - {{domxref("DOMRectReadOnly.bottom")}} {{ReadOnlyInline}}
-  - : Returns the bottom coordinate value of the `DOMRect` (usually the same as `y + height`).
+  - : Returns the bottom coordinate value of the `DOMRectReadOnly` (usually the same as `y + height`).
 - {{domxref("DOMRectReadOnly.left")}} {{ReadOnlyInline}}
-  - : Returns the left coordinate value of the `DOMRect` (usually the same as `x`).
+  - : Returns the left coordinate value of the `DOMRectReadOnly` (usually the same as `x`).
 
 ## Static methods
 
 - {{domxref("DOMRectReadOnly/fromRect_static", "DOMRectReadOnly.fromRect()")}}
-  - : Creates a new `DOMRect` object with a given location and dimensions.
+  - : Creates a new `DOMRectReadOnly` object with a given location and dimensions.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Fixed typos (and 1 error) in the `DOMRectReadOnly` index page and constructor page.

### Motivation

- **Fixing an error.** The index page said the constructor cannot be called without raising an error.  I tried it in the consoles of Firefox Developer Edition and Safari, and no errors were raised.
- **Inconsistency.** Probably leftover from a copy-paste, there were references to both `DOMPoint` and `DOMRect` that did not belong. These are fixed.

### Additional details

n/a

### Related issues and pull requests

n/a
