### PR TITLE
fix apiref of `window.launchQueue`

### DIFF
--- a/files/en-us/web/api/window/launchqueue/index.md
+++ b/files/en-us/web/api/window/launchqueue/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.launchQueue
 ---
 
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef("Launch Handler API")}}{{SeeCompatTable}}
 
 The `launchQueue` read-only property of the {{domxref("Window")}} interface provides access to the {{domxref("LaunchQueue")}} class, which allows custom launch navigation handling to be implemented in a [progressive web app](/en-US/docs/Web/Progressive_web_apps) (PWA), with the handling context signified by the [`launch_handler`](/en-US/docs/Web/Manifest/launch_handler) manifest field `client_mode` value.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

since `window.launchQueue` is defined in Launch Handler API, it is better to use `{{APIRef("Launch Handler API")}}`, see https://developer.mozilla.org/en-US/docs/Web/API/Launch_Handler_API

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
