### PR TITLE
Remove link to the same event higher in the bubbling chain

### DIFF
--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -123,4 +123,3 @@ el.addEventListener("wheel", zoom, { passive: false });
 ## See also
 
 - {{domxref("WheelEvent")}}
-- [Document: `wheel` event](/en-US/docs/Web/API/Element/wheel_event)


### PR DESCRIPTION
This was an autolink to the same page. That event is bubbling, and we document them only on the `EventTarget`.