### PR TITLE
typo: remove trailing s in clip page

### DIFF
--- a/files/en-us/web/svg/attribute/clip/index.md
+++ b/files/en-us/web/svg/attribute/clip/index.md
@@ -77,4 +77,4 @@ The value `auto` defines a clipping path along the bounds of the viewport create
 
 ## Browser compatibility
 
-{{Compat}}s
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

There was a typo in the `clip` attribute page.

![image](https://github.com/mdn/content/assets/22801583/8635f118-130c-4813-82ac-59b054f4dd11)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

N/A

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

---