### PR TITLE
Be clearer about "direct eval"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -62,9 +62,12 @@ eval(String(expression)); // returns 4
 
 ### Direct and indirect eval
 
-There are two modes of `eval()` calls: _direct_ eval and _indirect_ eval. Direct eval only has one form: `eval( )` (the invoked function's name is `eval` and its value is the global `eval` function). Everything else, including invoking it via an aliased variable, via a member access or other expression, or through the optional chaining [`?.`](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator, is indirect.
+There are two modes of `eval()` calls: _direct_ eval and _indirect_ eval. Direct eval, as the name implies, refers to _directly_ calling the global `eval` function. Everything else, including invoking it via an aliased variable, via a member access or other expression, or through the optional chaining [`?.`](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator, is indirect.
 
 ```js
+// Direct call
+eval("x + y");
+
 // Indirect call using the comma operator to return eval
 (0, eval)("x + y");
 

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -62,7 +62,7 @@ eval(String(expression)); // returns 4
 
 ### Direct and indirect eval
 
-There are two modes of `eval()` calls: _direct_ eval and _indirect_ eval. Direct eval, as the name implies, refers to _directly_ calling the global `eval` function. Everything else, including invoking it via an aliased variable, via a member access or other expression, or through the optional chaining [`?.`](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator, is indirect.
+There are two modes of `eval()` calls: _direct_ eval and _indirect_ eval. Direct eval, as the name implies, refers to _directly_ calling the global `eval` function with `eval(...)`. Everything else, including invoking it via an aliased variable, via a member access or other expression, or through the optional chaining [`?.`](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator, is indirect.
 
 ```js
 // Direct call


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I reworded this sentence and added a new example in the next paragraph:

> There are two modes of eval() calls: direct eval and indirect eval. Direct eval only has one form: eval( ) (the invoked function's name is eval and its value is the global eval function).

### Motivation

Described in #30251

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #30251

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
