### PR TITLE
Mark `MediaStream` `active` & `inactive` event as non-standard

### DIFF
--- a/files/en-us/web/api/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/index.md
@@ -54,9 +54,9 @@ _This interface inherits methods from its parent, {{domxref("EventTarget")}}._
   - : Fired when a new {{domxref("MediaStreamTrack")}} object is added.
 - {{domxref("MediaStream/removetrack_event", "removetrack")}}
   - : Fired when a {{domxref("MediaStreamTrack")}} object has been removed.
-- {{domxref("MediaStream/active_event", "active")}}
+- {{domxref("MediaStream/active_event", "active")}} {{Non-standard_Inline}}
   - : Fired when the MediaStream is activated.
-- {{domxref("MediaStream/inactive_event", "inactive")}}
+- {{domxref("MediaStream/inactive_event", "inactive")}} {{Non-standard_Inline}}
   - : Fired when the MediaStream is inactivated.
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the two events have been removed from [spec](https://w3c.github.io/mediacapture-main/) via https://github.com/w3c/mediacapture-main/pull/291, currntly they are not in standard 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Depends on: https://github.com/mdn/browser-compat-data/pull/21645

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
