### PR TITLE
Fix spec-url for <alpha-value>

### DIFF
--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -2,8 +2,7 @@
 title: <alpha-value>
 slug: Web/CSS/alpha-value
 page-type: css-type
-spec-urls: https://drafts.csswg.org/css-color/#alpha-syntax
----
+spec-urls: https://drafts.csswg.org/css-color/#typedef-color-alpha-value
 
 {{CSSRef}}
 

--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -3,6 +3,7 @@ title: <alpha-value>
 slug: Web/CSS/alpha-value
 page-type: css-type
 spec-urls: https://drafts.csswg.org/css-color/#typedef-color-alpha-value
+---
 
 {{CSSRef}}
 

--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -2,7 +2,7 @@
 title: <alpha-value>
 slug: Web/CSS/alpha-value
 page-type: css-type
-spec-urls: https://drafts.csswg.org/css-color/#type-def-alpha-value
+spec-urls: https://drafts.csswg.org/css-color/#alpha-syntax
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
The spec URL was wrong; this may be the reason the syntax doesn't appear (mdn/yari#10179) but, even if not, should be fixed.