### PR TITLE
Add lh/rlh units to Firefox 120 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -20,6 +20,8 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### CSS
 
+- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units are now supported. These allow setting properties relative to the line height of an element, for example, precisely aligning background decoration with multiline text.
+
 #### Removals
 
 ### JavaScript

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -20,7 +20,7 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ### CSS
 
-- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units are now supported. These allow setting properties relative to the line height of an element, for example, precisely aligning background decoration with multiline text.
+- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units are now supported. These allow setting properties relative to the line height of an element, for example, precisely aligning background decoration with multiline text ([Firefox bug 1310170](https://bugzil.la/1310170)).
 
 #### Removals
 


### PR DESCRIPTION
### Description

Mentiones lh/rlh CSS units support in Firefox 120.

### Related issues and pull requests

Part of the Firefox 120 release task #29781