### PR TITLE
Update `::-webkit-scrollbar` text regarding overflow: scroll

### DIFF
--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -16,9 +16,7 @@ browser-compat:
 
 {{CSSRef}}{{Non-standard_Header}}
 
-The `::-webkit-scrollbar` CSS pseudo-element affects the style of an element's scrollbar when it has `overflow:scroll;` set.
-
-> **Note:** If `overflow:scroll;` is not set, no scrollbar is displayed.
+The `::-webkit-scrollbar` CSS pseudo-element affects the style of an element's scrollbar when it has scrollable overflow.
 
 > **Note:** `::-webkit-scrollbar` is only available in [Blink](https://www.chromium.org/blink/)- and [WebKit](https://webkit.org)-based browsers (e.g., Chrome, Edge, Opera, Safari, all browsers on iOS, and [others](https://en.wikipedia.org/wiki/List_of_web_browsers#WebKit-based)). A standardized method of styling scrollbars is available with {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}}, but is currently only supported in Firefox.
 


### PR DESCRIPTION
### Description
Remove note saying `overflow:scroll` is required, and reword first sentence to say scrollable overflow rather than `overflow:scroll`.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The current text is misleading, overflow:scroll; is not required, as is demonstrated further down by using an auto value.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
