### PR TITLE
Unify usage `setTimeout()` method

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -2241,7 +2241,6 @@
 /en-US/docs/DOM/window.self	/en-US/docs/Web/API/Window/self
 /en-US/docs/DOM/window.setImmediate	/en-US/docs/Web/API/Window/setImmediate
 /en-US/docs/DOM/window.setInterval	/en-US/docs/Web/API/setInterval
-/en-US/docs/DOM/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/DOM/window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/DOM/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/DOM/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -2665,7 +2664,6 @@
 /en-US/docs/DOM:window.scrollbars	/en-US/docs/Web/API/Window/scrollbars
 /en-US/docs/DOM:window.self	/en-US/docs/Web/API/Window/self
 /en-US/docs/DOM:window.setInterval	/en-US/docs/Web/API/setInterval
-/en-US/docs/DOM:window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/DOM:window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/DOM:window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/DOM:window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -3388,7 +3386,6 @@
 /en-US/docs/Document_Object_Model_(DOM)/window.scrollbars	/en-US/docs/Web/API/Window/scrollbars
 /en-US/docs/Document_Object_Model_(DOM)/window.setImmediate	/en-US/docs/Web/API/Window/setImmediate
 /en-US/docs/Document_Object_Model_(DOM)/window.setInterval	/en-US/docs/Web/API/setInterval
-/en-US/docs/Document_Object_Model_(DOM)/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/Document_Object_Model_(DOM)/window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/Document_Object_Model_(DOM)/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/Document_Object_Model_(DOM)/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -10916,7 +10913,6 @@
 /en-US/docs/Web/API/window.self	/en-US/docs/Web/API/Window/self
 /en-US/docs/Web/API/window.setImmediate	/en-US/docs/Web/API/Window/setImmediate
 /en-US/docs/Web/API/window.setInterval	/en-US/docs/Web/API/setInterval
-/en-US/docs/Web/API/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/Web/API/window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/Web/API/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/Web/API/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -13708,7 +13704,6 @@
 /en-US/docs/window.scrollY	/en-US/docs/Web/API/Window/scrollY
 /en-US/docs/window.scrollbars	/en-US/docs/Web/API/Window/scrollbars
 /en-US/docs/window.setInterval	/en-US/docs/Web/API/setInterval
-/en-US/docs/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
 /en-US/docs/window.status	/en-US/docs/Web/API/Window/status

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -2241,6 +2241,7 @@
 /en-US/docs/DOM/window.self	/en-US/docs/Web/API/Window/self
 /en-US/docs/DOM/window.setImmediate	/en-US/docs/Web/API/Window/setImmediate
 /en-US/docs/DOM/window.setInterval	/en-US/docs/Web/API/setInterval
+/en-US/docs/DOM/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/DOM/window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/DOM/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/DOM/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -2664,6 +2665,7 @@
 /en-US/docs/DOM:window.scrollbars	/en-US/docs/Web/API/Window/scrollbars
 /en-US/docs/DOM:window.self	/en-US/docs/Web/API/Window/self
 /en-US/docs/DOM:window.setInterval	/en-US/docs/Web/API/setInterval
+/en-US/docs/DOM:window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/DOM:window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/DOM:window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/DOM:window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -3386,6 +3388,7 @@
 /en-US/docs/Document_Object_Model_(DOM)/window.scrollbars	/en-US/docs/Web/API/Window/scrollbars
 /en-US/docs/Document_Object_Model_(DOM)/window.setImmediate	/en-US/docs/Web/API/Window/setImmediate
 /en-US/docs/Document_Object_Model_(DOM)/window.setInterval	/en-US/docs/Web/API/setInterval
+/en-US/docs/Document_Object_Model_(DOM)/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/Document_Object_Model_(DOM)/window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/Document_Object_Model_(DOM)/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/Document_Object_Model_(DOM)/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -10913,6 +10916,7 @@
 /en-US/docs/Web/API/window.self	/en-US/docs/Web/API/Window/self
 /en-US/docs/Web/API/window.setImmediate	/en-US/docs/Web/API/Window/setImmediate
 /en-US/docs/Web/API/window.setInterval	/en-US/docs/Web/API/setInterval
+/en-US/docs/Web/API/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/Web/API/window.showModalDialog	/en-US/docs/Web/API/Window/showModalDialog
 /en-US/docs/Web/API/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/Web/API/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
@@ -13704,6 +13708,7 @@
 /en-US/docs/window.scrollY	/en-US/docs/Web/API/Window/scrollY
 /en-US/docs/window.scrollbars	/en-US/docs/Web/API/Window/scrollbars
 /en-US/docs/window.setInterval	/en-US/docs/Web/API/setInterval
+/en-US/docs/window.setTimeout	/en-US/docs/Web/API/setTimeout
 /en-US/docs/window.sidebar	/en-US/docs/Web/API/Window/sidebar
 /en-US/docs/window.sizeToContent	/en-US/docs/Web/API/Window/sizeToContent
 /en-US/docs/window.status	/en-US/docs/Web/API/Window/status

--- a/files/en-us/web/api/audiodecoder/dequeue_event/index.md
+++ b/files/en-us/web/api/audiodecoder/dequeue_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.AudioDecoder.dequeue_event
 
 The **`dequeue`** event of the {{domxref("AudioDecoder")}} interface fires to signal a decrease in {{domxref("AudioDecoder.decodeQueueSize")}}.
 
-This eliminates the need for developers to use a {{domxref("setTimeout", "setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
+This eliminates the need for developers to use a {{domxref("setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
 
 ## Syntax
 

--- a/files/en-us/web/api/audioencoder/dequeue_event/index.md
+++ b/files/en-us/web/api/audioencoder/dequeue_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.AudioEncoder.dequeue_event
 
 The **`dequeue`** event of the {{domxref("AudioEncoder")}} interface fires to signal a decrease in {{domxref("AudioEncoder.encodeQueueSize")}}.
 
-This eliminates the need for developers to use a {{domxref("setTimeout", "setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
+This eliminates the need for developers to use a {{domxref("setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
 
 ## Syntax
 

--- a/files/en-us/web/api/clearinterval/index.md
+++ b/files/en-us/web/api/clearinterval/index.md
@@ -27,7 +27,7 @@ clearInterval(intervalID)
 
 It's worth noting that the pool of IDs used by
 {{domxref("setInterval", "setInterval()")}} and
-{{domxref("setTimeout", "setTimeout()")}} are shared, which
+{{domxref("setTimeout()")}} are shared, which
 means you can technically use `clearInterval()` and
 {{domxref("clearTimeout", "clearTimeout()")}} interchangeably.
 However, for clarity, you should avoid doing so.
@@ -50,7 +50,7 @@ See the [`setInterval()` examples](/en-US/docs/Web/API/setInterval#examples).
 
 ## See also
 
-- {{domxref("setTimeout")}}
+- {{domxref("setTimeout()")}}
 - {{domxref("setInterval")}}
 - {{domxref("clearTimeout")}}
 - {{domxref("Window.requestAnimationFrame")}}

--- a/files/en-us/web/api/clearinterval/index.md
+++ b/files/en-us/web/api/clearinterval/index.md
@@ -51,6 +51,6 @@ See the [`setInterval()` examples](/en-US/docs/Web/API/setInterval#examples).
 ## See also
 
 - {{domxref("setTimeout()")}}
-- {{domxref("setInterval")}}
-- {{domxref("clearTimeout")}}
-- {{domxref("Window.requestAnimationFrame")}}
+- {{domxref("setInterval()")}}
+- {{domxref("clearTimeout()")}}
+- {{domxref("Window.requestAnimationFrame()")}}

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -61,7 +61,7 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 - {{domxref("Window.cancelAnimationFrame", "DedicatedWorkerGlobalScope.cancelAnimationFrame()")}}
   - : Cancels a callback scheduled by requestAnimationFrame.
 - {{domxref("clearInterval", "DedicatedWorkerGlobalScope.clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
+  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
 - {{domxref("clearTimeout", "DedicatedWorkerGlobalScope.clearTimeout()")}}
   - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
 - {{domxref("WorkerGlobalScope.dump", "DedicatedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -63,7 +63,7 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 - {{domxref("clearInterval", "DedicatedWorkerGlobalScope.clearInterval()")}}
   - : Cancels the repeated execution set using {{domxref("setInterval")}}.
 - {{domxref("clearTimeout", "DedicatedWorkerGlobalScope.clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
+  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
 - {{domxref("WorkerGlobalScope.dump", "DedicatedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
   - : Writes a message to the console.
 - {{domxref("WorkerGlobalScope.importScripts", "DedicatedWorkerGlobalScope.importScripts()")}}
@@ -72,7 +72,7 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Requests the browser to execute a callback function before painting the next frame.
 - {{domxref("setInterval", "DedicatedWorkerGlobalScope.setInterval()")}}
   - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout", "DedicatedWorkerGlobalScope.setTimeout()")}}
+- {{domxref("setTimeout()", "DedicatedWorkerGlobalScope.setTimeout()")}}
   - : Sets a delay for executing a function.
 
 ## Events

--- a/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
+++ b/files/en-us/web/api/performance/measureuseragentspecificmemory/index.md
@@ -155,5 +155,5 @@ if (crossOriginIsolated) {
 
 ## See also
 
-- {{domxref("setTimeout")}}
+- {{domxref("setTimeout()")}}
 - [Monitor your web page's total memory usage with measureUserAgentSpecificMemory() - web.dev](https://web.dev/articles/monitor-total-page-memory-usage)

--- a/files/en-us/web/api/popover_api/using/index.md
+++ b/files/en-us/web/api/popover_api/using/index.md
@@ -153,7 +153,7 @@ See our [Toggle help UI example](https://mdn.github.io/dom-examples/popover-api/
 
 ## Dismissing popovers automatically via a timer
 
-Another common pattern in JavaScript is dismissing popovers automatically after a certain amount of time. You might for example want to create a system of "toast" notifications, where you have multiple actions underway at a time (for example multiple files uploading), and want to show a notification when each one succeeds or fails. For this you'll want to use manual popovers so you can show several at the same time, and use {{domxref("setTimeout")}} to remove them. A function for handling such popovers might look like so:
+Another common pattern in JavaScript is dismissing popovers automatically after a certain amount of time. You might for example want to create a system of "toast" notifications, where you have multiple actions underway at a time (for example multiple files uploading), and want to show a notification when each one succeeds or fails. For this you'll want to use manual popovers so you can show several at the same time, and use {{domxref("setTimeout()")}} to remove them. A function for handling such popovers might look like so:
 
 ```js
 function makeToast(result) {

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -69,14 +69,14 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 - {{domxref("clearInterval", "ServiceWorkerGlobalScope.clearInterval()")}}
   - : Cancels the repeated execution set using {{domxref("setInterval")}}.
 - {{domxref("clearTimeout", "ServiceWorkerGlobalScope.clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
+  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
 - {{domxref("WorkerGlobalScope.dump", "ServiceWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
   - : Writes a message to the console.
 - {{domxref("WorkerGlobalScope.importScripts", "ServiceWorkerGlobalScope.importScripts()")}}
   - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
 - {{domxref("setInterval", "ServiceWorkerGlobalScope.setInterval()")}}
   - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout", "ServiceWorkerGlobalScope.setTimeout()")}}
+- {{domxref("setTimeout()", "ServiceWorkerGlobalScope.setTimeout()")}}
   - : Sets a delay for executing a function.
 
 ## Events

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -234,6 +234,6 @@ interval has completed before recursing.
 
 - [Polyfill of `setInterval` which allows passing arguments to the callback in `core-js`](https://github.com/zloirock/core-js#settimeout-and-setinterval)
 - {{domxref("setTimeout()")}}
-- {{domxref("clearTimeout")}}
-- {{domxref("clearInterval")}}
-- {{domxref("window.requestAnimationFrame")}}
+- {{domxref("clearTimeout()")}}
+- {{domxref("clearInterval()")}}
+- {{domxref("window.requestAnimationFrame()")}}

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -233,7 +233,7 @@ interval has completed before recursing.
 ## See also
 
 - [Polyfill of `setInterval` which allows passing arguments to the callback in `core-js`](https://github.com/zloirock/core-js#settimeout-and-setinterval)
-- {{domxref("setTimeout")}}
+- {{domxref("setTimeout()")}}
 - {{domxref("clearTimeout")}}
 - {{domxref("clearInterval")}}
 - {{domxref("window.requestAnimationFrame")}}

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -59,14 +59,14 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 - {{domxref("clearInterval", "SharedWorkerGlobalScope.clearInterval()")}}
   - : Cancels the repeated execution set using {{domxref("setInterval")}}.
 - {{domxref("clearTimeout", "SharedWorkerGlobalScope.clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout")}}.
+  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
 - {{domxref("WorkerGlobalScope.dump", "SharedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
   - : Writes a message to the console.
 - {{domxref("WorkerGlobalScope.importScripts", "SharedWorkerGlobalScope.importScripts()")}}
   - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
 - {{domxref("setInterval", "SharedWorkerGlobalScope.setInterval()")}}
   - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout", "SharedWorkerGlobalScope.setTimeout()")}}
+- {{domxref("setTimeout()", "SharedWorkerGlobalScope.setTimeout()")}}
   - : Sets a delay for executing a function.
 
 ## Events

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -57,7 +57,7 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 - {{domxref("btoa", "SharedWorkerGlobalScope.btoa()")}}
   - : Creates a base-64 encoded ASCII string from a string of binary data.
 - {{domxref("clearInterval", "SharedWorkerGlobalScope.clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
+  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
 - {{domxref("clearTimeout", "SharedWorkerGlobalScope.clearTimeout()")}}
   - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
 - {{domxref("WorkerGlobalScope.dump", "SharedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}

--- a/files/en-us/web/api/videodecoder/dequeue_event/index.md
+++ b/files/en-us/web/api/videodecoder/dequeue_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.VideoDecoder.dequeue_event
 
 The **`dequeue`** event of the {{domxref("VideoDecoder")}} interface fires to signal a decrease in {{domxref("VideoDecoder.decodeQueueSize")}}.
 
-This eliminates the need for developers to use a {{domxref("setTimeout", "setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
+This eliminates the need for developers to use a {{domxref("setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
 
 ## Syntax
 

--- a/files/en-us/web/api/videoencoder/dequeue_event/index.md
+++ b/files/en-us/web/api/videoencoder/dequeue_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.VideoEncoder.dequeue_event
 
 The **`dequeue`** event of the {{domxref("VideoEncoder")}} interface fires to signal a decrease in {{domxref("VideoEncoder.encodeQueueSize")}}.
 
-This eliminates the need for developers to use a {{domxref("setTimeout", "setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
+This eliminates the need for developers to use a {{domxref("setTimeout()")}} poll to determine when the queue has decreased, and more work should be queued up.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -241,7 +241,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Schedules a function to execute every time a given number of milliseconds elapses.
 - {{domxref("Window.setResizable()")}} {{Non-standard_Inline}}
   - : Toggles a user's ability to resize a window.
-- {{domxref("setTimeout", "Window.setTimeout()")}}
+- {{domxref("setTimeout()", "Window.setTimeout()")}}
   - : Schedules a function to execute in a given amount of time.
 - {{domxref("Window.showDirectoryPicker()")}} {{Experimental_Inline}}
   - : Displays a directory picker which allows the user to select a directory.

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -67,7 +67,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
 - {{domxref("setInterval", "WorkerGlobalScope.setInterval()")}}
   - : Schedules a function to execute every time a given number of milliseconds elapses.
-- {{domxref("setTimeout", "WorkerGlobalScope.setTimeout()")}}
+- {{domxref("setTimeout()", "WorkerGlobalScope.setTimeout()")}}
   - : Schedules a function to execute in a given amount of time.
 - {{domxref("reportError", "WorkerGlobalScope.reportError()")}}
   - : Reports an error in a script, emulating an unhandled exception.

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -359,7 +359,7 @@ When the "Create new column" button is clicked, the `createColumn()` function is
 We then add an event listener to the close button via {{domxref("EventTarget.addEventListener", "addEventListener")}}. Clicking the close button does two things:
 
 - Adds the `fade-out` class to the `<div>`. Adding the class triggers the exit animation set on that class.
-- Removes the `<div>` after a 1000ms delay. The {{domxref("setTimeout")}} delays removal of the `<div>` from the DOM (via {{domxref("Element.remove()")}}) until after the animation ends.
+- Removes the `<div>` after a 1000ms delay. The {{domxref("setTimeout()")}} delays removal of the `<div>` from the DOM (via {{domxref("Element.remove()")}}) until after the animation ends.
 
 #### CSS
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -201,7 +201,7 @@ For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Cont
 - `'unsafe-inline'`
   - : Allow use of inline resources.
 - `'unsafe-eval'`
-  - : Allow use of dynamic code evaluation such as {{jsxref("Global_Objects/eval", "eval")}}, {{domxref("Window.setTimeout", "setTimeout")}}, and `window.execScript` {{non-standard_inline}}.
+  - : Allow use of dynamic code evaluation such as {{jsxref("Global_Objects/eval", "eval")}}, {{domxref("setTimeout")}}, and `window.execScript` {{non-standard_inline}}.
 - `'unsafe-hashes'`
   - : Allows enabling specific inline event handlers.
 - `'unsafe-allow-redirects'` {{experimental_inline}}

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -201,7 +201,7 @@ For detailed reference see [CSP Source Values](/en-US/docs/Web/HTTP/Headers/Cont
 - `'unsafe-inline'`
   - : Allow use of inline resources.
 - `'unsafe-eval'`
-  - : Allow use of dynamic code evaluation such as {{jsxref("Global_Objects/eval", "eval")}}, {{domxref("setTimeout")}}, and `window.execScript` {{non-standard_inline}}.
+  - : Allow use of dynamic code evaluation such as {{jsxref("Global_Objects/eval", "eval")}}, {{domxref("setTimeout()")}}, and `window.execScript` {{non-standard_inline}}.
 - `'unsafe-hashes'`
   - : Allows enabling specific inline event handlers.
 - `'unsafe-allow-redirects'` {{experimental_inline}}

--- a/files/en-us/web/webdriver/errors/scripttimeout/index.md
+++ b/files/en-us/web/webdriver/errors/scripttimeout/index.md
@@ -24,7 +24,7 @@ session = webdriver.Firefox()
 try:
     session.execute_script("""
         let [resolve] = arguments;
-        window.setTimeout(resolve, 35000);
+        setTimeout(resolve, 35000);
         """)
 except exceptions.ScriptTimeoutException as e:
     print(e.message)
@@ -45,7 +45,7 @@ from selenium.common import exceptions
 session = webdriver.Firefox(capabilities={"alwaysMatch": {"timeouts": {"script": 150000}}})
 session.execute_script("""
     let [resolve] = arguments;
-    window.setTimeout(resolve, 35000);
+    setTimeout(resolve, 35000);
     """)
 print("finished successfully")
 ```


### PR DESCRIPTION
### Description

This PR brings all uses of the `setTimeout()` method to a single form:
- without unnecessay `Window.`,
- with `()`.

### Motivation

Content unification.

### Additional details

Also this PR removes some unused redirects.
This needs to be checked, but as far as I understand, these redirects are no longer needed.

### Related issues and pull requests

Relates to #6938
