### PR TITLE
Update browser availability note on webkit-scrollbar page

### DIFF
--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -20,7 +20,8 @@ The `::-webkit-scrollbar` CSS pseudo-element affects the style of an element's s
 
 > **Note:** If `overflow:scroll;` is not set, no scrollbar is displayed.
 
-> **Note:** `::-webkit-scrollbar` is only available in [Blink](https://www.chromium.org/blink/)- and [WebKit](https://webkit.org)-based browsers (e.g., Chrome, Edge, Opera, Safari, all browsers on iOS, and [others](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). A standardized method of styling scrollbars is available with {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}}, but is currently not supported in all browsers.
+> **Note:** The `::-webkit-scrollbar` vendor-prefixed pseudo-element is not supported on all browsers (see [Browser compatibility](#browser_compatibility)).
+> The {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}} standard properties may be used as an alternative for browsers that do not support this pseudo-element.
 
 ## CSS Scrollbar Selectors
 

--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -20,7 +20,7 @@ The `::-webkit-scrollbar` CSS pseudo-element affects the style of an element's s
 
 > **Note:** If `overflow:scroll;` is not set, no scrollbar is displayed.
 
-> **Note:** `::-webkit-scrollbar` is only available in [Blink](https://www.chromium.org/blink/)- and [WebKit](https://webkit.org)-based browsers (e.g., Chrome, Edge, Opera, Safari, all browsers on iOS, and [others](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). A standardized method of styling scrollbars is available with {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}}, but is currently only supported in Firefox.
+> **Note:** `::-webkit-scrollbar` is only available in [Blink](https://www.chromium.org/blink/)- and [WebKit](https://webkit.org)-based browsers (e.g., Chrome, Edge, Opera, Safari, all browsers on iOS, and [others](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). A standardized method of styling scrollbars is available with {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}}, but is currently not supported in all browsers.
 
 ## CSS Scrollbar Selectors
 


### PR DESCRIPTION
As standard properties are available in Chromium soon the current note text was misleading.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

"scrollbar-color and scrollbar-width, but is currently only supported in Firefox." -> "scrollbar-color and scrollbar-width, but is currently not supported in all browsers."

### Motivation

Chromium will support these properties from 121.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
