### PR TITLE
GroupData: Remove URL.create/revoke ObjectURL from File API entry

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -477,7 +477,7 @@
         "FileReader",
         "FileReaderSync"
       ],
-      "methods": ["URL.createObjectURL()", "URL.revokeObjectURL()"],
+      "methods": [],
       "properties": [],
       "events": []
     },


### PR DESCRIPTION
They are now in URL API.