### PR TITLE
Remove mention of Navigator.securityPolicy

### DIFF
--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -98,8 +98,6 @@ _Doesn't inherit any properties._
   - : Returns the build identifier of the browser. In modern browsers this property now returns a fixed timestamp as a privacy measure, e.g. `20181001000000` in Firefox 64 onwards.
 - {{domxref("Navigator.globalPrivacyControl")}} {{ReadOnlyInline}} {{Experimental_Inline}} {{non-standard_inline}}
   - : Returns a boolean indicating a user's consent to their information being shared or sold.
-- {{domxref("Navigator.securitypolicy")}} {{Non-standard_Inline}}
-  - : Returns an empty string. In Netscape 4.7x, returns "US & CA domestic policy" or "Export policy".
 - {{domxref("Navigator.standalone")}} {{Non-standard_Inline}}
   - : Returns a boolean indicating whether the browser is running in standalone mode. Available on Apple's iOS Safari only.
 


### PR DESCRIPTION
`Navigator.securityPolicy` was used by Netscape in the 90s when the US governement was restricting exportation of crypto.

The restriction is long gone, and this non-standard property was removed in 2011 (Firefox 6): https://bugzilla.mozilla.org/show_bug.cgi?id=605098

No mention in BCD either.


Its memory will be lost in time, like tears in the rain; time to go.