### PR TITLE
Replace capital letters with small or petite capitals in font-variant-caps

### DIFF
--- a/files/en-us/web/css/font-variant-caps/index.md
+++ b/files/en-us/web/css/font-variant-caps/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.font-variant-caps
 
 {{CSSRef}}
 
-The **`font-variant-caps`** [CSS](/en-US/docs/Web/CSS) property controls the use of alternate glyphs for capital letters.
+The **`font-variant-caps`** [CSS](/en-US/docs/Web/CSS) property controls the use of alternate glyphs used for small or petite capitals or for titling.
 
 {{EmbedInteractiveExample("pages/css/font-variant-caps.html")}}
 


### PR DESCRIPTION
This pull request fixes #29910 

It changes the summary in 'font-variant-caps' page from 'capital letters' to the text matching what is explicitly written in [w3 docs of `font-variant-caps`](https://www.w3.org/TR/css-fonts-4/#font-variant-caps-prop).

To propose the better wording, I used the exact same text as is already used in linked docs, to keep the pages consistent.