### PR TITLE
highlight current Sanitizer API instability more clearly

### DIFF
--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -9,10 +9,10 @@ browser-compat: api.Sanitizer
 
 {{DefaultAPISidebar("HTML Sanitizer API")}}{{SeeCompatTable}}
 
+{{securecontext_header}}
+
 > **Warning:** This documentation reflects stale browser implementations.
 > The specification has changed significantly since the docs were written, and they will need to be updated once browser implementations catch up.
-
-{{securecontext_header}}
 
 The **HTML Sanitizer API** allow developers to take untrusted strings of HTML and {{domxref('Document')}} or {{domxref('DocumentFragment')}} objects, and sanitize them for safe insertion into a document's DOM.
 

--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Sanitizer
 
 {{DefaultAPISidebar("HTML Sanitizer API")}}{{SeeCompatTable}}
 
-> **Note:** This documentation reflects stale browser implementations.
+> **Warning:** This documentation reflects stale browser implementations.
 > The specification has changed significantly since the docs were written, and they will need to be updated once browser implementations catch up.
 
 {{securecontext_header}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

More prominently highlights the stale implementation note on the HTML Sanitizer API documentation.

### Motivation

The current note banner on the documented Sanitizer API explaining that the documentation is for a stale implementation is not very noticeable, especially given it is sandwiched between two other note banners:

![image](https://github.com/mdn/content/assets/3483866/fb89db83-cd85-44d1-93ce-1727ede1bae4)

Given Chromium has [unshipped the stale version in v119](https://chromestatus.com/feature/5115076981293056), it should be more clearly communicated in MDN.

### Additional details

* https://groups.google.com/a/chromium.org/g/blink-dev/c/PNTt4oFXt8c/m/C1bS0ityBAAJ
* https://chromestatus.com/feature/5115076981293056
* https://chromereleases.googleblog.com/2023/10/stable-channel-update-for-desktop_31.html
* https://developer.chrome.com/blog/sanitizer-api-deprecation/

Updated banners: 

![image](https://github.com/mdn/content/assets/3483866/c20fb310-f50f-4603-b5be-020cd5258663)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
