### PR TITLE
Remove link to non-existent properties

### DIFF
--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -17,7 +17,7 @@ page-type: firefox-release-notes
 ### CSS
 
 - The property {{cssxref("background-blend-mode")}} has been enabled by default ([Firefox bug 970600](https://bugzil.la/970600)).
-- The non-standard {{cssxref("overflow-clip-box")}} property has been implemented for use in UA stylesheets only ([Firefox bug 966992](https://bugzil.la/966992)).
+- The non-standard `overflow-clip-box`")}}` property has been implemented for use in UA stylesheets only ([Firefox bug 966992](https://bugzil.la/966992)).
 - The {{cssxref("line-height")}} property now affects single-line text inputs (`<input type=text|password|email|search|tel|url|unknown>` types) although it cannot shrink them below a line height of `1.0` ([Firefox bug 349259](https://bugzil.la/349259)).
 - The {{cssxref("line-height")}} property now also affects `type=button`, with no restrictions ([Firefox bug 697451](https://bugzil.la/697451)).
 - Change to keyframes' name does not affect current elements ([Firefox bug 978648](https://bugzil.la/978648)).

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -25,9 +25,6 @@ Firefox supports a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_,
 - {{CSSxRef("-moz-image-region")}} {{deprecated_inline}}
 - {{CSSxRef("-moz-orient")}} {{non-standard_inline}}
 - {{CSSxRef("font-smooth", "-moz-osx-font-smoothing")}} {{non-standard_inline}}
-- {{CSSxRef("overflow-clip-box")}} {{experimental_inline}} (To use inside the UA spreadsheet)
-- {{CSSxRef("overflow-clip-box-block")}} {{experimental_inline}} (To use inside the UA spreadsheet)
-- {{CSSxRef("overflow-clip-box-inline")}} {{experimental_inline}} (To use inside the UA spreadsheet)
 - {{CSSxRef("-moz-user-focus")}} {{non-standard_inline}}
 - {{CSSxRef("-moz-user-input")}} {{non-standard_inline}}
 - {{CSSxRef("user-modify", "-moz-user-modify")}} {{non-standard_inline}}


### PR DESCRIPTION
These 3 properties were never visible from a website. They did exist, but only in the UA spreadsheet. They don't qualify for MDN so they won't be documented (in fact, we likely removed these pages).