### PR TITLE
Fix absence of bcd for some css features

### DIFF
--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -3,6 +3,7 @@ title: "@color-profile"
 slug: Web/CSS/@color-profile
 page-type: css-at-rule
 browser-compat: css.at-rules.color-profile
+spec-urls: https://www.w3.org/TR/css-color-5/#at-profile
 ---
 
 {{CSSRef}}
@@ -61,4 +62,4 @@ The `src` descriptor specifies the URL to retrieve the color-profile information
 
 ## Browser compatibility
 
-{{Compat}}
+There is no browser implementing this feature.

--- a/files/en-us/web/css/@font-feature-values/font-display/index.md
+++ b/files/en-us/web/css/@font-feature-values/font-display/index.md
@@ -3,6 +3,7 @@ title: font-display
 slug: Web/CSS/@font-feature-values/font-display
 page-type: css-at-rule-descriptor
 browser-compat: css.at-rules.font-feature-values.font-display
+spec-urls: https://drafts.csswg.org/css-fonts/#descdef-font-feature-values-font-display
 ---
 
 {{CSSRef}}
@@ -66,7 +67,7 @@ The `font-display` descriptor in this example sets the default `font-display` va
 
 ## Browser compatibility
 
-{{Compat}}
+There is no browser implementing this feature.
 
 ## See also
 

--- a/files/en-us/web/css/_colon_current/index.md
+++ b/files/en-us/web/css/_colon_current/index.md
@@ -77,7 +77,7 @@ This is the third caption
 
 ## Browser compatibility
 
-{{Compat}}
+There is no browser implementing this feature.
 
 ## See also
 

--- a/files/en-us/web/css/_doublecolon_cue-region/index.md
+++ b/files/en-us/web/css/_doublecolon_cue-region/index.md
@@ -3,6 +3,7 @@ title: "::cue-region"
 slug: Web/CSS/::cue-region
 page-type: css-pseudo-element
 browser-compat: css.selectors.cue-region
+spec-urls: https://w3c.github.io/webvtt/#the-cue-region-pseudo-element
 ---
 
 {{CSSRef}}{{SeeCompatTable}}
@@ -70,7 +71,7 @@ Rules whose selectors include this element may only use the following CSS proper
 
 ## Browser compatibility
 
-{{Compat}}
+There is no browser implementing this feature.
 
 ## See also
 

--- a/files/en-us/web/css/color_value/device-cmyk/index.md
+++ b/files/en-us/web/css/color_value/device-cmyk/index.md
@@ -46,4 +46,4 @@ Functional notation: `device-cmyk(C M Y K[ / A][, color])`
 
 ## Browser compatibility
 
-{{Compat}}
+There is no browser implementing this feature.


### PR DESCRIPTION
A few CSS features are documented but not implemented (yet).

For these features, we use _spec-urls_ and a hardcoded browser compat text. For example, in: [@media/shape](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/shape)

A few pages about CSS weren't doing this, leading to big red boxes and flaws. This PR fixes the 5 of them.

Note: when the feature is implemented, BCD is notified and fixed and browser vendors' writers update docs, and will add the `{{compat}}` to these pages at that moment, so this way of doing is safe.