### PR TITLE
Remove misleading note about reflow in createDocumentFragment

### DIFF
--- a/files/en-us/web/api/document/createdocumentfragment/index.md
+++ b/files/en-us/web/api/document/createdocumentfragment/index.md
@@ -34,9 +34,8 @@ elements to the document fragment and then append the document fragment to the D
 In the DOM tree, the document fragment is replaced by all its children.
 
 Since the document fragment is _in memory_ and not part of the main DOM tree,
-appending children to it does not cause page [reflow](https://developers.google.com/speed/docs/insights/browser-reflow?csw=1)
-(computation of element's position and geometry). Historically, using document fragments
-could result in [better performance](https://johnresig.com/blog/dom-documentfragments/).
+using document fragments could result in [better performance](https://johnresig.com/blog/dom-documentfragments/)
+in some older engines.
 
 You can also use the `DocumentFragment` constructor to create a new
 fragment:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This removes a misleading note about traditional DOM insertion that could cause a reflow where a `DocumentFragment` wouldn't.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This is very misleading and some readers are still thinking they should use a `DocumentFragment` when it's actually probably detrimental to do so.  
The idea that `DocumentFragment` is faster than usual DOM manipulations is just an historical myth, as pointed out by the very next sentence.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
