### PR TITLE
Local testing server - remove case of example centric ness

### DIFF
--- a/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -83,7 +83,7 @@ To do this:
    py -V
    ```
 
-3. This should return a version number. If this is OK, navigate to the directory that your example is inside, using the `cd` command.
+3. This should return a version number. If this is OK, navigate to the directory that contains the website code you want to test, using the `cd` command.
 
    ```bash
    # include the directory name to enter it, for example


### PR DESCRIPTION
The "how to set up a local testing server" doc explains how to run the Learn examples that can't be run just by double clicking files.

In #30978 someone was confused by what we meant by example in the Python server step. While this is invalid if you read the whole document, it is possible that some links go just to this location. 
As a trivial fix I have therefore changed the text to say "the website code you want to test".'

We could make this whole page fully independent of the learn examples, but I don't see the value/necessity.