### PR TITLE
doc: fix example parameter ("xmlns:href" ==> "xlink:href")

### DIFF
--- a/files/en-us/web/svg/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/index.md
@@ -62,7 +62,7 @@ By default, parameters don't have a namespace at all. They are only known to be 
 <svg
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <script xmlns:href="cool-script.js" type="text/ecmascript" />
+  <script xlink:href="cool-script.js" type="text/ecmascript" />
 </svg>
 ```
 


### PR DESCRIPTION
### Description

Fix the first example XML in the section "Declaring namespace prefixes". The
`xlink` namespace prefix is declared, but where it would be used to specify
the `href` parameter in that namespace was spelled `xmlns:href` rather than
`xlink:href`. This change corrects that.
