### PR TITLE
Fix broken links on Firefox 55 for devs

### DIFF
--- a/files/en-us/mozilla/firefox/releases/55/index.md
+++ b/files/en-us/mozilla/firefox/releases/55/index.md
@@ -59,7 +59,7 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 
 #### DOM
 
-- The {{domxref("Window")}} properties {{domxref("Window.scrollX", "scrollX")}} and {{domxref("Window.scrollY", "scrollY")}} (as well as their aliases {{domxref("Window.pageXOffset", "pageXOffset")}} and {{domxref("Window.pageYOffset", "pageYOffset")}}) have been updated to be subpixel precise. Instead of returning an integer, these now return a floating-point value which more accurately describes the scroll position on subpixel-precise displays ([Firefox bug 1151421](https://bugzil.la/1151421)). If need be, you can use {{jsxref("Math.round()")}} to convert them into integers.
+- The {{domxref("Window")}} properties {{domxref("Window.scrollX", "scrollX")}} and {{domxref("Window.scrollY", "scrollY")}} (as well as their aliases `pageXOffset` and `pageYOffset` have been updated to be subpixel precise. Instead of returning an integer, these now return a floating-point value which more accurately describes the scroll position on subpixel-precise displays ([Firefox bug 1151421](https://bugzil.la/1151421)). If need be, you can use {{jsxref("Math.round()")}} to convert them into integers.
 - {{domxref("MediaQueryList")}} (and other related features) have been updated to match the latest spec. See [Firefox bug 1354441](https://bugzil.la/1354441), and also see {{domxref("MediaQueryList")}} and {{domxref("MediaQueryListEvent")}}.
 - Methods of the {{domxref("DOMTokenList")}} that modify the list value now automatically trim whitespace and remove duplicate tokens ([Firefox bug 869788](https://bugzil.la/869788), also see [Trimming of whitespace and removal of duplicates](/en-US/docs/Web/API/DOMTokenList#trimming_of_whitespace_and_removal_of_duplicates)).
 - The {{domxref("HTMLInputElement")}}'s `maxLength` property can now be dynamically altered with JavaScript after the equivalent HTML has been created ([Firefox bug 1352799](https://bugzil.la/1352799)).
@@ -112,7 +112,7 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 #### Encrypted Media Extensions API
 
 - Firefox currently allows Encrypted Media Extensions to be used in insecure contexts, despite this not being allowed in the specification. This will be changed in the near future, and starting in Firefox 55, deprecation warnings are output to the [web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) when this is done. ([Firefox bug 1361000](https://bugzil.la/1361000)).
-- Firefox currently doesn't require that at least one {{domxref("MediaKeySystemCapabilities")}} object be included in the `suggestedConfigurations` parameter passed into {{domxref("Navigator.requestMediaKeySystemAccess()")}}, which the specification does mandate. Starting in Firefox 55, a warning is output to the web console when any audio or video configuration is specified without specifying supported codecs. Soon, failure to include a valid configuration for one or more of audio and video will throw an exception [Firefox bug 1368683](https://bugzil.la/1368683)).
+- Firefox currently doesn't require that at least one `MediaKeySystemCapabilities` object be included in the `suggestedConfigurations` parameter passed into {{domxref("Navigator.requestMediaKeySystemAccess()")}}, which the specification does mandate. Starting in Firefox 55, a warning is output to the web console when any audio or video configuration is specified without specifying supported codecs. Soon, failure to include a valid configuration for one or more of audio and video will throw an exception [Firefox bug 1368683](https://bugzil.la/1368683)).
 
 #### WebGL
 
@@ -123,7 +123,7 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 - The {{domxref("Geolocation")}} API is now available only to [secure contexts](/en-US/docs/Web/Security/Secure_Contexts) ([Firefox bug 1072859](https://bugzil.la/1072859)).
 - The {{domxref("Storage API")}} is now available only to [secure contexts](/en-US/docs/Web/Security/Secure_Contexts) ([Firefox bug 1268804](https://bugzil.la/1268804)).
 - The loading of mixed content is now allowed on localhost ([Firefox bug 903966](https://bugzil.la/903966)).
-- Loading of remote JAR files has been disabled again ([Firefox bug 1329336](https://bugzil.la/1329336)). See [Security and the jar protocol](/en-US/docs/Mozilla/Security/Security_and_the_jar_protocol) for the full story.
+- Loading of remote JAR files has been disabled again ([Firefox bug 1329336](https://bugzil.la/1329336)).
 
 ### Plugins
 
@@ -132,7 +132,7 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 
 ### Other
 
-- Firefox on Linux can now be made to run in [headless mode](/en-US/docs/Mozilla/Firefox/Headless_mode) using the `-headless` flag (see [Firefox bug 1356681](https://bugzil.la/1356681)).
+- Firefox on Linux can now be made to run in headless mode using the `-headless` flag (see [Firefox bug 1356681](https://bugzil.la/1356681)).
 
 ## Removals from the web platform
 
@@ -152,12 +152,12 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 
 ### APIs
 
-- The `UIEvent.isChar` property has never been supported by any browser but Firefox, and it has never been fully-implemented except on macOS. For that reason, it was removed in Firefox 55 to align with other browsers.
+- The `UIEvent.isChar` property has never been supported by any browser but Firefox, and it has never been fully implemented except on macOS. For that reason, it was removed in Firefox 55 to align with other browsers.
 - The proprietary Firefox OS Device Storage API has been removed from the platform ([Firefox bug 1299500](https://bugzil.la/1299500)).
 - The `aShowDialog` parameter of the non-standard {{domxref("Window.find()")}} method (which could be specified to open up a "Find" dialog in the browser) has been removed ([Firefox bug 1348409](https://bugzil.la/1348409)).
 - The `HTMLFormElement.requestAutoComplete()` method has been removed (see {{domxref("HTMLFormElement")}}) ([Firefox bug 1270740](https://bugzil.la/1270740)).
 - The non-standard, Mozilla-specific, WebRTC offer options `mozDontOfferDataChannel` and `mozBundleOnly` have been removed from the `RTCOfferOptions` dictionary and are no longer supported by {{domxref("RTCPeerConnection.createOffer()")}} ([Firefox bug 1196974](https://bugzil.la/1196974)).
-- Support for the proprietary Firefox OS [Audio Channels API](/en-US/docs/Archive/B2G_OS/API/Audio_Channels_API) has been removed from {{domxref("HTMLMediaElement")}} and {{domxref("AudioContext")}} ([Firefox bug 1358061](https://bugzil.la/1358061)).
+- Support for the proprietary Firefox OS `Audio Channels API` has been removed from {{domxref("HTMLMediaElement")}} and {{domxref("AudioContext")}} ([Firefox bug 1358061](https://bugzil.la/1358061)).
 
 ### SVG
 


### PR DESCRIPTION
My original goal was to fix red links to aliases, but the other broken links were obvious to fix (a red link to a WebRTC dictionary, explanation pages long gone and a link to the long-gone documentation of a Firefox OS feature that got removed in Fx 55)

(Given that ~20% of the remaining flaws are in _Fx for developers_ pages, this is always useful)