### PR TITLE
chore(CSS): Add version details for vendor-prefixed appearance values

### DIFF
--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -69,6 +69,10 @@ The following values may be operational on historical browser versions using **`
 - Chrome, Edge and Safari entries below indicate release version support for values used with the `-webkit-appearance` vendor-prefix property.
 - Firefox entries indicate support using `-moz-appearance`.
 - Values with an asterisk (\*) have clear intents for removal.
+- For each cell of browser version and value:
+  - `<={version}`: indicates a value is supported up to and including `{version}`
+  - `<{version}`: support was removed in a release earlier than `{version}`
+  - a blank cell indicates that support was never added
 
 | Value                                  | Safari | Firefox | Chrome   | Edge  |
 | -------------------------------------- | ------ | ------- | -------- | ----- |

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -66,8 +66,8 @@ The following values may be operational on historical browser versions using **`
 <details>
 <summary>Non-standard values</summary>
 
-- Chrome, Edge and Safari entries below indicate release version support for values used with the `-webkit-appearance` vendor-prefix property.
 - Firefox entries indicate support using `-moz-appearance`.
+- Chrome, Edge and Safari entries below indicate release version support for values used with the `-webkit-appearance` vendor-prefix property.
 - Values with an asterisk (\*) have clear intents for removal.
 - For each cell of browser version and value:
   - `<={version}`: indicates a value is supported up to and including `{version}`

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -61,86 +61,90 @@ Some examples are provided, but the list is not exhaustive.
 
 #### Non-standard values
 
-The following values may be operational on historical browser versions using **`-moz-appearance`** or **`-webkit-appearance`** prefix, but not on the standard **`appearance`** property:
+The following values may be operational on historical browser versions using **`-moz-appearance`** or **`-webkit-appearance`** prefix, but not on the standard **`appearance`** property.
 
 <details>
 <summary>Non-standard values</summary>
 
-| Value                                  | Safari | Firefox | Chrome | Edge |
-| -------------------------------------- | ------ | ------- | ------ | ---- |
-| `attachment`                           | Y      |         |        |      |
-| `borderless-attachment`                | Y      |         |        |      |
-| `button-bevel`                         | Y      | Y       | Y      | Y    |
-| `caps-lock-indicator`                  | Y      |         |        | Y    |
-| `caret`                                | Y      | Y       | Y      | Y    |
-| `checkbox-container`                   |        | Y       |        |      |
-| `checkbox-label`                       |        | Y       |        |      |
-| `checkmenuitem`                        |        | Y       |        |      |
-| `color-well`                           | Y      |         |        |      |
-| `continuous-capacity-level-indicator`  | Y      |         |        |      |
-| `default-button`                       | Y      |         |        | Y    |
-| `discrete-capacity-level-indicator`    | Y      |         |        |      |
-| `inner-spin-button`                    | Y      | Y       | Y      |      |
-| `image-controls-button`                | Y      |         |        |      |
-| `list-button`                          | Y      |         |        |      |
-| `listitem`                             | Y      | Y       | Y      | Y    |
-| `media-enter-fullscreen-button`        | Y      |         | Y      |      |
-| `media-exit-fullscreen-button`         | Y      |         | Y      |      |
-| `media-fullscreen-volume-slider`       | Y      |         |        |      |
-| `media-fullscreen-volume-slider-thumb` | Y      |         |        |      |
-| `media-mute-button`                    | Y      |         |        | Y    |
-| `media-play-button`                    | Y      |         |        | Y    |
-| `media-overlay-play-button`            | Y      |         | Y      |      |
-| `media-return-to-realtime-button`      | Y      |         |        |      |
-| `media-rewind-button`                  | Y      |         |        |      |
-| `media-seek-back-button`               | Y      |         | Y      |      |
-| `media-seek-forward-button`            | Y      |         | Y      |      |
-| `media-toggle-closed-captions-button`  | Y      |         | Y      |      |
-| `media-slider`                         | Y      |         | Y      | Y    |
-| `media-sliderthumb`                    | Y      |         | Y      | Y    |
-| `media-volume-slider-container`        | Y      |         | Y      |      |
-| `media-volume-slider-mute-button`      | Y      |         |        |      |
-| `media-volume-slider`                  | Y      |         | Y      |      |
-| `media-volume-sliderthumb`             | Y      |         | Y      |      |
-| `media-controls-background`            | Y      |         | Y      |      |
-| `media-controls-dark-bar-background`   | Y      |         |        |      |
-| `media-controls-fullscreen-background` | Y      |         | Y      |      |
-| `media-controls-light-bar-background`  | Y      |         |        |      |
-| `media-current-time-display`           | Y      |         | Y      |      |
-| `media-time-remaining-display`         | Y      |         | Y      |      |
-| `menulist-text`                        | Y      | Y       | Y      | Y    |
-| `menulist-textfield`                   | Y      | Y       | Y      | Y    |
-| `meterbar`                             |        | Y       |        |      |
-| `number-input`                         |        | Y       |        |      |
-| `progress-bar-value`                   | Y      |         | Y      |      |
-| `progressbar`                          |        | Y       |        |      |
-| `progressbar-vertical`                 |        | Y       |        |      |
-| `range`                                |        | Y       |        |      |
-| `range-thumb`                          |        | Y       |        |      |
-| `rating-level-indicator`               | Y      |         |        |      |
-| `relevancy-level-indicator`            | Y      |         |        |      |
-| `scale-horizontal`                     |        | Y       |        |      |
-| `scalethumbend`                        |        | Y       |        |      |
-| `scalethumb-horizontal`                |        | Y       |        |      |
-| `scalethumbstart`                      |        | Y       |        |      |
-| `scalethumbtick`                       |        | Y       |        |      |
-| `scalethumb-vertical`                  |        | Y       |        |      |
-| `scale-vertical`                       |        | Y       |        |      |
-| `scrollbarthumb-horizontal`            |        | Y       |        |      |
-| `scrollbarthumb-vertical`              |        | Y       |        |      |
-| `scrollbartrack-horizontal`            |        | Y       |        |      |
-| `scrollbartrack-vertical`              |        | Y       |        |      |
-| `searchfield-decoration`               | Y      |         |        | Y    |
-| `searchfield-results-decoration`       | Y      | Y       | Y      | Y    |
-| `searchfield-results-button`           | Y      |         |        | Y    |
-| `searchfield-cancel-button`            | Y      | Y       | Y      | Y    |
-| `snapshotted-plugin-overlay`           | Y      |         |        |      |
-| `sheet`                                |        |         |        |      |
-| `slider-vertical`                      |        |         | Y      | Y    |
-| `sliderthumb-horizontal`               |        |         | Y      | Y    |
-| `sliderthumb-vertical`                 |        |         | Y      | Y    |
-| `textfield-multiline`                  |        | Y       |        |      |
-| `-apple-pay-button`                    | Y      |         |        |      |
+- Chrome, Edge and Safari entries below indicate release version support for values used with the `-webkit-appearance` vendor-prefix property.
+- Firefox entries indicate support using `-moz-appearance`.
+- Values with an asterisk (\*) have clear intents for removal.
+
+| Value                                  | Safari | Firefox | Chrome   | Edge  |
+| -------------------------------------- | ------ | ------- | -------- | ----- |
+| `attachment`                           | <=13.1 |         |          |       |
+| `borderless-attachment`                | <=13.1 |         |          |       |
+| `button-bevel`                         | <=13.1 | <75     |          | <80   |
+| `caps-lock-indicator`                  | <=13.1 |         |          | <80   |
+| `caret`                                | <=13.1 | <75     | <=73     | <80   |
+| `checkbox-container`                   |        | <75     |          |       |
+| `checkbox-label`                       |        | <75     |          |       |
+| `checkmenuitem`                        |        | <75     |          |       |
+| `color-well`                           | <=13.1 |         |          |       |
+| `continuous-capacity-level-indicator`  | <=13.1 |         |          |       |
+| `default-button`                       | <=13.1 |         |          | <80   |
+| `discrete-capacity-level-indicator`    | <=13.1 |         |          |       |
+| `inner-spin-button`                    | <=13.1 | <75     | <=118 \* | <=119 |
+| `image-controls-button`                | <=13.1 |         |          |       |
+| `list-button`                          | <=13.1 |         |          |       |
+| `listitem`                             | <=13.1 | <75     | <=73     | <80   |
+| `media-enter-fullscreen-button`        | <=13.1 |         | <=73     |       |
+| `media-exit-fullscreen-button`         | <=13.1 |         | <=73     |       |
+| `media-fullscreen-volume-slider`       | <=13.1 |         |          |       |
+| `media-fullscreen-volume-slider-thumb` | <=13.1 |         |          |       |
+| `media-mute-button`                    | <=13.1 |         |          | <80   |
+| `media-play-button`                    | <=13.1 |         |          | <80   |
+| `media-overlay-play-button`            | <=13.1 |         | <=73     |       |
+| `media-return-to-realtime-button`      | <=13.1 |         |          |       |
+| `media-rewind-button`                  | <=13.1 |         |          |       |
+| `media-seek-back-button`               | <=13.1 |         | <73      |       |
+| `media-seek-forward-button`            | <=13.1 |         | <73      |       |
+| `media-toggle-closed-captions-button`  | <=13.1 |         | <=73     |       |
+| `media-slider`                         | <=13.1 |         | <=117    | <=80  |
+| `media-sliderthumb`                    | <=13.1 |         | <=117    | <=80  |
+| `media-volume-slider-container`        | <=13.1 |         | <=73     |       |
+| `media-volume-slider-mute-button`      | <=13.1 |         |          |       |
+| `media-volume-slider`                  | <=13.1 |         | <=117    | <=80  |
+| `media-volume-sliderthumb`             | <=13.1 |         | <=117    | <=80  |
+| `media-controls-background`            | <=13.1 |         | <=73     |       |
+| `media-controls-dark-bar-background`   | <=13.1 |         |          |       |
+| `media-controls-fullscreen-background` | <=13.1 |         | <=73     |       |
+| `media-controls-light-bar-background`  | <=13.1 |         |          |       |
+| `media-current-time-display`           |        |         | <=73     |       |
+| `media-time-remaining-display`         | <=13.1 |         | <=73     |       |
+| `menulist-text`                        | <=13.1 | <75     | <=73     | <80   |
+| `menulist-textfield`                   | <=13.1 | <75     | <=73     | <80   |
+| `meterbar`                             |        | <=100   |          |       |
+| `number-input`                         |        | <=75    |          |       |
+| `progress-bar-value`                   | <=13.1 |         | <=73     |       |
+| `progressbar`                          |        | <=100   |          |       |
+| `progressbar-vertical`                 |        | <=75    |          |       |
+| `range`                                |        | <=75    |          |       |
+| `range-thumb`                          |        | <=75    |          |       |
+| `rating-level-indicator`               | <=13.1 |         |          |       |
+| `relevancy-level-indicator`            | <=13.1 |         |          |       |
+| `scale-horizontal`                     |        | <=75    |          |       |
+| `scalethumbend`                        |        | <=75    |          |       |
+| `scalethumb-horizontal`                |        | <=75    |          |       |
+| `scalethumbstart`                      |        | <=75    |          |       |
+| `scalethumbtick`                       |        | <=75    |          |       |
+| `scalethumb-vertical`                  |        | <=75    |          |       |
+| `scale-vertical`                       |        | <=75    |          |       |
+| `scrollbarthumb-horizontal`            |        | <=75    |          |       |
+| `scrollbarthumb-vertical`              |        | <=75    |          |       |
+| `scrollbartrack-horizontal`            |        | <=75    |          |       |
+| `scrollbartrack-vertical`              |        | <=75    |          |       |
+| `searchfield-decoration`               | <=13.1 |         |          | <80   |
+| `searchfield-results-decoration`       | <=13.1 | <75     | <73      | <80   |
+| `searchfield-results-button`           | <=13.1 |         |          | <80   |
+| `searchfield-cancel-button`            | <=13.1 | <75     | <=118 \* | <=119 |
+| `snapshotted-plugin-overlay`           | <=13.1 |         |          |       |
+| `sheet`                                |        |         |          |       |
+| `slider-vertical`                      |        |         | <=118 \* | <=119 |
+| `sliderthumb-horizontal`               |        |         | <=117    | <=80  |
+| `sliderthumb-vertical`                 |        |         | <=117    | <=80  |
+| `textfield-multiline`                  |        | <=100   |          |       |
+| `-apple-pay-button`                    | <=13.1 |         |          |       |
 
 </details>
 


### PR DESCRIPTION
### Description

This PR adds some version support info on non-standard vendor-prefixed appearance values.
I am not adding to BCD as most of this is historic, and scheduled for removal.

### Additional details

See https://codepen.io/bsmth/full/wvNqOEO

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/28687
