### PR TITLE
fix: tref only works with xlink:href

### DIFF
--- a/files/en-us/web/svg/element/tref/index.md
+++ b/files/en-us/web/svg/element/tref/index.md
@@ -52,7 +52,7 @@ This element implements the {{domxref("SVGTRefElement")}} interface.
   </text>
 
   <text x="100" y="200" font-size="45" fill="red" >
-    <tref href="#ReferencedText"/>
+    <tref xlink:href="#ReferencedText"/>
   </text>
 
   <!-- Show outline of canvas using 'rect' element -->


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Some elements, namely `<cursor>`, `<filter>`, `<font-face-uri>`, `<glyphRef>`, and `<tref>` only work with `xlink:href`, and not `href`.

The example was incorrectly using `href` which clients, including ones that support SVG 2, will not render. I tested this in Eye of GNOME (GNOME's default image viewer.)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The SVG will now render correctly in viewers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Compare the list of nodes that support XLink's href to the SVG 2 href:

* https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href
* https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href

Nodes that are deprecated/removed in SVG 2 do not support the SVG 2 `href` attribute, so `xlink:href` must still be used.

I was investigating this following this comment in SVGO:

* https://github.com/svg/svgo/pull/1535#discussion_r693548357

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
