### PR TITLE
fix: typo in aria-errormessage article

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-errormessage/index.md
@@ -11,7 +11,7 @@ The `aria-errormessage` attribute on an object identifies the element that provi
 
 When there is a user-created error, you want to let them know it exists and tell them how to fix it. There are two attributes you need to use: set [`aria-invalid="true"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid) to define the object as being in an error state, then add the `aria-errormessage` attribute with the value being the `id` of the element containing the error message text for that object.
 
-The `aria-errormessage` should only be used when the value of an object is not valid; when[`aria-invalid`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid) is set to `true`. If the object is valid and you include the `aria-errormessage` attribute, make sure the element referenced is hidden, as the message it contains is not relevant.
+The `aria-errormessage` attribute should only be used when the value of an object is not valid; when [`aria-invalid`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid) is set to `true`. If the object is valid and you include the `aria-errormessage` attribute, make sure the element referenced is hidden, as the message it contains is not relevant.
 
 When `aria-errormessage` is relevant, the element it references must be visible so users can see or hear the error message.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The following sentence in the `aria-errormessage` article has some typos:

> The `aria-errormessage` should only be used when the value of an object is not valid; when[`aria-invalid`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid) is set to true.

- I think "The `aria-errormessage`" should be changed to "The `aria-errormessage` attribute"
- There is a space missing between "when" and "`aria-invalid`"

Link to the article: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This PR updates the article to address the issues above.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

None.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

None.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
