### PR TITLE
feat: updates `Breadcrumb`'s glossary entry

### DIFF
--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -14,6 +14,8 @@ A location breadcrumb for this document might look something like this:
 
 Breadcrumb trails enable users to be aware of their location within a website. This type of navigation, if done correctly, helps users know where they are in a site and how they got there. They can also help a user get back to where they were before and can reduce the number of clicks needed to get to a higher-level page.
 
+> **Note:** There's no dedicated [semantic HTML element](/en-US/docs/Web/HTML/Element/ol) for breadcrumb navigation menus, it's recommended to use an [`<ol>`](/en-US/docs/Web/HTML/Element/ol) to represent it's hierarchical structure.
+
 ## See also
 
 - [Breadcrumb Navigation](/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation)

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -16,6 +16,7 @@ Breadcrumb trails enable users to be aware of their location within a website. T
 
 ## See also
 
+- [Breadcrumb Navigation](/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation)
 - [Breadcrumb Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)
 - [Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
 - [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-location.html)

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -17,6 +17,7 @@ Breadcrumb trails enable users to be aware of their location within a website. T
 ## See also
 
 - [Breadcrumb Navigation](/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation)
+- [Breadcrumb Structured Data](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)
 - [Breadcrumb Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)
 - [Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
 - [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-location.html)

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -14,7 +14,7 @@ A location breadcrumb for this document might look something like this:
 
 Breadcrumb trails enable users to be aware of their location within a website. This type of navigation, if done correctly, helps users know where they are in a site and how they got there. They can also help a user get back to where they were before and can reduce the number of clicks needed to get to a higher-level page.
 
-> **Note:** While there's no dedicated [semantic HTML element](https://html.spec.whatwg.org/multipage/semantics-other.html#rel-up) for breadcrumb navigation menus, the [`<ol>`](/en-US/docs/Web/HTML/Element/ol) element is commonly used to represent their hierarchical structure.
+> **Note:** While there's no dedicated [semantic HTML element](https://html.spec.whatwg.org/multipage/semantics-other.html#rel-up) for breadcrumb navigation menus, the {{htmlelement("ol")}} element is commonly used to represent their hierarchical structure.
 
 ## See also
 

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -14,7 +14,7 @@ A location breadcrumb for this document might look something like this:
 
 Breadcrumb trails enable users to be aware of their location within a website. This type of navigation, if done correctly, helps users know where they are in a site and how they got there. They can also help a user get back to where they were before and can reduce the number of clicks needed to get to a higher-level page.
 
-> **Note:** There's no dedicated [semantic HTML element](https://html.spec.whatwg.org/multipage/semantics-other.html#rel-up) for breadcrumb navigation menus, it's recommended to use an [`<ol>`](/en-US/docs/Web/HTML/Element/ol) to represent its hierarchical structure.
+> **Note:** While there's no dedicated [semantic HTML element](https://html.spec.whatwg.org/multipage/semantics-other.html#rel-up) for breadcrumb navigation menus, the [`<ol>`](/en-US/docs/Web/HTML/Element/ol) element is commonly used to represent their hierarchical structure.
 
 ## See also
 

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -19,7 +19,7 @@ Breadcrumb trails enable users to be aware of their location within a website. T
 ## See also
 
 - [Breadcrumb Navigation](/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation)
-- [Breadcrumb Structured Data](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)
+- [Google Search Central: Breadcrumb Structured Data](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)
 - [APG Guide: Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
 - [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-location.html)
 - [Understanding Technique 65 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G65)

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -21,5 +21,5 @@ Breadcrumb trails enable users to be aware of their location within a website. T
 - [Breadcrumb Navigation](/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation)
 - [Google Search Central: Breadcrumb Structured Data](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)
 - [APG Guide: Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
-- [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-location.html)
-- [Understanding Technique 65 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G65)
+- [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/location)
+- [Understanding Technique 65 | W3C Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Techniques/general/G65)

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -13,3 +13,10 @@ A location breadcrumb for this document might look something like this:
 [MDN](/) > [Glossary](/en-US/docs/Glossary) > Breadcrumb
 
 Breadcrumb trails enable users to be aware of their location within a website. This type of navigation, if done correctly, helps users know where they are in a site and how they got there. They can also help a user get back to where they were before and can reduce the number of clicks needed to get to a higher-level page.
+
+## See also
+
+- [Breadcrumb Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)
+- [Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
+- [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-location.html)
+- [Understanding Technique 65 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G65)

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -14,7 +14,7 @@ A location breadcrumb for this document might look something like this:
 
 Breadcrumb trails enable users to be aware of their location within a website. This type of navigation, if done correctly, helps users know where they are in a site and how they got there. They can also help a user get back to where they were before and can reduce the number of clicks needed to get to a higher-level page.
 
-> **Note:** There's no dedicated [semantic HTML element](/en-US/docs/Web/HTML/Element/ol) for breadcrumb navigation menus, it's recommended to use an [`<ol>`](/en-US/docs/Web/HTML/Element/ol) to represent it's hierarchical structure.
+> **Note:** There's no dedicated [semantic HTML element](https://html.spec.whatwg.org/multipage/semantics-other.html#rel-up) for breadcrumb navigation menus, it's recommended to use an [`<ol>`](/en-US/docs/Web/HTML/Element/ol) to represent its hierarchical structure.
 
 ## See also
 

--- a/files/en-us/glossary/breadcrumb/index.md
+++ b/files/en-us/glossary/breadcrumb/index.md
@@ -20,7 +20,6 @@ Breadcrumb trails enable users to be aware of their location within a website. T
 
 - [Breadcrumb Navigation](/en-US/docs/Web/CSS/Layout_cookbook/Breadcrumb_Navigation)
 - [Breadcrumb Structured Data](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb)
-- [Breadcrumb Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)
-- [Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
+- [APG Guide: Breadcrumb Example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)
 - [Understanding Success Criterion 2.4.8 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-location.html)
 - [Understanding Technique 65 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G65)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
- Adds a `See also` section featuring helpful links related to creating a breadcrumb navigation menu.
- Adds a note suggesting the use of the `<ol>` element.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
When I was building a breadcrumb menu, I couldn't find what HTML elements I was supposed to use, both `<p>` and `<ol>` made sense to me, in the beginning I was inclined towards `<p>` as the [HTML5 spec](https://html.spec.whatwg.org/multipage/semantics-other.html#rel-up) recommends it, ultimately I went with `<ol>` as I think it better indicates the hierarchical structure breadcrumbs have.

[Google](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb#json-ld) also uses it in it's HTML example for adding Breadcrumb structured data

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
