### PR TITLE
Web Locks API | update GroupData & fix apiref

### DIFF
--- a/files/en-us/web/api/lock/index.md
+++ b/files/en-us/web/api/lock/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.Lock
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks API")}}
 
 The **`Lock`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides the name and mode of a lock.
 This may be a newly requested lock that is received in the callback to {{domxref('LockManager.request','LockManager.request()')}}, or a record of an active or queued lock returned by {{domxref('LockManager.query()')}}.

--- a/files/en-us/web/api/lock/index.md
+++ b/files/en-us/web/api/lock/index.md
@@ -5,10 +5,12 @@ page-type: web-api-interface
 browser-compat: api.Lock
 ---
 
-{{APIRef("Web Locks API")}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`Lock`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides the name and mode of a lock.
 This may be a newly requested lock that is received in the callback to {{domxref('LockManager.request','LockManager.request()')}}, or a record of an active or queued lock returned by {{domxref('LockManager.query()')}}.
+
+{{AvailableInWorkers}}
 
 ## Instance properties
 

--- a/files/en-us/web/api/lock/mode/index.md
+++ b/files/en-us/web/api/lock/mode/index.md
@@ -6,10 +6,12 @@ page-type: web-api-instance-property
 browser-compat: api.Lock.mode
 ---
 
-{{APIRef("Web Locks API")}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`mode`** read-only property of the {{domxref("Lock")}} interface returns the access mode passed to {{domxref('LockManager.request()')}} when the lock was requested.
 The mode is either `"exclusive"` (the default) or `"shared"`.
+
+{{AvailableInWorkers}}
 
 ## Value
 

--- a/files/en-us/web/api/lock/mode/index.md
+++ b/files/en-us/web/api/lock/mode/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Lock.mode
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks API")}}
 
 The **`mode`** read-only property of the {{domxref("Lock")}} interface returns the access mode passed to {{domxref('LockManager.request()')}} when the lock was requested.
 The mode is either `"exclusive"` (the default) or `"shared"`.

--- a/files/en-us/web/api/lock/name/index.md
+++ b/files/en-us/web/api/lock/name/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Lock.name
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks API")}}
 
 The **`name`** read-only property of
 the {{domxref("Lock")}} interface returns the _name_ passed to

--- a/files/en-us/web/api/lock/name/index.md
+++ b/files/en-us/web/api/lock/name/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Lock.name
 ---
 
-{{APIRef("Web Locks API")}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`name`** read-only property of
 the {{domxref("Lock")}} interface returns the _name_ passed to
@@ -17,6 +17,8 @@ by the developer to represent an abstract resource for which use is being coordi
 across multiple tabs, workers, or other code within the origin. For example, if only one
 tab of a web application should be synchronizing network resources with an offline
 database, it could use a lock name such as `"net_db_sync"`.
+
+{{AvailableInWorkers}}
 
 ## Value
 

--- a/files/en-us/web/api/lockmanager/index.md
+++ b/files/en-us/web/api/lockmanager/index.md
@@ -5,9 +5,11 @@ page-type: web-api-interface
 browser-compat: api.LockManager
 ---
 
-{{APIRef("Web Locks API")}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`LockManager`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing `Lock` object. To get an instance of `LockManager`, call {{domxref('navigator.locks')}}.
+
+{{AvailableInWorkers}}
 
 ## Instance methods
 

--- a/files/en-us/web/api/lockmanager/index.md
+++ b/files/en-us/web/api/lockmanager/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.LockManager
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks API")}}
 
 The **`LockManager`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing `Lock` object. To get an instance of `LockManager`, call {{domxref('navigator.locks')}}.
 

--- a/files/en-us/web/api/lockmanager/query/index.md
+++ b/files/en-us/web/api/lockmanager/query/index.md
@@ -6,9 +6,11 @@ page-type: web-api-instance-method
 browser-compat: api.LockManager.query
 ---
 
-{{APIRef("Web Locks API")}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`query()`** method of the {{domxref("LockManager")}} interface returns a {{jsxref('Promise')}} that resolves with an object containing information about held and pending locks.
+
+{{AvailableInWorkers}}
 
 ## Syntax
 

--- a/files/en-us/web/api/lockmanager/query/index.md
+++ b/files/en-us/web/api/lockmanager/query/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.LockManager.query
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks API")}}
 
 The **`query()`** method of the {{domxref("LockManager")}} interface returns a {{jsxref('Promise')}} that resolves with an object containing information about held and pending locks.
 

--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.LockManager.request
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks API")}}
 
 The **`request()`** method of the {{domxref("LockManager")}} interface requests a {{domxref('Lock')}} object with parameters specifying its name and characteristics.
 The requested `Lock` is passed to a callback, while the function itself returns a {{jsxref('Promise')}} that resolves (or rejects) with the result of the callback after the lock is released, or rejects if the request is aborted.

--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.LockManager.request
 ---
 
-{{APIRef("Web Locks API")}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`request()`** method of the {{domxref("LockManager")}} interface requests a {{domxref('Lock')}} object with parameters specifying its name and characteristics.
 The requested `Lock` is passed to a callback, while the function itself returns a {{jsxref('Promise')}} that resolves (or rejects) with the result of the callback after the lock is released, or rejects if the request is aborted.
@@ -23,6 +23,8 @@ When a `"shared"` lock for a given name is held, other `"shared"` locks for the 
 This shared/exclusive lock pattern is common in database transaction architecture, for example to allow multiple simultaneous readers (each requests a `"shared"` lock) but only one writer (a single `"exclusive"` lock).
 This is known as the readers-writer pattern.
 In the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API), this is exposed as `"readonly"` and `"readwrite"` transactions which have the same semantics.
+
+{{AvailableInWorkers}}
 
 ## Syntax
 

--- a/files/en-us/web/api/navigator/locks/index.md
+++ b/files/en-us/web/api/navigator/locks/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Navigator.locks
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}{{securecontext_header}}
 
 The **`locks`** read-only property of
 the {{domxref("Navigator")}} interface returns a {{domxref("LockManager")}} object

--- a/files/en-us/web/api/navigator/locks/index.md
+++ b/files/en-us/web/api/navigator/locks/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Navigator.locks
 ---
 
-{{APIRef("Web Locks")}}{{securecontext_header}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`locks`** read-only property of
 the {{domxref("Navigator")}} interface returns a {{domxref("LockManager")}} object

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -5,13 +5,14 @@ page-type: web-api-overview
 browser-compat:
   - api.LockManager
   - api.Lock
+spec-urls: https://w3c.github.io/web-locks/
 ---
 
 {{DefaultAPISidebar("Web Locks API")}}{{securecontext_header}}
 
 The Web Locks API allows scripts running in one tab or worker to asynchronously acquire a lock, hold it while work is performed, then release it. While held, no other script executing in the same origin can acquire the same lock, which allows a web app running in multiple tabs or workers to coordinate work and the use of resources.
 
-## Web Locks Concepts and Usage
+## Concepts and Usage
 
 A lock is an abstract concept representing some potentially shared resource, identified by a name chosen by the web app. For example, if a web app running in multiple tabs wants to ensure that only one tab is syncing data between the network and Indexed DB, each tab could try to acquire a "my_net_db_sync" lock, but only one tab will succeed (the [leader election pattern](https://en.wikipedia.org/wiki/Leader_election).)
 
@@ -102,9 +103,16 @@ A deadlock occurs when a process can no longer make progress because each part i
 ## Interfaces
 
 - {{domxref("Lock")}}
-  - : Provides the name and mode of a previously requested lock, which is received in the callback to {{domxref('LockManager.request','LockManager.request()')}}.
+  - : Provides the name and mode of a previously requested lock, which is received in the callback to {{domxref("LockManager.request()")}}.
 - {{domxref("LockManager")}}
-  - : Provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing Lock object. To get an instance of LockManager, call {{domxref('navigator.locks')}}.
+  - : Provides methods for requesting a new {{domxref("Lock")}} object and querying for an existing Lock object. To get an instance of LockManager, call {{domxref("navigator.locks")}}.
+
+### Extensions to other interfaces
+
+- {{domxref("Navigator.locks")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("LockManager")}} object that provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing {{domxref('Lock')}} object.
+- {{domxref("WorkerNavigator.locks")}} {{ReadOnlyInline}}
+  - : Returns a {{DOMxRef("LockManager")}} object which provides methods for requesting a new {{DOMxRef('Lock')}} object and querying for an existing `Lock` object.
 
 ## Specifications
 

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -10,7 +10,7 @@ spec-urls: https://w3c.github.io/web-locks/
 
 {{DefaultAPISidebar("Web Locks API")}}{{securecontext_header}}
 
-The Web Locks API allows scripts running in one tab or worker to asynchronously acquire a lock, hold it while work is performed, then release it. While held, no other script executing in the same origin can acquire the same lock, which allows a web app running in multiple tabs or workers to coordinate work and the use of resources.
+The **Web Locks API** allows scripts running in one tab or worker to asynchronously acquire a lock, hold it while work is performed, then release it. While held, no other script executing in the same origin can acquire the same lock, which allows a web app running in multiple tabs or workers to coordinate work and the use of resources.
 
 ## Concepts and Usage
 

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -69,7 +69,7 @@ await do_something_else_without_lock();
 Several options can be passed when requesting a lock:
 
 - `mode`: The default mode is "exclusive", but "shared" can be specified. There can be only one "exclusive" holder of a lock, but multiple "shared" requests can be granted at the same time. This can be used to implement the [readers-writer pattern](https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock).
-- `signal`: An **AbortSignal** can be passed in, allowing a lock request to be aborted. This can be used to implement a timeout on requests.
+- `signal`: An {{domxref("AbortSignal")}} can be passed in, allowing a lock request to be aborted. This can be used to implement a timeout on requests.
 - `ifAvailable`: If specified, the lock request will fail if the lock cannot be granted immediately without waiting. The callback is invoked with `null`.
 
 ### Monitoring

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -69,8 +69,9 @@ await do_something_else_without_lock();
 Several options can be passed when requesting a lock:
 
 - `mode`: The default mode is "exclusive", but "shared" can be specified. There can be only one "exclusive" holder of a lock, but multiple "shared" requests can be granted at the same time. This can be used to implement the [readers-writer pattern](https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock).
-- `signal`: An {{domxref("AbortSignal")}} can be passed in, allowing a lock request to be aborted. This can be used to implement a timeout on requests.
 - `ifAvailable`: If specified, the lock request will fail if the lock cannot be granted immediately without waiting. The callback is invoked with `null`.
+- `steal`: If specified, then any held locks with the same name will be released, and the request will be granted, preempting any queued requests for it.
+- `signal`: An {{domxref("AbortSignal")}} can be passed in, allowing a lock request to be aborted. This can be used to implement a timeout on requests.
 
 ### Monitoring
 

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -12,6 +12,8 @@ spec-urls: https://w3c.github.io/web-locks/
 
 The **Web Locks API** allows scripts running in one tab or worker to asynchronously acquire a lock, hold it while work is performed, then release it. While held, no other script executing in the same origin can acquire the same lock, which allows a web app running in multiple tabs or workers to coordinate work and the use of resources.
 
+{{AvailableInWorkers}}
+
 ## Concepts and Usage
 
 A lock is an abstract concept representing some potentially shared resource, identified by a name chosen by the web app. For example, if a web app running in multiple tabs wants to ensure that only one tab is syncing data between the network and Indexed DB, each tab could try to acquire a "my_net_db_sync" lock, but only one tab will succeed (the [leader election pattern](https://en.wikipedia.org/wiki/Leader_election).)

--- a/files/en-us/web/api/workernavigator/locks/index.md
+++ b/files/en-us/web/api/workernavigator/locks/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.WorkerNavigator.locks
 ---
 
-{{APIRef("Web Locks")}}{{securecontext_header}}
+{{APIRef("Web Locks API")}}{{securecontext_header}}
 
 The **`locks`** read-only property of
 the {{domxref("WorkerNavigator")}} interface returns a {{domxref("LockManager")}}

--- a/files/en-us/web/api/workernavigator/locks/index.md
+++ b/files/en-us/web/api/workernavigator/locks/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.WorkerNavigator.locks
 ---
 
-{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}{{securecontext_header}}
 
 The **`locks`** read-only property of
 the {{domxref("WorkerNavigator")}} interface returns a {{domxref("LockManager")}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1959,7 +1959,7 @@
       "overview": ["Web Locks API"],
       "interfaces": ["Lock", "LockManager"],
       "methods": [],
-      "properties": [],
+      "properties": ["Navigator.locks", "WorkerNavigator.locks"],
       "events": []
     },
     "Web MIDI API": {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fix apiref for Web Locks API related pages | should use {{APIRef("Web Locks API")}} rather than {{APIRef("Web Locks")}}

add {{securecontext_header}} & {{AvailableInWorkers}}

add `Navigator.locks` `WorkerNavigator.locks` to GroupData, also add contents for the two properties in API landing page

also update *Options* section in API landing page | add the missing `steal` option

some other update

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

reference to https://w3c.github.io/web-locks/

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
