### PR TITLE
Remove link to removed glossary link

### DIFF
--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -73,7 +73,6 @@ The MDN [Web Performance Learning Area](/en-US/docs/Learn/Performance) contains 
 - {{glossary('First contentful paint')}}
 - {{glossary('First CPU idle')}}
 - {{glossary('First input delay')}}
-- {{glossary('First interactive')}}
 - {{glossary('First meaningful paint')}}
 - {{glossary('First paint')}}
 - {{glossary('HTTP')}}


### PR DESCRIPTION
First interactive glossary entry, useless, has been removed. Adapting the _See also_ section here.