### PR TITLE
Minor: code comment location

### DIFF
--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -118,8 +118,8 @@ Declarations in a keyframe qualified with `!important` are ignored.
     margin-top: 50px;
   }
   50% {
-    margin-top: 150px !important;
-  } /* ignored */
+    margin-top: 150px !important;  /* ignored */
+  }
   to {
     margin-top: 100px;
   }
@@ -160,5 +160,6 @@ See [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animatio
 - {{cssxref("animation-range")}}
 - [CSS scroll-driven animations](/en-US/docs/Web/CSS/CSS_scroll-driven_animations)
 - [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations)
+- [CSS animations](/en-US/docs/Web/CSS/CSS_animations/) module
 - [Animate elements on scroll with Scroll-driven animations](https://developer.chrome.com/docs/css-ui/scroll-driven-animations)
 - {{domxref("AnimationEvent")}}

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -118,7 +118,7 @@ Declarations in a keyframe qualified with `!important` are ignored.
     margin-top: 50px;
   }
   50% {
-    margin-top: 150px !important;  /* ignored */
+    margin-top: 150px !important; /* ignored */
   }
   to {
     margin-top: 100px;

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -160,6 +160,6 @@ See [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animatio
 - {{cssxref("animation-range")}}
 - [CSS scroll-driven animations](/en-US/docs/Web/CSS/CSS_scroll-driven_animations)
 - [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations)
-- [CSS animations](/en-US/docs/Web/CSS/CSS_animations/) module
+- [CSS animations](/en-US/docs/Web/CSS/CSS_animations) module
 - [Animate elements on scroll with Scroll-driven animations](https://developer.chrome.com/docs/css-ui/scroll-driven-animations)
 - {{domxref("AnimationEvent")}}


### PR DESCRIPTION
The comment was after the block and should have been after or before the property. set it to match the other comment.

Aso added a link to CSS module since I was editing. 