### PR TITLE
Remove obsolete link from `Web/API/Navigator/getVRDisplays`

### DIFF
--- a/files/en-us/web/api/navigator/getvrdisplays/index.md
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.md
@@ -11,10 +11,7 @@ browser-compat: api.Navigator.getVRDisplays
 
 {{APIRef("WebVR API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
-The **`getVRDisplays()`** method of the
-{{domxref("Navigator")}} interface returns a promise that resolves to an array of
-{{domxref("VRDisplay")}} objects representing any available VR displays connected to the
-computer.
+The **`getVRDisplays()`** method of the {{domxref("Navigator")}} interface returns a promise that resolves to an array of {{domxref("VRDisplay")}} objects representing any available VR displays connected to the computer.
 
 ## Syntax
 
@@ -45,5 +42,3 @@ See [`VRDisplay`](/en-US/docs/Web/API/VRDisplay#examples) for example code.
 ## See also
 
 - [WebVR API homepage](/en-US/docs/Web/API/WebVR_API)
-- <https://mixedreality.mozilla.org/> —
-  demos, downloads, and other resources from the Mozilla VR team.


### PR DESCRIPTION
### Description

This PR removes obsolete link from `Web/API/Navigator/getVRDisplays`.

### Motivation

https://mixedreality.mozilla.org/ now redirects to https://hubs.mozilla.com/labs/ that is not directly related to `Web/API/Navigator/getVRDisplays`.
