### PR TITLE
chore(docs): Update Fx 120 release notes for release cycle

### DIFF
--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -6,17 +6,13 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 120 that affect developers. Firefox 120 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [November 21, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 120 that affect developers. Firefox 120 was released on [November 21, 2023](https://whattrainisitnow.com/calendar/).
 
 ## Changes for web developers
-
-### Developer tools
 
 ### HTML
 
 - Support for the `media` attribute in the [`<source>`](/en-US/docs/Web/HTML/Element/source) element has been reintroduced and expanded to include `<audio>` and `<video>` elements. This attribute was first added in Firefox 15 but was removed in Firefox 53 when its use was limited to `<source>` element within `<picture>`. With this release, the `media` attribute will be available in `<source>` elements within `<audio>`, `<video>`, and `<picture>` ([Firefox bug 1836128](https://bugzil.la/1836128)).
-
-#### Removals
 
 ### CSS
 
@@ -51,11 +47,9 @@ This article provides information about the changes in Firefox 120 that affect d
 
   - Timezone `'Z'` is now accepted for non-ISO formats (e.g. `Jan 1 1970 10:00Z`) ([Firefox bug 1852422](https://bugzil.la/1852422))
 
-#### Removals
-
 ### SVG
 
-#### Removals
+No notable changes
 
 ### HTTP
 
@@ -65,11 +59,9 @@ This article provides information about the changes in Firefox 120 that affect d
   Users can enable the header, in both normal and private browsing modes, by setting the preference `privacy.globalprivacycontrol.enabled` to `true` (in `about:config`).
   The {{domxref("Navigator.globalPrivacyControl")}} and {{domxref("WorkerNavigator.globalPrivacyControl")}} properties allow JavaScript to check the user consent preference ([Firefox bug 1856029](https://bugzil.la/1856029)).
 
-#### Removals
-
 ### Security
 
-#### Removals
+No notable changes
 
 ### APIs
 
@@ -78,16 +70,6 @@ This article provides information about the changes in Firefox 120 that affect d
 - The [Minimum PIN Length Extension (`minPinLength`)](/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) of the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) is supported, allowing a relying party server to request the authenticator's minimum PIN length during creation/registration ([Firefox bug 1844450](https://bugzil.la/1844450)).
 - The {{domxref("Navigator.userActivation")}} property and {{domxref("UserActivation")}} interface are now supported.
   These can be used to check whether the user is interacting with the page, or has interacted with it since page load (see [Firefox bug 1791079](https://bugzil.la/1791079)).
-
-#### DOM
-
-#### Media, WebRTC, and Web Audio
-
-#### Removals
-
-### WebAssembly
-
-#### Removals
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -98,9 +80,7 @@ This article provides information about the changes in Firefox 120 that affect d
 
 ## Changes for add-on developers
 
-### Removals
-
-### Other
+No notable changes
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -6,7 +6,7 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 120 that affect developers. Firefox 120 was released on [November 21, 2023](https://whattrainisitnow.com/calendar/).
+This article provides information about the changes in Firefox 120 that affect developers. Firefox 120 was released on [November 21, 2023](https://whattrainisitnow.com/release/?version=120).
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -6,7 +6,7 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 121 that affect developers. Firefox 121 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [December 19, 2023](https://whattrainisitnow.com/calendar/).
+This article provides information about the changes in Firefox 121 that affect developers. Firefox 121 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [December 19, 2023](https://whattrainisitnow.com/release/?version=121).
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -6,7 +6,7 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 121 that affect developers. Firefox 121 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [December 19, 2023](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates).
+This article provides information about the changes in Firefox 121 that affect developers. Firefox 121 is the current [Beta version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta) and ships on [December 19, 2023](https://whattrainisitnow.com/calendar/).
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -6,7 +6,7 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 122 that affect developers. Firefox 122 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [January 23, 2024](https://whattrainisitnow.com/calendar/).
+This article provides information about the changes in Firefox 122 that affect developers. Firefox 122 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [January 23, 2024](https://whattrainisitnow.com/release/?version=122).
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -1,0 +1,65 @@
+---
+title: Firefox 122 for developers
+slug: Mozilla/Firefox/Releases/122
+page-type: firefox-release-notes
+---
+
+{{FirefoxSidebar}}
+
+This article provides information about the changes in Firefox 122 that affect developers. Firefox 122 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [January 23, 2024](https://whattrainisitnow.com/calendar/) .
+
+## Changes for web developers
+
+### Developer Tools
+
+### HTML
+
+#### Removals
+
+### CSS
+
+#### Removals
+
+### JavaScript
+
+#### Removals
+
+### SVG
+
+#### Removals
+
+### HTTP
+
+#### Removals
+
+### Security
+
+#### Removals
+
+### APIs
+
+#### DOM
+
+#### Media, WebRTC, and Web Audio
+
+#### Removals
+
+### WebAssembly
+
+#### Removals
+
+### WebDriver conformance (WebDriver BiDi, Marionette)
+
+#### WebDriver BiDi
+
+#### Marionette
+
+## Changes for add-on developers
+
+### Removals
+
+### Other
+
+## Older versions
+
+{{Firefox_for_developers(121)}}

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -6,7 +6,7 @@ page-type: firefox-release-notes
 
 {{FirefoxSidebar}}
 
-This article provides information about the changes in Firefox 122 that affect developers. Firefox 122 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [January 23, 2024](https://whattrainisitnow.com/calendar/) .
+This article provides information about the changes in Firefox 122 that affect developers. Firefox 122 is the current [Nightly version of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) and ships on [January 23, 2024](https://whattrainisitnow.com/calendar/).
 
 ## Changes for web developers
 


### PR DESCRIPTION
Release note work for Fx 120.


__changes:__

* Clean up empty sections in 120 relnotes
* "Nightly" -> "Beta"
* Add template for 122


__Note:__
The [RapidRelease calendar at wiki.mozilla.org](https://wiki.mozilla.org/RapidRelease/Calendar#Future_branch_dates) has a deprecation notice to use https://whattrainisitnow.com instead. I am switching this URL out in the current docs and in the template.