### PR TITLE
Remove a mention of WindowOrWorkerScope in fetch()

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -16,8 +16,6 @@ A {{domxref("fetch()")}} promise only rejects when a network error is encountere
 A {{domxref("fetch()")}} promise _does not_ reject on HTTP errors (`404`, etc.).
 Instead, a `then()` handler must check the {{domxref("Response.ok")}} and/or {{domxref("Response.status")}} properties.
 
-`WindowOrWorkerGlobalScope` is implemented by both {{domxref("Window")}} and {{domxref("WorkerGlobalScope")}}, which means that the `fetch()` method is available in pretty much any context in which you might want to fetch resources.
-
 The `fetch()` method is controlled by the `connect-src` directive of [Content Security Policy](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) rather than the directive of the resources it's retrieving.
 
 > **Note:** The `fetch()` method's parameters are identical to those of the {{domxref("Request.Request","Request()")}} constructor.


### PR DESCRIPTION
@wbamberg I think this sentence is useless the banner generated by `{{AvailableInWorkers}}` should be enough. (Anyway the mention of a mixin is not good).