### PR TITLE
Fix grammar

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -7,7 +7,7 @@ browser-compat: api.console
 
 {{APIRef("Console API")}}
 
-The **`console`** object provides access to the debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works varies from browser to browser or server runtimes (Node.js for example), but there is a _de facto_ set of features that are typically provided.
+The **`console`** object provides access to the debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works vary from browser to browser or server runtimes (Node.js for example), but there is a _de facto_ set of features that are typically provided.
 
 The `console` object can be accessed from any global object. {{domxref("Window")}} on browsing scopes and {{domxref("WorkerGlobalScope")}} as specific variants in workers via the property console. It's exposed as {{domxref("Window.console")}}, and can be referenced as `console`. For example:
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -7,7 +7,7 @@ browser-compat: api.console
 
 {{APIRef("Console API")}}
 
-The **`console`** object provides access to the debugging console (e.g. the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works vary from browser to browser or server runtimes (Node.js for example), but there is a _de facto_ set of features that are typically provided.
+The **`console`** object provides access to the debugging console (e.g., the [Web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html) in Firefox). The specifics of how it works vary from browser to browser or server runtimes (Node.js, for example), but there is a _de facto_ set of features that are typically provided.
 
 The `console` object can be accessed from any global object. {{domxref("Window")}} on browsing scopes and {{domxref("WorkerGlobalScope")}} as specific variants in workers via the property console. It's exposed as {{domxref("Window.console")}}, and can be referenced as `console`. For example:
 


### PR DESCRIPTION
The noun "specifics" is plural, so I believe the corresponding verb should also be plural. Therefore, the verb should be "vary" instead of "varies."
