### PR TITLE
"Using WebGL extensions" - add  https://web3dsurvey.com

### DIFF
--- a/files/en-us/web/api/webgl_api/using_extensions/index.md
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.md
@@ -111,3 +111,4 @@ If an extension defines specific symbols or functions that are not available in 
 - {{domxref("WebGLRenderingContext.getSupportedExtensions()")}}
 - {{domxref("WebGLRenderingContext.getExtension()")}}
 - [webglreport.com](https://webglreport.com/)
+- [web3dsurvey.com - WebGL Extension Support Survey](https://web3dsurvey.com/)


### PR DESCRIPTION
This is a website that surveys which extensions are actually supported in the wild: https://web3dsurvey.com

### Description

This is a website that I created earlier this year.  It is included on a number of prominent WebGL related websites including [webglfundamentals.org](https://webglfundamentals.org/), threejs and modelviewer.dev.  It aggregates the results in the various reports you see. 

This helps users determine which extensions they can use safely and which are more optional.  It is a survey of just the last 2 weeks of data, so it is very current.

 The website also links back to the MDN docs for most official extensions.

### Motivation

This makes WebGL developer live's easier since they know what is and isn't supported in the wild.

### Additional details

### Related issues and pull requests
