### PR TITLE
Extend the `Location.assign` page with other URL options

### DIFF
--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -31,7 +31,7 @@ assign(url)
 ### Parameters
 
 - `url`
-  - : A string containing the URL of the page to navigate to. It can be either an absolute URL or a relative URL.
+  - : A string containing the URL of the page to navigate to; for example, an absolute URL such as `https://developer.mozilla.org/en-US/docs/Web/API/Location/reload`, or a relative URL — such as `"/Web` (just a path, for navigating to another document at the same origin) or `#specifications` (just a fragment string, for navigating to some part of the same page), and so on.
 
 ### Return value
 

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -46,7 +46,7 @@ window.location.assign(
 );
 
 // Then navigate to its Specifications section
-window.location.assign("#specification");
+window.location.assign("#specifications");
 
 // Eventually navigate to https://developer.mozilla.org/en-US/docs/Web
 window.location.assign("/Web");

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -31,7 +31,7 @@ assign(url)
 ### Parameters
 
 - `url`
-  - : A string containing the URL of the page to navigate to.
+  - : A string containing the URL of the page to navigate to. It can be an absolute and full path, as well as relative path to a subdirectory of website.
 
 ### Return value
 
@@ -43,6 +43,16 @@ None ({{jsxref("undefined")}}).
 // Navigate to the Location.reload article
 window.location.assign(
   "https://developer.mozilla.org/en-US/docs/Web/API/Location/reload",
+);
+
+// Then navigate to it's #Specifications section
+window.location.assign(
+  "#specification",
+);
+
+// Eventually navigate to https://developer.mozilla.org/en-US/docs/Web
+window.location.assign(
+  "/Web"
 );
 ```
 

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -31,7 +31,7 @@ assign(url)
 ### Parameters
 
 - `url`
-  - : A string containing the URL of the page to navigate to. It can be an absolute and full path, as well as relative path to a subdirectory of website.
+  - : A string containing the URL of the page to navigate to. It can be either an absolute URL or a relative URL.
 
 ### Return value
 
@@ -45,7 +45,7 @@ window.location.assign(
   "https://developer.mozilla.org/en-US/docs/Web/API/Location/reload",
 );
 
-// Then navigate to it's #Specifications section
+// Then navigate to its Specifications section
 window.location.assign("#specification");
 
 // Eventually navigate to https://developer.mozilla.org/en-US/docs/Web

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -31,7 +31,7 @@ assign(url)
 ### Parameters
 
 - `url`
-  - : A string containing the URL of the page to navigate to; for example, an absolute URL such as `https://developer.mozilla.org/en-US/docs/Web/API/Location/reload`, or a relative URL — such as `"/Web` (just a path, for navigating to another document at the same origin) or `#specifications` (just a fragment string, for navigating to some part of the same page), and so on.
+  - : A string containing the URL of the page to navigate to; for example, an absolute URL such as `https://developer.mozilla.org/en-US/docs/Web/API/Location/reload`, or a relative URL — such as `"/Web` (just a path, for navigating to another document at the same origin) or `#specifications` (just a fragment string, for navigating to some part of the same page), and so on.
 
 ### Return value
 

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -46,14 +46,10 @@ window.location.assign(
 );
 
 // Then navigate to it's #Specifications section
-window.location.assign(
-  "#specification",
-);
+window.location.assign("#specification");
 
 // Eventually navigate to https://developer.mozilla.org/en-US/docs/Web
-window.location.assign(
-  "/Web"
-);
+window.location.assign("/Web");
 ```
 
 ## Specifications


### PR DESCRIPTION
This pull request closes #30017 

It extends the description of `url` parameter of `Location.assign` function to mention the possibility of using other options of URLs to navigate to, both relative and absolute.
Also, the Examples section was provided with two additional `location.assign` calls: one to navigate to relative `#specification` URL, and second to use absolute path to navigate directly to subdirectory of the root.

I decided to put both calls into one example, to keep the navigation history and to utilize the fact, that after first example call the website will contain the `Specification` section to navigate to.