### PR TITLE
fix: typo in javascript building blocks test

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.md
@@ -8,7 +8,7 @@ page-type: learn-module-assessment
 
 The aim of this skill test is to assess whether you've understood our [Making decisions in your code — conditionals](/en-US/docs/Learn/JavaScript/Building_blocks/conditionals) article.
 
-> **Note:** You can try solutions by downloading the code and putting it in an online an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> **Note:** You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.md
@@ -8,7 +8,7 @@ page-type: learn-module-assessment
 
 The aim of this skill test is to assess whether you've understood our [Introduction to events](/en-US/docs/Learn/JavaScript/Building_blocks/Events) article.
 
-> **Note:** You can try solutions by downloading the code and putting it in an online an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> **Note:** You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
@@ -8,7 +8,7 @@ page-type: learn-module-assessment
 
 The aim of this skill test is to assess whether you've understood our [Functions — reusable blocks of code](/en-US/docs/Learn/JavaScript/Building_blocks/Functions), [Build your own function](/en-US/docs/Learn/JavaScript/Building_blocks/Build_your_own_function), and [Function return values](/en-US/docs/Learn/JavaScript/Building_blocks/Return_values) articles.
 
-> **Note:** You can try solutions by downloading the code and putting it in an online an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
+> **Note:** You can try solutions by downloading the code and putting it in an online editor such as [CodePen](https://codepen.io/), [JSFiddle](https://jsfiddle.net/), or [Glitch](https://glitch.com/).
 > If there is an error, it will be logged in the results panel on the page or into the browser's JavaScript console to help you.
 >
 > If you get stuck, you can reach out to us in one of our [communication channels](/en-US/docs/MDN/Community/Communication_channels).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The Markdown files contain a recurring typo where "an online an online" appears in each test. I have addressed this issue by removing the last occurrence of the phrase.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I began my frontend learning journey with MDN guides, and I truly appreciate the Mozilla Developer Network. I believe it's time for me to contribute, especially after noticing those typos. Also I love you guys 💖

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Changed files
``` 
files/en-us/learn/javascript/building_blocks/test_your_skills_colon__conditionals/index.md
files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.md      
files/en-us/learn/javascript/building_blocks/test_your_skills_colon__functions/index.md
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
