### PR TITLE
commands.onCommand add tab

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -38,10 +38,8 @@ Events have three functions:
 
     - `name`
       - : `string`. Name of the command. This matches the name given to the command in its [manifest.json entry](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands).
-
-## Browser compatibility
-
-{{Compat}}
+    - `tab`
+      - : {{WebExtAPIRef('tabs.Tab')}}. The tab that was active when the command shortcut was entered.
 
 ## Examples
 
@@ -69,5 +67,9 @@ browser.commands.onCommand.addListener((command) => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
 
 > **Note:** This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/commands/) API.


### PR DESCRIPTION
### Description

Add documentation for the `tab` property returned by `commands.onCommand`. 

### Motivation

To add details of this new Chrome feature

### Additional details

Planned for Firefox, see [Bug 1843866](https://bugzilla.mozilla.org/show_bug.cgi?id=1843866) Add tab parameter to commands.onCommand

### Related issues and pull requests

Fixes [#29555](https://github.com/mdn/content/issues/29555)
Related BCD in https://github.com/mdn/browser-compat-data/pull/21281