### PR TITLE
Fix incorrect min-width examples in `nesting_at-rules/index.md`

### DIFF
--- a/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
@@ -71,7 +71,7 @@ At-rules can be nested within other at-rules. Below you can see an example of th
   display: grid;
   @media (orientation: landscape) {
     grid-auto-flow: column;
-    @media (min-width > 1024px) {
+    @media (min-width: 1024px) {
       max-inline-size: 1024px;
     }
   }
@@ -89,7 +89,7 @@ At-rules can be nested within other at-rules. Below you can see an example of th
     grid-auto-flow: column;
   }
 }
-@media (orientation: landscape) and (min-width > 1024px) {
+@media (orientation: landscape) and (min-width: 1024px) {
   .foo {
     max-inline-size: 1024px;
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Based on these examples, I was having no luck getting nested media queries to work with min-width in Chrome. Then I looked up the the regular `@media` docs and they all showed examples using a colon. This works in Chrome:

```css
		#foo {
			flex-direction: column;

			@media (max-width: 720px) {
				flex-direction: row;
			}
		}
```

### Motivation

Showing examples that work.

### Additional details



### Related issues and pull requests

