### PR TITLE
fix: Add missing interface `DOMPointReadOnly` to `GroupData.json`

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -562,6 +562,7 @@
         "DOMMatrix",
         "DOMMatrixReadOnly",
         "DOMPoint",
+        "DOMPointReadOnly",
         "DOMQuad",
         "DOMRect",
         "DOMRectReadOnly"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The pages under Geometry interfaces are missing the `DOMPointReadOnly` interface in the sidebar. 

### Motivation

The sidebars usually aren’t missing interfaces from their own group.

### Additional details

n/a

### Related issues and pull requests

n/a