### PR TITLE
Add a note regarding not required nesting selector

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -124,6 +124,8 @@ p img {
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/nesting.html", '100%', 800)}}
 
+> **Note:** In the example above, the `&` nesting selector is not required but adding it explicitly helps to understand that CSS nesting is being used.
+
 ## Using combinators
 
 You can combine any of the selectors that we discovered in previous lessons with combinators in order to pick out part of your document. For example, to select list items with a class of "a" which are direct children of a `<ul>`, try the following:

--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -124,7 +124,7 @@ p img {
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/nesting.html", '100%', 800)}}
 
-> **Note:** In the example above, the `&` nesting selector is not required but adding it explicitly helps to understand that CSS nesting is being used.
+> **Note:** In the example above, the `&` nesting selector is not required, but adding it helps to explicitly show that CSS nesting is being used.
 
 ## Using combinators
 


### PR DESCRIPTION
This pull request fixes #29799 
It adds the **Note** paragraph regarding the example above, mentioning that `&` operator is not required however useful.
Note added as per the conclusion in the issue.