### PR TITLE
make snippet svg2 compatible

### DIFF
--- a/files/en-us/web/css/filter-function/blur/index.md
+++ b/files/en-us/web/css/filter-function/blur/index.md
@@ -67,7 +67,7 @@ This example shows three images: the image with a `blur()` filter function appli
   <filter id="blur">
     <feGaussianBlur stdDeviation="3.5" edgeMode="duplicate" />
   </filter>
-  <image xlink:href="flag.jpg" filter="url(#blur)" />
+  <image href="flag.jpg" xlink:href="flag.jpg" filter="url(#blur)" />
 </svg>
 ```
 
@@ -96,7 +96,7 @@ svg:not([height]) {
           <filter id="svgBlur">
             <feGaussianBlur stdDeviation="3.5" />
           </filter>
-          <image xlink:href="flag.jpg" filter="url(#svgBlur)" />
+          <image href="flag.jpg" xlink:href="flag.jpg" filter="url(#svgBlur)" />
         </svg>
       </td>
       <td>


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The code snippet for comparing svg based filter does not work on newer browsers because of a deprecated attribute `xlink:href`. 
![image](https://github.com/mdn/content/assets/18361420/69f6b57f-4d86-4dc1-95cf-626a01c4573c)

### Motivation
Just so nobody else spends time wondering what's wrong.

### Additional details
- [Mdn xlink:href page](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) mentions this as deprecated.
- [Stackoverflow answer](https://stackoverflow.com/a/46845023) suggests to keep both attributes for backward compatibility.
