### PR TITLE
Fix redirected link from Web/Guide to Web/Media

### DIFF
--- a/files/en-us/web/media/autoplay_guide/index.md
+++ b/files/en-us/web/media/autoplay_guide/index.md
@@ -341,4 +341,4 @@ Browsers may have preferences that control the way autoplay works, or how autopl
 - [Web media technologies](/en-US/docs/Web/Media)
 - [Video and audio content](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content) (Learning guide)
 - [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
-- [Cross-browser audio basics](/en-US/docs/Web/Guide/Audio_and_video_delivery/Cross-browser_audio_basics)
+- [Cross-browser audio basics](/en-US/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics)


### PR DESCRIPTION
We moved this page earlier today and we missed this link. The flaw dashboard didn't.