### PR TITLE
Remove link to dictionary in See also

### DIFF
--- a/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/constraints/index.md
@@ -582,7 +582,6 @@ Here you can see the complete example in action.
 ## See also
 
 - [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API)
-- {{domxref("MediaTrackCapabilities")}}
 - {{domxref("MediaTrackConstraints")}}
 - {{domxref("MediaTrackSettings")}}
 - {{domxref("MediaDevices.getSupportedConstraints()")}}


### PR DESCRIPTION
`MediaTrackCapabilities` is a dictionary; it won't have a specific page. Removing from the _See also_ section.