### PR TITLE
Revert "Fixed typo in example code for Fetch API (#29833)"

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -144,7 +144,7 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
         <pre>
 // space in "C ontent-Type"
 const headers = {
-  'Content-Type': 'text/xml',
+  'C ontent-Type': 'text/xml',
   'Breaking-Bad': '<3',
 };
 fetch('https://example.com/', { headers });


### PR DESCRIPTION
This reverts commit 5321e3801bb4fcc235253065f53cdfd788785866.

The intentional typo "**C ontent-Type**" in the "Failing examples" is necessary for the example to make sense.