### PR TITLE
Update submit_event page

### DIFF
--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLFormElement.submit_event
 
 The **`submit`** event fires when a {{HtmlElement("form")}} is submitted.
 
-Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or {{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}} inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
+Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}` inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
 
 The `submit` event fires when:
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -12,13 +12,13 @@ The **`submit`** event fires when a {{HtmlElement("form")}} is submitted.
 
 Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or {{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}} inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
 
-The `submit` event fires when
+The `submit` event fires when:
 
-- the user clicks a {{Glossary("submit button")}}
-- presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form
-- calling the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method
+- the user clicks a {{Glossary("submit button")}},
+- the user presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form,
+- a script calls the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method
 
-However the event is NOT sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
+However, the event is _not_ sent to the form when a script calls the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
 
 > **Note:** Trying to submit a form that does not pass [validation](/en-US/docs/Learn/Forms/Form_validation) triggers an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event. In this case, the validation prevents form submission, and thus there is no `submit` event.
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -12,7 +12,13 @@ The **`submit`** event fires when a {{HtmlElement("form")}} is submitted.
 
 Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or {{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}} inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
 
-The `submit` event fires when the user clicks a {{Glossary("submit button")}} or presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form. The event is not sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
+The `submit` event fires when
+
+- the user clicks a {{Glossary("submit button")}}
+- presses <kbd>Enter</kbd> while editing a field (e.g. {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form
+- calling the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method
+
+However the event is NOT sent to the form when calling the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
 
 > **Note:** Trying to submit a form that does not pass [validation](/en-US/docs/Learn/Forms/Form_validation) triggers an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event. In this case, the validation prevents form submission, and thus there is no `submit` event.
 


### PR DESCRIPTION
### Description

The doc forgot to mention `requestSubmit()` method so I decide to add it in for reading convenience.

### Motivation

(see above)

### Additional details

- https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit#usage_notes

### Related issues and pull requests

None, I found this problem while reading MDN.
