### PR TITLE
docs(css): Add module landing page for overscroll behavior

### DIFF
--- a/files/en-us/glossary/scroll_boundary/index.md
+++ b/files/en-us/glossary/scroll_boundary/index.md
@@ -6,23 +6,19 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **scroll boundary** is the point at which a scrollable element cannot be scrolled any further in a particular direction, either at the top or bottom (or left/right for horizontal scrolling). This typically refers to the edge of the scrollport.
+A **scroll boundary** is the point at which a scrollable element cannot be scrolled any further in a particular direction, either at the top or bottom (or left/right for horizontal scrolling). This typically is the edge of the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport).
 
-When the content of a {{Glossary("Scroll_container", "scroll container")}} does not exceed the container size in the scrolling direction, the container is considered to be at its scroll boundary at all times. This is because there's no extra content to scroll through.
+When the content of a {{Glossary("Scroll_container", "scroll container")}} does not exceed the container size in the scrolling direction, the container is considered to be at its scroll boundary at all times. This is because there's no extra content to scroll through. If the content is prevented from scrolling, such as when {{cssxref("overflow", "overflow: hidden")}} is set, the element is not a scroll container, and therefore, there is no scroll boundary.
 
-### Boundary default action
-
-This refers to a browser's default behavior when the scroll boundary of the scrollport is reached. This can lead to a visual effect such as a bounce or a functional action like pull-to-refresh on mobile devices.
+When the scroll boundary of the scrollport is reached by a user scrolling the content, a visual effect such as a bounce or a functional action like pull-to-refresh on mobile devices may occur. This default browser behavior is called the **boundary default action**.
 
 For example, on mobile devices, dragging a page downward when already at the top causes a bounce effect and sometimes triggers a page refresh. This bounce or refresh is the boundary default action.
 
 Boundary default actions can be local or non-local.
 
-### Local and non-local boundary defaults
+- A **local boundary default** is the action that occurring at the boundary of a specific scrollable area confined to that element. This action is considered _local_ as it does not affect any ancestor containers or the rest of the webpage.
 
-A **local boundary default** is the action that occurs at the boundary of a specific scrollable area and is confined to the element. For example, the action could be to display a visual effect within the element to indicate the end of scrolling. This action does not affect the larger container or the rest of the webpage.
-
-On the other hand, a **non-local boundary default action** has effects beyond the specific element. An example of this is scroll chaining, where reaching the scroll boundary of one element triggers scrolling in a parent element or even initiate a page-wide action, such as navigation.
+- A **non-local boundary default action** is when reaching the scroll boundary of a scroll container has effects beyond the specific element being scrolled. An example of this is {{Glossary("Scroll_chaining", "scroll chaining")}}, where reaching the scroll boundary of one element triggers scrolling in a parent or ancestor element, and possibly even initiating a page-wide action, such as navigation.
 
 ## See also
 

--- a/files/en-us/glossary/scroll_boundary/index.md
+++ b/files/en-us/glossary/scroll_boundary/index.md
@@ -1,16 +1,14 @@
 ---
-title: Scroll chaining
-slug: Glossary/Scroll_chaining
+title: Scroll boundary
+slug: Glossary/Scroll_boundary
 page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}
 
-**Scroll chaining** refers to the behavior observed when scrolling within a scrollable element, such as a `<div>` or `<textarea>`, triggers scrolling in its parent element or the underlying page. This propagation results in a "chained effect", where there is a seamless transition of the scroll action to the parent element when the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached. This behavior creates a continuous scrolling experience, both vertically and horizontally.
+A **scroll boundary** is the point at which a scrollable element cannot be scrolled any further in a particular direction, either at the top or bottom (or left/right for horizontal scrolling). This typically refers to the edge of the scrollport.
 
-## Related terms
-
-There are a few important terms related to the concept of scroll chaining. These are explained below.
+When the content of a {{Glossary("Scroll_container", "scroll container")}} does not exceed the container size in the scrolling direction, the container is considered to be at its scroll boundary at all times. This is because there's no extra content to scroll through.
 
 ### Boundary default action
 
@@ -25,10 +23,6 @@ Boundary default actions can be local or non-local.
 A local boundary default is the action that occurs at the boundary of a specific scrollable area and is confined to the element. For example, the action could be to display a visual effect within the element to indicate the end of scrolling. This action does not affect the larger container or the rest of the webpage.
 
 On the other hand, a non-local boundary default action has effects beyond the specific element. An example of this is scroll chaining, where reaching the scroll boundary of one element triggers scrolling in a parent element or even initiate a page-wide action, such as navigation.
-
-### Scroll chain
-
-A scroll chain is the order of scrollable elements where the scrolling action passes from one element to another. This happens when an inner element is scrolled to its limit, and the scrolling continues to its parent element, creating a 'chain' of scrolling actions. Chaining typically recurses up the containing block.
 
 ## See also
 

--- a/files/en-us/glossary/scroll_boundary/index.md
+++ b/files/en-us/glossary/scroll_boundary/index.md
@@ -20,9 +20,9 @@ Boundary default actions can be local or non-local.
 
 ### Local and non-local boundary defaults
 
-A local boundary default is the action that occurs at the boundary of a specific scrollable area and is confined to the element. For example, the action could be to display a visual effect within the element to indicate the end of scrolling. This action does not affect the larger container or the rest of the webpage.
+A **local boundary default** is the action that occurs at the boundary of a specific scrollable area and is confined to the element. For example, the action could be to display a visual effect within the element to indicate the end of scrolling. This action does not affect the larger container or the rest of the webpage.
 
-On the other hand, a non-local boundary default action has effects beyond the specific element. An example of this is scroll chaining, where reaching the scroll boundary of one element triggers scrolling in a parent element or even initiate a page-wide action, such as navigation.
+On the other hand, a **non-local boundary default action** has effects beyond the specific element. An example of this is scroll chaining, where reaching the scroll boundary of one element triggers scrolling in a parent element or even initiate a page-wide action, such as navigation.
 
 ## See also
 

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -40,5 +40,5 @@ A scroll chain is the order of scrollable elements where the scrolling action pa
 
 ## See also
 
-- {{CSSxRef("overflow")}}
-- {{CSSxRef("scroll-snap")}}
+- [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module
+- [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -6,9 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Scroll chaining** refers to the behavior observed when scrolling within a scrollable element, such as a `<div>` or `<textarea>`, triggers scrolling in its parent element or the underlying page. This propagation results in a "chained effect", where there is a seamless transition of the scroll action to the parent element when the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top or bottom) of the scrollable element is reached. This behavior creates a continuous scrolling experience.
-
-You can use the shorthand {{CSSxRef("overscroll-behavior")}} CSS property to customize or disable the browser's default behavior.
+**Scroll chaining** refers to the behavior observed when scrolling within a scrollable element, such as a `<div>` or `<textarea>`, triggers scrolling in its parent element or the underlying page. This propagation results in a "chained effect", where there is a seamless transition of the scroll action to the parent element when the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached. This behavior creates a continuous scrolling experience, both vertically and horizontally.
 
 ## Related terms
 
@@ -40,5 +38,7 @@ A scroll chain is the order of scrollable elements where the scrolling action pa
 
 ## See also
 
+- {{CSSxRef("overscroll-behavior")}} CSS property
 - [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module
+- [CSS overscroll behavior](/en-US/docs/Web/CSS/CSS_overscroll_behavior) module
 - [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -1,0 +1,44 @@
+---
+title: Scroll chaining
+slug: Glossary/Scroll_chaining
+page-type: glossary-definition
+---
+
+{{GlossarySidebar}}
+
+**Scroll chaining** refers to the behavior observed when scrolling within a scrollable element, such as a `<div>` or `<textarea>`, triggers scrolling in its parent element or the underlying page. This propagation results in a "chained effect", where there is a seamless transition of the scroll action to the parent element when the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top or bottom) of the scrollable element is reached. This behavior creates a continuous scrolling experience.
+
+You can use the shorthand {{CSSxRef("overscroll-behavior")}} CSS property to customize or disable the browser's default behavior.
+
+## Related terms
+
+There are a few important terms related to the concept of scroll chaining. These are explained below.
+
+### Scroll boundary
+
+The scroll boundary is the point at which a scrollable element cannot be scrolled any further in a particular direction, either at the top or bottom (or left/right for horizontal scrolling). This typically refers to the edge of the scrollport.
+
+When the content of a {{Glossary("Scroll_container)}} does not exceed the container size in the scrolling direction, the container is considered to be at its scroll boundary at all times. This is because there's no extra content to scroll through.
+
+### Boundary default action
+
+This refers to a browser's default behavior when the scroll boundary of the scrollport is reached. This can lead to a visual effect such as a bounce or a functional action like pull-to-refresh on mobile devices.
+
+For example, on mobile devices, dragging a page downward when already at the top causes a bounce effect and sometimes triggers a page refresh. This bounce or refresh is the boundary default action.
+
+Boundary default actions can be local or non-local.
+
+### Local and non-local boundary defaults
+
+A local boundary default is the action that occurs at the boundary of a specific scrollable area and is confined to the element. For example, the action could be to display a visual effect within the element to indicate the end of scrolling. This action does not affect the larger container or the rest of the webpage.
+
+On the other hand, a non-local boundary default action has effects beyond the specific element. An example of this is scroll chaining, where reaching the scroll boundary of one element triggers scrolling in a parent element or even initiate a page-wide action, such as navigation.
+
+### Scroll chain
+
+A scroll chain is the order of scrollable elements where the scrolling action passes from one element to another. This happens when an inner element is scrolled to its limit, and the scrolling continues to its parent element, creating a 'chain' of scrolling actions. Chaining typically recurses up the containing block.
+
+## See also
+
+- {{CSSxRef("overflow")}}
+- {{CSSxRef("scroll-snap")}}

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 **Scroll chaining** refers to the behavior observed when a user scrolls past the {{Glossary("Scroll_boundary", "Scroll boundary")}} of a scrollable element, causing scrolling on an ancestor element.
 
-When a user scrolls within a scrollable element such as a `<div>` or `<textarea>` and the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached, there is a "chained effect" in which the scroll action is seamlessly propagated to the parent element. This behavior creates a continuous scrolling experience, both vertically and horizontally.
+When a user scrolls within a scrollable element such as a `<div>` or `<textarea>` and the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached, there may be a "chained effect" in which the scroll action is seamlessly propagated to the parent element. This behavior creates a continuous scrolling experience, both vertically and horizontally.
 
 A **scroll chain** is the order of scrollable elements where the scrolling action passes from one element to another. This happens when an inner element is scrolled to its limit, and the scrolling continues to its parent element, creating a 'chain' of scrolling actions. Chaining typically recurses up the containing block.
 

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -8,27 +8,7 @@ page-type: glossary-definition
 
 **Scroll chaining** refers to the behavior observed when scrolling within a scrollable element, such as a `<div>` or `<textarea>`, triggers scrolling in its parent element or the underlying page. This propagation results in a "chained effect", where there is a seamless transition of the scroll action to the parent element when the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached. This behavior creates a continuous scrolling experience, both vertically and horizontally.
 
-## Related terms
-
-There are a few important terms related to the concept of scroll chaining. These are explained below.
-
-### Boundary default action
-
-This refers to a browser's default behavior when the scroll boundary of the scrollport is reached. This can lead to a visual effect such as a bounce or a functional action like pull-to-refresh on mobile devices.
-
-For example, on mobile devices, dragging a page downward when already at the top causes a bounce effect and sometimes triggers a page refresh. This bounce or refresh is the boundary default action.
-
-Boundary default actions can be local or non-local.
-
-### Local and non-local boundary defaults
-
-A local boundary default is the action that occurs at the boundary of a specific scrollable area and is confined to the element. For example, the action could be to display a visual effect within the element to indicate the end of scrolling. This action does not affect the larger container or the rest of the webpage.
-
-On the other hand, a non-local boundary default action has effects beyond the specific element. An example of this is scroll chaining, where reaching the scroll boundary of one element triggers scrolling in a parent element or even initiate a page-wide action, such as navigation.
-
-### Scroll chain
-
-A scroll chain is the order of scrollable elements where the scrolling action passes from one element to another. This happens when an inner element is scrolled to its limit, and the scrolling continues to its parent element, creating a 'chain' of scrolling actions. Chaining typically recurses up the containing block.
+A **scroll chain** is the order of scrollable elements where the scrolling action passes from one element to another. This happens when an inner element is scrolled to its limit, and the scrolling continues to its parent element, creating a 'chain' of scrolling actions. Chaining typically recurses up the containing block.
 
 ## See also
 

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -6,7 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Scroll chaining** refers to the behavior observed when scrolling within a scrollable element, such as a `<div>` or `<textarea>`, triggers scrolling in its parent element or the underlying page. This propagation results in a "chained effect", where there is a seamless transition of the scroll action to the parent element when the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached. This behavior creates a continuous scrolling experience, both vertically and horizontally.
+**Scroll chaining** refers to the behavior observed when a user scrolls past the {{Glossary("Scroll_boundary", "Scroll boundary")}} of a scrollable element, causing scrolling on an ancestor element.
+
+When a user scrolls within a scrollable element such as a `<div>` or `<textarea>` and the [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) boundary (top, bottom, left or right) of the scrollable element is reached, there is a "chained effect" in which the scroll action is seamlessly propagated to the parent element. This behavior creates a continuous scrolling experience, both vertically and horizontally.
 
 A **scroll chain** is the order of scrollable elements where the scrolling action passes from one element to another. This happens when an inner element is scrolled to its limit, and the scrolling continues to its parent element, creating a 'chain' of scrolling actions. Chaining typically recurses up the containing block.
 

--- a/files/en-us/glossary/scroll_chaining/index.md
+++ b/files/en-us/glossary/scroll_chaining/index.md
@@ -18,7 +18,7 @@ There are a few important terms related to the concept of scroll chaining. These
 
 The scroll boundary is the point at which a scrollable element cannot be scrolled any further in a particular direction, either at the top or bottom (or left/right for horizontal scrolling). This typically refers to the edge of the scrollport.
 
-When the content of a {{Glossary("Scroll_container)}} does not exceed the container size in the scrolling direction, the container is considered to be at its scroll boundary at all times. This is because there's no extra content to scroll through.
+When the content of a {{Glossary("Scroll_container")}} does not exceed the container size in the scrolling direction, the container is considered to be at its scroll boundary at all times. This is because there's no extra content to scroll through.
 
 ### Boundary default action
 

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -21,11 +21,8 @@ The **CSS overscroll behavior** module properties enable you to control the beha
 
 ### Glossary terms
 
-- {{Glossary("Scroll_chaining")}}
-  It also covers the following terms:
-  - [Scroll boundary](/en-US/docs/Glossary/Scroll_chaining#scroll_boundary)
-  - [Boundary default action](/en-US/docs/Glossary/Scroll_chaining#boundary_default_action)
-  - [Local and non-local boundary defaults](/en-US/docs/Glossary/Scroll_chaining#local_and_non-local_boundary_defaults)
+- {{Glossary("Scroll_boundary", "Scroll boundary")}}
+- {{Glossary("Scroll_chaining", "Scroll chaining")}}
 
 ## Guides
 
@@ -45,9 +42,7 @@ The **CSS overscroll behavior** module properties enable you to control the beha
 - [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module:
 
   - {{cssxref("overflow")}} CSS property
-  - {{Glossary("Scroll_container")}} glossary term
-    It also covers the following term:
-    - [Scrollport](/en-US/docs/Glossary/Scroll_container#scrollport)
+  - {{Glossary("Scroll_container", "Scroll container")}} and [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) glossary terms
 
 - [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module:
 
@@ -60,3 +55,4 @@ The **CSS overscroll behavior** module properties enable you to control the beha
 ## See also
 
 - [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module
+- [Take control of your scroll - customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior) on developer.chrome.com (2017)

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -7,9 +7,9 @@ spec-urls: https://drafts.csswg.org/css-overscroll/
 
 {{CSSRef}}
 
-The **CSS overscroll behavior** module provides properties to control the behavior of a scroll container when its scroll position reaches the scroll boundary. Controlling this aspect is particularly useful in scenarios where embedded scrollable areas should not trigger scrolling of the parent container.
+The **CSS overscroll behavior** module provides properties to control the behavior of a {{Glossary("Scroll_container", "scroll container")}} when its scroll position reaches the {{Glossary("Scroll_boundary", "scroll boundary")}}. Controlling this aspect is particularly useful in scenarios where embedded scrollable areas should not trigger scrolling of the parent container.
 
-When commenting on a blog, you might notice that if your comment exceeds the length of the provided {{htmlelement("textarea")}}, scrolling beyond the end of the text area causes the entire blog to scroll. This is because reaching the end of a scrollable area, known as the scroll boundary, can lead to scrolling other content or the entire page. This continuous scrolling experience is called {{Glossary("Scroll_chaining", "scroll chaining")}}.
+When commenting on a blog, you might notice that if your comment exceeds the length of the provided {{htmlelement("textarea")}}, scrolling beyond the end of the text area causes the entire blog to scroll. This is because reaching the end of a scrollable area, known as the {{Glossary("Scroll_boundary", "scroll boundary")}}, can lead to scrolling other content or the entire page. This continuous scrolling experience is called {{Glossary("Scroll_chaining", "scroll chaining")}}.
 
 In situations where the contents of an element are larger than its container and {{cssxref("overflow")}} allows or defaults to scrolling (like in `<textarea>`), continued scrolling past the element's scrollable area will initiate scrolling in the parent element or the underlying page.
 

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -7,7 +7,15 @@ spec-urls: https://drafts.csswg.org/css-overscroll/
 
 {{CSSRef}}
 
-The **CSS overscroll behavior** module properties enable you to control the behavior of a scroll container when its scroll position reaches the scroll boundary. Controlling this aspect is particularly useful in scenarios where embedded scrollable areas should not trigger scrolling of the parent container.
+The **CSS overscroll behavior** module provides properties to control the behavior of a scroll container when its scroll position reaches the scroll boundary. Controlling this aspect is particularly useful in scenarios where embedded scrollable areas should not trigger scrolling of the parent container.
+
+When commenting on a blog, you might notice that if your comment exceeds the length of the provided {{htmlement("textarea")}}, scrolling beyond the end of the text area causes the entire blog to scroll. This is because reaching the end of a scrollable area, known as the scroll boundary, can lead to scrolling other content or the entire page. This continuous scrolling experience is called {{Glossary("Scroll_chaining", "scroll chaining")}}.
+
+In situations where the contents of an element are larger than its container, and {{cssxref("overflow")}} allows or defaults to scrolling (like in `<textarea>`), continued scrolling past the element's scrollable area will initiate scrolling in the parent element or the underlying page.
+
+Conversely, scrolling through a website's terms and conditions and reaching the end of the content to enable a checkbox, may not force the page to scroll or bounce (as on a phone). This example shows that you can control overscroll behavior and prevent scroll chaining.
+
+This module defines the overscroll behavior, enabling you to specify the actions when a user scrolls beyond the boundaries of a scrollable element.
 
 ## Reference
 

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -31,22 +31,11 @@ The **CSS overscroll behavior** module properties enable you to control the beha
 
 ## Related concepts
 
-- [CSSOM view](/en-US/docs/Web/CSS/CSSOM_view) module:
-
-  - [getBoundingClientRect](/en-US/docs/Web/API/Element/getBoundingClientRect) method
-
-- [CSS display](/en-US/docs/Web/CSS/CSS_display) module:
-
-  - [Containing block](/en-US/docs/Web/CSS/Containing_block)
-
-- [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module:
-
-  - {{cssxref("overflow")}} CSS property
-  - {{Glossary("Scroll_container", "Scroll container")}} and [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) glossary terms
-
-- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module:
-
-  - {{CSSxref("position")}} property
+- [Containing block](/en-US/docs/Web/CSS/Containing_block) concept ([CSS display](/en-US/docs/Web/CSS/CSS_display) module)
+- {{cssxref("overflow")}} CSS property ([CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module)
+- {{CSSxref("position")}} CSS property ([CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module)
+- [getBoundingClientRect](/en-US/docs/Web/API/Element/getBoundingClientRect) method ([CSSOM view](/en-US/docs/Web/CSS/CSSOM_view) module)
+- {{Glossary("Scroll_container", "Scroll container")}} and [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) glossary terms ([CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module)
 
 ## Specifications
 
@@ -54,5 +43,7 @@ The **CSS overscroll behavior** module properties enable you to control the beha
 
 ## See also
 
+- [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module
+- [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module
 - [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module
 - [Take control of your scroll - customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior) on developer.chrome.com (2017)

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -1,0 +1,62 @@
+---
+title: CSS overscroll behavior
+slug: Web/CSS/CSS_overscroll_behavior
+page-type: css-module
+spec-urls: https://drafts.csswg.org/css-overscroll/
+---
+
+{{CSSRef}}
+
+The **CSS overscroll behavior** module properties enable you to control the behavior of a scroll container when its scroll position reaches the scroll boundary. Controlling this aspect is particularly useful in scenarios where embedded scrollable areas should not trigger scrolling of the parent container.
+
+## Reference
+
+### CSS properties
+
+- {{CSSxRef("overscroll-behavior")}} shorthand
+- {{CSSxRef("overscroll-behavior-block")}}
+- {{CSSxRef("overscroll-behavior-inline")}}
+- {{CSSxRef("overscroll-behavior-x")}}
+- {{CSSxRef("overscroll-behavior-y")}}
+
+### Glossary terms
+
+- {{Glossary("Scroll_chaining")}}
+  It also covers the following terms:
+  - [Scroll boundary](/en-US/docs/Glossary/Scroll_chaining#Scroll_boundary)
+  - [Boundary default action](/en-US/docs/Glossary/Scroll_chaining#Boundary_default_action)
+  - [Local and non-local boundary defaults](/en-US/docs/Glossary/Scroll_chaining#Local_and_non-local_boundary_defaults)
+
+## Guides
+
+- [CSS building blocks: Overflowing content](/en-US/docs/Learn/CSS/Building_blocks/Overflowing_content)
+  - : Learn what overflow is and how to manage it.
+
+## Related concepts
+
+- [CSSOM view](/en-US/docs/Web/CSS/CSSOM_view) module:
+
+  - [getBoundingClientRect](/en-US/docs/Web/API/Element/getBoundingClientRect) method
+
+- [CSS display](/en-US/docs/Web/CSS/CSS_display) module:
+
+  - [Containing block](/en-US/docs/Web/CSS/Containing_block)
+
+- [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module:
+
+  - {{cssxref("overflow")}} CSS property
+  - {{Glossary("Scroll_container")}} glossary term
+    It also covers the following term:
+    - [Scrollport](/en-US/docs/Glossary/Scroll_container#scrollport)
+
+- [CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module:
+
+  - {{CSSxref("position")}} property
+
+## Specifications
+
+{{Specifications}}
+
+## See also
+
+- [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -9,9 +9,9 @@ spec-urls: https://drafts.csswg.org/css-overscroll/
 
 The **CSS overscroll behavior** module provides properties to control the behavior of a scroll container when its scroll position reaches the scroll boundary. Controlling this aspect is particularly useful in scenarios where embedded scrollable areas should not trigger scrolling of the parent container.
 
-When commenting on a blog, you might notice that if your comment exceeds the length of the provided {{htmlement("textarea")}}, scrolling beyond the end of the text area causes the entire blog to scroll. This is because reaching the end of a scrollable area, known as the scroll boundary, can lead to scrolling other content or the entire page. This continuous scrolling experience is called {{Glossary("Scroll_chaining", "scroll chaining")}}.
+When commenting on a blog, you might notice that if your comment exceeds the length of the provided {{htmlelement("textarea")}}, scrolling beyond the end of the text area causes the entire blog to scroll. This is because reaching the end of a scrollable area, known as the scroll boundary, can lead to scrolling other content or the entire page. This continuous scrolling experience is called {{Glossary("Scroll_chaining", "scroll chaining")}}.
 
-In situations where the contents of an element are larger than its container, and {{cssxref("overflow")}} allows or defaults to scrolling (like in `<textarea>`), continued scrolling past the element's scrollable area will initiate scrolling in the parent element or the underlying page.
+In situations where the contents of an element are larger than its container and {{cssxref("overflow")}} allows or defaults to scrolling (like in `<textarea>`), continued scrolling past the element's scrollable area will initiate scrolling in the parent element or the underlying page.
 
 Conversely, scrolling through a website's terms and conditions and reaching the end of the content to enable a checkbox, may not force the page to scroll or bounce (as on a phone). This example shows that you can control overscroll behavior and prevent scroll chaining.
 
@@ -51,6 +51,7 @@ This module defines the overscroll behavior, enabling you to specify the actions
 
 ## See also
 
+- [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role) ARIA role
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module
 - [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module
 - [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -39,11 +39,34 @@ This module defines the overscroll behavior, enabling you to specify the actions
 
 ## Related concepts
 
-- [Containing block](/en-US/docs/Web/CSS/Containing_block) concept ([CSS display](/en-US/docs/Web/CSS/CSS_display) module)
-- {{cssxref("overflow")}} CSS property ([CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module)
-- {{CSSxref("position")}} CSS property ([CSS positioned layout](/en-US/docs/Web/CSS/CSS_positioned_layout) module)
-- [getBoundingClientRect](/en-US/docs/Web/API/Element/getBoundingClientRect) method ([CSSOM view](/en-US/docs/Web/CSS/CSSOM_view) module)
-- {{Glossary("Scroll_container", "Scroll container")}} and [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) glossary terms ([CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module)
+- [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role) ARIA role
+- [Containing block](/en-US/docs/Web/CSS/Containing_block) concept
+- [CSS overflow](/en-US/docs/Web/CSS/CSS_overflow) module:
+  - {{cssxref("overflow")}} shorthand property
+    - {{Cssxref("overflow-x")}}
+    - {{Cssxref("overflow-y")}}
+    - {{CSSxRef("overflow-block")}}
+    - {{CSSxRef("overflow-inline")}}
+  - {{CSSxRef("overflow-clip-margin")}} property
+  - {{CSSxRef("scroll-behavior")}} property
+  - {{CSSxRef("text-overflow")}} property
+- {{Glossary("Scroll_container", "Scroll container")}} and [scrollport](/en-US/docs/Glossary/Scroll_container#scrollport) glossary terms
+
+- [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module:
+
+  - {{cssxref("scroll-padding")}} shorthand property
+  - {{cssxref("scroll-snap-type")}} property
+  - {{cssxref("scroll-margin")}} shorthand property
+  - {{cssxref("scroll-snap-stop")}} property
+  - {{cssxref("scroll-snap-align")}} property
+
+- [CSSOM view](/en-US/docs/Web/CSS/CSSOM_view) module:
+  - {{domxref("Element.getBoundingClientRect()")}} method
+  - {{domxref("Element.scroll()")}} method
+  - {{domxref("Element.scrollBy()")}} method
+  - {{domxref("Element.scrollIntoView()")}} method
+  - {{domxref("Element.scrollTo()")}} method
+  - {{domxref("Document.scroll_event", "scroll")}} Document event
 
 ## Specifications
 
@@ -51,7 +74,6 @@ This module defines the overscroll behavior, enabling you to specify the actions
 
 ## See also
 
-- [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role) ARIA role
 - [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module
 - [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module
 - [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap) module

--- a/files/en-us/web/css/css_overscroll_behavior/index.md
+++ b/files/en-us/web/css/css_overscroll_behavior/index.md
@@ -23,9 +23,9 @@ The **CSS overscroll behavior** module properties enable you to control the beha
 
 - {{Glossary("Scroll_chaining")}}
   It also covers the following terms:
-  - [Scroll boundary](/en-US/docs/Glossary/Scroll_chaining#Scroll_boundary)
-  - [Boundary default action](/en-US/docs/Glossary/Scroll_chaining#Boundary_default_action)
-  - [Local and non-local boundary defaults](/en-US/docs/Glossary/Scroll_chaining#Local_and_non-local_boundary_defaults)
+  - [Scroll boundary](/en-US/docs/Glossary/Scroll_chaining#scroll_boundary)
+  - [Boundary default action](/en-US/docs/Glossary/Scroll_chaining#boundary_default_action)
+  - [Local and non-local boundary defaults](/en-US/docs/Glossary/Scroll_chaining#local_and_non-local_boundary_defaults)
 
 ## Guides
 

--- a/files/en-us/web/css/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/overscroll-behavior-block/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-block` property is specified as a keyword chosen from t
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no {{Glossary("Scroll_chaining", "scroll chaining")}} occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/overscroll-behavior-inline/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-inline` property is specified as a keyword chosen from 
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no {{Glossary("Scroll_chaining", "scroll chaining")}} occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-x` property is specified as a keyword chosen from the l
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no {{Glossary("Scroll_chaining", "scroll chaining")}} occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior-y/index.md
+++ b/files/en-us/web/css/overscroll-behavior-y/index.md
@@ -34,7 +34,7 @@ The `overscroll-behavior-y` property is specified as a keyword chosen from the l
 - `auto`
   - : The default scroll overflow behavior occurs as normal.
 - `contain`
-  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no scroll chaining occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
+  - : Default scroll overflow behavior (e.g., "bounce" effects) is observed inside the element where this value is set. However, no {{Glossary("Scroll_chaining", "scroll chaining")}} occurs on neighboring scrolling areas; the underlying elements will not scroll. The `contain` value disables native browser navigation, including the vertical pull-to-refresh gesture and horizontal swipe navigation.
 - `none`
   - : No scroll chaining occurs to neighboring scrolling areas, and default scroll overflow behavior is prevented.
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -52,7 +52,7 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
 
 ## Description
 
-By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content at the top of a page that also has scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called {{Glossary("scroll_chaining")}}.
+By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content at the top of a page that also has scrolling content, once the dialog box's {{Glossary("Scroll_boundary", "scroll boundary")}} is reached, the underlying page will then start to scroll — this is called {{Glossary("Scroll_chaining", "scroll chaining")}}.
 
 In some cases, these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -52,7 +52,7 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
 
 ## Description
 
-By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content at the top of a page that also has scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called **scroll chaining**.
+By default, mobile browsers tend to provide a "bounce" effect or even a page refresh when the top or bottom of a page (or other scroll area) is reached. You may also have noticed that when you have a dialog box with scrolling content at the top of a page that also has scrolling content, once the dialog box's scroll boundary is reached, the underlying page will then start to scroll — this is called {{Glossary("scroll_chaining")}}.
 
 In some cases, these behaviors are not desirable. You can use `overscroll-behavior` to get rid of unwanted scroll chaining and the browser's Facebook/Twitter app-inspired "pull to refresh"-type behavior.
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -103,4 +103,4 @@ html {
 
 ## See also
 
-- [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior/#demo)
+- [Take control of your scroll: customizing pull-to-refresh and overflow effects](https://developer.chrome.com/blog/overscroll-behavior) on developer.chrome.com (2017)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR creates a new module landing page for the overscroll behavior module. It also creates a new glossary page to explain some related relevant terms.

Note that at this moment the module landing page does not include the "in action" section. I hope it can be taken up in a subsequent PR.

Spec: https://drafts.csswg.org/css-overscroll/

### Motivation

Scrolling is a focus area in [Interop 2023](https://wpt.fyi/interop-2023). Overscroll behavior is one of the features covered in scrolling. 

### Related issues and pull requests

This work is being tracked through the doc issue https://github.com/mdn/mdn/issues/416.

TO DO

- [ ] Add the module page to the sidebar


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
