### PR TITLE
Changed "Type error" to "Uncaught ReferenceError"

### DIFF
--- a/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
@@ -162,8 +162,8 @@ function updateName() {
 
 Here we are selecting a button (line 1), then attaching an event listener to it (line 3) so that when the button is clicked, the `updateName()` code block (lines 5–8) is run. The `updateName()` code block (these types of reusable code blocks are called "functions") asks the user for a new name, and then inserts that name into the button text to update the display.
 
-If you swapped the order of the first two lines of code, it would no longer work — instead, you'd get an error returned in the [browser developer console](/en-US/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools) — `TypeError: button is undefined`.
-This means that the `button` object does not exist yet, so we can't add an event listener to it.
+If you swapped the order of the first two lines of code, it would no longer work — instead, you'd get an error returned in the [browser developer console](/en-US/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools) — `Uncaught ReferenceError: Cannot access 'button' before initialization`.
+This means that the `button` object does not initialization yet, so we can't add an event listener to it.
 
 > **Note:** This is a very common error — you need to be careful that the objects referenced in your code exist before you try to do stuff to them.
 


### PR DESCRIPTION
Fixed a mistake where the "TypeError" was incorrectly mentioned instead of "Uncaught ReferenceError."

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
``` js 
const button = document.querySelector("button");
button.addEventListener("click", updateName);
```
If you swapped the order of the first two lines of code, it should return **Uncaught ReferenceError: Cannot access 'button' before initialization** or **Uncaught ReferenceError: can't access lexical declaration 'button' before initialization** (in Firefox) — instead it was mistakenly written **TypeError: button is undefined**. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This clarification helps readers understand the nature of the error and to improve accuracy in error description

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[Cannot access "x" before initialization](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init)



<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
