### PR TITLE
fix(css): failsafe hue rotation in color_wheel.svg

### DIFF
--- a/files/en-us/web/css/hue/color_wheel.svg
+++ b/files/en-us/web/css/hue/color_wheel.svg
@@ -8,13 +8,7 @@
       border-radius: 50%;
       height: 100%;
       width: 100%;
-      background: conic-gradient(red, #ff0, #0f0, #0ff, #00f, #f0f, red);
-    }
-
-    @supports (background: conic-gradient(in hsl longer hue, red, red)) {
-      div {
-        background: conic-gradient(in hsl longer hue, red, red);
-      }
+      background: conic-gradient(red, #ff0, green, #0ff, blue, #f0f, red);
     }
   </style>
   <path fill="#fff" d="M0 0h400v400H0z" />

--- a/files/en-us/web/css/hue/color_wheel.svg
+++ b/files/en-us/web/css/hue/color_wheel.svg
@@ -1,11 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
   <style>
     text {
-      font: 20px sans-serif
+      font: 20px sans-serif;
+    }
+
+    div {
+      border-radius: 50%;
+      height: 100%;
+      width: 100%;
+      background: conic-gradient(red, #ff0, #0f0, #0ff, #00f, #f0f, red);
+    }
+
+    @supports (background: conic-gradient(in hsl longer hue, red, red)) {
+      div {
+        background: conic-gradient(in hsl longer hue, red, red);
+      }
     }
   </style>
   <path fill="#fff" d="M0 0h400v400H0z" />
   <foreignObject width="320" height="320" x="40" y="40">
-    <div xmlns="http://www.w3.org/1999/xhtml" style="background:conic-gradient(red,#ff0,#0f0,#0ff,#00f,#f0f,red);background:conic-gradient(in hsl longer hue,red,red);border-radius:50%;height:100%;width:100%" />
-  </foreignObject><text x="200" y="30" text-anchor="middle">0°</text><text x="347" y="115" dominant-baseline="middle">60°</text><text x="347" y="285" dominant-baseline="middle">120°</text><text x="200" y="370" dominant-baseline="hanging" text-anchor="middle">180°</text><text x="53" y="285" dominant-baseline="middle" text-anchor="end">240°</text><text x="53" y="115" dominant-baseline="middle" text-anchor="end">300°</text>
+    <div xmlns="http://www.w3.org/1999/xhtml" />
+  </foreignObject>
+  <text x="200" y="30" text-anchor="middle">0°</text>
+  <text x="347" y="115" dominant-baseline="middle">60°</text>
+  <text x="347" y="285" dominant-baseline="middle">120°</text>
+  <text x="200" y="370" dominant-baseline="hanging" text-anchor="middle">
+    180°
+  </text>
+  <text x="53" y="285" dominant-baseline="middle" text-anchor="end">240°</text>
+  <text x="53" y="115" dominant-baseline="middle" text-anchor="end">300°</text>
 </svg>


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/30266

Use [`@ supports`](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports) for hue rotation Firefox doesn't support  longer hue rotation.

Don't know how to see text diff for SVGs in PR. Here is the new code:
```html
<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
  <style>
    text {
      font: 20px sans-serif;
    }

    div {
      border-radius: 50%;
      height: 100%;
      width: 100%;
      background: conic-gradient(red, #ff0, #0f0, #0ff, #00f, #f0f, red);
    }

    @supports (background: conic-gradient(in hsl longer hue, red, red)) {
      div {
        background: conic-gradient(in hsl longer hue, red, red);
      }
    }
  </style>
  <path fill="#fff" d="M0 0h400v400H0z" />
  <foreignObject width="320" height="320" x="40" y="40">
    <div xmlns="http://www.w3.org/1999/xhtml" />
  </foreignObject>
  <text x="200" y="30" text-anchor="middle">0°</text>
  <text x="347" y="115" dominant-baseline="middle">60°</text>
  <text x="347" y="285" dominant-baseline="middle">120°</text>
  <text x="200" y="370" dominant-baseline="hanging" text-anchor="middle">
    180°
  </text>
  <text x="53" y="285" dominant-baseline="middle" text-anchor="end">240°</text>
  <text x="53" y="115" dominant-baseline="middle" text-anchor="end">300°</text>
</svg>
```