### PR TITLE
Add link to cancel event to HTMLInputElement page

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -295,7 +295,7 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 - [`input`](/en-US/docs/Web/API/HTMLElement/input_event)
   - : Fires when the `value` of an {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element has been changed. Note that this is actually fired on the {{domxref("HTMLElement")}} interface and also applies to [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) elements, but we've listed it here because it is most commonly used with form input elements.
-- [`cancel`](/en-US/docs/Web/API/HTMLElement/cancel_event)
+- {{domxref("HTMLElement/cancel_event", "cancel")}}
   - : Fires when the file prompt of an {{HTMLElement("input")}} with `type="file"` is dismissed without a file being selected. Note that this is actually fired on the {{domxref("HTMLElement")}} interface, but we've listed it here because form input elements are one of the few types of element it is used with.
 - [`invalid`](/en-US/docs/Web/API/HTMLInputElement/invalid_event)
   - : Fired when an element does not satisfy its constraints during constraint validation.

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -295,6 +295,8 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 - [`input`](/en-US/docs/Web/API/HTMLElement/input_event)
   - : Fires when the `value` of an {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element has been changed. Note that this is actually fired on the {{domxref("HTMLElement")}} interface and also applies to [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) elements, but we've listed it here because it is most commonly used with form input elements.
+- [`cancel`](/en-US/docs/Web/API/HTMLElement/cancel_event)
+  - : Fires when the file prompt of an {{HTMLElement("input")}} with `type="file"` is dismissed without a file being selected. Note that this is actually fired on the {{domxref("HTMLElement")}} interface, but we've listed it here because form input elements are one of the few types of element it is used with.
 - [`invalid`](/en-US/docs/Web/API/HTMLInputElement/invalid_event)
   - : Fired when an element does not satisfy its constraints during constraint validation.
 - [`search`](/en-US/docs/Web/API/HTMLInputElement/search_event) {{Non-standard_Inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This PR adds a link to the "cancel" event that can be used with `HTMLInputElement` to the `HTMLInputElement` page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The "cancel" event lives with the `HTMLElement` interface, but it is only used with `<dialog>` elements and `<input type="file">` elements. It is currently linked to on the `HTMLElement` page and the `<input type="file">` page, but these aren't necessarily the most obvious places to find it.

Because it's a JavaScript event, I think there should be a link to it on the `HTMLInputElement` page.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
#31014
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
