### PR TITLE
prose: fix inline display of HTML entities

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -713,7 +713,7 @@ You do this with character references. These are special codes that represent ch
 | '                 | `&apos;`                       |
 | &                 | `&amp;`                        |
 
-The character reference equivalent could be easily remembered because the text it uses can be seen as less than for '\&lt;', quotation for ' \&quot; ' and similarly for others. To find more about entity references, see [List of XML and HTML character entity references](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references) (Wikipedia).
+The character reference equivalent could be easily remembered because the text it uses can be seen as less than for `\&lt;`, quotation for `\&quot;` and similarly for others. To find more about entity references, see [List of XML and HTML character entity references](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references) (Wikipedia).
 
 In the example below, there are two paragraphs:
 

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -713,7 +713,7 @@ You do this with character references. These are special codes that represent ch
 | '                 | `&apos;`                       |
 | &                 | `&amp;`                        |
 
-The character reference equivalent could be easily remembered because the text it uses can be seen as less than for `\&lt;`, quotation for `\&quot;` and similarly for others. To find more about entity references, see [List of XML and HTML character entity references](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references) (Wikipedia).
+The character reference equivalent could be easily remembered because the text it uses can be seen as less than for `&lt;`, quotation for `&quot;` and similarly for others. To find more about entity references, see [List of XML and HTML character entity references](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references) (Wikipedia).
 
 In the example below, there are two paragraphs:
 


### PR DESCRIPTION
Current display is not consistent with the rest of MDN content and impacts readability.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed the way HTML entities are displayed inline on a page.

### Motivation

- Readability: I found the original phrase a bit hard to parse because of both lack of inline 'code' formatting and also due to the different way the entities were written with apostrophes with/without whitespace ('&lt;' vs. ' &quot; ').
- Consistency: In other places on the website, the entities are written with backticks ``. See [String.prototype.fontcolor() page](https://github.com/mdn/content/blob/342410eb17c299064cb935e2601230260b45c273/files/en-us/web/javascript/reference/global_objects/string/fontcolor/index.md?plain=1#L29)
