### PR TITLE
Update WebAssembly BCD paths

### DIFF
--- a/files/en-us/webassembly/javascript_interface/compile/index.md
+++ b/files/en-us/webassembly/javascript_interface/compile/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.compile()
 slug: WebAssembly/JavaScript_interface/compile
 page-type: webassembly-function
-browser-compat: javascript.builtins.WebAssembly.compile
+browser-compat: webassembly.api.compile
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/compileerror/compileerror/index.md
+++ b/files/en-us/webassembly/javascript_interface/compileerror/compileerror/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.CompileError() constructor
 slug: WebAssembly/JavaScript_interface/CompileError/CompileError
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.CompileError.CompileError
+browser-compat: webassembly.api.CompileError.CompileError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/compileerror/index.md
+++ b/files/en-us/webassembly/javascript_interface/compileerror/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.CompileError
 slug: WebAssembly/JavaScript_interface/CompileError
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.CompileError
+browser-compat: webassembly.api.CompileError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/compilestreaming/index.md
+++ b/files/en-us/webassembly/javascript_interface/compilestreaming/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.compileStreaming()
 slug: WebAssembly/JavaScript_interface/compileStreaming
 page-type: webassembly-function
-browser-compat: javascript.builtins.WebAssembly.compileStreaming
+browser-compat: webassembly.api.compileStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/exception/exception/index.md
+++ b/files/en-us/webassembly/javascript_interface/exception/exception/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Exception constructor
 slug: WebAssembly/JavaScript_interface/Exception/Exception
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Exception.Exception
+browser-compat: webassembly.api.Exception.Exception
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/exception/getarg/index.md
+++ b/files/en-us/webassembly/javascript_interface/exception/getarg/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Exception.prototype.getArg()
 slug: WebAssembly/JavaScript_interface/Exception/getArg
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Exception.getArg
+browser-compat: webassembly.api.Exception.getArg
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/exception/index.md
+++ b/files/en-us/webassembly/javascript_interface/exception/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Exception
 slug: WebAssembly/JavaScript_interface/Exception
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Exception
+browser-compat: webassembly.api.Exception
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/exception/is/index.md
+++ b/files/en-us/webassembly/javascript_interface/exception/is/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Exception.prototype.is()
 slug: WebAssembly/JavaScript_interface/Exception/is
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Exception.is
+browser-compat: webassembly.api.Exception.is
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/exception/stack/index.md
+++ b/files/en-us/webassembly/javascript_interface/exception/stack/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Exception/stack
 page-type: webassembly-instance-property
 status:
   - non-standard
-browser-compat: webassembly.apiwebassembly.api.Exception.stack
+browser-compat: webassembly.api.Exception.stack
 ---
 
 {{WebAssemblySidebar}} {{non-standard_header}}

--- a/files/en-us/webassembly/javascript_interface/exception/stack/index.md
+++ b/files/en-us/webassembly/javascript_interface/exception/stack/index.md
@@ -4,7 +4,7 @@ slug: WebAssembly/JavaScript_interface/Exception/stack
 page-type: webassembly-instance-property
 status:
   - non-standard
-browser-compat: javascript.builtins.WebAssembly.Exception.stack
+browser-compat: webassembly.apiwebassembly.api.Exception.stack
 ---
 
 {{WebAssemblySidebar}} {{non-standard_header}}

--- a/files/en-us/webassembly/javascript_interface/global/global/index.md
+++ b/files/en-us/webassembly/javascript_interface/global/global/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Global() constructor
 slug: WebAssembly/JavaScript_interface/Global/Global
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Global.Global
+browser-compat: webassembly.api.Global.Global
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/global/index.md
+++ b/files/en-us/webassembly/javascript_interface/global/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Global
 slug: WebAssembly/JavaScript_interface/Global
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Global
+browser-compat: webassembly.api.Global
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/instance/exports/index.md
+++ b/files/en-us/webassembly/javascript_interface/instance/exports/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Instance.prototype.exports
 slug: WebAssembly/JavaScript_interface/Instance/exports
 page-type: webassembly-instance-property
-browser-compat: javascript.builtins.WebAssembly.Instance.exports
+browser-compat: webassembly.api.Instance.exports
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/instance/index.md
+++ b/files/en-us/webassembly/javascript_interface/instance/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Instance
 slug: WebAssembly/JavaScript_interface/Instance
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Instance
+browser-compat: webassembly.api.Instance
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/instance/instance/index.md
+++ b/files/en-us/webassembly/javascript_interface/instance/instance/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Instance() constructor
 slug: WebAssembly/JavaScript_interface/Instance/Instance
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Instance.Instance
+browser-compat: webassembly.api.Instance.Instance
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/instantiate/index.md
+++ b/files/en-us/webassembly/javascript_interface/instantiate/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.instantiate()
 slug: WebAssembly/JavaScript_interface/instantiate
 page-type: webassembly-function
-browser-compat: javascript.builtins.WebAssembly.instantiate
+browser-compat: webassembly.api.instantiate
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/instantiatestreaming/index.md
+++ b/files/en-us/webassembly/javascript_interface/instantiatestreaming/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.instantiateStreaming()
 slug: WebAssembly/JavaScript_interface/instantiateStreaming
 page-type: webassembly-function
-browser-compat: javascript.builtins.WebAssembly.instantiateStreaming
+browser-compat: webassembly.api.instantiateStreaming
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/linkerror/index.md
+++ b/files/en-us/webassembly/javascript_interface/linkerror/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.LinkError
 slug: WebAssembly/JavaScript_interface/LinkError
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.LinkError
+browser-compat: webassembly.api.LinkError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/linkerror/linkerror/index.md
+++ b/files/en-us/webassembly/javascript_interface/linkerror/linkerror/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.LinkError() constructor
 slug: WebAssembly/JavaScript_interface/LinkError/LinkError
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.LinkError.LinkError
+browser-compat: webassembly.api.LinkError.LinkError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/memory/buffer/index.md
+++ b/files/en-us/webassembly/javascript_interface/memory/buffer/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Memory.prototype.buffer
 slug: WebAssembly/JavaScript_interface/Memory/buffer
 page-type: webassembly-instance-property
-browser-compat: javascript.builtins.WebAssembly.Memory.buffer
+browser-compat: webassembly.api.Memory.buffer
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/memory/grow/index.md
+++ b/files/en-us/webassembly/javascript_interface/memory/grow/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Memory.prototype.grow()
 slug: WebAssembly/JavaScript_interface/Memory/grow
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Memory.grow
+browser-compat: webassembly.api.Memory.grow
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/memory/index.md
+++ b/files/en-us/webassembly/javascript_interface/memory/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Memory
 slug: WebAssembly/JavaScript_interface/Memory
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Memory
+browser-compat: webassembly.api.Memory
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/memory/memory/index.md
+++ b/files/en-us/webassembly/javascript_interface/memory/memory/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Memory() constructor
 slug: WebAssembly/JavaScript_interface/Memory/Memory
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Memory.Memory
+browser-compat: webassembly.api.Memory.Memory
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/module/customsections/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/customsections/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Module.customSections()
 slug: WebAssembly/JavaScript_interface/Module/customSections
 page-type: webassembly-static-method
-browser-compat: javascript.builtins.WebAssembly.Module.customSections
+browser-compat: webassembly.api.Module.customSections
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/module/exports/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/exports/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Module.exports()
 slug: WebAssembly/JavaScript_interface/Module/exports
 page-type: webassembly-static-method
-browser-compat: javascript.builtins.WebAssembly.Module.exports
+browser-compat: webassembly.api.Module.exports
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/module/imports/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/imports/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Module.imports()
 slug: WebAssembly/JavaScript_interface/Module/imports
 page-type: webassembly-static-method
-browser-compat: javascript.builtins.WebAssembly.Module.imports
+browser-compat: webassembly.api.Module.imports
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/module/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Module
 slug: WebAssembly/JavaScript_interface/Module
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Module
+browser-compat: webassembly.api.Module
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/module/module/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/module/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Module() constructor
 slug: WebAssembly/JavaScript_interface/Module/Module
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Module.Module
+browser-compat: webassembly.api.Module.Module
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/runtimeerror/index.md
+++ b/files/en-us/webassembly/javascript_interface/runtimeerror/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.RuntimeError
 slug: WebAssembly/JavaScript_interface/RuntimeError
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.RuntimeError
+browser-compat: webassembly.api.RuntimeError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
+++ b/files/en-us/webassembly/javascript_interface/runtimeerror/runtimeerror/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.RuntimeError() constructor
 slug: WebAssembly/JavaScript_interface/RuntimeError/RuntimeError
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.RuntimeError.RuntimeError
+browser-compat: webassembly.api.RuntimeError.RuntimeError
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/table/get/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/get/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Table.prototype.get()
 slug: WebAssembly/JavaScript_interface/Table/get
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Table.get
+browser-compat: webassembly.api.Table.get
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/table/grow/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/grow/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Table.prototype.grow()
 slug: WebAssembly/JavaScript_interface/Table/grow
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Table.grow
+browser-compat: webassembly.api.Table.grow
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/table/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Table
 slug: WebAssembly/JavaScript_interface/Table
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Table
+browser-compat: webassembly.api.Table
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/table/length/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/length/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Table.prototype.length
 slug: WebAssembly/JavaScript_interface/Table/length
 page-type: webassembly-instance-property
-browser-compat: javascript.builtins.WebAssembly.Table.length
+browser-compat: webassembly.api.Table.length
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/table/set/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/set/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Table.prototype.set()
 slug: WebAssembly/JavaScript_interface/Table/set
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Table.set
+browser-compat: webassembly.api.Table.set
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/table/table/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/table/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Table() constructor
 slug: WebAssembly/JavaScript_interface/Table/Table
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Table.Table
+browser-compat: webassembly.api.Table.Table
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/tag/index.md
+++ b/files/en-us/webassembly/javascript_interface/tag/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Tag
 slug: WebAssembly/JavaScript_interface/Tag
 page-type: webassembly-interface
-browser-compat: javascript.builtins.WebAssembly.Tag
+browser-compat: webassembly.api.Tag
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/tag/tag/index.md
+++ b/files/en-us/webassembly/javascript_interface/tag/tag/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Tag() constructor
 slug: WebAssembly/JavaScript_interface/Tag/Tag
 page-type: webassembly-constructor
-browser-compat: javascript.builtins.WebAssembly.Tag.Tag
+browser-compat: webassembly.api.Tag.Tag
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/tag/type/index.md
+++ b/files/en-us/webassembly/javascript_interface/tag/type/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.Tag.prototype.type()
 slug: WebAssembly/JavaScript_interface/Tag/type
 page-type: webassembly-instance-method
-browser-compat: javascript.builtins.WebAssembly.Tag.type
+browser-compat: webassembly.api.Tag.type
 ---
 
 {{WebAssemblySidebar}}

--- a/files/en-us/webassembly/javascript_interface/validate/index.md
+++ b/files/en-us/webassembly/javascript_interface/validate/index.md
@@ -2,7 +2,7 @@
 title: WebAssembly.validate()
 slug: WebAssembly/JavaScript_interface/validate
 page-type: webassembly-function
-browser-compat: javascript.builtins.WebAssembly.validate
+browser-compat: webassembly.api.validate
 ---
 
 {{WebAssemblySidebar}}


### PR DESCRIPTION
### Description

Updates the BCD paths for WebAssembly API features which have been moved from the JavaScript tree to the WebAssembly tree and which also move to `webassembly.api` in BCD.

### Motivation

Unblocking this BCD PR by @queengooborg: https://github.com/mdn/browser-compat-data/pull/20609

### Additional details

None.

### Related issues and pull requests

Follow-up to https://github.com/mdn/content/pull/20603
