### PR TITLE
Remove properties and methods that inheirts from `WorkerGlobalScope` in `DedicatedWorkerGlobalScope` `ServiceWorkerGlobalScope` `SharedWorkerGlobalScope`

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -29,6 +29,8 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 
 ## Events
 
+Listen to this event using {{domxref("EventTarget/addEventListener()", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
 - {{domxref("DedicatedWorkerGlobalScope/message_event", "message")}}
   - : Fired when the worker receives a message from its parent.
 - {{domxref("DedicatedWorkerGlobalScope/messageerror_event", "messageerror")}}

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -29,9 +29,9 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 
 ## Events
 
-- [`message`](/en-US/docs/Web/API/DedicatedWorkerGlobalScope/message_event)
+- {{domxref("DedicatedWorkerGlobalScope/message_event", "message")}}
   - : Fired when the worker receives a message from its parent.
-- [`messageerror`](/en-US/docs/Web/API/DedicatedWorkerGlobalScope/messageerror_event)
+- {{domxref("DedicatedWorkerGlobalScope/messageerror_event", "messageerror")}}
   - : Fired when a worker receives a message that can't be deserialized.
 
 ## Specifications

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -18,31 +18,6 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("DedicatedWorkerGlobalScope.name")}} {{ReadOnlyInline}}
   - : The name that the {{domxref("Worker")}} was (optionally) given when it was created using the {{domxref("Worker.Worker", "Worker()")}} constructor. This is mainly useful for debugging purposes.
 
-### Instance properties inherited from WorkerGlobalScope
-
-- {{domxref("caches", "DedicatedWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
-- {{domxref("console", "DedicatedWorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
-  - : Returns the {{domxref("console")}} associated with the worker.
-- {{domxref("WorkerGlobalScope.fonts", "DedicatedWorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
-- {{domxref("indexedDB", "DedicatedWorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
-  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
-- {{domxref("isSecureContext", "DedicatedWorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
-  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
-- {{domxref("WorkerGlobalScope.location", "DedicatedWorkerGlobalScope.location")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.navigator", "DedicatedWorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("origin", "DedicatedWorkerGlobalScope.origin")}} {{ReadOnlyInline}}
-  - : Returns the global object's origin, serialized as a string.
-- {{domxref("performance_property", "DedicatedWorkerGlobalScope.performance")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
-- {{domxref("scheduler_property", "DedicatedWorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
-- {{domxref("WorkerGlobalScope.self", "DedicatedWorkerGlobalScope.self")}}
-  - : Returns an object reference to the `DedicatedWorkerGlobalScope` object itself.
-
 ## Instance methods
 
 _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
@@ -51,29 +26,6 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
   - : Discards any tasks queued in the `WorkerGlobalScope`'s event loop, effectively closing this particular scope.
 - {{domxref("DedicatedWorkerGlobalScope.postMessage()")}}
   - : Sends a message — which can consist of `any` JavaScript object — to the parent document that first spawned the worker.
-
-### Inherited from WorkerGlobalScope
-
-- {{domxref("atob", "DedicatedWorkerGlobalScope.atob()")}}
-  - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "DedicatedWorkerGlobalScope.btoa()")}}
-  - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("Window.cancelAnimationFrame", "DedicatedWorkerGlobalScope.cancelAnimationFrame()")}}
-  - : Cancels a callback scheduled by requestAnimationFrame.
-- {{domxref("clearInterval", "DedicatedWorkerGlobalScope.clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
-- {{domxref("clearTimeout", "DedicatedWorkerGlobalScope.clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
-- {{domxref("WorkerGlobalScope.dump", "DedicatedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
-  - : Writes a message to the console.
-- {{domxref("WorkerGlobalScope.importScripts", "DedicatedWorkerGlobalScope.importScripts()")}}
-  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-- {{domxref("Window.requestAnimationFrame", "DedicatedWorkerGlobalScope.requestAnimationFrame()")}}
-  - : Requests the browser to execute a callback function before painting the next frame.
-- {{domxref("setInterval", "DedicatedWorkerGlobalScope.setInterval()")}}
-  - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout()", "DedicatedWorkerGlobalScope.setTimeout()")}}
-  - : Sets a delay for executing a function.
 
 ## Events
 

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -28,56 +28,12 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("ServiceWorkerGlobalScope.registration")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("ServiceWorkerRegistration")}} object that represents the service worker's registration.
 
-### Instance properties inherited from WorkerGlobalScope
-
-- {{domxref("caches", "ServiceWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
-- {{domxref("console", "ServiceWorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
-  - : Returns the {{domxref("console")}} associated with the worker.
-- {{domxref("WorkerGlobalScope.fonts", "ServiceWorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
-- {{domxref("indexedDB", "ServiceWorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
-  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
-- {{domxref("isSecureContext", "ServiceWorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
-  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
-- {{domxref("WorkerGlobalScope.location", "ServiceWorkerGlobalScope.location")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.navigator", "ServiceWorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("origin", "ServiceWorkerGlobalScope.origin")}} {{ReadOnlyInline}}
-  - : Returns the global object's origin, serialized as a string.
-- {{domxref("performance_property", "ServiceWorkerGlobalScope.performance")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
-- {{domxref("scheduler_property", "ServiceWorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
-- {{domxref("WorkerGlobalScope.self", "ServiceWorkerGlobalScope.self")}}
-  - : Returns an object reference to the `ServiceWorkerGlobalScope` object itself.
-
 ## Instance methods
 
 _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
 
 - {{domxref("ServiceWorkerGlobalScope.skipWaiting()")}}
   - : Allows the current service worker registration to progress from waiting to active state while service worker clients are using it.
-
-### Inherited from WorkerGlobalScope
-
-- {{domxref("atob", "ServiceWorkerGlobalScope.atob()")}}
-  - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "ServiceWorkerGlobalScope.btoa()")}}
-  - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("clearInterval", "ServiceWorkerGlobalScope.clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval")}}.
-- {{domxref("clearTimeout", "ServiceWorkerGlobalScope.clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
-- {{domxref("WorkerGlobalScope.dump", "ServiceWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
-  - : Writes a message to the console.
-- {{domxref("WorkerGlobalScope.importScripts", "ServiceWorkerGlobalScope.importScripts()")}}
-  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-- {{domxref("setInterval", "ServiceWorkerGlobalScope.setInterval()")}}
-  - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout()", "ServiceWorkerGlobalScope.setTimeout()")}}
-  - : Sets a delay for executing a function.
 
 ## Events
 

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -37,6 +37,8 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 
 ## Events
 
+Listen to this event using {{domxref("EventTarget/addEventListener()", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
 - {{domxref("ServiceWorkerGlobalScope/activate_event", "activate")}}
   - : Occurs when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active")}} worker.
 - {{domxref("ServiceWorkerGlobalScope/backgroundfetchabort_event", "backgroundfetchabort")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -18,56 +18,12 @@ _This interface inherits properties from the {{domxref("WorkerGlobalScope")}} in
 - {{domxref("SharedWorkerGlobalScope.name")}} {{ReadOnlyInline}}
   - : The name that the {{domxref("SharedWorker")}} was (optionally) given when it was created using the {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} constructor. This is mainly useful for debugging purposes.
 
-### Instance properties inherited from WorkerGlobalScope
-
-- {{domxref("caches", "SharedWorkerGlobalScope.caches")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("CacheStorage")}} object associated with the current context. This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
-- {{domxref("console", "SharedWorkerGlobalScope.console")}} {{ReadOnlyInline}} {{Non-standard_inline}}
-  - : Returns the {{domxref("console")}} associated with the worker.
-- {{domxref("WorkerGlobalScope.fonts", "SharedWorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
-- {{domxref("indexedDB", "SharedWorkerGlobalScope.indexedDB")}} {{ReadOnlyInline}}
-  - : Provides a mechanism for applications to asynchronously access capabilities of indexed databases; returns an {{domxref("IDBFactory")}} object.
-- {{domxref("isSecureContext", "SharedWorkerGlobalScope.isSecureContext")}} {{ReadOnlyInline}}
-  - : Returns a boolean indicating whether the current context is secure (`true`) or not (`false`).
-- {{domxref("WorkerGlobalScope.location", "SharedWorkerGlobalScope.location")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerLocation")}} associated with the worker. `WorkerLocation` is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
-- {{domxref("WorkerGlobalScope.navigator", "SharedWorkerGlobalScope.navigator")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("WorkerNavigator")}} associated with the worker. `WorkerNavigator` is a specific navigator object, mostly a subset of the {{domxref("Navigator")}} for browsing scopes, but adapted to workers.
-- {{domxref("origin", "SharedWorkerGlobalScope.origin")}} {{ReadOnlyInline}}
-  - : Returns the global object's origin, serialized as a string.
-- {{domxref("performance_property", "SharedWorkerGlobalScope.performance")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Performance")}} object associated with the worker, which is a regular performance object, but with a subset of its properties and methods available.
-- {{domxref("scheduler_property", "SharedWorkerGlobalScope.scheduler")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("Scheduler")}} object associated with the current context. This is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
-- {{domxref("WorkerGlobalScope.self", "SharedWorkerGlobalScope.self")}}
-  - : Returns an object reference to the `SharedWorkerGlobalScope` object itself.
-
 ## Instance methods
 
 _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} interface, and its parent {{domxref("EventTarget")}}._
 
 - {{domxref("SharedWorkerGlobalScope.close()")}}
   - : Discards any tasks queued in the `SharedWorkerGlobalScope`'s event loop, effectively closing this particular scope.
-
-### Inherited from WorkerGlobalScope
-
-- {{domxref("atob", "SharedWorkerGlobalScope.atob()")}}
-  - : Decodes a string of data which has been encoded using base-64 encoding.
-- {{domxref("btoa", "SharedWorkerGlobalScope.btoa()")}}
-  - : Creates a base-64 encoded ASCII string from a string of binary data.
-- {{domxref("clearInterval", "SharedWorkerGlobalScope.clearInterval()")}}
-  - : Cancels the repeated execution set using {{domxref("setInterval()")}}.
-- {{domxref("clearTimeout", "SharedWorkerGlobalScope.clearTimeout()")}}
-  - : Cancels the repeated execution set using {{domxref("setTimeout()")}}.
-- {{domxref("WorkerGlobalScope.dump", "SharedWorkerGlobalScope.dump()")}} {{deprecated_inline}} {{non-standard_inline}}
-  - : Writes a message to the console.
-- {{domxref("WorkerGlobalScope.importScripts", "SharedWorkerGlobalScope.importScripts()")}}
-  - : Imports one or more scripts into the worker's scope. You can specify as many as you'd like, separated by commas. For example: `importScripts('foo.js', 'bar.js');`
-- {{domxref("setInterval", "SharedWorkerGlobalScope.setInterval()")}}
-  - : Schedules the execution of a function every X milliseconds.
-- {{domxref("setTimeout()", "SharedWorkerGlobalScope.setTimeout()")}}
-  - : Sets a delay for executing a function.
 
 ## Events
 

--- a/files/en-us/web/api/sharedworkerglobalscope/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/index.md
@@ -27,9 +27,9 @@ _This interface inherits methods from the {{domxref("WorkerGlobalScope")}} inter
 
 ## Events
 
-Listen to this event using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) or by assigning an event listener to the `oneventname` property of this interface.
+Listen to this event using {{domxref("EventTarget.addEventListener()", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
-- [`connect`](/en-US/docs/Web/API/SharedWorkerGlobalScope/connect_event)
+- {{domxref("SharedWorkerGlobalScope/connect_event", "connect")}}
   - : Fired on shared workers when a new client connects.
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove properties and methods that inheirts from `WorkerGlobalScope` in `DedicatedWorkerGlobalScope` `ServiceWorkerGlobalScope` `SharedWorkerGlobalScope`

Some small style fix

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
