### PR TITLE
Move printing guide

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -6418,7 +6418,7 @@
 /en-US/docs/Plugins/Guide/Version,_UI,_and_Status_Information	/en-US/docs/Glossary/Plugin
 /en-US/docs/Plugins/Guide/Version_UI_and_Status_Information	/en-US/docs/Glossary/Plugin
 /en-US/docs/Plugins/Roadmap	/en-US/docs/Glossary/Plugin
-/en-US/docs/Printing	/en-US/docs/Web/Guide/Printing
+/en-US/docs/Printing	/en-US/docs/Web/CSS/CSS_media_queries/Printing
 /en-US/docs/Properly_Configuring_Server_MIME_Types	/en-US/docs/Learn/Server-side/Configuring_server_MIME_types
 /en-US/docs/Properties_compatibility_table_for_forms_widgets	/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls
 /en-US/docs/Property_compatibility_table_for_form_widgets	/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls
@@ -12154,6 +12154,7 @@
 /en-US/docs/Web/Guide/Needs_categorization/Functions_available_to_workers	/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
 /en-US/docs/Web/Guide/Performance/Using_web_workers	/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
 /en-US/docs/Web/Guide/Prefixes	/en-US/docs/Glossary/Vendor_Prefix
+/en-US/docs/Web/Guide/Printing	/en-US/docs/Web/CSS/CSS_media_queries/Printing
 /en-US/docs/Web/Guide/Responsive_design	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Guide/Responsive_design/Responsive_design_references	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Guide/SVG-in-OpenType	/en-US/docs/Web/Guide

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -77908,6 +77908,26 @@
       "sujeetkalaskar"
     ]
   },
+  "Web/CSS/CSS_media_queries/Printing": {
+    "modified": "2019-03-18T20:51:52.142Z",
+    "contributors": [
+      "benrwb",
+      "wbamberg",
+      "oshliaer",
+      "stevemao",
+      "teoli",
+      "olegskl",
+      "GabrielF",
+      "harshadotcom",
+      "Bognar",
+      "kscarfone",
+      "fusionchess",
+      "ethertank",
+      "Sheppy",
+      "tw2113",
+      "dl748"
+    ]
+  },
   "Web/CSS/CSS_media_queries/Testing_media_queries": {
     "modified": "2020-10-15T21:07:28.917Z",
     "contributors": [
@@ -92331,26 +92351,6 @@
   "Web/Guide/Performance": {
     "modified": "2019-03-23T23:30:00.833Z",
     "contributors": ["estelle", "chrisdavidmills", "shahzad11", "Sheppy"]
-  },
-  "Web/Guide/Printing": {
-    "modified": "2019-03-18T20:51:52.142Z",
-    "contributors": [
-      "benrwb",
-      "wbamberg",
-      "oshliaer",
-      "stevemao",
-      "teoli",
-      "olegskl",
-      "GabrielF",
-      "harshadotcom",
-      "Bognar",
-      "kscarfone",
-      "fusionchess",
-      "ethertank",
-      "Sheppy",
-      "tw2113",
-      "dl748"
-    ]
   },
   "Web/Guide/User_input_methods": {
     "modified": "2020-07-22T12:38:46.565Z",

--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -38,6 +38,6 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- [Printing](/en-US/docs/Web/Guide/Printing)
+- [Printing](/en-US/docs/Web/CSS/CSS_media_queries/Printing)
 - {{ domxref("window.beforeprint_event", "beforeprint") }} event
 - {{ domxref("window.afterprint_event", "afterprint") }} event

--- a/files/en-us/web/css/css_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/index.md
@@ -52,6 +52,8 @@ You can learn more about programmatically using media queries in [Testing media 
   - : Describes how to use media queries in your JavaScript code to determine the state of a device, and to set up listeners that notify your code when the results of media queries change (such as when the user rotates the screen or resizes the browser).
 - [Using media queries for accessibility](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries_for_accessibility)
   - : Learn how Media Queries can help users understand your website better.
+- [Printing](/en-US/docs/Web/CSS/CSS_media_queries/Printing)
+  - : Tips and techniques for helping improve web content printer output.
 
 ## Specifications
 

--- a/files/en-us/web/css/css_media_queries/printing/index.md
+++ b/files/en-us/web/css/css_media_queries/printing/index.md
@@ -4,11 +4,7 @@ slug: Web/CSS/CSS_media_queries/Printing
 page-type: guide
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/Guide")}}
-</section>
-
-There may be times in which your website or application would like to improve the user's experience when printing content. There are a number of possible scenarios:
+There may be times in which your website or application would like to improve the user's experience when printing content. There are several possible scenarios:
 
 - You wish to adjust layout to take advantage of the size and shape of the paper.
 - You wish to use different styles to enhance the appearance of your content on paper.
@@ -25,7 +21,7 @@ Add the following to your {{HTMLElement("head")}} tag.
 <link href="/path/to/print.css" media="print" rel="stylesheet" />
 ```
 
-## Using media queries to improve layout
+## Using media queries and @page to improve layout
 
 You can use the CSS {{cssxref("@media")}} at-rule to set a different appearance for your webpage when it is printed on paper and when it is displayed on the screen. The `print` option sets the styles that will be used when the content is printed.
 
@@ -41,6 +37,8 @@ Add this at the end of your stylesheet. Note that specificity and precedence rul
   }
 }
 ```
+
+You can also use the {{cssxref("@page")}} at-rule to modify different aspects of printed pages including the page's dimensions, orientation, and margins. The `@page` at-rule can be used to target all pages in a print-out or just a specific subset of pages
 
 ## Detecting print requests
 
@@ -96,3 +94,4 @@ document.getElementById("print_external").addEventListener("click", () => {
 - {{ domxref("window.afterprint_event", "afterprint") }} event
 - [Media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries)
 - {{cssxref("@media")}}
+- [CSS paged media](/en-US/docs/Web/CSS/CSS_paged_media) module

--- a/files/en-us/web/css/css_media_queries/printing/index.md
+++ b/files/en-us/web/css/css_media_queries/printing/index.md
@@ -1,6 +1,6 @@
 ---
 title: Printing
-slug: Web/Guide/Printing
+slug: Web/CSS/CSS_media_queries/Printing
 page-type: guide
 ---
 

--- a/files/en-us/web/css/css_paged_media/index.md
+++ b/files/en-us/web/css/css_paged_media/index.md
@@ -35,3 +35,8 @@ The **CSS paged media** module defines the properties that control the presentat
 ## Specifications
 
 {{Specifications}}
+
+## See also
+
+- [Printing](/en-US/docs/Web/CSS/CSS_media_queries/Printing) guide
+- [CSS media queries](/en-US/docs/Web/CSS/CSS_media_queries) module


### PR DESCRIPTION
Part of https://github.com/openwebdocs/project/issues/185
move print guide to under CSS media queries
add printing module with @page to printing page
edit links pointing to old location to new location
