### PR TITLE
Fix: nits and improvements for `console` pages - follow-up of #30065

### DIFF
--- a/files/en-us/web/api/console/assert_static/index.md
+++ b/files/en-us/web/api/console/assert_static/index.md
@@ -74,3 +74,9 @@ details.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.assert()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#assert)
+- [Node.JS documentation for `console.assert()`](https://nodejs.org/docs/latest/api/console.html#consoleassertvalue-message)
+- [Google Chrome's documentation for `console.dir()`](https://developer.chrome.com/docs/devtools/console/api/#dir)

--- a/files/en-us/web/api/console/assert_static/index.md
+++ b/files/en-us/web/api/console/assert_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.assert_static
 
 {{APIRef("Console API")}}
 
-The **`console.assert()`** method writes an error message to the console if the assertion is false. If the assertion is true, nothing happens.
+The **`console.assert()`** static method writes an error message to the console if the assertion is false. If the assertion is true, nothing happens.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/assert_static/index.md
+++ b/files/en-us/web/api/console/assert_static/index.md
@@ -29,11 +29,11 @@ assert(assertion, msg, subst1, /* …, */ substN)
 - `assertion`
   - : Any boolean expression. If the assertion is false, the message is written to the console.
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output to the console.
 - `msg`
-  - : A JavaScript string containing zero or more substitution strings.
+  - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within `msg`. This parameter gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 
 ### Return value
 

--- a/files/en-us/web/api/console/assert_static/index.md
+++ b/files/en-us/web/api/console/assert_static/index.md
@@ -8,8 +8,7 @@ browser-compat: api.console.assert_static
 
 {{APIRef("Console API")}}
 
-The **`console.assert()`** method writes an error message to
-the console if the assertion is false. If the assertion is true, nothing happens.
+The **`console.assert()`** method writes an error message to the console if the assertion is false. If the assertion is true, nothing happens.
 
 {{AvailableInWorkers}}
 
@@ -28,17 +27,13 @@ assert(assertion, msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `assertion`
-  - : Any boolean expression. If the assertion is false, the message is written to the
-    console.
+  - : Any boolean expression. If the assertion is false, the message is written to the console.
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these
-    objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within
-    `msg`. This parameter gives you additional control over the format of the
-    output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This parameter gives you additional control over the format of the output.
 
 ### Return value
 
@@ -46,8 +41,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-The following code example demonstrates the use of a JavaScript object following the
-assertion:
+The following code example demonstrates the use of a JavaScript object following the assertion:
 
 ```js
 const errorMsg = "the # is not even";
@@ -64,8 +58,7 @@ for (let number = 2; number <= 5; number++) {
 // Assertion failed: {number: 5, errorMsg: "the # is not even"}
 ```
 
-See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) in the documentation of {{domxref("console")}} for further
-details.
+See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) in the documentation of {{domxref("console")}} for further details.
 
 ## Specifications
 

--- a/files/en-us/web/api/console/clear_static/index.md
+++ b/files/en-us/web/api/console/clear_static/index.md
@@ -31,3 +31,9 @@ None ({{jsxref("undefined")}}).
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.clear()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#clear)
+- [Node.JS documentation for `console.clear()`](https://nodejs.org/docs/latest/api/console.html#consoleclear)
+- [Google Chrome's documentation for `console.clear()`](https://developer.chrome.com/docs/devtools/console/api/#clear)

--- a/files/en-us/web/api/console/clear_static/index.md
+++ b/files/en-us/web/api/console/clear_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.clear_static
 
 {{APIRef("Console API")}}
 
-The **`console.clear()`** method clears the console if the console allows it. A graphical console, like those running on browsers, will allow it; a console displaying on the terminal, like the one running on Node, will not support it, and will have no effect (and no error).
+The **`console.clear()`** static method clears the console if the console allows it. A graphical console, like those running on browsers, will allow it; a console displaying on the terminal, like the one running on Node, will not support it, and will have no effect (and no error).
 
 ## Syntax
 

--- a/files/en-us/web/api/console/count_static/index.md
+++ b/files/en-us/web/api/console/count_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.count_static
 
 {{APIRef("Console API")}}
 
-The **`console.count()`** method logs the number of times that this particular call to `count()` has been called.
+The **`console.count()`** static method logs the number of times that this particular call to `count()` has been called.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/count_static/index.md
+++ b/files/en-us/web/api/console/count_static/index.md
@@ -99,3 +99,9 @@ We're now maintaining separate counts based only on the value of `label`.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.count()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#count)
+- [Node.JS documentation for `console.count()`](https://nodejs.org/docs/latest/api/console.html#consolecountlabel)
+- [Google Chrome's documentation for `console.count()`](https://developer.chrome.com/docs/devtools/console/api/#count)

--- a/files/en-us/web/api/console/count_static/index.md
+++ b/files/en-us/web/api/console/count_static/index.md
@@ -59,7 +59,7 @@ Console output will look something like this:
 
 The label is displayed as `default` because no explicit label was supplied.
 
-If we pass the `user` variable as the `label` argument to the first invocation of `count()`, and the string "alice" to the second:
+If we pass the `user` variable as the `label` argument to the first invocation of `console.count()`, and the string "alice" to the second:
 
 ```js
 let user = "";

--- a/files/en-us/web/api/console/count_static/index.md
+++ b/files/en-us/web/api/console/count_static/index.md
@@ -8,8 +8,7 @@ browser-compat: api.console.count_static
 
 {{APIRef("Console API")}}
 
-The **`console.count()`** method logs the number of times that
-this particular call to `count()` has been called.
+The **`console.count()`** method logs the number of times that this particular call to `count()` has been called.
 
 {{AvailableInWorkers}}
 
@@ -23,9 +22,7 @@ count(label)
 ### Parameters
 
 - `label` {{Optional_Inline}}
-  - : A string. If supplied, `count()` outputs the number of
-    times it has been called with that label. If omitted, `count()` behaves as
-    though it was called with the "default" label.
+  - : A string. If supplied, `count()` outputs the number of times it has been called with that label. If omitted, `count()` behaves as though it was called with the "default" label.
 
 ### Return value
 
@@ -62,8 +59,7 @@ Console output will look something like this:
 
 The label is displayed as `default` because no explicit label was supplied.
 
-If we pass the `user` variable as the `label` argument to the
-first invocation of `count()`, and the string "alice" to the second:
+If we pass the `user` variable as the `label` argument to the first invocation of `count()`, and the string "alice" to the second:
 
 ```js
 let user = "";

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -8,8 +8,7 @@ browser-compat: api.console.countReset_static
 
 {{APIRef("Console API")}}
 
-The **`console.countReset()`** method resets counter used with
-{{domxref("console.count()")}}.
+The **`console.countReset()`** method resets counter used with {{domxref("console.count()")}}.
 
 {{AvailableInWorkers}}
 
@@ -23,9 +22,7 @@ countReset(label)
 ### Parameters
 
 - `label` {{optional_inline}}
-  - : A string. If supplied, `countReset()` resets the count for
-    that label to 0. If omitted, `countReset()` resets the default counter to
-    0\.
+  - : A string. If supplied, `countReset()` resets the count for that label to 0. If omitted, `countReset()` resets the default counter to 0.
 
 ### Return value
 
@@ -62,12 +59,9 @@ Console output will look something like this:
 "default: 0"
 ```
 
-Note that the call to `console.counterReset()` resets the value of the
-default counter to zero.
+Note that the call to `console.counterReset()` resets the value of the default counter to zero.
 
-If we pass the `user` variable as the `label` argument with the
-string "bob" to the first invocation of `count()`, and the string "alice" to
-the second:
+If we pass the `user` variable as the `label` argument with the string "bob" to the first invocation of `count()`, and the string "alice" to the second:
 
 ```js
 let user = "";
@@ -96,8 +90,7 @@ We will see output like this:
 "alice: 3"
 ```
 
-Resetting the value of the counter "bob" only changes the value of that counter. The
-value of "alice" is unchanged.
+Resetting the value of the counter "bob" only changes the value of that counter. The value of "alice" is unchanged.
 
 ## Specifications
 

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -61,7 +61,7 @@ Console output will look something like this:
 
 Note that the call to `console.counterReset()` resets the value of the default counter to zero.
 
-If we pass the `user` variable as the `label` argument with the string "bob" to the first invocation of `count()`, and the string "alice" to the second:
+If we pass the `user` variable as the `label` argument with the string "bob" to the first invocation of `console.count()`, and the string "alice" to the second:
 
 ```js
 let user = "";

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -106,3 +106,9 @@ value of "alice" is unchanged.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.countReset()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#countreset)
+- [Node.JS documentation for `console.countReset()`](https://nodejs.org/docs/latest/api/console.html#consolecountresetlabel)
+- [Google Chrome's documentation for `console.countReset()`](https://developer.chrome.com/docs/devtools/console/api/#countreset)

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.countReset_static
 
 {{APIRef("Console API")}}
 
-The **`console.countReset()`** method resets counter used with {{domxref("console.count()")}}.
+The **`console.countReset()`** static method resets counter used with {{domxref("console.count()")}}.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/debug_static/index.md
+++ b/files/en-us/web/api/console/debug_static/index.md
@@ -52,3 +52,9 @@ None ({{jsxref("undefined")}}).
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.debug()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#debug)
+- [Node.JS documentation for `console.debug()`](https://nodejs.org/docs/latest/api/console.html#consoledebugdata-args)
+- [Google Chrome's documentation for `console.debug()`](https://developer.chrome.com/docs/devtools/console/api/#debug)

--- a/files/en-us/web/api/console/debug_static/index.md
+++ b/files/en-us/web/api/console/debug_static/index.md
@@ -8,10 +8,7 @@ browser-compat: api.console.debug_static
 
 {{APIRef("Console API")}}
 
-The **`console.debug()`** method outputs a message to the console at
-the "debug" log level. The message is only displayed to the user if the console is configured to
-display debug output. In most cases, the log level is configured within the console UI. This log
-level might correspond to the `Debug` or `Verbose` log level.
+The **`console.debug()`** method outputs a message to the console at the "debug" log level. The message is only displayed to the user if the console is configured to display debug output. In most cases, the log level is configured within the console UI. This log level might correspond to the `Debug` or `Verbose` log level.
 
 {{AvailableInWorkers}}
 
@@ -27,19 +24,13 @@ debug(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these
-    objects are appended together in the order listed and output to the console.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output to the console.
 - `msg`
-  - : A JavaScript string containing zero or more substitution strings, which are replaced
-    with `subst1` through `substN` in consecutive order.
+  - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within
-    `msg`. This gives you additional control over the format of the output. See
-    [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a
-    description of how substitutions work.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 
-See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of the {{domxref("console")}} object for
-details.
+See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of the {{domxref("console")}} object for details.
 
 ### Return value
 

--- a/files/en-us/web/api/console/debug_static/index.md
+++ b/files/en-us/web/api/console/debug_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.debug_static
 
 {{APIRef("Console API")}}
 
-The **`console.debug()`** method outputs a message to the console at the "debug" log level. The message is only displayed to the user if the console is configured to display debug output. In most cases, the log level is configured within the console UI. This log level might correspond to the `Debug` or `Verbose` log level.
+The **`console.debug()`** static method outputs a message to the console at the "debug" log level. The message is only displayed to the user if the console is configured to display debug output. In most cases, the log level is configured within the console UI. This log level might correspond to the `Debug` or `Verbose` log level.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/debug_static/index.md
+++ b/files/en-us/web/api/console/debug_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.debug_static
 
 {{APIRef("Console API")}}
 
-The **`console.debug()`** method outputs a message to the web console at
+The **`console.debug()`** method outputs a message to the console at
 the "debug" log level. The message is only displayed to the user if the console is configured to
 display debug output. In most cases, the log level is configured within the console UI. This log
 level might correspond to the `Debug` or `Verbose` log level.

--- a/files/en-us/web/api/console/dir_static/index.md
+++ b/files/en-us/web/api/console/dir_static/index.md
@@ -45,5 +45,6 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- [MSDN: Using the F12 Tools Console to View Errors and Status](<https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/samples/gg589530(v=vs.85)>)
-- [Chrome Console API reference](https://developer.chrome.com/docs/devtools/console/api/#dir)
+- [Microsoft Edge's documentation for `console.dir()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#dir)
+- [Node.JS documentation for `console.dir()`](https://nodejs.org/docs/latest/api/console.html#consoledirobj-options)
+- [Google Chrome's documentation for `console.dir()`](https://developer.chrome.com/docs/devtools/console/api/#dir)

--- a/files/en-us/web/api/console/dir_static/index.md
+++ b/files/en-us/web/api/console/dir_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.dir_static
 
 {{APIRef("Console API")}}
 
-The method **`console.dir()`** displays an interactive list of the properties of the specified JavaScript object. The output is presented as a hierarchical listing with disclosure triangles that let you see the contents of child objects.
+The **`console.dir()`** static method displays an interactive list of the properties of the specified JavaScript object. The output is presented as a hierarchical listing with disclosure triangles that let you see the contents of child objects.
 
 In other words, `console.dir()` is the way to see all the properties of a specified JavaScript object in console by which the developer can easily get the properties of the object.
 

--- a/files/en-us/web/api/console/dir_static/index.md
+++ b/files/en-us/web/api/console/dir_static/index.md
@@ -14,7 +14,7 @@ In other words, `console.dir()` is the way to see all the properties of a specif
 
 {{AvailableInWorkers}}
 
-![console-dir.png](console-dir.png)
+![A screenshot of the Firefox console where console.dir(document.location) is run. We can see the URL of the page, followed by a block of properties. If the property is a fonction or an object, a disclosure triangle is prepended.](console-dir.png)
 
 ## Syntax
 

--- a/files/en-us/web/api/console/dir_static/index.md
+++ b/files/en-us/web/api/console/dir_static/index.md
@@ -8,13 +8,9 @@ browser-compat: api.console.dir_static
 
 {{APIRef("Console API")}}
 
-The method **`console.dir()`** displays an interactive list of the properties of
-the specified JavaScript object. The output is presented as a hierarchical
-listing with disclosure triangles that let you see the contents of child objects.
+The method **`console.dir()`** displays an interactive list of the properties of the specified JavaScript object. The output is presented as a hierarchical listing with disclosure triangles that let you see the contents of child objects.
 
-In other words, `console.dir()` is the way to see all the properties of a
-specified JavaScript object in console by which the developer can easily get the
-properties of the object.
+In other words, `console.dir()` is the way to see all the properties of a specified JavaScript object in console by which the developer can easily get the properties of the object.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/dirxml_static/index.md
+++ b/files/en-us/web/api/console/dirxml_static/index.md
@@ -35,3 +35,9 @@ None ({{jsxref("undefined")}}).
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.dirxml()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#dirxml)
+- [Node.JS documentation for `console.dirxml()`](https://nodejs.org/docs/latest/api/console.html#consoledirxmldata)
+- [Google Chrome's documentation for `console.dirxml()`](https://developer.chrome.com/docs/devtools/console/api/#dirxml)

--- a/files/en-us/web/api/console/dirxml_static/index.md
+++ b/files/en-us/web/api/console/dirxml_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.dirxml_static
 
 {{APIRef("Console API")}}
 
-The **`console.dirxml()`** method displays an interactive tree of the descendant elements of the specified XML/HTML element. If it is not possible to display as an element the JavaScript Object view is shown instead. The output is presented as a hierarchical listing of expandable nodes that let you see the contents of child nodes.
+The **`console.dirxml()`** static method displays an interactive tree of the descendant elements of the specified XML/HTML element. If it is not possible to display as an element the JavaScript Object view is shown instead. The output is presented as a hierarchical listing of expandable nodes that let you see the contents of child nodes.
 
 ## Syntax
 

--- a/files/en-us/web/api/console/dirxml_static/index.md
+++ b/files/en-us/web/api/console/dirxml_static/index.md
@@ -8,10 +8,7 @@ browser-compat: api.console.dirxml_static
 
 {{APIRef("Console API")}}
 
-The **`console.dirxml()`** method displays an interactive tree of the descendant elements of the specified XML/HTML
-element. If it is not possible to display as an element the JavaScript Object view is
-shown instead. The output is presented as a hierarchical listing of expandable nodes
-that let you see the contents of child nodes.
+The **`console.dirxml()`** method displays an interactive tree of the descendant elements of the specified XML/HTML element. If it is not possible to display as an element the JavaScript Object view is shown instead. The output is presented as a hierarchical listing of expandable nodes that let you see the contents of child nodes.
 
 ## Syntax
 

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.error_static
 
 {{APIRef("Console API")}}
 
-The **`console.error()`** method outputs an error message to the console.
+The **`console.error()`** static method outputs an error message to the console.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -49,5 +49,6 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- [MSDN: Using the F12 Tools Console to View Errors and Status](<https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/samples/gg589530(v=vs.85)>)
-- [Chrome Developer Tools: Using the Console](https://developer.chrome.com/docs/devtools/console/api/#error)
+- [Microsoft Edge's documentation for `console.error()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#error)
+- [Node.JS documentation for `console.error()`](https://nodejs.org/docs/latest/api/console.html#consoleerrordata-args)
+- [Google Chrome's documentation for `console.error()`](https://developer.chrome.com/docs/devtools/console/api/#error)

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -24,16 +24,13 @@ error(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of
-    these objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within
-    `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
 
-See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for
-details.
+See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
 
 ### Return value
 

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.error_static
 
 {{APIRef("Console API")}}
 
-The **`console.error()`** method outputs an error message to the Web console.
+The **`console.error()`** method outputs an error message to the console.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/error_static/index.md
+++ b/files/en-us/web/api/console/error_static/index.md
@@ -24,13 +24,13 @@ error(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output to the console.
 - `msg`
-  - : A JavaScript string containing zero or more substitution strings.
+  - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 
-See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
+See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of the {{domxref("console")}} object for details.
 
 ### Return value
 

--- a/files/en-us/web/api/console/group_static/index.md
+++ b/files/en-us/web/api/console/group_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.group_static
 
 {{APIRef("Console API")}}
 
-The **`console.group()`** method creates a new inline group in the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) log, causing any subsequent console messages to be indented by an additional level,
+The **`console.group()`** method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level,
 until {{domxref("console.groupEnd()")}} is called.
 
 {{AvailableInWorkers}}

--- a/files/en-us/web/api/console/group_static/index.md
+++ b/files/en-us/web/api/console/group_static/index.md
@@ -8,8 +8,7 @@ browser-compat: api.console.group_static
 
 {{APIRef("Console API")}}
 
-The **`console.group()`** method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level,
-until {{domxref("console.groupEnd()")}} is called.
+The **`console.group()`** method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level, until {{domxref("console.groupEnd()")}} is called.
 
 {{AvailableInWorkers}}
 
@@ -31,13 +30,9 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-You can use nested groups to help organize your output by visually associating related
-messages. To create a new nested block, call `console.group()`. The
-`console.groupCollapsed()` method is similar, but the new block is
-collapsed and requires clicking a disclosure button to read it.
+You can use nested groups to help organize your output by visually associating related messages. To create a new nested block, call `console.group()`. The `console.groupCollapsed()` method is similar, but the new block is collapsed and requires clicking a disclosure button to read it.
 
-To exit the current group, call `console.groupEnd()`.
-For example, given this code:
+To exit the current group, call `console.groupEnd()`. For example, given this code:
 
 ```js
 console.log("This is the outer level");

--- a/files/en-us/web/api/console/group_static/index.md
+++ b/files/en-us/web/api/console/group_static/index.md
@@ -69,3 +69,7 @@ See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_th
 ## See also
 
 - {{domxref("console.groupEnd()")}}
+- {{domxref("console.groupCollapsed()")}}
+- [Microsoft Edge's documentation for `console.group()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#group)
+- [Node.JS documentation for `console.group()`](https://nodejs.org/docs/latest/api/console.html#consolegrouplabel)
+- [Google Chrome's documentation for `console.group()`](https://developer.chrome.com/docs/devtools/console/api/#group)

--- a/files/en-us/web/api/console/group_static/index.md
+++ b/files/en-us/web/api/console/group_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.group_static
 
 {{APIRef("Console API")}}
 
-The **`console.group()`** method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level, until {{domxref("console.groupEnd()")}} is called.
+The **`console.group()`** static method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level, until {{domxref("console.groupEnd()")}} is called.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/groupcollapsed_static/index.md
+++ b/files/en-us/web/api/console/groupcollapsed_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.groupCollapsed_static
 
 {{APIRef("Console API")}}
 
-The **`console.groupCollapsed()`** method creates a new inline group in the console. Unlike {{domxref("console.group()")}}, however, the new group is created collapsed. The user will need to use the disclosure button next to it to expand it, revealing the entries created in the group.
+The **`console.groupCollapsed()`** static method creates a new inline group in the console. Unlike {{domxref("console.group()")}}, however, the new group is created collapsed. The user will need to use the disclosure button next to it to expand it, revealing the entries created in the group.
 
 Call {{domxref("console.groupEnd()")}} to back out to the parent group.
 

--- a/files/en-us/web/api/console/groupcollapsed_static/index.md
+++ b/files/en-us/web/api/console/groupcollapsed_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.groupCollapsed_static
 
 {{APIRef("Console API")}}
 
-The **`console.groupCollapsed()`** method creates a new inline group in the Web Console. Unlike {{domxref("console.group()")}},
+The **`console.groupCollapsed()`** method creates a new inline group in the console. Unlike {{domxref("console.group()")}},
 however, the new group is created collapsed. The user will need to use the disclosure
 button next to it to expand it, revealing the entries created in the group.
 

--- a/files/en-us/web/api/console/groupcollapsed_static/index.md
+++ b/files/en-us/web/api/console/groupcollapsed_static/index.md
@@ -42,3 +42,11 @@ None ({{jsxref("undefined")}}).
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("console.group()")}}
+- {{domxref("console.groupEnd()")}}
+- [Microsoft Edge's documentation for `console.groupCollapsed()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#groupcollapsed)
+- [Node.JS documentation for `console.groupCollapsed()`](https://nodejs.org/docs/latest/api/console.html#consolegroupcollapsed)
+- [Google Chrome's documentation for `console.groupCollapsed()`](https://developer.chrome.com/docs/devtools/console/api/#groupcollapsed)

--- a/files/en-us/web/api/console/groupcollapsed_static/index.md
+++ b/files/en-us/web/api/console/groupcollapsed_static/index.md
@@ -8,14 +8,11 @@ browser-compat: api.console.groupCollapsed_static
 
 {{APIRef("Console API")}}
 
-The **`console.groupCollapsed()`** method creates a new inline group in the console. Unlike {{domxref("console.group()")}},
-however, the new group is created collapsed. The user will need to use the disclosure
-button next to it to expand it, revealing the entries created in the group.
+The **`console.groupCollapsed()`** method creates a new inline group in the console. Unlike {{domxref("console.group()")}}, however, the new group is created collapsed. The user will need to use the disclosure button next to it to expand it, revealing the entries created in the group.
 
 Call {{domxref("console.groupEnd()")}} to back out to the parent group.
 
-See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and
-examples.
+See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and examples.
 
 {{AvailableInWorkers}}
 
@@ -28,8 +25,8 @@ groupCollapsed(label)
 
 ### Parameters
 
-- `label`
-  - : Label for the group. Optional.
+- `label` {{Optional_Inline}}
+  - : Label for the group.
 
 ### Return value
 

--- a/files/en-us/web/api/console/groupend_static/index.md
+++ b/files/en-us/web/api/console/groupend_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.groupEnd_static
 
 {{APIRef("Console API")}}
 
-The **`console.groupEnd()`** method exits the current inline group in the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html). See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and examples.
+The **`console.groupEnd()`** method exits the current inline group in the console. See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and examples.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/groupend_static/index.md
+++ b/files/en-us/web/api/console/groupend_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.groupEnd_static
 
 {{APIRef("Console API")}}
 
-The **`console.groupEnd()`** method exits the current inline group in the console. See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and examples.
+The **`console.groupEnd()`** static method exits the current inline group in the console. See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and examples.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/groupend_static/index.md
+++ b/files/en-us/web/api/console/groupend_static/index.md
@@ -37,3 +37,7 @@ None ({{jsxref("undefined")}}).
 ## See also
 
 - {{domxref("console.group()")}}
+- {{domxref("console.groupCollapsed()")}}
+- [Microsoft Edge's documentation for `console.groupEnd()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#groupend)
+- [Node.JS documentation for `console.groupEnd()`](https://nodejs.org/docs/latest/api/console.html#consolegroupend)
+- [Google Chrome's documentation for `console.groupEnd()`](https://developer.chrome.com/docs/devtools/console/api/#groupend)

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -7,7 +7,7 @@ browser-compat: api.console
 
 {{APIRef("Console API")}}
 
-The **`console`** object provides access to the debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works varies from browser to browser or server runtimes (Node.js for example) , but there is a _de facto_ set of features that are typically provided.
+The **`console`** object provides access to the debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works varies from browser to browser or server runtimes (Node.js for example), but there is a _de facto_ set of features that are typically provided.
 
 The `console` object can be accessed from any global object. {{domxref("Window")}} on browsing scopes and {{domxref("WorkerGlobalScope")}} as specific variants in workers via the property console. It's exposed as {{domxref("Window.console")}}, and can be referenced as `console`. For example:
 
@@ -111,7 +111,7 @@ My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
 
 #### Using string substitutions
 
-When passing a string to one of the `console` methods that accepts a string (such as `console.log()`), you may use these substitution strings:
+When passing a string to one of the `console` object's methods that accepts a string (such as `console.log()`), you may use these substitution strings:
 
 - `%o` or `%O`
   - : Outputs a JavaScript object. Clicking the object name opens more information about it in the inspector.

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -7,7 +7,7 @@ browser-compat: api.console
 
 {{APIRef("Console API")}}
 
-The **`console`** object provides access to the browser's debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works varies from browser to browser, but there is a _de facto_ set of features that are typically provided.
+The **`console`** object provides access to the debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works varies from browser to browser or server runtimes (Node.js for example) , but there is a _de facto_ set of features that are typically provided.
 
 The `console` object can be accessed from any global object. {{domxref("Window")}} on browsing scopes and {{domxref("WorkerGlobalScope")}} as specific variants in workers via the property console. It's exposed as {{domxref("Window.console")}}, and can be referenced as `console`. For example:
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -40,11 +40,11 @@ This page documents the [Methods](#methods) available on the `console` object an
 - {{domxref("console.error()")}}
   - : Outputs an error message. You may use [string substitution](#using_string_substitutions) and additional arguments with this method.
 - `console.exception()` {{Non-standard_inline}} {{deprecated_inline}}
-  - : An alias for `error()`.
+  - : An alias for `console.error()`.
 - {{domxref("console.group()")}}
-  - : Creates a new inline [group](#using_groups_in_the_console), indenting all following output by another level. To move back out a level, call `groupEnd()`.
+  - : Creates a new inline [group](#using_groups_in_the_console), indenting all following output by another level. To move back out a level, call `console.groupEnd()`.
 - {{domxref("console.groupCollapsed()")}}
-  - : Creates a new inline [group](#using_groups_in_the_console), indenting all following output by another level. However, unlike `group()` this starts with the inline group collapsed requiring the use of a disclosure button to expand it. To move back out a level, call `groupEnd()`.
+  - : Creates a new inline [group](#using_groups_in_the_console), indenting all following output by another level. However, unlike `console.group()` this starts with the inline group collapsed requiring the use of a disclosure button to expand it. To move back out a level, call `console.groupEnd()`.
 - {{domxref("console.groupEnd()")}}
   - : Exits the current inline [group](#using_groups_in_the_console).
 - {{domxref("console.info()")}}
@@ -111,7 +111,7 @@ My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
 
 #### Using string substitutions
 
-When passing a string to one of the `console` object's methods that accepts a string (such as `log()`), you may use these substitution strings:
+When passing a string to one of the `console` methods that accepts a string (such as `console.log()`), you may use these substitution strings:
 
 - `%o` or `%O`
   - : Outputs a JavaScript object. Clicking the object name opens more information about it in the inspector.

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -234,8 +234,6 @@ Will log the time needed by the user to dismiss the alert box, log the time to t
 
 Notice that the timer's name is displayed both when the timer is started and when it's stopped.
 
-> **Note:** It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header. If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.
-
 ### Stack traces
 
 The console object also supports outputting a stack trace; this will show you the call path taken to reach the point at which you call {{domxref("console.trace()")}}. Given code like this:

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -7,22 +7,15 @@ browser-compat: api.console
 
 {{APIRef("Console API")}}
 
-The **`console`** object provides access to the browser's
-debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox).
-The specifics of how it works varies from browser to browser, but there is a _de facto_
-set of features that are typically provided.
+The **`console`** object provides access to the browser's debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works varies from browser to browser, but there is a _de facto_ set of features that are typically provided.
 
-The `console` object can be accessed from any global object. {{domxref("Window")}} on
-browsing scopes and {{domxref("WorkerGlobalScope")}} as specific variants in workers via the
-property console. It's exposed as {{domxref("Window.console")}}, and can be referenced as
-`console`. For example:
+The `console` object can be accessed from any global object. {{domxref("Window")}} on browsing scopes and {{domxref("WorkerGlobalScope")}} as specific variants in workers via the property console. It's exposed as {{domxref("Window.console")}}, and can be referenced as `console`. For example:
 
 ```js
 console.log("Failed to open the specified link");
 ```
 
-This page documents the [Methods](#methods) available on the `console` object and
-gives a few [Usage](#usage) examples.
+This page documents the [Methods](#methods) available on the `console` object and gives a few [Usage](#usage) examples.
 
 {{AvailableInWorkers}}
 
@@ -241,8 +234,7 @@ Will log the time needed by the user to dismiss the alert box, log the time to t
 
 Notice that the timer's name is displayed both when the timer is started and when it's stopped.
 
-> **Note:** It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header.
-> If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.
+> **Note:** It's important to note that if you're using this to log the timing for network traffic, the timer will report the total time for the transaction, while the time listed in the network panel is just the amount of time required for the header. If you have response body logging enabled, the time listed for the response header and body combined should match what you see in the console output.
 
 ### Stack traces
 

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -24,13 +24,13 @@ info(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output to the console.
 - `msg`
-  - : A JavaScript string containing zero or more substitution strings.
+  - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 
-See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
+See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of the {{domxref("console")}} object for details.
 
 ### Return value
 

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -9,8 +9,8 @@ browser-compat: api.console.info_static
 {{APIRef("Console API")}}
 
 The **`console.info()`** method outputs an
-informational message to the Web console. In Firefox, a small "i" icon is displayed
-next to these items in the Web console's log.
+informational message to the console. In Firefox, a small "i" icon is displayed
+next to these items in the console's log.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -8,9 +8,7 @@ browser-compat: api.console.info_static
 
 {{APIRef("Console API")}}
 
-The **`console.info()`** method outputs an
-informational message to the console. In Firefox, a small "i" icon is displayed
-next to these items in the console's log.
+The **`console.info()`** method outputs an informational message to the console. In Firefox, a small "i" icon is displayed next to these items in the console's log.
 
 {{AvailableInWorkers}}
 
@@ -26,13 +24,11 @@ info(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these
-    objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within
-    `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
 
 See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
 

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.info_static
 
 {{APIRef("Console API")}}
 
-The **`console.info()`** method outputs an informational message to the console. In Firefox, a small "i" icon is displayed next to these items in the console's log.
+The **`console.info()`** static method outputs an informational message to the console. In Firefox, a small "i" icon is displayed next to these items in the console's log.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/info_static/index.md
+++ b/files/en-us/web/api/console/info_static/index.md
@@ -50,4 +50,6 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- [MSDN: Using the F12 Tools Console to View Errors and Status](<https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/samples/gg589530(v=vs.85)>)
+- [Microsoft Edge's documentation for `console.info()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#info)
+- [Node.JS documentation for `console.info()`](https://nodejs.org/docs/latest/api/console.html#consoleinfodata-args)
+- [Google Chrome's documentation for `console.info()`](https://developer.chrome.com/docs/devtools/console/api/#info)

--- a/files/en-us/web/api/console/log_static/index.md
+++ b/files/en-us/web/api/console/log_static/index.md
@@ -8,9 +8,7 @@ browser-compat: api.console.log_static
 
 {{APIRef("Console API")}}
 
-The **`console.log()`** method outputs a message to the console.
-The message may be a single string (with optional substitution values), or it may be any one
-or more JavaScript objects.
+The **`console.log()`** method outputs a message to the console. The message may be a single string (with optional substitution values), or it may be any one or more JavaScript objects.
 
 {{AvailableInWorkers}}
 
@@ -26,17 +24,11 @@ log(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output.
-    Objects are output in the order listed. Please be warned that if
-    you log objects in the latest versions of Chrome and Firefox, what you get logged on
-    the console is a _reference to the object_, which is not necessarily the
-    'value' of the object at the moment in time you call `console.log()`, but
-    it is the value of the object at the moment you open the console.
+  - : A list of JavaScript objects to output. Objects are output in the order listed. Please be warned that if you log objects in the latest versions of Chrome and Firefox, what you get logged on the console is a _reference to the object_, which is not necessarily the 'value' of the object at the moment in time you call `console.log()`, but it is the value of the object at the moment you open the console.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within
-    `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
 
 See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
 

--- a/files/en-us/web/api/console/log_static/index.md
+++ b/files/en-us/web/api/console/log_static/index.md
@@ -74,5 +74,6 @@ There are other alternatives that work in browsers, such as [`structuredClone()`
 
 ## See also
 
-- [MSDN: Using the F12 Tools Console to View Errors and Status](<https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/samples/gg589530(v=vs.85)>)
-- [NodeJS: Console API](https://nodejs.org/docs/latest/api/console.html#console_console_log_data)
+- [Microsoft Edge's documentation for `console.log()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#log)
+- [Node.JS documentation for `console.log()`](https://nodejs.org/docs/latest/api/console.html#consolelogdata-args)
+- [Google Chrome's documentation for `console.log()`](https://developer.chrome.com/docs/devtools/console/api/#log)

--- a/files/en-us/web/api/console/log_static/index.md
+++ b/files/en-us/web/api/console/log_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.log_static
 
 {{APIRef("Console API")}}
 
-The **`console.log()`** method outputs a message to the console. The message may be a single string (with optional substitution values), or it may be any one or more JavaScript objects.
+The **`console.log()`** static method outputs a message to the console. The message may be a single string (with optional substitution values), or it may be any one or more JavaScript objects.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/log_static/index.md
+++ b/files/en-us/web/api/console/log_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.log_static
 
 {{APIRef("Console API")}}
 
-The **`console.log()`** method outputs a message to the web console.
+The **`console.log()`** method outputs a message to the console.
 The message may be a single string (with optional substitution values), or it may be any one
 or more JavaScript objects.
 

--- a/files/en-us/web/api/console/profile_static/index.md
+++ b/files/en-us/web/api/console/profile_static/index.md
@@ -12,9 +12,7 @@ browser-compat: api.console.profile_static
 
 The **`console.profile()`** starts recording a performance profile (for example, the [Firefox performance tool](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)).
 
-You can optionally supply an argument to name the profile and this then enables you to
-stop only that profile if multiple profiles being recorded. See
-{{domxref("console.profileEnd()")}} to see how this argument is interpreted.
+You can optionally supply an argument to name the profile and this then enables you to stop only that profile if multiple profiles being recorded. See {{domxref("console.profileEnd()")}} to see how this argument is interpreted.
 
 To stop recording call {{domxref("console.profileEnd()")}}.
 

--- a/files/en-us/web/api/console/profile_static/index.md
+++ b/files/en-us/web/api/console/profile_static/index.md
@@ -26,8 +26,8 @@ profile(profileName)
 
 ### Parameters
 
-- `profileName`
-  - : The name to give the profile. Optional.
+- `profileName` {{Optional_Inline}}
+  - : The name to give the profile.
 
 ### Return value
 

--- a/files/en-us/web/api/console/profile_static/index.md
+++ b/files/en-us/web/api/console/profile_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.console.profile_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.profile()`** starts recording a performance profile (for example, the [Firefox performance tool](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)).
+The **`console.profile()`** static method starts recording a performance profile (for example, the [Firefox performance tool](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)).
 
 You can optionally supply an argument to name the profile and this then enables you to stop only that profile if multiple profiles being recorded. See {{domxref("console.profileEnd()")}} to see how this argument is interpreted.
 

--- a/files/en-us/web/api/console/profileend_static/index.md
+++ b/files/en-us/web/api/console/profileend_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.console.profileEnd_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.profileEnd()`** method stops recording a profile previously started with {{DOMxRef("console.profile()")}}.
+The **`console.profileEnd()`** static method stops recording a profile previously started with {{DOMxRef("console.profile()")}}.
 
 You can optionally supply an argument to name the profile. Doing so enables you to stop only that profile if you have multiple profiles being recorded.
 

--- a/files/en-us/web/api/console/profileend_static/index.md
+++ b/files/en-us/web/api/console/profileend_static/index.md
@@ -30,8 +30,8 @@ profileEnd(profileName)
 
 ### Parameters
 
-- `profileName`
-  - : The name to give the profile. This parameter is optional.
+- `profileName` {{Optional_Inline}}
+  - : The name to give the profile.
 
 ### Return value
 

--- a/files/en-us/web/api/console/profileend_static/index.md
+++ b/files/en-us/web/api/console/profileend_static/index.md
@@ -10,15 +10,13 @@ browser-compat: api.console.profileEnd_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-> **Warning:** Calling this API immediately after console.profile() can cause it to not work. To work around this, call it in a setTimeout with at least 5ms delay. See [Firefox bug 1240249](https://bugzil.la/1240249).
-
 The **`console.profileEnd()`** method stops recording a profile previously started with {{DOMxRef("console.profile()")}}.
 
 You can optionally supply an argument to name the profile. Doing so enables you to stop only that profile if you have multiple profiles being recorded.
 
-- if `console.profileEnd()` is passed a profile name, and it matches the name of a profile being recorded, then that profile is stopped.
-- if `console.profileEnd()` is passed a profile name and it does not match the name of a profile being recorded, no changes will be made.
-- if `console.profileEnd()` is not passed a profile name, the most recently started profile is stopped.
+- If `console.profileEnd()` is passed a profile name, and it matches the name of a profile being recorded, then that profile is stopped.
+- If `console.profileEnd()` is passed a profile name and it does not match the name of a profile being recorded, no changes will be made.
+- If `console.profileEnd()` is not passed a profile name, the most recently started profile is stopped.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/profileend_static/index.md
+++ b/files/en-us/web/api/console/profileend_static/index.md
@@ -10,22 +10,15 @@ browser-compat: api.console.profileEnd_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-> **Warning:** Calling this API immediately after console.profile() can cause it to not work. To
-> work around this, call it in a setTimeout with at least 5ms delay. See
-> [Firefox bug 1240249](https://bugzil.la/1240249).
+> **Warning:** Calling this API immediately after console.profile() can cause it to not work. To work around this, call it in a setTimeout with at least 5ms delay. See [Firefox bug 1240249](https://bugzil.la/1240249).
 
-The **`console.profileEnd()`** method stops recording a profile previously started with
-{{DOMxRef("console.profile()")}}.
+The **`console.profileEnd()`** method stops recording a profile previously started with {{DOMxRef("console.profile()")}}.
 
-You can optionally supply an argument to name the profile. Doing so enables you to stop
-only that profile if you have multiple profiles being recorded.
+You can optionally supply an argument to name the profile. Doing so enables you to stop only that profile if you have multiple profiles being recorded.
 
-- if `console.profileEnd()` is passed a profile name, and it matches the
-  name of a profile being recorded, then that profile is stopped.
-- if `console.profileEnd()` is passed a profile name and it does not match
-  the name of a profile being recorded, no changes will be made.
-- if `console.profileEnd()` is not passed a profile name, the most recently
-  started profile is stopped.
+- if `console.profileEnd()` is passed a profile name, and it matches the name of a profile being recorded, then that profile is stopped.
+- if `console.profileEnd()` is passed a profile name and it does not match the name of a profile being recorded, no changes will be made.
+- if `console.profileEnd()` is not passed a profile name, the most recently started profile is stopped.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/table_static/index.md
+++ b/files/en-us/web/api/console/table_static/index.md
@@ -10,17 +10,11 @@ browser-compat: api.console.table_static
 
 The **`console.table()`** method displays tabular data as a table.
 
-This function takes one mandatory argument `data`, which must be an array or
-an object, and one additional optional parameter `columns`.
+This function takes one mandatory argument `data`, which must be an array or an object, and one additional optional parameter `columns`.
 
-It logs `data` as a table. Each element in the array (or enumerable property
-if `data` is an object) will be a row in the table.
+It logs `data` as a table. Each element in the array (or enumerable property if `data` is an object) will be a row in the table.
 
-The first column in the table will be labeled `(index)`. If
-`data` is an array, then its values will be the array indices. If
-`data` is an object, then its values will be the property names. Note that
-(in Firefox) `console.table` is limited to displaying 1000 rows (first row is
-the labeled index).
+The first column in the table will be labeled `(index)`. If `data` is an array, then its values will be the array indices. If `data` is an object, then its values will be the property names. Note that (in Firefox) `console.table` is limited to displaying 1000 rows (first row is the labeled index).
 
 {{AvailableInWorkers}}
 
@@ -60,8 +54,7 @@ console.table(me);
 
 ### Collections of compound types
 
-If the elements in the array, or properties in the object, are themselves arrays or
-objects, then their elements or properties are enumerated in the row, one per column:
+If the elements in the array, or properties in the object, are themselves arrays or objects, then their elements or properties are enumerated in the row, one per column:
 
 ```js
 // an array of arrays
@@ -95,8 +88,7 @@ const maria = new Person("Maria", "Cruz");
 console.table([tyrone, janet, maria]);
 ```
 
-Note that if the array contains objects, then the columns are labeled with the property
-name.
+Note that if the array contains objects, then the columns are labeled with the property name.
 
 | (index) | firstName | lastName |
 | ------- | --------- | -------- |
@@ -124,8 +116,7 @@ console.table(family);
 
 ### Restricting the columns displayed
 
-By default, `console.table()` lists all elements in each row. You can use
-the optional `columns` parameter to select a subset of columns to display:
+By default, `console.table()` lists all elements in each row. You can use the optional `columns` parameter to select a subset of columns to display:
 
 ```js
 // an array of objects, logging only firstName

--- a/files/en-us/web/api/console/table_static/index.md
+++ b/files/en-us/web/api/console/table_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.table_static
 
 {{APIRef("Console API")}}
 
-The **`console.table()`** method displays tabular data as a table.
+The **`console.table()`** static method displays tabular data as a table.
 
 This function takes one mandatory argument `data`, which must be an array or an object, and one additional optional parameter `columns`.
 

--- a/files/en-us/web/api/console/table_static/index.md
+++ b/files/en-us/web/api/console/table_static/index.md
@@ -177,3 +177,9 @@ None ({{jsxref("undefined")}}).
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.table()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#table)
+- [Node.JS documentation for `console.table()`](https://nodejs.org/docs/latest/api/console.html#consoletabletabulardata-properties)
+- [Google Chrome's documentation for `console.table()`](https://developer.chrome.com/docs/devtools/console/api/#table)

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -48,3 +48,6 @@ None ({{jsxref("undefined")}}).
 
 - {{domxref("console.timeEnd()")}}
 - {{domxref("console.timeLog()")}}
+- [Microsoft Edge's documentation for `console.time()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#time)
+- [Node.JS documentation for `console.time()`](https://nodejs.org/docs/latest/api/console.html#consoletimelabel)
+- [Google Chrome's documentation for `console.time()`](https://developer.chrome.com/docs/devtools/console/api/#time)

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -24,7 +24,7 @@ time(label)
 ### Parameters
 
 - `label` {{optional_inline}}
-  - : A `string` representing the name to give the new timer. This will identify the timer; use the same name when calling {{domxref("console.timeEnd()")}} to stop the timer and get the time output to the console. If omitted, the label "default" is used.
+  - : A string representing the name to give the new timer. This will identify the timer; use the same name when calling {{domxref("console.timeEnd()")}} to stop the timer and get the time output to the console. If omitted, the label "default" is used.
 
 ### Return value
 

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.time_static
 
 {{APIRef("Console API")}}
 
-The **`console.time()`** method starts a timer you can use to track how long an operation takes. You give each timer a unique name, and may have up to 10,000 timers running on a given page. When you call {{domxref("console.timeEnd()")}} with the same name, the browser will output the time, in milliseconds, that elapsed since the timer was started.
+The **`console.time()`** static method starts a timer you can use to track how long an operation takes. You give each timer a unique name, and may have up to 10,000 timers running on a given page. When you call {{domxref("console.timeEnd()")}} with the same name, the browser will output the time, in milliseconds, that elapsed since the timer was started.
 
 See [Timers](/en-US/docs/Web/API/console#timers) in the {{domxref("console")}} documentation for details and examples.
 

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -8,13 +8,9 @@ browser-compat: api.console.time_static
 
 {{APIRef("Console API")}}
 
-The **`console.time()`** method starts a timer you can use to track
-how long an operation takes. You give each timer a unique name, and may have up to 10,000 timers
-running on a given page. When you call {{domxref("console.timeEnd()")}} with the same name, the
-browser will output the time, in milliseconds, that elapsed since the timer was started.
+The **`console.time()`** method starts a timer you can use to track how long an operation takes. You give each timer a unique name, and may have up to 10,000 timers running on a given page. When you call {{domxref("console.timeEnd()")}} with the same name, the browser will output the time, in milliseconds, that elapsed since the timer was started.
 
-See [Timers](/en-US/docs/Web/API/console#timers) in the
-{{domxref("console")}} documentation for details and examples.
+See [Timers](/en-US/docs/Web/API/console#timers) in the {{domxref("console")}} documentation for details and examples.
 
 {{AvailableInWorkers}}
 
@@ -28,9 +24,7 @@ time(label)
 ### Parameters
 
 - `label` {{optional_inline}}
-  - : A `string` representing the name to give the new timer. This will identify the timer; use the same name when
-    calling {{domxref("console.timeEnd()")}} to stop the timer and get the time output to
-    the console. If omitted, the label "default" is used.
+  - : A `string` representing the name to give the new timer. This will identify the timer; use the same name when calling {{domxref("console.timeEnd()")}} to stop the timer and get the time output to the console. If omitted, the label "default" is used.
 
 ### Return value
 

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -26,7 +26,7 @@ timeEnd(label)
 
 - `label` {{optional_inline}}
   - : A `string` representing the name of the timer to stop. Once stopped, the elapsed time is automatically
-    displayed in the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) along
+    displayed in the console along
     with an indicator that the time has ended. If omitted, the label "default" is used.
 
 ### Return value

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -10,8 +10,7 @@ browser-compat: api.console.timeEnd_static
 
 The **`console.timeEnd()`** stops a timer that was previously started by calling {{domxref("console.time()")}}.
 
-See [Timers](/en-US/docs/Web/API/console#timers) in the documentation for
-details and examples.
+See [Timers](/en-US/docs/Web/API/console#timers) in the documentation for details and examples.
 
 {{AvailableInWorkers}}
 
@@ -25,9 +24,7 @@ timeEnd(label)
 ### Parameters
 
 - `label` {{optional_inline}}
-  - : A `string` representing the name of the timer to stop. Once stopped, the elapsed time is automatically
-    displayed in the console along
-    with an indicator that the time has ended. If omitted, the label "default" is used.
+  - : A `string` representing the name of the timer to stop. Once stopped, the elapsed time is automatically displayed in the console along with an indicator that the time has ended. If omitted, the label "default" is used.
 
 ### Return value
 
@@ -43,14 +40,11 @@ alert("Do a bunch of other stuff…");
 console.timeEnd("answer time");
 ```
 
-The output from the example above shows the time taken by the user to dismiss the first
-alert box, followed by the cumulative time it took for the user to dismiss both alerts:
+The output from the example above shows the time taken by the user to dismiss the first alert box, followed by the cumulative time it took for the user to dismiss both alerts:
 
 ![Timer output in Firefox console](timer_output.png)
 
-Notice that the timer's name is displayed when the timer value is logged using
-`timeLog()` and again when it's stopped. In addition, the call to timeEnd()
-has the additional information, "timer ended" to make it obvious that the timer is no
+Notice that the timer's name is displayed when the timer value is logged using `timeLog()` and again when it's stopped. In addition, the call to timeEnd() has the additional information, "timer ended" to make it obvious that the timer is no
 longer tracking time.
 
 ## Specifications

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.timeEnd_static
 
 {{APIRef("Console API")}}
 
-The **`console.timeEnd()`** stops a timer that was previously started by calling {{domxref("console.time()")}}.
+The **`console.timeEnd()`** static method stops a timer that was previously started by calling {{domxref("console.time()")}}.
 
 See [Timers](/en-US/docs/Web/API/console#timers) in the documentation for details and examples.
 

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -24,7 +24,7 @@ timeEnd(label)
 ### Parameters
 
 - `label` {{optional_inline}}
-  - : A `string` representing the name of the timer to stop. Once stopped, the elapsed time is automatically displayed in the console along with an indicator that the time has ended. If omitted, the label "default" is used.
+  - : A string representing the name of the timer to stop. Once stopped, the elapsed time is automatically displayed in the console along with an indicator that the time has ended. If omitted, the label "default" is used.
 
 ### Return value
 
@@ -44,7 +44,7 @@ The output from the example above shows the time taken by the user to dismiss th
 
 ![Timer output in Firefox console](timer_output.png)
 
-Notice that the timer's name is displayed when the timer value is logged using `timeLog()` and again when it's stopped. In addition, the call to timeEnd() has the additional information, "timer ended" to make it obvious that the timer is no
+Notice that the timer's name is displayed when the timer value is logged using `console.timeLog()` and again when it's stopped. In addition, the call to `console.timeEnd()` has the additional information, "timer ended" to make it obvious that the timer is no
 longer tracking time.
 
 ## Specifications

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -60,3 +60,11 @@ longer tracking time.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("console.time()")}}
+- {{domxref("console.timeLog()")}}
+- [Microsoft Edge's documentation for `console.timeEnd()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#timeend)
+- [Node.JS documentation for `console.timeEnd()`](https://nodejs.org/docs/latest/api/console.html#consoletimeendlabel)
+- [Google Chrome's documentation for `console.timeEnd()`](https://developer.chrome.com/docs/devtools/console/api/#timeend)

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -106,3 +106,9 @@ longer tracking time.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("console.time()")}}
+- {{domxref("console.timeEnd()")}}
+- [Node.JS documentation for `console.timeLog()`](https://nodejs.org/docs/latest/api/console.html#consoletimeloglabel-data)

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -86,18 +86,14 @@ alert("Do a bunch of other stuff…");
 console.timeEnd("answer time");
 ```
 
-The output from the example above shows the time taken by the user to dismiss the first
-alert box, followed by the cumulative time it took for the user to dismiss both alerts:
+The output from the example above shows the time taken by the user to dismiss the first alert box, followed by the cumulative time it took for the user to dismiss both alerts:
 
 ```plain
 answer time: 2542ms debugger eval code:3:9
 answer time: 4161ms - timer ended
 ```
 
-Notice that the timer's name is displayed when the timer value is logged using
-`timeLog()` and again when it's stopped. In addition, the call to `timeEnd()`
-has the additional information, "timer ended" to make it obvious that the timer is no
-longer tracking time.
+Notice that the timer's name is displayed when the timer value is logged using `timeLog()` and again when it's stopped. In addition, the call to `timeEnd()` has the additional information, "timer ended" to make it obvious that the timer is no longer tracking time.
 
 ## Specifications
 

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.timeLog_static
 
 {{APIRef("Console API")}}{{AvailableInWorkers}}
 
-The **`console.timeLog()`** method logs the current value of a timer that was previously started by calling {{domxref("console.time()")}}.
+The **`console.timeLog()`** static method logs the current value of a timer that was previously started by calling {{domxref("console.time()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -59,7 +59,7 @@ console.timeLog();
 // default: 780ms
 ```
 
-If there is no corresponding timer, `timeLog()` logs a warning like:
+If there is no corresponding timer, `console.timeLog()` logs a warning like:
 
 ```plain
 Timer "timer name" doesn't exist.
@@ -93,7 +93,7 @@ answer time: 2542ms debugger eval code:3:9
 answer time: 4161ms - timer ended
 ```
 
-Notice that the timer's name is displayed when the timer value is logged using `timeLog()` and again when it's stopped. In addition, the call to `timeEnd()` has the additional information, "timer ended" to make it obvious that the timer is no longer tracking time.
+Notice that the timer's name is displayed when the timer value is logged using `console.timeLog()` and again when it's stopped. In addition, the call to `console.timeEnd()` has the additional information, "timer ended" to make it obvious that the timer is no longer tracking time.
 
 ## Specifications
 

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.console.timeStamp_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.timeStamp`** method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
+The **`console.timeStamp()`** method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
 
 You can optionally supply an argument to label the timestamp, and this label will then be shown alongside the marker.
 

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -24,8 +24,8 @@ timeStamp(label)
 
 ### Parameters
 
-- `label`
-  - : Label for the timestamp. Optional.
+- `label` {{Optional_Inline}}
+  - : Label for the timestamp.
 
 ### Return value
 

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.console.timeStamp_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.timeStamp()`** method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
+The **`console.timeStamp()`** static method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
 
 You can optionally supply an argument to label the timestamp, and this label will then be shown alongside the marker.
 

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -10,12 +10,9 @@ browser-compat: api.console.timeStamp_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.timeStamp`** method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you
-correlate a point in your code with the other events recorded in the timeline, such as
-layout and paint events.
+The **`console.timeStamp`** method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
 
-You can optionally supply an argument to label the timestamp, and this label will then
-be shown alongside the marker.
+You can optionally supply an argument to label the timestamp, and this label will then be shown alongside the marker.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -41,5 +41,6 @@ None ({{jsxref("undefined")}}).
 ## See also
 
 - {{domxref("console.time()")}}
+- {{domxref("console.timeLog()")}}
 - {{domxref("console.timeEnd()")}}
 - [Adding markers with the console API](https://web.archive.org/web/20211207010020/https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#adding-markers-with-the-console-api)

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.trace_static
 
 {{APIRef("Console API")}}
 
-The **`console.trace()`** method outputs a stack trace to the console.
+The **`console.trace()`** static method outputs a stack trace to the console.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -8,8 +8,7 @@ browser-compat: api.console.trace_static
 
 {{APIRef("Console API")}}
 
-The **`console.trace()`** method outputs a stack trace to the
-[Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html).
+The **`console.trace()`** method outputs a stack trace to the console.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -14,8 +14,7 @@ The **`console.trace()`** method outputs a stack trace to the console.
 
 > **Note:** In some browsers, `console.trace()` may also output the sequence of calls and asynchronous events leading to the current `console.trace()` which are not on the call stack — to help identify the origin of the current event evaluation loop.
 
-See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the
-{{domxref("console")}} documentation for details and examples.
+See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the {{domxref("console")}} documentation for details and examples.
 
 ## Syntax
 
@@ -27,9 +26,7 @@ trace(object1, /* …, */ objectN)
 ### Parameters
 
 - `objects` {{optional_inline}}
-  - : Zero or more objects to be output to console along with the trace. These are
-    assembled and formatted the same way they would be if passed to the
-    {{domxref("console.log()")}} method.
+  - : Zero or more objects to be output to console along with the trace. These are assembled and formatted the same way they would be if passed to the {{domxref("console.log()")}} method.
 
 ### Return value
 

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -64,3 +64,9 @@ foo
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Microsoft Edge's documentation for `console.trace()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#trace)
+- [Node.JS documentation for `console.trace()`](https://nodejs.org/docs/latest/api/console.html#consoletracemessage-args)
+- [Google Chrome's documentation for `console.trace()`](https://developer.chrome.com/docs/devtools/console/api/#trace)

--- a/files/en-us/web/api/console/warn_static/index.md
+++ b/files/en-us/web/api/console/warn_static/index.md
@@ -26,13 +26,13 @@ warn(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output to the console.
 - `msg`
-  - : A JavaScript string containing zero or more substitution strings.
+  - : A JavaScript string containing zero or more substitution strings, which are replaced with `subst1` through `substN` in consecutive order.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output. See [Using string substitutions](/en-US/docs/Web/API/console#using_string_substitutions) for a description of how substitutions work.
 
-See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
+See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of the {{domxref("console")}} object for details.
 
 ### Return value
 

--- a/files/en-us/web/api/console/warn_static/index.md
+++ b/files/en-us/web/api/console/warn_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.warn_static
 
 {{APIRef("Console API")}}
 
-The **`console.warn()`** method outputs a warning message to the console.
+The **`console.warn()`** static method outputs a warning message to the console.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/warn_static/index.md
+++ b/files/en-us/web/api/console/warn_static/index.md
@@ -8,13 +8,11 @@ browser-compat: api.console.warn_static
 
 {{APIRef("Console API")}}
 
-The **`console.warn()`** method outputs a warning message to the Web
-console.
+The **`console.warn()`** method outputs a warning message to the console.
 
 {{AvailableInWorkers}}
 
-> **Note:** In Chrome and Firefox, warnings have a small exclamation point icon next to them in the Web
-> console log.
+> **Note:** In Chrome and Firefox, warnings have a small exclamation point icon next to them in the console log.
 
 ## Syntax
 
@@ -28,13 +26,11 @@ warn(msg, subst1, /* …, */ substN)
 ### Parameters
 
 - `obj1` … `objN`
-  - : A list of JavaScript objects to output. The string representations of each of these
-    objects are appended together in the order listed and output.
+  - : A list of JavaScript objects to output. The string representations of each of these objects are appended together in the order listed and output.
 - `msg`
   - : A JavaScript string containing zero or more substitution strings.
 - `subst1` … `substN`
-  - : JavaScript objects with which to replace substitution strings within
-    `msg`. This gives you additional control over the format of the output.
+  - : JavaScript objects with which to replace substitution strings within `msg`. This gives you additional control over the format of the output.
 
 See [Outputting text to the console](/en-US/docs/Web/API/console#outputting_text_to_the_console) in the documentation of {{domxref("console")}} for details.
 

--- a/files/en-us/web/api/console/warn_static/index.md
+++ b/files/en-us/web/api/console/warn_static/index.md
@@ -52,4 +52,6 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- [MSDN: Using the F12 Tools Console to View Errors and Status](<https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/samples/gg589530(v=vs.85)>)
+- [Microsoft Edge's documentation for `console.warn()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#warn)
+- [Node.JS documentation for `console.warn()`](https://nodejs.org/docs/latest/api/console.html#consolewarndata-args)
+- [Google Chrome's documentation for `console.warn()`](https://developer.chrome.com/docs/devtools/console/api/#warn)


### PR DESCRIPTION
Upstreaming fixes I've been making in `fr` (cf. mdn/translated-content/pull/16974).

I gladly admit some of these might be opinionated and tried to split this into singular commits for each type of change.

Among other things:

- I've removed MSDN links and decided it could be nice to have pointers from other docs (Chrome/Edge/Node): please let me know if you think this doesn't have much value in this context. I can remove those "See also" third party links.
- I've found newlines/wrapping to be heterogeneous and went with fixing this. If that contradicts any Prettier/convention rule, please let me know.

See #30065 for recent changes here.