### PR TITLE
Rename two pseudo-classes never implemented

### DIFF
--- a/files/en-us/web/css/column_combinator/index.md
+++ b/files/en-us/web/css/column_combinator/index.md
@@ -83,5 +83,5 @@ col.selected||td {
 - {{HTMLElement("col")}}
 - {{HTMLElement("colgroup")}}
 - {{CSSxRef("grid")}}
-- {{CSSxRef(":nth-col")}}
-- {{CSSxRef(":nth-last-col")}}
+- {{CSSxRef(":nth-of-type")}}
+- {{CSSxRef(":nth-last-of-type")}}


### PR DESCRIPTION
The links were redirects, and they were never implemented under this name.