### PR TITLE
Use more accessible terminology

### DIFF
--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__strings/index.md
@@ -53,7 +53,7 @@ In the next string task, you are given the same quote that you ended up with in 
 
 1. Change the casing to correct sentence case (all lowercase, except for upper case first letter). Store the new quote in a variable called `fixedQuote`.
 2. In `fixedQuote`, replace "green eggs and ham" with another food that you really don't like.
-3. There is one more small fix to do — add a full stop onto the end of the quote, and save the final version in a variable called `finalQuote`.
+3. There is one more small fix to do — add a full stop onto the end of the quote("full stop" is British English for "adding a period at the end of the sentence"), and save the final version in a variable called `finalQuote`.
 
 Try updating the live code below to recreate the finished example:
 

--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__strings/index.md
@@ -53,7 +53,7 @@ In the next string task, you are given the same quote that you ended up with in 
 
 1. Change the casing to correct sentence case (all lowercase, except for upper case first letter). Store the new quote in a variable called `fixedQuote`.
 2. In `fixedQuote`, replace "green eggs and ham" with another food that you really don't like.
-3. There is one more small fix to do — add a full stop onto the end of the quote("full stop" is British English for "adding a period at the end of the sentence"), and save the final version in a variable called `finalQuote`.
+3. There is one more small fix to do — add a period to the end of the quote, and save the final version in a variable called `finalQuote`.
 
 Try updating the live code below to recreate the finished example:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

When I was doing the exercises in the "Test Your Skills" section in the "Strings" part of the link below:

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Test_your_skills:_Strings

"Strings 3" exercise has the flowing sentence:

"There is one more small fix to do — add a full stop onto the end of the quote, and save the final version in a variable called finalQuote."

Because JavaScript has a lot of terms that people are still getting used to and are not familiar with. Saying "full stop" may confuse readers. Using " a period" might be more internationally recognized


### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
