### PR TITLE
Add word "tilde" to subsequent-sibling combinator page

### DIFF
--- a/files/en-us/web/css/subsequent-sibling_combinator/index.md
+++ b/files/en-us/web/css/subsequent-sibling_combinator/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.subsequent-sibling
 
 {{CSSRef("Selectors")}}
 
-The **subsequent-sibling combinator** (`~` tilde) separates two selectors and matches _all instances_ of the second element that follow the first element (not necessarily immediately) and share the same parent element.
+The **subsequent-sibling combinator** (`~`, a tilde) separates two selectors and matches _all instances_ of the second element that follow the first element (not necessarily immediately) and share the same parent element.
 
 In the following example, the subsequent-sibling combinator (`~`) helps to select and style paragraphs that are both siblings of an image and appear after any image.
 

--- a/files/en-us/web/css/subsequent-sibling_combinator/index.md
+++ b/files/en-us/web/css/subsequent-sibling_combinator/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.subsequent-sibling
 
 {{CSSRef("Selectors")}}
 
-The **subsequent-sibling combinator** (`~`) separates two selectors and matches _all instances_ of the second element that follow the first element (not necessarily immediately) and share the same parent element.
+The **subsequent-sibling combinator** (`~` tilde) separates two selectors and matches _all instances_ of the second element that follow the first element (not necessarily immediately) and share the same parent element.
 
 In the following example, the subsequent-sibling combinator (`~`) helps to select and style paragraphs that are both siblings of an image and appear after any image.
 


### PR DESCRIPTION

### Description

Adds the word "tilde" to the subesquent-sibling combinator page

### Motivation

Adding the word "tilde" to this page makes it possible to find this page by searching for the name of the character used for the selector.

### Additional details

Without this change, the subsequent-sibling combinator page does not appear in a search for "tilde": https://developer.mozilla.org/en-US/search?q=tilde

![Screenshot 2023-12-01 at 15 37 35](https://github.com/mdn/content/assets/1754187/8ab968dd-30c4-4456-b1e9-37f7cf815330)



### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
