### PR TITLE
Remove incorrect link

### DIFF
--- a/files/en-us/web/html/attributes/multiple/index.md
+++ b/files/en-us/web/html/attributes/multiple/index.md
@@ -85,9 +85,9 @@ input:invalid {
 }
 ```
 
-If and only if the `multiple` attribute is specified, the value can be a list of properly-formed comma-separated email addresses. Any trailing and leading whitespace is removed from each address in the list. If the [`required`](/en-US/docs/Web/HTML/Attributes/required) attribute is present, at least one email address is required.
+If and only if the `multiple` attribute is specified, the value can be a list of properly-formed comma-separated email addresses. Any trailing and leading whitespace is removed from each address in the list. If the [`required`](/en-US/docs/Web/HTML/required) attribute is present, at least one email address is required.
 
-Some browsers support the appearance of the [`list`](/en-US/docs/Web/HTML/Attributes/list) of options from the associated {{htmlelement('datalist')}} for subsequent email addresses when `multiple` is present. Others do not.
+Some browsers support the appearance of the [`list`](/en-US/docs/Web/HTML/Element/input#list) of options from the associated {{htmlelement('datalist')}} for subsequent email addresses when `multiple` is present. Others do not.
 
 {{EmbedLiveSample("email_input", 600, 80) }}
 

--- a/files/en-us/web/html/attributes/multiple/index.md
+++ b/files/en-us/web/html/attributes/multiple/index.md
@@ -120,7 +120,7 @@ When `multiple` is set on the {{HTMLElement("input/file", "file")}} input type, 
 
 Note the difference in appearance between the example with `multiple` set and the other `file` input without.
 
-When the form is submitted, had we used [`method="get"`](/en-US/docs/Web/HTML/Element/form) each selected file's name would have been added to URL parameters as`?uploads=img1.jpg&uploads=img2.svg`. However, since we are submitting [multipart](/en-US/docs/Web/API/XMLHttpRequest/multipart) form data, we much use post. See the {{htmlelement('form')}} element and [sending form data](/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_method_attribute) for more information.
+When the form is submitted, had we used [`method="get"`](/en-US/docs/Web/HTML/Element/form) each selected file's name would have been added to URL parameters as`?uploads=img1.jpg&uploads=img2.svg`. However, since we are submitting multipart form data, we much use post. See the {{htmlelement('form')}} element and [sending form data](/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_method_attribute) for more information.
 
 ### select
 

--- a/files/en-us/web/html/attributes/multiple/index.md
+++ b/files/en-us/web/html/attributes/multiple/index.md
@@ -85,7 +85,7 @@ input:invalid {
 }
 ```
 
-If and only if the `multiple` attribute is specified, the value can be a list of properly-formed comma-separated email addresses. Any trailing and leading whitespace is removed from each address in the list. If the [`required`](/en-US/docs/Web/HTML/required) attribute is present, at least one email address is required.
+If and only if the `multiple` attribute is specified, the value can be a list of properly-formed comma-separated email addresses. Any trailing and leading whitespace is removed from each address in the list. If the [`required`](/en-US/docs/Web/HTML/Attributes/required) attribute is present, at least one email address is required.
 
 Some browsers support the appearance of the [`list`](/en-US/docs/Web/HTML/Element/input#list) of options from the associated {{htmlelement('datalist')}} for subsequent email addresses when `multiple` is present. Others do not.
 


### PR DESCRIPTION
`multipart` is not a member of `XMLHttpRequest`. Don't think it is worth a glossary entry.