### PR TITLE
one-time-code definition fix

### DIFF
--- a/files/en-us/web/html/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/attributes/autocomplete/index.md
@@ -59,7 +59,8 @@ If an {{HTMLElement("input")}}, {{HTMLElement("select")}} or {{HTMLElement("text
 - "`current-password`"
   - : The user's current password.
 - "`one-time-code`"
-  - : A one-time password (OTP) for verifying user information, most commonly a phone number used as an additional factor in a sign-in flow.
+  - : A one-time password (OTP) for verifying user identity that is used as an additional factor in a sign-in flow.
+    Most commonly this is a code received via some out-of-channel mechanism, such as SMS, e-mail, or authenticator application.
 - "`organization-title`"
   - : A job title, or the title a person has within an organization, such as "Senior Technical Writer", "President", or "Assistant Troop Leader".
 - "`organization`"

--- a/files/en-us/web/html/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/attributes/autocomplete/index.md
@@ -60,7 +60,7 @@ If an {{HTMLElement("input")}}, {{HTMLElement("select")}} or {{HTMLElement("text
   - : The user's current password.
 - "`one-time-code`"
   - : A one-time password (OTP) for verifying user identity that is used as an additional factor in a sign-in flow.
-    Most commonly this is a code received via some out-of-channel mechanism, such as SMS, e-mail, or authenticator application.
+    Most commonly this is a code received via some out-of-channel mechanism, such as SMS, email, or authenticator application.
 - "`organization-title`"
   - : A job title, or the title a person has within an organization, such as "Senior Technical Writer", "President", or "Assistant Troop Leader".
 - "`organization`"


### PR DESCRIPTION
Fixes #30952.

The original said a one-time-code was a phone number. It isn't :-).