### PR TITLE
Add linkage from originAgentCluster property to the HTTP header

### DIFF
--- a/files/en-us/web/api/window/originagentcluster/index.md
+++ b/files/en-us/web/api/window/originagentcluster/index.md
@@ -20,6 +20,8 @@ Windows that are part of an origin-keyed agent cluster are subjects to some addi
 - Send [`WebAssembly.Module`](/en-US/docs/WebAssembly/JavaScript_interface/Module) objects to other same-site cross-origin pages via {{domxref("Window.postMessage()")}}.
 - Send {{jsxref("SharedArrayBuffer")}} or [`WebAssembly.Memory`](/en-US/docs/WebAssembly/JavaScript_interface/Memory) objects to other same-site cross-origin pages.
 
+To request that the browser assign this window to an origin-keyed agent cluster, the server must send the {{httpheader("Origin-Agent-Cluster")}} response header.
+
 Note that the origin-keyed agent cluster feature is only supported in {{glossary("Secure Context", "secure contexts")}}. If a site is not a secure context, the `window.originAgentCluster` will always return `false`.
 
 ## Specifications
@@ -32,4 +34,5 @@ Note that the origin-keyed agent cluster feature is only supported in {{glossary
 
 ## See also
 
+- {{httpheader("Origin-Agent-Cluster")}} HTTP response header
 - [Requesting performance isolation with the Origin-Agent-Cluster header](https://web.dev/articles/origin-agent-cluster)


### PR DESCRIPTION
Now we have a page for the `Origin-Agent-Cluster` header, let's link to it from the associated property page.