### PR TITLE
Permission API: speaker-selection not supported

### DIFF
--- a/files/en-us/web/api/audio_output_devices_api/index.md
+++ b/files/en-us/web/api/audio_output_devices_api/index.md
@@ -68,7 +68,8 @@ Access to the API is subject to the following constraints:
     - This can come from selection in the prompt launched by `MediaDevices.selectAudioOutput()`
     - User permission to set the output device is also implicitly granted if the user has already granted permission to use a media input device in the same group with [`MediaDevices.getUserMedia()`](/en-US/docs/Web/API/MediaDevices/getUserMedia).
 
-The permission status can be queried using the [Permissions API](/en-US/docs/Web/API/Permissions_API) method [`navigator.permissions.query()`](/en-US/docs/Web/API/Permissions/query), passing a permission descriptor with the `speaker-selection` permission.
+<!-- The line below is "true" but this is not implemented in any browser -->
+<!-- The permission status can be queried using the [Permissions API](/en-US/docs/Web/API/Permissions_API) method [`navigator.permissions.query()`](/en-US/docs/Web/API/Permissions/query), passing a permission descriptor with the `speaker-selection` permission. -->
 
 ## Examples
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -43,7 +43,6 @@ A non-exhaustive list of permission-aware APIs includes:
 - [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs): `accelerometer`, `gyroscope`, `magnetometer`, `ambient-light-sensor`
 - [Storage Access API](/en-US/docs/Web/API/Storage_Access_API): `storage-access`
 - [Storage API](/en-US/docs/Web/API/Storage_API): `persistent-storage`
-- [Audio Output Devices API](/en-US/docs/Web/API/Audio_Output_Devices_API): `speaker-selection`
 - [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API): `midi`
 - [Window Management API](/en-US/docs/Web/API/Window_Management_API): `window-management`
 


### PR DESCRIPTION
The `speaker-selection` permission of the Permission API is not supported in any browser - it was incorrectly indicated as being supported in FF, but this has been removed in https://github.com/mdn/browser-compat-data/issues/17033

Given that, it is better not to mention it. This removes/comments the two mentions in the APIs where it might (eventually) be supported.