### PR TITLE
docs(CSS): Range syntax support is maturing, adding example of range syntax to MQ Learn

### DIFF
--- a/files/en-us/learn/css/css_layout/media_queries/index.md
+++ b/files/en-us/learn/css/css_layout/media_queries/index.md
@@ -144,6 +144,27 @@ Also in Level 4 is the `pointer` media feature. This takes three possible values
 
 Using `pointer` can help you to design better interfaces that respond to the type of interaction a user is having with a screen. For example, you could create larger hit areas if you know that the user is interacting with the device as a touchscreen.
 
+#### Using ranged syntax
+
+One common case is to check if the viewport width is between two values:
+
+```css
+@media (min-width: 30em) and (max-width: 50em) {
+  /* … */
+}
+```
+
+If you want to improve the readability of this, you can use "range" syntax:
+
+```css
+@media (30em <= width <= 50em) {
+  /* … */
+}
+```
+
+So in this case, styles are applied when the viewport width is between `30em` and `50em`.
+For more information on using this style, see [Using Media Queries: Syntax improvements in Level 4](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax_improvements_in_level_4)
+
 ## More complex media queries
 
 With all of the different possible media queries, you may want to combine them, or create lists of queries — any of which could be matched.

--- a/files/en-us/web/css/css_media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/using_media_queries/index.md
@@ -233,10 +233,10 @@ _It has no effect on modern browsers._
 ## Syntax improvements in Level 4
 
 The Media Queries Level 4 specification includes some syntax improvements to make media queries using features that have a "range" type, for example width or height, less verbose.
-Level 4 adds a _range context_ for writing such queries. For example, using the `max-` functionality for width we might write the following:
+Level 4 adds a _range context_ for writing such queries.
+You can check the [`@media` browser compatibility table](/en-US/docs/Web/CSS/@media#browser_compatibility) for details on support.
 
-> **Note:** The Media Queries Level 4 specification has reasonable support in modern browsers, but some media features are not well supported.
-> See the [`@media` browser compatibility table](/en-US/docs/Web/CSS/@media#browser_compatibility) for more details.
+To see how the "range" syntax works, let's look at an example that applies styles based on `max-width`:
 
 ```css
 @media (max-width: 30em) {
@@ -252,7 +252,7 @@ In Media Queries Level 4 this can be written as:
 }
 ```
 
-Using `min-` and `max-` we might test for a width between two values like so:
+Using `min-` and `max-` we can check for a width between two values like so:
 
 ```css
 @media (min-width: 30em) and (max-width: 50em) {
@@ -260,7 +260,7 @@ Using `min-` and `max-` we might test for a width between two values like so:
 }
 ```
 
-This would convert to the Level 4 syntax as:
+You can write this using the "range" syntax as:
 
 ```css
 @media (30em <= width <= 50em) {


### PR DESCRIPTION

Range syntax for media queries looks good at the moment, removing a note that support is unstable, and adding basic example to Learn article.

See https://developer.mozilla.org/en-US/docs/Web/CSS/@media#browser_compatibility

![image](https://github.com/mdn/content/assets/43580235/f9403813-a972-419c-9b97-cb74da4329c7)
