### PR TITLE
Express>Mongoose - replace removed function

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -73,7 +73,7 @@ exports.author_delete_post = asyncHandler(async (req, res, next) => {
     return;
   } else {
     // Author has no books. Delete object and redirect to the list of authors.
-    await Author.findByIdAndRemove(req.body.authorid);
+    await Author.findByIdAndDelete(req.body.authorid);
     res.redirect("/catalog/authors");
   }
 });
@@ -85,7 +85,7 @@ If there are no books then we delete the author object and redirect to the list 
 If there are still books then we just re-render the form, passing in the author and list of books to be deleted.
 
 > **Note:** We could check if the call to `findById()` returns any result, and if not, immediately render the list of all authors.
-> We've left the code as it is above for brevity (it will still return the list of authors if the id is not found, but this will happen after `findByIdAndRemove()`).
+> We've left the code as it is above for brevity (it will still return the list of authors if the id is not found, but this will happen after `findByIdAndDelete()`).
 
 ## View
 

--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -453,7 +453,7 @@ The [`find()`](<https://mongoosejs.com/docs/api/model.html#Model.find()>) method
 
 - [`findById()`](<https://mongoosejs.com/docs/api/model.html#Model.findById()>): Finds the document with the specified `id` (every document has a unique `id`).
 - [`findOne()`](<https://mongoosejs.com/docs/api/model.html#Model.findOne()>): Finds a single document that matches the specified criteria.
-- [`findByIdAndRemove()`](<https://mongoosejs.com/docs/api/model.html#Model.findByIdAndRemove()>), [`findByIdAndUpdate()`](<https://mongoosejs.com/docs/api/model.html#Model.findByIdAndUpdate()>), [`findOneAndRemove()`](<https://mongoosejs.com/docs/api/model.html#Model.findOneAndRemove()>), [`findOneAndUpdate()`](<https://mongoosejs.com/docs/api/model.html#Model.findOneAndUpdate()>): Finds a single document by `id` or criteria and either updates or removes it. These are useful convenience functions for updating and removing records.
+- [`findByIdAndDelete()`](<https://mongoosejs.com/docs/api/model.html#Model.findByIdAndDelete()>), [`findByIdAndUpdate()`](<https://mongoosejs.com/docs/api/model.html#Model.findByIdAndUpdate()>), [`findOneAndRemove()`](<https://mongoosejs.com/docs/api/model.html#Model.findOneAndRemove()>), [`findOneAndUpdate()`](<https://mongoosejs.com/docs/api/model.html#Model.findOneAndUpdate()>): Finds a single document by `id` or criteria and either updates or removes it. These are useful convenience functions for updating and removing records.
 
 > **Note:** There is also a [`countDocuments()`](<https://mongoosejs.com/docs/api/model.html#Model.countDocuments()>) method that you can use to get the number of items that match conditions. This is useful if you want to perform a count without actually fetching the records.
 


### PR DESCRIPTION
Fixes #30152

This replaces mongoose `Model.findByIdAndRemove()` with `findByIdAndDelete()`, which replaces it in mongoose 8. This was also present in Mongoose7 so users should be OK if mid way through this. 

Mongoose updated to 8 and tested in https://github.com/mdn/express-locallibrary-tutorial/pull/242