### PR TITLE
proxy.settings-passthrough guidance update

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -7,18 +7,16 @@ browser-compat: webextensions.api.proxy.settings
 
 {{AddonSidebar()}}
 
-A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object that can be used to change the browser's proxy settings.
+A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object used to change the browser's proxy settings.
 
-> **Note:** Changing proxy settings requires private browsing window access because proxy settings affect private and non-private windows. Whether an extension can access private browsing windows is under user control. For details, see [Extensions in Private Browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing). Your extension can check whether it can access private browsing windows using {{WebExtAPIRef("extension.isAllowedIncognitoAccess")}}. If your extension does not have private window permission, calls to `proxy.settings.set()` throw an exception.
+> **Note:** Changing proxy settings requires private browsing window access because proxy settings affect private and non-private windows. Whether an extension can access private browsing windows is under user control. See [Extensions in Private Browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing) for details. Your extension can check whether it hat access to private browsing windows using {{WebExtAPIRef("extension.isAllowedIncognitoAccess")}}. If your extension doesn't have private window permission, calls to `proxy.settings.set()` throw an exception.
 
-The underlying value is an object with the properties listed below.
-
-When setting this object, all properties are optional. Note that any properties that are omitted will be reset to their default value.
+The underlying value is an object. When setting this object, all properties are optional. Any omitted properties are reset to their default value.
 
 - `autoConfigUrl` {{optional_inline}}
   - : `string`. A URL to use to configure the proxy.
 - `autoLogin` {{optional_inline}}
-  - : `boolean`. Do not prompt for authentication if the password is saved. Defaults to `false`.
+  - : `boolean`. Don't prompt for authentication if the password is saved. Defaults to `false`.
 - `ftp` {{optional_inline}} {{Deprecated_Inline}}
   - : `string`. The address of the FTP proxy. Can include a port.
 - `http` {{optional_inline}}
@@ -26,11 +24,22 @@ When setting this object, all properties are optional. Note that any properties 
 - `httpProxyAll` {{optional_inline}}
   - : `boolean`. Use the HTTP proxy server for all protocols. Defaults to `false`.
 - `passthrough` {{optional_inline}}
-  - : `string`. A comma-separated list of hosts which should not be proxied. Defaults to "localhost, 127.0.0.1".
+
+  - : `string`. A comma-separated list of hosts that shouldn't be proxied. Can be defined as:
+
+    - `HOST_PATTERN[:PORT]`, but not with scheme, e.g., `SCHEME://]HOST_PATTERN[:PORT]`. See [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns)
+    - `IP_LITERAL[:PORT]`, but not with scheme, e.g., `SCHEME://]IP_LITERAL[:PORT]`
+    - `IP_LITERAL/PREFIX_LENGTH_IN_BITS`, using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation)
+    - `<local>`, to bypass proxying for all hostnames that don't contain periods.
+
+    You can use IPv6 addresses.
+
+    Hosts`localhost` and `127.0.0.1` are never proxied.
+
 - `proxyDNS` {{optional_inline}}
   - : `boolean`. Proxy DNS when using SOCKS5. Defaults to `false`.
 - `proxyType` {{optional_inline}}
-  - : `string`. The type of proxy to use. This may take any one of the following values: "none", "autoDetect", "system", "manual", "autoConfig". Defaults to "system".
+  - : `string`. The type of proxy to use. This may take: "none", "autoDetect", "system", "manual", "autoConfig". Defaults to "system".
 - `socks` {{optional_inline}}
   - : `string`. The address of the SOCKS proxy. Can include a port.
 - `socksVersion` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -9,7 +9,7 @@ browser-compat: webextensions.api.proxy.settings
 
 A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object used to change the browser's proxy settings.
 
-> **Note:** Changing proxy settings requires private browsing window access because proxy settings affect private and non-private windows. Whether an extension can access private browsing windows is under user control. See [Extensions in Private Browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing) for details. Your extension can check whether it hat access to private browsing windows using {{WebExtAPIRef("extension.isAllowedIncognitoAccess")}}. If your extension doesn't have private window permission, calls to `proxy.settings.set()` throw an exception.
+> **Note:** Changing proxy settings requires private browsing window access because proxy settings affect private and non-private windows. Whether an extension can access private browsing windows is under user control. See [Extensions in Private Browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing) for details. Your extension can check whether it has access to private browsing windows using {{WebExtAPIRef("extension.isAllowedIncognitoAccess")}}. If your extension doesn't have private window permission, calls to `proxy.settings.set()` throw an exception.
 
 The underlying value is an object. When setting this object, all properties are optional. Any omitted properties are reset to their default value.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -34,7 +34,7 @@ The underlying value is an object. When setting this object, all properties are 
 
     You can use IPv6 addresses. For example, `[::123]`.
 
-    Hosts `localhost` and `127.0.0.1` are never proxied.
+    Hosts `localhost`, `127.0.0.1`, and `[::1]` are never proxied.
 
 - `proxyDNS` {{optional_inline}}
   - : `boolean`. Proxy DNS when using SOCKS5. Defaults to `false`.

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -27,14 +27,14 @@ The underlying value is an object. When setting this object, all properties are 
 
   - : `string`. A comma-separated list of hosts that shouldn't be proxied. Can be defined as:
 
-    - `HOST_PATTERN[:PORT]`, but not with scheme, e.g., `SCHEME://]HOST_PATTERN[:PORT]`. See [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns)
-    - `IP_LITERAL[:PORT]`, but not with scheme, e.g., `SCHEME://]IP_LITERAL[:PORT]`
+    - `HOST_NAME[:PORT]`, for example: `example.com` or `example.com:1234`
+    - `IP_LITERAL[:PORT]`
     - `IP_LITERAL/PREFIX_LENGTH_IN_BITS`, using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation)
     - `<local>`, to bypass proxying for all hostnames that don't contain periods.
 
-    You can use IPv6 addresses.
+    You can use IPv6 addresses. For example, `[::123]`.
 
-    Hosts`localhost` and `127.0.0.1` are never proxied.
+    Hosts `localhost` and `127.0.0.1` are never proxied.
 
 - `proxyDNS` {{optional_inline}}
   - : `boolean`. Proxy DNS when using SOCKS5. Defaults to `false`.


### PR DESCRIPTION
### Description

Add guidance as to the values and default settings for proxy.settings.passthrough.

### Motivation

Guidance was missing, so excepted values may not have been clear.

### Related issues and pull requests

Fixes #29680
