### PR TITLE
Add spec url for Sec-GPC header

### DIFF
--- a/files/en-us/web/http/headers/sec-gpc/index.md
+++ b/files/en-us/web/http/headers/sec-gpc/index.md
@@ -6,6 +6,7 @@ status:
   - experimental
   - non-standard
 browser-compat: http.headers.Sec-GPC
+spec-urls: https://privacycg.github.io/gpc-spec/
 ---
 
 {{HTTPSidebar}}{{SeeCompatTable}}{{non-standard_header}}


### PR DESCRIPTION
The Sec-GPC header wasn't displaying the spec. This is "non standard" so for BCD the spec is not present. This adds the spec link to the page since we still want it in docs.