### PR TITLE
Add -moz-image-rect removal notice to Firefox 120 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -25,7 +25,7 @@ This article provides information about the changes in Firefox 120 that affect d
 
 #### Removals
 
-- The non-standard {{cssxref("-moz-image-rect")}} CSS function for clipping images has been removed. First introduced in Firefox 4 this function has never been standardized or implemented in other browsers. ([Firefox bug 1856999](https://bugzil.la/1853867)).
+- The non-standard {{cssxref("-moz-image-rect")}} CSS function for clipping background images has been removed. First introduced in Firefox 4, this function was never standardized or implemented in other browsers ([Firefox bug 1856999](https://bugzil.la/1853867)).
 
 ### JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -25,6 +25,8 @@ This article provides information about the changes in Firefox 120 that affect d
 
 #### Removals
 
+- The non-standard {{cssxref("-moz-image-rect")}} CSS function for clipping images has been removed. First introduced in Firefox 4 this function has never been standardized or implemented in other browsers. ([Firefox bug 1856999](https://bugzil.la/1853867)).
+
 ### JavaScript
 
 - {{jsxref("Date.parse()")}} now accepts several additional date formats:


### PR DESCRIPTION
### Description

Adds `-moz-image-rect` removal notice to Firefox 120 release notes.

### Motivation

Removal in Firefox 120, [see Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1853867)

### Related issues and pull requests

Part of the Firefox 120 release task #29784