### PR TITLE
fix: correct link to `dataset` property

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -9599,7 +9599,6 @@
 /en-US/docs/Web/API/SVGAnimationElement/onbegin	/en-US/docs/Web/API/SVGAnimationElement/beginEvent_event
 /en-US/docs/Web/API/SVGAnimationElement/onend	/en-US/docs/Web/API/SVGAnimationElement/endEvent_event
 /en-US/docs/Web/API/SVGAnimationElement/onrepeat	/en-US/docs/Web/API/SVGAnimationElement/repeatEvent_event
-/en-US/docs/Web/API/SVGElement/dataset	/en-US/docs/Web/API/HTMLElement/dataset
 /en-US/docs/Web/API/SVGElement/onabort	/en-US/docs/Web/API/HTMLMediaElement/abort_event
 /en-US/docs/Web/API/SVGElement/onblur	/en-US/docs/Web/API/Window/blur_event
 /en-US/docs/Web/API/SVGElement/onchange	/en-US/docs/Web/API/HTMLElement/change_event

--- a/files/en-us/learn/html/howto/use_data_attributes/index.md
+++ b/files/en-us/learn/html/howto/use_data_attributes/index.md
@@ -74,5 +74,5 @@ Do not store content that should be visible and accessible in data attributes, b
 ## See also
 
 - This article is adapted from [Using data attributes in JavaScript and CSS on hacks.mozilla.org](https://hacks.mozilla.org/2012/10/using-data-attributes-in-javascript-and-css/).
-- Custom attributes are also supported in SVG 2; see {{domxref("SVGElement.dataset")}} and {{SVGAttr("data-*")}} for more information.
+- Custom attributes are also supported in SVG 2; see {{domxref("HTMLElement.dataset")}} and {{SVGAttr("data-*")}} for more information.
 - [How to use HTML data attributes](https://www.sitepoint.com/use-html5-data-attributes/) (Sitepoint)


### PR DESCRIPTION
### Description

This PR fixes link to `HTMLElement.dataset` property and removes unused redirect.

Am I correct in understanding that if the URL is not used within the `mdn/content` project, then it should be removed from the `_redirects.txt` file? Or do they remain for reasons of existence external links, SEO?

### Motivation

Reduce flaws in documents.

