### PR TITLE
Extend the getTargetRanges method documentation

### DIFF
--- a/files/en-us/web/api/inputevent/gettargetranges/index.md
+++ b/files/en-us/web/api/inputevent/gettargetranges/index.md
@@ -12,6 +12,44 @@ The **`getTargetRanges()`** method of the {{domxref("InputEvent")}} interface re
 
 This allows web apps to override text edit behavior before the browser modifies the DOM tree, and provides more control over input events to improve performance.
 
+Depending on the value of `inputType` and the current editing host, the expected return value of this method varies:
+
+<table>
+  <thead>
+    <tr>
+      <th>inputType</th>
+      <th>Editing host</th>
+      <th>Response of <code>getTargetRanges()</code></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>"historyUndo"</code> or <code>"historyRedo"</code></td>
+      <td>Any</td>
+      <td>empty Array</td>
+    </tr>
+    <tr>
+      <td>All remaining</td>
+      <td><code>contenteditable</code></td>
+      <td>
+        an Array of
+        {{domxref("StaticRange")}}
+        objects associated with event
+      </td>
+    </tr>
+    <tr>
+      <td>All remaining</td>
+      <td>
+        <a href="/en-US/docs/Web/HTML/Element/input"><code>input</code></a>
+        or <a href="/en-US/docs/Web/HTML/Element/textarea"><code>textarea</code></a>
+      </td>
+      <td>
+        an empty Array
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
### Description

Introduce a new table mirroring an existing table in the W3C spec that explains the expected return values for the `getTargetRanges` method. Notably, this table highlights that for editing hosts that are not `contenteditable`, the expected return value for this method is an empty array (which is not currently clear anywhere except the W3C docs).

### Motivation

When experimenting with `beforeinput` and `getTargetRanges`, I was confused to find that the result seemed to always be an empty array (even when I thought I was configuring everything correctly). The existing docs didn't explain that, per the W3C spec, returning an empty array is the expected behavior in certain scenarios.

### Additional details

Matching W3C spec: https://w3c.github.io/input-events/#interface-InputEvent-Methods
