### PR TITLE
Mention webkitURL alias and clarify how to fall back to prefixed variant

### DIFF
--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -11,7 +11,11 @@ The **`URL`** interface is used to parse, construct, normalize, and encode {{glo
 
 You normally create a new `URL` object by specifying the URL as a string when calling its constructor, or by providing a relative URL and a base URL. You can then easily read the parsed components of the URL or make changes to the URL.
 
-If a browser doesn't yet support the {{domxref("URL.URL", "URL()")}} constructor, you can access a URL object using the {{domxref("Window")}} interface's {{domxref("URL")}} property. Be sure to check to see if any of your target browsers require this to be prefixed.
+`webkitURL` is an alias to `URL`. Some older browsers only support `webkitURL` (or other prefix). If compatibility with such browsers is needed, you can use property accessor syntax and fall back to the prefixed variant(s), e.g.:
+
+```js
+const URL = window.URL || window.webkitURL;
+```
 
 {{AvailableInWorkers}}
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1366738#c10

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Mention webkitURL alias and clarify how to fall back to prefixed variant.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The old text was unclear to me (you *can't* access a URL object from `window.URL` if the browser doesn't support it!).

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

`URL` has existed in browsers unprefixed for many years now, maybe it's not needed to mention how to fall back to prefixed variants at all?

(Even in that case, `webkitURL` should still be mentioned because it's a standardized alias.)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
