### PR TITLE
Allow starting `<custom-ident>` with double dashes

### DIFF
--- a/files/en-us/web/css/custom-ident/index.md
+++ b/files/en-us/web/css/custom-ident/index.md
@@ -28,7 +28,7 @@ Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers as they ar
 
 ### Forbidden values
 
-A `<custom-ident>` must not be placed between single or double quotes as this would be identical to a {{CSSxRef("&lt;string&gt;")}}. Moreover, the first character must not be a decimal digit, nor a hyphen (`-`) followed by a decimal digit or another hyphen.
+A `<custom-ident>` must not be placed between single or double quotes as this would be identical to a {{CSSxRef("&lt;string&gt;")}}. Moreover, the first character must not be a decimal digit, nor a hyphen (`-`) followed by a decimal digit.
 
 To prevent ambiguity, each property that uses `<custom-ident>` forbids the use of specific values:
 
@@ -128,7 +128,6 @@ bili\.bob         A correctly escaped period
 34rem             It must not start with a decimal digit.
 -12rad            It must not start with a dash followed by a decimal digit.
 bili.bob          Only alphanumeric characters, _, and - needn't be escaped.
---toto            It must not start with two dashes. This would be a custom property.
 'bilibob'         This would be a <string>.
 "bilibob"         This would be a <string>.
 ```


### PR DESCRIPTION

### Description

This PR allows starting `<custom-ident>` with double dashes.

### Motivation

The [`<custom-ident>` page](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident) incorrectly states that custom idents can't start with two double dashes, it two places:

- [“Forbidden values” section](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident#forbidden_values)
- [“Invalid identifiers” section](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident#invalid_identifiers)

### Additional details

I did not find any place in the CSS specs that forbids using two dashes at the start of a `<custom-ident>`. Yes, at this point it might become a valid `<dashed-ident>`, but it won't stop properties that accept `<custom-ident>` from accepting this `<dashed-ident>`-looking custom ident.

There are also several places that mention either an ability to accept double dashed idents, or the `<dashed-ident>` being just a `<custom-ident>` that starts with two dashes, not mentioning the potential limitation.

From the dashed-ident definition:

> The `<dashed-ident>` production is a `<custom-ident>`, with all the case-sensitivity that implies, with the additional restriction that it must start with two dashes (U+002D HYPHEN-MINUS).

From the [`will-change` spec](https://drafts.csswg.org/css-will-change/#valdef-will-change-custom-ident):

> Specifying a custom property must have no effect, which means that effects that happen through custom properties do not count for the rules below that are conditioned on any non-initial value of a property causing something.
>
> > Note: Specifying a value that’s not recognized as a property is fine; it simply has no effect. This allows you to safely specify new properties that exist in some user agents without negatively affecting down-level user agents that don’t know about that property.

And, just in case, here is a CodePen that shows that properties that expect custom-ident work fine in an interop way with the dashed-ident: https://codepen.io/kizu/pen/vYbdyEz

References:

- https://drafts.csswg.org/css-values/#custom-idents
- https://drafts.csswg.org/css-values/#dashed-idents