### PR TITLE
line-style: Fix error and associate link

### DIFF
--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -83,7 +83,7 @@ To see the code for this sample, [view the source on GitHub](https://github.com/
 
 ### Data types
 
-- {{cssxref("line-type")}} enumerated type
+- {{cssxref("line-style")}} enumerated type
 
 ## Guides
 


### PR DESCRIPTION
this should have been line-style, not line type.

https://drafts.csswg.org/css-backgrounds/#typedef-line-style