### PR TITLE
Fix examples for backgroud-position-[x/y]

### DIFF
--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -31,7 +31,7 @@ background-position-x: 0px;
 background-position-x: 1cm;
 background-position-x: 8em;
 
-/* Side-relative values or two-value syntax*/
+/* Side-relative values */
 background-position-x: right 3px;
 background-position-x: left 25%;
 

--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -31,7 +31,7 @@ background-position-x: 0px;
 background-position-x: 1cm;
 background-position-x: 8em;
 
-/* Side-relative values */
+/* Side-relative values or two-value syntax*/
 background-position-x: right 3px;
 background-position-x: left 25%;
 
@@ -139,6 +139,4 @@ div {
 
 - {{cssxref("background-position")}}
 - {{cssxref("background-position-y")}}
-- {{cssxref("background-position-inline")}}
-- {{cssxref("background-position-block")}}
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Using_multiple_backgrounds)

--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -99,9 +99,9 @@ div {
 
 {{EmbedLiveSample('Basic_example', '100%', 300)}}
 
-### Two-value syntax
+### Side-relative values
 
-The following example shows support for the multiple value syntax, which allows the developer to offset the background from any edge.
+The following example shows support for the side-relative value syntax, which allows the developer to offset the background from any edge.
 
 #### HTML
 

--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -91,13 +91,41 @@ div {
   background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
   background-repeat: no-repeat;
   background-position-x: center;
-  background-position-y: bottom 10px;
+  background-position-y: bottom;
 }
 ```
 
 #### Result
 
 {{EmbedLiveSample('Basic_example', '100%', 300)}}
+
+### Two-value syntax
+
+The following example shows support for the multiple value syntax, which allows the developer to offset the background from any edge.
+
+#### HTML
+
+```html
+<div></div>
+```
+
+#### CSS
+
+```css
+div {
+  width: 300px;
+  height: 300px;
+  background-color: seagreen;
+  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-repeat: no-repeat;
+  background-position-x: right 20px;
+  background-position-y: bottom 10px;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Two-value_syntax', '100%', 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/background-position-x/index.md
+++ b/files/en-us/web/css/background-position-x/index.md
@@ -101,7 +101,7 @@ div {
 
 ### Side-relative values
 
-The following example shows support for the side-relative value syntax, which allows the developer to offset the background from any edge.
+The following example shows support for side-relative offset syntax, which allows the developer to offset the background from any edge.
 
 #### HTML
 
@@ -125,7 +125,7 @@ div {
 
 #### Result
 
-{{EmbedLiveSample('Two-value_syntax', '100%', 300)}}
+{{EmbedLiveSample('Side-relative_values', '100%', 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -31,7 +31,7 @@ background-position-y: 0px;
 background-position-y: 1cm;
 background-position-y: 8em;
 
-/* Side-relative values or two-value syntax*/
+/* Side-relative values */
 background-position-y: bottom 3px;
 background-position-y: bottom 10%;
 

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -31,7 +31,7 @@ background-position-y: 0px;
 background-position-y: 1cm;
 background-position-y: 8em;
 
-/* Side-relative values */
+/* Side-relative values or two-value syntax*/
 background-position-y: bottom 3px;
 background-position-y: bottom 10%;
 
@@ -139,6 +139,4 @@ div {
 
 - {{cssxref("background-position")}}
 - {{cssxref("background-position-x")}}
-- {{cssxref("background-position-inline")}}
-- {{cssxref("background-position-block")}}
 - [Using multiple backgrounds](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Using_multiple_backgrounds)

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -91,13 +91,41 @@ div {
   background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
   background-repeat: no-repeat;
   background-position-x: center;
-  background-position-y: bottom 10px;
+  background-position-y: bottom;
 }
 ```
 
 #### Result
 
 {{EmbedLiveSample('Basic_example', '100%', 300)}}
+
+### Two-value syntax
+
+The following example shows support for the multiple value syntax, which allows the developer to offset the background from any edge.
+
+#### HTML
+
+```html
+<div></div>
+```
+
+#### CSS
+
+```css
+div {
+  width: 300px;
+  height: 300px;
+  background-color: seagreen;
+  background-image: url(https://mdn.dev/archives/media/attachments/2020/07/29/17350/3b4892b7e820122ac6dd7678891d4507/firefox.png);
+  background-repeat: no-repeat;
+  background-position-x: right 20px;
+  background-position-y: bottom 10px;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Two-value_syntax', '100%', 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/background-position-y/index.md
+++ b/files/en-us/web/css/background-position-y/index.md
@@ -99,9 +99,9 @@ div {
 
 {{EmbedLiveSample('Basic_example', '100%', 300)}}
 
-### Two-value syntax
+### Side-relative values
 
-The following example shows support for the multiple value syntax, which allows the developer to offset the background from any edge.
+The following example shows support for side-relative offset syntax, which allows the developer to offset the background from any edge.
 
 #### HTML
 
@@ -125,7 +125,7 @@ div {
 
 #### Result
 
-{{EmbedLiveSample('Two-value_syntax', '100%', 300)}}
+{{EmbedLiveSample('Side-relative_values', '100%', 300)}}
 
 ## Specifications
 


### PR DESCRIPTION
This PR fixes the examples for the `background-position-x` and `background-position-y` CSS properties.  The examples use two-value syntax for `background-position-y`, which is currently unsupported in Chrome.  This fixes the issue by adding a second example for the two-value syntax, instead of integrating it into the basic example.
