### PR TITLE
fix(ci): pr-test.yml throws error for non .md files

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -56,14 +56,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js environment
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install all yarn packages
-        if: ${{ env.GIT_DIFF_CONTENT }}
+        if: ${{ env.GIT_DIFF_CONTENT }} || ${{ env.GIT_DIFF_FILES }}
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note


### PR DESCRIPTION
The pr-test.yml workflow throws error if non .md file is pulled:
https://github.com/mdn/content/actions/runs/6868151500/job/18678031379?pr=30275
```log
echo files/en-us/web/css/hue/color_wheel.svg
  
  export CONTENT_ROOT=$(pwd)/files
  yarn filecheck files/en-us/web/css/hue/color_wheel.svg
  shell: /usr/bin/bash -e {0}
  env:
    BASE_SHA: 35bb8cea8badfbc1b3fffbd0ade2699893dc8fe1
    HEAD_SHA: 9dfdb55a2346fb0da234a9525581fa2b356ea270
    BUILD_OUT_ROOT: build
    GIT_DIFF_CONTENT: 
    GIT_DIFF_FILES: files/en-us/web/css/hue/color_wheel.svg
files/en-us/web/css/hue/color_wheel.svg
yarn run v1.22.19
$ env-cmd --silent cross-env CONTENT_ROOT=files yari-filecheck --cwd=. files/en-us/web/css/hue/color_wheel.svg
/bin/sh: 1: env-cmd: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 127.
```

## Solution

Do node and yarn install for non `.md` files as well.

## Testing

Testing has been done here: https://github.com/OnkarRuikar/content/pull/27