### PR TITLE
Fix render-blocking font example

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/renderblockingstatus/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/renderblockingstatus/index.md
@@ -22,7 +22,12 @@ Render-blocking resources are static files, such as fonts, CSS, and JavaScript t
 In addition to the automatic render-blocking mechanism, `blocking="render"` can be provided as an attribute and value to {{HTMLElement("script")}}, {{HTMLElement("style")}} or {{HTMLElement("link")}} elements to specify explicit render-blocking. For example:
 
 ```html
-<link blocking="render" href="critical-font.woff2" as="font" />
+<link
+  blocking="render"
+  rel="preload"
+  href="critical-font.woff2"
+  as="font"
+  crossorigin />
 ```
 
 ## Value

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -383,7 +383,12 @@ You can include `render` token inside a `blocking` attribute;
 the rendering of the page will be blocked till the resource is fetched. For example:
 
 ```html
-<link blocking="render" href="critical-font.woff2" as="font" />
+<link
+  blocking="render"
+  rel="preload"
+  href="critical-font.woff2"
+  as="font"
+  crossorigin />
 ```
 
 ## Technical summary


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

There's a [couple of examples like this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#blocking_rendering_till_a_resource_is_fetched):

```html
<link blocking="render" href="critical-font.woff2" as="font" />
```

This doesn't make sense, especially by [MDN's own docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#:~:text=The%20rel%20attribute%20has%20no%20default%20value.):

> The rel attribute has no default value. If the attribute is omitted or if none of the values in the attribute are supported, then the document has no particular relationship with the destination resource other than there being a hyperlink between the two. In this case, on [<link>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link) and [<form>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form), if the rel attribute is absent, has no keywords, or if not one or more of the space-separated keywords above, then the element does not create any links. [<a>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) and [<area>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area) will still created links, but without a defined relationship.

This was added in #14648 but the linked explainer uses `rel=preload` and `crossorigin` which are missing here (`crossorigin` is needed for preloading fonts for CORS reasons) . So this PR adde those attributes to the example to make it valid.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Correct bad examples.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://github.com/whatwg/html/issues/7131

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Corrects example added in https://github.com/mdn/content/pull/14648

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
