### PR TITLE
WorkerNavigator: storage, fix intro sentence to refer to interface

### DIFF
--- a/files/en-us/web/api/workernavigator/storage/index.md
+++ b/files/en-us/web/api/workernavigator/storage/index.md
@@ -8,8 +8,8 @@ browser-compat: api.WorkerNavigator.storage
 
 {{securecontext_header}}{{APIRef("Storage")}}
 
-The **`WorkerNavigator.storage`**
-read-only property returns the singleton {{domxref("StorageManager")}} object used to
+The **`storage`** read-only property of the {{domxref("WorkerNavigator")}} interface
+returns the singleton {{domxref("StorageManager")}} object used to
 access the overall storage capabilities of the browser for the current site or app.
 The returned object lets you examine and configure persistence of data stores and
 learn approximately how much more space your browser has available for local storage


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changes first sentence from:

> The WorkerNavigator.storage read-only property

…to:

> The `storage` read-only property of the [WorkerNavigator](https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator) interface

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The new version matches better with the pages of WorkerNavigator’s other properties, such as [WorkerNavigator: `serviceWorker`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator/serviceWorker). 

The new version is also more accurate because `WorkerNavigator.storage` erroneously suggests that `WorkerNavigator` is the name of a real variable and that `storage` is a real property on that variable.

<!-- ❓ Why are you making these changes and how do they help readers? -->