### PR TITLE
Add documentation for Element(Internals).aria[Col/Row]IndexText

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -68,6 +68,11 @@ See related [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/
 - `<string>`
   - The human-readable text alternative of the numeric [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)
 
+## ARIAMixin API
+
+- {{domxref("Element.ariaColIndexText")}}
+  - : The [`ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText) property, part of the {{domxref("ARIAMixin")}} interface, reflects the value of the `aria-colindextext` attribute, which defines a human readable text alternative of aria-colindex.
+
 ## Associated roles
 
 Used in roles:
@@ -85,6 +90,7 @@ Inherits into roles:
 
 ## See Also
 
+- [`Element.ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText)
 - [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)
 - [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext)
 - [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount)

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -71,7 +71,9 @@ See related [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/
 ## ARIAMixin API
 
 - {{domxref("Element.ariaColIndexText")}}
-  - : The [`ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText) property, part of the {{domxref("ARIAMixin")}} interface, reflects the value of the `aria-colindextext` attribute, which defines a human readable text alternative of aria-colindex.
+  - : The [`ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-colindextext` attribute.
+- {{domxref("ElementInternals.ariaColIndexText")}}
+  - : The [`ariaColIndexText`](/en-US/docs/Web/API/ElementInternals/ariaColIndexText) property, part of the {{domxref("ElementInternals")}} interface, reflects the value of the `aria-colindextext` attribute.
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -20,6 +20,13 @@ The `aria-rowindextext` is added to each {{HTMLElement('tr')}} or to elements wi
 - `<string>`
   - The human-readable text alternative of the numeric [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
 
+## ARIAMixin API
+
+- {{domxref("Element.ariaRowIndexText")}}
+  - : The [`ariaRowIndexText`](/en-US/docs/Web/API/Element/ariaRowIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindextext` attribute.
+- {{domxref("ElementInternals.ariaRowIndexText")}}
+  - : The [`ariaRowIndexText`](/en-US/docs/Web/API/ElementInternals/ariaRowIndexText) property, part of the {{domxref("ElementInternals")}} interface, reflects the value of the `aria-rowindextext` attribute.
+
 ## Associated roles
 
 Used in roles:

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -1,0 +1,96 @@
+---
+title: Element.ariaColIndexText
+slug: Web/API/Element/ariaColIndexText
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - ariaColIndexText
+  - AriaAttributes
+  - AriaMixin
+  - Element
+browser-compat: api.Element.ariaColIndexText
+---
+
+{{DefaultAPISidebar("DOM")}}
+
+The **`ariaColIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+
+## Value
+
+A string.
+
+## Examples
+
+In this example the `aria-colindex` attribute on the element with an ID of `role-heading` is set to "Aria Role column". Using `ariaColIndexText` we update the value to the string "New column name".
+
+```html
+<table
+  id="semantic-table"
+  role="table"
+  aria-label="Semantic Elements"
+  aria-describedby="semantic_elements_table_desc"
+  aria-rowcount="100">
+  <caption id="semantic_elements_table_desc">
+    Semantic Elements to use instead of ARIA's roles
+  </caption>
+  <thead role="rowgroup">
+    <tr role="row">
+      <th
+        role="columnheader"
+        id="role-heading"
+        aria-sort="none"
+        aria-rowindex="1"
+        aria-colindex="1"
+        aria-colindextext="Aria Role column">
+        ARIA Role
+      </th>
+      <th
+        role="columnheader"
+        id="element-heading"
+        aria-sort="none"
+        aria-rowindex="1">
+        Semantic Element
+      </th>
+    </tr>
+  </thead>
+  <tbody role="rowgroup">
+    <tr role="row">
+      <td role="cell" aria-rowindex="11">header</td>
+      <td role="cell" aria-rowindex="11">h1</td>
+    </tr>
+    <tr role="row">
+      <td role="cell" aria-rowindex="16">header</td>
+      <td role="cell" aria-rowindex="16">h6</td>
+    </tr>
+    <tr role="row">
+      <td role="cell" aria-rowindex="18">rowgroup</td>
+      <td role="cell" aria-rowindex="18">thead</td>
+    </tr>
+    <tr role="row">
+      <td role="cell" aria-rowindex="24">term</td>
+      <td role="cell" aria-rowindex="24">dt</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+```js
+let el = document.getElementById('role-heading');
+console.log(el.ariaColIndexText); // "Aria Role"
+el.ariaColIndexText = "New column name"
+console.log(el.ariaColIndexText); // "New column name"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -2,14 +2,6 @@
 title: Element.ariaColIndexText
 slug: Web/API/Element/ariaColIndexText
 page-type: web-api-instance-property
-tags:
-  - API
-  - Property
-  - Reference
-  - ariaColIndexText
-  - AriaAttributes
-  - AriaMixin
-  - Element
 browser-compat: api.Element.ariaColIndexText
 ---
 
@@ -77,9 +69,9 @@ In this example the `aria-colindex` attribute on the element with an ID of `role
 ```
 
 ```js
-let el = document.getElementById('role-heading');
+let el = document.getElementById("role-heading");
 console.log(el.ariaColIndexText); // "Aria Role"
-el.ariaColIndexText = "New column name"
+el.ariaColIndexText = "New column name";
 console.log(el.ariaColIndexText); // "New column name"
 ```
 

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -1,0 +1,95 @@
+---
+title: Element.ariaRowIndexText
+slug: Web/API/Element/ariaRowIndexText
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - ariaRowIndexText
+  - AriaAttributes
+  - AriaMixin
+  - Element
+browser-compat: api.Element.ariaRowIndexText
+---
+
+{{DefaultAPISidebar("DOM")}}
+
+The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+
+## Value
+
+A string.
+
+## Examples
+
+In this example the `aria-rowindextext` attribute on the element with an ID of `role-heading` is set to "Heading row". Using `ariaRowIndexText` we update the value to "Updated heading row".
+
+```html
+<table
+  id="semantic-table"
+  role="table"
+  aria-label="Semantic Elements"
+  aria-describedby="semantic_elements_table_desc"
+  aria-rowcount="100">
+  <caption id="semantic_elements_table_desc">
+    Semantic Elements to use instead of ARIA's roles
+  </caption>
+  <thead role="rowgroup">
+    <tr role="row">
+      <th
+        role="columnheader"
+        id="role-heading"
+        aria-sort="none"
+        aria-rowindex="1"
+        aria-rowindextext="Heading row">
+        ARIA Role
+      </th>
+      <th
+        role="columnheader"
+        id="element-heading"
+        aria-sort="none"
+        aria-rowindex="1">
+        Semantic Element
+      </th>
+    </tr>
+  </thead>
+  <tbody role="rowgroup">
+    <tr role="row">
+      <td role="cell" aria-rowindex="11">header</td>
+      <td role="cell" aria-rowindex="11">h1</td>
+    </tr>
+    <tr role="row">
+      <td role="cell" aria-rowindex="16">header</td>
+      <td role="cell" aria-rowindex="16">h6</td>
+    </tr>
+    <tr role="row">
+      <td role="cell" aria-rowindex="18">rowgroup</td>
+      <td role="cell" aria-rowindex="18">thead</td>
+    </tr>
+    <tr role="row">
+      <td role="cell" aria-rowindex="24">term</td>
+      <td role="cell" aria-rowindex="24">dt</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+```js
+let el = document.getElementById('role-heading');
+console.log(el.ariaRowIndexText); // "Heading row"
+el.ariaRowIndexText = "Updated heading row"
+console.log(el.ariaRowIndexText); // "Updated heading row"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -2,14 +2,6 @@
 title: Element.ariaRowIndexText
 slug: Web/API/Element/ariaRowIndexText
 page-type: web-api-instance-property
-tags:
-  - API
-  - Property
-  - Reference
-  - ariaRowIndexText
-  - AriaAttributes
-  - AriaMixin
-  - Element
 browser-compat: api.Element.ariaRowIndexText
 ---
 
@@ -76,9 +68,9 @@ In this example the `aria-rowindextext` attribute on the element with an ID of `
 ```
 
 ```js
-let el = document.getElementById('role-heading');
+let el = document.getElementById("role-heading");
 console.log(el.ariaRowIndexText); // "Heading row"
-el.ariaRowIndexText = "Updated heading row"
+el.ariaRowIndexText = "Updated heading row";
 console.log(el.ariaRowIndexText); // "Updated heading row"
 ```
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -102,6 +102,8 @@ _The `Element` interface includes the following properties, defined on the `ARIA
   - : A string reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("Element.ariaColIndex")}}
   - : A string reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+- {{domxref("Element.ariaColIndexText")}}
+  - : A string reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("Element.ariaColSpan")}}
   - : A string reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("Element.ariaCurrent")}}
@@ -150,6 +152,8 @@ _The `Element` interface includes the following properties, defined on the `ARIA
   - : A string reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("Element.ariaRowIndex")}}
   - : A string reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+- {{domxref("Element.ariaRowIndexText")}}
+  - : A string reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("Element.ariaRowSpan")}}
   - : A string reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("Element.ariaSelected")}}

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -1,0 +1,44 @@
+---
+title: ElementInternals.ariaColIndexText
+slug: Web/API/ElementInternals/ariaColIndexText
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - ariaColIndexText
+  - AriaAttributes
+  - AriaMixin
+  - ElementInternals
+browser-compat: api.ElementInternals.ariaColIndexText
+---
+
+{{DefaultAPISidebar("DOM")}}
+
+The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+
+> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+
+## Value
+
+A string.
+
+## Examples
+
+In this example the value of `ariaColIndexText` is set to "Column name".
+
+```js
+this.internals_.ariaColIndexText = "Column name";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -2,14 +2,6 @@
 title: ElementInternals.ariaColIndexText
 slug: Web/API/ElementInternals/ariaColIndexText
 page-type: web-api-instance-property
-tags:
-  - API
-  - Property
-  - Reference
-  - ariaColIndexText
-  - AriaAttributes
-  - AriaMixin
-  - ElementInternals
 browser-compat: api.ElementInternals.ariaColIndexText
 ---
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -1,0 +1,44 @@
+---
+title: ElementInternals.ariaRowIndexText
+slug: Web/API/ElementInternals/ariaRowIndexText
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - ariaRowIndexText
+  - AriaAttributes
+  - AriaMixin
+  - ElementInternals
+browser-compat: api.ElementInternals.ariaRowIndexText
+---
+
+{{DefaultAPISidebar("DOM")}}
+
+The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+
+> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+
+## Value
+
+A string.
+
+## Examples
+
+In this example the value of `ariaRowIndexText` is set to "Heading row".
+
+```js
+this.internals_.ariaRowIndexText = "Heading row";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [ARIA: table role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -2,14 +2,6 @@
 title: ElementInternals.ariaRowIndexText
 slug: Web/API/ElementInternals/ariaRowIndexText
 page-type: web-api-instance-property
-tags:
-  - API
-  - Property
-  - Reference
-  - ariaRowIndexText
-  - AriaAttributes
-  - AriaMixin
-  - ElementInternals
 browser-compat: api.ElementInternals.ariaRowIndexText
 ---
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -49,6 +49,8 @@ The `ElementInternals` interface includes the following properties, defined on t
   - : A string reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndex")}}
   - : A string reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+- {{domxref("ElementInternals.ariaColIndexText")}}
+  - : A string reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("ElementInternals.ariaColSpan")}}
   - : A string reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaCurrent")}}
@@ -99,6 +101,8 @@ The `ElementInternals` interface includes the following properties, defined on t
   - : A string reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndex")}}
   - : A string reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+- {{domxref("ElementInternals.ariaRowIndexText")}}
+  - : A string reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("ElementInternals.ariaRowSpan")}}
   - : A string reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaSelected")}}
@@ -143,10 +147,10 @@ class CustomCheckbox extends HTMLElement {
   // …
 }
 
-window.customElements.define("custom-checkbox", CustomCheckbox);
+window.customElements.define('custom-checkbox', CustomCheckbox);
 
-let element = document.createElement("custom-checkbox");
-let form = document.createElement("form");
+let element = document.createElement('custom-checkbox');
+let form = document.createElement('form');
 
 // Append element to form to associate it
 form.appendChild(element);

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -147,10 +147,10 @@ class CustomCheckbox extends HTMLElement {
   // …
 }
 
-window.customElements.define('custom-checkbox', CustomCheckbox);
+window.customElements.define("custom-checkbox", CustomCheckbox);
 
-let element = document.createElement('custom-checkbox');
-let form = document.createElement('form');
+let element = document.createElement("custom-checkbox");
+let form = document.createElement("form");
 
 // Append element to form to associate it
 form.appendChild(element);


### PR DESCRIPTION
Firefox 119 added support for Element(Internals).aria[Col/Row]IndexText. See https://github.com/mdn/browser-compat-data/pull/21207

Reverts mdn/content#23489 (originally these docs were removed because no browser had support)