### PR TITLE
docs(http): Add info about 'Accept-Ranges: none' in range requests

### DIFF
--- a/files/en-us/web/http/headers/range/index.md
+++ b/files/en-us/web/http/headers/range/index.md
@@ -9,9 +9,11 @@ browser-compat: http.headers.Range
 
 The **`Range`** HTTP request header indicates the parts of a resource that the server should return.
 Several parts can be requested at the same time in one `Range` header, and the server may send back these ranges in a multipart document.
-If the server sends back ranges, it uses the {{HTTPStatus("206", "206 Partial Content")}} for the response.
+If the server sends back ranges, it uses the {{HTTPStatus("206", "206 Partial Content")}} status code for the response.
 If the ranges are invalid, the server returns the {{HTTPStatus("416", "416 Range Not Satisfiable")}} error.
-The server can also ignore the `Range` header and return the whole resource with a {{HTTPStatus("200")}} status code.
+
+A server that doesn't support range requests may ignore the `Range` header and return the whole resource with a {{HTTPStatus("200")}} status code.
+Ignoring the `Range` header is equivalent to `Accept-Ranges: none`, so the {{HTTPHeader("Accept-Ranges")}} response header is rarely used for this purpose.
 
 Currently only [`bytes` units are registered](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units) which are _offsets_ (zero-indexed & inclusive).
 If the requested data has a [content coding](/en-US/docs/Web/HTTP/Headers/Content-Encoding) applied, each byte range represents the encoded sequence of bytes, not the bytes that would be obtained after decoding.
@@ -116,6 +118,7 @@ Range: bytes=0-499, -499
 - {{HTTPHeader("If-Range")}}
 - {{HTTPHeader("Content-Range")}}
 - {{HTTPHeader("Content-Type")}}
+- {{HTTPHeader("Accept-Ranges")}}
 - {{HTTPStatus("206", "206 Partial Content")}}
 - {{HTTPStatus("416", "416 Range Not Satisfiable")}}
 - [HTTP range requests](/en-US/docs/Web/HTTP/Range_requests) guide


### PR DESCRIPTION
We don't mention `Accept-Ranges: none` response header although the absence of `Accept-Ranges` is essentially the same. Nonetheless linking to the doc page for this from `HTTP/Headers/Range`.

This is not foolproof (see [the RFC](https://www.rfc-editor.org/rfc/rfc9110#section-14.3-6)):

>A client MAY generate range requests regardless of having received an Accept-Ranges field. The information only provides advice for the sake of improving performance and reducing unnecessary network transfers. Conversely, a client MUST NOT assume that receiving an Accept-Ranges field means that future range requests will return partial responses. The content might change, the server might only support range requests at certain times or under certain conditions, or a different intermediary might process the next request. A server that does not support any kind of range request for the target resource MAY send
>
>     Accept-Ranges: none
>
>to advise the client not to attempt a range request on the same request path. The range unit "none" is reserved for this purpose.

 
Fixes #30358