### PR TITLE
fixed BrowserStack automation dashboard link

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/your_own_automation_environment/index.md
@@ -627,7 +627,7 @@ Let's update our `bstack_google_test.js` demo, to show how these features work:
 
 These are fairly intuitive — once the test completes, we send an API call to BrowserStack to update the test with a passed or failed status, and a reason for the result.
 
-If you now go back to your [BrowserStack automation dashboard](https://www.browserstack.com/automate) page, you should see your test session available, as before, but with the updated data attached to it:
+If you now go back to your [BrowserStack automation dashboard](https://live.browserstack.com/dashboard) page, you should see your test session available, as before, but with the updated data attached to it:
 
 ![BrowserStack Custom Results](bstack_custom_results.png)
 


### PR DESCRIPTION
Previous link redirected to [Automated Selenium Testing On A Grid of 3000+ Browsers & Mobile Devices | BrowserStack](https://www.browserstack.com/automate) page instead.
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added correct link to indicate to readers where to find their BrowserStack username and access key.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
To help users easily find their BrowserStack username and access key.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
