### PR TITLE
Document Window.setResizable()

### DIFF
--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -241,8 +241,6 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Scrolls to a particular set of coordinates in the document.
 - {{domxref("setInterval", "Window.setInterval()")}}
   - : Schedules a function to execute every time a given number of milliseconds elapses.
-- {{domxref("Window.setResizable()")}} {{Non-standard_Inline}}
-  - : Toggles a user's ability to resize a window.
 - {{domxref("setTimeout()", "Window.setTimeout()")}}
   - : Schedules a function to execute in a given amount of time.
 - {{domxref("Window.showDirectoryPicker()")}} {{Experimental_Inline}}
@@ -276,6 +274,8 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Lets a website or app gain access to a sandboxed file system for its own use.
 - {{domxref("Window.setImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Executes a function after the browser has finished other heavy tasks.
+- {{domxref("Window.setResizable()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
+  - : Does nothing (no-op). Kept for backward compatibility with Netscape 4.x.
 - {{domxref("Window.showModalDialog()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Displays a modal dialog.
 - {{domxref("Window.webkitConvertPointFromNodeToPage()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}

--- a/files/en-us/web/api/window/setresizable/index.md
+++ b/files/en-us/web/api/window/setresizable/index.md
@@ -1,0 +1,32 @@
+---
+title: "Window: setResizable() method"
+short-title: setResizable()
+slug: Web/API/Window/setResizable
+page-type: web-api-instance-method
+status:
+  - deprecated
+  - non-standard
+browser-compat: api.Window.setResizable
+---
+
+{{APIRef("HTML DOM")}} {{deprecated_header}}{{non-standard_header}}
+
+This method does nothing; it is a no-op. It is solely kept for compatibility with Netscape 4.x.
+
+## Syntax
+
+```js-nolint
+setResizable()
+```
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Specifications
+
+Not part of any current specifications.
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
`Window.setResizable()` is the only member of `Window` not yet documented.

It is a no-op kept on Firefoxen for compatibility purposes:
![Capture d’écran 2023-12-01 à 09 44 57](https://github.com/mdn/content/assets/1466293/430d6964-2546-4b18-b671-e7b41fbee2da)
