### PR TITLE
Add optional tag to lastAccessed property in tabs API

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -51,7 +51,7 @@ Values of this type are objects. They contain the following properties:
   - : `boolean`. True if the tab can be [rendered in Reader Mode](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode), false otherwise.
 - `isInReaderMode`
   - : `boolean`. True if the tab is currently being [rendered in Reader Mode](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode), false otherwise.
-- `lastAccessed`
+- `lastAccessed` {{optional_inline}}
   - : `double`. Time at which the tab was last accessed, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `mutedInfo` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.MutedInfo')}}. The current muted state for the tab and the reason for the last state change.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds an optional tag to the `lastAccessed` property in the `browser.tabs` API.

### Motivation

This is defined as optional in the source code: https://searchfox.org/mozilla-central/rev/5134f3f1c7794fcff1bde59dc7b4ae65cc460919/browser/components/extensions/schemas/tabs.json#134

### Additional details

NA

### Related issues and pull requests

NA