### PR TITLE
Neutralize link to inexistant dictionary property

### DIFF
--- a/files/en-us/web/api/intersectionobserver/thresholds/index.md
+++ b/files/en-us/web/api/intersectionobserver/thresholds/index.md
@@ -32,7 +32,7 @@ If no `threshold` option was included when
 
 > **Note:** Although the `options` object you can specify when creating an
 > {{domxref("IntersectionObserver")}} has a field named
-> {{domxref("IntersectionObserver.threshold", "threshold")}}, this property is called
+> `threshold`, this property is called
 > `thresholds`. Confusing? Yes. If you accidentally use
 > `thresholds` as the name of the field in your `options`, the
 > `thresholds` array will wind up being `[0.0]`, which is likely


### PR DESCRIPTION
We don't document dictionary properties in their own page, so this link will never work. The links around it are sufficient.