### PR TITLE
Remove link to deleted code snippet area

### DIFF
--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -121,7 +121,3 @@ requested attribute does not exist on the specified element.
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [Code snippets:getAttributeNS](/en-US/docs/Mozilla/Add-ons/Code_snippets/getAttributeNS)


### PR DESCRIPTION
The _code snippet_ area has been deleted years ago. Deleting this _See also_ section.