### PR TITLE
Clarifies scope broadening, fixing #30306

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -127,9 +127,11 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-There is frequent confusion surrounding the meaning and use of _scope_. Since a
-service worker can't have a scope broader than its own location, only use the
-`scope` option when you need a scope that is narrower than the default.
+There is frequent confusion surrounding the meaning and use of _scope_.
+A service worker can't have a scope broader than its own location,
+unless the server specifies a broader maximum scope in a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed)
+header on the service worker script. Therefore you should use the scope option
+when you need a narrower `scope` than the default.
 
 The following code, if included in `example.com/index.html`, at the root of
 a site, would only apply to resources under `example.com/product`.
@@ -153,6 +155,30 @@ if ("serviceWorker" in navigator) {
 However, servers can remove this restriction by setting a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed) header on the service
 worker script, and then you can specify a max scope for that service worker above the
 service worker's location.
+
+The following code, if included in `example.com/index.html`, would apply to all
+resources under `example.com` if the server set the Service-Worker-Allowed header
+to `/` or `https://example.com/`. If the server doesn't set the header,
+the service worker registration will fail, as the requested `scope` is too broad.
+
+```js
+if ("serviceWorker" in navigator) {
+  // Declaring a broadened scope
+  navigator.serviceWorker.register("/js/sw.js", { scope: "/" }).then(
+    (registration) => {
+      // The registration succeeded because the Service-Worker-Allowed header
+      // had set a broadened maximum scope for the service worker script
+      console.log("Service worker registration succeeded:", registration);
+    },
+    (error) => {
+      // This happens if the Service-Worker-Allowed header doesn't broaden the scope
+      console.error(`Service worker registration failed: ${error}`);
+    },
+  );
+} else {
+  console.error("Service workers are not supported.");
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -157,7 +157,7 @@ worker script, and then you can specify a max scope for that service worker abov
 service worker's location.
 
 The following code, if included in `example.com/index.html`, would apply to all
-resources under `example.com` if the server set the Service-Worker-Allowed header
+resources under `example.com` if the server set the `Service-Worker-Allowed` header
 to `/` or `https://example.com/`. If the server doesn't set the header,
 the service worker registration will fail, as the requested `scope` is too broad.
 

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -152,8 +152,8 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-However, servers can remove this restriction by setting a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed) header on the service
-worker script, and then you can specify a max scope for that service worker above the
+As noted above, servers can remove the restriction on scope by setting the `Service-Worker-Allowed`
+header on the service worker script, specifying a maximum scope for that service worker above the
 service worker's location.
 
 The following code, if included in `example.com/index.html`, would apply to all

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -38,7 +38,7 @@ register(scriptURL, options)
         service worker's registration scope; that is, what range of URLs a service worker
         can control. This is usually a relative URL. It is relative to the base URL of the
         application. By default, the `scope` value for a service worker
-        registration is set to the directory where the service worker script is located.
+        registration is set to the directory where the service worker script is located (by resolving `./` against `scriptURL`).
         See the [Examples](#examples) section for more information on how it
         works.
     - `type`
@@ -98,14 +98,7 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-The following code, if included in `example.com/index.html`, at the root of
-a site, would apply to exactly the same pages as the example above. Remember the scope,
-when included, uses the page's location as its base.
-
-Alternatively, if this code were included in a page at
-`example.com/product/description.html`, with the JavaScript file residing
-at `example.com/product/sw.js`, then the service worker would only apply to
-resources under `example.com/product`.
+The following code, if included in `example.com/index.html`, at the root of a site, would apply to exactly the same pages as the example above. Alternatively, if this code were included in a page at `example.com/product/description.html`, then the service worker would only apply to resources under `example.com/product`. Remember the scope, when included, uses the page's location as its base.
 
 ```js
 if ("serviceWorker" in navigator) {
@@ -150,7 +143,7 @@ The following code, if included in `example.com/product/index.html`, would apply
 ```js
 if ("serviceWorker" in navigator) {
   // Declaring a broadened scope
-  navigator.serviceWorker.register("/js/sw.js", { scope: "/" }).then(
+  navigator.serviceWorker.register("/sw.js", { scope: "/" }).then(
     (registration) => {
       // The registration succeeded because the Service-Worker-Allowed header
       // had set a broadened maximum scope for the service worker script

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -75,17 +75,13 @@ object.
 The examples described here should be taken together to get a better understanding of
 how service workers scope applies to a page.
 
-The following example uses the default value of `scope` (by omitting it).
-The service worker code in this case, if
-included in `example.com/index.html`, will
-control `example.com/index.html`, as well as pages underneath it, like
-`example.com/product/description.html`.
+The following example uses the default value of `scope` (by omitting it). Suppose the service worker code is at `example.com/sw.js`, and the registration code at `example.com/index.html`. The service worker code will control `example.com/index.html`, as well as pages underneath it, like `example.com/product/description.html`.
 
 ```js
 if ("serviceWorker" in navigator) {
   // Register a service worker hosted at the root of the
   // site using the default scope.
-  navigator.serviceWorker.register("/sw.js").then(
+  navigator.serviceWorker.register("./sw.js").then(
     (registration) => {
       console.log("Service worker registration succeeded:", registration);
     },
@@ -98,12 +94,12 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-The following code, if included in `example.com/index.html`, at the root of a site, would apply to exactly the same pages as the example above. Alternatively, if this code were included in a page at `example.com/product/description.html`, then the service worker would only apply to resources under `example.com/product`. Remember the scope, when included, uses the page's location as its base.
+The following code, with all code in the same place, would apply to exactly the same pages as the example above. Alternatively, if the service worker code is at `example.com/product/sw.js`, and the registration code at `example.com/product/description.html`. then the service worker would only apply to resources under `example.com/product`. Remember the scope, when included, uses the page's location as its base.
 
 ```js
 if ("serviceWorker" in navigator) {
   // declaring scope manually
-  navigator.serviceWorker.register("/sw.js", { scope: "./" }).then(
+  navigator.serviceWorker.register("./sw.js", { scope: "./" }).then(
     (registration) => {
       console.log("Service worker registration succeeded:", registration);
     },
@@ -123,7 +119,7 @@ The following code, if included in `example.com/index.html`, at the root of a si
 ```js
 if ("serviceWorker" in navigator) {
   // declaring scope manually
-  navigator.serviceWorker.register("/sw.js", { scope: "/product/" }).then(
+  navigator.serviceWorker.register("./sw.js", { scope: "/product/" }).then(
     (registration) => {
       console.log("Service worker registration succeeded:", registration);
     },
@@ -143,7 +139,7 @@ The following code, if included in `example.com/product/index.html`, would apply
 ```js
 if ("serviceWorker" in navigator) {
   // Declaring a broadened scope
-  navigator.serviceWorker.register("/sw.js", { scope: "/" }).then(
+  navigator.serviceWorker.register("./sw.js", { scope: "/" }).then(
     (registration) => {
       // The registration succeeded because the Service-Worker-Allowed header
       // had set a broadened maximum scope for the service worker script

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -127,14 +127,9 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-There is frequent confusion surrounding the meaning and use of _scope_.
-A service worker can't have a scope broader than its own location,
-unless the server specifies a broader maximum scope in a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed)
-header on the service worker script. Therefore you should use the scope option
-when you need a narrower `scope` than the default.
+There is frequent confusion surrounding the meaning and use of _scope_. A service worker can't have a scope broader than its own location, unless the server specifies a broader maximum scope in a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed) header on the service worker script. Therefore you should use the scope option when you need a narrower `scope` than the default.
 
-The following code, if included in `example.com/index.html`, at the root of
-a site, would only apply to resources under `example.com/product`.
+The following code, if included in `example.com/index.html`, at the root of a site, would only apply to resources under `example.com/product`.
 
 ```js
 if ("serviceWorker" in navigator) {
@@ -152,14 +147,9 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-As noted above, servers can remove the restriction on scope by setting the `Service-Worker-Allowed`
-header on the service worker script, specifying a maximum scope for that service worker above the
-service worker's location.
+As noted above, servers can remove the restriction on scope by setting the `Service-Worker-Allowed` header on the service worker script, specifying a maximum scope for that service worker above the service worker's location.
 
-The following code, if included in `example.com/index.html`, would apply to all
-resources under `example.com` if the server set the `Service-Worker-Allowed` header
-to `/` or `https://example.com/`. If the server doesn't set the header,
-the service worker registration will fail, as the requested `scope` is too broad.
+The following code, if included in `example.com/index.html`, would apply to all resources under `example.com` if the server set the `Service-Worker-Allowed` header to `/` or `https://example.com/`. If the server doesn't set the header, the service worker registration will fail, as the requested `scope` is too broad.
 
 ```js
 if ("serviceWorker" in navigator) {

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -127,7 +127,7 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-There is frequent confusion surrounding the meaning and use of _scope_. A service worker can't have a scope broader than its own location, unless the server specifies a broader maximum scope in a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed) header on the service worker script. Therefore you should use the scope option when you need a narrower `scope` than the default.
+There is frequent confusion surrounding the meaning and use of _scope_. A service worker can't have a scope broader than its own location, unless the server specifies a broader maximum scope in a [Service-Worker-Allowed](https://w3c.github.io/ServiceWorker/#service-worker-allowed) header on the service worker script. Therefore you should use the `scope` option when you need a _narrower_ scope than the default.
 
 The following code, if included in `example.com/index.html`, at the root of a site, would only apply to resources under `example.com/product`.
 
@@ -149,7 +149,7 @@ if ("serviceWorker" in navigator) {
 
 As noted above, servers can remove the restriction on scope by setting the `Service-Worker-Allowed` header on the service worker script, specifying a maximum scope for that service worker above the service worker's location.
 
-The following code, if included in `example.com/index.html`, would apply to all resources under `example.com` if the server set the `Service-Worker-Allowed` header to `/` or `https://example.com/`. If the server doesn't set the header, the service worker registration will fail, as the requested `scope` is too broad.
+The following code, if included in `example.com/product/index.html`, would apply to all resources under `example.com` if the server set the `Service-Worker-Allowed` header to `/` or `https://example.com/`. If the server doesn't set the header, the service worker registration will fail, as the requested `scope` is too broad.
 
 ```js
 if ("serviceWorker" in navigator) {

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -138,7 +138,7 @@ if ("serviceWorker" in navigator) {
 
 As noted above, servers can change the default maximum scope by setting the `Service-Worker-Allowed` header on the service worker script. In this case, the `scope` option should specify a scope narrower than the header value, but potentially larger than the service worker's location.
 
-The following code, if included in `example.com/product/index.html`, would apply to all resources under `example.com` if the server set the `Service-Worker-Allowed` header to `/` or `https://example.com/`. If the server doesn't set the header, the service worker registration will fail, as the requested `scope` is too broad.
+The following code, if included in `example.com/product/index.html`, would apply to all resources under `example.com` if the server set the `Service-Worker-Allowed` header to `/` or `https://example.com/` when serving `sw.js`. If the server doesn't set the header, the service worker registration will fail, as the requested `scope` is too broad.
 
 ```js
 if ("serviceWorker" in navigator) {

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -17,10 +17,6 @@ _scope_, which is subsequently used for navigation matching. You can call this
 method unconditionally from the controlled page. I.e., you don't need to first check
 whether there's an active registration.
 
-There is frequent confusion surrounding the meaning and use of _scope_. Since a
-service worker can't have a scope broader than its own location, only use the
-`scope` option when you need a scope that is narrower than the default.
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -147,7 +147,7 @@ if ("serviceWorker" in navigator) {
 }
 ```
 
-As noted above, servers can remove the restriction on scope by setting the `Service-Worker-Allowed` header on the service worker script, specifying a maximum scope for that service worker above the service worker's location.
+As noted above, servers can change the default maximum scope by setting the `Service-Worker-Allowed` header on the service worker script. In this case, the `scope` option should specify a scope narrower than the header value, but potentially larger than the service worker's location.
 
 The following code, if included in `example.com/product/index.html`, would apply to all resources under `example.com` if the server set the `Service-Worker-Allowed` header to `/` or `https://example.com/`. If the server doesn't set the header, the service worker registration will fail, as the requested `scope` is too broad.
 


### PR DESCRIPTION
Adds a remark early on regarding scope rules, and adds an example of registering a service worker with a broadened scope.

### Description

Adds a remark on the possibility of scope broadening in the first paragraph on setting the scope manually.
The previous text made it seem like this wasn't possible, only to be counteracted a couple of paragraphs later.
Also adds an example of scope broadening, specifying failure or success conditions based on the Service-Worker-Allowed header.

### Motivation

The previous text was confusing. I've had colleagues ask me about the scope rules citing it cannot be broadened
after skimming the article.

### Related issues and pull requests

Fixes #30306
Fixes #10547