### PR TITLE
Fix links to static console methods

### DIFF
--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -109,7 +109,7 @@ Great progress has been made to update IndexedDB to the latest draft specificati
 
 ### Developer tools
 
-- The {{ domxref("console") }} object has two new methods, {{ domxref("console.time()") }} and {{ domxref("console.timeEnd()") }}, which can be used to set timers on a page.
+- The {{ domxref("console") }} object has two new methods, {{ domxref("console/time_static", "console.time()") }} and {{ domxref("console/timeEnd_static", "console.timeEnd()") }}, which can be used to set timers on a page.
 - The new [Page Inspector](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/index.html) has been added, providing an excellent way to examine and manipulate the HTML and CSS behind your content.
 
 ## Changes for Mozilla and add-on developers

--- a/files/en-us/mozilla/firefox/releases/28/index.md
+++ b/files/en-us/mozilla/firefox/releases/28/index.md
@@ -12,8 +12,8 @@ Firefox 28 was released on March 18, 2014. This article lists key changes that a
 
 ### Developer Tools
 
-- The {{domxref("console.exception")}} property has been added ([Firefox bug 922214](https://bugzil.la/922214)).
-- The {{domxref("console.assert")}} property has been added ([Firefox bug 760193](https://bugzil.la/760193)).
+- The `console.exception`` property has been added ([Firefox bug 922214](https://bugzil.la/922214)).
+- The {{domxref("console/assert_static", "console.assert()")}} property has been added ([Firefox bug 760193](https://bugzil.la/760193)).
 - App Manager: a new Manifest Editor was added.
 - App Manager: the toolbox used for debugging apps is now embedded in the app manager UI.
 - Web Console: added a "split console" mode - press Escape to quickly open the console in any other tool.

--- a/files/en-us/mozilla/firefox/releases/28/index.md
+++ b/files/en-us/mozilla/firefox/releases/28/index.md
@@ -12,7 +12,7 @@ Firefox 28 was released on March 18, 2014. This article lists key changes that a
 
 ### Developer Tools
 
-- The `console.exception`` property has been added ([Firefox bug 922214](https://bugzil.la/922214)).
+- The `console.exception` property has been added ([Firefox bug 922214](https://bugzil.la/922214)).
 - The {{domxref("console/assert_static", "console.assert()")}} property has been added ([Firefox bug 760193](https://bugzil.la/760193)).
 - App Manager: a new Manifest Editor was added.
 - App Manager: the toolbox used for debugging apps is now embedded in the app manager UI.

--- a/files/en-us/mozilla/firefox/releases/40/index.md
+++ b/files/en-us/mozilla/firefox/releases/40/index.md
@@ -115,7 +115,7 @@ New extensions to the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API):
 
 #### Dev Tools
 
-- The property {{domxref("console.timeStamp")}} has been added ([Firefox bug 922221](https://bugzil.la/922221)).
+- The property {{domxref("console/timeStamp_static", "console.timeStamp()")}} has been added ([Firefox bug 922221](https://bugzil.la/922221)).
 
 ### MathML
 

--- a/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currentframe/index.md
@@ -50,7 +50,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console/log_static", "console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/currenttime/index.md
@@ -50,7 +50,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console/log_static", "console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/index.md
@@ -71,7 +71,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-Next, in our main scripts file we'll load the processor, create an instance of {{domxref("AudioWorkletNode")}} — passing the name of the processor to it — and connect the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+Next, in our main scripts file we'll load the processor, create an instance of {{domxref("AudioWorkletNode")}} — passing the name of the processor to it — and connect the node to an audio graph. We should see the output of {{domxref("console/log_static", "console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/samplerate/index.md
@@ -50,7 +50,7 @@ console.log(usefulVariable);
 registerProcessor("test-processor", TestProcessor);
 ```
 
-The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console.log()")}} calls in the console:
+The main script loads the processor, creates an instance of {{domxref("AudioWorkletNode")}}, passes the name of the processor to it, and connects the node to an audio graph. We should see the output of {{domxref("console/log_static", "console.log()")}} calls in the console:
 
 ```js
 const audioContext = new AudioContext();

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.countReset_static
 
 {{APIRef("Console API")}}
 
-The **`console.countReset()`** static method resets counter used with {{domxref("console.count()")}}.
+The **`console.countReset()`** static method resets counter used with {{domxref("console/count_static", "console.count()")}}.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/console/group_static/index.md
+++ b/files/en-us/web/api/console/group_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.group_static
 
 {{APIRef("Console API")}}
 
-The **`console.group()`** static method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level, until {{domxref("console.groupEnd()")}} is called.
+The **`console.group()`** static method creates a new inline group in the console log, causing any subsequent console messages to be indented by an additional level, until {{domxref("console/groupEnd_static", "console.groupEnd()")}} is called.
 
 {{AvailableInWorkers}}
 
@@ -63,8 +63,8 @@ See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_th
 
 ## See also
 
-- {{domxref("console.groupEnd()")}}
-- {{domxref("console.groupCollapsed()")}}
+- {{domxref("console/groupEnd_static", "console.groupEnd()")}}
+- {{domxref("console/groupCollapsed_static", "console.groupCollapsed()")}}
 - [Microsoft Edge's documentation for `console.group()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#group)
 - [Node.JS documentation for `console.group()`](https://nodejs.org/docs/latest/api/console.html#consolegrouplabel)
 - [Google Chrome's documentation for `console.group()`](https://developer.chrome.com/docs/devtools/console/api/#group)

--- a/files/en-us/web/api/console/groupcollapsed_static/index.md
+++ b/files/en-us/web/api/console/groupcollapsed_static/index.md
@@ -8,9 +8,9 @@ browser-compat: api.console.groupCollapsed_static
 
 {{APIRef("Console API")}}
 
-The **`console.groupCollapsed()`** static method creates a new inline group in the console. Unlike {{domxref("console.group()")}}, however, the new group is created collapsed. The user will need to use the disclosure button next to it to expand it, revealing the entries created in the group.
+The **`console.groupCollapsed()`** static method creates a new inline group in the console. Unlike {{domxref("console/group_static", "console.group()")}}, however, the new group is created collapsed. The user will need to use the disclosure button next to it to expand it, revealing the entries created in the group.
 
-Call {{domxref("console.groupEnd()")}} to back out to the parent group.
+Call {{domxref("console/groupEnd_static", "console.groupEnd()")}} to back out to the parent group.
 
 See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxref("console")}} documentation for details and examples.
 
@@ -42,8 +42,8 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{domxref("console.group()")}}
-- {{domxref("console.groupEnd()")}}
+- {{domxref("console/group_static", "console.group()")}}
+- {{domxref("console/groupEnd_static", "console.groupEnd()")}}
 - [Microsoft Edge's documentation for `console.groupCollapsed()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#groupcollapsed)
 - [Node.JS documentation for `console.groupCollapsed()`](https://nodejs.org/docs/latest/api/console.html#consolegroupcollapsed)
 - [Google Chrome's documentation for `console.groupCollapsed()`](https://developer.chrome.com/docs/devtools/console/api/#groupcollapsed)

--- a/files/en-us/web/api/console/groupend_static/index.md
+++ b/files/en-us/web/api/console/groupend_static/index.md
@@ -36,8 +36,8 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{domxref("console.group()")}}
-- {{domxref("console.groupCollapsed()")}}
+- {{domxref("console/group_static", "console.group()")}}
+- {{domxref("console/groupCollapsed_static", "console.groupCollapsed()")}}
 - [Microsoft Edge's documentation for `console.groupEnd()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#groupend)
 - [Node.JS documentation for `console.groupEnd()`](https://nodejs.org/docs/latest/api/console.html#consolegroupend)
 - [Google Chrome's documentation for `console.groupEnd()`](https://developer.chrome.com/docs/devtools/console/api/#groupend)

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -23,58 +23,58 @@ This page documents the [Methods](#methods) available on the `console` object an
 
 ## Instance methods
 
-- {{domxref("console.assert()")}}
+- {{domxref("console/assert_static", "console.assert()")}}
   - : Log a message and stack trace to console if the first argument is `false`.
-- {{domxref("console.clear()")}}
+- {{domxref("console/clear_static", "console.clear()")}}
   - : Clear the console.
-- {{domxref("console.count()")}}
+- {{domxref("console/count_static", "console.count()")}}
   - : Log the number of times this line has been called with the given label.
-- {{domxref("console.countReset()")}}
+- {{domxref("console/countReset_static", "console.countReset()")}}
   - : Resets the value of the counter with the given label.
-- {{domxref("console.debug()")}}
+- {{domxref("console/debug_static", "console.debug()")}}
   - : Outputs a message to the console with the log level `debug`.
-- {{domxref("console.dir()")}}
+- {{domxref("console/dir_static", "console.dir()")}}
   - : Displays an interactive listing of the properties of a specified JavaScript object. This listing lets you use disclosure triangles to examine the contents of child objects.
-- {{domxref("console.dirxml()")}}
+- {{domxref("console/dirxml_static", "console.dirxml()")}}
   - : Displays an XML/HTML Element representation of the specified object if possible or the JavaScript Object view if it is not possible.
-- {{domxref("console.error()")}}
+- {{domxref("console/error_static", "console.error()")}}
   - : Outputs an error message. You may use [string substitution](#using_string_substitutions) and additional arguments with this method.
 - `console.exception()` {{Non-standard_inline}} {{deprecated_inline}}
   - : An alias for `console.error()`.
-- {{domxref("console.group()")}}
+- {{domxref("console/group_static", "console.group()")}}
   - : Creates a new inline [group](#using_groups_in_the_console), indenting all following output by another level. To move back out a level, call `console.groupEnd()`.
-- {{domxref("console.groupCollapsed()")}}
+- {{domxref("console/groupCollapsed_static", "console.groupCollapsed()")}}
   - : Creates a new inline [group](#using_groups_in_the_console), indenting all following output by another level. However, unlike `console.group()` this starts with the inline group collapsed requiring the use of a disclosure button to expand it. To move back out a level, call `console.groupEnd()`.
-- {{domxref("console.groupEnd()")}}
+- {{domxref("console/groupEnd_static", "console.groupEnd()")}}
   - : Exits the current inline [group](#using_groups_in_the_console).
-- {{domxref("console.info()")}}
+- {{domxref("console/info_static", "console.info()")}}
   - : Informative logging of information. You may use [string substitution](#using_string_substitutions) and additional arguments with this method.
-- {{domxref("console.log()")}}
+- {{domxref("console/log_static", "console.log()")}}
   - : For general output of logging information. You may use [string substitution](#using_string_substitutions) and additional arguments with this method.
-- {{domxref("console.profile()")}} {{Non-standard_inline}}
+- {{domxref("console/profile_static", "console.profile()")}} {{Non-standard_inline}}
   - : Starts the browser's built-in profiler (for example, the [Firefox performance tool](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)). You can specify an optional name for the profile.
-- {{domxref("console.profileEnd()")}} {{Non-standard_inline}}
+- {{domxref("console/profileEnd_static", "console.profileEnd()")}} {{Non-standard_inline}}
   - : Stops the profiler. You can see the resulting profile in the browser's performance tool (for example, the [Firefox performance tool](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)).
-- {{domxref("console.table()")}}
+- {{domxref("console/table_static", "console.table()")}}
   - : Displays tabular data as a table.
-- {{domxref("console.time()")}}
+- {{domxref("console/time_static", "console.time()")}}
   - : Starts a [timer](#timers) with a name specified as an input parameter. Up to 10,000 simultaneous timers can run on a given page.
-- {{domxref("console.timeEnd()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}
   - : Stops the specified [timer](#timers) and logs the elapsed time in milliseconds since it started.
-- {{domxref("console.timeLog()")}}
+- {{domxref("console/timeLog_static", "console.timeLog()")}}
   - : Logs the value of the specified [timer](#timers) to the console.
-- {{domxref("console.timeStamp()")}} {{Non-standard_inline}}
+- {{domxref("console/timeStamp_static", "console.timeStamp()")}} {{Non-standard_inline}}
   - : Adds a marker to the browser performance tool's timeline ([Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/) or [Firefox](https://profiler.firefox.com/docs/#/./guide-ui-tour-timeline)).
-- {{domxref("console.trace()")}}
+- {{domxref("console/trace_static", "console.trace()")}}
   - : Outputs a [stack trace](#stack_traces).
-- {{domxref("console.warn()")}}
+- {{domxref("console/warn_static", "console.warn()")}}
   - : Outputs a warning message. You may use [string substitution](#using_string_substitutions) and additional arguments with this method.
 
 ## Examples
 
 ### Outputting text to the console
 
-The most frequently-used feature of the console is logging of text and other data. There are several categories of output you can generate, using the {{domxref("console.log()")}}, {{domxref("console.info()")}}, {{domxref("console.warn()")}}, {{domxref("console.error()")}}, or {{domxref("console.debug()")}} methods. Each of these results in output styled differently in the log, and you can use the filtering controls provided by your browser to only view the kinds of output that interest you.
+The most frequently-used feature of the console is logging of text and other data. There are several categories of output you can generate, using the {{domxref("console/log_static", "console.log()")}}, {{domxref("console/info_static", "console.info()")}}, {{domxref("console/warn_static", "console.warn()")}}, {{domxref("console/error_static", "console.error()")}}, or {{domxref("console/debug_static", "console.debug()")}} methods. Each of these results in output styled differently in the log, and you can use the filtering controls provided by your browser to only view the kinds of output that interest you.
 
 There are two ways to use each of the output methods; you can pass in a list of objects whose string representations get concatenated into one string, then output to the console, or you can pass in a string containing zero or more substitution strings followed by a list of objects to replace them.
 
@@ -236,7 +236,7 @@ Notice that the timer's name is displayed both when the timer is started and whe
 
 ### Stack traces
 
-The console object also supports outputting a stack trace; this will show you the call path taken to reach the point at which you call {{domxref("console.trace()")}}. Given code like this:
+The console object also supports outputting a stack trace; this will show you the call path taken to reach the point at which you call {{domxref("console/trace_static", "console.trace()")}}. Given code like this:
 
 ```js
 function foo() {

--- a/files/en-us/web/api/console/profile_static/index.md
+++ b/files/en-us/web/api/console/profile_static/index.md
@@ -12,9 +12,9 @@ browser-compat: api.console.profile_static
 
 The **`console.profile()`** static method starts recording a performance profile (for example, the [Firefox performance tool](https://firefox-source-docs.mozilla.org/devtools-user/performance/index.html)).
 
-You can optionally supply an argument to name the profile and this then enables you to stop only that profile if multiple profiles being recorded. See {{domxref("console.profileEnd()")}} to see how this argument is interpreted.
+You can optionally supply an argument to name the profile and this then enables you to stop only that profile if multiple profiles being recorded. See {{domxref("console/profileEnd_static", "console.profileEnd()")}} to see how this argument is interpreted.
 
-To stop recording call {{domxref("console.profileEnd()")}}.
+To stop recording call {{domxref("console/profileEnd_static", "console.profileEnd()")}}.
 
 {{AvailableInWorkers}}
 
@@ -39,4 +39,4 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{domxref("console.profileEnd()")}}
+- {{domxref("console/profileEnd_static", "console.profileEnd()")}}

--- a/files/en-us/web/api/console/profileend_static/index.md
+++ b/files/en-us/web/api/console/profileend_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.console.profileEnd_static
 
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.profileEnd()`** static method stops recording a profile previously started with {{DOMxRef("console.profile()")}}.
+The **`console.profileEnd()`** static method stops recording a profile previously started with {{domxref("console/profile_static", "console.profile()")}}.
 
 You can optionally supply an argument to name the profile. Doing so enables you to stop only that profile if you have multiple profiles being recorded.
 
@@ -41,4 +41,4 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{DOMxRef("console.profile()")}}
+- {{domxref("console/profile_static", "console.profile()")}}

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.time_static
 
 {{APIRef("Console API")}}
 
-The **`console.time()`** static method starts a timer you can use to track how long an operation takes. You give each timer a unique name, and may have up to 10,000 timers running on a given page. When you call {{domxref("console.timeEnd()")}} with the same name, the browser will output the time, in milliseconds, that elapsed since the timer was started.
+The **`console.time()`** static method starts a timer you can use to track how long an operation takes. You give each timer a unique name, and may have up to 10,000 timers running on a given page. When you call {{domxref("console/timeEnd_static", "console.timeEnd()")}} with the same name, the browser will output the time, in milliseconds, that elapsed since the timer was started.
 
 See [Timers](/en-US/docs/Web/API/console#timers) in the {{domxref("console")}} documentation for details and examples.
 
@@ -24,7 +24,7 @@ time(label)
 ### Parameters
 
 - `label` {{optional_inline}}
-  - : A string representing the name to give the new timer. This will identify the timer; use the same name when calling {{domxref("console.timeEnd()")}} to stop the timer and get the time output to the console. If omitted, the label "default" is used.
+  - : A string representing the name to give the new timer. This will identify the timer; use the same name when calling {{domxref("console/timeEnd_static", "console.timeEnd()")}} to stop the timer and get the time output to the console. If omitted, the label "default" is used.
 
 ### Return value
 
@@ -40,8 +40,8 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{domxref("console.timeEnd()")}}
-- {{domxref("console.timeLog()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}
+- {{domxref("console/timeLog_static", "console.timeLog()")}}
 - [Microsoft Edge's documentation for `console.time()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#time)
 - [Node.JS documentation for `console.time()`](https://nodejs.org/docs/latest/api/console.html#consoletimelabel)
 - [Google Chrome's documentation for `console.time()`](https://developer.chrome.com/docs/devtools/console/api/#time)

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.timeEnd_static
 
 {{APIRef("Console API")}}
 
-The **`console.timeEnd()`** static method stops a timer that was previously started by calling {{domxref("console.time()")}}.
+The **`console.timeEnd()`** static method stops a timer that was previously started by calling {{domxref("console/time_static", "console.time()")}}.
 
 See [Timers](/en-US/docs/Web/API/console#timers) in the documentation for details and examples.
 
@@ -57,8 +57,8 @@ longer tracking time.
 
 ## See also
 
-- {{domxref("console.time()")}}
-- {{domxref("console.timeLog()")}}
+- {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeLog_static", "console.timeLog()")}}
 - [Microsoft Edge's documentation for `console.timeEnd()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#timeend)
 - [Node.JS documentation for `console.timeEnd()`](https://nodejs.org/docs/latest/api/console.html#consoletimeendlabel)
 - [Google Chrome's documentation for `console.timeEnd()`](https://developer.chrome.com/docs/devtools/console/api/#timeend)

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.console.timeLog_static
 
 {{APIRef("Console API")}}{{AvailableInWorkers}}
 
-The **`console.timeLog()`** static method logs the current value of a timer that was previously started by calling {{domxref("console.time()")}}.
+The **`console.timeLog()`** static method logs the current value of a timer that was previously started by calling {{domxref("console/time_static", "console.time()")}}.
 
 ## Syntax
 
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 
 The `console.timeLog()` method logs the current value of a timer.
 
-The method can be passed the name of a timer. This will attempt to log the value of a timer created with that name in a previous call to {{domxref("console.time()")}}:
+The method can be passed the name of a timer. This will attempt to log the value of a timer created with that name in a previous call to {{domxref("console/time_static", "console.time()")}}:
 
 ```js
 console.time("reticulating splines");
@@ -105,6 +105,6 @@ Notice that the timer's name is displayed when the timer value is logged using `
 
 ## See also
 
-- {{domxref("console.time()")}}
-- {{domxref("console.timeEnd()")}}
+- {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}
 - [Node.JS documentation for `console.timeLog()`](https://nodejs.org/docs/latest/api/console.html#consoletimeloglabel-data)

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{domxref("console.time()")}}
-- {{domxref("console.timeLog()")}}
-- {{domxref("console.timeEnd()")}}
+- {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeLog_static", "console.timeLog()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}
 - [Adding markers with the console API](https://web.archive.org/web/20211207010020/https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#adding-markers-with-the-console-api)

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -26,7 +26,7 @@ trace(object1, /* …, */ objectN)
 ### Parameters
 
 - `objects` {{optional_inline}}
-  - : Zero or more objects to be output to console along with the trace. These are assembled and formatted the same way they would be if passed to the {{domxref("console.log()")}} method.
+  - : Zero or more objects to be output to console along with the trace. These are assembled and formatted the same way they would be if passed to the {{domxref("console/log_static", "console.log()")}} method.
 
 ### Return value
 

--- a/files/en-us/web/api/console_api/index.md
+++ b/files/en-us/web/api/console_api/index.md
@@ -20,7 +20,7 @@ The Console API started as a largely proprietary API, with different browsers im
 
 Usage is very simple — the {{domxref("console")}} object contains many methods that you can call to perform rudimentary debugging tasks, generally focused around logging various values to the browser's [Web Console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html).
 
-By far the most commonly-used method is {{domxref("console.log")}}, which is used to log the current value contained inside a specific variable.
+By far the most commonly-used method is {{domxref("console/log_static", "console.log()")}}, which is used to log the current value contained inside a specific variable.
 
 ## Interfaces
 

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -248,7 +248,7 @@ It has two methods:
 
 As noted above, `StylePropertyMapReadOnly.get('--customProperty')` returns a {{domxref('CSSUnparsedValue')}}. We can parse `CSSUnparsedValue` object instances with the inherited {{domxref('CSSStyleValue/parse_static', 'CSSStyleValue.parse()')}} and {{domxref('CSSStyleValue/parseAll_static', 'CSSStyleValue.parseAll()')}} methods.
 
-Let's examine a CSS example with several custom properties, transforms, `calc()`s, and other features. We'll take a look at what their types are by employing short JavaScript snippets outputting to {{domxref('console.log()')}}:
+Let's examine a CSS example with several custom properties, transforms, `calc()`s, and other features. We'll take a look at what their types are by employing short JavaScript snippets outputting to {{domxref("console/log_static", "console.log()")}}:
 
 ```css
 :root {

--- a/files/en-us/web/api/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/index.md
@@ -37,7 +37,7 @@ No
 
 ## Examples
 
-We create an element with a [`width`](/en-US/docs/Web/CSS/width) determined using a [`calc()`](/en-US/docs/Web/CSS/calc) function, then {{DOMxRef("console.log()")}} the `operator` and `values`, and dig into the values a bit.
+We create an element with a [`width`](/en-US/docs/Web/CSS/width) determined using a [`calc()`](/en-US/docs/Web/CSS/calc) function, then {{domxref("console/log_static", "console.log()")}} the `operator` and `values`, and dig into the values a bit.
 
 ```html
 <div>has width</div>

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -41,7 +41,7 @@ No
 
 ## Examples
 
-We create an element with a [`width`](/en-US/docs/Web/CSS/width) determined using a [`calc()`](/en-US/docs/Web/CSS/calc) function, then {{DOMxRef("console.log()")}} the `operator`.
+We create an element with a [`width`](/en-US/docs/Web/CSS/width) determined using a [`calc()`](/en-US/docs/Web/CSS/calc) function, then {{domxref("console/log_static", "console.log()")}} the `operator`.
 
 ```html
 <div>has width</div>

--- a/files/en-us/web/api/cssmathvalue/operator/index.md
+++ b/files/en-us/web/api/cssmathvalue/operator/index.md
@@ -32,7 +32,7 @@ A {{jsxref('String')}}.
 
 We create an element with a [`width`](/en-US/docs/Web/CSS/width)
 determined using a [`calc()`](/en-US/docs/Web/CSS/calc) function,
-then {{DOMxRef("console.log()")}} the
+then {{domxref("console/log_static", "console.log()")}} the
 `operator`.
 
 ```html

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -201,7 +201,7 @@ console.error = (msg) =>
   (logElem.textContent = `${logElem.textContent}\nError: ${msg}`);
 ```
 
-This allows us to use {{domxref("console.log()")}} and {{domxref("console.error()")}} to log information to the log box in the document.
+This allows us to use {{domxref("console/log_static", "console.log()")}} and {{domxref("console/error_static", "console.error()")}} to log information to the log box in the document.
 
 ##### Starting display capture
 

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -118,7 +118,7 @@ items.forEach((item) => {
 ### Printing the contents of an array
 
 > **Note:** In order to display the content of an array in the console,
-> you can use {{domxref("console/table", "console.table()")}}, which prints a formatted
+> you can use {{domxref("console/table_static", "console.table()")}}, which prints a formatted
 > version of the array.
 >
 > The following example illustrates an alternative approach, using

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -73,5 +73,5 @@ For more complex scenarios, you may want to use the [performance API](/en-US/doc
 
 - [Polyfill of `Date.now` in `core-js`](https://github.com/zloirock/core-js#ecmascript-date)
 - {{domxref("Performance.now()")}}
-- {{domxref("console.time()")}}
-- {{domxref("console.timeEnd()")}}
+- {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -182,9 +182,9 @@
     },
     "Console API": {
       "overview": ["Console API"],
-      "interfaces": ["Console"],
+      "interfaces": ["console"],
       "methods": [],
-      "properties": ["Window.console", "WorkerGlobalScope.console"],
+      "properties": ["Window.console"],
       "events": []
     },
     "Cookie Store API": {


### PR DESCRIPTION
Console  methods are now marked as static, this fixes the flaws induced by this move. (Also it fixes the sidebar as `WorkerGlobalScope.console` doesn't exist and won't.