### PR TITLE
HTMLAnchorElement "hash" property: the fragment *is* percent-encoded

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.md
@@ -13,7 +13,7 @@ The
 string containing a `'#'` followed by the fragment
 identifier of the URL.
 
-The fragment is not [URL encoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
+The fragment is [URL encoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value


### PR DESCRIPTION
The documentation was stating the contrary of the actual encoding state. The fragment *is* percent-encoded, actually.

As described in the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/hash#browser_compatibility), from Firefox 29 to Firefox 40, the returned value was incorrectly percent-decoded (i.e. not percent-encoded).

Firefox 29 was released on April 29, 2014. Firefox 41 was released on September 22, 2015. Now we are 8 years later.

----

Documentation page: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/hash

Refs:

- https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/41#miscellaneous
- https://bugzilla.mozilla.org/show_bug.cgi?id=1093611