### PR TITLE
fix(games) Remove broken links, refer to WebXR instead of WebVR API

### DIFF
--- a/files/en-us/games/publishing_games/game_distribution/index.md
+++ b/files/en-us/games/publishing_games/game_distribution/index.md
@@ -70,7 +70,7 @@ Let's see what the available options are regarding the marketplaces/stores avail
 
 ### Web stores
 
-The best platforms for HTML games are the Web-based stores. It's easy to [prepare a game for them](https://code.tutsplus.com/tutorials/preparing-for-firefox-os--mobile-18515) as such an action involves little to no modification of the game itself — usually adding a manifest file containing necessary information in a zipped package containing all the resources is enough.
+The best platforms for HTML games are Web-based stores. You can prepare games for web stores by adding a manifest file and other data, such as resources, in a zipped package. Not many modifications of the game itself are required.
 
 - [The Chrome Web Store](https://chrome.google.com/webstore/) is also an attractive option — again, having a manifest file ready, zipping your game and filling in the online submission form is about all that's required.
 

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 A typical 3D scene in a game — even the simplest one — contains standard items like shapes located in a coordinate system, a camera to actually see them, lights and materials to make it look better, animations to make it look alive, etc. **Three.js**, as with any other 3D library, provides built-in helper functions to help you implement common 3D functionality more quickly. In this article we'll take you through the real basics of using Three, including setting up a development environment, structuring the necessary HTML, the fundamental objects of Three, and how to build up a basic demo.
 
-> **Note:** We chose Three because it is one of the most popular [WebGL](/en-US/docs/Web/API/WebGL_API) libraries, and it is easy to get started with. We are not trying to say it is better than any other WebGL library available, and you should feel free to try another library, such as [CopperLicht](https://www.ambiera.com/copperlicht/index.html), [GLGE](http://www.glge.org/), or [PlayCanvas](https://playcanvas.com/).
+> **Note:** We chose Three because it is one of the most popular [WebGL](/en-US/docs/Web/API/WebGL_API) libraries, and it is easy to get started with. We are not trying to say it is better than any other WebGL library available, and you should feel free to try another library, such as [CopperLicht](https://www.ambiera.com/copperlicht/index.html) or [PlayCanvas](https://playcanvas.com/).
 
 ## Environment setup
 

--- a/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
@@ -26,8 +26,8 @@ The [WebVR API](/en-US/docs/Web/API/WebVR_API) is the central API for capturing 
 
 ### Browser support and spec status
 
-The [WebVR spec](https://mozvr.github.io/webvr-spec/webvr.html), led by [Vladimir Vukicevic](https://twitter.com/vvuk) from Mozilla and [Brandon Jones](https://twitter.com/tojiro) from Google is being replaced by the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API), but may still be available in some browsers while that API is finalized.
-For more info, see <https://mixedreality.mozilla.org/>, [WebVR.info](https://webvr.info/) websites.
+The [WebVR spec](https://mozvr.github.io/webvr-spec/webvr.html), led by [Vladimir Vukicevic](https://twitter.com/vvuk) from Mozilla and [Brandon Jones](https://twitter.com/tojiro) from Google, is being replaced by the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API). WebVR may still be available in some browsers while WebXR is finalized.
+For more info, see the <https://mixedreality.mozilla.org/> and [WebVR.info](https://webvr.info/) websites.
 
 ### Using the WebVR API
 

--- a/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
@@ -26,9 +26,8 @@ The [WebVR API](/en-US/docs/Web/API/WebVR_API) is the central API for capturing 
 
 ### Browser support and spec status
 
-Currently browser support for the WebVR API is still experimental — it works in [nightly builds of Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/) and [experimental builds of Chrome](https://drive.google.com/folderview?id=0BzudLt22BqGRbW9WTHMtOWMzNjQ&usp=sharing#list) (Mozilla and Google teamed up to work on the implementation together), but sooner rather than later we'll see it in regular builds.
-
-The [WebVR spec](https://mozvr.github.io/webvr-spec/webvr.html) is in Editor's Draft status which means it is still subject to change. The development is led by [Vladimir Vukicevic](https://twitter.com/vvuk) from Mozilla and [Brandon Jones](https://twitter.com/tojiro) from Google. For more info be sure to visit the <https://mixedreality.mozilla.org/> and [WebVR.info](https://webvr.info/) websites.
+The [WebVR spec](https://mozvr.github.io/webvr-spec/webvr.html), led by [Vladimir Vukicevic](https://twitter.com/vvuk) from Mozilla and [Brandon Jones](https://twitter.com/tojiro) from Google is being replaced by the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API), but may still be available in some browsers while that API is finalized.
+For more info, see <https://mixedreality.mozilla.org/>, [WebVR.info](https://webvr.info/) websites.
 
 ### Using the WebVR API
 


### PR DESCRIPTION
Removing a few dead links.

__Broken URLs:__

* https://code.tutsplus.com/tutorials/preparing-for-firefox-os--mobile-18515
* http://www.glge.org/ (removing as this is apparently abandoned since 10 years)
* https://drive.google.com/folderview?id=0BzudLt22BqGRbW9WTHMtOWMzNjQ&usp=sharing#list


__Notes:__
The WebVR article needs a little refresh to make sure prose is all pointing to WebXR instead. Leaving this for a follow-up. Maybe @zfox23 would like to have a look 👀 