### PR TITLE
added missing information regarding the click event

### DIFF
--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -18,7 +18,7 @@ If the button is pressed on one element and the pointer is moved outside the ele
 
 `click` fires after both the {{domxref("Element/mousedown_event", "mousedown")}} and {{domxref("Element/mouseup_event", "mouseup")}} events have fired, in that order.
 
-The event is a device-independent event — meaning it can be activated by touch, keyboard, mouse, and any other mechanism provided by assistive technology.
+The event is a device-independent event — meaning it can be activated by touch, keyboard, mouse, and any other mechanism provided by assistive technology.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -9,6 +9,7 @@ browser-compat: api.Element.click_event
 {{APIRef}}
 
 An element receives a **`click`** event when any of the following occurs:
+
 - a pointing-device button (such as a mouse's primary button) is both pressed and released while the pointer is located inside the element.
 - a touch gesture is performed on the element
 - the <kbd>Space</kbd> key or <kbd>Enter</kbd> key is pressed while the element is focused

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -17,8 +17,7 @@ If the button is pressed on one element and the pointer is moved outside the ele
 
 `click` fires after both the {{domxref("Element/mousedown_event", "mousedown")}} and {{domxref("Element/mouseup_event", "mouseup")}} events have fired, in that order.
 
-the event is a device independent event, meaning it can be activated with a touch, keyboard, mouse and any other mechanism provided by an assistive technology.
-.
+The event is a device-independent event — meaning it can be activated by touch, keyboard, mouse, and any other mechanism provided by assistive technology.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -8,7 +8,10 @@ browser-compat: api.Element.click_event
 
 {{APIRef}}
 
-An element receives a **`click`** event when a touch gesture is performed on the element or Space or Enter ke is pressed using a keyboard while the element is focused or a pointing device button (such as a mouse's primary mouse button) is both pressed and released while the pointer is located inside the element.
+An element receives a **`click`** event when any of the following occurs:
+- a pointing-device button (such as a mouse's primary button) is both pressed and released while the pointer is located inside the element.
+- a touch gesture is performed on the element
+- the <kbd>Space</kbd> key or <kbd>Enter</kbd> key is pressed while the element is focused
 
 If the button is pressed on one element and the pointer is moved outside the element before the button is released, the event is fired on the most specific ancestor element that contained both elements.
 

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -8,12 +8,14 @@ browser-compat: api.Element.click_event
 
 {{APIRef}}
 
-An element receives a **`click`** event when a pointing device button (such as a mouse's primary mouse button) is both pressed and released while the pointer is located inside the element.
+An element receives a **`click`** event when a touch gesture is performed on the element or Space or Enter ke is pressed using a keyboard while the element is focused or a pointing device button (such as a mouse's primary mouse button) is both pressed and released while the pointer is located inside the element.
 
 If the button is pressed on one element and the pointer is moved outside the element before the button is released, the event is fired on the most specific ancestor element that contained both elements.
 
 `click` fires after both the {{domxref("Element/mousedown_event", "mousedown")}} and {{domxref("Element/mouseup_event", "mouseup")}} events have fired, in that order.
 
+the event is a device independent event, meaning it can be activated with a touch, keyboard, mouse and any other mechanism provided by an assistive technology.
+.
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -16,6 +16,7 @@ If the button is pressed on one element and the pointer is moved outside the ele
 
 the event is a device independent event, meaning it can be activated with a touch, keyboard, mouse and any other mechanism provided by an assistive technology.
 .
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.


### PR DESCRIPTION

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Added missing information about click event.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change will give clarity to readers about the click event. As the current page regarding the event focuses on mouse, there is hi chance that it can mislead readers. readers may associate the event only with mouse and try to add additional event handlers for keyDown, keyUP and keyPress to make the element accessible for keyboard users. this is not correct. The Click event can also be activated with a keyboard. This change will prevent that misunderstanding.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #30263
