### PR TITLE
Fix grammar

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -123,7 +123,7 @@ class Counter {
     this.count = 0;
   }
   add(array) {
-    // Only function expressions will have its own this binding
+    // Only a function expression will have its own this binding.
     array.forEach(function countEntry(entry) {
       this.sum += entry;
       ++this.count;

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -123,7 +123,7 @@ class Counter {
     this.count = 0;
   }
   add(array) {
-    // Only a function expression will have its own this binding.
+    // Only function expressions have their own this bindings.
     array.forEach(function countEntry(entry) {
       this.sum += entry;
       ++this.count;


### PR DESCRIPTION
The plural noun "expressions" and the singular pronoun "its" do not agree. You can either make both singular or both plural. I chose to make both singular.