### PR TITLE
Fix bug #30924 regarding CSS math functions example content

### DIFF
--- a/files/en-us/web/css/css_functions/using_css_math_functions/index.md
+++ b/files/en-us/web/css/css_functions/using_css_math_functions/index.md
@@ -264,7 +264,7 @@ Click on the play icon below to see the `clamp()` example in the code playground
   <code>width: clamp(10%, 9999px, 90%);</code>
 </div>
 <div class="clamp3">
-  <code>width: clamp(25px, 1px, 150px);</code>
+  <code>width: clamp(125px, 1px, 250px);</code>
 </div>
 <div class="clamp4">
   <code>width: clamp(25px, 9999px, 150px);</code>


### PR DESCRIPTION
A ten-character change to fix the incorrect HTML in some example code.

Fixes #30924.

Thank you for the catch, @dzichonka!