### PR TITLE
refX and refY set to the tip of the arrowhead

### DIFF
--- a/files/en-us/web/svg/element/marker/index.md
+++ b/files/en-us/web/svg/element/marker/index.md
@@ -33,7 +33,7 @@ svg {
     <marker
       id="arrow"
       viewBox="0 0 10 10"
-      refX="10" 
+      refX="10"
       refY="5"  <!-- refX and refY set to the tip of the arrowhead -->
       markerWidth="6"
       markerHeight="6"

--- a/files/en-us/web/svg/element/marker/index.md
+++ b/files/en-us/web/svg/element/marker/index.md
@@ -33,8 +33,8 @@ svg {
     <marker
       id="arrow"
       viewBox="0 0 10 10"
-      refX="5"
-      refY="5"
+      refX="10" 
+      refY="5"  <!-- refX and refY set to the tip of the arrowhead -->
       markerWidth="6"
       markerHeight="6"
       orient="auto-start-reverse">


### PR DESCRIPTION
This change would only apply to arrowhead marker. Setting 'refX' and 'refY' to the tip of the arrow head, that is the vertex (10,5) of the triangle, gives a more accurate representation of the arrow because it doesn't increase its length when adding the arrowhead. This is convenient for vectors representation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
