### PR TITLE
Update FileSystemDirectoryHandle page getFilesRecursively function.

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -102,7 +102,7 @@ async function* getFilesRecursively(entry, path = []) {
     }
   } else if (entry.kind === "directory") {
     for await (const handle of entry.values()) {
-      if(handle.kind === "directory") path.push(handle.name);
+      if (handle.kind === "directory") path.push(handle.name);
 
       yield* getFilesRecursively(handle, path);
     }

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -90,16 +90,21 @@ async function returnPathDirectories(directoryHandle) {
 The following example scans recursively through a directory to return {{domxref('FileSystemFileHandle')}} objects for each file in that directory:
 
 ```js
-async function* getFilesRecursively(entry) {
+async function* getFilesRecursively(entry, path = []) {
   if (entry.kind === "file") {
     const file = await entry.getFile();
     if (file !== null) {
-      file.relativePath = getRelativePath(entry);
+      path.push(entry.name);
+      file.relativePath = path.join("/");
+      path.length = 0;
+
       yield file;
     }
   } else if (entry.kind === "directory") {
     for await (const handle of entry.values()) {
-      yield* getFilesRecursively(handle);
+      if(handle.kind === "directory") path.push(handle.name);
+
+      yield* getFilesRecursively(handle, path);
     }
   }
 }


### PR DESCRIPTION
### Description

Added information about how to get relative path to the `getFilesRecursively` function sample for the `FileSystemDirectoryHandle` page.

### Motivation

It will inform the reader instead of the missing `getRelativePath` function.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle#return_handles_for_all_files_in_a_directory
