### PR TITLE
Deprecate `FileReader.readAsBinaryString()`

### DIFF
--- a/files/en-us/web/api/filereader/index.md
+++ b/files/en-us/web/api/filereader/index.md
@@ -47,7 +47,7 @@ See [Using files from web applications](/en-US/docs/Web/API/File_API/Using_files
   - : Aborts the read operation. Upon return, the `readyState` will be `DONE`.
 - {{domxref("FileReader.readAsArrayBuffer()")}}
   - : Starts reading the contents of the specified {{domxref("Blob")}}, once finished, the `result` attribute contains an {{jsxref("ArrayBuffer")}} representing the file's data.
-- {{domxref("FileReader.readAsBinaryString()")}}
+- {{domxref("FileReader.readAsBinaryString()")}} {{deprecated_inline}}
   - : Starts reading the contents of the specified {{domxref("Blob")}}, once finished, the `result` attribute contains the raw binary data from the file as a string.
 - {{domxref("FileReader.readAsDataURL()")}}
   - : Starts reading the contents of the specified {{domxref("Blob")}}, once finished, the `result` attribute contains a `data:` URL representing the file's data.

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -3,10 +3,14 @@ title: "FileReader: readAsBinaryString() method"
 short-title: readAsBinaryString()
 slug: Web/API/FileReader/readAsBinaryString
 page-type: web-api-instance-method
+status:
+  - deprecated
 browser-compat: api.FileReader.readAsBinaryString
 ---
 
-{{APIRef("File API")}}
+{{APIRef("File API")}}{{Deprecated_Header}}
+
+> **Note:** This method is deprecated in favor of {{DOMxRef("FileReaderSync.readAsArrayBuffer","readAsArrayBuffer()")}}.
 
 The `readAsBinaryString` method is used to start reading the contents of the
 specified {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -10,7 +10,7 @@ browser-compat: api.FileReader.readAsBinaryString
 
 {{APIRef("File API")}}{{Deprecated_Header}}
 
-> **Note:** This method is deprecated in favor of {{DOMxRef("FileReaderSync.readAsArrayBuffer","readAsArrayBuffer()")}}.
+> **Note:** This method is deprecated in favor of {{DOMxRef("FileReader.readAsArrayBuffer","readAsArrayBuffer()")}}.
 
 The `readAsBinaryString` method is used to start reading the contents of the
 specified {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

see https://github.com/mdn/browser-compat-data/pull/21273

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
