### PR TITLE
Correction: Strings are compered by code units not code points

### DIFF
--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -22,7 +22,7 @@ x < y
 The operands are compared with multiple rounds of coercion, which can be summarized as follows:
 
 - First, objects are [converted to primitives](/en-US/docs/Web/JavaScript/Data_structures#primitive_coercion) by calling its [`[@@toPrimitive]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) (with `"number"` as hint), [`valueOf()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf), and [`toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString) methods, in that order. The left operand is always coerced before the right one. Note that although `[@@toPrimitive]()` is called with the `"number"` hint (meaning there's a slight preference for the object to become a number), the return value is not [converted to a number](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion), since strings are still specially handled.
-- If both values are strings, they are compared as strings, based on the values of the Unicode code points they contain.
+- If both values are strings, they are compared as strings, based on the values of the UTF-16 code units (not Unicode code points) they contain.
 - Otherwise JavaScript attempts to convert non-numeric types to numeric values:
   - Boolean values `true` and `false` are converted to 1 and 0 respectively.
   - `null` is converted to 0.
@@ -55,6 +55,8 @@ x >= y === y <= x;
 "a" < "b"; // true
 "a" < "a"; // false
 "a" < "3"; // false
+
+"\uD855\uDE51" < "\uFF3A" // true
 ```
 
 ### String to number comparison

--- a/files/en-us/web/javascript/reference/operators/less_than/index.md
+++ b/files/en-us/web/javascript/reference/operators/less_than/index.md
@@ -56,7 +56,7 @@ x >= y === y <= x;
 "a" < "a"; // false
 "a" < "3"; // false
 
-"\uD855\uDE51" < "\uFF3A" // true
+"\uD855\uDE51" < "\uFF3A"; // true
 ```
 
 ### String to number comparison


### PR DESCRIPTION

### Description

Correction of incorrect information and one example affected by this difference.

### Motivation

While reading [page describing array sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort), I thought that, on arrays containing only strings, default ordering of `sort` is incompatible with less than operator.

### Additional details

[Specification](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islessthan)

### Related issues and pull requests
