### PR TITLE
Deprecate -moz-image-rect function

### DIFF
--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/-moz-image-rect
 page-type: css-function
 status:
   - deprecated
-  - experimental
   - non-standard
 browser-compat: css.types.-moz-image-rect
 ---

--- a/files/en-us/web/css/-moz-image-rect/index.md
+++ b/files/en-us/web/css/-moz-image-rect/index.md
@@ -3,12 +3,13 @@ title: "-moz-image-rect"
 slug: Web/CSS/-moz-image-rect
 page-type: css-function
 status:
+  - deprecated
   - experimental
   - non-standard
 browser-compat: css.types.-moz-image-rect
 ---
 
-{{CSSRef}}{{Non-standard_Header}}{{SeeCompatTable}}
+{{CSSRef}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 The **`-moz-image-rect`** value for [CSS](/en-US/docs/Web/CSS) {{CSSxRef("background-image")}} lets you use a portion of a larger image as a background.
 

--- a/files/en-us/web/css/-moz-image-region/index.md
+++ b/files/en-us/web/css/-moz-image-region/index.md
@@ -13,8 +13,6 @@ For certain XUL elements and pseudo-elements that use an image from the {{CSSxRe
 
 The syntax is similar to the {{CSSxRef("clip")}} property. All four values are relative to the upper left corner of the image.
 
-> **Note:** For a system that works on any background, see {{CSSxRef("-moz-image-rect")}}.
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/image/image/index.md
+++ b/files/en-us/web/css/image/image/index.md
@@ -146,7 +146,6 @@ The above will put a semi-transparent black mask over the Firefox logo backgroun
 - {{CSSxRef("element", "element()")}}
 - {{CSSxRef("url", "url()")}}
 - {{CSSxRef("clip-path")}}
-- {{CSSxRef("-moz-image-rect")}}
 - {{CSSxRef("&lt;gradient&gt;")}}
 - {{CSSxRef("image/image-set", "image-set()")}}
 - {{CSSxRef("cross-fade", "cross-fade()")}}

--- a/files/en-us/web/css/shape/index.md
+++ b/files/en-us/web/css/shape/index.md
@@ -61,4 +61,3 @@ img.clip04 {
 ## See also
 
 - Related CSS property: {{ cssxref("clip") }}
-- The [`-moz-image-rect()`](/en-US/docs/Web/CSS/-moz-image-rect) function has similar coordinate values to `rect()`.


### PR DESCRIPTION
### Description

Deprecated docs for non-standard `-moz-image-rect` function for clipping background images.

### Motivation

Removal in the upcoming Firefox 120 release.

### Related issues and pull requests

Part of the Firefox 120 release project #29784