### PR TITLE
fix: Remove broken internal link to '<ol compact>' 

### DIFF
--- a/files/en-us/web/html/element/ol/index.md
+++ b/files/en-us/web/html/element/ol/index.md
@@ -224,5 +224,5 @@ To determine which list to use, try changing the order of the list items; if the
 
   - the {{CSSxRef("list-style")}} property, to choose the way the ordinal displays
   - [CSS counters](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters), to handle complex nested lists
-  - the {{CSSxRef("line-height")}} property, to simulate the deprecated [`compact`](#compact) attribute
+  - the {{CSSxRef("line-height")}} property, to simulate the deprecated `compact` attribute
   - the {{CSSxRef("margin")}} property, to control the list indentation


### PR DESCRIPTION
### Description

remove the broken link
