### PR TITLE
FF121Expr: HTMLSelectElement showPicker()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -61,7 +61,7 @@ Layout for `input type="search"` has been updated. This causes a search field to
 
 ### showPicker() method for HTML select elements
 
-The {{domxref("HTMLSelectElement.showPicker()")}} method programmatically launches the browser picker for a `select` element, triggered by user interaction.
+The {{domxref("HTMLSelectElement.showPicker()")}} method programmatically launches the browser picker for a {{HTMLElement("select")}} element, triggered by user interaction.
 (See [Firefox bug 1854112](https://bugzil.la/1854112) for more details.)
 
 <table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -59,6 +59,47 @@ Layout for `input type="search"` has been updated. This causes a search field to
   </tbody>
 </table>
 
+### showPicker() method for HTML select elements
+
+The {{domxref("HTMLSelectElement.showPicker()")}} method programmatically launches the browser picker for a `select` element, triggered by user interaction.
+(See [Firefox bug 1854112](https://bugzil.la/1854112) for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>121</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>121</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>121</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>121</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.select.showPicker.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Toggle password display
 
 HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/Element/input/password)) include an "eye" icon that can be toggled to display or obscure the password text ([Firefox bug 502258](https://bugzil.la/502258)).


### PR DESCRIPTION
FF121 adds `HTMLSelectElement.showPicker()` support behind a preference (and in nightly). Other docs have been done. This adds it to the experimental features.

Related docs work can be tracked in #30336