### PR TITLE
Remove non-working browser compat section from the Wasm landing page

### DIFF
--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -2,16 +2,16 @@
 title: WebAssembly
 slug: WebAssembly
 page-type: landing-page
-browser-compat: javascript.builtins.WebAssembly
+spec-urls: https://webassembly.github.io/spec/js-api/
 ---
 
 {{WebAssemblySidebar}}
 
-WebAssembly is a new type of code that can be run in modern web browsers — it is a low-level assembly-like language with a compact binary format that runs with near-native performance and provides languages such as C/C++, C# and Rust with a compilation target so that they can run on the web. It is also designed to run alongside JavaScript, allowing both to work together.
+WebAssembly is a type of code that can be run in modern web browsers — it is a low-level assembly-like language with a compact binary format that runs with near-native performance and provides languages such as C/C++, C# and Rust with a compilation target so that they can run on the web. It is also designed to run alongside JavaScript, allowing both to work together.
 
 ## In a Nutshell
 
-WebAssembly has huge implications for the web platform — it provides a way to run code written in multiple languages on the web at near native speed, with client apps running on the web that previously couldn't have done so.
+WebAssembly has huge implications for the web platform — it provides a way to run code written in multiple languages on the web at near-native speed, with client apps running on the web that previously couldn't have done so.
 
 WebAssembly is designed to complement and run alongside JavaScript — using the WebAssembly JavaScript APIs, you can load WebAssembly modules into a JavaScript app and share functionality between the two. This allows you to take advantage of WebAssembly's performance and power and JavaScript's expressiveness and flexibility in the same apps, even if you don't know how to write WebAssembly code.
 
@@ -30,20 +30,20 @@ And what's even better is that it is being developed as a web standard via the [
 - [Loading and running WebAssembly code](/en-US/docs/WebAssembly/Loading_and_running)
   - : After you have a Wasm module, this article covers how to fetch, compile and instantiate it, combining the [WebAssembly JavaScript](/en-US/docs/WebAssembly/JavaScript_interface) API with the [Fetch](/en-US/docs/Web/API/Fetch_API) or [XHR](/en-US/docs/Web/API/XMLHttpRequest) APIs.
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)
-  - : Once you've loaded a Wasm module, you'll want to use it. In this article we show you how to use WebAssembly via the WebAssembly JavaScript API.
+  - : Once you've loaded a Wasm module, you'll want to use it. In this article, we show you how to use WebAssembly via the WebAssembly JavaScript API.
 - [Exported WebAssembly functions](/en-US/docs/WebAssembly/Exported_functions)
-  - : Exported WebAssembly functions are the JavaScript reflections of WebAssembly functions which allow calling WebAssembly code from JavaScript. This article describes what they are.
+  - : Exported WebAssembly functions are the JavaScript reflections of WebAssembly functions, which allow calling WebAssembly code from JavaScript. This article describes what they are.
 - [Understanding WebAssembly text format](/en-US/docs/WebAssembly/Understanding_the_text_format)
   - : This article explains the Wasm text format. This is the low-level textual representation of a Wasm module shown in browser developer tools when debugging.
 - [Converting WebAssembly text format to Wasm](/en-US/docs/WebAssembly/Text_format_to_Wasm)
-  - : This article provides a guide on how to convert a WebAssembly module written in the text format into a Wasm binary.
+  - : This article provides a guide on how to convert a WebAssembly module written in text format into a Wasm binary.
 
 ## API reference
 
 - [WebAssembly instruction reference](/en-US/docs/WebAssembly/Reference)
   - : Reference documentation with interactive samples for the set of WebAssembly operators.
 - [WebAssembly JavaScript interface](/en-US/docs/WebAssembly/JavaScript_interface)
-  - : This object acts as the namespace for all WebAssembly related functionality.
+  - : This object acts as the namespace for all WebAssembly-related functionality.
 - [`WebAssembly.Global()`](/en-US/docs/WebAssembly/JavaScript_interface/Global)
   - : A `WebAssembly.Global` object represents a global variable instance, accessible from both JavaScript and importable/exportable across one or more [`WebAssembly.Module`](/en-US/docs/WebAssembly/JavaScript_interface/Module) instances. This allows dynamic linking of multiple modules.
 - [`WebAssembly.Module()`](/en-US/docs/WebAssembly/JavaScript_interface/Module)
@@ -83,10 +83,6 @@ And what's even better is that it is being developed as a web standard via the [
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
Overview pages usually don't have browser-compat section; this one was not working.

I replaced the key in YAML so that the spec section works.

Also, I fixed a bit of grammar (and removed a "new" that didn't age well – Wasm is no more new)