### PR TITLE
Remove non-existent link in See also

### DIFF
--- a/files/en-us/glossary/privileged/index.md
+++ b/files/en-us/glossary/privileged/index.md
@@ -11,4 +11,3 @@ Users are said to be **privileged** when they are granted additional rights to a
 ## See also
 
 - [Privilege (computing)](<https://en.wikipedia.org/wiki/Privilege_(computing)>) on Wikipedia
-- [Information Security Tutorial](/en-US/docs/Web/Security/Information_Security_Basics)


### PR DESCRIPTION
This page doesn't exist and the information architecture of the Security will be redone when we will deal with it: unlikely a page with that exact name will be created.