### PR TITLE
Improve example for SVGGeometryElement.isPointIn[Fill/Stroke]()

### DIFF
--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -71,8 +71,8 @@ for (const point of points) {
     const pointObj = new DOMPoint(point[0], point[1]);
     isPointInFill = circle.isPointInFill(pointObj);
   } catch (e) {
-    // Fallback for browsers that don't support .isPointInFill(DOMPoint)
-    const pointObj = svg.createSVGPoint(point[0], point[1]);
+    // Fallback for browsers that don't support DOMPoint as an argument
+    const pointObj = svg.createSVGPoint();
     pointObj.x = point[0];
     pointObj.y = point[1];
     isPointInFill = circle.isPointInFill(pointObj);

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -48,37 +48,44 @@ A boolean indicating whether the given point is within the fill or not.
     fill="white"
     stroke="black"
     stroke-width="10" />
-
-  <circle cx="10" cy="10" r="5" fill="seagreen" />
-  <circle cx="40" cy="30" r="5" fill="seagreen" />
 </svg>
 ```
 
 ### JavaScript
 
 ```js
+const svg = document.getElementsByTagName("svg")[0];
 const circle = document.getElementById("circle");
+const points = [
+  ["10", "10"],
+  ["40", "30"],
+  ["70", "40"],
+  ["15", "75"],
+  ["83", "83"]
+];
 
-try {
-  // Point is outside
-  console.log("Point at 10,10:", circle.isPointInFill(new DOMPoint(10, 10)));
+for (const point of points) {
+  let isPointInFill;
+  
+  try {
+    const pointObj = new DOMPoint(point[0], point[1]);
+    isPointInFill = circle.isPointInFill(pointObj);
+  } catch(e) {
+    // Fallback for browsers that don't support .isPointInFill(DOMPoint)
+    const pointObj = svg.createSVGPoint(point[0], point[1]);
+    pointObj.x = point[0];
+    pointObj.y = point[1];
+    isPointInFill = circle.isPointInFill(pointObj);
+  }
 
-  // Point is inside
-  console.log("Point at 40,30:", circle.isPointInFill(new DOMPoint(40, 30)));
-} catch (e) {
-  // for the browsers that still support the deprecated interface SVGPoint
-  const svg = document.getElementsByTagName("svg")[0];
-  const point = svg.createSVGPoint();
+  console.log(`Point at ${point[0]},${point[1]}: ${isPointInFill}`);
 
-  // Point is outside
-  point.x = 10;
-  point.y = 10;
-  console.log("Point at 10,10: ", circle.isPointInFill(point));
-
-  // Point is inside
-  point.x = 40;
-  point.y = 30;
-  console.log("Point at 40,30: ", circle.isPointInFill(point));
+  const pointEl = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+  pointEl.style.cx = point[0];
+  pointEl.style.cy = point[1];
+  pointEl.style.r = 5;
+   pointEl.style.fill = isPointInFill ? "seagreen" : "rgb(255, 0, 0, 0.5)";
+  svg.appendChild(pointEl);
 }
 ```
 

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -87,7 +87,7 @@ for (const point of points) {
   pointEl.style.cx = point[0];
   pointEl.style.cy = point[1];
   pointEl.style.r = 5;
-  pointEl.style.fill = isPointInFill ? "seagreen" : "rgb(255, 0, 0, 0.5)";
+  pointEl.style.fill = isPointInFill ? "seagreen" : "rgb(255 0 0 / 0.5)";
   svg.appendChild(pointEl);
 }
 ```

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -61,16 +61,16 @@ const points = [
   ["40", "30"],
   ["70", "40"],
   ["15", "75"],
-  ["83", "83"]
+  ["83", "83"],
 ];
 
 for (const point of points) {
   let isPointInFill;
-  
+
   try {
     const pointObj = new DOMPoint(point[0], point[1]);
     isPointInFill = circle.isPointInFill(pointObj);
-  } catch(e) {
+  } catch (e) {
     // Fallback for browsers that don't support .isPointInFill(DOMPoint)
     const pointObj = svg.createSVGPoint(point[0], point[1]);
     pointObj.x = point[0];
@@ -80,11 +80,14 @@ for (const point of points) {
 
   console.log(`Point at ${point[0]},${point[1]}: ${isPointInFill}`);
 
-  const pointEl = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+  const pointEl = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "circle",
+  );
   pointEl.style.cx = point[0];
   pointEl.style.cy = point[1];
   pointEl.style.r = 5;
-   pointEl.style.fill = isPointInFill ? "seagreen" : "rgb(255, 0, 0, 0.5)";
+  pointEl.style.fill = isPointInFill ? "seagreen" : "rgb(255, 0, 0, 0.5)";
   svg.appendChild(pointEl);
 }
 ```

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -49,46 +49,47 @@ A boolean indicating whether the given point is within the stroke or not.
     fill="white"
     stroke="black"
     stroke-width="10" />
-
-  <circle cx="10" cy="10" r="5" fill="seagreen" />
-  <circle cx="40" cy="30" r="5" fill="seagreen" />
-  <circle cx="83" cy="17" r="5" fill="seagreen" />
 </svg>
 ```
 
 ### JavaScript
 
 ```js
+const svg = document.getElementsByTagName("svg")[0];
 const circle = document.getElementById("circle");
+const points = [
+  ["10", "10"],
+  ["40", "30"],
+  ["70", "40"],
+  ["15", "75"],
+  ["83", "83"],
+];
 
-try {
-  // Point not in circle
-  console.log("Point at 10,10:", circle.isPointInStroke(new DOMPoint(10, 10)));
+for (const point of points) {
+  let isPointInStroke;
 
-  // Point in circle but not stroke
-  console.log("Point at 40,30:", circle.isPointInStroke(new DOMPoint(40, 30)));
+  try {
+    const pointObj = new DOMPoint(point[0], point[1]);
+    isPointInFill = circle.isPointInStroke(pointObj);
+  } catch (e) {
+    // Fallback for browsers that don't support .isPointInStroke(DOMPoint)
+    const pointObj = svg.createSVGPoint(point[0], point[1]);
+    pointObj.x = point[0];
+    pointObj.y = point[1];
+    isPointInStroke = circle.isPointInStroke(pointObj);
+  }
 
-  // Point in circle stroke
-  console.log("Point at 83,17:", circle.isPointInStroke(new DOMPoint(83, 17)));
-} catch (e) {
-  // for the browsers that still support the deprecated interface SVGPoint
-  const svg = document.getElementsByTagName("svg")[0];
-  const point = svg.createSVGPoint();
+  console.log(`Point at ${point[0]},${point[1]}: ${isPointInStroke}`);
 
-  // Point not in circle
-  point.x = 10;
-  point.y = 10;
-  console.log("Point at 10,10:", circle.isPointInStroke(point));
-
-  // Point in circle but not stroke
-  point.x = 40;
-  point.y = 30;
-  console.log("Point at 40,30:", circle.isPointInStroke(point));
-
-  // Point in circle stroke
-  point.x = 83;
-  point.y = 17;
-  console.log("Point at 83,17:", circle.isPointInStroke(point));
+  const pointEl = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "circle",
+  );
+  pointEl.style.cx = point[0];
+  pointEl.style.cy = point[1];
+  pointEl.style.r = 5;
+  pointEl.style.fill = isPointInStroke ? "seagreen" : "rgb(255, 0, 0, 0.5)";
+  svg.appendChild(pointEl);
 }
 ```
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -88,7 +88,7 @@ for (const point of points) {
   pointEl.style.cx = point[0];
   pointEl.style.cy = point[1];
   pointEl.style.r = 5;
-  pointEl.style.fill = isPointInStroke ? "seagreen" : "rgb(255, 0, 0, 0.5)";
+  pointEl.style.fill = isPointInStroke ? "seagreen" : "rgb(255 0 0 / 0.5)";
   svg.appendChild(pointEl);
 }
 ```

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -72,8 +72,8 @@ for (const point of points) {
     const pointObj = new DOMPoint(point[0], point[1]);
     isPointInFill = circle.isPointInStroke(pointObj);
   } catch (e) {
-    // Fallback for browsers that don't support .isPointInStroke(DOMPoint)
-    const pointObj = svg.createSVGPoint(point[0], point[1]);
+    // Fallback for browsers that don't support DOMPoint as an argument
+    const pointObj = svg.createSVGPoint();
     pointObj.x = point[0];
     pointObj.y = point[1];
     isPointInStroke = circle.isPointInStroke(pointObj);


### PR DESCRIPTION
This PR improves the example for the `isPointInFill()` and `isPointInStroke()` methods of the `SVGGeometryElement` API.  This performs three upgrades:

- Instead of defining the points three times, uses an array of points which can be adjusted as desired
- Sets the fill of the points based on if they're in the fill/stroke or not
  - Green and red are used, but red is set to half opacity for colorblind accessibility