### PR TITLE
Fix example on `Web/API/Screen`

### DIFF
--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -70,7 +70,7 @@ _Also inherits methods from its parent {{domxref("EventTarget")}}_.
 ## Examples
 
 ```js
-if (screen.pixelDepth < 8) {
+if (screen.colorDepth < 8) {
   // use low-color version of page
 } else {
   // use regular, colorful page


### PR DESCRIPTION
### Description

This PR fixes example on `Web/API/Screen`.

### Motivation

The comments in the example indicate that we want to define the color depth, not the pixel depth.