### PR TITLE
FF121 iframe lazy loading updates:

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -99,48 +99,6 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
   </tbody>
 </table>
 
-### Lazy loading of iframes
-
-This feature allows web pages and JavaScript to provide a hint to the browser as to whether iframes should be loaded immediately on page load, or only when they are needed (just before they will appear in the window's {{Glossary("visual viewport")}}).
-The hint can be provided via the [`loading`](/en-US/docs/Web/HTML/Element/iframe#loading) attribute on the [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) element or in JavaScript using {{domxref("HTMLIFrameElement.loading")}}.
-See [Firefox bug 1622090](https://bugzil.la/1622090) for more details.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>120</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>120</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>120</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>120</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.iframe_lazy_loading.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## CSS
 
 ### Hex boxes to display stray control characters

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -14,7 +14,7 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### HTML
 
-- [Lazy loading](/en-US/docs/Web/Performance/Lazy_loading) of `<iframes>` is now supported, allowing developers to indicate that particular iframes should only be loaded when (and if) they become visible. This can speed up initial load time by reducing the resources that need to be fetched on page load (some frames may not need to be fetched at all).
+- [Lazy loading](/en-US/docs/Web/Performance/Lazy_loading) of `<iframes>` is now supported, allowing developers to hint that particular `<iframe>`s should only be loaded when (and if) they become visible. This can speed up initial load time by reducing the resources that need to be fetched on page load (some `<iframes>` may not need to be fetched at all).
   The hint can be provided via the [`loading`](/en-US/docs/Web/HTML/Element/iframe#loading) attribute on the [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) element, or in JavaScript using {{domxref("HTMLIFrameElement.loading")}}.
   ([Firefox bug 1622090](https://bugzil.la/1622090)).
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -14,6 +14,10 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### HTML
 
+- [Lazy loading](/en-US/docs/Web/Performance/Lazy_loading) of `<iframes>` is now supported, allowing developers to indicate that particular iframes should only be loaded when (and if) they become visible. This can speed up initial load time by reducing the resources that need to be fetched on page load (some frames may not need to be fetched at all).
+  The hint can be provided via the [`loading`](/en-US/docs/Web/HTML/Element/iframe#loading) attribute on the [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe) element, or in JavaScript using {{domxref("HTMLIFrameElement.loading")}}.
+  ([Firefox bug 1622090](https://bugzil.la/1622090)).
+
 #### Removals
 
 ### CSS

--- a/files/en-us/web/api/htmliframeelement/loading/index.md
+++ b/files/en-us/web/api/htmliframeelement/loading/index.md
@@ -20,6 +20,7 @@ The possible values are:
 
 - `eager`
   - : Load the iframe as soon as the element is processed.
+    This is the default.
 - `lazy`
   - : Load the iframe when the browser believes that it is likely to be need in the near future.
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -56,7 +56,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `lazy`
 
       - : Defer loading of the iframe until it reaches a calculated distance from the {{glossary("visual viewport")}}, as defined by the browser.
-        The intent is to avoid the network and storage bandwidth needed to fetch the frame until its reasonably certain that it will be needed.
+        The intent is to avoid using the network and storage bandwidth required to fetch the frame until the browser is reasonably certain that it will be needed.
         This improves the performance and cost in most typical use cases, in particular by reducing initial page load times.
 
         > **Note:** Loading is only deferred when JavaScript is enabled.

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -52,12 +52,12 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : Indicates when the browser should load the iframe:
 
     - `eager`
-      - : Load the iframe immediately, regardless if it is outside the visible viewport (this is the default value).
+      - : Load the iframe immediately on page load (this is the default value).
     - `lazy`
 
-      - : Defer loading of the iframe until it reaches a calculated distance from the viewport, as defined by the browser.
-        The intent is to avoid the network and storage bandwidth needed until its reasonably certain that it will be needed.
-        This improves the performance and cost in most typical use cases.
+      - : Defer loading of the iframe until it reaches a calculated distance from the {{glossary("visual viewport")}}, as defined by the browser.
+        The intent is to avoid the network and storage bandwidth needed to fetch the frame until its reasonably certain that it will be needed.
+        This improves the performance and cost in most typical use cases, in particular by reducing initial page load times.
 
         > **Note:** Loading is only deferred when JavaScript is enabled.
         > This is an anti-tracking measure.

--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -72,7 +72,7 @@ This allows non-critical resources to load only if needed, potentially speeding 
 <iframe src="video-player.html" title="..." loading="lazy"></iframe>
 ```
 
-The `load` event fires when the eagerly-loaded content has all been loaded; at that time, it's entirely possible (or even likely) that there may be lazily-loaded images or iframes that are within the {{Glossary("visual viewport")}} that haven't yet loaded.
+The `load` event fires when the eagerly-loaded content has all been loaded. At that time, it's entirely possible (or even likely) that there may be lazily-loaded images or iframes within the {{Glossary("visual viewport")}} that haven't yet loaded.
 
 You can determine if a given image has finished loading by examining the value of its Boolean {{domxref("HTMLImageElement.complete", "complete")}} property.
 

--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -64,21 +64,17 @@ Very often, webpages contain many images that contribute to data-usage and how f
 
 #### Loading attribute
 
-The [`loading`](/en-US/docs/Web/HTML/Element/img#loading) attribute on an {{HTMLElement("img")}} element (or the [`loading`](/en-US/docs/Web/HTML/Element/iframe#loading) attribute on an {{HTMLElement("iframe")}}) can be used to instruct the browser to defer loading of images/iframes that are off-screen until the user scrolls near them.
+The [`loading`](/en-US/docs/Web/HTML/Element/img#loading) attribute on an {{HTMLElement("img")}} element, or the [`loading`](/en-US/docs/Web/HTML/Element/iframe#loading) attribute on an {{HTMLElement("iframe")}}, can be used to instruct the browser to defer loading of images/iframes that are off-screen until the user scrolls near them.
+This allows non-critical resources to load only if needed, potentially speeding up initial page loads and reducing network usage.
 
 ```html
 <img src="image.jpg" alt="..." loading="lazy" />
 <iframe src="video-player.html" title="..." loading="lazy"></iframe>
 ```
 
-The `load` event fires when the eagerly-loaded content has all been loaded; at that time, it's entirely possible (or even likely) that there may be lazily-loaded images that are within the {{Glossary("visual viewport")}} that haven't yet loaded.
+The `load` event fires when the eagerly-loaded content has all been loaded; at that time, it's entirely possible (or even likely) that there may be lazily-loaded images or iframes that are within the {{Glossary("visual viewport")}} that haven't yet loaded.
 
 You can determine if a given image has finished loading by examining the value of its Boolean {{domxref("HTMLImageElement.complete", "complete")}} property.
-
-#### Polyfill
-
-Include this polyfill to provide support for older and currently incompatible browsers:
-[loading-attribute-polyfill](https://github.com/mfranzke/loading-attribute-polyfill).
 
 #### Intersection Observer API
 


### PR DESCRIPTION
FF121 supports [`<iframe>` `loading` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#loading) (and API version) in https://bugzilla.mozilla.org/show_bug.cgi?id=1860729. 

This updates release note, experimental features, and minor tweaks to the docs.

Related docs work can be tracked in #30340