### PR TITLE
Refactored the Web/API/MutationObserver/observe "Basic usage" example

### DIFF
--- a/files/en-us/web/api/mutationobserver/observe/index.md
+++ b/files/en-us/web/api/mutationobserver/observe/index.md
@@ -106,18 +106,17 @@ In this example, we demonstrate how to call the method **`observe()`** on an ins
 and an `options` object.
 
 ```js
-// identify an element to observe
-const elementToObserve = document.querySelector("#targetElementId");
-
 // create a new instance of `MutationObserver` named `observer`,
 // passing it a callback function
 const observer = new MutationObserver(() => {
   console.log("callback that runs when observer is triggered");
 });
 
-// call `observe()` on that MutationObserver instance,
-// passing it the element to observe, and the options object
-observer.observe(elementToObserve, { subtree: true, childList: true });
+// call `observe()`, passing it the element to observe, and the options object
+observer.observe(document.querySelector("#element-to-observe"), {
+  subtree: true,
+  childList: true,
+});
 ```
 
 ### Using `attributeFilter`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- I renamed the `querySelector` argument from "#targetElementId" to "#element-to-observe" to follow the style of other CSS selectors and give it a semantically relevant name.
- I inlined the `elementToObserve` variable because it was defined at the top but only used at the bottom. This required the reader to keep it in mind throughout the example, even when it wasn't used.
- This made the last line a little longer, so I formatted it.  Unfortunately, I'm having issues with my local pre-commit script so I'm not sure if this formatting is consistent with the rest of the project. Please let me know how to fix if it's incorrect.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
