### PR TITLE
fix(region roles document): correction of sentence/link break

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/region_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/region_role/index.md
@@ -44,7 +44,7 @@ Using the {{HTMLElement('section')}} element will automatically communicate a se
 
 ## Accessibility concerns
 
-Use sparingly[! Landmark roles](/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles) are intended to be used sparingly, to identify larger overall sections of the document. Using too many landmark roles can create "noise" in screen readers, making it difficult to understand the overall layout of the page.
+Use sparingly! [Landmark roles](/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles) are intended to be used sparingly, to identify larger overall sections of the document. Using too many landmark roles can create "noise" in screen readers, making it difficult to understand the overall layout of the page.
 
 Only use the `region` role if no other relevant [content sectioning](/en-US/docs/Web/HTML/Element#content_sectioning) element or [landmark role](/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles) applies. If multiple regions exist on a page, it may be worth reinvestigating the page's overall structure.
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The Landmark roles link in the second sentence of the Accessibility concerns section of the Region Role document overlapped with the ending punctuation of the previous sentence.

This PR fixes that.

### Motivation

It looked bad/off and it was an easy fix.

Two minute rule to make the world a better place.

### Additional details

#dorelentlesslygood

### Related issues and pull requests

n/a
