### PR TITLE
fix: correct the order of actions

### DIFF
--- a/files/en-us/glossary/crlf/index.md
+++ b/files/en-us/glossary/crlf/index.md
@@ -11,7 +11,7 @@ CR and LF are [control characters](https://en.wikipedia.org/wiki/Control_charact
 - CR = **Carriage Return** (`\r`, `0x0D` in hexadecimal, 13 in decimal) — moves the cursor to the beginning of the line without advancing to the next line.
 - LF = **Line Feed** (`\n`, `0x0A` in hexadecimal, 10 in decimal) — moves the cursor down to the next line without returning to the beginning of the line.
 
-A CR immediately followed by a LF (CRLF, `\r\n`, or `0x0D0A`) moves the cursor down to the next line and then to the beginning of the line.
+A CR immediately followed by a LF (CRLF, `\r\n`, or `0x0D0A`) moves the cursor to the beginning of the line and then down to the next line.
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct the order of actions:

- `CR`: move the cursor to the begining of the line.
- `LF`: move the cursor to the new line.

Although the final result is the same (`CRLF` or `LFCR`), correcting the order helps readers understand.
