### PR TITLE
fix(js): Interactive example for backreferences is renamed

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/groups_and_backreferences/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 Groups group multiple patterns as a whole, and capturing groups provide extra submatch information when using a regular expression pattern to match against a string. Backreferences refer to a previously captured group in the same regular expression.
 
-{{EmbedInteractiveExample("pages/js/regexp-groups-ranges.html")}}
+{{EmbedInteractiveExample("pages/js/regexp-groups-backreferences.html")}}
 
 ## Types
 


### PR DESCRIPTION
Example's been renamed in a companion repo, but not in the source here. Updating the docs to pick up the latest version.

Fixes #30962