### PR TITLE
docs(http): Add details for 304 response with examples

### DIFF
--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -8,7 +8,7 @@ browser-compat: http.status.304
 {{HTTPSidebar}}
 
 The HTTP **`304 Not Modified`** client redirection response code indicates that there is no need to retransmit the requested resources.
-This happens when the request is a conditional {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request with an {{HTTPHeader("If-None-Match")}} or an {{HTTPHeader("If-Modified-Since")}} header and the condition evaluates to false.
+This response code is sent when the request is a conditional {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request with an {{HTTPHeader("If-None-Match")}} or an {{HTTPHeader("If-Modified-Since")}} header and the condition evaluates to false.
 It is an implicit redirection to a cached resource that would have resulted in a {{HTTPStatus("200")}} `OK` response if the condition evaluated to true.
 
 The response must not contain a body and must include the headers that would

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -7,12 +7,9 @@ browser-compat: http.status.304
 
 {{HTTPSidebar}}
 
-The HTTP **`304 Not Modified`** client redirection response
-code indicates that there is no need to retransmit the requested resources. It is an
-implicit redirection to a cached resource. This happens when the request method is
-a {{glossary("Safe/HTTP", "safe")}} method, such as {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}},
-or when the request is conditional and uses an {{HTTPHeader("If-None-Match")}} or an
-{{HTTPHeader("If-Modified-Since")}} header.
+The HTTP **`304 Not Modified`** client redirection response code indicates that there is no need to retransmit the requested resources.
+This happens when the request is a conditional {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} request with an {{HTTPHeader("If-None-Match")}} or an {{HTTPHeader("If-Modified-Since")}} header and the condition evaluates to false.
+It is an implicit redirection to a cached resource that would have resulted in a {{HTTPStatus("200")}} `OK` response if the condition evaluated to true.
 
 The response must not contain a body and must include the headers that would
 have been sent in an equivalent {{HTTPStatus("200")}} `OK` response:
@@ -28,6 +25,57 @@ have been sent in an equivalent {{HTTPStatus("200")}} `OK` response:
 
 ```http
 304 Not Modified
+```
+
+## Examples
+
+The examples below show {{HTTPMethod("GET")}} requests made using curl with conditional request headers and the HTTP responses received in return.
+The first example would return a {{HTTPStatus("200")}} `OK` if we know the resource has been updated since the timestamp in the {{HTTPHeader("If-Modified-Since")}} header.
+For illustration, the request uses a future date of 21st November 2050 to check whether if the resource has been updated since this date:
+
+```bash
+curl -v --header 'If-Modified-Since: Tue, 21 Nov 2050 08:00:00 GMT' \
+ https://developer.mozilla.org/en-US/
+```
+
+```http
+> Request
+GET /en-US/ HTTP/2
+Host: developer.mozilla.org
+User-Agent: curl/8.1.2
+Accept: */*
+If-Modified-Since: Tue, 21 Nov 2050 08:00:00 GMT
+
+< Response
+HTTP/2 304
+date: Tue, 21 Nov 2023 08:44:28 GMT
+expires: Tue, 21 Nov 2023 08:53:14 GMT
+age: 3194
+etag: "e27d81b845c3716cdb5d4220d78e2799"
+```
+
+A `304 Not Modified` response is also returned in response to a {{HTTPMethod("GET")}} request containing an {{HTTPHeader("If-None-Match")}} header with the [ETag](/en-US/docs/Web/HTTP/Headers/ETag) from the response above.
+Because the `etag` exists, a matching entity tag fails the condition, and a `304` response is returned:
+
+```bash
+curl -v --header 'If-None-Match: "e27d81b845c3716cdb5d4220d78e2799"' \
+ https://developer.mozilla.org/en-US/
+```
+
+```http
+> Request
+GET /en-US/ HTTP/2
+Host: developer.mozilla.org
+User-Agent: curl/8.1.2
+Accept: */*
+If-None-Match: "e27d81b845c3716cdb5d4220d78e2799"
+
+< Response
+HTTP/2 304
+date: Tue, 21 Nov 2023 08:47:37 GMT
+expires: Tue, 21 Nov 2023 09:38:23 GMT
+age: 2920
+etag: "e27d81b845c3716cdb5d4220d78e2799"
 ```
 
 ## Specifications
@@ -48,4 +96,5 @@ have been sent in an equivalent {{HTTPStatus("200")}} `OK` response:
 
 - {{HTTPHeader("If-Modified-Since")}}
 - {{HTTPHeader("If-None-Match")}}
+- [HTTP conditional requests](/en-US/docs/Web/HTTP/Conditional_requests)
 - [204 No Content](/en-US/docs/Web/HTTP/Status/204)


### PR DESCRIPTION

This PR adds details about 304 responses with some examples using curl.

### Motivation

We say:

>This happens when the request method is a safe method, such as GET or HEAD, or when the request is conditional

Whereas the request must be conditional. See 

* rfc9110 https://www.rfc-editor.org/rfc/rfc9110#status.304
* rfc7232 https://datatracker.ietf.org/doc/html/rfc7232#section-4.1
* rfc2616 https://datatracker.ietf.org/doc/html/rfc2616#section-10.3.5

### Related issues and pull requests

Fixes #30016
