### PR TITLE
Remove unused reference to indexOfPort in Web MIDI API documentation code example

### DIFF
--- a/files/en-us/web/api/web_midi_api/index.md
+++ b/files/en-us/web/api/web_midi_api/index.md
@@ -106,7 +106,7 @@ function listInputsAndOutputs(midiAccess) {
 
 ### Handling MIDI Input
 
-This example prints incoming MIDI messages on a single port to the console.
+This example prints all MIDI input messages to the console.
 
 ```js
 function onMIDIMessage(event) {
@@ -117,7 +117,7 @@ function onMIDIMessage(event) {
   console.log(str);
 }
 
-function startLoggingMIDIInput(midiAccess, indexOfPort) {
+function startLoggingMIDIInput(midiAccess) {
   midiAccess.inputs.forEach((entry) => {
     entry.onmidimessage = onMIDIMessage;
   });


### PR DESCRIPTION
### Description

Removes a reference to an unused parameter in a Web MIDI API example.

### Motivation

To resolve an issue raised by a community member.

### Related issues and pull requests

Resolves https://github.com/mdn/content/issues/30653.
