### PR TITLE
fix: rename group to groupToMap

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/groupby/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Object.groupBy
 
 {{JSRef}}
 
-> **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.group()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
+> **Note:** In some versions of some browsers, this method was implemented as the method `Array.prototype.groupToMap()`. Due to web compatibility issues, it is now implemented as a static method. Check the [browser compatibility table](#browser_compatibility) for details.
 
 The **`Object.groupBy()`** static method groups the elements of a given iterable according to the string values returned by a provided callback function. The returned object has separate properties for each group, containing arrays with the elements in the group.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Renamed `Array.prototype.group()` to `Array.prototype.groupToMap()` in order to reflect Safari changes.
