### PR TITLE
Fix anchor link to "Defining animation sequence using keyframes" document fragment

### DIFF
--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -16,7 +16,7 @@ There are three key advantages to CSS animations over traditional script-driven 
 
 ## Configuring an animation
 
-To create a CSS animation sequence, you style the element you want to animate with the {{cssxref("animation")}} property or its sub-properties. This lets you configure the timing, duration, and other details of how the animation sequence should progress. This does **not** configure the actual appearance of the animation, which is done using the {{cssxref("@keyframes")}} at-rule as described in the [Defining the animation sequence using keyframes](#defining_the_animation_sequence_using_keyframes) section below.
+To create a CSS animation sequence, you style the element you want to animate with the {{cssxref("animation")}} property or its sub-properties. This lets you configure the timing, duration, and other details of how the animation sequence should progress. This does **not** configure the actual appearance of the animation, which is done using the {{cssxref("@keyframes")}} at-rule as described in the [Defining animation sequence using keyframes](#defining_animation_sequence_using_keyframes) section below.
 
 The sub-properties of the {{cssxref("animation")}} property are:
 


### PR DESCRIPTION
### Description

I updated the anchor link so that it correctly points to the "Defining animation sequence using keyframes" heading, and removed the word "the" from the link text as well.

### Motivation

I noticed the anchor link did not scroll to the corresponding heading when clicked.