### PR TITLE
Remove note about Chrome prior to 37.

### DIFF
--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -96,8 +96,6 @@ Looking at the second main block first, you'll see that we first check to see if
 
 To avoid duplicating code, we have stored a few bits of housekeeping code inside the `handlePermission()` function, which is the first main block inside this snippet. Inside here we explicitly set the `Notification.permission` value (some old versions of Chrome failed to do this automatically), and show or hide the button depending on what the user chose in the permission dialog. We don't want to show it if permission has already been granted, but if the user chose to deny permission, we want to give them the chance to change their mind later on.
 
-> **Note:** Before version 37, Chrome doesn't let you call {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}} in the `load` event handler (see [issue 274284](https://crbug.com/274284)).
-
 ## Creating a notification
 
 Creating a notification is easy; just use the {{domxref("Notification")}} constructor. This constructor expects a title to display within the notification and some options to enhance the notification such as an {{domxref("Notification.icon","icon")}} or a text {{domxref("Notification.body","body")}}.


### PR DESCRIPTION
The note is useless nowadays. There is likely more things to update on this page, but this one was the only note.