### PR TITLE
align the description with the code example

### DIFF
--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -92,7 +92,7 @@ function askNotificationPermission() {
 }
 ```
 
-Looking at the second main block first, you'll see that we first check to see if Notifications are supported. If they are, we then run a check to see whether the promise-based version of `Notification.requestPermission()` is supported. If it is, we run the promise-based version (supported everywhere except Safari), and if not, we run the older callback-based version (which is supported in Safari).
+Looking at the second main block first, you'll see that we first check to see if Notifications are supported. If they are, we run the promise-based version of `Notification.requestPermission()`, and if not, we log a message to the console.
 
 To avoid duplicating code, we have stored a few bits of housekeeping code inside the `handlePermission()` function, which is the first main block inside this snippet. Inside here we explicitly set the `Notification.permission` value (some old versions of Chrome failed to do this automatically), and show or hide the button depending on what the user chose in the permission dialog. We don't want to show it if permission has already been granted, but if the user chose to deny permission, we want to give them the chance to change their mind later on.
 


### PR DESCRIPTION
### Description

align the description with the code example

### Motivation

The promise-based version of `requestPermission()` is [supported by the newest version of Safari](https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission_static#browser_compatibility), and we did not detect if the function is promise-based (the above content show that "There's no way to reliably feature-test whether `Notification.requestPermission` supports the promise-based version.".)
