### PR TITLE
additions and standardizations for polygon() and path()

### DIFF
--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -37,7 +37,7 @@ Note: The SVG [`<polygon>`](/en-US/docs/Web/SVG/Element/polygon) element has sep
 - [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) {{optional_inline}}
   - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the filling rule.
 - {{cssxref("length-percentage")}}
-  - : Each vertex of the polygon is represented with a pair of `<length-percentage>` values, which give the x/y coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
+  - : Each vertex of the polygon is represented by a pair of `<length-percentage>` values, which give the x/y coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
 
 ### Return value
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -28,7 +28,9 @@ polygon(nonzero, 0% 0%, 50% 50%, 0% 100%)
 polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 ```
 
-The parameters to `polygon()` are separated by a comma and optional whitespace. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2nd-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner. Note that this alternating space/comma format is strict, unlike the SVG [points](/en-US/docs/Web/SVG/Attribute/points) attribute, which is flexible about the use of space/comma separators.
+The parameters to `polygon()` are separated by a comma and optional whitespace. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2nd-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner.
+
+Note: The SVG [`<polygon>`](/en-US/docs/Web/SVG/Element/polygon) tag has [`fill-rule`](/en-US/docs/Web/SVG/Attribute/fill-rule) and [`points`](/en-US/docs/Web/SVG/Attribute/points) as separate attributes, and `points` is flexible about the usage of space and comma separators. CSS `polygon()` rules for separators are strictly enforced.
 
 ### Parameters
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -28,7 +28,7 @@ polygon(nonzero, 0% 0%, 50% 50%, 0% 100%)
 polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 ```
 
-The parameters to `polygon()` are separated by a comma and optional whitespace. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2nd-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner.
+The `polygon()` parameters are separated by a comma and optional whitespace. The first parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. Additional parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0 0" and "100% 100%" for the left/top and bottom right corners, respectively.
 
 Note: The SVG [`<polygon>`](/en-US/docs/Web/SVG/Element/polygon) element has separate attributes for [`fill-rule`](/en-US/docs/Web/SVG/Attribute/fill-rule) and [`points`](/en-US/docs/Web/SVG/Attribute/points), and `points` is flexible about the use of space and comma separators. CSS `polygon()` rules for separators are strictly enforced.
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -28,7 +28,7 @@ polygon(nonzero, 0% 0%, 50% 50%, 0% 100%)
 polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 ```
 
-The parameters to `polygon()` are comma-separated. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner. Note that this alternating space/comma format is strict, unlike the SVG [points](/en-US/docs/Web/SVG/Attribute/points) attribute, which is flexible about the use of space/comma separators.
+The parameters to `polygon()` are separated by a comma and optional whitespace. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2nd-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner. Note that this alternating space/comma format is strict, unlike the SVG [points](/en-US/docs/Web/SVG/Attribute/points) attribute, which is flexible about the use of space/comma separators.
 
 ### Parameters
 

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -28,6 +28,8 @@ polygon(nonzero, 0% 0%, 50% 50%, 0% 100%)
 polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 ```
 
+The parameters to `polygon()` are comma-separated. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner. Note that this alternating space/comma format is strict, unlike the SVG [points](/en-US/docs/Web/SVG/Attribute/points) attribute, which is flexible about the use of space/comma separators.
+
 ### Parameters
 
 - [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) {{optional_inline}}

--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -30,14 +30,14 @@ polygon(evenodd, 0% 0%, 50% 50%, 0% 100%)
 
 The parameters to `polygon()` are separated by a comma and optional whitespace. The 1st parameter is an optional [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) value. The 2nd-Nth parameters are points that define the polygon. Each point is a pair of x/y coordinate {{cssxref("length-percentage")}} values separated by a space, e.g. "0px 0px" for the left/top corner.
 
-Note: The SVG [`<polygon>`](/en-US/docs/Web/SVG/Element/polygon) tag has [`fill-rule`](/en-US/docs/Web/SVG/Attribute/fill-rule) and [`points`](/en-US/docs/Web/SVG/Attribute/points) as separate attributes, and `points` is flexible about the usage of space and comma separators. CSS `polygon()` rules for separators are strictly enforced.
+Note: The SVG [`<polygon>`](/en-US/docs/Web/SVG/Element/polygon) element has separate attributes for [`fill-rule`](/en-US/docs/Web/SVG/Attribute/fill-rule) and [`points`](/en-US/docs/Web/SVG/Attribute/points), and `points` is flexible about the use of space and comma separators. CSS `polygon()` rules for separators are strictly enforced.
 
 ### Parameters
 
 - [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) {{optional_inline}}
   - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the filling rule.
 - {{cssxref("length-percentage")}}
-  - : Each vertex of the polygon is represented with a pair of `<length-percentage>` values, which give the coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
+  - : Each vertex of the polygon is represented with a pair of `<length-percentage>` values, which give the x/y coordinates of the vertex relative to the shape's [reference box](/en-US/docs/Web/CSS/CSS_shapes/Basic_shapes#the_reference_box).
 
 ### Return value
 

--- a/files/en-us/web/css/path/index.md
+++ b/files/en-us/web/css/path/index.md
@@ -28,7 +28,7 @@ path([<'fill-rule'>,]?<string>)
 ### Parameters
 
 - [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) {{optional_inline}}
-  - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the filling rule.
+  - : An optional value of [`nonzero`](/en-US/docs/Web/SVG/Attribute/fill-rule#nonzero) (the default when omitted) or [`evenodd`](/en-US/docs/Web/SVG/Attribute/fill-rule#evenodd), which specifies the filling rule.
 - {{cssxref("string")}}
   - : A [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path). The syntax for the contents of this `<string>` is identical to SVG.
 

--- a/files/en-us/web/css/path/index.md
+++ b/files/en-us/web/css/path/index.md
@@ -27,13 +27,18 @@ path([<'fill-rule'>,]?<string>)
 
 ### Parameters
 
-- `<'fill-rule'>`
-  - : The filling rule for the interior of the path.
-    Possible values are `nonzero` or `evenodd`.
-    The default value is `nonzero`.
-    See [fill-rule](/en-US/docs/Web/SVG/Attribute/fill-rule) for more details.
-- `<string>`
-  - : The string is a [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path).
+- [`<fill-rule>`](/en-US/docs/Web/SVG/Attribute/fill-rule) {{optional_inline}}
+  - : An optional value of `nonzero` (the default when omitted) or `evenodd`, which specifies the filling rule.
+- {{cssxref("string")}}
+  - : A [data string](/en-US/docs/Web/SVG/Attribute/d) for defining an [SVG path](/en-US/docs/Web/SVG/Element/path). The syntax for the contents of this `<string>` is identical to SVG.
+
+### Return value
+
+Returns a {{cssxref("basic-shape")}} value.
+
+## Formal syntax
+
+{{csssyntax}}
 
 ## Examples
 


### PR DESCRIPTION
In  response to [commentary](https://github.com/mdn/yari/issues/10099) in mdn/yari#10099: I added a paragraph describing the `polygon()` syntax in words vs examples or syntax specifications. For `path()` all it took was a sentence. Copied some bits from the `polygon()` page to the `path()` page to make them more alike.

Why are the file systems paths for these two pages different? Shouldn't `path()` be a sub-directory under `basic-shape`?
