### PR TITLE
Remove links to E4X

### DIFF
--- a/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
@@ -94,7 +94,7 @@ This page is based largely on [https://www.squarefree.com/burningedg...eases/](h
 
   - : Loading of XUL overlays after the document has been displayed is now supported. See `nsIDOMXULDocument`. [Firefox bug 282103](https://bugzil.la/282103)
 
-- E4X
+- ECMAScript for XML (E4X)
 
   - : The Mozilla JavaScript engine now supports ECMAScript for XML (E4X), a draft ECMA standard that adds native XML datatypes to the language and provides operators for common XML operations. See [the ECMA specification](https://www.ecma-international.org/publications/standards/Ecma-357.htm). [Firefox bug 246441](https://bugzil.la/246441)
 

--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -21,7 +21,7 @@ Firefox 10 shipped on January 31, 2012. This article provides information about 
 
 - The method `WeakMap.set()` now returns `undefined`, instead of itself.
 - A bug was introduced in regular expression handling in Firefox 7; this has been fixed. See [Firefox bug 683838](https://bugzil.la/683838) if you want the gory details.
-- You can no longer use [E4X](/en-US/docs/E4X) syntax while in [ECMAScript 5 strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) (that is, after `"use strict;"`).
+- You can no longer use the deprecated EcmaScript for XML (E4X) syntax while in [ECMAScript 5 strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) (that is, after `"use strict;"`).
 
 ### DOM
 

--- a/files/en-us/mozilla/firefox/releases/17/index.md
+++ b/files/en-us/mozilla/firefox/releases/17/index.md
@@ -39,7 +39,7 @@ Firefox 17 shipped on November 20, 2012. This article lists key changes that are
 - The String methods [link](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/link) and [anchor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/anchor) now escape the `'"'` (quotation mark) ([Firefox bug 352437](https://bugzil.la/352437)).
 - Experimental support for strawman [`ParallelArray`](/en-US/docs/JavaScript/Reference/Global_Objects/ParallelArray) object has been implemented ([Firefox bug 778559](https://bugzil.la/778559)).
 - Support to iterate [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)/[`Set`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) ([Firefox bug 725909](https://bugzil.la/725909)).
-- Disabled [E4X](/en-US/docs/E4X) for web content by default ([Firefox bug 778851](https://bugzil.la/778851)).
+- Disabled [EcmaScript for XML (E4X), an abandoned JavaScript extension, for web content by default ([Firefox bug 778851](https://bugzil.la/778851)).
 - `__exposedProps__` must now be set for Chrome JavaScript objects exposed to content. Attempts to access Chrome objects from content without `__exposedProps__` set will fail silently ([Firefox bug 553102](https://bugzil.la/553102)).
 - [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops now work in terms of `.iterator()` and `.next()` ([Firefox bug 725907](https://bugzil.la/725907)).
 

--- a/files/en-us/mozilla/firefox/releases/17/index.md
+++ b/files/en-us/mozilla/firefox/releases/17/index.md
@@ -39,7 +39,7 @@ Firefox 17 shipped on November 20, 2012. This article lists key changes that are
 - The String methods [link](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/link) and [anchor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/anchor) now escape the `'"'` (quotation mark) ([Firefox bug 352437](https://bugzil.la/352437)).
 - Experimental support for strawman [`ParallelArray`](/en-US/docs/JavaScript/Reference/Global_Objects/ParallelArray) object has been implemented ([Firefox bug 778559](https://bugzil.la/778559)).
 - Support to iterate [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)/[`Set`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) ([Firefox bug 725909](https://bugzil.la/725909)).
-- Disabled [EcmaScript for XML (E4X), an abandoned JavaScript extension, for web content by default ([Firefox bug 778851](https://bugzil.la/778851)).
+- Disabled EcmaScript for XML (E4X), an abandoned JavaScript extension, for web content by default ([Firefox bug 778851](https://bugzil.la/778851)).
 - `__exposedProps__` must now be set for Chrome JavaScript objects exposed to content. Attempts to access Chrome objects from content without `__exposedProps__` set will fail silently ([Firefox bug 553102](https://bugzil.la/553102)).
 - [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) loops now work in terms of `.iterator()` and `.next()` ([Firefox bug 725907](https://bugzil.la/725907)).
 

--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -61,7 +61,7 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 
 ## Changes for add-on and Mozilla developers
 
-- [ECMAScript for XML (E4X)](/en-US/docs/E4X) is now fully disabled for all chrome and content scripts. It was previously disabled for content in Firefox 17 and has been removed entirely for Firefox 21. Use DOMParser/DOMSerializer or a non-native JXON algorithm instead.
+- EcmaScript for XML (E4X) is now fully disabled for all chrome and content scripts. It was previously disabled for content in Firefox 17 and has been removed entirely for Firefox 21. Use DOMParser/DOMSerializer or a non-native JXON algorithm instead.
 - The `nsIDOMParserJS` interface no longer exists ([Firefox bug 816410](https://bugzil.la/816410)). See `nsIDOMParser` for alternatives.
 - Content Preferences: The `nsIContentPrefService` interface is now deprecated and the asynchronous `nsIContentPrefService2` storage API has been implemented.
 - The `nsIProfile` and `nsIProfileChangeStatus` interfaces have been removed, along with other code supporting the pre-Firefox profile management system. You probably weren't using these interfaces, but if you were, you should stop doing so. This prevents defunct parts of the profile management system from vetoing the shutdown process.

--- a/files/en-us/mozilla/firefox/releases/21/index.md
+++ b/files/en-us/mozilla/firefox/releases/21/index.md
@@ -17,7 +17,7 @@ Firefox 21 was released on May 14, 2013. This article lists key changes that are
 
 ### JavaScript
 
-- [E4X](/en-US/docs/E4X), an ancient JavaScript extension, has been removed. Implemented only in Gecko, it never got significant traction ([Firefox bug 788293](https://bugzil.la/788293)).
+- EcmaScript for XML (E4X), an ancient JavaScript extension, has been removed. Implemented only in Gecko, it never got significant traction ([Firefox bug 788293](https://bugzil.la/788293)).
 - [parseInt](/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) no longer treats strings with leading "0" as octal ([Firefox bug 786135](https://bugzil.la/786135)).
 
 ### CSS

--- a/files/en-us/mozilla/firefox/releases/57/index.md
+++ b/files/en-us/mozilla/firefox/releases/57/index.md
@@ -58,7 +58,7 @@ _No changes._
 
 ### JavaScript
 
-- The non-standard {{JSxRef("Statements/for_each...in", "for each...in")}} (E4X) loop has been removed. Please use {{JSxRef("Statements/for...of", "for...of")}} instead and see [Warning: JavaScript 1.6's for-each-in loops are deprecated](/en-US/docs/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated) for migration help. ([Firefox bug 1083470](https://bugzil.la/1083470)).
+- The non-standard {{JSxRef("Statements/for_each...in", "for each...in")}} loop, originally part of EcmaScript for XML (E4X), has been removed. Please use {{JSxRef("Statements/for...of", "for...of")}} instead and see [Warning: JavaScript 1.6's for-each-in loops are deprecated](/en-US/docs/Web/JavaScript/Reference/Errors/For-each-in_loops_are_deprecated) for migration help. ([Firefox bug 1083470](https://bugzil.la/1083470)).
 - The {{JSxRef("Object.prototype.watch()")}} and {{JSxRef("Object.unwatch", "unwatch()")}} methods are deprecated, will now throw a warning when used, and will be removed soon ([Firefox bug 934669](https://bugzil.la/934669)).
 - The non-standard {{JSxRef("Iterator")}} and {{JSxRef("StopIteration")}} objects as well as the legacy iteration protocol have been removed ([Firefox bug 1098412](https://bugzil.la/1098412)).
 - Async generator is now enabled ([Firefox bug 1352312](https://bugzil.la/1352312)).


### PR DESCRIPTION
There were a few links left to this old deleted page. I removed them. _ECMAScript for XML_ is long gone.