### PR TITLE
Remove extraneous capitalization

### DIFF
--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -10,7 +10,7 @@ page-type: guide
 
 {{EmbedInteractiveExample("pages/js/expressions-operatorprecedence.html")}}
 
-## Precedence And Associativity
+## Precedence and Associativity
 
 Consider an expression describable by the representation below, where both `OP1` and `OP2` are fill-in-the-blanks for OPerators.
 

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -10,7 +10,7 @@ page-type: guide
 
 {{EmbedInteractiveExample("pages/js/expressions-operatorprecedence.html")}}
 
-## Precedence and Associativity
+## Precedence and associativity
 
 Consider an expression describable by the representation below, where both `OP1` and `OP2` are fill-in-the-blanks for OPerators.
 


### PR DESCRIPTION
Conjunctions like _and_, or _articles_, are not capitalized in titles, unless they start it (which is not the case here).