### PR TITLE
Corrected definition of HTMLIFrameElement's src property

### DIFF
--- a/files/en-us/web/api/htmliframeelement/src/index.md
+++ b/files/en-us/web/api/htmliframeelement/src/index.md
@@ -9,15 +9,16 @@ browser-compat: api.HTMLIFrameElement.src
 {{APIRef}}
 
 The **`HTMLIFrameElement.src`**
-property reflects the HTML [`referrerpolicy`](/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy) attribute of the
-{{HTMLElement("iframe")}} element defining which referrer is sent when fetching the
-resource.
+A string that reflects the [`src`](/en-US/docs/Web/HTML/Element/iframe#src) HTML attribute, containing
+the address of the content to be embedded. Note that programmatically removing an `<iframe>`'s src 
+attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in 
+the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
 
 ## Syntax
 
 ```js-nolint
-refStr = iframeElt.src
-iframeElt.src= refStr
+src = iframeElt.src
+iframeElt.src= src
 ```
 
 ## Example

--- a/files/en-us/web/api/htmliframeelement/src/index.md
+++ b/files/en-us/web/api/htmliframeelement/src/index.md
@@ -9,10 +9,9 @@ browser-compat: api.HTMLIFrameElement.src
 {{APIRef}}
 
 The **`HTMLIFrameElement.src`**
-A string that reflects the [`src`](/en-US/docs/Web/HTML/Element/iframe#src) HTML attribute, containing
-the address of the content to be embedded. Note that programmatically removing an `<iframe>`'s src 
-attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in 
-the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
+A string that reflects the [`src`](/en-US/docs/Web/HTML/Element/iframe#src) HTML attribute, containing the address of the content to be embedded.
+
+Note that programmatically removing an `<iframe>`'s src attribute (e.g. via {{domxref("Element.removeAttribute()")}}) causes `about:blank` to be loaded in the frame.
 
 ## Syntax
 


### PR DESCRIPTION
1. replaced incorrect definition of HTMLIFrameElement's src property with the definition at https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement#:~:text=HTMLIFrameElement.src

2. renamed two variables in the Syntax section accordingly