### PR TITLE
Update autocapitalize props

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -681,9 +681,9 @@ The following non-standard attributes are also available on some browsers. As a 
 
   - : (Safari only). A string which indicates how auto-capitalization should be applied while the user is editing this field. Permitted values are:
 
-    - `none`
+    - `none` or `off`
       - : Do not automatically capitalize any text
-    - `sentences`
+    - `sentences` or `on`
       - : Automatically capitalize the first character of each sentence.
     - `words`
       - : Automatically capitalize the first character of each word.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

According to HTML Standard, it also accepts the following `off` and `on` keywords.
https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization

I tested autocapitalize on iOS Safari 16.6 using the link below and found that the 'off' setting behaves identically to 'none', and 'on' mirrors 'sentences'.
https://codepen.io/ryo-manba/pen/rNPrwWM

