### PR TITLE
Replace innerHTML with innerText

### DIFF
--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -32,7 +32,7 @@ In our [fetch text example](https://github.com/mdn/dom-examples/tree/main/fetch/
 First, we loop through all of these and give each one an `onclick` event handler so that the `getData()` function is run — with the link's `data-page` identifier passed to it as an argument — when one of the links is clicked.
 
 When `getData()` is run, we create a new request using the {{domxref("Request.Request","Request()")}} constructor, then use it to fetch a specific `.txt` file.
-When the fetch is successful, we read a string out of the response using `text()`, then set the {{domxref("HtmlElement.innerText","innerText")}} of the {{htmlelement("article")}} element equal to the text object.
+When the fetch is successful, we read a string out of the response using `text()`, then set the {{domxref("HTMLElement.innerText","innerText")}} of the {{htmlelement("article")}} element equal to the text object.
 
 ```js
 const myArticle = document.querySelector("article");

--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -32,7 +32,7 @@ In our [fetch text example](https://github.com/mdn/dom-examples/tree/main/fetch/
 First, we loop through all of these and give each one an `onclick` event handler so that the `getData()` function is run — with the link's `data-page` identifier passed to it as an argument — when one of the links is clicked.
 
 When `getData()` is run, we create a new request using the {{domxref("Request.Request","Request()")}} constructor, then use it to fetch a specific `.txt` file.
-When the fetch is successful, we read a string out of the response using `text()`, then set the {{domxref("Element.innerHTML","innerHTML")}} of the {{htmlelement("article")}} element equal to the text object.
+When the fetch is successful, we read a string out of the response using `text()`, then set the {{domxref("HtmlElement.innerText","innerText")}} of the {{htmlelement("article")}} element equal to the text object.
 
 ```js
 const myArticle = document.querySelector("article");
@@ -52,7 +52,7 @@ function getData(pageId) {
   fetch(myRequest)
     .then((response) => response.text())
     .then((text) => {
-      myArticle.innerHTML = text;
+      myArticle.innertext = text;
     });
 }
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Change example from inserting data via innerHtml to innerText

### Motivation

Using element.innerHtml to display data that is supposedly text data can have unintended consequences when the text contains data that can be interpreted as html, even possibly security issues if the source of the data may be tainted by user input.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
