### PR TITLE
fix(css): reveal hidden style rule

### DIFF
--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -364,9 +364,7 @@ p {
   margin: 10px;
   border-radius: 5px;
 }
-```
 
-```css hidden
 .positioned {
   background: rgb(255 84 104 / 30%);
   border: 2px solid rgb(255 84 104);
@@ -414,15 +412,10 @@ p {
   margin: 10px;
   border-radius: 5px;
 }
-```
 
-```css hidden
 .positioned {
-  position: relative;
   background: rgb(255 84 104 / 30%);
   border: 2px solid rgb(255 84 104);
-  top: 30px;
-  left: 30px;
 }
 ```
 
@@ -465,9 +458,7 @@ p {
   margin: 10px;
   border-radius: 5px;
 }
-```
 
-```css hidden
 .positioned {
   background: rgb(255 84 104 / 30%);
   border: 2px solid rgb(255 84 104);


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/30716

I don't know why they kept it hidden when they introduced the hidden class in https://github.com/mdn/content/pull/23507 .

The PR
- reveals the definition for the first mention of `.positioned` class
- removes duplicate properties from the hidden `.positioned` rule for position relative example. This way in playground the properties won't be repeated.