### PR TITLE
Changed "Navigation.entries()" to "navigation.entries()".

### DIFF
--- a/files/en-us/web/api/navigation/entries/index.md
+++ b/files/en-us/web/api/navigation/entries/index.md
@@ -36,7 +36,7 @@ None.
 ### Return the number of entries in the history
 
 ```js
-let numOfEntries = Navigation.entries().length - 1;
+let numOfEntries = navigation.entries().length - 1;
 ```
 
 ### A smart back button

--- a/files/en-us/web/api/navigation/forward/index.md
+++ b/files/en-us/web/api/navigation/forward/index.md
@@ -40,7 +40,7 @@ Either one of these promises rejects if the navigation has failed for some reaso
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the {{domxref("Navigation.currentEntry")}}'s {{domxref("NavigationHistoryEntry.index")}} value is -1 or {{domxref("Navigation.entries", "Navigation.entries().length - 1")}}, i.e. either the current {{domxref("Document")}} is not yet active, or the current history entry is the last one in the history, meaning that forwards navigation is not possible.
+  - : Thrown if the {{domxref("Navigation.currentEntry")}}'s {{domxref("NavigationHistoryEntry.index")}} value is -1 or {{domxref("Navigation.entries", "navigation.entries().length - 1")}}, i.e. either the current {{domxref("Document")}} is not yet active, or the current history entry is the last one in the history, meaning that forwards navigation is not possible.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrected two instances of capitalization errors, changing `Navigation.entries()` to `navigation.entries()`.

### Motivation

I corrected the capitalization errors in the code because, in reality, there's no such API as `Navigation.entries()`. Instead, the correct format is `navigation.entries()`. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
