### PR TITLE
Fix broken links

### DIFF
--- a/files/en-us/games/introduction_to_html5_game_development/index.md
+++ b/files/en-us/games/introduction_to_html5_game_development/index.md
@@ -78,8 +78,7 @@ page-type: guide
       <td>
         <a href="/en-US/docs/Web/HTML">HTML</a>,
         <a href="/en-US/docs/Web/CSS">CSS</a>,
-        <a href="/en-US/docs/Web/SVG">SVG</a>,
-        <a href="/en-US/docs/Social_API">Social API</a> (and much more!)
+        <a href="/en-US/docs/Web/SVG">SVG</a> (and much more!)
       </td>
     </tr>
   </tbody>
@@ -114,5 +113,5 @@ page-type: guide
   - : Connect your app or site to a server to transmit data back and forth in real-time. Perfect for multiplayer gaming action, chat services, and so forth.
 - [Web Workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
   - : Spawn background threads running their own JavaScript code for multicore processors.
-- [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) and [File API](/en-US/docs/DOM/File_API)
+- [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) and [File API](/en-US/docs/Web/API/File_API)
   - : Send and receive any kind of data you want from a Web server like downloading new game levels and artwork to transmitting non-real-time game status information back and forth.


### PR DESCRIPTION
- _Social API_ was a Mozilla experiment that is long gone (and won't come back under this name)
- The link to _File API_ was still using the decade-old `/en-US/DOM` hierarchy instead of `/en-US/Web/API`.