### PR TITLE
Removed comma in example on Web/JavaScript/Reference/Global_Objects/Map/groupBy 

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/groupby/index.md
@@ -70,7 +70,7 @@ The code below uses `Map.groupBy()` with an arrow function that returns the obje
 const restock = { restock: true };
 const sufficient = { restock: false };
 const result = Map.groupBy(inventory, ({ quantity }) =>
-  quantity < 6 ? restock : sufficient,
+  quantity < 6 ? restock : sufficient
 );
 console.log(result.get(restock));
 // [{ name: "bananas", type: "fruit", quantity: 5 }]


### PR DESCRIPTION
Removed comma in the [Using Map.groupBy()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy#using_map.groupby) example callbackFn.

Updated the [Try it](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy#try_it) example in this [PR](https://github.com/mdn/interactive-examples/pull/2675).
