### PR TITLE
relnote(121): `Date.parse` fixes and additions

### DIFF
--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -22,6 +22,23 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### JavaScript
 
+- {{jsxref("Date.parse()")}} now accepts several additional date formats:
+
+  - Year > 9999 for `YYYY-MMM-DD` format (e.g. `19999-Jan-01`)
+  - `MMM-DD-YYYY` (e.g. `Jan-01-1970`)
+  - Milliseconds for non-ISO date formats (e.g. `Jan 1 1970 10:00:00.050`)
+  - Day of week at the beginning of formats which were being rejected, such as:
+
+    - `Wed, 1970-01-01`
+    - `Wed, 1970-Jan-01`
+
+    The day of week does not need to be correct, or a day of week at all; for example, `foo 1970-01-01` works.
+
+- Other {{jsxref("Date.parse()")}} fixes:
+
+  - `YYYY-M-DD` and `YYYY-MM-D` are no longer assumed GMT as an ISO date `YYYY-MM-DD` would be
+  - Milliseconds for all formats are truncated after 3 digits, rather than being rounded
+
 #### Removals
 
 ### SVG

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -24,20 +24,20 @@ This article provides information about the changes in Firefox 121 that affect d
 
 - {{jsxref("Date.parse()")}} now accepts several additional date formats:
 
-  - Year > 9999 for `YYYY-MMM-DD` format (e.g. `19999-Jan-01`)
-  - `MMM-DD-YYYY` (e.g. `Jan-01-1970`)
-  - Milliseconds for non-ISO date formats (e.g. `Jan 1 1970 10:00:00.050`)
+  - Year > 9999 for `YYYY-MMM-DD` format (e.g. `19999-Jan-01`) ([Firefox bug 1858851](https://bugzil.la/1858851))
+  - `MMM-DD-YYYY` (e.g. `Jan-01-1970`) ([Firefox bug 1863489](https://bugzil.la/1863489))
+  - Milliseconds for non-ISO date formats (e.g. `Jan 1 1970 10:00:00.050`) ([Firefox bug 1863125](https://bugzil.la/1863125))
   - Day of week at the beginning of formats which were being rejected, such as:
 
     - `Wed, 1970-01-01`
     - `Wed, 1970-Jan-01`
 
-    The day of week does not need to be correct, or a day of week at all; for example, `foo 1970-01-01` works.
+    The day of week does not need to be correct, or a day of week at all; for example, `foo 1970-01-01` works ([Firefox bug 1617562](https://bugzil.la/1617562)).
 
 - Other {{jsxref("Date.parse()")}} fixes:
 
-  - `YYYY-M-DD` and `YYYY-MM-D` are no longer assumed GMT as an ISO date `YYYY-MM-DD` would be
-  - Milliseconds for all formats are truncated after 3 digits, rather than being rounded
+  - `YYYY-M-DD` and `YYYY-MM-D` are no longer assumed GMT as an ISO date `YYYY-MM-DD` would be ([Firefox bug 1783731](https://bugzil.la/1783731)).
+  - Milliseconds for all formats are truncated after 3 digits, rather than being rounded ([Firefox bug 746529](https://bugzil.la/746529)).
 
 #### Removals
 


### PR DESCRIPTION
### Entry

- `Date.parse()` now accepts several additional date formats:

  - Year > 9999 for `YYYY-MMM-DD` format (e.g. `19999-Jan-01`)
  - `MMM-DD-YYYY` (e.g. `Jan-01-1970`)
  - Milliseconds for non-ISO date formats (e.g. `Jan 1 1970 10:00:00.050`)
  - Day of week at the beginning of formats which were being rejected, such as:

    - `Wed, 1970-01-01`
    - `Wed, 1970-Jan-01`

    The day of week does not need to be correct, or a day of week at all; for example, `foo 1970-01-01` works.

- Other `Date.parse()` fixes:

  - `YYYY-M-DD` and `YYYY-MM-D` are no longer assumed GMT as an ISO date `YYYY-MM-DD` would be
  - Milliseconds for all formats are truncated after 3 digits, rather than being rounded

### Bugzilla

In the order of the entries:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1858851
* https://bugzilla.mozilla.org/show_bug.cgi?id=1863489
* https://bugzilla.mozilla.org/show_bug.cgi?id=1863125
* https://bugzilla.mozilla.org/show_bug.cgi?id=1617562
* https://bugzilla.mozilla.org/show_bug.cgi?id=1783731
* https://bugzilla.mozilla.org/show_bug.cgi?id=746529

