### PR TITLE
Fix examples in `CookieStore` interface

### DIFF
--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -57,7 +57,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
 In this example, a cookie is deleted by passing the name to the `delete()` method.
 
 ```js
-const result = window.cookieStore.delete("cookie1");
+const result = cookieStore.delete("cookie1");
 
 console.log(result);
 ```

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -54,7 +54,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
 
 ## Examples
 
-In this example a cookie is deleted by passing the name to the `delete()` method.
+In this example, a cookie is deleted by passing the name to the `delete()` method.
 
 ```js
 let result = cookieStore.delete("cookie1");

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -57,7 +57,8 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion
 In this example, a cookie is deleted by passing the name to the `delete()` method.
 
 ```js
-let result = cookieStore.delete("cookie1");
+const result = window.cookieStore.delete("cookie1");
+
 console.log(result);
 ```
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -88,10 +88,11 @@ A {{jsxref("Promise")}} that resolves with an object representing the first cook
 
 ## Examples
 
-In this example we return a cookie named "cookie1". If the cookie is found the result of the Promise is an object containing the details of a single cookie.
+In this example, we return a cookie named "cookie1". If the cookie is found the result of the Promise is an object containing the details of a single cookie.
 
 ```js
-let cookie = cookieStore.get("cookie1");
+const cookie = await window.cookieStore.get("cookie1");
+
 if (cookie) {
   console.log(cookie);
 } else {

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -91,7 +91,7 @@ A {{jsxref("Promise")}} that resolves with an object representing the first cook
 In this example, we return a cookie named "cookie1". If the cookie is found the result of the Promise is an object containing the details of a single cookie.
 
 ```js
-const cookie = await window.cookieStore.get("cookie1");
+const cookie = await cookieStore.get("cookie1");
 
 if (cookie) {
   console.log(cookie);

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -88,11 +88,12 @@ Each object contains the following properties:
 
 ## Examples
 
-In this example we use `getAll()` with no parameters. This returns all of the cookies for this context as an array of objects.
+In this example, we use `getAll()` with no parameters. This returns all of the cookies for this context as an array of objects.
 
 ```js
-let cookies = await cookieStore.getAll();
-if (cookies) {
+const cookies = await window.cookieStore.getAll();
+
+if (cookies.length > 0) {
   console.log(cookies);
 } else {
   console.log("Cookie not found");

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -91,7 +91,7 @@ Each object contains the following properties:
 In this example, we use `getAll()` with no parameters. This returns all of the cookies for this context as an array of objects.
 
 ```js
-const cookies = await window.cookieStore.getAll();
+const cookies = await cookieStore.getAll();
 
 if (cookies.length > 0) {
   console.log(cookies);

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -33,7 +33,7 @@ The `CookieStore` is accessed via attributes in the global scope in a {{domxref(
 
 ## Examples
 
-In this example we set a cookie and write to the console feedback as to whether the operation succeeded or failed.
+In this example, we set a cookie and write to the console feedback as to whether the operation succeeded or failed.
 
 ```js
 const day = 24 * 60 * 60 * 1000;

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -76,7 +76,7 @@ The following example sets a cookie by passing an object with `name`, `value`, `
 ```js
 const day = 24 * 60 * 60 * 1000;
 
-window.cookieStore.set({
+cookieStore.set({
   name: "cookie1",
   value: "cookie1-value",
   expires: Date.now() + day,

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -75,7 +75,8 @@ The following example sets a cookie by passing an object with `name`, `value`, `
 
 ```js
 const day = 24 * 60 * 60 * 1000;
-cookieStore.set({
+
+window.cookieStore.set({
   name: "cookie1",
   value: "cookie1-value",
   expires: Date.now() + day,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
`CookieStore.get()` returns a Promise, and to get value must use `await`

`CookieStore.getAll()` returna a Promise resolves to an array, and to check if it is empty, we must check the `length` property of array

some other fixes

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

working on https://developer.mozilla.org/en-US/docs/Web/API/Cookie_Store_API
reference to https://wicg.github.io/cookie-store/

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
