### PR TITLE
fix(css): Clarify `top` property for sticky elements

### DIFF
--- a/files/en-us/web/css/top/index.md
+++ b/files/en-us/web/css/top/index.md
@@ -18,7 +18,7 @@ The effect of `top` depends on how the element is positioned (i.e., the value of
 - When `position` is set to `sticky`, the `top` property is used to compute the sticky-constraint rectangle.
 - When `position` is set to `static`, the `top` property has _no effect_.
 
-Consider the situation when both `top` and {{cssxref("bottom")}} values are specified. In this case:
+When both `top` and {{cssxref("bottom")}} values are specified, there are three different cases:
 
 - If `position` is set to `absolute` or `fixed` and {{cssxref("height")}} is unspecified (either `auto` or `100%`), both the `top` and `bottom` values are respected.
 - If `position` is set to `relative` or `height` is constrained, the `top` property takes precedence and the `bottom` property is ignored.

--- a/files/en-us/web/css/top/index.md
+++ b/files/en-us/web/css/top/index.md
@@ -18,7 +18,11 @@ The effect of `top` depends on how the element is positioned (i.e., the value of
 - When `position` is set to `sticky`, the `top` property is used to compute the sticky-constraint rectangle.
 - When `position` is set to `static`, the `top` property has _no effect_.
 
-When both `top` and {{cssxref("bottom")}} are specified, `position` is set to `absolute` or `fixed`, _and_ {{cssxref("height")}} is unspecified (either `auto` or `100%`) both the `top` and `bottom` distances are respected. In all other situations, if {{cssxref("height")}} is constrained in any way or `position` is set to `relative`, the `top` property takes precedence and the `bottom` property is ignored.
+Consider the situation when both `top` and {{cssxref("bottom")}} values are specified. In this case:
+
+- If `position` is set to `absolute` or `fixed` and {{cssxref("height")}} is unspecified (either `auto` or `100%`), both the `top` and `bottom` values are respected.
+- If `position` is set to `relative` or `height` is constrained, the `top` property takes precedence and the `bottom` property is ignored.
+- If `position` is set to `sticky`, both `top` and `bottom` values are considered. This means that a sticky element can potentially move up and down within its containing block based on the values of these two properties as long as the element's position box remains contained within its containing block.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

I've added a point about `top` and `bottom` for sticky elements to address the issue. Additionally, I've rewritten the paragraph for better clarity.

- Fixes https://github.com/mdn/content/issues/29952
