### PR TITLE
Revert running prettier npx

### DIFF
--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/introducing_complete_toolchain/index.md
@@ -139,7 +139,7 @@ We'll be using Prettier, which we first met in Chapter 2, to tidy our code in th
 You can check whether you've already got it installed globally using the following command:
 
 ```bash
-npx prettier -v
+prettier -v
 ```
 
 If installed, you'll get a version number returned like 2.0.2; if not, it'll return something along the lines of "command not found". If this is the case, install it using the following command:


### PR DESCRIPTION
Reverts #30141

That replaced running prettier globally with using `npx`. The change didn't make sense because none of the surrounding docs were updated. Further, it usually doesn't make sense to install prettier with npx because if you use it at all you use it all the time.