### PR TITLE
Correct NavigationDestination docs for key/id property

### DIFF
--- a/files/en-us/web/api/navigationdestination/id/index.md
+++ b/files/en-us/web/api/navigationdestination/id/index.md
@@ -11,13 +11,13 @@ browser-compat: api.NavigationDestination.id
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
 The **`id`** read-only property of the
-{{domxref("NavigationDestination")}} interface returns the {{domxref("NavigationHistoryEntry.id", "id")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or `null` otherwise.
+{{domxref("NavigationDestination")}} interface returns the {{domxref("NavigationHistoryEntry.id", "id")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or an empty string otherwise.
 
 The `id` is a unique, UA-generated value that always represents the history entry, useful to correlate a history entry with an external resource such as a storage cache.
 
 ## Value
 
-A string representing the `id` of the destination {{domxref("NavigationHistoryEntry")}}, or `null`.
+A string representing the `id` of the destination {{domxref("NavigationHistoryEntry")}}, or an empty string.
 
 ## Examples
 

--- a/files/en-us/web/api/navigationdestination/index.md
+++ b/files/en-us/web/api/navigationdestination/index.md
@@ -18,11 +18,11 @@ It is accessed via the {{domxref("NavigateEvent.destination")}} property.
 ## Instance properties
 
 - {{domxref("NavigationDestination.id", "id")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns the {{domxref("NavigationHistoryEntry.id", "id")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or `null` otherwise.
+  - : Returns the {{domxref("NavigationHistoryEntry.id", "id")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or an empty string otherwise.
 - {{domxref("NavigationDestination.index", "index")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the {{domxref("NavigationHistoryEntry.index", "index")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or `-1` otherwise.
 - {{domxref("NavigationDestination.key", "key")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns the {{domxref("NavigationHistoryEntry.key", "key")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or `null` otherwise.
+  - : Returns the {{domxref("NavigationHistoryEntry.key", "key")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or an empty string otherwise.
 - {{domxref("NavigationDestination.sameDocument", "sameDocument")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns `true` if the navigation is to the same `document` as the current {{domxref("Document")}} value, or `false` otherwise.
 - {{domxref("NavigationDestination.url", "url")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/navigationdestination/key/index.md
+++ b/files/en-us/web/api/navigationdestination/key/index.md
@@ -11,13 +11,13 @@ browser-compat: api.NavigationDestination.key
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
 The **`key`** read-only property of the
-{{domxref("NavigationDestination")}} interface returns the {{domxref("NavigationHistoryEntry.key", "key")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or `null` otherwise.
+{{domxref("NavigationDestination")}} interface returns the {{domxref("NavigationHistoryEntry.key", "key")}} value of the destination {{domxref("NavigationHistoryEntry")}} if the {{domxref("NavigateEvent.navigationType")}} is `traverse`, or an empty string otherwise.
 
 The `key` is a unique, UA-generated value that represents the history entry's slot in the history entries list, used to navigate to this place in the history via {{domxref("Navigation.traverseTo()")}}. It will be reused by other entries that replace the entry in the list (i.e. if the {{domxref("NavigateEvent.navigationType")}} is `replace`).
 
 ## Value
 
-A string representing the `key` of the destination {{domxref("NavigationHistoryEntry")}}, or `null`.
+A string representing the `key` of the destination {{domxref("NavigationHistoryEntry")}}, or an empty string.
 
 ## Examples
 


### PR DESCRIPTION
According to the spec, and Chromium, it will be an empty string and not null.

https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface
