### PR TITLE
Mark up code example

### DIFF
--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -9,7 +9,7 @@ browser-compat: html.elements.pre
 
 The **`<pre>`** [HTML](/en-US/docs/Web/HTML) element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or [monospaced](https://en.wikipedia.org/wiki/Monospaced_font), font. Whitespace inside this element is displayed as written.
 
-By default, `<pre>` is a [block-level](/en-US/docs/Glossary/Block-level_content) element, i.e. its default {{cssxref("display")}} value is block.
+By default, `<pre>` is a [block-level](/en-US/docs/Glossary/Block-level_content) element, i.e. its default {{cssxref("display")}} value is `block`.
 
 {{EmbedInteractiveExample("pages/tabbed/pre.html", "tabbed-standard")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `display` property has `block` as one of its possible values. The latter should therefore be written as code.

### Motivation

To disambiguate the sentence.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
