### PR TITLE
href source file name typo correction

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
@@ -77,7 +77,7 @@ We can add a `<script></script>` to our document, filled with the following Java
 ```js
 const conditional = document.querySelector(".conditional");
 if (CSS.supports("grid-template-columns", "subgrid")) {
-  conditional.setAttribute("href", "subgrid-layout.css.css");
+  conditional.setAttribute("href", "subgrid-layout.css");
 }
 ```
 


### PR DESCRIPTION
### Description

Inside example code template of CSS feature detection, setAttribute() source file name is changed.

### Motivation
It displays right code to readers.

### Related issues and pull requests
n/a


