### PR TITLE
Fix light-dark example in documentation

### DIFF
--- a/files/en-us/web/css/color_value/light-dark/index.md
+++ b/files/en-us/web/css/color_value/light-dark/index.md
@@ -76,7 +76,7 @@ We include three sections to enable targeting light colors, dark colors, and the
 </section>
 <section class="dark">
   <h2>Dark</h2>
-  <p>This section will be light due to the <code>color-scheme: dark;</code>.</p>
+  <p>This section will be dark due to the <code>color-scheme: dark;</code>.</p>
 </section>
 ```
 


### PR DESCRIPTION
### Description

Fix the light-dark example in the documentation to match the expected result.

### Motivation

Found an issue in the existing doc.

### Additional details

N/A

### Related issues and pull requests

N/A