### PR TITLE
chore(deps): Bump Prettier to 3.1.0, content changes

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
+++ b/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
@@ -77,9 +77,8 @@ function generatePrimes(quota) {
 document.querySelector("#generate").addEventListener("click", () => {
   const quota = document.querySelector("#quota").value;
   const primes = generatePrimes(quota);
-  document.querySelector(
-    "#output",
-  ).textContent = `Finished generating ${quota} primes!`;
+  document.querySelector("#output").textContent =
+    `Finished generating ${quota} primes!`;
 });
 
 document.querySelector("#reload").addEventListener("click", () => {
@@ -161,9 +160,8 @@ document.querySelector("#generate").addEventListener("click", () => {
 // update the output box with a message for the user, including the number of
 // primes that were generated, taken from the message data.
 worker.addEventListener("message", (message) => {
-  document.querySelector(
-    "#output",
-  ).textContent = `Finished generating ${message.data} primes!`;
+  document.querySelector("#output").textContent =
+    `Finished generating ${message.data} primes!`;
 });
 
 document.querySelector("#reload").addEventListener("click", () => {

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -445,8 +445,8 @@ We will also use the `Filter` enum in the `Todos.svelte` component.
      filter === Filter.ACTIVE
        ? todos.filter((t) => !t.completed)
        : filter === Filter.COMPLETED
-       ? todos.filter((t) => t.completed)
-       : todos;
+         ? todos.filter((t) => t.completed)
+         : todos;
 
    $: {
      if (filter === Filter.ALL) {
@@ -519,8 +519,8 @@ We will also use the `Filter` enum in the `Todos.svelte` component.
      filter === Filter.ACTIVE
        ? todos.filter((t) => !t.completed)
        : filter === Filter.COMPLETED
-       ? todos.filter((t) => t.completed)
-       : todos;
+         ? todos.filter((t) => t.completed)
+         : todos;
 
    $: {
      if (filter === Filter.ALL) {

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_variables_props/index.md
@@ -392,8 +392,8 @@ Finally for this article, let's implement the ability to filter our to-dos by st
      filter === "active"
        ? todos.filter((t) => !t.completed)
        : filter === "completed"
-       ? todos.filter((t) => t.completed)
-       : todos;
+         ? todos.filter((t) => t.completed)
+         : todos;
    ```
 
    We use the `filter` variable to control the active filter: _all_, _active_, or _completed_. Just assigning one of these values to the filter variable will activate the filter and update the list of to-dos. Let's see how to achieve this.

--- a/files/en-us/web/api/batterymanager/chargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.md
@@ -34,9 +34,8 @@ A number.
 navigator.getBattery().then((battery) => {
   const time = battery.chargingTime;
 
-  document.querySelector(
-    "#chargingTime",
-  ).textContent = `Time to fully charge the battery: ${time}s`;
+  document.querySelector("#chargingTime").textContent =
+    `Time to fully charge the battery: ${time}s`;
 });
 ```
 

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.md
@@ -33,9 +33,8 @@ A number.
 navigator.getBattery().then((battery) => {
   const time = battery.dischargingTime;
 
-  document.querySelector(
-    "#dischargingTime",
-  ).textContent = `Remaining time to fully discharge the battery: ${time}`;
+  document.querySelector("#dischargingTime").textContent =
+    `Remaining time to fully discharge the battery: ${time}`;
 });
 ```
 

--- a/files/en-us/web/api/batterymanager/levelchange_event/index.md
+++ b/files/en-us/web/api/batterymanager/levelchange_event/index.md
@@ -45,9 +45,8 @@ navigator.getBattery().then((battery) => {
         battery.chargingTime / 60
       }`;
     } else {
-      document.querySelector(
-        "#stateBattery",
-      ).textContent = `Discharging time: ${battery.dischargingTime / 60}`;
+      document.querySelector("#stateBattery").textContent =
+        `Discharging time: ${battery.dischargingTime / 60}`;
     }
   };
 });

--- a/files/en-us/web/api/document/createtreewalker/index.md
+++ b/files/en-us/web/api/document/createtreewalker/index.md
@@ -158,8 +158,8 @@ const treeWalker = document.createTreeWalker(
     node.classList.contains("no-escape")
       ? NodeFilter.FILTER_REJECT
       : node.closest(".escape")
-      ? NodeFilter.FILTER_ACCEPT
-      : NodeFilter.FILTER_SKIP,
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP,
 );
 
 while (treeWalker.nextNode()) {

--- a/files/en-us/web/api/htmlmarqueeelement/index.md
+++ b/files/en-us/web/api/htmlmarqueeelement/index.md
@@ -73,7 +73,7 @@ _Inherits methods from its parent, {{DOMxRef("HTMLElement")}}._
   height="200"
   behavior="alternate"
   style="border:solid">
-  <marquee behavior="alternate"> This text will bounce </marquee>
+  <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
 ```
 

--- a/files/en-us/web/api/ink_api/index.md
+++ b/files/en-us/web/api/ink_api/index.md
@@ -91,9 +91,8 @@ canvas.addEventListener("pointermove", async (evt) => {
 
     style = { color: `rgba(${r}, ${g}, ${b}, 1)`, diameter: 10 };
     move_cnt = 0;
-    document.getElementById(
-      "div",
-    ).style.backgroundColor = `rgba(${r}, ${g}, ${b}, 0.6)`;
+    document.getElementById("div").style.backgroundColor =
+      `rgba(${r}, ${g}, ${b}, 0.6)`;
   }
   move_cnt += 1;
   await presenter.updateInkTrailStartPoint(evt, style);

--- a/files/en-us/web/api/inkpresenter/updateinktrailstartpoint/index.md
+++ b/files/en-us/web/api/inkpresenter/updateinktrailstartpoint/index.md
@@ -97,9 +97,8 @@ canvas.addEventListener("pointermove", async (evt) => {
 
     style = { color: `rgba(${r}, ${g}, ${b}, 1)`, diameter: 10 };
     move_cnt = 0;
-    document.getElementById(
-      "div",
-    ).style.backgroundColor = `rgba(${r}, ${g}, ${b}, 0.6)`;
+    document.getElementById("div").style.backgroundColor =
+      `rgba(${r}, ${g}, ${b}, 0.6)`;
   }
   move_cnt += 1;
   await presenter.updateInkTrailStartPoint(evt, style);

--- a/files/en-us/web/api/keyboardevent/metakey/index.md
+++ b/files/en-us/web/api/keyboardevent/metakey/index.md
@@ -33,9 +33,8 @@ A boolean value.
 
 ```js
 function ismetaKey(e) {
-  document.querySelector(
-    "#output",
-  ).textContent = `metaKey pressed? ${e.metaKey}`;
+  document.querySelector("#output").textContent =
+    `metaKey pressed? ${e.metaKey}`;
 }
 ```
 

--- a/files/en-us/web/api/response/json/index.md
+++ b/files/en-us/web/api/response/json/index.md
@@ -49,9 +49,8 @@ fetch(myRequest)
       listItem.appendChild(document.createElement("strong")).textContent =
         product.Name;
       listItem.append(` can be found in ${product.Location}. Cost: `);
-      listItem.appendChild(
-        document.createElement("strong"),
-      ).textContent = `£${product.Price}`;
+      listItem.appendChild(document.createElement("strong")).textContent =
+        `£${product.Price}`;
       myList.appendChild(listItem);
     }
   })

--- a/files/en-us/web/api/rtcdatachannel/label/index.md
+++ b/files/en-us/web/api/rtcdatachannel/label/index.md
@@ -39,9 +39,8 @@ const dc = pc.createDataChannel("my channel");
 
 // …
 
-document.getElementById(
-  "channel-name",
-).innerHTML = `<span class='channelName'>${dc.label}</span>`;
+document.getElementById("channel-name").innerHTML =
+  `<span class='channelName'>${dc.label}</span>`;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
@@ -97,9 +97,8 @@ function setupWebGL(evt) {
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
     const linkErrLog = gl.getProgramInfoLog(program);
     cleanup();
-    document.querySelector(
-      "p",
-    ).textContent = `Shader program did not link successfully. Error log: ${linkErrLog}`;
+    document.querySelector("p").textContent =
+      `Shader program did not link successfully. Error log: ${linkErrLog}`;
     return;
   }
 

--- a/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.md
@@ -102,9 +102,8 @@ function setupWebGL(evt) {
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
     const linkErrLog = gl.getProgramInfoLog(program);
     cleanup();
-    document.querySelector(
-      "p",
-    ).textContent = `Shader program did not link successfully. Error log: ${linkErrLog}`;
+    document.querySelector("p").textContent =
+      `Shader program did not link successfully. Error log: ${linkErrLog}`;
     return;
   }
 

--- a/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.md
@@ -108,9 +108,8 @@ function setupWebGL(evt) {
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
     const linkErrLog = gl.getProgramInfoLog(program);
     cleanup();
-    document.querySelector(
-      "p",
-    ).textContent = `Shader program did not link successfully. Error log: ${linkErrLog}`;
+    document.querySelector("p").textContent =
+      `Shader program did not link successfully. Error log: ${linkErrLog}`;
     return;
   }
   initializeAttributes();

--- a/files/en-us/web/html/element/marquee/index.md
+++ b/files/en-us/web/html/element/marquee/index.md
@@ -65,7 +65,7 @@ The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scr
   height="200"
   behavior="alternate"
   style="border:solid">
-  <marquee behavior="alternate"> This text will bounce </marquee>
+  <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
 ```
 

--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -163,8 +163,8 @@ Here, we load 10 modules, `/modules/module-0.js`, `/modules/module-1.js`, etc., 
 
 ```js
 Promise.all(
-  Array.from({ length: 10 }).map((_, index) =>
-    import(`/modules/module-${index}.js`),
+  Array.from({ length: 10 }).map(
+    (_, index) => import(`/modules/module-${index}.js`),
   ),
 ).then((modules) => modules.forEach((module) => module.load()));
 ```

--- a/files/en-us/web/javascript/reference/operators/instanceof/index.md
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.md
@@ -215,7 +215,7 @@ if (!(mycar instanceof Car)) {
 This is really different from:
 
 ```js example-bad
-if (!mycar instanceof Car) {
+if ((!mycar) instanceof Car) {
   // unreachable code
 }
 ```

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -112,8 +112,8 @@ let classes = "header";
 classes += isLargeScreen()
   ? ""
   : item.isCollapsed
-  ? " icon-expander"
-  : " icon-collapser";
+    ? " icon-expander"
+    : " icon-collapser";
 ```
 
 With a template literal but without nesting, you could do this:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint-staged": "15.1.0",
     "markdownlint-cli2": "0.10.0",
     "markdownlint-rule-search-replace": "1.2.0",
-    "prettier": "3.0.3"
+    "prettier": "3.1.0"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6651,10 +6651,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
-  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+prettier@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
+  integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
 
 pretty-format@^29.7.0:
   version "29.7.0"


### PR DESCRIPTION
This PR includes some fixes in content required to get tests passing while bumping this dep.

Changes:

* [Ternaries are nested](https://prettier.io/blog/2023/11/13/3.1.0.html#add-indentation-back-to-nested-ternaries-9559httpsgithubcomprettierprettierpull9559-by-rattrayalexhttpsgithubcomrattrayalex)
* [Breaking in assignments](https://prettier.io/blog/2023/11/13/3.1.0.html#improve-formatting-for-assignment-its-left-can-break-15547httpsgithubcomprettierprettierpull15547-by-sosukesuzukihttpsgithubcomsosukesuzuki)
* [Marquee element](https://prettier.io/blog/2023/11/13/3.1.0.html#fix-formatting-of-menu-and-marquee-elements-15334httpsgithubcomprettierprettierpull15334-by-fiskerhttpsgithubcomfisker)
* [Unary expr on left of instanceof](https://prettier.io/blog/2023/11/13/3.1.0.html#disambiguate-unary-expressions-on-left-hand-side-of-instanceof-and-in-15468httpsgithubcomprettierprettierpull15468-by-lucacasonatohttpsgithubcomlucacasonato)

Tested on this branch:

```bash
 bsmth npm i -g prettier@3.1.0
...
 bsmth prettier -v
3.1.0
 bsmth prettier -c "**/*.md"
Checking formatting...
All matched files use Prettier code style!
```