### PR TITLE
Update: Document Picture-in-Picture API Usage

### DIFF
--- a/files/en-us/web/api/document_picture-in-picture_api/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/index.md
@@ -37,6 +37,7 @@ The Picture-in-Picture window is similar to a blank same-origin window opened vi
 - The Picture-in-Picture window never outlives the opening window.
 - The Picture-in-Picture window cannot be navigated.
 - The Picture-in-Picture window position cannot be set by the website.
+- The Picture-in-Picture window is limited to one per website at a time, with the user agent potentially further restricting the global number of Picture-in-Picture windows open.
 
 Apart from that, you can manipulate the Picture-in-Picture window's `Window` instance however you want, for example appending the content you want to display there onto its DOM, and copying stylesheets to it so that the appended content will be styled the same way as when it is in the main window. You can also close the Picture-in-Picture window (by clicking the browser-provided control, or by running {{domxref("Window.close()")}} on it), and then react to it closing using the standard [`pagehide`](/en-US/docs/Web/API/Window/pagehide_event). When it closes, you'll want to put the content it was showing back into the main app window.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add language on Document PiP usage restriction.

You can only open one PiP window per website, and the browser may restrict the number of PiP windows open globally (for Chrome 120, this number is 1).

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

It's important to alert readers of this restriction so that they don't use this API assuming that they can pop out multiple PiP windows at once.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
It's documented [here](https://github.com/WICG/document-picture-in-picture#:~:text=The%20website%20can%20have%20only%20one%20PiP%20window%20open%20at%20a%20time%2C%20and%20the%20user%20agent%20may%20also%20restrict%20how%20many%20PiP%20windows%20can%20be%20open%20globally%2C%20similar%20to%20HTMLVideoElement.requestPictureInPicture()%20API.).
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
