### PR TITLE
fix: improve parseFloat and parseInt explanation

### DIFF
--- a/files/en-us/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_dates/index.md
@@ -111,8 +111,8 @@ The following table summarizes the `Number` object's properties.
 
 | Method                               | Description                                                                                                                           |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| {{jsxref("Number.parseFloat()")}}    | Parses a string argument and returns a floating point number. Same as the global {{jsxref("parseFloat()")}} function.                 |
-| {{jsxref("Number.parseInt()")}}      | Parses a string argument and returns an integer of the specified radix or base. Same as the global {{jsxref("parseInt()")}} function. |
+| {{jsxref("Number.parseFloat()")}}    | Parses a value and returns a floating point number. Same as the global {{jsxref("parseFloat()")}} function.                           |
+| {{jsxref("Number.parseInt()")}}      | Parses a value and returns an integer of the specified radix or base. Same as the global {{jsxref("parseInt()")}} function.           |
 | {{jsxref("Number.isFinite()")}}      | Determines whether the passed value is a finite number.                                                                               |
 | {{jsxref("Number.isInteger()")}}     | Determines whether the passed value is an integer.                                                                                    |
 | {{jsxref("Number.isNaN()")}}         | Determines whether the passed value is {{jsxref("NaN")}}. More robust version of the original global {{jsxref("isNaN()")}}.           |


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Improve parseFloat and parseInt explanation in JavaScript Guide, Numbers and dates.

### Motivation

The `Number.parseFloat()` and `Number.parseInt()` can take any arguments (not just strings).
This might be nitpicky, but since e.g. `Number.parseInt()` is often used with floating point numbers I think this should be updated.
The wording of the change can probably be improved (e.g. "parses a value, usually a string or floating point number" instead of "parses a value").
