### PR TITLE
CSS counter() function

### DIFF
--- a/files/en-us/web/css/counter/index.md
+++ b/files/en-us/web/css/counter/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.counter
 
 The **`counter()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a string representing the current value of the named counter, if there is one.
 
-The `counter()` function is generally used within [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) {{CSSxRef("content")}} property values, but can theoretically be used anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
+The `counter()` function is generally used within [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) through the {{cssxref("content")}} property but, theoretically, it can be used wherever a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
 
 {{EmbedInteractiveExample("pages/tabbed/function-counter.html", "tabbed-shorter")}}
 
@@ -35,7 +35,7 @@ The `counter()` function accepts up to two parameters. The first parameter is th
 - `<counter-style>`
   - : A {{cssxref("&lt;list-style-type&gt;")}} name, {{cssxref("&lt;@counter-style&gt;")}} name or {{cssxref("symbols", "symbols()")}} function, where a counter style name is a `numeric`, `alphabetic`, or `symbolic` simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other [predefined counter style](/en-US/docs/Web/CSS/CSS_counter_styles). If omitted, the counter-style defaults to `decimal`.
 
-> **Note:** See also the {{cssxref("counters", "counters()")}} function which provides a third parameter, a string, to join the counter values when nesting counters.
+> **Note:** To join the counter values when nesting counters, use the {{cssxref("counters", "counters()")}} function, which provides an additional {{cssxref("string")}} parameter.
 
 ### Formal syntax
 
@@ -77,7 +77,7 @@ li::after {
 
 {{EmbedLiveSample("lower-roman compared to lower-alpha", "100%", 150)}}
 
-### Counter displayed three ways
+### Displaying a counter using three styles
 
 In this example, we use the `counter()` function three times.
 
@@ -93,7 +93,7 @@ In this example, we use the `counter()` function three times.
 
 #### CSS
 
-We include the `counter()` function with three different counter styles, including the default decimal value. We added padding to the list, providing space for the long `::marker` string.
+We include the `counter()` function with three different counter styles, including the default decimal value. We've added padding to the list to provide space for the long `::marker` string.
 
 ```css-nolint
 ol {

--- a/files/en-us/web/css/counter/index.md
+++ b/files/en-us/web/css/counter/index.md
@@ -116,7 +116,7 @@ li::after {
 
 #### Result
 
-{{EmbedLiveSample("Counter displayed three ways", "100%", 150)}}
+{{EmbedLiveSample("Displaying a counter using three styles", "100%", 150)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/counter/index.md
+++ b/files/en-us/web/css/counter/index.md
@@ -59,7 +59,7 @@ In this example, we display a counter using `lower-roman` and `lower-alpha` list
 
 #### CSS
 
-```css
+```css-nolint
 ol {
   counter-reset: count;
 }
@@ -67,8 +67,9 @@ li {
   counter-increment: count;
 }
 li::after {
-  content: "[" counter(count, lower-roman) "] == [" counter(count, lower-alpha)
-    "]";
+  content:
+    "[" counter(count, lower-roman) "] == ["
+    counter(count, lower-alpha) "]";
 }
 ```
 
@@ -94,7 +95,7 @@ In this example, we use the `counter()` function three times.
 
 We include the `counter()` function with three different counter styles, including the default decimal value. We added padding to the list, providing space for the long `::marker` string.
 
-```css
+```css-nolint
 ol {
   counter-reset: listCounter;
   padding-left: 5em;
@@ -103,14 +104,13 @@ li {
   counter-increment: listCounter;
 }
 li::marker {
-  content: "Item #" counter(listCounter) " is: ";
+  content:
+    "Item #" counter(listCounter) " is: ";
 }
 li::after {
-  content: "[" counter(listCounter, decimal-leading-zero) "] == [" counter(
-      listCounter,
-      upper-roman
-    )
-    "]";
+  content:
+    "[" counter(listCounter, decimal-leading-zero) "] == ["
+    counter(listCounter, upper-roman) "]";
 }
 ```
 

--- a/files/en-us/web/css/counter/index.md
+++ b/files/en-us/web/css/counter/index.md
@@ -8,7 +8,8 @@ browser-compat: css.types.counter
 {{CSSRef}}
 
 The **`counter()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) returns a string representing the current value of the named counter, if there is one.
-It is generally used in the {{CSSxRef("content")}} property of [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements), but can theoretically be used anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
+
+The `counter()` function is generally used within [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) {{CSSxRef("content")}} property values, but can theoretically be used anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
 
 {{EmbedInteractiveExample("pages/tabbed/function-counter.html", "tabbed-shorter")}}
 
@@ -22,15 +23,19 @@ counter(countername);
 counter(countername, upper-roman)
 ```
 
-A [counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) has no visible effect by itself.
-The `counter()` function (and {{cssxref("counters", "counters()")}} function) is what makes it useful by returning developer defined strings (or images).
+[Counters](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) have no visible effect by themselves.
+The `counter()` and {{cssxref("counters", "counters()")}} functions are what make counters useful by returning developer-defined strings (or images).
 
 ### Values
 
+The `counter()` function accepts up to two parameters. The first parameter is the `<counter-name>`. The optional second parameter is the `<counter-style>`.
+
 - `<counter-name>`
-  - : A {{cssxref("&lt;custom-ident&gt;")}} identifying the counter, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}}. The name cannot start with two dashes and can't be `none`, `unset`, `initial`, or `inherit`.
+  - : A {{cssxref("&lt;custom-ident&gt;")}} identifying the counter, which is the same case-sensitive name used with the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}} property values. The counter name cannot start with two dashes and can't be `none`, `unset`, `initial`, or `inherit`.
 - `<counter-style>`
   - : A {{cssxref("&lt;list-style-type&gt;")}} name, {{cssxref("&lt;@counter-style&gt;")}} name or {{cssxref("symbols", "symbols()")}} function, where a counter style name is a `numeric`, `alphabetic`, or `symbolic` simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other [predefined counter style](/en-US/docs/Web/CSS/CSS_counter_styles). If omitted, the counter-style defaults to `decimal`.
+
+> **Note:** See also the {{cssxref("counters", "counters()")}} function which provides a third parameter, a string, to join the counter values when nesting counters.
 
 ### Formal syntax
 
@@ -38,38 +43,9 @@ The `counter()` function (and {{cssxref("counters", "counters()")}} function) is
 
 ## Examples
 
-### default value compared to upper Roman
+### lower-roman compared to lower-alpha
 
-#### HTML
-
-```html
-<ol>
-  <li></li>
-  <li></li>
-  <li></li>
-</ol>
-```
-
-#### CSS
-
-```css
-ol {
-  counter-reset: listCounter;
-}
-li {
-  counter-increment: listCounter;
-}
-li::after {
-  content: "[" counter(listCounter) "] == [" counter(listCounter, upper-roman)
-    "]";
-}
-```
-
-#### Result
-
-{{EmbedLiveSample("default_value_compared_to_upper_Roman", "100%", 150)}}
-
-### decimal-leading-zero compared to lower-alpha
+In this example, we display a counter using `lower-roman` and `lower-alpha` list styles.
 
 #### HTML
 
@@ -91,9 +67,48 @@ li {
   counter-increment: count;
 }
 li::after {
-  content: "[" counter(count, decimal-leading-zero) "] == [" counter(
-      count,
-      lower-alpha
+  content: "[" counter(count, lower-roman) "] == [" counter(count, lower-alpha)
+    "]";
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("lower-roman compared to lower-alpha", "100%", 150)}}
+
+### Counter displayed three ways
+
+In this example, we use the `counter()` function three times.
+
+#### HTML
+
+```html
+<ol>
+  <li></li>
+  <li></li>
+  <li></li>
+</ol>
+```
+
+#### CSS
+
+We include the `counter()` function with three different counter styles, including the default decimal value. We added padding to the list, providing space for the long `::marker` string.
+
+```css
+ol {
+  counter-reset: listCounter;
+  padding-left: 5em;
+}
+li {
+  counter-increment: listCounter;
+}
+li::marker {
+  content: "Item #" counter(listCounter) " is: ";
+}
+li::after {
+  content: "[" counter(listCounter, decimal-leading-zero) "] == [" counter(
+      listCounter,
+      upper-roman
     )
     "]";
 }
@@ -101,7 +116,7 @@ li::after {
 
 #### Result
 
-{{EmbedLiveSample("decimal-leading-zero_compared_to_lower-alpha", "100%", 150)}}
+{{EmbedLiveSample("Counter displayed three ways", "100%", 150)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -158,7 +158,7 @@ li::before {
 
 #### Result
 
-{{EmbedLiveSample("decimal-leading-zero_compared_to_lower-alpha", "100%", 270)}}
+{{EmbedLiveSample("Comparing decimal-leading-zero counter value to lowercase letters", "100%", 270)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -7,11 +7,11 @@ browser-compat: css.types.counters
 
 {{CSSRef}}
 
-The **`counters()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables nested counters, returning a concatenated string representing the current values of the named and nested counters, if any, optionally in a specific list style.
+The **`counters()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables combining markers when nesting counters. The function returns a string that concatenates the current values of the named and nested counters, if any are present, with the string provided. The third, optional parameter enables defining the list style.
 
-The `counters()` function is generally used within [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) {{cssxref("content")}}, but can be used, theoretically, anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
+The `counters()` function is generally used within [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) through the {{cssxref("content")}} property, but theoretically, it can be used wherever a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
 
-The `counters()` function has two forms: `counters(<name>, <string>)` and `counters(<name>, <string>, <style>)`. The generated text is the value of all counters with the given `<name.`, from outermost to innermost, separated by the specified `<string>`. The counters are rendered in the `<style.` indicated, defaulting to `decimal` if no `<style>` was specified.
+The `counters()` function has two forms: `counters(<name>, <string>)` and `counters(<name>, <string>, <style>)`. The generated text is the value of all counters with the given `<name>`, arranged from the outermost to the innermost, and separated by the specified `<string>`. The counters are rendered in the `<style>` indicated, defaulting to `decimal` if no `<style>` is specified.
 
 {{EmbedInteractiveExample("pages/tabbed/function-counters.html", "tabbed-standard")}}
 
@@ -32,13 +32,13 @@ A [counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) has no vi
 The `counters()` function accepts two or three parameters. The first parameter is the `<counter-name>`. The second parameter is the concatenator `<string>`. The optional third parameter is the `<counter-style>`.
 
 - `<counter-name>`
-  - : A {{cssxref("&lt;custom-ident&gt;")}} identifying the counters, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}} properties. The name cannot start with two dashes and can't be `none`, `unset`, `initial`, or `inherit`. Alternatively, for inline, single-use counters, the {{cssxref("symbols")}} function can be used instead of a named counter in [`symbols()` supporting browsers](/en-US/docs/Web/CSS/symbols#browser_compatibility).
+  - : A {{cssxref("&lt;custom-ident&gt;")}} identifying the counters, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}} properties. The name cannot start with two dashes and can't be `none`, `unset`, `initial`, or `inherit`. Alternatively, for inline, single-use counters, the {{cssxref("symbols")}} function can be used instead of a named counter in [browsers that support `symbols()`](/en-US/docs/Web/CSS/symbols#browser_compatibility).
 - {{cssxref("&lt;string&gt;")}}
   - : Any number of text characters. Non-Latin characters must be encoded using their Unicode escape sequences: for example, `\000A9` represents the copyright symbol.
 - `<counter-style>`
-  - : A counter style name or [`symbols()`](/en-US/docs/Web/CSS/symbols) function, where a counter style name is a numeric, alphabetic, or symbolic simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other [predefined counter style](/en-US/docs/Web/CSS/CSS_counter_styles). If omitted, the counter-style defaults to decimal.
+  - : A counter style name or a [`symbols()`](/en-US/docs/Web/CSS/symbols) function. The counter style name can be a simple predefined style such as numeric, alphabetic, or symbolic, a complex longhand predefined style such as East Asian or Ethiopic, or another [predefined counter style](/en-US/docs/Web/CSS/CSS_counter_styles). If omitted, the counter-style defaults to decimal.
 
-The return value is the a string containing all the values of all the counters in the element's CSS counters set named `<counter-name>` in the the counter style defined by `<counter-style>` (or decimal, if omitted), sorted in outermost-first to innermost-last order, joined by the `<string>` specified.
+The return value is a string containing all the values of all the counters in the element's CSS counters set named `<counter-name>` in the counter style defined by `<counter-style>` (or decimal, if omitted). The return string is sorted in outermost-first to innermost-last order, joined by the `<string>` specified.
 
 > **Note:** See the {{cssxref("counter", "counter()")}} function, which omits the `<string>` a parameter, for non-concatenated counters.
 
@@ -48,9 +48,9 @@ The return value is the a string containing all the values of all the counters i
 
 ## Examples
 
-### default value compared to upper Roman
+### Comparing default counter value to uppercase roman numerals
 
-This example includes two `counters()` functions; one with `<counter-style>` set and the other defaulting to `decimal`.
+This example includes two `counters()` functions: one with `<counter-style>` set and the other defaulting to `decimal`.
 
 #### HTML
 
@@ -104,7 +104,7 @@ li::before {
 
 {{EmbedLiveSample("default_value_compared_to_upper_Roman", "100%", 270)}}
 
-### decimal-leading-zero compared to lower-alpha
+### Comparing decimal-leading-zero counter value to lowercase letters
 
 This example includes three `counters()` functions, each with different `<string>` and `<counter-style>` values.
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -82,7 +82,7 @@ This example includes two `counters()` functions; one with `<counter-style>` set
 
 #### CSS
 
-```css
+```css-nolint
 ol {
   counter-reset: listCounter;
 }
@@ -90,14 +90,13 @@ li {
   counter-increment: listCounter;
 }
 li::marker {
-  content: counters(listCounter, ".", upper-roman) ") ";
+  content:
+    counters(listCounter, ".", upper-roman) ") ";
 }
 li::before {
-  content: counters(listCounter, ".") " == " counters(
-      listCounter,
-      ".",
-      lower-roman
-    );
+  content:
+    counters(listCounter, ".") " == "
+    counters(listCounter, ".", lower-roman);
 }
 ```
 
@@ -139,7 +138,7 @@ This example includes three `counters()` functions, each with different `<string
 
 #### CSS
 
-```css
+```css-nolint
 ol {
   counter-reset: count;
 }
@@ -147,14 +146,13 @@ li {
   counter-increment: count;
 }
 li::marker {
-  content: counters(count, "-", decimal-leading-zero) ") ";
+  content:
+    counters(count, "-", decimal-leading-zero) ") ";
 }
 li::before {
-  content: counters(count, "~", upper-alpha) " == " counters(
-      count,
-      "*",
-      lower-alpha
-    );
+  content:
+    counters(count, "~", upper-alpha) " == "
+    counters(count,  "*", lower-alpha);
 }
 ```
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -7,7 +7,11 @@ browser-compat: css.types.counters
 
 {{CSSRef}}
 
-The **`counters()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables nested counters, returning a concatenated string representing the current values of the named counters, if there are any. The `counters()` function has two forms: `counters(name, string)` or `counters(name, string, style)`. It is generally used with [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements), but can be used, theoretically, anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported. The generated text is the value of all counters with the given name, from outermost to innermost, separated by the specified string. The counters are rendered in the style indicated, defaulting to `decimal` if no style is specified.
+The **`counters()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables nested counters, returning a concatenated string representing the current values of the named and nested counters, if any, optionally in a specific list style.
+
+The `counters()` function is generally used within [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) {{cssxref("content")}}, but can be used, theoretically, anywhere a [`<string>`](/en-US/docs/Web/CSS/string) value is supported.
+
+The `counters()` function has two forms: `counters(<name>, <string>)` and `counters(<name>, <string>, <style>)`. The generated text is the value of all counters with the given `<name.`, from outermost to innermost, separated by the specified `<string>`. The counters are rendered in the `<style.` indicated, defaulting to `decimal` if no `<style>` was specified.
 
 {{EmbedInteractiveExample("pages/tabbed/function-counters.html", "tabbed-standard")}}
 
@@ -15,22 +19,28 @@ The **`counters()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/C
 
 ```css
 /* Simple usage  - style defaults to decimal */
-counters(countername, '-');
+counters(countername, '.');
 
 /* changing the counter display */
-counters(countername, '.', upper-roman)
+counters(countername, '-', upper-roman)
 ```
 
-A [counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) has no visible effect by itself. The `counters()` function (and {{cssxref("counter", "counter()")}} function) is what makes it useful by returning developer defined content.
+A [counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) has no visible effect by itself. The `counters()` function (and {{cssxref("counter", "counter()")}} function) is what makes it useful by returning developer-defined content.
 
 ### Values
 
+The `counters()` function accepts two or three parameters. The first parameter is the `<counter-name>`. The second parameter is the concatenator `<string>`. The optional third parameter is the `<counter-style>`.
+
 - `<counter-name>`
-  - : A {{cssxref("&lt;custom-ident&gt;")}} identifying the counters, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}}. The name cannot start with two dashes and can't be `none`, `unset`, `initial`, or `inherit`.
-- `<counter-style>`
-  - : A counter style name or [`symbols()`](/en-US/docs/Web/CSS/symbols) function, where a counter style name is a numeric, alphabetic, or symbolic simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other [predefined counter style](/en-US/docs/Web/CSS/CSS_counter_styles). If omitted, the counter-style defaults to decimal
+  - : A {{cssxref("&lt;custom-ident&gt;")}} identifying the counters, which is the same case-sensitive name used for the {{cssxref("counter-reset")}} and {{cssxref("counter-increment")}} properties. The name cannot start with two dashes and can't be `none`, `unset`, `initial`, or `inherit`. Alternatively, for inline, single-use counters, the {{cssxref("symbols")}} function can be used instead of a named counter in [`symbols()` supporting browsers](/en-US/docs/Web/CSS/symbols#browser_compatibility).
 - {{cssxref("&lt;string&gt;")}}
   - : Any number of text characters. Non-Latin characters must be encoded using their Unicode escape sequences: for example, `\000A9` represents the copyright symbol.
+- `<counter-style>`
+  - : A counter style name or [`symbols()`](/en-US/docs/Web/CSS/symbols) function, where a counter style name is a numeric, alphabetic, or symbolic simple predefined counter style, a complex longhand east Asian or Ethiopic predefined counter style, or other [predefined counter style](/en-US/docs/Web/CSS/CSS_counter_styles). If omitted, the counter-style defaults to decimal.
+
+The return value is the a string containing all the values of all the counters in the element's CSS counters set named `<counter-name>` in the the counter style defined by `<counter-style>` (or decimal, if omitted), sorted in outermost-first to innermost-last order, joined by the `<string>` specified.
+
+> **Note:** See the {{cssxref("counter", "counter()")}} function, which omits the `<string>` a parameter, for non-concatenated counters.
 
 ### Formal syntax
 
@@ -39,6 +49,8 @@ A [counter](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters) has no vi
 ## Examples
 
 ### default value compared to upper Roman
+
+This example includes two `counters()` functions; one with `<counter-style>` set and the other defaulting to `decimal`.
 
 #### HTML
 
@@ -91,9 +103,11 @@ li::before {
 
 #### Result
 
-{{EmbedLiveSample("default_value_compared_to_upper_Roman", "100%", 150)}}
+{{EmbedLiveSample("default_value_compared_to_upper_Roman", "100%", 270)}}
 
 ### decimal-leading-zero compared to lower-alpha
+
+This example includes three `counters()` functions, each with different `<string>` and `<counter-style>` values.
 
 #### HTML
 
@@ -133,12 +147,12 @@ li {
   counter-increment: count;
 }
 li::marker {
-  content: counters(count, ".", upper-alpha) ") ";
+  content: counters(count, "-", decimal-leading-zero) ") ";
 }
 li::before {
-  content: counters(count, ".", decimal-leading-zero) " == " counters(
+  content: counters(count, "~", upper-alpha) " == " counters(
       count,
-      ".",
+      "*",
       lower-alpha
     );
 }
@@ -146,7 +160,7 @@ li::before {
 
 #### Result
 
-{{EmbedLiveSample("decimal-leading-zero_compared_to_lower-alpha", "100%", 150)}}
+{{EmbedLiveSample("decimal-leading-zero_compared_to_lower-alpha", "100%", 270)}}
 
 ## Specifications
 
@@ -159,12 +173,12 @@ li::before {
 ## See also
 
 - [Using CSS Counters](/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters)
-- {{cssxref("counter-set")}}
-- {{cssxref("counter-reset")}}
-- {{cssxref("counter-increment")}}
-- {{cssxref("@counter-style")}}
+- {{cssxref("counter-set")}} property
+- {{cssxref("counter-reset")}} property
+- {{cssxref("counter-increment")}} property
+- {{cssxref("@counter-style")}} at-rule
 - CSS [`counter()`](/en-US/docs/Web/CSS/counter) function
-- {{cssxref("::marker")}}
+- {{cssxref("::marker")}} pseudo-element
 - [CSS lists and counters](/en-US/docs/Web/CSS/CSS_lists) module
 - [CSS counter styles](/en-US/docs/Web/CSS/CSS_counter_styles) module
 - [CSS generated content](/en-US/docs/Web/CSS/CSS_generated_content) module

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -102,7 +102,7 @@ li::before {
 
 #### Result
 
-{{EmbedLiveSample("default_value_compared_to_upper_Roman", "100%", 270)}}
+{{EmbedLiveSample("Comparing default counter value to uppercase roman numerals", "100%", 270)}}
 
 ### Comparing decimal-leading-zero counter value to lowercase letters
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -40,7 +40,7 @@ The `counters()` function accepts two or three parameters. The first parameter i
 
 The return value is a string containing all the values of all the counters in the element's CSS counters set named `<counter-name>` in the counter style defined by `<counter-style>` (or decimal, if omitted). The return string is sorted in outermost-first to innermost-last order, joined by the `<string>` specified.
 
-> **Note:** See the {{cssxref("counter", "counter()")}} function, which omits the `<string>` a parameter, for non-concatenated counters.
+> **Note:** For information about non-concatenated counters, see the {{cssxref("counter", "counter()")}} function, which omits the `<string>` as a parameter.
 
 ### Formal syntax
 


### PR DESCRIPTION
Updating files associated with the CSS lists and counters module.
Removed linting from CSS so that the counters() functions could be legible.
