### PR TITLE
Fix a typo in StaticRange() constractor

### DIFF
--- a/files/en-us/web/api/staticrange/staticrange/index.md
+++ b/files/en-us/web/api/staticrange/staticrange/index.md
@@ -12,7 +12,7 @@ The **`StaticRange()`** constructor
 creates a new {{domxref("StaticRange")}} object representing a span of content within
 the DOM.
 
-This constructor includes properties identifying the standard and end positions of
+This constructor includes properties identifying the start and end positions of
 the range as well as a Boolean indicating whether or not the range is
 **collapsed** (that is, empty).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

"standard and end poisitions" looks a typo of "start and end positions".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
