### PR TITLE
Fix url of Global Privacy Control site

### DIFF
--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Navigator.globalPrivacyControl
 
 {{APIRef("DOM")}}{{SeeCompatTable}}{{non-standard_header}}
 
-The **`Navigator.globalPrivacyControl`** read-only property returns the user's [Global Privacy Control](globalprivacycontrol.org) setting for the current website.
+The **`Navigator.globalPrivacyControl`** read-only property returns the user's [Global Privacy Control](https://globalprivacycontrol.org/) setting for the current website.
 This setting indicates whether the user consents to the website or service selling or sharing their personal information with third parties.
 
 The value of the property reflects that of the {{httpheader("Sec-GPC")}} HTTP header.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

At <https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl>, a link for "Global Privacy Control" directs to <https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalprivacycontrol.org>.

To mitigate that, `https://` has been included.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
