### PR TITLE
[Window: devicePixelRatio property] Remove unsourced references to "76 DPI"; Fix what I imagine to be a typo

### DIFF
--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -29,12 +29,9 @@ user drags the window to a display with a different pixel density). See
 
 ## Value
 
-A double-precision floating-point value indicating the ratio of the display's
-resolution in physical pixels to the resolution in CSS pixels. A value of 1 indicates a
-classic 96 DPI (76 DPI on some platforms) display, while a value of 2 is expected for
-HiDPI/Retina displays. Other values may be returned as well in the case of unusually low
-resolution displays or, more often, when a screen has a higher pixel depth than double
-the standard resolution of 96 or 76 DPI.
+A double-precision floating-point value indicating the ratio of the display's resolution in physical pixels to the resolution in CSS pixels. A value of 1 indicates a classic 96 DPI display, while a value of 2 is expected for HiDPI/Retina displays.
+
+Other values may be returned in the case of unusually low resolution displays or, more often, when a screen has a higher pixel density than double the standard resolution of 96 DPI. Modern mobile device screens - which offer high display resolutions at small physical sizes - often yield a `devicePixelRatio` value greater than 2.
 
 ## Examples
 


### PR DESCRIPTION
### Description

1. Removes two references to "76 DPI" displays
2. Fixes a typo ("depth" -> "density")
3. Adds an example for higher device pixel ratios

### Motivation

1. Clarify documentation
2. Fix https://github.com/mdn/content/issues/30211

### Related issues and pull requests

Resolves https://github.com/mdn/content/issues/30211