### PR TITLE
Packets goes _between_ server and client

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -66,7 +66,7 @@ Websites can be reached directly via their IP addresses. You can use a [DNS look
 
 ## Packets explained
 
-Earlier we used the term "packets" to describe the format in which the data is sent from server to client. What do we mean here? Basically, when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
+Earlier we used the term "packets" to describe the format in which the data is transfered between the client and server. What do we mean here? Basically, when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
 
 ## See also
 

--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -66,7 +66,7 @@ Websites can be reached directly via their IP addresses. You can use a [DNS look
 
 ## Packets explained
 
-Earlier we used the term "packets" to describe the format in which the data is transfered between the client and server. What do we mean here? Basically, when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
+Earlier we used the term "packets" to describe the format in which the data is transferred between the client and server. What do we mean here? Basically, when data is sent across the web, it is sent in thousands of small chunks. There are multiple reasons why data is sent in small packets. They are sometimes dropped or corrupted, and it's easier to replace small chunks when this happens. Additionally, the packets can be routed along different paths, making the exchange faster and allowing many different users to download the same website at the same time. If each website was sent as a single big chunk, only one user could download it at a time, which obviously would make the web very inefficient and not much fun to use.
 
 ## See also
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
### Summary
The statement I propose to be removed on line 69 i.e "sent from server to client" indicates that packets are only sent to the client. Yet, servers also receive packets from clients.

<!-- ✍️ Summarize your changes in one or two sentences -->
### Changes
So I changed some content of line 69 from "sent from server to client" to "transfered between the client and server"

### Motivation
I thought it is important to clarify this because we have a reasonable number of  beginners using MDN.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
You can get more context here: https://chat.openai.com/share/e875af6c-d468-4174-9740-0f869e229047

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

