### PR TITLE
changed require to dynamic imports

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -273,7 +273,7 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
 
    ```js
    import babel from "gulp-babel";
-   import jshint from "gulp-jshint"
+   import jshint from "gulp-jshint";
    ```
 
 3. Add the following test to the bottom of `gulpfile.js`:

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -106,7 +106,8 @@ With this, you are ready to move on.
 
 Let's look at setting up Gulp and using it to automate some testing tools.
 
-1. To begin with, create a test npm project using the procedure detailed at the bottom of the previous section. Also, update the `package.json` file with the line: `"type": "module"` so that it'll look something like this:
+1. To begin with, create a test npm project using the procedure detailed at the bottom of the previous section.
+   Also, update the `package.json` file with the line: `"type": "module"` so that it'll look something like this:
 
    ```json
    {
@@ -137,7 +138,7 @@ Let's look at setting up Gulp and using it to automate some testing tools.
    npm install --save-dev gulp
    ```
 
-5. Now create a new file inside your project directory called `gulpfile.js`. This is the file that will run all our tasks. Inside this file, put the following:
+5. Now create a new file inside your project directory called `gulpfile.mjs`. This is the file that will run all our tasks. Inside this file, put the following:
 
    ```js
    import gulp from "gulp";

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -189,13 +189,15 @@ To use each plugin, you need to first install it via npm, then require any depen
 4. Export the html task using:
 
    ```js
-   exports.html = html;
+   const _html = html;
+   export { _html as html };
    ```
 
 5. Change the default export to:
 
    ```js
-   exports.default = html;
+   const _default = html;
+   export { _default as default};
    ```
 
 Here we are grabbing our development `index.html` file with `gulp.src()`, which allows us to grab a source file to do something with.
@@ -248,13 +250,15 @@ In the input version of the file, you may have noticed that we put an empty {{ht
 5. Export the css task using:
 
    ```js
-   exports.css = css;
+   const _css = css;
+   export { _css as css };
    ```
 
 6. Change the default task to:
 
    ```js
-   exports.default = series(html, css);
+   const _default = gulp.series(html, css);
+   export { _default as default };
    ```
 
 Here we grab our `style.css` file, run csslint on it (which outputs a list of any errors in your CSS to the terminal), then runs it through autoprefixer to add any prefixes needed to make nascent CSS features run in older browsers. At the end of the pipe chain, we output our modified prefixed CSS to the `build` directory. Note that this only works if csslint doesn't find any errors — try removing a curly brace from your CSS file and re-running gulp to see what output you get!
@@ -296,13 +300,15 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
 4. Export the js task using:
 
    ```js
-   exports.js = js;
+   const _js = js;
+   export { _js as js };
    ```
 
 5. Change the default task to:
 
    ```js
-   exports.default = series(html, css, js);
+   const _default = gulp.series(html, css, js);
+   export { _default as default };
    ```
 
 Here we grab our `main.js` file, run `jshint` on it and output the results to the terminal using `jshint.reporter`; we then pass the file to babel, which converts it to old style syntax and outputs the result into the `build` directory. Our original code included a [fat arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), which babel has modified into an old style function.
@@ -326,7 +332,9 @@ function watch() {
   gulp.watch("src/*.js", js);
 }
 
-exports.watch = watch;
+const _watch = watch;
+
+export { _watch as watch };
 ```
 
 Now try entering the `gulp watch` command into your terminal. Gulp will now watch your directory, and run the appropriate tasks whenever you save a change to an HTML, CSS, or JavaScript file.

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -114,7 +114,22 @@ With this, you are ready to move on.
 
 Let's look at setting up Gulp and using it to automate some testing tools.
 
-1. To begin with, create a test npm project using the procedure detailed at the bottom of the previous section.
+1. To begin with, create a test npm project using the procedure detailed at the bottom of the previous section. Also, update the `package.json` file with the line: `"type": "module"` so that it'll look something like this:
+
+```json
+{
+  "name": "node-test",
+  "version": "1.0.0",
+  "description": "Test for npm projects",
+  "main": "index.js",
+  "scripts": {
+    "test": "test"
+  },
+  "author": "Chris Mills",
+  "license": "MIT",
+  "type": "module"
+}
+```
 2. Next, you'll need some sample HTML, CSS and JavaScript content to test your system on — make copies of our sample [index.html](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/index.html), [main.js](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/main.js), and [style.css](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/style.css) files in a subfolder with the name `src` inside your project folder. You can try your own test content if you like, but bear in mind that such tools won't work on internal JS/CSS — you need external files.
 3. First, install gulp globally (meaning, it will be available across all projects) using the following command:
 

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -197,7 +197,7 @@ To use each plugin, you need to first install it via npm, then require any depen
 
    ```js
    const _default = html;
-   export { _default as default};
+   export { _default as default };
    ```
 
 Here we are grabbing our development `index.html` file with `gulp.src()`, which allows us to grab a source file to do something with.

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -211,8 +211,7 @@ To use each plugin, you need to first install it via npm, then require any depen
 5. Change the default export to:
 
    ```js
-   const _default = html;
-   export { _default as default };
+   export default html;
    ```
 
 Here we are grabbing our development `index.html` file with `gulp.src()`, which allows us to grab a source file to do something with.
@@ -272,8 +271,7 @@ In the input version of the file, you may have noticed that we put an empty {{ht
 6. Change the default task to:
 
    ```js
-   const _default = gulp.series(html, css);
-   export { _default as default };
+   export default gulp.series(html, css);
    ```
 
 Here we grab our `style.css` file, run csslint on it (which outputs a list of any errors in your CSS to the terminal), then runs it through autoprefixer to add any prefixes needed to make nascent CSS features run in older browsers. At the end of the pipe chain, we output our modified prefixed CSS to the `build` directory. Note that this only works if csslint doesn't find any errors — try removing a curly brace from your CSS file and re-running gulp to see what output you get!
@@ -322,8 +320,7 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
 5. Change the default task to:
 
    ```js
-   const _default = gulp.series(html, css, js);
-   export { _default as default };
+   export default gulp.series(html, css, js);
    ```
 
 Here we grab our `main.js` file, run `jshint` on it and output the results to the terminal using `jshint.reporter`; we then pass the file to babel, which converts it to old style syntax and outputs the result into the `build` directory. Our original code included a [fat arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), which babel has modified into an old style function.

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -172,7 +172,7 @@ To use each plugin, you need to first install it via npm, then require any depen
 2. Add the following dependency to `gulpfile.js`:
 
    ```js
-   const htmltidy = require("gulp-htmltidy");
+   import htmltidy from "gulp-htmltidy";
    ```
 
 3. Add the following test to the bottom of `gulpfile.js`:
@@ -216,8 +216,8 @@ In the input version of the file, you may have noticed that we put an empty {{ht
 2. Add the following dependencies to `gulpfile.js`:
 
    ```js
-   const autoprefixer = require("gulp-autoprefixer");
-   const csslint = require("gulp-csslint");
+   import autoprefixer from "gulp-autoprefixer";
+   import csslint from "gulp-csslint";
    ```
 
 3. Add the following test to the bottom of `gulpfile.js`:
@@ -245,19 +245,13 @@ In the input version of the file, you may have noticed that we put an empty {{ht
    ]
    ```
 
-5. Add this line after the const definitions:
-
-   ```js
-   const { series } = require("gulp");
-   ```
-
-6. Export the css task using:
+5. Export the css task using:
 
    ```js
    exports.css = css;
    ```
 
-7. Change the default task to:
+6. Change the default task to:
 
    ```js
    exports.default = series(html, css);
@@ -278,8 +272,8 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
 2. Add the following dependencies to `gulpfile.js`:
 
    ```js
-   const babel = require("gulp-babel");
-   const jshint = require("gulp-jshint");
+   import babel from "gulp-babel";
+   import jshint from "gulp-jshint"
    ```
 
 3. Add the following test to the bottom of `gulpfile.js`:

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -13,22 +13,14 @@ Manually running tests on several browsers and devices, several times per day, c
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Familiarity with the core <a href="/en-US/docs/Learn/HTML">HTML</a>,
-        <a href="/en-US/docs/Learn/CSS">CSS</a>, and
-        <a href="/en-US/docs/Learn/JavaScript">JavaScript</a> languages; an idea
-        of the high level
-        <a
-          href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Introduction"
-          >principles of cross-browser testing</a
-        >.
+        Familiarity with the core <a href="/en-US/docs/Learn/HTML">HTML</a>, <a href="/en-US/docs/Learn/CSS">CSS</a>, and <a href="/en-US/docs/Learn/JavaScript">JavaScript</a> languages;
+        an idea of the high level <a href="/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Introduction">principles of cross-browser testing</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        To provide an understanding of what automated testing entails, how it
-        can make your life easier, and how to make use of some of the commercial
-        products that make things easier.
+        To provide an understanding of what automated testing entails, how it can make your life easier, and how to make use of some of the commercial products that make things easier.
       </td>
     </tr>
   </tbody>
@@ -116,21 +108,23 @@ Let's look at setting up Gulp and using it to automate some testing tools.
 
 1. To begin with, create a test npm project using the procedure detailed at the bottom of the previous section. Also, update the `package.json` file with the line: `"type": "module"` so that it'll look something like this:
 
-```json
-{
-  "name": "node-test",
-  "version": "1.0.0",
-  "description": "Test for npm projects",
-  "main": "index.js",
-  "scripts": {
-    "test": "test"
-  },
-  "author": "Chris Mills",
-  "license": "MIT",
-  "type": "module"
-}
-```
-2. Next, you'll need some sample HTML, CSS and JavaScript content to test your system on — make copies of our sample [index.html](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/index.html), [main.js](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/main.js), and [style.css](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/style.css) files in a subfolder with the name `src` inside your project folder. You can try your own test content if you like, but bear in mind that such tools won't work on internal JS/CSS — you need external files.
+   ```json
+   {
+     "name": "node-test",
+     "version": "1.0.0",
+     "description": "Test for npm projects",
+     "main": "index.js",
+     "scripts": {
+       "test": "test"
+     },
+     "author": "Chris Mills",
+     "license": "MIT",
+     "type": "module"
+   }
+   ```
+
+2. Next, you'll need some sample HTML, CSS and JavaScript content to test your system on — make copies of our sample [index.html](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/index.html), [main.js](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/main.js), and [style.css](https://github.com/mdn/learning-area/blob/main/tools-testing/cross-browser-testing/automation/style.css) files in a subfolder with the name `src` inside your project folder.
+   You can try your own test content if you like, but bear in mind that such tools won't work on internal JS/CSS — you need external files.
 3. First, install gulp globally (meaning, it will be available across all projects) using the following command:
 
    ```bash
@@ -151,7 +145,7 @@ Let's look at setting up Gulp and using it to automate some testing tools.
    export default function (cb) {
      console.log("Gulp running");
      cb();
-   };
+   }
    ```
 
    This requires the `gulp` module we installed earlier, and then exports a default task that does nothing except for printing a message to the terminal — this is useful for letting us know that Gulp is working. Each gulp task is exported in the same basic format — `exports.taskName = taskFunction`. Each function takes one parameter — a callback to run when the task is completed.

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -146,9 +146,9 @@ Let's look at setting up Gulp and using it to automate some testing tools.
 5. Now create a new file inside your project directory called `gulpfile.js`. This is the file that will run all our tasks. Inside this file, put the following:
 
    ```js
-   const gulp = require("gulp");
+   import gulp from "gulp";
 
-   exports.default = function (cb) {
+   export default function (cb) {
      console.log("Gulp running");
      cb();
    };
@@ -193,7 +193,7 @@ To use each plugin, you need to first install it via npm, then require any depen
 3. Add the following test to the bottom of `gulpfile.js`:
 
    ```js
-   function html() {
+   export function html() {
      return gulp
        .src("src/index.html")
        .pipe(htmltidy())
@@ -201,14 +201,7 @@ To use each plugin, you need to first install it via npm, then require any depen
    }
    ```
 
-4. Export the html task using:
-
-   ```js
-   const _html = html;
-   export { _html as html };
-   ```
-
-5. Change the default export to:
+4. Change the default export to:
 
    ```js
    export default html;
@@ -239,7 +232,7 @@ In the input version of the file, you may have noticed that we put an empty {{ht
 3. Add the following test to the bottom of `gulpfile.js`:
 
    ```js
-   function css() {
+   export function css() {
      return gulp
        .src("src/style.css")
        .pipe(csslint())
@@ -261,14 +254,7 @@ In the input version of the file, you may have noticed that we put an empty {{ht
    ]
    ```
 
-5. Export the css task using:
-
-   ```js
-   const _css = css;
-   export { _css as css };
-   ```
-
-6. Change the default task to:
+5. Change the default task to:
 
    ```js
    export default gulp.series(html, css);
@@ -296,7 +282,7 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
 3. Add the following test to the bottom of `gulpfile.js`:
 
    ```js
-   function js() {
+   export function js() {
      return gulp
        .src("src/main.js")
        .pipe(jshint())
@@ -310,14 +296,7 @@ Here we grab our `style.css` file, run csslint on it (which outputs a list of an
    }
    ```
 
-4. Export the js task using:
-
-   ```js
-   const _js = js;
-   export { _js as js };
-   ```
-
-5. Change the default task to:
+4. Change the default task to:
 
    ```js
    export default gulp.series(html, css, js);
@@ -338,15 +317,11 @@ If you get errors, check that you've added all the dependencies and the tests as
 Gulp comes with a `watch()` function that you can use to watch your files and run tests whenever you save a file. For example, try adding the following to the bottom of your `gulpfile.js`:
 
 ```js
-function watch() {
+export function watch() {
   gulp.watch("src/*.html", html);
   gulp.watch("src/*.css", css);
   gulp.watch("src/*.js", js);
 }
-
-const _watch = watch;
-
-export { _watch as watch };
 ```
 
 Now try entering the `gulp watch` command into your terminal. Gulp will now watch your directory, and run the appropriate tasks whenever you save a change to an HTML, CSS, or JavaScript file.


### PR DESCRIPTION
In the previous state, the code presents the following error when the gulp command is ran: 

`Error [ERR_REQUIRE_ESM]: require() of ES Module /.../node-test/node_modules/gulp-autoprefixer/index.js from /.../node-test/gulpfile.js not supported. Instead change the require of index.js in /.../node-test/gulpfile.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/.../node-test/gulpfile.js:3:22) {
  code: 'ERR_REQUIRE_ESM'
}`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Changed required statements to imports statements needed to run gulp command without producing errors.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
To allow users to understand how to add tasks to Gulp without producing errors in the command line interface instead.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
