### PR TITLE
Fix Media Session API GroupData & Update `MediaMetadata` constructor parameters

### DIFF
--- a/files/en-us/web/api/media_session_api/index.md
+++ b/files/en-us/web/api/media_session_api/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaSession
 
 {{DefaultAPISidebar("Media Session API")}}
 
-The Media Session API provides a way to customize media notifications. It does this by providing metadata for display by the user agent for the media your web app is playing.
+The **Media Session API** provides a way to customize media notifications. It does this by providing metadata for display by the user agent for the media your web app is playing.
 
 It also provides action handlers that the browser can use to access platform media keys such as hardware keys found on keyboards, headsets, remote controls, and software keys found in notification areas and on lock screens of mobile devices. So you can seamlessly control web-provided media via your device, even when not looking at the web page.
 

--- a/files/en-us/web/api/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaMetadata
 
 {{APIRef("Media Session API")}}
 
-The **`MediaMetadata`** interface of the [Media Session API](/en-US/docs/Web/API/Media_Session_API) allows a web page to provide rich media metadata for display in a platform UI.
+The **`MediaMetadata`** interface of the {{domxref("Media Session API", "", "", "nocode")}} allows a web page to provide rich media metadata for display in a platform UI.
 
 ## Constructor
 

--- a/files/en-us/web/api/mediametadata/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.md
@@ -24,12 +24,20 @@ new MediaMetadata(metadata)
 
   - : The metadata parameters are as follows:
 
-    - `title`: The title of the media to be played.
-    - `artist`: The name of the artist, group, creator, etc. of the media
-      to be played.
-    - `album`: The name of the album, or collection, containing the media
-      to be played.
-    - `artwork`: An array of images associated with the playing media.
+    - `title` {{optional_inline}}
+      - : The title of the media to be played. It defaults to the empty string (`""`).
+    - `artist` {{optional_inline}}
+      - : The name of the artist, group, creator, etc. of the media to be played. It defaults to the empty string (`""`).
+    - `album` {{optional_inline}}
+      - : The name of the album, or collection, containing the media to be played. It defaults to the empty string (`""`).
+    - `artwork` {{optional_inline}}
+      - : An {{jsxref("Array")}} of objects that represent images associated with the playing media that defaults to be an empty array. The object structure is:
+        - `src`
+          - : The URL from which the user agent fetches the image's data.
+        - `sizes` {{optional_inline}}
+          - : Specifies the resource in multiple sizes so the user agent doesn't have to scale a single image. It defaults to the empty string (`""`).
+        - `type` {{optional_inline}}
+          - : The {{Glossary("MIME type")}} hint for the user agent that allows it to ignore images of types that it doesn't support. However, the user agent may still use MIME type sniffing after downloading the image to determine its type. It defaults to the empty string (`""`).
 
 ## Example
 

--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaSession
 
 {{APIRef("Media Session API")}}
 
-The **`MediaSession`** interface of the [Media Session API](/en-US/docs/Web/API/Media_Session_API) allows a web page to provide custom behaviors for standard media playback interactions, and to report metadata that can be sent by the user agent to the device or operating system for presentation in standardized user interface elements.
+The **`MediaSession`** interface of the {{domxref("Media Session API", "", "", "nocode")}} allows a web page to provide custom behaviors for standard media playback interactions, and to report metadata that can be sent by the user agent to the device or operating system for presentation in standardized user interface elements.
 
 For example, a smartphone might have a standard panel in its lock screen that provides controls for media playback and information display. A browser on the device can use `MediaSession` to make browser playback controllable from that standard/global user interface.
 

--- a/files/en-us/web/api/navigator/mediasession/index.md
+++ b/files/en-us/web/api/navigator/mediasession/index.md
@@ -6,10 +6,10 @@ page-type: web-api-instance-property
 browser-compat: api.Navigator.mediaSession
 ---
 
-{{APIRef}}
+{{APIRef("Media Session API")}}
 
-The read-only {{domxref("Navigator")}} property
-**`mediaSession`** returns a {{domxref("MediaSession")}}
+The read-only **`mediaSession`** property of the {{domxref("Navigator")}}
+interface returns a {{domxref("MediaSession")}}
 object that can be used to share with the browser metadata and other information about
 the current playback state of media being handled by a document.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -903,12 +903,11 @@
     },
     "Media Session API": {
       "overview": ["Media Session API"],
+      "guides": [],
       "interfaces": ["MediaMetadata", "MediaSession"],
       "methods": [],
       "properties": ["Navigator.mediaSession"],
-      "events": [],
-      "types": ["MediaSessionAction", "MediaSessionPlaybackState"],
-      "callbacks": ["MediaSessionActionHandler"]
+      "events": []
     },
     "Media Source Extensions": {
       "overview": ["Media Source Extensions API"],


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

remove the two `types` and `callbacks` useless member from Media Session API GroupData, this relates to #30665 

update `MediaMetadata` constructor parameters by add {{optional_inline}} if necessary and add details for `artwork` parameter

fix the usage of {{APIRef}} in `Navigator.mediaSession`

some other style update

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests



<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
