### PR TITLE
[GroupData] Remove entry from Media Source Extensions APi

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -892,10 +892,7 @@
         "SourceBufferList",
         "VideoPlaybackQuality"
       ],
-      "methods": [
-        "HTMLVideoElement.getVideoPlaybackQuality()",
-        "URL.createObjectURL()"
-      ],
+      "methods": [ "HTMLVideoElement.getVideoPlaybackQuality()" ],
       "properties": ["VideoTrack.sourceBuffer", "TextTrack.sourceBuffer"],
       "events": []
     },

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -892,7 +892,7 @@
         "SourceBufferList",
         "VideoPlaybackQuality"
       ],
-      "methods": [ "HTMLVideoElement.getVideoPlaybackQuality()" ],
+      "methods": ["HTMLVideoElement.getVideoPlaybackQuality()"],
       "properties": ["VideoTrack.sourceBuffer", "TextTrack.sourceBuffer"],
       "events": []
     },


### PR DESCRIPTION
`URL.createObjectURL()` is a static method that is not specific to MSE. (In fact it is part of the File API).

Removing it from this sidebar.