### PR TITLE
fix: and embedliveify example for `hidePopover()`

### DIFF
--- a/files/en-us/web/api/htmlelement/hidepopover/index.md
+++ b/files/en-us/web/api/htmlelement/hidepopover/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-method
 browser-compat: api.HTMLElement.hidePopover
 ---
 
-{{ APIRef("HTML DOM") }}
+{{APIRef("HTML DOM")}}
 
-The **`hidePopover()`** method of the {{domxref("HTMLElement")}} interface hides a {{domxref("Popover_API", "popover", "", "nocode")}} element (i.e. one that has a valid [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute) by removing it from the {{glossary("top layer")}} and styling it with `display: none`.
+The **`hidePopover()`** method of the {{domxref("HTMLElement")}} interface hides a [popover](/en-US/docs/Web/API/Popover_API) element (i.e. one that has a valid [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute) by removing it from the {{glossary("top layer")}} and styling it with `display: none`.
 
 When `hidePopover()` is called on a showing element with the [`popover`](/en-US/docs/Web/HTML/Global_attributes/popover) attribute, a {{domxref("HTMLElement/beforetoggle_event", "beforetoggle")}} event will be fired, followed by the popover being hidden, and then the {{domxref("HTMLElement/toggle_event", "toggle")}} event firing. If the element is already hidden, an error is thrown.
 
@@ -35,24 +35,16 @@ None ({{jsxref("undefined")}}).
 
 The following example provides functionality to hide a popover by pressing a particular key on the keyboard.
 
-First, some HTML:
+### HTML
 
 ```html
-<div id="mypopover">
-  <h2>Help!</h2>
-
-  <p>You can use the following commands to control the app</p>
-
-  <ul>
-    <li>Press <ins>C</ins> to order cheese</li>
-    <li>Press <ins>T</ins> to order tofu</li>
-    <li>Press <ins>B</ins> to order bacon</li>
-    <hr />
-    <li>Say "Service" to summon the robot waiter to take your order</li>
-    <li>Say "Escape" to engage the ejector seat</li>
-  </ul>
+<button popovertarget="mypopover">Toggle popover's display</button>
+<div id="mypopover" popover="manual">
+  You can press <kbd>h</kbd> on your keyboard to close the popover.
 </div>
 ```
+
+### JavaScript
 
 And now the JavaScript to wire up the functionality:
 
@@ -65,6 +57,10 @@ document.addEventListener("keydown", (event) => {
   }
 });
 ```
+
+### Result
+
+{{EmbedLiveSample("","100%",100)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/hidepopover/index.md
+++ b/files/en-us/web/api/htmlelement/hidepopover/index.md
@@ -46,8 +46,6 @@ The following example provides functionality to hide a popover by pressing a par
 
 ### JavaScript
 
-And now the JavaScript to wire up the functionality:
-
 ```js
 const popover = document.getElementById("mypopover");
 


### PR DESCRIPTION
During the review of mdn/translated-content/pull/17321, I noticed that the example was actually broken.

If we were to copy/paste in a sandbox/playground, we got:
"NotSupportedError: Failed to execute 'hidePopover' on 'HTMLElement': Not supported on elements that do not have a valid value for the 'popover' attribute. This might have been the result of the "beforetoggle" event handler changing the state of this popover.
" (Chrome)
"NotSupportedError: HTMLElement.hidePopover: Element is in the no popover state" (Firefox).

This intends to fix the example and also use the overall form of HTML/JavaScript/Result/EmbedLiveSample which is used elsewhere.