### PR TITLE
Fix broken link

### DIFF
--- a/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -69,7 +69,7 @@ The following Web APIs are available to workers:
 - {{domxref("Permissions API", "", "", "nocode")}}
 - {{domxref("Prioritized Task Scheduling API", "", "", "nocode")}}
 - {{domxref("Push API", "", "", "nocode")}}
-- {{domxref("Server-Sent Events", "", "", "nocode")}}
+- {{domxref("Server-sent events", "", "", "nocode")}}
 - {{domxref("Service Worker API", "", "", "nocode")}}
 - {{domxref("Streams API", "", "", "nocode")}}
 - {{domxref("Trusted Types API", "", "", "nocode")}}


### PR DESCRIPTION
There was a problem with the capitalization. The link was broken (red link) while the page does exist.