### PR TITLE
Remove a duplicated property

### DIFF
--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -43,7 +43,6 @@ You can [view this example's source on GitHub](https://github.com/mdn/css-exampl
 - {{cssxref("transform-origin")}}
 - {{cssxref("transform-style")}}
 - {{cssxref("translate")}}
-- {{cssxref("transform-origin")}}
 
 ### Functions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove the latter `transform-origin` because it has been duplicated.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
