### PR TITLE
Link all BCD entries for private class properties

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_properties/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_properties/index.md
@@ -2,7 +2,10 @@
 title: Private properties
 slug: Web/JavaScript/Reference/Classes/Private_properties
 page-type: javascript-language-feature
-browser-compat: javascript.classes.private_class_fields
+browser-compat:
+  - javascript.classes.private_class_fields
+  - javascript.classes.private_class_fields_in
+  - javascript.classes.private_class_methods
 ---
 
 {{jsSidebar("Classes")}}


### PR DESCRIPTION
This PR adds the `private_class_fields_in` and `private_class_methods` BCD entries to the private properties page for JavaScript classes.