### PR TITLE
Correcting a code example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -96,13 +96,23 @@ const f2b = (x) => new Uint8Array(new Float64Array([x]).buffer);
 const b2f = (x) => new Float64Array(x.buffer)[0];
 // Get a byte representation of NaN
 const n = f2b(NaN);
-// Change the first bit, which is the sign bit and doesn't matter for NaN
-n[0] = 1;
+const m = f2b(NaN);
+// Change the sign bit, which doesn't matter for NaN
+n[7] += 2**7;
+// n[0] += 2**7; for big endian processors
 const nan2 = b2f(n);
 console.log(nan2); // NaN
 console.log(Object.is(nan2, NaN)); // true
 console.log(f2b(NaN)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 127]
-console.log(f2b(nan2)); // Uint8Array(8) [1, 0, 0, 0, 0, 0, 248, 127]
+console.log(f2b(nan2)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 255]
+// Change the first bit, which is the least significant bit of the mantissa and doesn't matter for NaN
+m[0] = 1;
+// m[7] = 1; for big endian processors
+const nan3 = b2f(m);
+console.log(nan3); // NaN
+console.log(Object.is(nan3, NaN)); // true
+console.log(f2b(NaN)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 127]
+console.log(f2b(nan3)); // Uint8Array(8) [1, 0, 0, 0, 0, 0, 248, 127]
 ```
 
 ### Silently escaping NaN

--- a/files/en-us/web/javascript/reference/global_objects/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/nan/index.md
@@ -98,7 +98,7 @@ const b2f = (x) => new Float64Array(x.buffer)[0];
 const n = f2b(NaN);
 const m = f2b(NaN);
 // Change the sign bit, which doesn't matter for NaN
-n[7] += 2**7;
+n[7] += 2 ** 7;
 // n[0] += 2**7; for big endian processors
 const nan2 = b2f(n);
 console.log(nan2); // NaN


### PR DESCRIPTION
Please refer to the IEEE Standard 754 for floating-point encoding.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The example on the page is incorrect for both systems (little and big endian).
A number in JS is encoded to become:
SEEEEEEEEEEEMMMMMMMMM...MMM
S : sign bit
E : 11 exponent bits
M : 52 Mantissa bits
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
