### PR TITLE
Add missing xmlns namespace prefix

### DIFF
--- a/files/en-us/web/svg/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/index.md
@@ -62,7 +62,7 @@ By default, parameters don't have a namespace at all. They are only known to be 
 <svg
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <script href="cool-script.js" type="text/ecmascript" />
+  <script xmlns:href="cool-script.js" type="text/ecmascript" />
 </svg>
 ```
 


### PR DESCRIPTION
### Description

> This is done by putting the **namespace prefix and a colon** before the parameter name as shown on the `<script>` element in the example above.

The `xmlns` prefix mentioned in the content is missing. More details in #29888.

### Related issues and pull requests

Fix #29888