### PR TITLE
Clarify Grid Lines glossary definition

### DIFF
--- a/files/en-us/glossary/grid_lines/index.md
+++ b/files/en-us/glossary/grid_lines/index.md
@@ -8,6 +8,8 @@ page-type: glossary-definition
 
 **Grid lines** are created when you define {{glossary("Grid tracks", "tracks")}} in the explicit grid using [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layout).
 
+**Grid lines** are created when we using CSS Grid layout.
+
 ## Example
 
 In the following example there is a grid with three column tracks and two row tracks. This gives us 4 column lines and 3 row lines.

--- a/files/en-us/glossary/grid_lines/index.md
+++ b/files/en-us/glossary/grid_lines/index.md
@@ -6,9 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Grid lines** are created when you define {{glossary("Grid tracks", "tracks")}} in the explicit grid using [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layout).
-
-**Grid lines** are created when we using CSS Grid layout.
+**Grid lines** are created anytime you use a [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layout).
 
 ## Example
 


### PR DESCRIPTION
Grid lines are created by default even when we do not set the columns or rows explicitly. Therefore, it is more accurate to avoid stating that the grid lines are created when we use explicit grid.