### PR TITLE
chore(docs): Branches renamed from master to main

### DIFF
--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -19,7 +19,7 @@ For technical reasons related to how the [Fast Fourier transform](https://en.wik
 ## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bar graph style" output of the current audio input.
-For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo (see [app.js lines 108-193](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic/blob/gh-pages/scripts/app.js#L108-L193) for relevant code).
+For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo (see [app.js lines 89-183](https://github.com/mdn/webaudio-examples/blob/f58f98b06df1f1e007b1aad91119ee78e01853e0/voice-change-o-matic/scripts/app.js#L89-L183) for relevant code).
 
 ```js
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -19,7 +19,7 @@ For technical reasons related to how the [Fast Fourier transform](https://en.wik
 ## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bar graph style" output of the current audio input.
-For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo (see [app.js lines 89-183](https://github.com/mdn/webaudio-examples/blob/f58f98b06df1f1e007b1aad91119ee78e01853e0/voice-change-o-matic/scripts/app.js#L89-L183) for relevant code).
+For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo.
 
 ```js
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -22,7 +22,7 @@ node will play.
 
 ## Examples
 
-> **Note:** For a full working example, see [this code running live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
+> **Note:** For a full working example, see [this code running live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
 const myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);

--- a/files/en-us/web/api/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/index.md
@@ -75,7 +75,7 @@ _Inherits event handlers from its parent, {{domxref("AudioScheduledSourceNode")}
 
 In this example, we create a two-second buffer, fill it with white noise, and then play it using an `AudioBufferSourceNode`. The comments should clearly explain what is going on.
 
-> **Note:** You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
+> **Note:** You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -28,7 +28,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 
 ## Examples
 
-The following snippet is taken from our [AudioContext states demo](https://github.com/mdn/webaudio-examples/blob/master/audiocontext-states/index.html) ([see it running live](https://mdn.github.io/webaudio-examples/audiocontext-states/).) When the stop button is clicked, `close()` is called. When the promise resolves, the example is reset to its beginning state.
+The following snippet is taken from our [AudioContext states demo](https://github.com/mdn/webaudio-examples/blob/main/audiocontext-states/index.html) ([see it running live](https://mdn.github.io/webaudio-examples/audiocontext-states/).) When the stop button is clicked, `close()` is called. When the promise resolves, the example is reset to its beginning state.
 
 ```js
 stopBtn.onclick = () => {

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
@@ -87,7 +87,7 @@ From here, you can play and save the opus file.
 </html>
 ```
 
-> **Note:** You can [view this example live](https://mdn.github.io/webaudio-examples/create-media-stream-destination/index.html), or [study the source code](https://github.com/mdn/webaudio-examples/blob/master/create-media-stream-destination/index.html), on GitHub.
+> **Note:** You can [view this example live](https://mdn.github.io/webaudio-examples/create-media-stream-destination/index.html), or [study the source code](https://github.com/mdn/webaudio-examples/blob/main/create-media-stream-destination/index.html), on GitHub.
 
 ## Specifications
 

--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
@@ -52,7 +52,7 @@ In the following code we start to play an audio file after a play button is clic
 and start off a `requestAnimationFrame` loop running, which constantly
 outputs the `contextTime` and `performanceTime`.
 
-You can see full code of this [example at output-timestamp](https://github.com/mdn/webaudio-examples/blob/master/output-timestamp/index.html) ([see it live also](https://mdn.github.io/webaudio-examples/output-timestamp/)).
+You can see full code of this [example at output-timestamp](https://github.com/mdn/webaudio-examples/blob/main/output-timestamp/index.html) ([see it live also](https://mdn.github.io/webaudio-examples/output-timestamp/)).
 
 ```js
 // Press the play button

--- a/files/en-us/web/api/audiocontext/suspend/index.md
+++ b/files/en-us/web/api/audiocontext/suspend/index.md
@@ -28,7 +28,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}. The promise 
 
 ## Examples
 
-The following snippet is taken from our [AudioContext states demo](https://github.com/mdn/webaudio-examples/blob/master/audiocontext-states/index.html) ([see it running live](https://mdn.github.io/webaudio-examples/audiocontext-states/).) When the suspend/resume button is clicked, the {{domxref("BaseAudioContext/state", "AudioContext.state")}} is queried — if it is `running`, `suspend()` is called; if it is `suspended`, {{domxref("AudioContext/resume", "resume()")}} is called. In each case, the text label of the button is updated as appropriate once the promise resolves.
+The following snippet is taken from our [AudioContext states demo](https://github.com/mdn/webaudio-examples/blob/main/audiocontext-states/index.html) ([see it running live](https://mdn.github.io/webaudio-examples/audiocontext-states/).) When the suspend/resume button is clicked, the {{domxref("BaseAudioContext/state", "AudioContext.state")}} is queried — if it is `running`, `suspend()` is called; if it is `suspended`, {{domxref("AudioContext/resume", "resume()")}} is called. In each case, the text label of the button is updated as appropriate once the promise resolves.
 
 ```js
 susresBtn.onclick = () => {

--- a/files/en-us/web/api/audioparam/settargetattime/index.md
+++ b/files/en-us/web/api/audioparam/settargetattime/index.md
@@ -95,7 +95,7 @@ the time progresses.
 
 ## Examples
 
-In this example, we have a media source with two control buttons (see the [webaudio-examples repo](https://github.com/mdn/webaudio-examples/blob/master/audio-param/index.html) for the source code, or [view the example live](https://mdn.github.io/webaudio-examples/audio-param/).) When these buttons are pressed, `setTargetAtTime()` is used to
+In this example, we have a media source with two control buttons (see the [webaudio-examples repo](https://github.com/mdn/webaudio-examples/blob/main/audio-param/index.html) for the source code, or [view the example live](https://mdn.github.io/webaudio-examples/audio-param/).) When these buttons are pressed, `setTargetAtTime()` is used to
 fade the gain value up to 1.0, and down to 0, respectively, with the effect starting
 after 1 second, and the length of time the effect lasts being controlled by the
 timeConstant.

--- a/files/en-us/web/api/audioparam/setvalueattime/index.md
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.md
@@ -36,7 +36,7 @@ implementations of this interface return {{jsxref('undefined')}}.
 ## Examples
 
 This simple example features a media element source with two control buttons (see our
-[webaudio-examples repo](https://github.com/mdn/webaudio-examples/blob/master/audio-param/index.html) for the source code, or [view the example live](https://mdn.github.io/webaudio-examples/audio-param/)). When the buttons are pressed, the `currGain` variable is
+[webaudio-examples repo](https://github.com/mdn/webaudio-examples/blob/main/audio-param/index.html) for the source code, or [view the example live](https://mdn.github.io/webaudio-examples/audio-param/)). When the buttons are pressed, the `currGain` variable is
 incremented/decremented by 0.25, then the `setValueAtTime()` method is used
 to set the gain value equal to `currGain`, one second from now
 (`audioCtx.currentTime + 1`.)

--- a/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
+++ b/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
@@ -67,7 +67,7 @@ parameter.
 
 ## Examples
 
-In this example, we have a media source with a single button (see the [webaudio-examples repo](https://github.com/mdn/webaudio-examples/blob/master/audio-param/index.html) for the source code, or [view the example live](https://mdn.github.io/webaudio-examples/audio-param/).) When this button is pressed, `setValueCurveAtTime()` is used to
+In this example, we have a media source with a single button (see the [webaudio-examples repo](https://github.com/mdn/webaudio-examples/blob/main/audio-param/index.html) for the source code, or [view the example live](https://mdn.github.io/webaudio-examples/audio-param/).) When this button is pressed, `setValueCurveAtTime()` is used to
 change the gain value between the values contained in the waveArray array:
 
 ```js

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
@@ -95,7 +95,7 @@ on an `AudioContext` running at 44100Hz, will be automatically \*resampled\* to
 Now let's look at a more complex `createBuffer()` example, in which we
 create a three-second buffer, fill it with white noise, and then play it via an {{
   domxref("AudioBufferSourceNode") }}. The comment should clearly explain what is going
-on. You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
+on. You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
@@ -41,7 +41,7 @@ it via an {{ domxref("AudioBufferSourceNode") }}. The comments should clearly ex
 what is going on.
 
 > **Note:** You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/),
-> or [view the source](https://github.com/mdn/webaudio-examples/blob/master/audio-buffer/index.html).
+> or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -40,7 +40,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 button is clicked by changing the `gain` property value.
 
 The below snippet wouldn't work as is — for a complete working example, check out our
-[Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo ([view source](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic/blob/gh-pages/scripts/app.js).)
+[Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo ([view source](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic/scripts/app.js).)
 
 ```html
 <div>

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
@@ -33,7 +33,7 @@ An {{domxref("OscillatorNode")}}.
 ## Examples
 
 The following example shows basic usage of an AudioContext to create an oscillator
-node. For applied examples/information, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/master/violent-theremin/scripts/app.js) for relevant code); also see our {{domxref("OscillatorNode")}} page for
+node. For applied examples/information, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/main/violent-theremin/scripts/app.js) for relevant code); also see our {{domxref("OscillatorNode")}} page for
 more information.
 
 ```js

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -63,7 +63,7 @@ The following example shows how to use a `ScriptProcessorNode` to take a track l
 
 For each channel and each sample frame, the script node's {{domxref("ScriptProcessorNode.audioprocess_event", "audioprocess")}} event handler uses the associated `audioProcessingEvent` to loop through each channel of the input buffer, and each sample in each channel, and add a small amount of white noise, before setting that result to be the output sample in each case.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/script-processor-node/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/script-processor-node/).
+> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/script-processor-node/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/script-processor-node/).
 
 ```js
 const myScript = document.querySelector("script");

--- a/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.md
+++ b/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.md
@@ -60,7 +60,7 @@ In this section we will first cover the promise-based syntax and then the callba
 
 In this example `loadAudio()` uses {{domxref("fetch()")}} to retrieve an audio file and decodes it into an {{domxref("AudioBuffer")}}. It then caches the `audioBuffer` in the global `buffer` variable for later playback.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/decode-audio-data/promise/).
+> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/promise/).
 
 ```js
 let audioCtx;
@@ -84,7 +84,7 @@ async function loadAudio() {
 In this example `loadAudio()` uses {{domxref("fetch()")}} to retrieve an audio
 file and decodes it into an {{domxref("AudioBuffer")}} using the callback-based version of `decodeAudioData()`. In the callback, it plays the decoded buffer.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/callback/), or [view the source](https://github.com/mdn/webaudio-examples/blob/master/decode-audio-data/callback/).
+> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/callback/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/callback/).
 
 ```js
 let audioCtx;

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
@@ -55,7 +55,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 In the following example we are using a biquad filter on a media stream (for the full
-demo, see our [stream-source-buffer demo](https://mdn.github.io/webaudio-examples/stream-source-buffer/) live, or [read the source](https://github.com/mdn/webaudio-examples/blob/master/stream-source-buffer/index.html).) As part of this demo, we get the frequency responses for this biquad
+demo, see our [stream-source-buffer demo](https://mdn.github.io/webaudio-examples/stream-source-buffer/) live, or [read the source](https://github.com/mdn/webaudio-examples/blob/main/stream-source-buffer/index.html).) As part of this demo, we get the frequency responses for this biquad
 filter, for five sample frequencies. We first create the {{jsxref("Float32Array")}}s we
 need, one containing the input frequencies, and two to receive the output magnitude and
 phase values:

--- a/files/en-us/web/api/iirfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/iirfilternode/getfrequencyresponse/index.md
@@ -48,7 +48,7 @@ None ({{jsxref("undefined")}}).
 
 In the following example we are using an IIR filter on a media stream (for a complete
 full demo, see our [stream-source-buffer demo](https://mdn.github.io/webaudio-examples/stream-source-buffer/) live,
-or [read its source](https://github.com/mdn/webaudio-examples/blob/master/stream-source-buffer/index.html)). As part of this demo, we get the frequency responses for this IIR
+or [read its source](https://github.com/mdn/webaudio-examples/blob/main/stream-source-buffer/index.html)). As part of this demo, we get the frequency responses for this IIR
 filter, for five sample frequencies. We first create the {{jsxref("Float32Array")}}
 objects we need, one containing the input frequencies, and two to receive the output
 magnitude and phase values:

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
@@ -72,7 +72,7 @@ const source = offlineCtx.createBufferSource();
 ```
 
 For a full working example, see our [offline-audio-context-promise](https://mdn.github.io/webaudio-examples/offline-audio-context-promise/)
-GitHub repo (see the [source code](https://github.com/mdn/webaudio-examples/blob/master/offline-audio-context-promise/index.html) too.)
+GitHub repo (see the [source code](https://github.com/mdn/webaudio-examples/blob/main/offline-audio-context-promise/index.html) too.)
 
 ## Specifications
 

--- a/files/en-us/web/api/oscillatornode/detune/index.md
+++ b/files/en-us/web/api/oscillatornode/detune/index.md
@@ -18,7 +18,7 @@ An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
 
 ## Examples
 
-The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For applied examples/information, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/master/violent-theremin/scripts/app.js) for relevant code).
+The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For applied examples/information, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/main/violent-theremin/scripts/app.js) for relevant code).
 
 ```js
 // create web audio api context

--- a/files/en-us/web/api/oscillatornode/frequency/index.md
+++ b/files/en-us/web/api/oscillatornode/frequency/index.md
@@ -18,7 +18,7 @@ An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
 
 ## Examples
 
-The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/master/violent-theremin/scripts/app.js) for relevant code).
+The following example shows basic usage of an {{ domxref("AudioContext") }} to create an oscillator node. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/main/violent-theremin/scripts/app.js) for relevant code).
 
 ```js
 // create web audio api context

--- a/files/en-us/web/api/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/index.md
@@ -70,7 +70,7 @@ _Inherits methods from its parent, {{domxref("AudioScheduledSourceNode")}}, and 
 
 ## Examples
 
-The following example shows basic usage of an {{domxref("AudioContext")}} to create an oscillator node and to start playing a tone on it. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/master/violent-theremin/scripts/app.js) for relevant code).
+The following example shows basic usage of an {{domxref("AudioContext")}} to create an oscillator node and to start playing a tone on it. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/main/violent-theremin/scripts/app.js) for relevant code).
 
 ```js
 // create web audio api context

--- a/files/en-us/web/api/oscillatornode/type/index.md
+++ b/files/en-us/web/api/oscillatornode/type/index.md
@@ -43,7 +43,7 @@ available values are:
 ## Examples
 
 The following example shows basic usage of an {{ domxref("AudioContext") }} to create
-an oscillator node. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/master/violent-theremin/scripts/app.js) for relevant code).
+an oscillator node. For an applied example, check out our [Violent Theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) ([see app.js](https://github.com/mdn/webaudio-examples/blob/main/violent-theremin/scripts/app.js) for relevant code).
 
 ```js
 // create web audio api context

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -27,7 +27,7 @@ Use of native JavaScript modules is dependent on the {{jsxref("Statements/import
 
 ## Introducing an example
 
-To demonstrate usage of modules, we've created a [simple set of examples](https://github.com/mdn/js-examples/tree/master/module-examples) that you can find on GitHub. These examples demonstrate a simple set of modules that create a [`<canvas>`](/en-US/docs/Web/HTML/Element/canvas) element on a webpage, and then draw (and report information about) different shapes on the canvas.
+To demonstrate usage of modules, we've created a [simple set of examples](https://github.com/mdn/js-examples/tree/main/module-examples) that you can find on GitHub. These examples demonstrate a simple set of modules that create a [`<canvas>`](/en-US/docs/Web/HTML/Element/canvas) element on a webpage, and then draw (and report information about) different shapes on the canvas.
 
 These are fairly trivial, but have been kept deliberately simple to demonstrate modules clearly.
 
@@ -35,7 +35,7 @@ These are fairly trivial, but have been kept deliberately simple to demonstrate 
 
 ## Basic example structure
 
-In our first example (see [basic-modules](https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules)) we have a file structure as follows:
+In our first example (see [basic-modules](https://github.com/mdn/js-examples/tree/main/module-examples/basic-modules)) we have a file structure as follows:
 
 ```plain
 index.html
@@ -132,7 +132,7 @@ becomes
 ./modules/square.js
 ```
 
-You can see such lines in action in [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/basic-modules/main.js).
+You can see such lines in action in [`main.js`](https://github.com/mdn/js-examples/blob/main/module-examples/basic-modules/main.js).
 
 > **Note:** In some module systems, you can use a module specifier like `modules/square` that isn't a relative or absolute path, and that doesn't have a file extension.
 > This kind of specifier can be used in a browser environment if you first define an [import map](#importing_modules_using_import_maps).
@@ -486,7 +486,7 @@ import {
 } from "./modules/module.js";
 ```
 
-Let's look at a real example. In our [renaming](https://github.com/mdn/js-examples/tree/master/module-examples/renaming) directory you'll see the same module system as in the previous example, except that we've added `circle.js` and `triangle.js` modules to draw and report on circles and triangles.
+Let's look at a real example. In our [renaming](https://github.com/mdn/js-examples/tree/main/module-examples/renaming) directory you'll see the same module system as in the previous example, except that we've added `circle.js` and `triangle.js` modules to draw and report on circles and triangles.
 
 Inside each of these modules, we've got features with the same names being exported, and therefore each has the same `export` statement at the bottom:
 
@@ -568,7 +568,7 @@ Module.function1();
 Module.function2();
 ```
 
-Again, let's look at a real example. If you go to our [module-objects](https://github.com/mdn/js-examples/tree/master/module-examples/module-objects) directory, you'll see the same example again, but rewritten to take advantage of this new syntax. In the modules, the exports are all in the following simple form:
+Again, let's look at a real example. If you go to our [module-objects](https://github.com/mdn/js-examples/tree/main/module-examples/module-objects) directory, you'll see the same example again, but rewritten to take advantage of this new syntax. In the modules, the exports are all in the following simple form:
 
 ```js
 export { name, draw, reportArea, reportPerimeter };
@@ -598,7 +598,7 @@ So you can now write the code just the same as before (as long as you include th
 
 As we hinted at earlier, you can also export and import classes; this is another option for avoiding conflicts in your code, and is especially useful if you've already got your module code written in an object-oriented style.
 
-You can see an example of our shape drawing module rewritten with ES classes in our [classes](https://github.com/mdn/js-examples/tree/master/module-examples/classes) directory. As an example, the [`square.js`](https://github.com/mdn/js-examples/blob/master/module-examples/classes/modules/square.js) file now contains all its functionality in a single class:
+You can see an example of our shape drawing module rewritten with ES classes in our [classes](https://github.com/mdn/js-examples/tree/main/module-examples/classes) directory. As an example, the [`square.js`](https://github.com/mdn/js-examples/blob/main/module-examples/classes/modules/square.js) file now contains all its functionality in a single class:
 
 ```js
 class Square {
@@ -620,7 +620,7 @@ which we then export:
 export { Square };
 ```
 
-Over in [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/classes/main.js), we import it like this:
+Over in [`main.js`](https://github.com/mdn/js-examples/blob/main/module-examples/classes/main.js), we import it like this:
 
 ```js
 import { Square } from "./modules/square.js";
@@ -644,7 +644,7 @@ export * from "x.js";
 export { name } from "x.js";
 ```
 
-For an example, see our [module-aggregation](https://github.com/mdn/js-examples/tree/master/module-examples/module-aggregation) directory. In this example (based on our earlier classes example) we've got an extra module called `shapes.js`, which aggregates all the functionality from `circle.js`, `square.js`, and `triangle.js` together. We've also moved our submodules inside a subdirectory inside the `modules` directory called `shapes`. So the module structure in this example is:
+For an example, see our [module-aggregation](https://github.com/mdn/js-examples/tree/main/module-examples/module-aggregation) directory. In this example (based on our earlier classes example) we've got an extra module called `shapes.js`, which aggregates all the functionality from `circle.js`, `square.js`, and `triangle.js` together. We've also moved our submodules inside a subdirectory inside the `modules` directory called `shapes`. So the module structure in this example is:
 
 ```plain
 modules/
@@ -662,7 +662,7 @@ In each of the submodules, the export is of the same form, e.g.
 export { Square };
 ```
 
-Next up comes the aggregation part. Inside [`shapes.js`](https://github.com/mdn/js-examples/blob/master/module-examples/module-aggregation/modules/shapes.js), we include the following lines:
+Next up comes the aggregation part. Inside [`shapes.js`](https://github.com/mdn/js-examples/blob/main/module-examples/module-aggregation/modules/shapes.js), we include the following lines:
 
 ```js
 export { Square } from "./shapes/square.js";
@@ -705,9 +705,9 @@ import("./modules/myModule.js").then((module) => {
 
 <!-- https://whatpr.org/html/6395/webappapis.html#hostimportmoduledynamically(referencingscriptormodule,-specifier,-promisecapability) -->
 
-Let's look at an example. In the [dynamic-module-imports](https://github.com/mdn/js-examples/tree/master/module-examples/dynamic-module-imports) directory we've got another example based on our classes example. This time however we are not drawing anything on the canvas when the example loads. Instead, we include three buttons — "Circle", "Square", and "Triangle" — that, when pressed, dynamically load the required module and then use it to draw the associated shape.
+Let's look at an example. In the [dynamic-module-imports](https://github.com/mdn/js-examples/tree/main/module-examples/dynamic-module-imports) directory we've got another example based on our classes example. This time however we are not drawing anything on the canvas when the example loads. Instead, we include three buttons — "Circle", "Square", and "Triangle" — that, when pressed, dynamically load the required module and then use it to draw the associated shape.
 
-In this example we've only made changes to our [`index.html`](https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/index.html) and [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/dynamic-module-imports/main.js) files — the module exports remain the same as before.
+In this example we've only made changes to our [`index.html`](https://github.com/mdn/js-examples/blob/main/module-examples/dynamic-module-imports/index.html) and [`main.js`](https://github.com/mdn/js-examples/blob/main/module-examples/dynamic-module-imports/main.js) files — the module exports remain the same as before.
 
 Over in `main.js` we've grabbed a reference to each button using a [`document.querySelector()`](/en-US/docs/Web/API/Document/querySelector) call, for example:
 
@@ -754,9 +754,9 @@ Another advantage of dynamic imports is that they are always available, even in 
 
 Top level await is a feature available within modules. This means the `await` keyword can be used. It allows modules to act as big [asynchronous functions](/en-US/docs/Learn/JavaScript/Asynchronous/Introducing) meaning code can be evaluated before use in parent modules, but without blocking sibling modules from loading.
 
-Let's take a look at an example. You can find all the files and code described in this section within the [`top-level-await`](https://github.com/mdn/js-examples/tree/master/module-examples/top-level-await) directory, which extends from the previous examples.
+Let's take a look at an example. You can find all the files and code described in this section within the [`top-level-await`](https://github.com/mdn/js-examples/tree/main/module-examples/top-level-await) directory, which extends from the previous examples.
 
-Firstly we'll declare our color palette in a separate [`colors.json`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/data/colors.json) file:
+Firstly we'll declare our color palette in a separate [`colors.json`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/data/colors.json) file:
 
 ```json
 {
@@ -768,7 +768,7 @@ Firstly we'll declare our color palette in a separate [`colors.json`](https://gi
 }
 ```
 
-Then we'll create a module called [`getColors.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/modules/getColors.js) which uses a fetch request to load the [`colors.json`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/data/colors.json) file and return the data as an object.
+Then we'll create a module called [`getColors.js`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/modules/getColors.js) which uses a fetch request to load the [`colors.json`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/data/colors.json) file and return the data as an object.
 
 ```js
 // fetch request
@@ -781,7 +781,7 @@ Notice the last export line here.
 
 We're using the keyword `await` before specifying the constant `colors` to export. This means any other modules which include this one will wait until `colors` has been downloaded and parsed before using it.
 
-Let's include this module in our [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/main.js) file:
+Let's include this module in our [`main.js`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/main.js) file:
 
 ```js
 import colors from "./modules/getColors.js";
@@ -823,7 +823,7 @@ const triangle1 = new Module.Triangle(
 );
 ```
 
-This is useful because the code within [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/main.js) won't execute until the code in [`getColors.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/modules/getColors.js) has run. However it won't block other modules being loaded. For instance our [`canvas.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/modules/canvas.js) module will continue to load while `colors` is being fetched.
+This is useful because the code within [`main.js`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/main.js) won't execute until the code in [`getColors.js`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/modules/getColors.js) has run. However it won't block other modules being loaded. For instance our [`canvas.js`](https://github.com/mdn/js-examples/blob/main/module-examples/top-level-await/modules/canvas.js) module will continue to load while `colors` is being fetched.
 
 ## Import declarations are hoisted
 


### PR DESCRIPTION
Most of the changes here are `github.com/mdn/webaudio-examples/blob/master` -> `github.com/mdn/webaudio-examples/blob/main` with a few others changed in parallel