### PR TITLE
Clarify return value of Promise.prototype.catch()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
@@ -26,7 +26,7 @@ promiseInstance.catch(onRejected)
 
 ### Return value
 
-Returns a new {{jsxref("Promise")}}. This new promise is always pending when returned, regardless of the current promise's status. It's eventually rejected if `onRejected` throws an error or returns a Promise which is itself rejected; otherwise, it's eventually fulfilled.
+Returns a new {{jsxref("Promise")}}. This new promise is always pending when returned, regardless of the current promise's status. It's eventually rejected if `onRejected` throws an error or returns a Promise which is itself rejected; otherwise, it's eventually fulfilled with the current promise's fulfillment value.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
@@ -26,7 +26,7 @@ promiseInstance.catch(onRejected)
 
 ### Return value
 
-Returns a new {{jsxref("Promise")}}. This new promise is always pending when returned, regardless of the current promise's status. If `onRejected` is called, the returned promise will resolve based on the return value or thrown error of this call. If the current promise fulfills, `onRejected` is not called and the returned promise fulfills to the same value.
+Returns a new {{jsxref("Promise")}}. This new promise is always pending when returned, regardless of the current promise's status. If `onRejected` is called, the returned promise will resolve based on the return value of this call, or reject with the thrown error from this call. If the current promise fulfills, `onRejected` is not called and the returned promise fulfills to the same value.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
@@ -26,7 +26,7 @@ promiseInstance.catch(onRejected)
 
 ### Return value
 
-Returns a new {{jsxref("Promise")}}. This new promise is always pending when returned, regardless of the current promise's status. It's eventually rejected if `onRejected` throws an error or returns a Promise which is itself rejected; otherwise, it's eventually fulfilled with the current promise's fulfillment value.
+Returns a new {{jsxref("Promise")}}. This new promise is always pending when returned, regardless of the current promise's status. If `onRejected` is called, the returned promise will resolve based on the return value or thrown error of this call. If the current promise fulfills, `onRejected` is not called and the returned promise fulfills to the same value.
 
 ## Description
 


### PR DESCRIPTION
In case the promise is fulfilled, this change clarifies that the returned promise fulfills to the current promise fulfillment value.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarify return value of Promise.prototype.catch(). In case the current promise is fulfilled, this change clarifies that the returned promise fulfills to the current promise's fulfillment value.

### Motivation

It's not currently clear what the returned promise resolves to.