### PR TITLE
Drop stale `subgrid` and `masonry` warnings

### DIFF
--- a/files/en-us/web/css/grid-template-columns/index.md
+++ b/files/en-us/web/css/grid-template-columns/index.md
@@ -90,10 +90,6 @@ grid-template-columns: unset;
 - [`subgrid`](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.
 
-> **Warning:** The `masonry` value is from Level 3 of the Grid specification and currently only has an experimental implementation behind a flag in Firefox.
->
-> The `subgrid` value is from Level 2 of the Grid specification and currently only has implementation in Firefox 71 and onwards.
-
 ## Formal definition
 
 {{cssinfo}}

--- a/files/en-us/web/css/grid-template-rows/index.md
+++ b/files/en-us/web/css/grid-template-rows/index.md
@@ -91,10 +91,6 @@ This property may be specified as:
 - [`subgrid`](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.
 
-> **Warning:** The `masonry` value is from Level 3 of the Grid specification and currently only has an experimental implementation behind a flag in Firefox.
->
-> The `subgrid` value is from Level 2 of the Grid specification and currently only has implementation in Firefox 71 and onwards.
-
 ## Formal definition
 
 {{cssinfo}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Drop out-of-date text about which browsers have implemented grid's `subgrid` and `masonry` values.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

These notes are a cautionary tale against writing implementation status into body text, as none of this is correct now.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

- [`subgrid` support](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid#browser_compatibility)
- [`masonry` support](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout#browser_compatibility)