### PR TITLE
Fix link to pointlockchange event

### DIFF
--- a/files/en-us/web/api/document/pointerlockelement/index.md
+++ b/files/en-us/web/api/document/pointerlockelement/index.md
@@ -24,7 +24,7 @@ An {{domxref("Element")}} or `null`.
 
 This example contains a {{htmlelement("div")}} element that in turn contains a {{htmlelement("button")}}. Clicking the button requests pointer lock for the `<div>`.
 
-The example also listens for the {{domxref("Element/pointerlockchange_event", "pointerlockchange")}} event: when this event is fired, the event handler disables the "Lock" button if an element in the document has the pointer lock, and enables the button otherwise.
+The example also listens for the {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} event: when this event is fired, the event handler disables the "Lock" button if an element in the document has the pointer lock, and enables the button otherwise.
 
 The effect of this is that if you click the "Lock" button, the pointer is locked and the button is disabled: if you then exit pointer lock (for example, by pressing the <kbd>Escape</kbd> key), the button is enabled again.
 


### PR DESCRIPTION
The `pointerlockchange` event is not sent to the `Element` but to the `Document` (where it is rightfully documented, btw)

This fixes the link.

The spec:
![Capture d’écran 2023-12-05 à 11 43 17](https://github.com/mdn/content/assets/1466293/eb85c586-dffa-494c-9deb-d9d39d2b2992)
