### PR TITLE
Update HTTP Cache-Control s-maxage

### DIFF
--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -113,7 +113,7 @@ Age: 100
 
 #### `s-maxage`
 
-The `s-maxage` response directive also indicates how long the response is [fresh](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) for (similar to `max-age`) — but it is specific to shared caches, and they will ignore `max-age` when it is present.
+The `s-maxage` response directive also indicates how long the response is [fresh](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) for (similar to `max-age`) — but it is specific to shared caches and is always ignored by private caches. The `s-maxage` directive overrides the value specified by the `max-age` directive or the `Expires` header if they are present.
 
 ```http
 Cache-Control: s-maxage=604800

--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -113,7 +113,8 @@ Age: 100
 
 #### `s-maxage`
 
-The `s-maxage` response directive also indicates how long the response is [fresh](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) for (similar to `max-age`) — but it is specific to shared caches and is always ignored by private caches. The `s-maxage` directive overrides the value specified by the `max-age` directive or the `Expires` header if they are present.
+The `s-maxage` response directive indicates how long the response remains [fresh](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) in a shared cache.
+The `s-maxage` directive is ignored by private caches, and overrides the value specified by the `max-age` directive or the `Expires` header for shared caches, if they are present.
 
 ```http
 Cache-Control: s-maxage=604800


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Clarify that shared caches "ignore" (or override the value set by) `max-age` if `s-maxage` is present.
- Mention that `s-maxage` also overrides `Expires` if it is present.

### Motivation

Clarify who ignores what when max-age is present.

### Additional details

- RFC 9111: HTTP Caching https://www.rfc-editor.org/rfc/rfc9111.html#name-s-maxage

- HTTP/1.1: Header Field Definitions https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3
  * ~~I know it says it "has been superseded", but the latest version does not mention s-maxage.~~

- Also, as an example, that's how a popular cache (HAProxy) works:
> `max-age`
>
> The expiration is set as the lowest value between the s-maxage or max-age (in this order) directive in the
Cache-Control response header and this value.
>
> -- https://docs.haproxy.org/2.9/configuration.html#6.2.1-max-age

HAProxy also says:
> The cache won't store and won't deliver objects in these cases:
> . . .
> - If the response does not have an explicit expiration time (s-maxage or max-age
  Cache-Control directives or Expires header) or a validator (ETag or Last-Modified
  headers)

Which suggests it takes all of those values (including `Expires`) into account.


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
