### PR TITLE
adding necessary step for clarity

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -577,19 +577,19 @@ Let's update our `bstack_google_test.js` demo, to show how these features work:
    ```js
    npm install request
    ```
-3. Then, we'll need to import the node request module, so we can use it to send requests to the REST API. Add the following line at the very top of your code:
+2. Then, we'll need to import the node request module, so we can use it to send requests to the REST API. Add the following line at the very top of your code:
 
    ```js
    const request = require("request");
    ```
 
-4. Now we'll update our `capabilities` object to include a project name — add the following line before the closing curly brace, remembering to add a comma at the end of the previous line (you can vary the build and project names to organize the tests in different windows in the BrowserStack automation dashboard):
+3. Now we'll update our `capabilities` object to include a project name — add the following line before the closing curly brace, remembering to add a comma at the end of the previous line (you can vary the build and project names to organize the tests in different windows in the BrowserStack automation dashboard):
 
    ```js
    'project' : 'Google test 2'
    ```
 
-5. Next we need to access the `sessionId` of the current session, so we know where to send the request (the ID is included in the request URL, as you'll see later). Include the following lines just below the block that creates the `driver` object (`let driver …`) :
+4. Next we need to access the `sessionId` of the current session, so we know where to send the request (the ID is included in the request URL, as you'll see later). Include the following lines just below the block that creates the `driver` object (`let driver …`) :
 
    ```js
    let sessionId;
@@ -599,7 +599,7 @@ Let's update our `bstack_google_test.js` demo, to show how these features work:
    });
    ```
 
-6. Finally, update the `driver.sleep(2000)` block near the bottom of the code to add REST API calls (again, replace the `YOUR-USER-NAME` and `YOUR-ACCESS-KEY` placeholders in the code with your actual user name and access key values):
+5. Finally, update the `driver.sleep(2000)` block near the bottom of the code to add REST API calls (again, replace the `YOUR-USER-NAME` and `YOUR-ACCESS-KEY` placeholders in the code with your actual user name and access key values):
 
    ```js
    driver.sleep(2000).then(() => {

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -573,19 +573,23 @@ You can use the BrowserStack REST API and some other capabilities to annotate yo
 
 Let's update our `bstack_google_test.js` demo, to show how these features work:
 
-1. First, we'll need to import the node request module, so we can use it to send requests to the REST API. Add the following line at the very top of your code:
+1. Install the request module by running the following command inside your project directory:
+   ```js
+   npm install request
+   ```
+3. Then, we'll need to import the node request module, so we can use it to send requests to the REST API. Add the following line at the very top of your code:
 
    ```js
    const request = require("request");
    ```
 
-2. Now we'll update our `capabilities` object to include a project name — add the following line before the closing curly brace, remembering to add a comma at the end of the previous line (you can vary the build and project names to organize the tests in different windows in the BrowserStack automation dashboard):
+4. Now we'll update our `capabilities` object to include a project name — add the following line before the closing curly brace, remembering to add a comma at the end of the previous line (you can vary the build and project names to organize the tests in different windows in the BrowserStack automation dashboard):
 
    ```js
    'project' : 'Google test 2'
    ```
 
-3. Next we need to access the `sessionId` of the current session, so we know where to send the request (the ID is included in the request URL, as you'll see later). Include the following lines just below the block that creates the `driver` object (`let driver …`) :
+5. Next we need to access the `sessionId` of the current session, so we know where to send the request (the ID is included in the request URL, as you'll see later). Include the following lines just below the block that creates the `driver` object (`let driver …`) :
 
    ```js
    let sessionId;
@@ -595,7 +599,7 @@ Let's update our `bstack_google_test.js` demo, to show how these features work:
    });
    ```
 
-4. Finally, update the `driver.sleep(2000)` block near the bottom of the code to add REST API calls (again, replace the `YOUR-USER-NAME` and `YOUR-ACCESS-KEY` placeholders in the code with your actual user name and access key values):
+6. Finally, update the `driver.sleep(2000)` block near the bottom of the code to add REST API calls (again, replace the `YOUR-USER-NAME` and `YOUR-ACCESS-KEY` placeholders in the code with your actual user name and access key values):
 
    ```js
    driver.sleep(2000).then(() => {

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -574,6 +574,7 @@ You can use the BrowserStack REST API and some other capabilities to annotate yo
 Let's update our `bstack_google_test.js` demo, to show how these features work:
 
 1. Install the request module by running the following command inside your project directory:
+
    ```js
    npm install request
    ```

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -578,6 +578,7 @@ Let's update our `bstack_google_test.js` demo, to show how these features work:
    ```js
    npm install request
    ```
+
 2. Then, we'll need to import the node request module, so we can use it to send requests to the REST API. Add the following line at the very top of your code:
 
    ```js


### PR DESCRIPTION
Originally, steps to show how to fill in BrowserStack test details programmatically didn't indicate where the request module came from. This produced the following error:

```js
Error: Cannot find module 'request'
Require stack:
- /.../selenium-test/bstack_google_test.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/.../selenium-test/bstack_google_test.js:2:17)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/.../selenium-test/bstack_google_test.js'
  ]
}
```

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a beginning step which shows how to add the node request module to the `bstack_google_test.js` demo.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
To allow readers to know where the node request module comes from and avoid confusion when going through the steps within the Filling in BrowserStack test details programmatically section.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
