### PR TITLE
Remove mention of PhotoSettings

### DIFF
--- a/files/en-us/web/api/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/index.md
@@ -30,7 +30,7 @@ The `ImageCapture` interface is based on {{domxref("EventTarget")}}, so it inclu
 - {{domxref("ImageCapture.getPhotoCapabilities()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a `PhotoCapabilities` object containing the ranges of available configuration options.
 - {{domxref("ImageCapture.getPhotoSettings()")}} {{Experimental_Inline}}
-  - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("PhotoSettings")}} object containing the current photo configuration settings.
+  - : Returns a {{jsxref("Promise")}} that resolves with an object containing the current photo configuration settings.
 - {{domxref("ImageCapture.grabFrame()")}} {{Experimental_Inline}}
   - : Takes a snapshot of the live video in a {{domxref("MediaStreamTrack")}}, returning an {{domxref("ImageBitmap")}}, if successful.
 


### PR DESCRIPTION
The dictionary name is not visible to Web developers, no need to mention is, neither for a broken link to it.