### PR TITLE
fix deprecated of `Document.hidden`

### DIFF
--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -56,7 +56,7 @@ Some processes are exempt from this throttling behavior. In these cases, you can
 
 The Page Visibility API adds the following properties to the {{domxref("Document")}} interface:
 
-- {{domxref("Document.hidden")}} {{deprecated_inline}} {{ReadOnlyInline}}
+- {{domxref("Document.hidden")}} {{ReadOnlyInline}}
   - : Returns `true` if the page is in a state considered to be hidden to the user, and `false` otherwise.
 - {{domxref("Document.visibilityState")}} {{ReadOnlyInline}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the `Document.hidden` is not deprecated, see https://html.spec.whatwg.org/multipage/interaction.html#page-visibility

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
