### PR TITLE
FF121 Relnote: Promise.withResolvers()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -29,6 +29,8 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### JavaScript
 
+- The {{jsxref("Promise.withResolvers()")}} static method is now supported. This exposes the `resolve` and `reject` callback functions in the same scope as the returned {{jsxref("Promise")}}, allowing the the code that resolves or rejects the promise to be define its construction ([Firefox bug 1845586](https://bugzil.la/1845586))
+
 - {{jsxref("Date.parse()")}} now accepts several additional date formats:
 
   - Year > 9999 for `YYYY-MMM-DD` format (e.g. `19999-Jan-01`) ([Firefox bug 1858851](https://bugzil.la/1858851))

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -29,7 +29,7 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### JavaScript
 
-- The {{jsxref("Promise.withResolvers()")}} static method is now supported. This exposes the `resolve` and `reject` callback functions in the same scope as the returned {{jsxref("Promise")}}, allowing code that resolves or rejects the promise to be defined after its construction ([Firefox bug 1845586](https://bugzil.la/1845586))
+- The {{jsxref("Promise.withResolvers()")}} static method is now supported. This exposes the `resolve` and `reject` callback functions in the same scope as the returned {{jsxref("Promise")}}, allowing code that resolves or rejects the promise to be defined after its construction ([Firefox bug 1845586](https://bugzil.la/1845586)).
 
 - {{jsxref("Date.parse()")}} now accepts several additional date formats:
 

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -29,7 +29,7 @@ This article provides information about the changes in Firefox 121 that affect d
 
 ### JavaScript
 
-- The {{jsxref("Promise.withResolvers()")}} static method is now supported. This exposes the `resolve` and `reject` callback functions in the same scope as the returned {{jsxref("Promise")}}, allowing the the code that resolves or rejects the promise to be define its construction ([Firefox bug 1845586](https://bugzil.la/1845586))
+- The {{jsxref("Promise.withResolvers()")}} static method is now supported. This exposes the `resolve` and `reject` callback functions in the same scope as the returned {{jsxref("Promise")}}, allowing code that resolves or rejects the promise to be defined after its construction ([Firefox bug 1845586](https://bugzil.la/1845586))
 
 - {{jsxref("Date.parse()")}} now accepts several additional date formats:
 


### PR DESCRIPTION
FF121 supports [`Promise/withResolvers()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers) in https://bugzilla.mozilla.org/show_bug.cgi?id=1845586.
This adds the release note.

Other docs work tracked in #30334