### PR TITLE
fix: more accurate term and remove a self-referenced link

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/grow/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/grow/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 
 ## Description
 
-The `grow()` method grows a `SharedArrayBuffer` to the size specified by the `newLength` parameter, provided that the `SharedArrayBuffer` is [resizable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable) and the new size is less than or equal to the {{jsxref("SharedArrayBuffer/maxByteLength", "maxByteLength")}} of the `SharedArrayBuffer`. New bytes are initialized to 0.
+The `grow()` method grows a `SharedArrayBuffer` to the size specified by the `newLength` parameter, provided that the `SharedArrayBuffer` is [growable](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable) and the new size is less than or equal to the {{jsxref("SharedArrayBuffer/maxByteLength", "maxByteLength")}} of the `SharedArrayBuffer`. New bytes are initialized to 0.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/growable/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/growable/index.md
@@ -17,7 +17,7 @@ The `growable` property is an accessor property whose set accessor function is `
 
 ### Using growable
 
-In this example, we create a 8-byte buffer that is growable to a max length of 16 bytes, then check its {{jsxref("SharedArrayBuffer/growable", "growable")}} property, growing it if `growable` returns `true`:
+In this example, we create a 8-byte buffer that is growable to a max length of 16 bytes, then check its `growable` property, growing it if `growable` returns `true`:
 
 ```js
 const buffer = new SharedArrayBuffer(8, { maxByteLength: 16 });


### PR DESCRIPTION
### Description

use the more accurate term and remove a self-referenced link
