### PR TITLE
fixed BrowserStack authentication information link

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/automated_testing/index.md
@@ -558,7 +558,7 @@ Let's have a brief look at how we'd access the API using Node.js.
    getPlanDetails();
    ```
 
-3. You'll need to fill in your BrowserStack username and API key in the indicated places. These can be retrieved from your [BrowserStack automation dashboard](https://www.browserstack.com/automate). Fill these in now.
+3. You'll need to fill in your BrowserStack username and API key in the indicated places. These can be retrieved from your [BrowserStack Account & Profile Details](https://www.browserstack.com/accounts/profile/details), under the Authentication & Security section. Fill these in now.
 4. Make sure everything is saved, and run your file like so:
 
    ```bash


### PR DESCRIPTION
Previous link redirected readers to [Automated Selenium Testing On A Grid of 3000+ Browsers & Mobile Devices | BrowserStack](https://www.browserstack.com/automate) page instead.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Added correct link to indicate to readers where to find their BrowserStack username and access key.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
To help users easily find their BrowserStack username and access key.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Previous link: [Automated Selenium Testing On A Grid of 3000+ Browsers & Mobile Devices | BrowserStack](https://www.browserstack.com/automate)
Current link: [BrowserStack Account | Summary](https://www.browserstack.com/accounts/profile/details)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
