### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
@@ -279,7 +279,7 @@ class Server {
                     mask = (bytes[1] & 0b10000000) != 0; // must be true, "All messages from the client to the server have this bit set"
                 int opcode = bytes[0] & 0b00001111, // expecting 1 - text message
                     offset = 2;
-                ulong msglen = bytes[1] & 0b01111111;
+                ulong msglen = bytes[1] & (ulong)0b01111111;
 
                 if (msglen == 126) {
                     // bytes are reversed because websocket will print them in Big-Endian, whereas


### PR DESCRIPTION
### Description
Added an explicit cast of the integer value 0b01111111 to (ulong) to address IDE errors: CS0266 (Cannot implicitly convert type 'int' to 'ulong') and CS0034 (Operator '+' is ambiguous on operands of type 'int' and 'ulong') on lines 65 and 94 respectively (in wsserver.cs). 

### Motivation
Now the reader can have a working code out-of-the box and won't have to spend time figuring out the best way to fix it. Instead, they can work on expanding and better understanding the code.

### Additional details
Tested in Visual Studio 2022 (.NET 6.0). IDE errors before the patch:
![wsserver cs errors](https://github.com/mdn/content/assets/29168179/e88e6e0f-f237-4806-8888-234327df2eee)

### Related issues and pull requests
n/a
