### PR TITLE
Remove link to XUL

### DIFF
--- a/files/en-us/web/api/document/createelementns/index.md
+++ b/files/en-us/web/api/document/createelementns/index.md
@@ -61,7 +61,7 @@ The new {{DOMxRef("Element")}}.
 ## Examples
 
 This creates a new `<div>` element in the {{Glossary("XHTML")}} namespace and
-appends it to the vbox element. Although this is not an extremely useful [XUL](/en-US/docs/Mozilla/Tech/XUL) document, it does demonstrate the use of
+appends it to the vbox element. Although this is not an extremely useful XUL document, it does demonstrate the use of
 elements from two different namespaces within a single document:
 
 ```xml


### PR DESCRIPTION
Even if we want to refactor this example in the future, there is no reason to keep this broken link.