### PR TITLE
CustomStateSet plus using custom elements

### DIFF
--- a/files/en-us/web/api/customstateset/add/index.md
+++ b/files/en-us/web/api/customstateset/add/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.add
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`add`** method of the {{domxref("CustomStateSet")}} interface adds an item to the `CustomStateSet`, after checking that the value is in the correct format.
 

--- a/files/en-us/web/api/customstateset/clear/index.md
+++ b/files/en-us/web/api/customstateset/clear/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.clear
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`clear()`** method of the {{domxref("CustomStateSet")}} interface removes all elements from the `CustomStateSet` object.
 

--- a/files/en-us/web/api/customstateset/delete/index.md
+++ b/files/en-us/web/api/customstateset/delete/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.delete
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`delete()`** method of the {{domxref("CustomStateSet")}} interface deletes a single value from the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/entries/index.md
+++ b/files/en-us/web/api/customstateset/entries/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.entries
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`entries`** method of the {{domxref("CustomStateSet")}} interface returns a new [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) object, containing an array of `[value,value]` for each element in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/foreach/index.md
+++ b/files/en-us/web/api/customstateset/foreach/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.forEach
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`forEach()`** method of the {{domxref("CustomStateSet")}} interface executes a provided function for each value in the `CustomStateSet` object.
 

--- a/files/en-us/web/api/customstateset/has/index.md
+++ b/files/en-us/web/api/customstateset/has/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.has
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`has()`** method of the {{domxref("CustomStateSet")}} interface returns a {{jsxref("Boolean")}} asserting whether an element is present with the given value.
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -148,3 +148,7 @@ labeled-checkbox:--checked {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+[Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements)

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -75,6 +75,8 @@ The custom state pseudo-class matches the custom element only if the state is `t
 This example, which is adapted from the specification, demonstrates a custom checkbox element that has an internal "checked" state.
 This is mapped to the `--checked` custom state, allowing styling to be applied using the `:--checked` custom state pseudo class.
 
+#### JavaScript
+
 First we define our class `LabeledCheckbox` which extends from `HTMLElement`.
 In the constructor we just call the `super()` method, leaving most of the "work" to `connectedCallback()`, which is invoked when a custom element is added to the page.
 The content of the element is defined using a `<style>` element to be the text `[]` or `[x]` followed by a label.
@@ -136,11 +138,15 @@ We then call the {{domxref("CustomElementRegistry/define", "define()")}} method 
 customElements.define("labeled-checkbox", LabeledCheckbox);
 ```
 
+#### HTML
+
 After registering the custom element we can use use the element in HTML as shown:
 
 ```html
 <labeled-checkbox>You need to check this</labeled-checkbox>
 ```
+
+#### CSS
 
 Finally we use the `:--checked` custom state pseudo class to select CSS for when the box is checked.
 
@@ -153,7 +159,123 @@ labeled-checkbox:--checked {
 }
 ```
 
+#### Result
+
+The result can be tested below.
+Click the element to see a different border being applied as the checkbox `checked` state is toggled.
+
 {{EmbedLiveSample("Labeled Checkbox", "100%", 50)}}
+
+### Non-boolean internal states
+
+This example shows how to handle the case where the custom element has an internal property with multiple possible value.
+
+The custom element in this case has a `state` property with allowed values: "loading", "interactive" and "complete".
+To make this work we map each value to its own custom state and create code to ensure that only the dashed identifier corresponding to the internal state is set.
+You can see this in the implementation of the `set state()` method: we set the internal state, add the dashed identifier for the matching custom state to `CustomStateSet`, and remove the dashed identifiers associated with all the other values.
+
+Most of the rest of the code is very similar to the previous example (we show different text for each state as the user toggles through them).
+
+#### JavaScript
+
+```js
+class ManyStateElement extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    // Attach an ElementInternals to get states property
+    this._internals = this.attachInternals();
+    this.state = "loading";
+    this.addEventListener("click", this._onClick.bind(this));
+
+    const shadowRoot = this.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `<style>
+        :host {
+          display: block;
+          font-family: monospace;
+        }
+       :host::before { content: '[ unknown ]'; white-space: pre; }
+       :host(:--loading)::before { content: '[ loading ]' }
+       :host(:--interactive)::before { content: '[ interactive ]' }
+       :host(:--complete)::before { content: '[ complete ]' }
+       </style>
+       <slot>Click me</slot>`;
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  set state(stateName) {
+    // Set internal state to passed value
+    // Add dashed identifier matching state and delete others
+    if (stateName == "loading") {
+      this._state = "loading";
+      this._internals.states.add("--loading");
+      this._internals.states.delete("--interactive");
+      this._internals.states.delete("--complete");
+    } else if (stateName == "interactive") {
+      this._state = "interactive";
+      this._internals.states.delete("--loading");
+      this._internals.states.add("--interactive");
+      this._internals.states.delete("--complete");
+    } else if (stateName == "complete") {
+      this._state = "complete";
+      this._internals.states.delete("--loading");
+      this._internals.states.delete("--interactive");
+      this._internals.states.add("--complete");
+    }
+  }
+
+  _onClick(event) {
+    // Cycle the state when element clicked
+    if (this.state === "loading") {
+      this.state = "interactive";
+    } else if (this.state === "interactive") {
+      this.state = "complete";
+    } else if (this.state === "complete") {
+      this.state = "loading";
+    }
+  }
+}
+
+customElements.define("many-state-element", ManyStateElement);
+```
+
+#### HTML
+
+After registering the new element we add it to the HTML.
+This is similar to the previous example except we don't specify a value and use the default value from the slot (`<slot>Click me</slot>`).
+
+```html
+<many-state-element></many-state-element>
+```
+
+#### CSS
+
+In the CSS we use the three custom state pseudo classes to select CSS for each of the internal state values: `:--loading`, `:--interactive`, `:--complete`.
+Note that the custom element code ensures that only one of these custom states can be defined at a time.
+
+```css
+many-state-element:--loading {
+  border: dotted grey;
+}
+many-state-element:--interactive {
+  border: dashed blue;
+}
+many-state-element:--complete {
+  border: solid green;
+}
+```
+
+#### Results
+
+The result can be tested below.
+Click the element to see a different border being applied as the state changes.
+
+{{EmbedLiveSample("Non-boolean internal states", "100%", 50)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -128,10 +128,13 @@ class LabeledCheckbox extends HTMLElement {
 }
 ```
 
-The `connectedCallback()` method uses {{domxref("HTMLElement.attachInternals()", "`this.attachInternals()`")}} to attach an {{domxref("ElementInternals", "`ElementInternals`")}} object, from which we use `ElementInternals.states` to get the `CustomStateSet`.
-The `set checked(flag)` method adds the `"--checked"` dashed identifier to the `CustomStateSet` if the flag is set and delete the identifier if the flag is `false`.
-The `get checked()` method just checks whether the `--checked` property is defined in the set.
-The property value is toggled when the element is clicked.
+In the `LabeledCheckbox` class:
+
+- The `connectedCallback()` method uses {{domxref("HTMLElement.attachInternals()", "`this.attachInternals()`")}} to attach an {{domxref("ElementInternals", "`ElementInternals`")}} object.
+- In the `get checked()` and `set checked()` we use `ElementInternals.states` to get the `CustomStateSet`.
+- The `set checked(flag)` method adds the `"--checked"` dashed identifier to the `CustomStateSet` if the flag is set and delete the identifier if the flag is `false`.
+- The `get checked()` method just checks whether the `--checked` property is defined in the set.
+- The property value is toggled when the element is clicked.
 
 We then call the {{domxref("CustomElementRegistry/define", "define()")}} method on the object returned by {{domxref("Window.customElements")}} in order to register the custom element:
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -41,7 +41,7 @@ The interface can be used to expose the internal states of a custom element, all
 
 Built in HTML elements can have different _states_, such as "enabled" and "disabled, "checked" and "unchecked", "initial", "loading" and "ready".
 Some of these states are public and can be set or queried using properties/attributes, while others are effectively internal, and cannot be directly set.
-Whether external or internal, commonly elements states can be selected and styled using [CSS pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) as selectors.
+Whether external or internal, element states can generally be selected and styled using [CSS pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) as selectors.
 
 The `CustomStateSet` allows developers to add and delete states for autonomous custom elements (but not elements derived from built-in elements).
 These states can then be used as as custom state pseudo-class selectors in a similar way to the pseudo-classes for built-in elements.
@@ -50,7 +50,7 @@ These states can then be used as as custom state pseudo-class selectors in a sim
 
 To make the {{domxref("CustomStateSet")}} available, a custom element must first call {{domxref("HTMLElement.attachInternals()")}} in order to attach an {{domxref("ElementInternals")}} object.
 `CustomStateSet` is then returned by {{domxref("ElementInternals.states")}}.
-Note that `ElementInternals` cannot be attached to a custom element based on a built-in element, so this feature only works for autonomous custom elements. <!-- https://github.com/whatwg/html/issues/5166 -->
+Note that `ElementInternals` cannot be attached to a custom element based on a built-in element, so this feature only works for autonomous custom elements (see [github.com/whatwg/html/issues/5166](https://github.com/whatwg/html/issues/5166)).
 
 The `CustomStateSet` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
 Each value is a dashed identifier, with the format: `--mystatename`.
@@ -78,9 +78,10 @@ This is mapped to the `--checked` custom state, allowing styling to be applied u
 #### JavaScript
 
 First we define our class `LabeledCheckbox` which extends from `HTMLElement`.
-In the constructor we just call the `super()` method, leaving most of the "work" to `connectedCallback()`, which is invoked when a custom element is added to the page.
+In the constructor we call the `super()` method, leaving most of the "work" to `connectedCallback()`, which is invoked when a custom element is added to the page.
 The content of the element is defined using a `<style>` element to be the text `[]` or `[x]` followed by a label.
-What's interesting here is that the custom state pseudo class (that we'll be talking about below following code below) is used to select the text to display: `:host(:--checked)::`.
+What's noteworthy here is that the custom state pseudo class is used to select the text to display: `:host(:--checked)::`.
+After the example below, we'll cover what's happening in the snippet in more detail.
 
 ```js
 class LabeledCheckbox extends HTMLElement {
@@ -127,7 +128,7 @@ class LabeledCheckbox extends HTMLElement {
 }
 ```
 
-The `connectedCallback()` method uses `this.attachInternals()` to attach an `ElementInternals` object, from which we use `ElementInternals.states` to get the `CustomStateSet`.
+The `connectedCallback()` method uses {{domxref("HTMLElement.attachInternals()", "`this.attachInternals()`")}} to attach an {{domxref("ElementInternals", "`ElementInternals`")}} object, from which we use `ElementInternals.states` to get the `CustomStateSet`.
 The `set checked(flag)` method adds the `"--checked"` dashed identifier to the `CustomStateSet` if the flag is set and delete the identifier if the flag is `false`.
 The `get checked()` method just checks whether the `--checked` property is defined in the set.
 The property value is toggled when the element is clicked.
@@ -161,7 +162,6 @@ labeled-checkbox:--checked {
 
 #### Result
 
-The result can be tested below.
 Click the element to see a different border being applied as the checkbox `checked` state is toggled.
 
 {{EmbedLiveSample("Labeled Checkbox", "100%", 50)}}
@@ -171,10 +171,10 @@ Click the element to see a different border being applied as the checkbox `check
 This example shows how to handle the case where the custom element has an internal property with multiple possible value.
 
 The custom element in this case has a `state` property with allowed values: "loading", "interactive" and "complete".
-To make this work we map each value to its own custom state and create code to ensure that only the dashed identifier corresponding to the internal state is set.
+To make this work, we map each value to its custom state and create code to ensure that only the dashed identifier corresponding to the internal state is set.
 You can see this in the implementation of the `set state()` method: we set the internal state, add the dashed identifier for the matching custom state to `CustomStateSet`, and remove the dashed identifiers associated with all the other values.
 
-Most of the rest of the code is very similar to the previous example (we show different text for each state as the user toggles through them).
+Most of the remaining code is similar to the example that demonstrates a single boolean state (we show different text for each state as the user toggles through them).
 
 #### JavaScript
 
@@ -247,7 +247,7 @@ customElements.define("many-state-element", ManyStateElement);
 #### HTML
 
 After registering the new element we add it to the HTML.
-This is similar to the previous example except we don't specify a value and use the default value from the slot (`<slot>Click me</slot>`).
+This is similar to the example that demonstrates a single boolean state, except we don't specify a value and use the default value from the slot (`<slot>Click me</slot>`).
 
 ```html
 <many-state-element></many-state-element>
@@ -272,7 +272,6 @@ many-state-element:--complete {
 
 #### Results
 
-The result can be tested below.
 Click the element to see a different border being applied as the state changes.
 
 {{EmbedLiveSample("Non-boolean internal states", "100%", 50)}}

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.CustomStateSet
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of possible states for a custom element to be in, and allows states to be added and removed from the set.
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CustomStateSet
 
 The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of states for an [autonomous custom element](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element), and allows states to be added and removed from the set.
 
-The interface can be used to expose the internal states of a custom element, which cannot be directly set using properties, allowing them to be used in CSS selectors by code that uses the element.
+The interface can be used to expose the internal states of a custom element, allowing them to be used in CSS selectors by code that uses the element.
 
 ## Instance properties
 
@@ -41,10 +41,10 @@ The interface can be used to expose the internal states of a custom element, whi
 
 Built in HTML elements can have different _states_, such as "enabled" and "disabled, "checked" and "unchecked", "initial", "loading" and "ready".
 Some of these states are public and can be set or queried using properties/attributes, while others are effectively internal, and cannot be directly set.
-Whether external or internal, commonly these states can be used as CSS selectors for styling the element.
+Whether external or internal, commonly elements states can be selected and styled using [CSS pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) as selectors.
 
 The `CustomStateSet` allows developers to add and delete states for autonomous custom elements (but not elements derived from built-in elements).
-These states can then be used as as CSS selectors in a similar way to the states of built-in elements.
+These states can then be used as as custom state pseudo-class selectors in a similar way to the pseudo-classes for built-in elements.
 
 ### Setting custom element states
 
@@ -53,7 +53,7 @@ To make the {{domxref("CustomStateSet")}} available, a custom element must first
 Note that `ElementInternals` cannot be attached to a custom element based on a built-in element, so this feature only works for autonomous custom elements. <!-- https://github.com/whatwg/html/issues/5166 -->
 
 The `CustomStateSet` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
-Each value is a dashed identifier, with the format: `--mystate`.
+Each value is a dashed identifier, with the format: `--mystatename`.
 Identifiers can be added to the set or deleted.
 If an identifier is present in the set the particular state is `true`, while if it is removed the state is `false`.
 
@@ -64,17 +64,16 @@ The states can be used within the custom element but are not directly accessible
 ### Interaction with CSS
 
 Developers can select a custom element with a specific state using its state _custom state pseudo-class_.
-The format of this pseudo-class is `:--mystate`, where `--mystate` is the state as defined in the element.
+The format of this pseudo-class is `:--mystatename`, where `--mystatename` is the state as defined in the element.
 
-The custom state pseudo-class matches the custom element only if the state is `true` (i.e. if `--mystate` is present in the `CustomStateSet`).
+The custom state pseudo-class matches the custom element only if the state is `true` (i.e. if `--mystatename` is present in the `CustomStateSet`).
 
 ## Examples
 
 ### Labeled Checkbox
 
-This example, which is adapted from the specification, demonstrates a custom checkbox element that exposes its "checked" state as the custom state `--checked`, allowing styling to be applied using the `:--checked` custom state pseudo class.
-
-> **Note:** If you wanted to be able to set the checked state of the custom element using an attribute you could instead define a custom property.
+This example, which is adapted from the specification, demonstrates a custom checkbox element that has an internal "checked" state.
+This is mapped to the `--checked` custom state, allowing styling to be applied using the `:--checked` custom state pseudo class.
 
 First we define our class `LabeledCheckbox` which extends from `HTMLElement`.
 In the constructor we just call the `super()` method, leaving most of the "work" to `connectedCallback()`, which is invoked when a custom element is added to the page.

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -9,7 +9,9 @@ browser-compat: api.CustomStateSet
 
 {{APIRef("Web Components")}}{{SeeCompatTable}}
 
-The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of possible states for a custom element to be in, and allows states to be added and removed from the set.
+The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of states for an [autonomous custom element](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element), and allows states to be added and removed from the set.
+
+The interface can be used to expose the internal states of a custom element, which cannot be directly set using properties, allowing them to be used in CSS selectors by code that uses the element.
 
 ## Instance properties
 
@@ -37,63 +39,56 @@ The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/We
 
 ## Description
 
-An HTML form element, such as a checkbox has different _states_, "checked" and "unchecked". Likewise, developers creating custom elements need to assign possible states to these elements. The `CustomStateList` allows these states to be stored, and accessed from the custom element.
+Built in HTML elements can have different _states_, such as "enabled" and "disabled, "checked" and "unchecked", "initial", "loading" and "ready".
+Some of these states are public and can be set or queried using properties/attributes, while others are effectively internal, and cannot be directly set.
+Whether external or internal, commonly these states can be used as CSS selectors for styling the element.
 
-An instance of `CustomStateList` is returned by {{domxref("ElementInternals.states")}}.
+The `CustomStateSet` allows developers to add and delete states for autonomous custom elements (but not elements derived from built-in elements).
+These states can then be used as as CSS selectors in a similar way to the states of built-in elements.
 
-A `CustomStateList` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
-Each value stored in a `CustomStateList` is a `<dashed-ident>`, in the format `--mystate`.
+### Setting custom element states
+
+To make the {{domxref("CustomStateSet")}} available, a custom element must first call {{domxref("HTMLElement.attachInternals()")}} in order to attach an {{domxref("ElementInternals")}} object.
+`CustomStateSet` is then returned by {{domxref("ElementInternals.states")}}.
+Note that `ElementInternals` cannot be attached to a custom element based on a built-in element, so this feature only works for autonomous custom elements. <!-- https://github.com/whatwg/html/issues/5166 -->
+
+The `CustomStateSet` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
+Each value is a dashed identifier, with the format: `--mystate`.
+Identifiers can be added to the set or deleted.
+If an identifier is present in the set the particular state is `true`, while if it is removed the state is `false`.
+
+Custom elements that have states with more than two values can represent them with multiple boolean states, only one of which is `true` (present in the `CustomStateSet`) at a time.
+
+The states can be used within the custom element but are not directly accessible outside of the custom component.
 
 ### Interaction with CSS
 
-States are stored as a `<dashed-ident>` as this format can then be accessed from CSS using the _custom state pseudo-class_.
-In the same way that you can use CSS to determine if a checkbox is checked using the {{cssxref(":checked")}} pseudo-class,
-you can use a custom state pseudo-class to select a custom element that is in a certain state.
+Developers can select a custom element with a specific state using its state _custom state pseudo-class_.
+The format of this pseudo-class is `:--mystate`, where `--mystate` is the state as defined in the element.
+
+The custom state pseudo-class matches the custom element only if the state is `true` (i.e. if `--mystate` is present in the `CustomStateSet`).
 
 ## Examples
 
-### Custom Element with States
-
-The following function adds and removes the state `--checked` to a `CustomStateSet`, then prints to the console `true` or `false` as the custom checkbox is checked or unchecked.
-
-The state of the element can be accessed from CSS using the custom state pseudo-class `--checked`.
-
-```js
-class MyCustomElement extends HTMLElement {
-  set checked(flag) {
-    if (flag) {
-      this._internals.states.add("--checked");
-    } else {
-      this._internals.states.delete("--checked");
-    }
-
-    console.log(this._internals.states.has("--checked"));
-  }
-}
-```
-
-```css
-labeled-checkbox {
-  border: dashed red;
-}
-labeled-checkbox:--checked {
-  border: solid;
-}
-```
-
 ### Labeled Checkbox
 
-<!--[UNDER CONSTRUCTION]
-This is the example from spec (partial).
-The example above copies from it but isn't complete. Might we worth making it worked example.
-I don't want to direct copy. Would like to do the non-boolean state thingy. But perhaps this is not he
-This is where I want to show the multi state case - not sure what yet.
--->
+This example, which is adapted from the specification, demonstrates a custom checkbox element that exposes its "checked" state as the custom state `--checked`, allowing styling to be applied using the `:--checked` custom state pseudo class.
+
+> **Note:** If you wanted to be able to set the checked state of the custom element using an attribute you could instead define a custom property.
+
+First we define our class `LabeledCheckbox` which extends from `HTMLElement`.
+In the constructor we just call the `super()` method, leaving most of the "work" to `connectedCallback()`, which is invoked when a custom element is added to the page.
+The content of the element is defined using a `<style>` element to be the text `[]` or `[x]` followed by a label.
+What's interesting here is that the custom state pseudo class (that we'll be talking about below following code below) is used to select the text to display: `:host(:--checked)::`.
 
 ```js
 class LabeledCheckbox extends HTMLElement {
   constructor() {
     super();
+  }
+
+  connectedCallback() {
+    // Attach an ElementInternals to get states property
     this._internals = this.attachInternals();
     this.addEventListener("click", this._onClick.bind(this));
 
@@ -114,17 +109,40 @@ class LabeledCheckbox extends HTMLElement {
   }
 
   set checked(flag) {
-    if (flag) this._internals.states.add("--checked");
-    else this._internals.states.delete("--checked");
+    if (flag) {
+      this._internals.states.add("--checked");
+    } else {
+      this._internals.states.delete("--checked");
+    }
   }
 
   _onClick(event) {
+    // Toggle the 'checked' property when the element is clicked
     this.checked = !this.checked;
   }
 }
+```
 
+The `connectedCallback()` method uses `this.attachInternals()` to attach an `ElementInternals` object, from which we use `ElementInternals.states` to get the `CustomStateSet`.
+The `set checked(flag)` method adds the `"--checked"` dashed identifier to the `CustomStateSet` if the flag is set and delete the identifier if the flag is `false`.
+The `get checked()` method just checks whether the `--checked` property is defined in the set.
+The property value is toggled when the element is clicked.
+
+We then call the {{domxref("CustomElementRegistry/define", "define()")}} method on the object returned by {{domxref("Window.customElements")}} in order to register the custom element:
+
+```js
 customElements.define("labeled-checkbox", LabeledCheckbox);
 ```
+
+After registering the custom element we can use use the element in HTML as shown:
+
+```html
+<p>
+  <labeled-checkbox>You need to check this</labeled-checkbox>
+</p>
+```
+
+Finally we use the `:--checked` custom state pseudo class to select CSS for when the box is checked.
 
 ```css
 labeled-checkbox {
@@ -135,11 +153,7 @@ labeled-checkbox:--checked {
 }
 ```
 
-```html
-<labeled-checkbox>You need to check this</labeled-checkbox>
-```
-
-{{EmbedLiveSample("Labeled Checkbox")}}
+{{EmbedLiveSample("Labeled Checkbox", "100%", 50)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -11,21 +11,6 @@ browser-compat: api.CustomStateSet
 
 The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of possible states for a custom element to be in, and allows states to be added and removed from the set.
 
-## Description
-
-An HTML form element, such as a checkbox has different _states_, "checked" and "unchecked". Likewise, developers creating custom elements need to assign possible states to these elements. The `CustomStateList` allows these states to be stored, and accessed from the custom element.
-
-An instance of `CustomStateList` is returned by {{domxref("ElementInternals.states")}}.
-
-A `CustomStateList` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
-Each value stored in a `CustomStateList` is a `<dashed-ident>`, in the format `--mystate`.
-
-### Interaction with CSS
-
-States are stored as a `<dashed-ident>` as this format can then be accessed from CSS using the _custom state pseudo-class_.
-In the same way that you can use CSS to determine if a checkbox is checked using the {{cssxref(":checked")}} pseudo-class,
-you can use a custom state pseudo-class to select a custom element that is in a certain state.
-
 ## Instance properties
 
 - {{domxref("CustomStateSet.size")}} {{Experimental_Inline}}
@@ -50,7 +35,24 @@ you can use a custom state pseudo-class to select a custom element that is in a 
 - {{domxref("CustomStateSet.values()")}} {{Experimental_Inline}}
   - : Returns a new iterator object that yields the values for each element in the `CustomStateSet` object in insertion order.
 
+## Description
+
+An HTML form element, such as a checkbox has different _states_, "checked" and "unchecked". Likewise, developers creating custom elements need to assign possible states to these elements. The `CustomStateList` allows these states to be stored, and accessed from the custom element.
+
+An instance of `CustomStateList` is returned by {{domxref("ElementInternals.states")}}.
+
+A `CustomStateList` instance is a [`Set`-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_browser_apis) that can hold an ordered set of state values.
+Each value stored in a `CustomStateList` is a `<dashed-ident>`, in the format `--mystate`.
+
+### Interaction with CSS
+
+States are stored as a `<dashed-ident>` as this format can then be accessed from CSS using the _custom state pseudo-class_.
+In the same way that you can use CSS to determine if a checkbox is checked using the {{cssxref(":checked")}} pseudo-class,
+you can use a custom state pseudo-class to select a custom element that is in a certain state.
+
 ## Examples
+
+### Custom Element with States
 
 The following function adds and removes the state `--checked` to a `CustomStateSet`, then prints to the console `true` or `false` as the custom checkbox is checked or unchecked.
 
@@ -78,6 +80,66 @@ labeled-checkbox:--checked {
   border: solid;
 }
 ```
+
+### Labeled Checkbox
+
+<!--[UNDER CONSTRUCTION]
+This is the example from spec (partial).
+The example above copies from it but isn't complete. Might we worth making it worked example.
+I don't want to direct copy. Would like to do the non-boolean state thingy. But perhaps this is not he
+This is where I want to show the multi state case - not sure what yet.
+-->
+
+```js
+class LabeledCheckbox extends HTMLElement {
+  constructor() {
+    super();
+    this._internals = this.attachInternals();
+    this.addEventListener("click", this._onClick.bind(this));
+
+    const shadowRoot = this.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `<style>
+       :host::before {
+         content: '[ ]';
+         white-space: pre;
+         font-family: monospace;
+       }
+       :host(:--checked)::before { content: '[x]'; background: grey; }
+       </style>
+       <slot>Label</slot>`;
+  }
+
+  get checked() {
+    return this._internals.states.has("--checked");
+  }
+
+  set checked(flag) {
+    if (flag) this._internals.states.add("--checked");
+    else this._internals.states.delete("--checked");
+  }
+
+  _onClick(event) {
+    this.checked = !this.checked;
+  }
+}
+
+customElements.define("labeled-checkbox", LabeledCheckbox);
+```
+
+```css
+labeled-checkbox {
+  border: dashed red;
+}
+labeled-checkbox:--checked {
+  border: solid;
+}
+```
+
+```html
+<labeled-checkbox>You need to check this</labeled-checkbox>
+```
+
+{{EmbedLiveSample("Labeled Checkbox")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -93,6 +93,9 @@ class LabeledCheckbox extends HTMLElement {
 
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
+        :host {
+          display: block;
+        }
        :host::before {
          content: '[ ]';
          white-space: pre;
@@ -136,9 +139,7 @@ customElements.define("labeled-checkbox", LabeledCheckbox);
 After registering the custom element we can use use the element in HTML as shown:
 
 ```html
-<p>
-  <labeled-checkbox>You need to check this</labeled-checkbox>
-</p>
+<labeled-checkbox>You need to check this</labeled-checkbox>
 ```
 
 Finally we use the `:--checked` custom state pseudo class to select CSS for when the box is checked.

--- a/files/en-us/web/api/customstateset/keys/index.md
+++ b/files/en-us/web/api/customstateset/keys/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.keys
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`keys()`** method of the {{domxref("CustomStateSet")}} interface is an alias for {{domxref("CustomStateSet.values")}}.
 

--- a/files/en-us/web/api/customstateset/size/index.md
+++ b/files/en-us/web/api/customstateset/size/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.size
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`size`** property of the {{domxref("CustomStateSet")}} interface returns the number of values in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/values/index.md
+++ b/files/en-us/web/api/customstateset/values/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CustomStateSet.values
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`values()`** method of the {{domxref("CustomStateSet")}} interface returns a new iterator object that yields the values for each element in the `CustomStateSet` object in insertion order.
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaAtomic
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
 

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaAutoComplete
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaBusy
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaChecked
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaColCount
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaColIndex
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.ElementInternals.ariaColIndexText
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaColSpan
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaCurrent
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaDescription
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaDisabled
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaExpanded
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaHasPopup
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 

--- a/files/en-us/web/api/elementinternals/ariahidden/index.md
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaHidden
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
-The **`ariaHidden`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)) attribute, which indicates whether the element is exposed to an accessibility API.
+The **`ariaHidden`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaKeyShortcuts
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 

--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaLabel
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}}
 
-The **`ariaLabel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)) attribute, which defines a string value that labels the current Element.
+The **`ariaLabel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current Element.
 
 > **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaLevel
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 

--- a/files/en-us/web/api/elementinternals/arialive/index.md
+++ b/files/en-us/web/api/elementinternals/arialive/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaLive
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaLive`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaModal
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaMultiLine
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaMultiLine`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaMultiSelectable
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.md
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaOrientation
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaOrientation`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaPlaceholder
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaPosInSet
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaPressed
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaReadOnly
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ElementInternals.ariaRelevant
 ---
 
-{{APIRef("DOM")}}{{Non-standard_header}}
+{{APIRef("Web Components")}}{{Non-standard_header}}
 
 The **`ariaRelevant`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaRequired
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaRoleDescription
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaRowCount
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaRowIndex
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.ElementInternals.ariaRowIndexText
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaRowSpan
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaSelected
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaSetSize
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaSort
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaValueMax
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaValueMax`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute, which defines the maximum allowed value for a range widget.
 

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaValueMin
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaValueMin`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) attribute, which defines the minimum allowed value for a range widget.
 

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaValueNow
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaValueNow`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.ariaValueText
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ariaValueText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of aria-valuenow for a range widget.
 

--- a/files/en-us/web/api/elementinternals/checkvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/checkvalidity/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ElementInternals.checkValidity
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`checkValidity()`** method of the {{domxref("ElementInternals")}} interface checks if the element meets any [constraint validation](/en-US/docs/Web/HTML/Constraint_validation) rules applied to it.
 

--- a/files/en-us/web/api/elementinternals/form/index.md
+++ b/files/en-us/web/api/elementinternals/form/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.form
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`form`** read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("HTMLFormElement")}} associated with this element.
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.ElementInternals
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`ElementInternals`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) gives web developers a way to allow custom elements to fully participate in HTML forms. It provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the [Accessibility Object Model](https://wicg.github.io/aom/explainer.html) to the element.
 

--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.labels
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`labels`** read-only property of the {{domxref("ElementInternals")}} interface returns the labels associated with the element.
 

--- a/files/en-us/web/api/elementinternals/reportvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/reportvalidity/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ElementInternals.reportValidity
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`reportValidity()`** method of the {{domxref("ElementInternals")}} interface checks if the element meets any [constraint validation](/en-US/docs/Web/HTML/Constraint_validation) rules applied to it.
 

--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.role
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`role`** read-only property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles) for the element. For example, a checkbox might have [`role="checkbox"`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role).
 

--- a/files/en-us/web/api/elementinternals/setformvalue/index.md
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ElementInternals.setFormValue
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`setFormValue()`** method of the {{domxref("ElementInternals")}} interface sets the element's submission value and state, communicating these to the user agent.
 

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ElementInternals.setValidity
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`setValidity()`** method of the {{domxref("ElementInternals")}} interface sets the validity of the element.
 

--- a/files/en-us/web/api/elementinternals/shadowroot/index.md
+++ b/files/en-us/web/api/elementinternals/shadowroot/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.shadowRoot
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`shadowRoot`** read-only property of the {{domxref("ElementInternals")}} interface returns the {{domxref("ShadowRoot")}} for this element.
 

--- a/files/en-us/web/api/elementinternals/states/index.md
+++ b/files/en-us/web/api/elementinternals/states/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ElementInternals.states
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}{{SeeCompatTable}}
 
 The **`states`** read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("CustomStateSet")}} representing the possible states of the custom element.
 

--- a/files/en-us/web/api/elementinternals/validationmessage/index.md
+++ b/files/en-us/web/api/elementinternals/validationmessage/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.validationMessage
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`validationMessage`** read-only property of the {{domxref("ElementInternals")}} interface returns the validation message for the element.
 

--- a/files/en-us/web/api/elementinternals/validity/index.md
+++ b/files/en-us/web/api/elementinternals/validity/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.validity
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`validity`** read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("ValidityState")}} object which represents the different validity states the element can be in, with respect to constraint validation.
 

--- a/files/en-us/web/api/elementinternals/willvalidate/index.md
+++ b/files/en-us/web/api/elementinternals/willvalidate/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ElementInternals.willValidate
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("Web Components")}}
 
 The **`willValidate`** read-only property of the {{domxref("ElementInternals")}} interface returns `true` if the element is a submittable element that is a candidate for [constraint validation](/en-US/docs/Web/HTML/Constraint_validation).
 

--- a/files/en-us/web/api/htmlelement/attachinternals/index.md
+++ b/files/en-us/web/api/htmlelement/attachinternals/index.md
@@ -6,9 +6,10 @@ page-type: web-api-instance-method
 browser-compat: api.HTMLElement.attachInternals
 ---
 
-{{APIRef('DOM')}}
+{{APIRef("Web Components")}}
 
-The **`HTMLElement.attachInternals()`** method returns an {{domxref("ElementInternals")}} object. This method allows a [custom element](/en-US/docs/Web/API/Web_components/Using_custom_elements) to participate in HTML forms. The `ElementInternals` interface provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the [Accessibility Object Model](https://wicg.github.io/aom/explainer.html) to the element.
+The **`HTMLElement.attachInternals()`** method returns an {{domxref("ElementInternals")}} object.
+This method allows a [custom element](/en-US/docs/Web/API/Web_components/Using_custom_elements) to participate in HTML forms. The `ElementInternals` interface provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the [Accessibility Object Model](https://wicg.github.io/aom/explainer.html) to the element.
 
 ## Syntax
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -175,6 +175,60 @@ Note that if the element's HTML declaration includes an observed attribute, then
 
 For a complete example showing the use of `attributeChangedCallback()`, see [Lifecycle callbacks](#lifecycle_callbacks) in this page.
 
+### Custom states and custom state pseudo-class CSS selectors
+
+Built in HTML elements can have different _states_, such as "hover", "disabled", and "read only".
+Some of these states can be set as attributes using HTML or JavaScript, while others are internal, and cannot.
+Whether external or internal, commonly these states have corresponding CSS [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) that can be used to select and style the element when it is in a particular state.
+
+Autonomous custom elements (but not elements based on built-in elements) also allow you to define states and select against them using _custom state pseudo-classes_.
+The code below shows how this works using the example of an autonomous custom element that has an internal state "`collapsed`".
+
+The `collapsed` state is represented as a boolean property (with setter and getter methods) that is not visible outside of the element.
+To make this state selectable in CSS the custom element first calls {{domxref("HTMLElement.attachInternals()")}} in its constructor in order to attach an {{domxref("ElementInternals")}} object, which in turn provides access to a {{domxref("CustomStateSet")}} through the {{domxref("ElementInternals.states")}} property.
+The setter for the (internal) collapsed state adds the _dashed identifier_ `--hidden` to the `CustomStateSet` when the state is `true`, and removes it when the state is `false`.
+The dashed identifier is just a string preceded by two dashes: in this case we called it `--hidden`, but we could have just as easily called it `--collapsed`.
+
+```js
+class MyCustomElement extends HTMLElement {
+  constructor() {
+    this._internals = this.attachInternals();
+    super();
+  }
+
+  get collapsed() {
+    return this._internals.states.has("--hidden");
+  }
+
+  set collapsed(flag) {
+    if (flag) {
+      // Existence of identifier corresponds to "true"
+      this._internals.states.add("--hidden");
+    } else {
+      // Absence of identifier corresponds to "false"
+      this._internals.states.delete("--hidden");
+    }
+  }
+}
+
+// Register the custom element
+customElements.define("my-custom-element", MyCustomElement);
+```
+
+After adding `<my-custom-element>` to the HTML we can use the dashed identifier added to the `CustomStateSet`, prefixed with `:`, as a custom state pseudo-class for selecting the element state.
+For example, below we select on the `--hidden` state being true (and hence the element's `collapsed` state) using the `:--hidden` selector, and remove the border.
+
+```css
+my-custom-element {
+  border: dashed red;
+}
+my-custom-element:--hidden {
+  border: none;
+}
+```
+
+There is are more complete live example in {{domxref("CustomStateSet")}}.
+
 ## Examples
 
 In the rest of this guide we'll look at a few example custom elements. You can find the source for all these examples, and more, in the [web-components-examples](https://github.com/mdn/web-components-examples) repository, and you can see them all live at <https://mdn.github.io/web-components-examples/>.

--- a/files/en-us/web/api/window/customelements/index.md
+++ b/files/en-us/web/api/window/customelements/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.customElements
 ---
 
-{{APIRef}}
+{{APIRef("Web Components")}}
 
 The **`customElements`** read-only property of the {{domxref("Window")}} interface returns a reference to the {{domxref("CustomElementRegistry")}} object, which can be used to register new [custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) and get information about previously registered custom elements.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1755,6 +1755,8 @@
       ],
       "interfaces": [
         "CustomElementRegistry",
+        "CustomStateSet",
+        "ElementInternals",
         "HTMLSlotElement",
         "HTMLTemplateElement",
         "ShadowRoot"
@@ -1762,6 +1764,7 @@
       "methods": [
         "Document.createElement()",
         "Element.attachShadow()",
+        "HTMLElement.attachInternals()",
         "Node.getRootNode()"
       ],
       "properties": [


### PR DESCRIPTION
This updates [CustomStateSet](https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet) and [Using custom components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements) to reflect the addition of support for exposing _states_ from a custom web component so that they can be used as a selector for CSS.

Note, it also moves CustomStateSet and ElementInternals into the Web Components sidebar rather than DOM sidebar - of course all of these are also DOM, but they can only be used in custom components.

Things to do.

- [x]  `CustomStateSet`
  - [x] needs to show how to attachInternals - you can't use this otherwise.
  - [x] Text incorrectly refers to it as `CustomStateList`
  - [x] Structure needs to follow current templates
   - [x] Example is cut down version of the spec checked state checkbox thingy. Better to either show whole thing or a different example.
   - [x] Omits how you handle multiple non-boolean states. Perhaps a loading, non, loading state like spec but worked.
   - [x] I think these can only be done with automatic components, not built ins. Confirming.
- [x] [Using custom components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements) - cross link and at least outline what you can do.


Related docs work in #30339