### PR TITLE
Fix to logic in centenarian example

### DIFF
--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -151,7 +151,7 @@ function myTag(strings, personExp, ageExp) {
   const str1 = strings[1]; // " is a "
   const str2 = strings[2]; // "."
 
-  const ageStr = ageExp > 99 ? "centenarian" : "youngster";
+  const ageStr = ageExp < 100 ? "youngster" : "centenarian";
 
   // We can even return a string built using a template literal
   return `${str0}${personExp}${str1}${ageStr}${str2}`;


### PR DESCRIPTION
Age need not be integral, and someone who is, for example, 99.5 years old is not a centenarian.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
