### PR TITLE
fix(a11y): Point to CDC archive for 2018 report, link to current CDC Disability and Health resources

### DIFF
--- a/files/en-us/learn/accessibility/what_is_accessibility/index.md
+++ b/files/en-us/learn/accessibility/what_is_accessibility/index.md
@@ -99,7 +99,7 @@ A good foundation of accessibility for people with cognitive impairments include
 - Many people with cognitive impairments also have physical disabilities. Websites must conform to the W3C's [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/), including [cognitive accessibility guidelines](/en-US/docs/Web/Accessibility/Cognitive_accessibility#wcag_guidelines).
 - The W3C's [Cognitive and Learning Disabilities Accessibility Task Force](https://www.w3.org/WAI/GL/task-forces/coga/) produces web accessibility guidelines for people with cognitive impairments.
 - WebAIM has a [Cognitive page](https://webaim.org/articles/cognitive/) of relevant information and resources.
-- The United States Centers for Disease Control estimate that, as of 2018, 1 in 4 US citizens have a disability and, of them, [cognitive impairment is the most common for young people](https://www.cdc.gov/media/releases/2018/p0816-disability.html).
+- The United States Centers for Disease Control estimate that, as of 2018, 1 in 4 US citizens have a disability and, of them, [cognitive impairment is the most common for young people](https://archive.cdc.gov/www_cdc_gov/media/releases/2018/p0816-disability.html).
 - In the US, some intellectual disabilities have historically been referred to as "mental retardation." Many now consider this term disparaging, so its use should be avoided.
 - In the UK, some intellectual disabilities are referred to as "learning disabilities" or "learning difficulties".
 

--- a/files/en-us/web/accessibility/cognitive_accessibility/index.md
+++ b/files/en-us/web/accessibility/cognitive_accessibility/index.md
@@ -268,7 +268,7 @@ The above are good design practices. They will benefit everyone.
 - Many people with cognitive impairments also have physical disabilities. Websites must conform with the W3C's [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/).
 - The W3C's [Cognitive and Learning Disabilities Accessibility Task Force](https://www.w3.org/WAI/GL/task-forces/coga/) produces web accessibility guidelines for people with cognitive impairments.
 - WebAIM has a [Cognitive page](https://webaim.org/articles/cognitive/) of relevant information and resources.
-- The United States Centers for Disease Control estimate that, as of 2018, 1 in 4 U.S. citizens have a disability and, of them, [cognitive impairment is the most common for young people](https://www.cdc.gov/media/releases/2018/p0816-disability.html).
+- The United States Centers for Disease Control estimate that, as of 2018, 1 in 4 U.S. citizens have a disability and, of them, [cognitive impairment is the most common for young people](https://archive.cdc.gov/www_cdc_gov/media/releases/2018/p0816-disability.html).
 - In the U.S., "intellectual disabilities" used to be called "mental retardation". In the U.K., "intellectual disabilities" is commonly called "learning disabilities" or "learning difficulties".
 
 ## See also
@@ -281,4 +281,4 @@ The above are good design practices. They will benefit everyone.
 - [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/), including [cognitive accessibility guidelines](#wcag_guidelines).
 - [CThe W3Cs cognitive and Learning Disabilities Accessibility Task Force](https://www.w3.org/WAI/GL/task-forces/coga/)
 - [WebAIM Cognitive information](https://webaim.org/articles/cognitive/)
-- [CDC information on disabilities.](https://www.cdc.gov/media/releases/2018/p0816-disability.html)
+- [CDC information on disabilities.](https://www.cdc.gov/ncbddd/disabilityandhealth/)

--- a/files/en-us/web/accessibility/cognitive_accessibility/index.md
+++ b/files/en-us/web/accessibility/cognitive_accessibility/index.md
@@ -278,7 +278,7 @@ The above are good design practices. They will benefit everyone.
 - [Accessibility for seizure disorders](/en-US/docs/Web/Accessibility/Seizure_disorders)
 - [Understanding WCAG Guidelines](/en-US/docs/Web/Accessibility/Understanding_WCAG)
 - [Accessibility overview](/en-US/docs/Learn/Accessibility)
-- [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/), including [cognitive accessibility guidelines](#wcag_guidelines).
+- [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/), including [cognitive accessibility guidelines](#wcag_guidelines)
 - [CThe W3Cs cognitive and Learning Disabilities Accessibility Task Force](https://www.w3.org/WAI/GL/task-forces/coga/)
 - [WebAIM Cognitive information](https://webaim.org/articles/cognitive/)
-- [CDC information on disabilities.](https://www.cdc.gov/ncbddd/disabilityandhealth/)
+- [CDC information on disabilities](https://www.cdc.gov/ncbddd/disabilityandhealth/)


### PR DESCRIPTION
The following is broken:

* https://www.cdc.gov/media/releases/2018/p0816-disability.html

I've decided to link to the archived version for now:

* https://archive.cdc.gov/www_cdc_gov/media/releases/2018/p0816-disability.html

For See Also, linking to

* "CDC information on disabilities" -> https://www.cdc.gov/ncbddd/disabilityandhealth/