### PR TITLE
Fix `MacroBrokenLinkError` on `Web/API/Document/applets`

### DIFF
--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Document.applets
 
 The **`applets`** property of the {{domxref("Document")}} returns an empty {{domxref("HTMLCollection")}}. This property is kept only for compatibility reasons; in older versions of browsers, it returned a list of the applets within a document.
 
-> **Note:** Support for the {{htmlelement("applet")}} element has been removed by all browsers. Therefore, calling `document.applets` always
+> **Note:** Support for the `<applet>` element has been removed by all browsers. Therefore, calling `document.applets` always
 > returns an empty collection.
 
 ## Value


### PR DESCRIPTION
### Description

This PR replaced the active link with `<applet>` because `Web/HTML/Element/applet` page has been deleted a long time ago.
It fixes `MacroBrokenLinkError` on `Web/API/Document/applets`.

### Related issues and pull requests

Relates to #26850
