### PR TITLE
Replace verbose sorting logic in Express tutorial

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
@@ -205,7 +205,8 @@ The view structure and behavior is almost the same as for the **genre_form.pug**
 The main differences are in how we implement the selection-type fields: `Author` and `Genre`.
 
 - The set of genres are displayed as checkboxes, and use the `checked` value we set in the controller to determine whether or not the box should be selected.
-- The set of authors are displayed as a single-selection alphabetically ordered drop-down list. If the user has previously selected a book author (i.e. when fixing invalid field values after initial form submission, or when updating book details) the author will be re-selected when the form is displayed. Here we determine what author to select by comparing the id of the current author option with the value previously entered by the user (passed in via the `book` variable).
+- The set of authors are displayed as a single-selection alphabetically ordered drop-down list (the list passed to the template is already sorted, so we don't need to do that in the template).
+  If the user has previously selected a book author (i.e. when fixing invalid field values after initial form submission, or when updating book details) the author will be re-selected when the form is displayed. Here we determine what author to select by comparing the id of the current author option with the value previously entered by the user (passed in via the `book` variable).
 
 > **Note:** If there is an error in the submitted form, then, when the form is to be re-rendered, the new book author's id and the existing books's authors ids are of type `Schema.Types.ObjectId`. So to compare them we must convert them to strings first.
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
@@ -35,7 +35,7 @@ exports.book_create_get = asyncHandler(async (req, res, next) => {
 });
 ```
 
-This uses `await` on the result of `Promise.all()` to get all `Author` and `Genre` objects in parallel (the same approach used in [Express Tutorial Part 5: Displaying library data](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data)). The authors are sorted alphabetically by chaining `.sort({ family_name: 1 })` on to the query.
+This uses `await` on the result of `Promise.all()` to get all `Author` and `Genre` objects in parallel (the same approach used in [Express Tutorial Part 5: Displaying library data](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data)).
 These are then passed to the view **`book_form.pug`** as variables named `authors` and `genres` (along with the page `title`).
 
 ## Controller—post route

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
@@ -24,7 +24,7 @@ exports.book_create_get = asyncHandler(async (req, res, next) => {
   // Get all authors and genres, which we can use for adding to our book.
   const [allAuthors, allGenres] = await Promise.all([
     Author.find().sort({ family_name: 1 }).exec(),
-    Genre.find().exec(),
+    Genre.find().sort({ name: 1 }).exec(),
   ]);
 
   res.render("book_form", {
@@ -90,7 +90,7 @@ exports.book_create_post = [
       // Get all authors and genres for form.
       const [allAuthors, allGenres] = await Promise.all([
         Author.find().sort({ family_name: 1 }).exec(),
-        Genre.find().exec(),
+        Genre.find().sort({ name: 1 }).exec(),
       ]);
 
       // Mark our selected genres as checked.

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_book_form/index.md
@@ -23,7 +23,7 @@ Find the exported `book_create_get()` controller method and replace it with the 
 exports.book_create_get = asyncHandler(async (req, res, next) => {
   // Get all authors and genres, which we can use for adding to our book.
   const [allAuthors, allGenres] = await Promise.all([
-    Author.find().exec(),
+    Author.find().sort({ family_name: 1 }).exec(),
     Genre.find().exec(),
   ]);
 
@@ -35,7 +35,7 @@ exports.book_create_get = asyncHandler(async (req, res, next) => {
 });
 ```
 
-This uses `await` on the result of `Promise.all()` to get all `Author` and `Genre` objects in parallel (the same approach used in [Express Tutorial Part 5: Displaying library data](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data)).
+This uses `await` on the result of `Promise.all()` to get all `Author` and `Genre` objects in parallel (the same approach used in [Express Tutorial Part 5: Displaying library data](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data)). The authors are sorted alphabetically by chaining `.sort({ family_name: 1 })` on to the query.
 These are then passed to the view **`book_form.pug`** as variables named `authors` and `genres` (along with the page `title`).
 
 ## Controller—post route
@@ -89,7 +89,7 @@ exports.book_create_post = [
 
       // Get all authors and genres for form.
       const [allAuthors, allGenres] = await Promise.all([
-        Author.find().exec(),
+        Author.find().sort({ family_name: 1 }).exec(),
         Genre.find().exec(),
       ]);
 
@@ -174,7 +174,6 @@ block content
     div.form-group
       label(for='author') Author:
       select#author.form-control(type='select', placeholder='Select author' name='author' required='true' )
-        - authors.sort(function(a, b) {let textA = a.family_name.toUpperCase(); let textB = b.family_name.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
         for author in authors
           if book
             option(value=author._id selected=(author._id.toString()===book.author._id.toString() ? 'selected' : false) ) #{author.name}
@@ -207,14 +206,6 @@ The main differences are in how we implement the selection-type fields: `Author`
 
 - The set of genres are displayed as checkboxes, and use the `checked` value we set in the controller to determine whether or not the box should be selected.
 - The set of authors are displayed as a single-selection alphabetically ordered drop-down list. If the user has previously selected a book author (i.e. when fixing invalid field values after initial form submission, or when updating book details) the author will be re-selected when the form is displayed. Here we determine what author to select by comparing the id of the current author option with the value previously entered by the user (passed in via the `book` variable).
-- The authors are ordered alphabetically before adding them as options in the drop-down list:
-
-  ```pug
-  - authors.sort(function(a, b) {let textA = a.family_name.toUpperCase(); let textB = b.family_name.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
-  ```
-
-  Note that the code starts with `-`.
-  In pug this is referred to as "unbuffered code", and doesn't add anything to the view (see [pug docs](https://pugjs.org/language/code.html) for more detail).
 
 > **Note:** If there is an error in the submitted form, then, when the form is to be re-rendered, the new book author's id and the existing books's authors ids are of type `Schema.Types.ObjectId`. So to compare them we must convert them to strings first.
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_bookinstance_form/index.md
@@ -28,7 +28,7 @@ Find the exported `bookinstance_create_get()` controller method and replace it w
 ```js
 // Display BookInstance create form on GET.
 exports.bookinstance_create_get = asyncHandler(async (req, res, next) => {
-  const allBooks = await Book.find({}, "title").exec();
+  const allBooks = await Book.find({}, "title").sort({ title: 1 }).exec();
 
   res.render("bookinstance_form", {
     title: "Create BookInstance",
@@ -37,7 +37,7 @@ exports.bookinstance_create_get = asyncHandler(async (req, res, next) => {
 });
 ```
 
-The controller gets a list of all books (`allBooks`) and passes it via `book_list` to the view **`bookinstance_form.pug`** (along with a `title`).
+The controller gets a sorted list of all books (`allBooks`) and passes it via `book_list` to the view **`bookinstance_form.pug`** (along with a `title`).
 Note that no book has been selected when we first display this form, so we don't pass the `selected_book` variable to `render()`.
 Because of this, `selected_book` will have a value of `undefined` in the template.
 
@@ -76,7 +76,7 @@ exports.bookinstance_create_post = [
     if (!errors.isEmpty()) {
       // There are errors.
       // Render form again with sanitized values and error messages.
-      const allBooks = await Book.find({}, "title").exec();
+      const allBooks = await Book.find({}, "title").sort({ title: 1 }).exec();
 
       res.render("bookinstance_form", {
         title: "Create BookInstance",
@@ -113,7 +113,6 @@ block content
     div.form-group
       label(for='book') Book:
       select#book.form-control(type='select' placeholder='Select book' name='book' required='true')
-        - book_list.sort(function(a, b) {let textA = a.title.toUpperCase(); let textB = b.title.toUpperCase(); return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;});
         for book in book_list
           option(value=book._id, selected=(selected_book==book._id.toString() ? '' : false) ) #{book.title}
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
@@ -16,7 +16,7 @@ exports.book_update_get = asyncHandler(async (req, res, next) => {
   // Get book, authors and genres for form.
   const [book, allAuthors, allGenres] = await Promise.all([
     Book.findById(req.params.id).populate("author").populate("genre").exec(),
-    Author.find().exec(),
+    Author.find().sort({ family_name: 1 }).exec(),
     Genre.find().exec(),
   ]);
 
@@ -109,7 +109,7 @@ exports.book_update_post = [
 
       // Get all authors and genres for form
       const [allAuthors, allGenres] = await Promise.all([
-        Author.find().exec(),
+        Author.find().sort({ family_name: 1 }).exec(),
         Genre.find().exec(),
       ]);
 

--- a/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/update_book_form/index.md
@@ -17,7 +17,7 @@ exports.book_update_get = asyncHandler(async (req, res, next) => {
   const [book, allAuthors, allGenres] = await Promise.all([
     Book.findById(req.params.id).populate("author").populate("genre").exec(),
     Author.find().sort({ family_name: 1 }).exec(),
-    Genre.find().exec(),
+    Genre.find().sort({ name: 1 }).exec(),
   ]);
 
   if (book === null) {
@@ -110,7 +110,7 @@ exports.book_update_post = [
       // Get all authors and genres for form
       const [allAuthors, allGenres] = await Promise.all([
         Author.find().sort({ family_name: 1 }).exec(),
-        Genre.find().exec(),
+        Genre.find().sort({ name: 1 }).exec(),
       ]);
 
       // Mark our selected genres as checked.


### PR DESCRIPTION
### Description

Removed verbose sorting logic from view templates and replaced them with a `sort()` method chained to the db query in the controller files.

### Motivation

The sort() method is explained and used earlier in the tutorial in _Part 5: Displaying library data_. For some reason it is not used here in Part 6. Instead, the data is sorted inside the view templates using an extremely verbose method in comparison, making it harder to read and understand what's going on.

### Additional details

Here is where the sort method is explained in the previous section. My changes use the same syntax:
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Author_list_page
<img width="805" alt="Screenshot 2023-11-21 at 11 02 06 PM" src="https://github.com/mdn/content/assets/98435978/2fac3145-68b2-4276-b4a0-366c9929dfd3">

And here is how the sorting logic currently looks in the form sections. My changes remove this code from a number of places.

<img width="763" alt="Screenshot 2023-11-21 at 11 19 08 PM" src="https://github.com/mdn/content/assets/98435978/53c25222-d595-467f-892f-c7b710219b91">


Links to where this logic is used:
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms/Create_book_form
https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms/Create_BookInstance_form

### Related issues and pull requests
