### PR TITLE
Slightly improve outdated Navigator.getUserMedia()

### DIFF
--- a/files/en-us/web/api/navigator/getusermedia/index.md
+++ b/files/en-us/web/api/navigator/getusermedia/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Navigator.getUserMedia
 The deprecated **`Navigator.getUserMedia()`** method prompts the user for permission to use up to one video input device (such as a camera or shared screen) and up to one audio input device (such as a microphone) as the source for a {{domxref("MediaStream")}}.
 
 If permission is granted, a `MediaStream` whose video and/or audio tracks come from those devices is delivered to the specified success callback.
-If permission is denied, no compatible input devices exist, or any other error condition occurs, the error callback is executed with a {{domxref("MediaStreamError")}} object describing what went wrong.
+If permission is denied, no compatible input devices exist, or any other error condition occurs, the error callback is executed with an object describing what went wrong.
 If the user instead doesn't make a choice at all, neither callback is executed.
 
 > **Note:** This is a legacy method.
@@ -53,9 +53,8 @@ getUserMedia(constraints, successCallback, errorCallback)
 
 - `errorCallback`
   - : When the call fails, the function specified in the `errorCallback` is
-    invoked with a {{domxref("MediaStreamError")}} object as its sole argument; this
-    object is modeled on {{domxref("DOMException")}}. See [Errors](#errors) below for a
-    list of the errors which can occur.
+    invoked with an object as its sole argument; this
+    object is modeled on {{domxref("DOMException")}}. 
 
 ### Return value
 
@@ -94,26 +93,6 @@ if (navigator.getUserMedia) {
   console.log("getUserMedia not supported");
 }
 ```
-
-## Permissions
-
-To use `getUserMedia()` in an installable app, you need to specify one or both of the following fields inside your
-manifest file:
-
-```json
-{
-  "permissions": {
-    "audio-capture": {
-      "description": "Required to capture audio using getUserMedia()"
-    },
-    "video-capture": {
-      "description": "Required to capture video using getUserMedia()"
-    }
-  }
-}
-```
-
-See [permission: audio-capture](/en-US/docs/Web/Apps/Developing/App_permissions#audio-capture) and [permission: video-capture](/en-US/docs/Web/Apps/Developing/App_permissions#video-capture) for more information.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/navigator/getusermedia/index.md
+++ b/files/en-us/web/api/navigator/getusermedia/index.md
@@ -54,7 +54,7 @@ getUserMedia(constraints, successCallback, errorCallback)
 - `errorCallback`
   - : When the call fails, the function specified in the `errorCallback` is
     invoked with an object as its sole argument; this
-    object is modeled on {{domxref("DOMException")}}. 
+    object is modeled on {{domxref("DOMException")}}.
 
 ### Return value
 


### PR DESCRIPTION
- Removed the _Permissions_ section that is irrelevant nowadays
- Removed mention of the name of the dictionary `MediaStreamError` (as well as the non-existent list of errors)