### PR TITLE
fix: NavigateEvent info property invalid JS example

### DIFF
--- a/files/en-us/web/api/navigateevent/info/index.md
+++ b/files/en-us/web/api/navigateevent/info/index.md
@@ -25,7 +25,7 @@ One example of how `info` might be used is to trigger different single-page navi
 navigation.addEventListener("navigate", (event) => {
   if (isPhotoNavigation(event)) {
     event.intercept({ async handler() {
-      switch (event.info.?via) {
+      switch (event.info?.via) {
         case "go-left": {
           await animateLeft();
           break;

--- a/files/en-us/web/api/navigateevent/info/index.md
+++ b/files/en-us/web/api/navigateevent/info/index.md
@@ -24,24 +24,26 @@ One example of how `info` might be used is to trigger different single-page navi
 ```js
 navigation.addEventListener("navigate", (event) => {
   if (isPhotoNavigation(event)) {
-    event.intercept({ async handler() {
-      switch (event.info?.via) {
-        case "go-left": {
-          await animateLeft();
-          break;
+    event.intercept({
+      async handler() {
+        switch (event.info?.via) {
+          case "go-left": {
+            await animateLeft();
+            break;
+          }
+          case "go-right": {
+            await animateRight();
+            break;
+          }
+          case "gallery": {
+            await animateZoomFromThumbnail(event.info.thumbnail);
+            break;
+          }
         }
-        case "go-right": {
-          await animateRight();
-          break;
-        }
-        case "gallery": {
-          await animateZoomFromThumbnail(event.info.thumbnail);
-          break;
-        }
-      }
 
-      // TODO: actually load the photo.
-    } });
+        // TODO: actually load the photo.
+      },
+    });
   }
 });
 ```


### PR DESCRIPTION
The example was trying to use the nullish chaining operator (`?.`) but had the punctuation flipped (`.?`).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
