### PR TITLE
Fix: mistake in a console.log() representation in "Array.prototype.findIndex()"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -84,7 +84,7 @@ const firstTrough = numbers
     if (idx < arr.length - 1 && num >= arr[idx + 1]) return false;
     return true;
   });
-console.log(firstTrough); // 2
+console.log(firstTrough); // 1
 ```
 
 ### Using findIndex() on sparse arrays


### PR DESCRIPTION
### Description

In the "Using the third argument of callbackFn example". 

The trough is at index 1 not 2, as the element -1 was filtered from the "numbers" array before calling the findIndex()

```js
const numbers = [3, -1, 1, 4, 1, 5, 9, 2, 6];
const firstTrough = numbers
  .filter((num) => num > 0)
  .findIndex((num, idx, arr) => {
    if (idx > 0 && num >= arr[idx - 1]) return false;
    if (idx < arr.length - 1 && num >= arr[idx + 1]) return false;
    return true;
  });
console.log(firstTrough); // 2 !!! ==> this should be 1 not 2
```

### Motivation

- I was going through the examples and stumbled upon that error.

### Additional details

### Related issues and pull requests

