### PR TITLE
Remove statement about Node.js returning a promise for `import.meta.resolve()`

### DIFF
--- a/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
@@ -95,7 +95,7 @@ Some tools recognize `new URL("./lib/helper.js", import.meta.url).href` as a dep
 This means that `import.meta.resolve()` is not required to be implemented by all conformant JavaScript implementations. However, `import.meta.resolve()` may also be available in non-browser environments:
 
 - Deno implements [compatibility with browser behavior](https://deno.land/manual/runtime/import_meta_api).
-- Node.js has an implementation that is available using [the `--experimental-import-meta-resolve` flag](https://nodejs.org/docs/latest/api/esm.html#importmetaresolvespecifier).
+- Node.js also implements [the `import.meta.resolve()` function](https://nodejs.org/docs/latest/api/esm.html#importmetaresolvespecifier), but adds an additional `parent` parameter if you use the `--experimental-import-meta-resolve` flag.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
+++ b/files/en-us/web/javascript/reference/operators/import.meta/resolve/index.md
@@ -95,7 +95,7 @@ Some tools recognize `new URL("./lib/helper.js", import.meta.url).href` as a dep
 This means that `import.meta.resolve()` is not required to be implemented by all conformant JavaScript implementations. However, `import.meta.resolve()` may also be available in non-browser environments:
 
 - Deno implements [compatibility with browser behavior](https://deno.land/manual/runtime/import_meta_api).
-- Node.js has an implementation that is available using the `--experimental-import-meta-resolve` and currently returns a `Promise` instead of a string, although this may change to match browsers.
+- Node.js has an implementation that is available using [the `--experimental-import-meta-resolve` flag](https://nodejs.org/docs/latest/api/esm.html#importmetaresolvespecifier).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Since Node.js version 20.x (now LTS), Node.js returns a `string` instead of a `Promise<string>` for `import.meta.resolve()` and doesn't require the flag anymore.

### Summary

- Removes the statement about Node.js returning a promise for `import.meta.resolve()`.
- Adds a link to the Node.js documentation about the `import.meta.resolve()` function.
- Adds a statement about an additional `parent` parameter when using the experimental flag.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

[Node.js v20 release notes mentioning this change](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#custom-esm-loader-hooks-run-on-dedicated-thread).

