### PR TITLE
Remove wrong info about fullscreen support

### DIFF
--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -35,19 +35,6 @@ if (elem.requestFullscreen) {
 
 This code checks for the existence of the `requestFullscreen()` method before calling it.
 
-### Presentation differences
-
-It's worth noting a key difference here between the Gecko and WebKit implementations at this time: Gecko automatically adds CSS rules to the element to stretch it to fill the screen: "`width: 100%; height: 100%`". WebKit doesn't do this; instead, it centers the fullscreen element at the same size in a screen that's otherwise black. To get the same fullscreen behavior in WebKit, you need to add your own "`width: 100%; height: 100%;`" CSS rules to the element yourself:
-
-```css
-#myvideo:-webkit-full-screen {
-  width: 100%;
-  height: 100%;
-}
-```
-
-On the other hand, if you're trying to emulate WebKit's behavior on Gecko, you need to place the element you want to present inside another element, which you'll make fullscreen instead, and use CSS rules to adjust the inner element to match the appearance you want.
-
 ### Notification
 
 When fullscreen mode is successfully engaged, the document which contains the element receives a {{domxref("Element/fullscreenchange_event", "fullscreenchange")}} event. When fullscreen mode is exited, the document again receives a {{domxref("Document/fullscreenchange_event", "fullscreenchange")}} event. Note that the {{domxref("Document/fullscreenchange_event", "fullscreenchange")}} event doesn't provide any information itself as to whether the document is entering or exiting fullscreen mode, but if the document has a non null {{DOMxRef("document.fullscreenElement", "fullscreenElement")}}, you know you're in fullscreen mode.
@@ -95,7 +82,7 @@ When the page is loaded, this code is run to set up an event listener to watch f
 document.addEventListener(
   "keydown",
   (e) => {
-    if (e.keyCode === 13) {
+    if (e.key === "Enter") {
       toggleFullScreen();
     }
   },

--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -16,8 +16,6 @@ The **Fullscreen API** adds methods to present a specific {{DOMxRef("Element")}}
 
 See the article [Guide to the Fullscreen API](/en-US/docs/Web/API/Fullscreen_API/Guide) for details on how to use the API.
 
-> **Note:** Support for this API varies somewhat across browsers, with many requiring vendor prefixes and/or not implementing the latest specification. See the [Browser compatibility](#browser_compatibility) section below for details on support for this API. You may wish to consider using a library such as [Fscreen](https://github.com/rafgraph/fscreen) for vendor agnostic access to the Fullscreen API.
-
 ## Interfaces
 
 _The Fullscreen API has no interfaces of its own. Instead, it augments several other interfaces to add the methods, properties, and event handlers needed to provide fullscreen functionality. These are listed in the following sections._
@@ -38,8 +36,6 @@ The Fullscreen API adds methods to the {{DOMxRef("Document")}} and {{DOMxRef("El
 
 ## Instance properties
 
-_The {{DOMxRef("Document")}} interface provides properties that can be used to determine if fullscreen mode is supported and available, and if fullscreen mode is currently active, which element is using the screen._
-
 - {{DOMxRef("Document.fullscreenElement")}} / {{DOMxRef("ShadowRoot.fullscreenElement")}}
   - : The `fullscreenElement` property tells you the {{DOMxRef("Element")}} that's currently being displayed in fullscreen mode on the DOM (or shadow DOM). If this is `null`, the document (or shadow DOM) is not in fullscreen mode.
 - {{DOMxRef("Document.fullscreenEnabled")}}
@@ -54,8 +50,6 @@ _The {{DOMxRef("Document")}} interface provides properties that can be used to d
     > **Note:** Use the {{DOMxRef("Document.fullscreenElement", "fullscreenElement")}} property on the {{DOMxRef("Document")}} or {{DOMxRef("ShadowRoot")}} instead; if it's not `null`, then it's an {{DOMxRef("Element")}} currently being displayed in fullscreen mode.
 
 ## Events
-
-_The Fullscreen API defines two events which can be used to detect when fullscreen mode is turned on and off, as well as when errors occur during the process of changing between fullscreen and windowed modes._
 
 - {{domxref("Element/fullscreenchange_event", "fullscreenchange")}}
   - : Sent to an {{DOMxRef("Element")}} when it transitions into or out of fullscreen mode.


### PR DESCRIPTION
Reading [Rachel's post about baseline](https://web.dev/blog/baseline2023), I saw that it includes a bit about the Fullscreen API, but our docs there includes a note saying that it's not well-supported. This PR removes the note and also:
- removes some stuff about presentation differences which is also no longer true as far as I can see
- updates a code sample to use `event.key` instead of the deprecated `event.keyCode`
- removes some summaries which are not part of our practice.