### PR TITLE
Rename function

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/fromasync/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fromasync/index.md
@@ -124,7 +124,7 @@ Array.fromAsync(
 `Array.fromAsync()` awaits each value yielded from the object sequentially. `Promise.all()` awaits all values concurrently.
 
 ```js
-function* makeAsyncIterable() {
+function* makeIterableOfPromises() {
   for (let i = 0; i < 5; i++) {
     yield new Promise((resolve) => setTimeout(resolve, 100));
   }
@@ -132,12 +132,12 @@ function* makeAsyncIterable() {
 
 (async () => {
   console.time("Array.fromAsync() time");
-  await Array.fromAsync(makeAsyncIterable());
+  await Array.fromAsync(makeIterableOfPromises());
   console.timeEnd("Array.fromAsync() time");
   // Array.fromAsync() time: 503.610ms
 
   console.time("Promise.all() time");
-  await Promise.all(makeAsyncIterable());
+  await Promise.all(makeIterableOfPromises());
   console.timeEnd("Promise.all() time");
   // Promise.all() time: 101.728ms
 })();


### PR DESCRIPTION
makeAsyncIterable named function is in fact is not async iterable. It is regular iterable of promises. It's name results in confusion. I have renamed its name to makeIterableOfPromises.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
