### PR TITLE
WebTransportSendStream docs plus WebTransportReceiveStream and friends

### DIFF
--- a/files/en-us/web/api/web_workers_api/transferable_objects/index.md
+++ b/files/en-us/web/api/web_workers_api/transferable_objects/index.md
@@ -79,6 +79,7 @@ The items that various specifications indicate can be _transferred_ are:
 - {{domxref("WritableStream")}}
 - {{domxref("TransformStream")}}
 - {{domxref("WebTransportReceiveStream")}}
+- {{domxref("WebTransportSendStream")}}
 - {{domxref("AudioData")}}
 - {{domxref("ImageBitmap")}}
 - {{domxref("VideoFrame")}}

--- a/files/en-us/web/api/webtransport/createbidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createbidirectionalstream/index.md
@@ -50,7 +50,7 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("WebTransportBidirectionalS
 
 ## Examples
 
-An initial function is used to get references to the {{domxref("WebTransportBidirectionalStream.readable")}} and {{domxref("WebTransportBidirectionalStream.writable")}} properties. These are references to `ReadableStream` and `WritableStream` instances, which can be used to read from and write to the server.
+An initial function is used to get references to the {{domxref("WebTransportBidirectionalStream.readable")}} and {{domxref("WebTransportBidirectionalStream.writable")}} properties. These are references to `WebTransportReceiveStream` and `WebTransportSendStream` instances, which are readable and writable streams that can be used to read from and write to the server.
 
 ```js
 async function setUpBidirectional() {
@@ -67,7 +67,7 @@ async function setUpBidirectional() {
 }
 ```
 
-Reading from the `ReadableStream` can then be done as follows:
+Reading from the `WebTransportReceiveStream` can then be done as follows:
 
 ```js
 async function readData(readable) {
@@ -83,7 +83,7 @@ async function readData(readable) {
 }
 ```
 
-And writing to the `WritableStream` can be done like this:
+And writing to the `WebTransportSendStream` can be done like this:
 
 ```js
 async function writeData(writable) {
@@ -106,6 +106,7 @@ async function writeData(writable) {
 ## See also
 
 - [Using WebTransport](https://developer.chrome.com/articles/webtransport/)
+- {{domxref("WebTransport.createUnidirectionalStream()")}}
 - {{domxref("WebSockets API", "WebSockets API", "", "nocode")}}
 - {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [WebTransport over HTTP/3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/)

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -10,7 +10,8 @@ browser-compat: api.WebTransport.createUnidirectionalStream
 
 The **`createUnidirectionalStream()`** method of the {{domxref("WebTransport")}} interface asynchronously opens a unidirectional stream.
 
-The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WritableStream")}} object, which can be used to reliably write data to the server.
+The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WebTransportSendStream")}} object.
+This object inherits from {{domxref("WriteableStream")}}, and can be used to reliably write data to the server, and to query stream statistics and other information.
 
 "Reliable" means that transmission and order of data are guaranteed. This provides slower delivery (albeit faster than with WebSockets) than {{domxref("WebTransport.datagrams", "datagrams")}}, but is needed in situations where reliability and ordering are important, like chat applications.
 
@@ -41,7 +42,10 @@ createUnidirectionalStream(options)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object (this is a {{domxref("WritableStream")}}).
+A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object.
+
+Note that this object inherits from {{domxref("WritableStream")}}.
+Implementations based on older versions of the specficiatoion may return a `WritableStream` instead.
 
 ### Exceptions
 
@@ -50,7 +54,8 @@ A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object (this
 
 ## Examples
 
-Use the `createUnidirectionalStream()` method to get a reference to a {{domxref("WritableStream")}}. From this you can {{domxref("WritableStream.getWriter", "get a writer", "", "nocode")}} to allow data to be written to the stream and sent to the server.
+Use the `createUnidirectionalStream()` method to get a reference to a {{domxref("WebTransportSendStream")}}.
+From this you can {{domxref("WritableStream.getWriter", "get a writer", "", "nocode")}} to allow data to be written to the stream and sent to the server.
 
 Use the {{domxref("WritableStreamDefaultWriter.close", "close()")}} method of the resulting {{domxref("WritableStreamDefaultWriter")}} to close the associated HTTP/3 connection. The browser tries to send all pending data before actually closing the associated connection.
 
@@ -101,6 +106,7 @@ await writer.abort();
 ## See also
 
 - [Using WebTransport](https://developer.chrome.com/articles/webtransport/)
+- {{domxref("WebTransport.createBidirectionalStream()")}}
 - {{domxref("WebSockets API", "WebSockets API", "", "nocode")}}
 - {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [WebTransport over HTTP/3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/)

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -10,8 +10,8 @@ browser-compat: api.WebTransport.createUnidirectionalStream
 
 The **`createUnidirectionalStream()`** method of the {{domxref("WebTransport")}} interface asynchronously opens a unidirectional stream.
 
-The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WebTransportSendStream")}} object.
-This object inherits from {{domxref("WritableStream")}}, and can be used to reliably write data to the server, and to query stream statistics and other information.
+The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WritableStream")}} object, which can be used to reliably write data to the server.
+<!-- Note, returns a `WebTransportSendStream` according to spec, but not yet implemented -->
 
 "Reliable" means that transmission and order of data are guaranteed. This provides slower delivery (albeit faster than with WebSockets) than {{domxref("WebTransport.datagrams", "datagrams")}}, but is needed in situations where reliability and ordering are important, like chat applications.
 
@@ -42,10 +42,7 @@ createUnidirectionalStream(options)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a {{domxref("WebTransportSendStream")}} object.
-
-Note that this object inherits from {{domxref("WritableStream")}}.
-Implementations based on older versions of the specification may return a `WritableStream` instead.
+A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object (this is a {{domxref("WritableStream")}}).
 
 ### Exceptions
 
@@ -54,8 +51,7 @@ Implementations based on older versions of the specification may return a `Writa
 
 ## Examples
 
-Use the `createUnidirectionalStream()` method to get a reference to a {{domxref("WebTransportSendStream")}}.
-From this you can {{domxref("WritableStream.getWriter", "get a writer", "", "nocode")}} to allow data to be written to the stream and sent to the server.
+Use the `createUnidirectionalStream()` method to get a reference to a {{domxref("WritableStream")}}. From this you can {{domxref("WritableStream.getWriter", "get a writer", "", "nocode")}} to allow data to be written to the stream and sent to the server.
 
 Use the {{domxref("WritableStreamDefaultWriter.close", "close()")}} method of the resulting {{domxref("WritableStreamDefaultWriter")}} to close the associated HTTP/3 connection. The browser tries to send all pending data before actually closing the associated connection.
 

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -45,7 +45,7 @@ createUnidirectionalStream(options)
 A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object.
 
 Note that this object inherits from {{domxref("WritableStream")}}.
-Implementations based on older versions of the specficiatoion may return a `WritableStream` instead.
+Implementations based on older versions of the specification may return a `WritableStream` instead.
 
 ### Exceptions
 

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -11,6 +11,7 @@ browser-compat: api.WebTransport.createUnidirectionalStream
 The **`createUnidirectionalStream()`** method of the {{domxref("WebTransport")}} interface asynchronously opens a unidirectional stream.
 
 The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WritableStream")}} object, which can be used to reliably write data to the server.
+
 <!-- Note, returns a `WebTransportSendStream` according to spec, but not yet implemented -->
 
 "Reliable" means that transmission and order of data are guaranteed. This provides slower delivery (albeit faster than with WebSockets) than {{domxref("WebTransport.datagrams", "datagrams")}}, but is needed in situations where reliability and ordering are important, like chat applications.

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -42,7 +42,7 @@ createUnidirectionalStream(options)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a `WebTransportSendStream` object.
+A {{jsxref("Promise")}} that resolves to a {{domxref("WebTransportSendStream")}} object.
 
 Note that this object inherits from {{domxref("WritableStream")}}.
 Implementations based on older versions of the specification may return a `WritableStream` instead.

--- a/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransport/createunidirectionalstream/index.md
@@ -11,7 +11,7 @@ browser-compat: api.WebTransport.createUnidirectionalStream
 The **`createUnidirectionalStream()`** method of the {{domxref("WebTransport")}} interface asynchronously opens a unidirectional stream.
 
 The method returns a {{jsxref("Promise")}} that resolves to a {{domxref("WebTransportSendStream")}} object.
-This object inherits from {{domxref("WriteableStream")}}, and can be used to reliably write data to the server, and to query stream statistics and other information.
+This object inherits from {{domxref("WritableStream")}}, and can be used to reliably write data to the server, and to query stream statistics and other information.
 
 "Reliable" means that transmission and order of data are guaranteed. This provides slower delivery (albeit faster than with WebSockets) than {{domxref("WebTransport.datagrams", "datagrams")}}, but is needed in situations where reliability and ordering are important, like chat applications.
 

--- a/files/en-us/web/api/webtransport_api/index.md
+++ b/files/en-us/web/api/webtransport_api/index.md
@@ -96,13 +96,18 @@ async function readData() {
 
 "Reliable" means that transmission and order of data are guaranteed. That provides slower delivery (albeit faster than with WebSockets), and is needed in situations where reliability and ordering are important (such as chat applications, for example).
 
+When using reliable transmission via streams you can also set the relative priority of different streams over the same transport.
+
 ### Unidirectional transmission
 
-To open a unidirectional stream from a user agent, you use the {{domxref("WebTransport.createUnidirectionalStream()")}} method to get a reference to a {{domxref("WritableStream")}}. From this you can {{domxref("WritableStream.getWriter", "get a writer")}} to allow data to be written to the stream and sent to the server.
+To open a unidirectional stream from a user agent, you use the {{domxref("WebTransport.createUnidirectionalStream()")}} method to get a reference to a {{domxref("WebTransportSendStream")}}.
+The `sendorder` property in the object passed as an argument is a number that sets the relative priority of this stream compared to other streams using the transport (bytes are sent first on streams with a higher number).
 
 ```js
 async function writeData() {
-  const stream = await transport.createUnidirectionalStream();
+  const stream = await transport.createUnidirectionalStream({
+    sendOrder: "999995555",
+  });
   const writer = stream.writable.getWriter();
   const data1 = new Uint8Array([65, 66, 67]);
   const data2 = new Uint8Array([68, 69, 70]);
@@ -118,9 +123,14 @@ async function writeData() {
 }
 ```
 
+The returned {{domxref("WebTransportSendStream")}} object inherits from {{domxref("WritableStream")}}, and can be used to {{domxref("WritableStream.getWriter", "get a writer")}} that allows data to be written to the stream and sent to the server.
+It can also be used to get statistics and other information for the stream.
+
 Note also the use of the {{domxref("WritableStreamDefaultWriter.close()")}} method to close the associated HTTP/3 connection once all data has been sent.
 
-If the server opens a unidirectional stream to transmit data to the client, this can be accessed via the {{domxref("WebTransport.incomingUnidirectionalStreams")}} property, which returns a {{domxref("ReadableStream")}} of `WebTransportReceiveStream` objects. Each one can be used to read {{jsxref("Uint8Array")}} instances sent by the server.
+If the server opens a unidirectional stream to transmit data to the client, this can be accessed on the client via the {{domxref("WebTransport.incomingUnidirectionalStreams")}} property, which returns a {{domxref("ReadableStream")}} of {{domxref("WebTransportReceiveStream")}} objects. These can be used to read {{jsxref("Uint8Array")}} instances sent by the server.
+
+> **Note:** In earlier versions of the specification `ReadableStream` and `WritableStream` were used as receive and send streams for unidirectional and bidirectional streams intead of `WebTransportReceiveStream` and `WebTransportSendStream`.
 
 In this case, the first thing to do is set up a function to read a `WebTransportReceiveStream`. These objects inherit from the `ReadableStream` class, so can be used in just the same way:
 
@@ -157,22 +167,25 @@ async function receiveUnidirectional() {
 
 #### Bidirectional transmission
 
-To open a bidirectional stream from a user agent, you use the {{domxref("WebTransport.createBidirectionalStream()")}} method to get a reference to a {{domxref("WebTransportBidirectionalStream")}}. In the same way as the {{domxref("WebTransportDatagramDuplexStream")}}, this contains `readable` and `writable` properties returning references to `ReadableStream` and `WritableStream` instances, which can be used to read from and write to the server.
+To open a bidirectional stream from a user agent, you use the {{domxref("WebTransport.createBidirectionalStream()")}} method to get a reference to a {{domxref("WebTransportBidirectionalStream")}}.
+This contains `readable` and `writable` properties returning references to `WebTransportReceiveStream` and `WebTransportSendStream` instances that can be used to read from and write to the server.
+
+> **Note:** `WebTransportBidirectionalStream` is similar to {{domxref("WebTransportDatagramDuplexStream")}}, except that in that interface the `readable` and `writable` properties are `ReadableStream` and `WritableStream` respectively.
 
 ```js
 async function setUpBidirectional() {
   const stream = await transport.createBidirectionalStream();
   // stream is a WebTransportBidirectionalStream
-  // stream.readable is a ReadableStream
+  // stream.readable is a WebTransportReceiveStream
   const readable = stream.readable;
-  // stream.writable is a WritableStream
+  // stream.writable is a WebTransportSendStream
   const writable = stream.writable;
 
   ...
 }
 ```
 
-Reading from the `ReadableStream` can then be done as follows:
+Reading from the `WebTransportReceiveStream` can then be done as follows:
 
 ```js
 async function readData(readable) {
@@ -188,7 +201,7 @@ async function readData(readable) {
 }
 ```
 
-And writing to the `WritableStream` can be done like this:
+And writing to the `WebTransportSendStream` can be done like this:
 
 ```js
 async function writeData(writable) {
@@ -228,6 +241,10 @@ async function receiveBidirectional() {
   - : Represents a duplex stream that can be used for unreliable transport of datagrams between client and server. Provides access to a {{domxref("ReadableStream")}} for reading incoming datagrams, a {{domxref("WritableStream")}} for writing outgoing datagrams, and various settings and statistics related to the stream.
 - {{domxref("WebTransportError")}}
   - : Represents an error related to the WebTransport API, which can arise from server errors, network connection problems, or client-initiated abort operations (for example, arising from a {{domxref("WritableStream.abort()")}} call).
+- {{domxref("WebTransportReceiveStream")}}
+  - : Provides streaming features for an incoming WebTransport unidirectional or bidirectional {{domxref("WebTransport")}} stream.
+- {{domxref("WebTransportSendStream")}}
+  - : Provides streaming features for an outgoing WebTransport unidirectional or bidirectional {{domxref("WebTransport")}} stream.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransport_api/index.md
+++ b/files/en-us/web/api/webtransport_api/index.md
@@ -100,14 +100,11 @@ When using reliable transmission via streams you can also set the relative prior
 
 ### Unidirectional transmission
 
-To open a unidirectional stream from a user agent, you use the {{domxref("WebTransport.createUnidirectionalStream()")}} method to get a reference to a {{domxref("WebTransportSendStream")}}.
-The `sendorder` property in the object passed as an argument is a number that sets the relative priority of this stream compared to other streams using the transport (bytes are sent first on streams with a higher number).
+To open a unidirectional stream from a user agent, you use the {{domxref("WebTransport.createUnidirectionalStream()")}} method to get a reference to a {{domxref("WritableStream")}}. From this you can {{domxref("WritableStream.getWriter", "get a writer")}} to allow data to be written to the stream and sent to the server.
 
 ```js
 async function writeData() {
-  const stream = await transport.createUnidirectionalStream({
-    sendOrder: "999995555",
-  });
+  const stream = await transport.createUnidirectionalStream();
   const writer = stream.writable.getWriter();
   const data1 = new Uint8Array([65, 66, 67]);
   const data2 = new Uint8Array([68, 69, 70]);
@@ -123,14 +120,9 @@ async function writeData() {
 }
 ```
 
-The returned {{domxref("WebTransportSendStream")}} object inherits from {{domxref("WritableStream")}}, and can be used to {{domxref("WritableStream.getWriter", "get a writer")}} that allows data to be written to the stream and sent to the server.
-It can also be used to get statistics and other information for the stream.
-
 Note also the use of the {{domxref("WritableStreamDefaultWriter.close()")}} method to close the associated HTTP/3 connection once all data has been sent.
 
 If the server opens a unidirectional stream to transmit data to the client, this can be accessed on the client via the {{domxref("WebTransport.incomingUnidirectionalStreams")}} property, which returns a {{domxref("ReadableStream")}} of {{domxref("WebTransportReceiveStream")}} objects. These can be used to read {{jsxref("Uint8Array")}} instances sent by the server.
-
-> **Note:** In earlier versions of the specification `ReadableStream` and `WritableStream` were used as receive and send streams for unidirectional and bidirectional streams intead of `WebTransportReceiveStream` and `WebTransportSendStream`.
 
 In this case, the first thing to do is set up a function to read a `WebTransportReceiveStream`. These objects inherit from the `ReadableStream` class, so can be used in just the same way:
 

--- a/files/en-us/web/api/webtransportbidirectionalstream/index.md
+++ b/files/en-us/web/api/webtransportbidirectionalstream/index.md
@@ -7,7 +7,7 @@ browser-compat: api.WebTransportBidirectionalStream
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}}
 
-The **`WebTransportBidirectionalStream`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a bidirectional stream created by a server or a client that can be used for reliable transport. Provides access to a {{domxref("ReadableStream")}} for reading incoming data, and a {{domxref("WritableStream")}} for writing outgoing data.
+The **`WebTransportBidirectionalStream`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a bidirectional stream created by a server or a client that can be used for reliable transport. Provides access to a {{domxref("WebTransportReceiveStream")}} for reading incoming data, and a {{domxref("WebTransportSendStream")}} for writing outgoing data.
 
 {{InheritanceDiagram}}
 
@@ -16,30 +16,31 @@ The **`WebTransportBidirectionalStream`** interface of the {{domxref("WebTranspo
 ## Instance properties
 
 - {{domxref("WebTransportBidirectionalStream.readable", "readable")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("ReadableStream")}} instance that can be used to read incoming data.
+  - : Returns a {{domxref("WebTransportReceiveStream")}} instance that can be used to read incoming data.
 - {{domxref("WebTransportBidirectionalStream.writable", "writable")}} {{ReadOnlyInline}}
-  - : Returns a {{domxref("WritableStream")}} instance that can be used to write outgoing data.
+  - : Returns a {{domxref("WebTransportSendStream")}} instance that can be used to write outgoing data.
 
 ## Examples
 
 ### Bidirectional transmission initiated by the user agent
 
-To open a bidirectional stream from a user agent, you use the {{domxref("WebTransport.createBidirectionalStream()")}} method to get a reference to a {{domxref("WebTransportBidirectionalStream")}}. The `readable` and `writable` properties return references to `ReadableStream` and `WritableStream` instances, which can be used to read from and write to the server.
+To open a bidirectional stream from a user agent, you use the {{domxref("WebTransport.createBidirectionalStream()")}} method to get a reference to a {{domxref("WebTransportBidirectionalStream")}}. The `readable` and `writable` properties return references to `WebTransportReceiveStream` and `WebTransportSendStream` instances.
+These inherit from `ReadableStream` and `WebTransportReceiveStream` respectively, and can be used to read from and write to the server.
 
 ```js
 async function setUpBidirectional() {
   const stream = await transport.createBidirectionalStream();
   // stream is a WebTransportBidirectionalStream
-  // stream.readable is a ReadableStream
+  // stream.readable is a WebTransportReceiveStream
   const readable = stream.readable;
-  // stream.writable is a WritableStream
+  // stream.writable is a WebTransportSendStream
   const writable = stream.writable;
 
   ...
 }
 ```
 
-Reading from the `ReadableStream` can then be done as follows:
+Reading from the `WebTransportReceiveStream` can be done in the same way as you would read a `ReadableStream`:
 
 ```js
 async function readData(readable) {
@@ -55,7 +56,7 @@ async function readData(readable) {
 }
 ```
 
-And writing to the `WritableStream` can be done like this:
+And writing to the `WebTransportSendStream` can be done like this:
 
 ```js
 async function writeData(writable) {

--- a/files/en-us/web/api/webtransportbidirectionalstream/readable/index.md
+++ b/files/en-us/web/api/webtransportbidirectionalstream/readable/index.md
@@ -8,13 +8,13 @@ browser-compat: api.WebTransportBidirectionalStream.readable
 
 {{APIRef("WebTransport API")}}
 
-The **`readable`** read-only property of the {{domxref("WebTransportBidirectionalStream")}} interface returns a {{domxref("ReadableStream")}} instance that can be used to reliably read incoming data.
+The **`readable`** read-only property of the {{domxref("WebTransportBidirectionalStream")}} interface returns a {{domxref("WebTransportReceiveStream")}} instance that can be used to reliably read incoming data.
 
 {{AvailableInWorkers}}
 
 ## Value
 
-A {{domxref("ReadableStream")}}.
+A {{domxref("WebTransportReceiveStream")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportbidirectionalstream/writable/index.md
+++ b/files/en-us/web/api/webtransportbidirectionalstream/writable/index.md
@@ -8,13 +8,13 @@ browser-compat: api.WebTransportBidirectionalStream.writable
 
 {{APIRef("WebTransport API")}}
 
-The **`writable`** read-only property of the {{domxref("WebTransportBidirectionalStream")}} interface returns a {{domxref("WritableStream")}} instance that can be used to write outgoing data.
+The **`writable`** read-only property of the {{domxref("WebTransportBidirectionalStream")}} interface returns a {{domxref("WebTransportSendStream")}} instance that can be used to write outgoing data.
 
 {{AvailableInWorkers}}
 
 ## Value
 
-A {{domxref("WritableStream")}}.
+A {{domxref("WebTransportSendStream")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportreceivestream/getstats/index.md
+++ b/files/en-us/web/api/webtransportreceivestream/getstats/index.md
@@ -44,7 +44,7 @@ The returned object has the following properties:
 ## Examples
 
 The code snippet below uses `await` to wait on the {{jsxref("Promise")}} returned by `getStats()`.
-When the promise fulfills, the result for the `bytesSent` property in the stats object is logged to the console.
+When the promise fulfills, the number of bytes that have not yet been read is logged to the console.
 
 ```js
 const stats = await stream.getStats();

--- a/files/en-us/web/api/webtransportreceivestream/index.md
+++ b/files/en-us/web/api/webtransportreceivestream/index.md
@@ -7,9 +7,9 @@ status:
 browser-compat: api.WebTransportReceiveStream
 ---
 
-{{APIRef("WebTransport API")}}{{SeeCompatTable}}
+{{APIRef("WebTransport API")}}{{SeeCompatTable}}{{securecontext_header}}
 
-The `WebTransportReceiveStream` interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} is a {{domxref("ReadableStream")}} that can be used to read from an incoming unidirectional or bidirectional {{domxref("WebTransport")}} stream from a server.
+The `WebTransportReceiveStream` interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} is a {{domxref("ReadableStream")}} that can be used to read from an incoming unidirectional or bidirectional {{domxref("WebTransport")}} stream.
 
 The stream is a [readable byte stream](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams) of [`Uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), and can be consumed using either a BYOB reader ([`ReadableStreamBYOBReader`](/en-US/docs/Web/API/ReadableStreamBYOBReader)) or the default reader ([`ReadableStreamDefaultReader`](/en-US/docs/Web/API/ReadableStreamDefaultReader)).
 

--- a/files/en-us/web/api/webtransportsendstream/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendstream/getstats/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.WebTransportSendStream.getStats
 ---
 
-{{APIRef("WebTransport API")}}{{SeeCompatTable}}
+{{APIRef("WebTransport API")}}{{SeeCompatTable}}{{securecontext_header}}
 
 The **`getStats()`** method of the {{domxref("WebTransportSendStream")}} interface asynchronously returns an object containing statistics for the current stream.
 

--- a/files/en-us/web/api/webtransportsendstream/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendstream/getstats/index.md
@@ -1,0 +1,65 @@
+---
+title: "WebTransportSendStream: getStats() method"
+short-title: getStats()
+slug: Web/API/WebTransportSendStream/getStats
+page-type: web-api-instance-method
+status:
+  - experimental
+browser-compat: api.WebTransportSendStream.getStats
+---
+
+{{APIRef("WebTransport API")}}{{SeeCompatTable}}
+
+The **`getStats()`** method of the {{domxref("WebTransportSendStream")}} interface asynchronously returns an object containing statistics for the current stream.
+
+The statistics include the total number of bytes written to the stream, the number that have been sent (ignoring packet overhead), and the number of bytes that have been set at least once, and the number that have been acknowledged (up until the first sequentially-ordered non-acknowledged byte).
+It therefore provides a measure of how quickly the application is sending bytes to the server on this particular stream.
+
+{{AvailableInWorkers}}
+
+## Syntax
+
+```js-nolint
+getStats()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to a object containing statistics about the current stream.
+The returned object has the following properties:
+
+- `bytesAcknowledged`
+  - : A positive integer indicating the number of bytes written to this stream that have been sent and acknowledged as received by the server, using QUIC's ACK mechanism.
+    Only sequential bytes up to, but not including, the first non-acknowledged byte, are counted.
+    This number can only increase and is always less than or equal to `bytesSent`.
+    When the connection is over HTTP/2, the value will match `bytesSent`.
+- `bytesSent`
+  - : A positive integer indicating the number of bytes written to this stream that have been sent at least once (but not necessarily acknowledged).
+    This number can only increase, and is always less than or equal to `bytesWritten`.
+    Note that this count does not include bytes sent as network overhead (such as packet headers).
+- `bytesWritten`
+  - : A positive integer indicating the number of bytes successfully written to this stream.
+    This number can only increase.
+
+## Examples
+
+The code snippet below uses `await` to wait on the {{jsxref("Promise")}} returned by `getStats()`.
+When the promise fulfills, the result for the number of bytes that have been sent but not acknowledged is logged to the console.
+
+```js
+const stats = await stream.getStats();
+const bytesNotReceived = stats.bytesWritten - stats.bytesAcknowledged;
+console.log(`Bytes still successfully sent: ${bytesNotReceived}`);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/webtransportsendstream/index.md
+++ b/files/en-us/web/api/webtransportsendstream/index.md
@@ -39,7 +39,7 @@ _Also inherits methods from its parent interface, {{domxref("WritableStream")}}.
 <!-- WebTransportSendStream.sendGroup not implemented in any browser -->
 
 - {{domxref("WebTransportSendStream.sendOrder")}} {{Experimental_Inline}}
-  - : ?.
+  - : Indicates the send priority of this stream relative to other streams for which the value has been set.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportsendstream/index.md
+++ b/files/en-us/web/api/webtransportsendstream/index.md
@@ -1,0 +1,60 @@
+---
+title: WebTransportSendStream
+slug: Web/API/WebTransportSendStream
+page-type: web-api-interface
+status:
+  - experimental
+browser-compat: api.WebTransportSendStream
+---
+
+{{APIRef("WebTransport API")}}{{SeeCompatTable}}{{securecontext_header}}
+
+The `WebTransportSendStream` interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} is a specialized {{domxref("WritableStream")}} that is used to send outbound data in both unidirectional or bidirectional {{domxref("WebTransport")}} streams.
+
+The send stream is a [writable stream](/en-US/docs/Web/API/Streams_API/Using_writable_streams) of [`Uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), that can be written to in order to send data to a server.
+It additionally provides streaming features such as setting the send order, and getting stream statistics.
+
+Objects of this type are not constructed directly.
+When creating a unidirectional stream the {{domxref("WebTransport.createUnidirectionalStream()")}} returns an object of this type for sending data.
+When creating a bidirectional stream using {{domxref("WebTransport.createBidirectionalStream()")}}, the method returns a {{domxref("WebTransportBidirectionalStream")}}, and the send stream object can be obtained from its {{domxref("WebTransportBidirectionalStream.writable", "writable")}} property.
+When a bidirectional stream is initiated by the remote end, an object of this type can similarly be obtained using {{domxref("WebTransport.incomingBidirectionalStreams")}}.
+
+`WebTransportSendStream` is a [transferable object](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects).
+
+{{InheritanceDiagram}}
+
+{{AvailableInWorkers}}
+
+## Instance properties
+
+_Also inherits properties from its parent interface, {{domxref("WritableStream")}}._
+
+- {{domxref("WebTransportSendStream.getStats()")}} {{Experimental_Inline}}
+  - : Returns a {{jsxref("Promise")}} that resolves with statistics related to this stream.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{domxref("WritableStream")}}._
+
+<!-- WebTransportSendStream.sendGroup not implemented in any browser -->
+
+- {{domxref("WebTransportSendStream.sendOrder")}} {{Experimental_Inline}}
+  - : ?.
+
+## Examples
+
+See [`WebTransport.incomingUnidirectionalStreams`](/en-US/docs/Web/API/WebTransport/incomingUnidirectionalStreams) for an example of how to get a {{domxref("ReadableStream")}} of `WebTransportSendStream` objects.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using WebTransport](https://developer.chrome.com/articles/webtransport/)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [WebTransport over HTTP/3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/)

--- a/files/en-us/web/api/webtransportsendstream/sendorder/index.md
+++ b/files/en-us/web/api/webtransportsendstream/sendorder/index.md
@@ -1,0 +1,60 @@
+---
+title: "WebTransportSendStream: sendOrder property"
+short-title: sendOrder
+slug: Web/API/WebTransportSendStream/sendOrder
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.WebTransportSendStream.sendOrder
+---
+
+{{APIRef("WebTransport API")}}{{SeeCompatTable}}{{securecontext_header}}
+
+The **`sendOrder`** property of the {{domxref("WebTransportSendStream")}} interface indicates the send priority of this stream relative to other streams for which the value has been set.
+
+Queued bytes are sent first for streams that have a higher value.
+If not set, the send order depends on the implementation.
+
+{{AvailableInWorkers}}
+
+## Value
+
+A number indicating the relative priority of this stream when sending bytes.
+
+## Examples
+
+The example below shows how you can set the initial `sendOrder` when calling {{domxref("WebTransport.createUnidirectionalStream()")}} to create the send stream, read the value from the stream, and then change the order.
+After changing the order the priority of this stream would increase, becoming higher than any stream with a priority of less than "596996858".
+
+```js
+async function writeData() {
+  const stream = await transport.createUnidirectionalStream({
+    sendOrder: "400", // Set initial stream order
+  });
+
+  console.log(`Stream order: ${stream.sendOrder}`); // Stream order: 400
+
+  // write data ...
+
+  // Change the stream order
+  stream.sendOrder = 596996858;
+  console.log(`Stream order: ${stream.sendOrder}`); // Stream order: 596996858
+
+  // write more data ...
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using WebTransport](https://developer.chrome.com/articles/webtransport/)
+- {{domxref("WebSockets API", "WebSockets API", "", "nocode")}}
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [WebTransport over HTTP/3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/)

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -2165,6 +2165,7 @@
         "WebTransportBidirectionalStream",
         "WebTransportDatagramDuplexStream",
         "WebTransportReceiveStream",
+        "WebTransportSendStream",
         "WebTransportError"
       ],
       "methods": [],


### PR DESCRIPTION
`WebTransportSendStream` was added to FF114 and `WebTransportSendStream.sendOrder` was added in FF121. This adds documentation for the interface and associated changes. 

`WebTransportSendStream` inherits from `WriteableStream` and is the output send-stream counterpart of `WebTransportReceiveStream`. Essentially it is a writable stream that provides statistics for the stream, and means to change the send order priority after creating the stream. 

Previous versions of the spec used readable/writable streams for these two, and those are compatible except for this additional information.

What I have done is changed to use the new interfaces as per the docs. I have mentioned that the old spec did different things in a few places, and will update BCD too where appropriate.

Note that `WebTransportSendStream` should also be returned by [createUnidirectionalStream](https://pr30486.content.dev.mdn.mozit.cloud/en-US/docs/Web/API/WebTransport/createUnidirectionalStream) according tothe spec, but is not by any implementation.

Related docs work can be tracked in #30481