### PR TITLE
De-XHRify AudioProcessingEvent example

### DIFF
--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -42,6 +42,8 @@ _Also implements the properties inherited from its parent, {{domxref("Event")}}_
 
 ## Examples
 
+### Adding white noise using a script processor
+
 The following example shows how to use of a `ScriptProcessorNode` to take a
 track loaded via {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}, process it, adding a bit
 of white noise to each audio sample of the input track (buffer) and play it through the
@@ -52,7 +54,7 @@ buffer, and each sample in each channel, and add a small amount of white noise, 
 setting that result to be the output sample in each case.
 
 > **Note:** For a full working example, see our [script-processor-node](https://mdn.github.io/webaudio-examples/script-processor-node/)
-> GitHub repo. (You can also access the [source code](https://github.com/mdn/webaudio-examples/blob/master/script-processor-node/index.html).)
+> GitHub repo. (You can also access the [source code](https://github.com/mdn/webaudio-examples/tree/main/script-processor-node).)
 
 ```js
 const myScript = document.querySelector("script");
@@ -60,72 +62,69 @@ const myPre = document.querySelector("pre");
 const playButton = document.querySelector("button");
 
 // Create AudioContext and buffer source
-const audioCtx = new AudioContext();
-const source = audioCtx.createBufferSource();
+let audioCtx;
 
-// Create a ScriptProcessorNode with a bufferSize of 4096 and a single input and output channel
-const scriptNode = audioCtx.createScriptProcessor(4096, 1, 1);
-console.log(scriptNode.bufferSize);
+async function init() {
+  audioCtx = new AudioContext();
+  const source = audioCtx.createBufferSource();
 
-// load in an audio track via XHR and decodeAudioData
+  // Create a ScriptProcessorNode with a bufferSize of 4096 and
+  // a single input and output channel
+  const scriptNode = audioCtx.createScriptProcessor(4096, 1, 1);
 
-function getData() {
-  request = new XMLHttpRequest();
-  request.open("GET", "viper.ogg", true);
-  request.responseType = "arraybuffer";
-  request.onload = () => {
-    const audioData = request.response;
-
-    audioCtx.decodeAudioData(
-      audioData,
-      (buffer) => {
-        myBuffer = buffer;
-        source.buffer = myBuffer;
-      },
-      (e) => console.error(`Error with decoding audio data: ${e.err}`),
+  // Load in an audio track using fetch() and decodeAudioData()
+  try {
+    const response = await fetch("viper.ogg");
+    const arrayBuffer = await response.arrayBuffer();
+    source.buffer = await audioCtx.decodeAudioData(arrayBuffer);
+  } catch (err) {
+    console.error(
+      `Unable to fetch the audio file: ${name} Error: ${err.message}`,
     );
-  };
-  request.send();
-}
-
-// Give the node a function to process audio events
-scriptNode.onaudioprocess = (audioProcessingEvent) => {
-  // The input buffer is the song we loaded earlier
-  const inputBuffer = audioProcessingEvent.inputBuffer;
-
-  // The output buffer contains the samples that will be modified and played
-  const outputBuffer = audioProcessingEvent.outputBuffer;
-
-  // Loop through the output channels (in this case there is only one)
-  for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
-    const inputData = inputBuffer.getChannelData(channel);
-    const outputData = outputBuffer.getChannelData(channel);
-
-    // Loop through the 4096 samples
-    for (let sample = 0; sample < inputBuffer.length; sample++) {
-      // make output equal to the same as the input
-      outputData[sample] = inputData[sample];
-
-      // add noise to each output sample
-      outputData[sample] += (Math.random() * 2 - 1) * 0.2;
-    }
   }
-};
 
-getData();
+  // Give the node a function to process audio events
+  scriptNode.addEventListener("audioprocess", (audioProcessingEvent) => {
+    // The input buffer is the song we loaded earlier
+    let inputBuffer = audioProcessingEvent.inputBuffer;
 
-// Wire up the play button
-playButton.onclick = () => {
+    // The output buffer contains the samples that will be modified
+    // and played
+    let outputBuffer = audioProcessingEvent.outputBuffer;
+
+    // Loop through the output channels (in this case there is only one)
+    for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
+      let inputData = inputBuffer.getChannelData(channel);
+      let outputData = outputBuffer.getChannelData(channel);
+
+      // Loop through the 4096 samples
+      for (let sample = 0; sample < inputBuffer.length; sample++) {
+        // make output equal to the same as the input
+        outputData[sample] = inputData[sample];
+
+        // add noise to each output sample
+        outputData[sample] += (Math.random() * 2 - 1) * 0.1;
+      }
+    }
+  });
+
   source.connect(scriptNode);
   scriptNode.connect(audioCtx.destination);
   source.start();
-};
 
-// When the buffer source stops playing, disconnect everything
-source.onended = () => {
-  source.disconnect(scriptNode);
-  scriptNode.disconnect(audioCtx.destination);
-};
+  // When the buffer source stops playing, disconnect everything
+  source.addEventListener("ended", () => {
+    source.disconnect(scriptNode);
+    scriptNode.disconnect(audioCtx.destination);
+  });
+}
+
+// wire up play button
+playButton.addEventListener("click", () => {
+  if (!audioCtx) {
+    init();
+  }
+});
 ```
 
 ## Browser compatibility


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/30131.

This updates the https://developer.mozilla.org/en-US/docs/Web/API/AudioProcessingEvent page, that was using XHR in its example.

This PR aligns the page with the example updates that were made in http://github.com/mdn/webaudio-examples/pull/116.