### PR TITLE
docs(css): Add details about number of properties and values in CSS syntax

### DIFF
--- a/files/en-us/web/css/syntax/index.md
+++ b/files/en-us/web/css/syntax/index.md
@@ -19,7 +19,7 @@ Both properties and values are case-insensitive by default in CSS. The pair is s
 
 ![css syntax - declaration.png](css_syntax_-_declaration.png)
 
-There are more than [100 different properties](/en-US/docs/Web/CSS/Reference) in CSS and a nearly infinite number of different values. Not all pairs of properties and values are allowed and each property defines what are the valid values. When a value is not valid for a given property, the declaration is deemed _invalid_ and is wholly ignored by the CSS engine.
+There are [hundreds of different properties](/en-US/docs/Web/CSS/Reference) in CSS and a practically endless number of different values. Not all pairs of properties and values are allowed and each property defines what are the valid values. When a value is not valid for a given property, the declaration is deemed _invalid_ and is wholly ignored by the CSS engine.
 
 ## CSS declaration blocks
 


### PR DESCRIPTION
replace "100 or more" with "hundreds". Learning 100-200 properties seemed possible to me, but on following the link there were actually hundreds of properties, too many for me to learn.

replace "almost infinite" with "practically endless". In a context where precise meaning is important, "almost infinite" is distracting, since it makes no sense if it is interpreted literally.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
