### PR TITLE
improve `Relation to strings` example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -369,25 +369,19 @@ console.log([...mySet]); // Will show you exactly the same Array as myArray
 
 ```js
 // Use to remove duplicate elements from an array
-
 const numbers = [2, 13, 4, 4, 2, 13, 13, 4, 4, 5, 5, 6, 6, 7, 5, 32, 13, 4, 5];
 
-console.log([...new Set(numbers)]);
-
-// [2, 13, 4, 5, 6, 7, 32]
+console.log([...new Set(numbers)]); // [2, 13, 4, 5, 6, 7, 32]
 ```
 
 ### Relation to strings
 
 ```js
-const text = "India";
+// Case sensitive (set will contain "F" and "f")
+new Set("Firefox"); // Set(7) [ "F", "i", "r", "e", "f", "o", "x" ]
 
-const mySet = new Set(text); // Set(5) {'I', 'n', 'd', 'i', 'a'}
-mySet.size; // 5
-
-// case sensitive & duplicate omission
-new Set("Firefox"); // Set(7) { "F", "i", "r", "e", "f", "o", "x" }
-new Set("firefox"); // Set(6) { "f", "i", "r", "e", "o", "x" }
+// Duplicate omission ("f" occurs twice in the string but set will contain only one)
+new Set("firefox"); // Set(6) [ "f", "i", "r", "e", "o", "x" ]
 ```
 
 ### Use a set to ensure the uniqueness of a list of values


### PR DESCRIPTION
### Description

Made the comments for [Relation to strings](http://localhost:5042/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#relation_to_strings) example more detailed to explain `Set`'s the behavior.
Also remove nearby example of using `.size` because this is already in the [Using the Set object](http://localhost:5042/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#using_the_set_object) example.

### Motivation

I think in this example we need to show the features of working with strings more clearly.

### Related issues and pull requests

Relates to https://github.com/mdn/translated-content/pull/16739