### PR TITLE
corrected builtin function use

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -226,9 +226,10 @@ const fsSource = `
     varying highp vec2 vTextureCoord;
 
     uniform sampler2D uSampler;
+    out vec4 fragColor;
 
     void main(void) {
-      gl_FragColor = texture2D(uSampler, vTextureCoord);
+      fragColor = texture(uSampler, vTextureCoord);
     }
   `;
 ```


### PR DESCRIPTION
WebGL is not supporting `texture2D` builtin function and "gl_FragColor" keyword any more. As "https://stackoverflow.com/questions/12307278/texture-vs-texture2d-in-glsl" suggests, we should use `texture` instead.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

WebGL is not supporting `texture2D` builtin function and "gl_FragColor" keyword any more. We should use `texture` instead.

### Motivation

I am learning and writing code to use texture in GLSL. I used the given code but it failed

### Additional details

As the [post](https://stackoverflow.com/questions/12307278/texture-vs-texture2d-in-glsl ) suggested, see [3.30 GLSL specification](https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.3.30.pdf)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
