### PR TITLE
Clarify TextDecoder(Stream).ignoreBOM

### DIFF
--- a/files/en-us/web/api/textdecoder/ignorebom/index.md
+++ b/files/en-us/web/api/textdecoder/ignorebom/index.md
@@ -8,11 +8,11 @@ browser-compat: api.TextDecoder.ignoreBOM
 
 {{APIRef("Encoding API")}}
 
-The **`ignoreBOM`** read-only property of the {{domxref("TextDecoder")}} interface is a {{jsxref('Boolean')}} indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) is ignored.
+The **`ignoreBOM`** read-only property of the {{domxref("TextDecoder")}} interface is a {{jsxref('Boolean')}} indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) will be included in the output or skipped over.
 
 ## Value
 
-`true` if the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) is ignored; `false` otherwise.
+`true` if the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) will be included in the decoded text; `false` if it will be skipped over when decoding and omitted.
 
 ## Specifications
 

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -25,16 +25,16 @@ new TextDecoder(label, options)
     This may be [any valid label](/en-US/docs/Web/API/Encoding_API/Encodings).
 - `options` {{optional_inline}}
 
-  - : An object with the property:
+  - : An object with the following properties:
 
-    - `fatal`
+    - `fatal` {{optional_inline}}
 
       - : A boolean value indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a {{jsxref("TypeError")}} when decoding invalid data.
         It defaults to `false`, which means that the decoder will substitute malformed data with a replacement character.
 
-    - `ignoreBOM`
-      - : A boolean value indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) is ignored.
-        It defaults to `false`.
+    - `ignoreBOM` {{optional_inline}}
+      - : A boolean value indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) will be included in the output or skipped over.
+        It defaults to `false`, which means that the byte order mark will be skipped over when decoding and will not be included in the decoded text.
 
 ### Exceptions
 

--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.md
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.md
@@ -8,11 +8,11 @@ browser-compat: api.TextDecoderStream.ignoreBOM
 
 {{APIRef("Encoding API")}}
 
-The **`ignoreBOM`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{jsxref("boolean")}} indicating if the byte order mark (BOM) is to be ignored.
+The **`ignoreBOM`** read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref('Boolean')}} indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) will be included in the output or skipped over.
 
 ## Value
 
-A {{jsxref("boolean")}}, initially `false`.
+`true` if the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) will be included in the decoded text; `false` if it will be skipped over when decoding and omitted.
 
 ## Examples
 

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
@@ -24,11 +24,16 @@ new TextDecoderStream(label, options)
     This may be [any valid label](/en-US/docs/Web/API/Encoding_API/Encodings).
 - `options` {{optional_inline}}
 
-  - : An object with the property:
+  - : An object with the following properties:
 
-    - `fatal`
-      - : A boolean value indicating if this object must throw a {{jsxref("TypeError")}} when decoding invalid data.
+    - `fatal` {{optional_inline}}
+
+      - : A boolean value indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a {{jsxref("TypeError")}} when decoding invalid data.
         It defaults to `false`, which means that the decoder will substitute malformed data with a replacement character.
+
+    - `ignoreBOM` {{optional_inline}}
+      - : A boolean value indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) will be included in the output or skipped over.
+        It defaults to `false`, which means that the byte order mark will be skipped over when decoding and will not be included in the decoded text.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR clarifies what the `ignoreBOM` property does and how it actually functions. It also adds it to the `TextDecoderStream` constructor options, where it was previously missing but [does function](https://encoding.spec.whatwg.org/#dom-textdecoderstream).

### Motivation

The original documentation misled me into thinking that setting ignoreBOM to true would cause the BOM to be *omitted* from the decoded text, when it works the exact opposite way.
