### PR TITLE
Fix the interface name of the link

### DIFF
--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -90,13 +90,11 @@ _This interface doesn't inherit any methods. None of the following methods alter
 
 ## Static methods
 
-_This interface inherits methods from {{domxref("DOMMatrixReadOnly")}}._
-
-- {{domxref("DOMMatrix.fromFloat32Array", "fromFloat32Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromFloat32Array", "fromFloat32Array()")}}
   - : Creates a new mutable `DOMMatrix` object given an array of single-precision (32-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
-- {{domxref("DOMMatrix.fromFloat64Array", "fromFloat64Array()")}}
+- {{domxref("DOMMatrixReadOnly.fromFloat64Array", "fromFloat64Array()")}}
   - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
-- {{domxref("DOMMatrix.fromMatrix", "fromMatrix()")}}
+- {{domxref("DOMMatrixReadOnly.fromMatrix", "fromMatrix()")}}
   - : Creates a new mutable `DOMMatrix` object given an existing matrix or a {{domxref("DOMMatrixInit")}} dictionary which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove a descriptoion for inheritence.
Fix the interface name of the link

### Motivation

The description says this interface inherits form itself.
And `DOMMatrix` should be `DOMMatrixReadOnly` in this article.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
