### PR TITLE
Remove broken link for drag event

### DIFF
--- a/files/en-us/web/api/htmlelement/drag_event/index.md
+++ b/files/en-us/web/api/htmlelement/drag_event/index.md
@@ -10,6 +10,8 @@ browser-compat: api.HTMLElement.drag_event
 
 The `drag` event is fired every few hundred milliseconds as an element or text selection is being dragged by the user.
 
+This event is cancelable and may bubble up to the {{domxref("Document")}} and {{domxref("Window")}} objects.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -149,17 +151,9 @@ target.addEventListener("drop", (event) => {
 
 ## See also
 
-- Other drag and drop events:
-
-  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
-  - {{domxref("HTMLElement/dragend_event", "dragend")}}
-  - {{domxref("HTMLElement/dragover_event", "dragover")}}
-  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
-  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
-  - {{domxref("HTMLElement/drop_event", "drop")}}
-
-- This event on other targets:
-
-  - {{domxref("Window")}}: {{domxref("Window/drag_event", "drag")}} event
-  - {{domxref("Document")}}: {{domxref("Document/drag_event", "drag")}} event
-  - {{domxref("SVGElement")}}: {{domxref("SVGElement/drag_event", "drag")}} event
+- {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+- {{domxref("HTMLElement/dragend_event", "dragend")}}
+- {{domxref("HTMLElement/dragover_event", "dragover")}}
+- {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+- {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+- {{domxref("HTMLElement/drop_event", "drop")}}


### PR DESCRIPTION
This event bubbles to `Document` and `Window`: we will never have the page on them.

So I fixed the _See also_ section not to have broken links, and added a sentence in the description explaining that they bubble up to these objects if not canceled.