### PR TITLE
CanvasCaptureMediaStreamTrack & captureStream() | fix apiref & syntax update

### DIFF
--- a/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
@@ -8,14 +8,11 @@ browser-compat: api.CanvasCaptureMediaStreamTrack.canvas
 
 {{APIRef}}
 
-The {{domxref("CanvasCaptureMediaStreamTrack")}} **`canvas`**
-read-only property returns the {{domxref("HTMLCanvasElement")}} from which frames are
-being captured.
+The **`canvas`** read-only property of the {{domxref("CanvasCaptureMediaStreamTrack")}} interface returns the {{domxref("HTMLCanvasElement")}} from which frames are being captured.
 
 ## Value
 
-An `HTMLCanvasElement` indicating the canvas which is the source of the
-frames being captured.
+An `HTMLCanvasElement` indicating the canvas which is the source of the frames being captured.
 
 ## Example
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CanvasCaptureMediaStreamTrack.canvas
 ---
 
-{{APIRef}}
+{{APIRef("Media Capture and Streams")}}
 
 The **`canvas`** read-only property of the {{domxref("CanvasCaptureMediaStreamTrack")}} interface returns the {{domxref("HTMLCanvasElement")}} from which frames are being captured.
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
@@ -12,7 +12,7 @@ The **`canvas`** read-only property of the {{domxref("CanvasCaptureMediaStreamTr
 
 ## Value
 
-A `HTMLCanvasElement` indicating the canvas which is the source of the frames being captured.
+An `HTMLCanvasElement` indicating the canvas, which is the source of the frames being captured.
 
 ## Example
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
@@ -12,7 +12,7 @@ The **`canvas`** read-only property of the {{domxref("CanvasCaptureMediaStreamTr
 
 ## Value
 
-An `HTMLCanvasElement` indicating the canvas which is the source of the frames being captured.
+A `HTMLCanvasElement` indicating the canvas which is the source of the frames being captured.
 
 ## Example
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/index.md
@@ -7,9 +7,7 @@ browser-compat: api.CanvasCaptureMediaStreamTrack
 
 {{APIRef("Media Capture and Streams")}}
 
-The **`CanvasCaptureMediaStreamTrack`** interface represents the video track contained in a {{domxref("MediaStream")}} being generated from a {{HTMLElement("canvas")}} following a call to {{domxref("HTMLCanvasElement.captureStream()")}}.
-
-Part of the [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API).
+The **`CanvasCaptureMediaStreamTrack`** interface of the {{domxref("Media Capture and Streams API", "", "", "nocode")}} represents the video track contained in a {{domxref("MediaStream")}} being generated from a {{HTMLElement("canvas")}} following a call to {{domxref("HTMLCanvasElement.captureStream()")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
@@ -22,12 +22,12 @@ the stream.
 ## Syntax
 
 ```js-nolint
-stream.requestFrame()
+requestFrame()
 ```
 
 ### Return value
 
-`undefined`
+None ({{jsxref("undefined")}}).
 
 ## Usage notes
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
@@ -8,9 +8,7 @@ browser-compat: api.CanvasCaptureMediaStreamTrack.requestFrame
 
 {{APIRef("Media Capture and Streams")}}
 
-The {{domxref("CanvasCaptureMediaStreamTrack")}} method
-**`requestFrame()`** requests that a frame be captured from
-the canvas and sent to the stream.
+The **`requestFrame()`** method of the {{domxref("CanvasCaptureMediaStreamTrack")}} interface requests that a frame be captured from the canvas and sent to the stream.
 
 Applications that need to carefully control
 the timing of rendering and frame capture can use `requestFrame()` to

--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
@@ -8,12 +8,13 @@ browser-compat: api.HTMLCanvasElement.captureStream
 
 {{APIRef("Media Capture and Streams")}}
 
-The {{domxref("HTMLCanvasElement")}} **`captureStream()`** method returns a {{domxref("MediaStream")}}
+The **`captureStream()`** method of the {{domxref("HTMLCanvasElement")}} interface returns a {{domxref("MediaStream")}}
 which includes a {{domxref("CanvasCaptureMediaStreamTrack")}} containing a real-time video capture of the canvas's contents.
 
 ## Syntax
 
 ```js-nolint
+captureStream()
 captureStream(frameRate)
 ```
 

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.md
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.md
@@ -6,12 +6,9 @@ page-type: web-api-instance-method
 browser-compat: api.HTMLMediaElement.captureStream
 ---
 
-{{APIRef("HTML Media Capture")}}
+{{APIRef("Media Capture and Streams")}}
 
-The **`captureStream()`** method of the
-{{domxref("HTMLMediaElement")}} interface returns a {{domxref('MediaStream')}} object
-which is streaming a real-time capture of the content being rendered in the media
-element.
+The **`captureStream()`** method of the {{domxref("HTMLMediaElement")}} interface returns a {{domxref('MediaStream')}} object which is streaming a real-time capture of the content being rendered in the media element.
 
 This can be used, for example, as a source for a [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("RTCPeerConnection")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fix apiref of `CanvasCaptureMediaStreamTrack.canvas` and `HTMLMediaElement.captureStream()`

update *syntax* and *return value* for `CanvasCaptureMediaStreamTrack.requestFrame()` and `HTMLCanvasElement.captureStream()`

soem other fixes

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
