### PR TITLE
chore(css): Add missing ray() function to motion path page

### DIFF
--- a/files/en-us/web/css/css_motion_path/index.md
+++ b/files/en-us/web/css/css_motion_path/index.md
@@ -49,6 +49,10 @@ The idea is that when you want to animate an element moving along a path, you pr
 - {{cssxref("offset-position")}}
 - {{cssxref("offset-rotate")}}
 
+### Functions
+
+- {{cssxref("ray")}}
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
The motion path module page is missing the `ray()` function, adding a Functions section with the xref.