### PR TITLE
Adds explanation in example for the use of clients global 

### DIFF
--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -47,8 +47,8 @@ addEventListener("fetch", (event) => {
       // Eg, if it's cross-origin.
       if (!event.clientId) return;
 
-      // Get the client using clients, a global in worker scope
-      const client = await clients.get(event.clientId);
+      // Get the client
+      const client = await self.clients.get(event.clientId);
       // Exit early if we don't get the client.
       // Eg, if it closed.
       if (!client) return;

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -47,7 +47,7 @@ addEventListener("fetch", (event) => {
       // Eg, if it's cross-origin.
       if (!event.clientId) return;
 
-      // Get the client
+      // Get the client.
       const client = await self.clients.get(event.clientId);
       // Exit early if we don't get the client.
       // Eg, if it closed.

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-Sending a message from a service worker to a client:
+The code below sends a message from a service worker to a client. The client is fetched using the [get() method](/en-US/docs/Web/API/Clients/get) on [clients](/en-US/docs/Web/API/ServiceWorkerGlobalScope/clients) which is a global in  service worker scope.
 
 ```js
 addEventListener("fetch", (event) => {
@@ -47,7 +47,7 @@ addEventListener("fetch", (event) => {
       // Eg, if it's cross-origin.
       if (!event.clientId) return;
 
-      // Get the client.
+      // Get the client using clients, a global in worker scope
       const client = await clients.get(event.clientId);
       // Exit early if we don't get the client.
       // Eg, if it closed.

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-The code below sends a message from a service worker to a client. The client is fetched using the [get() method](/en-US/docs/Web/API/Clients/get) on [clients](/en-US/docs/Web/API/ServiceWorkerGlobalScope/clients) which is a global in  service worker scope.
+The code below sends a message from a service worker to a client. The client is fetched using the [get() method](/en-US/docs/Web/API/Clients/get) on [clients](/en-US/docs/Web/API/ServiceWorkerGlobalScope/clients) which is a global in service worker scope.
 
 ```js
 addEventListener("fetch", (event) => {

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-The code below sends a message from a service worker to a client. The client is fetched using the [get() method](/en-US/docs/Web/API/Clients/get) on [clients](/en-US/docs/Web/API/ServiceWorkerGlobalScope/clients) which is a global in service worker scope.
+The code below sends a message from a service worker to a client. The client is fetched using the {{domxref("Clients.get()", "get()")}} method on {{domxref("ServiceWorkerGlobalScope.clients", "clients")}}, which is a global in service worker scope.
 
 ```js
 addEventListener("fetch", (event) => {


### PR DESCRIPTION
### Description

Adds a one-liner to explain the clients global

### Motivation

Low hanging :mango: 

### Additional details

Thanks to @ChristopherWirtOfficial for reporting this and to @Josh-Cena for inputs.

### Related issues and pull requests

Fixes #10573 Issue with "Client.postMessage()": Page does not give a full code example, or enough context to create one 