### PR TITLE
RTCTransportStats - create docs

### DIFF
--- a/files/en-us/web/api/rtcicetransport/role/index.md
+++ b/files/en-us/web/api/rtcicetransport/role/index.md
@@ -18,13 +18,16 @@ You can learn more about ICE roles in
 
 ## Value
 
-A string specifying whether the {{domxref("RTCIceTransport")}}
-represents the controlling agent or the controlled agent. The value must be one of the following:
+A string specifying whether the {{domxref("RTCIceTransport")}} represents the controlling agent or the controlled agent.
 
-- `"controlling"`
-  - : The {{domxref("RTCIceTransport")}} object is serving as the controlling agent.
+The value must be one of the following:
+
 - `"controlled"`
   - : The transport is the controlled agent.
+- `"controlling"`
+  - : The {{domxref("RTCIceTransport")}} object is serving as the controlling agent.
+- `"unknown"`
+  - : The role has not yet been determined.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/id/index.md
+++ b/files/en-us/web/api/rtctransportstats/id/index.md
@@ -1,0 +1,27 @@
+---
+title: "RTCTransportStats: id property"
+short-title: id
+slug: Web/API/RTCTransportStats/id
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.id
+---
+
+{{APIRef("WebRTC")}}
+
+The **`id`** property of the {{domxref("RTCTransportStats")}} dictionary is a string which uniquely identifies the object for which this object provides statistics.
+
+Using the `id`, you can correlate this statistics object with others, in order to monitor statistics over time for a given WebRTC object, such as an {{domxref("RTCDtlsTransport")}}, or an {{domxref("RTCPeerConnection")}}.
+
+## Value
+
+A string that uniquely identifies the object for which this `RTCTransportStats` object provides statistics.
+
+The format of the ID string is not defined by the specification, so you cannot reliably make any assumptions about the contents of the string, or assume that the format of the string will remain unchanged for a given object type.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -27,9 +27,9 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
   - : The total number of payload bytes received on this transport (bytes received, not including headers, padding or ICE connectivity checks).
 - `iceRole` {{optional_inline}}
   - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}. This can be any of the following:
-      - `controlling`
-      - `controlled`
-      - `unknown`
+    - `controlling`
+    - `controlled`
+    - `unknown`
 - `iceLocalUsernameFragment` {{optional_inline}}
   - : A string indicating the local username fragment used in message validation procedures for this transport.
     This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -26,7 +26,10 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
 - `bytesReceived` {{optional_inline}}
   - : The total number of payload bytes received on this transport (bytes received, not including headers, padding or ICE connectivity checks).
 - `iceRole` {{optional_inline}}
-  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}: `controlling` or `controlled`.
+  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}. This can be any of the following:
+      - `controlling`
+      - `controlled`
+      - `unknown`
 - `iceLocalUsernameFragment` {{optional_inline}}
   - : A string indicating the local username fragment used in message validation procedures for this transport.
     This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -17,53 +17,73 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
 
 ## Instance properties
 
-- `packetsSent` {{optional_inline}}
-  - : The total number of packets sent over this transport.
-- `packetsReceived` {{optional_inline}}
-  - : The total number of packets received on this transport.
-- `bytesSent` {{optional_inline}}
-  - : The total number of payload bytes sent on this transport (bytes sent, not including headers, padding or ICE connectivity checks).
 - `bytesReceived` {{optional_inline}}
   - : The total number of payload bytes received on this transport (bytes received, not including headers, padding or ICE connectivity checks).
-- `iceRole` {{optional_inline}}
-  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}. This can be any of the following:
-    - `controlling`
-    - `controlled`
-    - `unknown`
+- `bytesSent` {{optional_inline}}
+  - : The total number of payload bytes sent on this transport (bytes sent, not including headers, padding or ICE connectivity checks).
+- `dtlsCipher` {{optional_inline}}
+  - : A string indicating the name of the cipher suite used for the DTLS transport, as defined in the "Description" column of the [TLS Cipher Suites](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4) section in the _IANA cipher suite registry_.
+    For example `"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"`.
+- `dtlsRole` {{optional_inline}}
+
+  - : The DTLS role of the associated {{domxref("RTCPeerConnection")}}.
+    This is one of:
+
+    - `client`
+    - `server`
+    - `unknown` (before the DTLS negotiation starts).
+
+- `dtlsState`
+
+  - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}.
+    This is one of:
+
+    - [`new`](/en-US/docs/Web/API/RTCDtlsTransport/state#new)
+    - [`connecting`](/en-US/docs/Web/API/RTCDtlsTransport/state#connecting)
+    - [`connected`](/en-US/docs/Web/API/RTCDtlsTransport/state#connected)
+    - [`closed`](/en-US/docs/Web/API/RTCDtlsTransport/state#closed)
+    - [`failed`](/en-US/docs/Web/API/RTCDtlsTransport/state#failed)
+
 - `iceLocalUsernameFragment` {{optional_inline}}
   - : A string indicating the local username fragment used in message validation procedures for this transport.
     This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.
-- `dtlsState`
-  - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}: `new`, `connecting`, `connected`, `closed`, or `failed`.
+- `iceRole` {{optional_inline}}
+
+  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.
+    This is one of:
+
+    - [`controlled`](/en-US/docs/Web/API/RTCIceTransport/role#controlled)
+    - [`controlling`](/en-US/docs/Web/API/RTCIceTransport/role#controlling)
+    - [`unknown`](/en-US/docs/Web/API/RTCIceTransport/role#unknown)
+
 - `iceState` {{optional_inline}}
-  - : A string indicating the current {{domxref("RTCIceTransport.state","state")}} of the underlying {{domxref("RTCIceTransport")}}: `new`, `checking`, `connected`, `completed`, `disconnected`, `failed`, or `closed`.
+
+  - : A string indicating the current {{domxref("RTCIceTransport.state","state")}} of the underlying {{domxref("RTCIceTransport")}}.
+    This is one of:
+
+    - [`new`](/en-US/docs/Web/API/RTCIceTransport/state#new)
+    - [`checking`](/en-US/docs/Web/API/RTCIceTransport/state#checking)
+    - [`connected`](/en-US/docs/Web/API/RTCIceTransport/state#connected)
+    - [`completed`](/en-US/docs/Web/API/RTCIceTransport/state#completed)
+    - [`disconnected`](/en-US/docs/Web/API/RTCIceTransport/state#disconnected)
+    - [`failed`](/en-US/docs/Web/API/RTCIceTransport/state#failed)
+    - [`closed`](/en-US/docs/Web/API/RTCIceTransport/state#closed)
+
 - `selectedCandidatePairId` {{optional_inline}}
   - : A string containing the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
 - `localCertificateId` {{optional_inline}}
   - : A string containing the id of the local certificate used by this transport.
     Only present for DTLS transports, and after DTLS has been negotiated.
+- `packetsSent` {{optional_inline}}
+  - : The total number of packets sent over this transport.
+- `packetsReceived` {{optional_inline}}
+  - : The total number of packets received on this transport.
 - `remoteCertificateId` {{optional_inline}}
   - : A string containing the id or the remote certificate used by this transport.
     Only present for DTLS transports, and after DTLS has been negotiated.
-- `tlsVersion` {{optional_inline}}
-
-  - : A string containing the negotiated TLS version.
-    This is present for DTLS transports, and only exists after DTLS has been negotiated.
-
-    The value comes from the DTLS handshake `ServerHello.version`, and is represented as four upper case hexadecimal digits, where the digits represent the two bytes of the version.
-    Note however that the bytes might not map directly to version numbers.
-    For example, DTLS represents version 1.2 as `'FEFD'` which numerically is `{254, 253}`.
-
-- `dtlsCipher` {{optional_inline}}
-
-  - : A string indicating the name of the cipher suite used for the DTLS transport, as defined in the "Description" column of the [TLS Cipher Suites](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4) section in the _IANA cipher suite registry_.
-    For example `"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"`.
-
-- `dtlsRole` {{optional_inline}}
-
-  - : The DTLS role of the associated {{domxref("RTCPeerConnection")}}.
-    This is one of `"client"`, `"server"`, or `"unknown"` (before the DTLS negotiation starts).
-
+- `selectedCandidatePairChanges` {{optional_inline}}
+  - : The number of times that the selected candidate pair of this transport has changed.
+    The value is initially zero and increases whenever a candidate pair selected or lost.
 - `srtpCipher` {{optional_inline}}
 
   - : A string indicating the descriptive name of the protection profile used for the [Secure Real-time Transport Protocol (SRTP)](/en-US/docs/Glossary/RTP) transport, as defined in the "Profile" column of the [IANA DTLS-SRTP protection profile registry](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml#srtp-protection-1) and [RFC5764](https://www.rfc-editor.org/rfc/rfc5764.html#section-4.1.2).
@@ -81,9 +101,14 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
      auth_tag_length: 80
     ```
 
-- `selectedCandidatePairChanges` {{optional_inline}}
-  - : The number of times that the selected candidate pair of this transport has changed.
-    The value is initially zero and increases whenever a candidate pair selected or lost.
+- `tlsVersion` {{optional_inline}}
+
+  - : A string containing the negotiated TLS version.
+    This is present for DTLS transports, and only exists after DTLS has been negotiated.
+
+    The value comes from the DTLS handshake `ServerHello.version`, and is represented as four upper case hexadecimal digits, where the digits represent the two bytes of the version.
+    Note however that the bytes might not map directly to version numbers.
+    For example, DTLS represents version 1.2 as `'FEFD'` which numerically is `{254, 253}`.
 
 ### Common instance properties
 

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -1,0 +1,102 @@
+---
+title: RTCTransportStats
+slug: Web/API/RTCTransportStats
+page-type: web-api-interface
+browser-compat: api.RTCStatsReport.type_transport
+---
+
+{{APIRef("WebRTC")}}
+
+The **`RTCTransportStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides information about the transport ({{domxref("RTCDtlsTransport")}} and its underlying {{domxref("RTCIceTransport")}}) used by a particular candidate pair.
+
+Note that if remote endpoint is aware of the BUNDLE SDP feature, all {{domxref("MediaStreamTrack")}} and data channels are bundled onto a single transport at the completion of negotiation.
+This is true for current browsers, but if connecting to an older endpoint that is not BUNDLE-aware, then separate transports might be used for different media.
+The policy to use in the negotiation is configured in the [`RTCPeerConnection` constructor](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection).
+
+These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCPeerConnection.getStats()")}} until you find a report with the [`type`](#type) of `transport`.
+
+## Instance properties
+
+- `packetsSent` {{optional_inline}}
+  - : The total number of packets sent over this transport.
+- `packetsReceived` {{optional_inline}}
+  - : The total number of packets received on this transport.
+- `bytesSent` {{optional_inline}}
+  - : The total number of payload bytes sent on this transport (bytes sent, not including headers, padding or ICE connectivity checks).
+- `bytesReceived` {{optional_inline}}
+  - : The total number of payload bytes received on this transport (bytes received, not including headers, padding or ICE connectivity checks).
+- `iceRole` {{optional_inline}}
+  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.
+- `iceLocalUsernameFragment` {{optional_inline}}
+  - : A string indicating the local username fragment used in message validation procedures for this transport, as sent in the `ice-ufrag` attribute of the {{glossary("SDP")}} offer when negotiating the ICE connection.
+    The value will change if the connection is renegotiated: on ICE restart or following {{domxref("RTCPeerConnection.setLocalDescription()")}}.
+- `dtlsState`
+  - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}: `new`, `connecting`, `connected`, `closed`, and `failed`.
+- `iceState` {{optional_inline}}
+  - : {{domxref("RTCIceTransportState")}}
+    Xxx Set to the current value of the state attribute of the underlying RTCIceTransport.
+- `selectedCandidatePairId` {{optional_inline}}
+  - : A string containing the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
+- `localCertificateId` {{optional_inline}}
+  - : A string containing the local certification <!-- For components where DTLS is negotiated -->
+- `remoteCertificateId` {{optional_inline}}
+  - : A string containing the remote certification. <!-- For components where DTLS is negotiated -->
+- `tlsVersion` {{optional_inline}}
+  - : A string containing the negotiated TLS versions.
+    Only exists after DTLS negotiation is complete.
+    <!-- For components where DTLS is negotiated, the TLS version agreed -->
+- `dtlsCipher` {{optional_inline}}
+  - : A string Xxxx
+    Xxx The value comes from ServerHello.supported_versions if present, otherwise from ServerHello.version. It is represented as four upper case hexadecimal digits, representing the two bytes of the version.
+- `dtlsRole` {{optional_inline}}
+  - : {{domxref("RTCDtlsRole")}}
+    "client" or "server" depending on the DTLS role. "unknown" before the DTLS negotiation starts.
+- `srtpCipher` {{optional_inline}}
+  - : Xxxx A string indicating the descriptive name of the protection profile used for the SRTP transport, as defined in the "Profile" column of the IANA DTLS-SRTP protection profile registry [IANA-DTLS-SRTP] and described further in [RFC5764].
+- `selectedCandidatePairChanges` {{optional_inline}}
+  - : Xxxx The number of times that the selected candidate pair of this transport has changed.
+    Going from not having a selected candidate pair to having a selected candidate pair, or the other way around, also increases this counter. It is initially zero and becomes one when an initial candidate pair is selected.
+
+### Common instance properties
+
+The following properties are common to all WebRTC statistics objects.
+
+<!-- RTCStats -->
+
+- {{domxref("RTCTransportStats.id", "id")}}
+  - : A string that uniquely identifies the object that is being monitored to produce this set of statistics.
+- {{domxref("RTCTransportStats.timestamp", "timestamp")}}
+  - : A {{domxref("DOMHighResTimeStamp")}} object indicating the time at which the sample was taken for this statistics object.
+- {{domxref("RTCTransportStats.type", "type")}}
+  - : A string with the value `"transport"`, indicating the type of statistics that the object contains.
+
+## Examples
+
+This example shows a function to return the transport statistics, or `null` if no statistics are provided.
+
+The function waits for the result of a call to {{domxref("RTCPeerConnection.getStats()")}} and then iterates the returned {{domxref("RTCStatsReport")}} to get just the stats of type `"transport"`.
+It then returns the statistics, or `null`, using the data in the report.
+
+```js
+async function numberOpenConnections (peerConnection) {
+  const stats = await peerConnection.getStats();
+  let transportStats = null;
+
+  stats.forEach((report) => {
+    if (report.type === "transport") {
+      transportStats = report;
+      break;
+    }
+  });
+
+return transportStats
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -9,7 +9,8 @@ browser-compat: api.RTCStatsReport.type_transport
 
 The **`RTCTransportStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides information about the transport ({{domxref("RTCDtlsTransport")}} and its underlying {{domxref("RTCIceTransport")}}) used by a particular candidate pair.
 
-Note that if remote endpoint is aware of the BUNDLE SDP feature, all {{domxref("MediaStreamTrack")}} and data channels are bundled onto a single transport at the completion of negotiation.
+The _BUNDLE_ feature is an SDP extension that allows negotiation to use a single transport for sending and receiving media described by multiple SDP media descriptions.
+If the remote endpoint is aware of this feature, all {{domxref("MediaStreamTrack")}} and data channels are bundled onto a single transport at the completion of negotiation.
 This is true for current browsers, but if connecting to an older endpoint that is not BUNDLE-aware, then separate transports might be used for different media.
 The policy to use in the negotiation is configured in the [`RTCPeerConnection` constructor](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection).
 

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -26,36 +26,61 @@ These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} 
 - `bytesReceived` {{optional_inline}}
   - : The total number of payload bytes received on this transport (bytes received, not including headers, padding or ICE connectivity checks).
 - `iceRole` {{optional_inline}}
-  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}.
+  - : A string indicating the [ICE `role`](/en-US/docs/Web/API/RTCIceTransport/role) of the underlying {{domxref("RTCDtlsTransport.iceTransport")}}: `controlling` or `controlled`.
 - `iceLocalUsernameFragment` {{optional_inline}}
-  - : A string indicating the local username fragment used in message validation procedures for this transport, as sent in the `ice-ufrag` attribute of the {{glossary("SDP")}} offer when negotiating the ICE connection.
-    The value will change if the connection is renegotiated: on ICE restart or following {{domxref("RTCPeerConnection.setLocalDescription()")}}.
+  - : A string indicating the local username fragment used in message validation procedures for this transport.
+    This is the same value as the local {{domxref("RTCIceCandidate.usernameFragment")}}, and will change if the connection is renegotiated.
 - `dtlsState`
-  - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}: `new`, `connecting`, `connected`, `closed`, and `failed`.
+  - : A string indicating the current {{domxref("RTCDtlsTransport.state","state")}} of the underlying {{domxref("RTCDtlsTransport")}}: `new`, `connecting`, `connected`, `closed`, or `failed`.
 - `iceState` {{optional_inline}}
-  - : {{domxref("RTCIceTransportState")}}
-    Xxx Set to the current value of the state attribute of the underlying RTCIceTransport.
+  - : A string indicating the current {{domxref("RTCIceTransport.state","state")}} of the underlying {{domxref("RTCIceTransport")}}: `new`, `checking`, `connected`, `completed`, `disconnected`, `failed`, or `closed`.
 - `selectedCandidatePairId` {{optional_inline}}
   - : A string containing the unique identifier for the object that was inspected to produce the {{domxref("RTCIceCandidatePairStats")}} associated with this transport.
 - `localCertificateId` {{optional_inline}}
-  - : A string containing the local certification <!-- For components where DTLS is negotiated -->
+  - : A string containing the id of the local certificate used by this transport.
+    Only present for DTLS transports, and after DTLS has been negotiated.
 - `remoteCertificateId` {{optional_inline}}
-  - : A string containing the remote certification. <!-- For components where DTLS is negotiated -->
+  - : A string containing the id or the remote certificate used by this transport.
+    Only present for DTLS transports, and after DTLS has been negotiated.
 - `tlsVersion` {{optional_inline}}
-  - : A string containing the negotiated TLS versions.
-    Only exists after DTLS negotiation is complete.
-    <!-- For components where DTLS is negotiated, the TLS version agreed -->
+
+  - : A string containing the negotiated TLS version.
+    This is present for DTLS transports, and only exists after DTLS has been negotiated.
+
+    The value comes from the DTLS handshake `ServerHello.version`, and is represented as four upper case hexadecimal digits, where the digits represent the two bytes of the version.
+    Note however that the bytes might not map directly to version numbers.
+    For example, DTLS represents version 1.2 as `'FEFD'` which numerically is `{254, 253}`.
+
 - `dtlsCipher` {{optional_inline}}
-  - : A string Xxxx
-    Xxx The value comes from ServerHello.supported_versions if present, otherwise from ServerHello.version. It is represented as four upper case hexadecimal digits, representing the two bytes of the version.
+
+  - : A string indicating the name of the cipher suite used for the DTLS transport, as defined in the "Description" column of the [TLS Cipher Suites](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4) section in the _IANA cipher suite registry_.
+    For example `"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"`.
+
 - `dtlsRole` {{optional_inline}}
-  - : {{domxref("RTCDtlsRole")}}
-    "client" or "server" depending on the DTLS role. "unknown" before the DTLS negotiation starts.
+
+  - : The DTLS role of the associated {{domxref("RTCPeerConnection")}}.
+    This is one of `"client"`, `"server"`, or `"unknown"` (before the DTLS negotiation starts).
+
 - `srtpCipher` {{optional_inline}}
-  - : Xxxx A string indicating the descriptive name of the protection profile used for the SRTP transport, as defined in the "Profile" column of the IANA DTLS-SRTP protection profile registry [IANA-DTLS-SRTP] and described further in [RFC5764].
+
+  - : A string indicating the descriptive name of the protection profile used for the [Secure Real-time Transport Protocol (SRTP)](/en-US/docs/Glossary/RTP) transport, as defined in the "Profile" column of the [IANA DTLS-SRTP protection profile registry](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml#srtp-protection-1) and [RFC5764](https://www.rfc-editor.org/rfc/rfc5764.html#section-4.1.2).
+
+    For example `"AES_CM_128_HMAC_SHA1_80"` specifies the following profile, where `maximum_lifetime` is the maximum number of packets that can be protected by a single set of keys.
+
+    ```plain
+    SRTP_AES128_CM_HMAC_SHA1_80
+     cipher: AES_128_CM
+     cipher_key_length: 128
+     cipher_salt_length: 112
+     maximum_lifetime: 2^31
+     auth_function: HMAC-SHA1
+     auth_key_length: 160
+     auth_tag_length: 80
+    ```
+
 - `selectedCandidatePairChanges` {{optional_inline}}
-  - : Xxxx The number of times that the selected candidate pair of this transport has changed.
-    Going from not having a selected candidate pair to having a selected candidate pair, or the other way around, also increases this counter. It is initially zero and becomes one when an initial candidate pair is selected.
+  - : The number of times that the selected candidate pair of this transport has changed.
+    The value is initially zero and increases whenever a candidate pair selected or lost.
 
 ### Common instance properties
 

--- a/files/en-us/web/api/rtctransportstats/timestamp/index.md
+++ b/files/en-us/web/api/rtctransportstats/timestamp/index.md
@@ -1,0 +1,25 @@
+---
+title: "RTCTransportStats: timestamp property"
+short-title: timestamp
+slug: Web/API/RTCTransportStats/timestamp
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_transport.timestamp
+---
+
+{{APIRef("WebRTC")}}
+
+The **`timestamp`** property of the {{domxref("RTCTransportStats")}} dictionary is a {{domxref("DOMHighResTimeStamp")}} object specifying the time at which the data in the object was sampled.
+
+## Value
+
+A {{domxref("DOMHighResTimeStamp")}} value indicating the time at which the activity described by the statistics in this object was recorded, in milliseconds elapsed since the beginning of January 1, 1970, UTC.
+
+The value should be accurate to within a few milliseconds but may not be entirely precise, either because of hardware or operating system limitations or because of [fingerprinting](/en-US/docs/Glossary/Fingerprinting) protection in the form of reduced clock precision or accuracy.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/type/index.md
+++ b/files/en-us/web/api/rtctransportstats/type/index.md
@@ -1,0 +1,27 @@
+---
+title: "RTCTransportStats: type property"
+short-title: type
+slug: Web/API/RTCTransportStats/type
+page-type: web-api-instance-property
+browser-compat: api.RTCTransportStats.type_transport.type
+---
+
+{{APIRef("WebRTC")}}
+
+The **`type`** property of the {{domxref("RTCTransportStats")}} dictionary is a string with the value `"transport"`.
+
+Different statistics are obtained by iterating the {{domxref("RTCStatsReport")}} object returned by a call to {{domxref("RTCPeerConnection.getStats()")}}.
+The type indicates the set of statistics available through the object in a particular iteration step.
+A value of `"transport"` indicates that the statistics available in the current step are those defined in {{domxref("RTCPeerConnectionStats")}}.
+
+## Value
+
+A string with the value `"transport"`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtctransportstats/type/index.md
+++ b/files/en-us/web/api/rtctransportstats/type/index.md
@@ -3,7 +3,7 @@ title: "RTCTransportStats: type property"
 short-title: type
 slug: Web/API/RTCTransportStats/type
 page-type: web-api-instance-property
-browser-compat: api.RTCTransportStats.type_transport.type
+browser-compat: api.RTCStatsReport.type_transport.type
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtctransportstats/type/index.md
+++ b/files/en-us/web/api/rtctransportstats/type/index.md
@@ -12,7 +12,7 @@ The **`type`** property of the {{domxref("RTCTransportStats")}} dictionary is a 
 
 Different statistics are obtained by iterating the {{domxref("RTCStatsReport")}} object returned by a call to {{domxref("RTCPeerConnection.getStats()")}}.
 The type indicates the set of statistics available through the object in a particular iteration step.
-A value of `"transport"` indicates that the statistics available in the current step are those defined in {{domxref("RTCPeerConnectionStats")}}.
+A value of `"transport"` indicates that the statistics available in the current step are those defined in {{domxref("RTCTransportStats")}}.
 
 ## Value
 


### PR DESCRIPTION
This adds docs for `RTCTransportStats`

This creates the top level doc and the "common" properties which are effectively boilerplate - id, type, timestamp. I didn't create sub docs for the properties because I don't know enough to understand the subtleties. What I've tried to do is create a top level doc that:
- Makes the BCD visible to readers.
- Provides an overview of the purpose/possible values of each property, cross linking to associated APIs that have the values it reflects.

I'm aware that the docs are fairly superficial. and provide little more than what is in the spec in most cases. What they do though is provide better linking and a little more context. Upshot, I think they will make it much easier to find the relevant information for users who want it, or for the next person who wants to create more detailed docs for each property. In other words, its a reasonable first step.

