### PR TITLE
Revert "Remove non-existent AudioWorkletProcessor.paramterDescriptors"

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7561,7 +7561,6 @@
 /en-US/docs/Web/API/AudioWorkletNode/AudioWorkletNode.parameters	/en-US/docs/Web/API/AudioWorkletNode/parameters
 /en-US/docs/Web/API/AudioWorkletNode/onprocessorerror	/en-US/docs/Web/API/AudioWorkletNode/processorerror_event
 /en-US/docs/Web/API/AudioWorkletNodeOptions	/en-US/docs/Web/API/AudioWorkletNode/AudioWorkletNode
-/en-US/docs/Web/API/AudioWorkletProcessor/parameterDescriptors	/en-US/docs/Web/API/AudioWorkletProcessor
 /en-US/docs/Web/API/BackgroundFetchRegistration/onprogress	/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event
 /en-US/docs/Web/API/BarcodeDetector/getSupportedFormats	/en-US/docs/Web/API/BarcodeDetector/getSupportedFormats_static
 /en-US/docs/Web/API/Barcode_Detector_API	/en-US/docs/Web/API/Barcode_Detection_API

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -20931,6 +20931,10 @@
     "modified": "2020-10-15T22:21:03.220Z",
     "contributors": ["1valdis"]
   },
+  "Web/API/AudioWorkletProcessor/parameterDescriptors": {
+    "modified": "2020-10-15T22:21:04.116Z",
+    "contributors": ["Sheppy", "chrisdavidmills", "1valdis"]
+  },
   "Web/API/AudioWorkletProcessor/port": {
     "modified": "2020-10-15T22:21:03.014Z",
     "contributors": ["chrisdavidmills", "1valdis"]

--- a/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.md
@@ -1,0 +1,55 @@
+---
+title: "AudioWorkletProcessor: parameterDescriptors property"
+short-title: parameterDescriptors
+slug: Web/API/AudioWorkletProcessor/parameterDescriptors
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.AudioWorkletProcessor.parameterDescriptors
+---
+
+{{APIRef("Web Audio API")}}{{SeeCompatTable}}
+
+The read-only **`parameterDescriptors`** property of an {{domxref("AudioWorkletProcessor")}}-derived class is a _static getter_,
+which returns an iterable of {{domxref("AudioParamDescriptor")}}-based objects.
+
+The property is not a part of the {{domxref("AudioWorkletProcessor")}}
+interface, but, if defined, it is called internally by the
+{{domxref("AudioWorkletProcessor")}} constructor to create a list of custom
+{{domxref("AudioParam")}} objects in the {{domxref("AudioWorkletNode.parameters",
+  "parameters")}} property of the associated {{domxref("AudioWorkletNode")}}.
+
+Defining the getter is optional.
+
+## Value
+
+An iterable of {{domxref("AudioParamDescriptor")}}-based objects. The properties of
+these objects are as follows:
+
+- `name`
+  - : The string which represents the name of the `AudioParam`. Under this name the `AudioParam` will be available in the {{domxref("AudioWorkletNode.parameters", "parameters")}} property of the node, and under this name the {{domxref("AudioWorkletProcessor.process")}} method will acquire the calculated values of this `AudioParam`.
+- `automationRate` {{optional_inline}}
+  - : Either [`"a-rate"`](/en-US/docs/Web/API/AudioParam#a-rate), or [`"k-rate"`](/en-US/docs/Web/API/AudioParam#k-rate) string which represents an automation rate of this `AudioParam`. Defaults to `"a-rate"`.
+- `minValue` {{optional_inline}}
+  - : A `float` which represents minimum value of the `AudioParam`. Defaults to `-3.4028235e38`.
+- `maxValue` {{optional_inline}}
+  - : A `float` which represents maximum value of the `AudioParam`. Defaults to `3.4028235e38`.
+- `defaultValue` {{optional_inline}}
+  - : A `float` which represents initial value of the `AudioParam`. Defaults to `0`.
+
+## Examples
+
+See [`AudioWorkletNode.parameters`](/en-US/docs/Web/API/AudioWorkletNode/parameters#examples) for example code showing how to add static `parameterDescriptors` getter to a custom `AudioWorkletProcessor`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
+- [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)

--- a/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/parameterdescriptors/index.md
@@ -5,7 +5,7 @@ slug: Web/API/AudioWorkletProcessor/parameterDescriptors
 page-type: web-api-instance-property
 status:
   - experimental
-browser-compat: api.AudioWorkletProcessor.parameterDescriptors
+spec-urls: https://webaudio.github.io/web-audio-api/#audioworkletprocess-callback-parameters
 ---
 
 {{APIRef("Web Audio API")}}{{SeeCompatTable}}
@@ -44,10 +44,6 @@ See [`AudioWorkletNode.parameters`](/en-US/docs/Web/API/AudioWorkletNode/paramet
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
Reverts mdn/content#30634

I misunderstood this for a member, when I deleted this.

In fact, it is a rare case of a callback. We should only remove the Compatibility section.