### PR TITLE
fix(html): Format <h1>-<h6> tags correctly

### DIFF
--- a/files/en-us/web/html/content_categories/index.md
+++ b/files/en-us/web/html/content_categories/index.md
@@ -61,7 +61,7 @@ The flow elements are:
 - {{HTMLElement("figure")}}
 - {{HTMLElement("footer")}}
 - {{HTMLElement("form")}}
-- {{HTMLElement("Heading_Elements", "&lt;h1&gt;-&lt;h6&gt;")}}
+- {{HTMLElement("Heading_Elements", "<code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code>")}}
 - {{HTMLElement("header")}}
 - {{HTMLElement("hgroup")}}
 - {{HTMLElement("hr")}}
@@ -130,7 +130,7 @@ Elements belonging to this category are {{HTMLElement("article")}}, {{HTMLElemen
 
 Heading content, a subset of flow content, defines the title of a section. This definition applies both to sections marked by an explicit [sectioning content](#sectioning_content) elements and to those implicitly defined by the heading content itself.
 
-Elements belonging to this category are {{HTMLElement("Heading_Elements", "&lt;h1&gt;-&lt;h6&gt;")}} and {{HTMLElement("hgroup")}}.
+Elements belonging to this category are {{HTMLElement("Heading_Elements", "<code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code>")}} and {{HTMLElement("hgroup")}}.
 
 > **Note:** Though likely to contain heading content, the {{HTMLElement("header")}} is not heading content itself.
 


### PR DESCRIPTION
In the page https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories, the formatting of the `<h1>-<h6>` tags was incorrect (the font and background color) because they were not enclosed within `<code></code>` tags