### PR TITLE
Firefox 96 never made Same-Site Lax the default

### DIFF
--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -32,8 +32,7 @@ No notable changes.
 
 ### HTTP
 
-- Cookies sent from the same domain but using different schemes (for example http or https) are now considered to be from different sites with respect to the cookie [SameSite](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) directive.
-  In addition, cookies are assumed to implicitly set `SameSite=Lax` if the `SameSite` attribute is not specified (previously the default was `SameSite=None`), and cookies with `SameSite=None` require a secure context. ([Firefox bug 1617609](https://bugzil.la/1617609)).
+No notable changes.
 
 ### APIs
 


### PR DESCRIPTION
This PR updates the release notes for Firefox 96, removing the inaccurate statement about `Same-Site: Lax` being the default.  See https://github.com/mdn/browser-compat-data/pull/21487#issuecomment-1841515374 for more details.