### PR TITLE
Fix spec mention in CSS Scoping

### DIFF
--- a/files/en-us/web/css/css_scoping/index.md
+++ b/files/en-us/web/css/css_scoping/index.md
@@ -69,7 +69,7 @@ Sometimes it's useful to be able to style a host from inside the shadow tree con
   - {{DOMxRef("HTMLTemplateElement")}} interface
   - {{DOMxRef("ShadowRoot")}} interface
 
-> **Note:** Despite the name, the {{CSSXref(":scope")}} pseudo-class, which represents elements that are a reference point (or scope) for selectors to match against, is defined in the [CSS pseudo-classes](/en-US/docs/Web/CSS/CSS_pseudo-classes) module. It is otherwise unrelated to the CSS scoping module, which is focused on scoping as it pertains to the Shadow DOM scoping mechanism.
+> **Note:** Despite the name, the {{CSSXref(":scope")}} pseudo-class, which represents elements that are a reference point (or scope) for selectors to match against, is defined in the [Selectors](/en-US/docs/Web/CSS/CSS_selectors) module. It is otherwise unrelated to the CSS scoping module, which is focused on scoping as it pertains to the Shadow DOM scoping mechanism.
 
 ## Specifications
 


### PR DESCRIPTION
The name of the module was incorrect. This fixes it.