### PR TITLE
Corrected dynamic import document redirect link

### DIFF
--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -30,7 +30,7 @@ Lazy loading can be applied to multiple resources and through multiple strategie
 JavaScript, CSS and HTML can be split into smaller chunks. This enables sending the minimal code required to provide value upfront, improving page-load times. The rest can be loaded on demand.
 
 - Entry point splitting: separates code by entry point(s) in the app
-- Dynamic splitting: separates code where [dynamic import()](/en-US/docs/Web/JavaScript/Reference/Statements/import) statements are used
+- Dynamic splitting: separates code where [dynamic import()](/en-US/docs/Web/JavaScript/Reference/Operators/import) statements are used 
 
 ### JavaScript
 

--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -30,7 +30,7 @@ Lazy loading can be applied to multiple resources and through multiple strategie
 JavaScript, CSS and HTML can be split into smaller chunks. This enables sending the minimal code required to provide value upfront, improving page-load times. The rest can be loaded on demand.
 
 - Entry point splitting: separates code by entry point(s) in the app
-- Dynamic splitting: separates code where [dynamic import()](/en-US/docs/Web/JavaScript/Reference/Operators/import) statements are used
+- Dynamic splitting: separates code where [dynamic import()](/en-US/docs/Web/JavaScript/Reference/Operators/import) expressions are used
 
 ### JavaScript
 

--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -30,7 +30,7 @@ Lazy loading can be applied to multiple resources and through multiple strategie
 JavaScript, CSS and HTML can be split into smaller chunks. This enables sending the minimal code required to provide value upfront, improving page-load times. The rest can be loaded on demand.
 
 - Entry point splitting: separates code by entry point(s) in the app
-- Dynamic splitting: separates code where [dynamic import()](/en-US/docs/Web/JavaScript/Reference/Operators/import) statements are used 
+- Dynamic splitting: separates code where [dynamic import()](/en-US/docs/Web/JavaScript/Reference/Operators/import) statements are used
 
 ### JavaScript
 


### PR DESCRIPTION
Correcting dynamic import document redirect link which was previously pointing to static import document.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correcting dynamic import document redirect link which was previously pointing to static import document.

### Motivation

It redirects the user to the correct page based on the context.

### Additional details

Static Import Doc - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import 
Dynamic Import Doc - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
