### PR TITLE
chore: align the description of "guides" field

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
@@ -69,8 +69,8 @@ So for example, "Response" will result in a link being created like so:
 ```
 
 There are a few exceptions.
-For example the "guides" sub-member contains the addresses that point to associated guides/tutorials.
-In this case the addresses are appended to the end of the MDN docs root — `https://developer.mozilla.org/<language-code>` — allowing an article anywhere on MDN to be included.
+For example the "guides" sub-member contains the URLs that point to associated guides/tutorials.
+In this case the URLs are appended to the end of the MDN docs root — `https://developer.mozilla.org/<language-code>` — allowing an article anywhere on MDN to be included.
 
 Here are the available members.
 These are all technically optional, but it is strongly encouraged that instead of omitting them, you include empty arrays.

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/sidebars/index.md
@@ -69,8 +69,8 @@ So for example, "Response" will result in a link being created like so:
 ```
 
 There are a few exceptions.
-For example the "guides" sub-member contains one or more sets of link information (title and slug) that defines links to associated guides/tutorials.
-In this case the slugs are appended to the end of the MDN docs root — `https://developer.mozilla.org/_<language-code>/docs` — allowing an article anywhere on MDN to be included.
+For example the "guides" sub-member contains the addresses that point to associated guides/tutorials.
+In this case the addresses are appended to the end of the MDN docs root — `https://developer.mozilla.org/<language-code>` — allowing an article anywhere on MDN to be included.
 
 Here are the available members.
 These are all technically optional, but it is strongly encouraged that instead of omitting them, you include empty arrays.


### PR DESCRIPTION
### Description

align the description of "guides" field

### Motivation

In #29844, I forgot to update the exception part. Create this to align the description.
