### PR TITLE
Rename requesttOffsetReferenceSpace() to getOffsetReferenceSpace()

### DIFF
--- a/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
+++ b/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
@@ -152,7 +152,7 @@ function onRefSpaceCreated(refSpace) {
 
 In this code, executed after the reference space has been created, we create an {{domxref("XRRigidTransform")}} representing the transform that will move the viewpoint upward by 1.5 meters. This approximates human height, though it assumes we've previously transformed the coordinate system so that the value of each coordinate is no longer constrained to -1 to 1, while maintaining the definition that a value of 1 represents one meter).
 
-The new transform is passed into `requestOffsetReferenceFrame()` to obtain a reference frame which maps the coordinates between the base coordinate system and that of the rendered image. The new reference space replaces the original one. Finally, drawing begins by calling the {{domxref("XRSession")}} method {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}.
+The new transform is passed into `getOffsetReferenceFrame()` to obtain a reference frame that maps the coordinates between the base coordinate system and that of the rendered image. The new reference space replaces the original one. Finally, drawing begins by calling the {{domxref("XRSession")}} method {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}.
 
 ## See also
 

--- a/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
+++ b/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
@@ -130,7 +130,7 @@ It's important, however, to keep in mind that while a `local-floor` space provid
 
 If upon attempting to create a `local-floor` reference space, the user's XR device doesn't have built-in support for determining floor level, the WebXR layer will still create a `local-floor` space. However, the floor level will be simulated by choosing and emulating the floor level and shifting the view upward by a fixed amount in order to ensure that the scene's contents render in the right place.
 
-Keep in mind that by default, the viewer's position is placed _immediately_ above the floor, like a camera lying on the ground. If you wish to simulate a human's perspective on the scene, you probably want to move the viewpoint upward by a distance that approximates human eye level by transforming it by providing an appropriate transform matrix to the {{domxref("XRReferenceSpace")}} method {{domxref("XRReferenceSpace.requestOffsetReferenceSpace", "requestOffsetReferenceSpace()")}}.
+Keep in mind that by default, the viewer's position is placed _immediately_ above the floor, like a camera lying on the ground. If you wish to simulate a human's perspective on the scene, you probably want to move the viewpoint upward by a distance that approximates human eye level by transforming it by providing an appropriate transform matrix to the {{domxref("XRReferenceSpace")}} method {{domxref("XRReferenceSpace.getOffsetReferenceSpace", "getOffsetReferenceSpace()")}}.
 
 This would change the `onRefSpaceCreated()` method from the above snippet to:
 

--- a/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
+++ b/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
@@ -152,7 +152,7 @@ function onRefSpaceCreated(refSpace) {
 
 In this code, executed after the reference space has been created, we create an {{domxref("XRRigidTransform")}} representing the transform that will move the viewpoint upward by 1.5 meters. This approximates human height, though it assumes we've previously transformed the coordinate system so that the value of each coordinate is no longer constrained to -1 to 1, while maintaining the definition that a value of 1 represents one meter).
 
-The new transform is passed into `getOffsetReferenceFrame()` to obtain a reference frame that maps the coordinates between the base coordinate system and that of the rendered image. The new reference space replaces the original one. Finally, drawing begins by calling the {{domxref("XRSession")}} method {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}.
+The new transform is passed into `getOffsetReferenceSpace()` to obtain a reference space that maps the coordinates between the base coordinate system and that of the rendered image. The new reference space replaces the original one. Finally, drawing begins by calling the {{domxref("XRSession")}} method {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}.
 
 ## See also
 


### PR DESCRIPTION
As used in the example below, the method name in the description is `getOffsetReferenceSpace()` and  not `referenceOffsetReferenceSpace()`. Fixing the broken link.