### PR TITLE
remove "twos complement" from unsigned types

### DIFF
--- a/files/en-us/web/api/webgl_api/types/index.md
+++ b/files/en-us/web/api/webgl_api/types/index.md
@@ -79,17 +79,17 @@ These types are used within a {{domxref("WebGLRenderingContext")}}.
     <tr>
       <td><code>GLubyte</code></td>
       <td><code>octet</code></td>
-      <td>8-bit twos complement unsigned integer.</td>
+      <td>8-bit unsigned integer.</td>
     </tr>
     <tr>
       <td><code>GLushort</code></td>
       <td><code>unsigned short</code></td>
-      <td>16-bit twos complement unsigned integer.</td>
+      <td>16-bit unsigned integer.</td>
     </tr>
     <tr>
       <td><code>GLuint</code></td>
       <td><code>unsigned long</code></td>
-      <td>32-bit twos complement unsigned integer.</td>
+      <td>32-bit unsigned integer.</td>
     </tr>
     <tr>
       <td><code>GLfloat</code></td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove "twos complement" from unsigned types.

### Motivation

"twos complement" isn't used in unsigned integers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
