### PR TITLE
Fix link to the pointer_up event

### DIFF
--- a/files/en-us/web/api/range/commonancestorcontainer/index.md
+++ b/files/en-us/web/api/range/commonancestorcontainer/index.md
@@ -29,8 +29,8 @@ A {{domxref("Node")}} object.
 
 ## Examples
 
-In this example, we create an event listener to handle {{domxref("Document/pointerup_event", "pointerup")}} events on
-a list. The listener gets the common ancestors of each piece of selected text, and
+In this example, we create an event listener to handle {{domxref("Element/pointerup_event", "pointerup")}} events on
+a list. The listener gets the common ancestors of each piece of selected text and
 triggers an animation to highlight them.
 
 ### HTML


### PR DESCRIPTION
The `pointer_up` event's target is the _element_ and it bubbles up to the document. So I fixed the link (the code is correct).