### PR TITLE
fix(css): a broken link

### DIFF
--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -55,7 +55,7 @@ So the `writing-mode` property is in reality setting the direction in which bloc
 
 ## Writing modes and block and inline layout
 
-We have already discussed [block and inline layout](/en-US/docs/Learn/CSS/Building_blocks/The_box_model#block_and_inline_boxes), and the fact that some things display as block elements and others as inline elements. As we have seen described above, block and inline is tied to the writing mode of the document, and not the physical screen. Blocks are only displayed from the top to the bottom of the page if you are using a writing mode that displays text horizontally, such as English.
+We have already discussed [block](/docs/Web/Guide/CSS/Block_formatting_context) and [inline](/docs/Web/CSS/Inline_formatting_context) layout, and the fact that some things display as block elements and others as inline elements. As we have seen described above, block and inline is tied to the writing mode of the document, and not the physical screen. Blocks are only displayed from the top to the bottom of the page if you are using a writing mode that displays text horizontally, such as English.
 
 If we look at an example this will become clearer. In this next example I have two boxes that contain a heading and a paragraph. The first uses `writing-mode: horizontal-tb`, a writing mode that is written horizontally and from the top of the page to the bottom. The second uses `writing-mode: vertical-rl`; this is a writing mode that is written vertically and from right to left.
 

--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -55,7 +55,7 @@ So the `writing-mode` property is in reality setting the direction in which bloc
 
 ## Writing modes and block and inline layout
 
-We have already discussed [block](/docs/Web/Guide/CSS/Block_formatting_context) and [inline](/docs/Web/CSS/Inline_formatting_context) layout, and the fact that some things display as block elements and others as inline elements. As we have seen described above, block and inline is tied to the writing mode of the document, and not the physical screen. Blocks are only displayed from the top to the bottom of the page if you are using a writing mode that displays text horizontally, such as English.
+We have already discussed [block](/en-US/docs/Web/Guide/CSS/Block_formatting_context) and [inline](/en-US/docs/Web/CSS/Inline_formatting_context) layout, and the fact that some things display as block elements and others as inline elements. As we have seen described above, block and inline is tied to the writing mode of the document, and not the physical screen. Blocks are only displayed from the top to the bottom of the page if you are using a writing mode that displays text horizontally, such as English.
 
 If we look at an example this will become clearer. In this next example I have two boxes that contain a heading and a paragraph. The first uses `writing-mode: horizontal-tb`, a writing mode that is written horizontally and from the top of the page to the bottom. The second uses `writing-mode: vertical-rl`; this is a writing mode that is written vertically and from right to left.
 

--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -55,7 +55,7 @@ So the `writing-mode` property is in reality setting the direction in which bloc
 
 ## Writing modes and block and inline layout
 
-We have already discussed [block](/en-US/docs/Web/Guide/CSS/Block_formatting_context) and [inline](/en-US/docs/Web/CSS/Inline_formatting_context) layout, and the fact that some things display as block elements and others as inline elements. As we have seen described above, block and inline is tied to the writing mode of the document, and not the physical screen. Blocks are only displayed from the top to the bottom of the page if you are using a writing mode that displays text horizontally, such as English.
+We have already discussed [block and inline layout](/en-US/docs/Web/CSS/CSS_flow_layout/Block_and_inline_layout_in_normal_flow), and the fact that some things display as block elements and others as inline elements. As we have seen described above, block and inline is tied to the writing mode of the document, and not the physical screen. Blocks are only displayed from the top to the bottom of the page if you are using a writing mode that displays text horizontally, such as English.
 
 If we look at an example this will become clearer. In this next example I have two boxes that contain a heading and a paragraph. The first uses `writing-mode: horizontal-tb`, a writing mode that is written horizontally and from the top of the page to the bottom. The second uses `writing-mode: vertical-rl`; this is a writing mode that is written vertically and from right to left.
 


### PR DESCRIPTION
The section referred by the `#block_and_inline_boxes` fragment no longer exists.