### PR TITLE
Preserve history by replacing dead links from FX4 release notes with Archive.org links

### DIFF
--- a/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
@@ -69,7 +69,7 @@ if (firstrun) {
 
 ## How to use one overlay per Firefox version
 
-Adding support for the add-on bar while staying compatible with Firefox 3.6 and older will require using two overlays. The [chrome.manifest](/en-US/docs/Chrome_Registration) file can specify which file is used by which Firefox version by using [manifest flags](/en-US/docs/Chrome_Registration#manifest_flags):
+Adding support for the add-on bar while staying compatible with Firefox 3.6 and older will require using two overlays. The [chrome.manifest](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration) file can specify which file is used by which Firefox version by using [manifest flags](https://web.archive.org/web/20191029205045/https://developer.mozilla.org/en-US/docs/Mozilla/Chrome_Registration#Manifest_Flags):
 
 ```plain
 overlay chrome://browser/content/browser.xul chrome://myaddon/content/myaddon/overlayold.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion<4.0
@@ -80,7 +80,7 @@ Note: the appversion has to be at least 2 digits long or it won't work with vers
 
 ### Adding a button by default
 
-See: [Adding a button by default](/en-US/docs/Code_snippets/Toolbar#adding_button_by_default)
+See: [Adding a button by default](https://web.archive.org/web/20191010115941/https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/Toolbar#Adding_button_by_default)
 
 ## Appearance differences
 


### PR DESCRIPTION
Follow-up from "flaws" found by our bot in https://github.com/mdn/content/pull/30853. It's neat to preserve history.