### PR TITLE
fix `Value` section of `Web/API/Navigator/languages`

### DIFF
--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -26,15 +26,15 @@ the extra `qvalues` (quality values) field (e.g. `en-US;q=0.8`).
 
 ## Value
 
-A string.
+An array of strings.
 
 ## Examples
 
 ### Listing the contents of navigator.language and navigator.languages
 
 ```js
-navigator.language; //"en-US"
-navigator.languages; //["en-US", "zh-CN", "ja-JP"]
+navigator.language; // "en-US"
+navigator.languages; // ["en-US", "zh-CN", "ja-JP"]
 ```
 
 ### Using Intl constructors to do language-specific formatting, with fallback


### PR DESCRIPTION
### Description

This PR fixes `Value` section of `Web/API/Navigator/languages` (sets `An array of strings` instead of `String`).
