### PR TITLE
remove the "summary" heading

### DIFF
--- a/files/en-us/web/html/element/acronym/index.md
+++ b/files/en-us/web/html/element/acronym/index.md
@@ -9,8 +9,6 @@ browser-compat: html.elements.acronym
 
 {{HTMLSidebar}}{{deprecated_header}}
 
-## Summary
-
 The **`<acronym>`** [HTML](/en-US/docs/Web/HTML) element allows authors to clearly indicate a sequence of characters that compose an acronym or abbreviation for a word.
 
 > **Warning:** Don't use this element. Use the {{HTMLElement("abbr")}} element instead.


### PR DESCRIPTION
### Description

remove the "summary" heading, as we no longer add a heading for the first paragraph.
