### PR TITLE
Update the `mix-blend-mode` CSS property page: add `plus-darker` and `plus-lighter` values

### DIFF
--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -47,9 +47,9 @@ mix-blend-mode: unset;
 - {{cssxref("&lt;blend-mode&gt;")}}
   - : The blending mode that should be applied.
 - `plus-darker`
-  - : Blending using the _plus-darker_ compositing operator.
+  - : Blending using the [_plus-darker_ compositing operator](https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_plus_darker).
 - `plus-lighter`
-  - : Blending using the _plus-lighter_ compositing operator. Useful for cross-fade effects (prevents unwanted blinking when two overlaying elements animate their opacity in opposite directions).
+  - : Blending using the [_plus-lighter_ compositing operator](https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_plus_lighter). Useful for cross-fade effects (prevents unwanted blinking when two overlaying elements animate their opacity in opposite directions).
 
 ## Formal definition
 

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -292,6 +292,32 @@ mix-blend-mode: unset;
           </div>
         </div>
       </div>
+      <div class="cell">
+        plus-darker
+        <div class="container plus-darker">
+          <div class="group">
+            <div class="item firefox"></div>
+            <svg class="item" viewBox="0 0 150 150">
+              <ellipse class="item R" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item G" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item B" cx="75" cy="75" rx="25" ry="70"></ellipse>
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div class="cell">
+        plus-lighter
+        <div class="container plus-lighter">
+          <div class="group">
+            <div class="item firefox"></div>
+            <svg class="item" viewBox="0 0 150 150">
+              <ellipse class="item R" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item G" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item B" cx="75" cy="75" rx="25" ry="70"></ellipse>
+            </svg>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="note">Blending globally (blend with the background)</div>
@@ -504,6 +530,32 @@ mix-blend-mode: unset;
           </div>
         </div>
       </div>
+      <div class="cell">
+        plus-darker
+        <div class="container plus-darker">
+          <div class="group">
+            <div class="item firefox"></div>
+            <svg class="item" viewBox="0 0 150 150">
+              <ellipse class="item R" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item G" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item B" cx="75" cy="75" rx="25" ry="70"></ellipse>
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div class="cell">
+        plus-lighter
+        <div class="container plus-lighter">
+          <div class="group">
+            <div class="item firefox"></div>
+            <svg class="item" viewBox="0 0 150 150">
+              <ellipse class="item R" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item G" cx="75" cy="75" rx="25" ry="70"></ellipse>
+              <ellipse class="item B" cx="75" cy="75" rx="25" ry="70"></ellipse>
+            </svg>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -637,6 +689,12 @@ body {
 }
 .luminosity .item {
   mix-blend-mode: luminosity;
+}
+.plus-darker .item {
+  mix-blend-mode: plus-darker;
+}
+.plus-lighter .item {
+  mix-blend-mode: plus-lighter;
 }
 ```
 

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -31,6 +31,8 @@ mix-blend-mode: hue;
 mix-blend-mode: saturation;
 mix-blend-mode: color;
 mix-blend-mode: luminosity;
+mix-blend-mode: plus-darker;
+mix-blend-mode: plus-lighter;
 
 /* Global values */
 mix-blend-mode: inherit;
@@ -44,6 +46,10 @@ mix-blend-mode: unset;
 
 - {{cssxref("&lt;blend-mode&gt;")}}
   - : The blending mode that should be applied.
+- `plus-darker`
+  - : Blending using the _plus-darker_ compositing operator.
+- `plus-lighter`blinking
+  - : Blending using the _plus-lighter_ compositing operator. Useful for cross-fade effects (prevents unwanted "blinking" when two overlaying elements animate their opacity in opposite directions).
 
 ## Formal definition
 

--- a/files/en-us/web/css/mix-blend-mode/index.md
+++ b/files/en-us/web/css/mix-blend-mode/index.md
@@ -48,8 +48,8 @@ mix-blend-mode: unset;
   - : The blending mode that should be applied.
 - `plus-darker`
   - : Blending using the _plus-darker_ compositing operator.
-- `plus-lighter`blinking
-  - : Blending using the _plus-lighter_ compositing operator. Useful for cross-fade effects (prevents unwanted "blinking" when two overlaying elements animate their opacity in opposite directions).
+- `plus-lighter`
+  - : Blending using the _plus-lighter_ compositing operator. Useful for cross-fade effects (prevents unwanted blinking when two overlaying elements animate their opacity in opposite directions).
 
 ## Formal definition
 


### PR DESCRIPTION
### Description

Add two recently added values `plus-darker` and `plus-lighter` to the "Values" section.

### Motivation

The [specification](https://drafts.fxtf.org/compositing/#mix-blend-mode) has been updated recently to add two more values in addition to those listed in the [`<blend-mode>`](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode) data type. The "Browser compatibility" section already lists the `plus-lighter` value but the "Values" section still misses both of them.

### Additional details

The `plus-lighter` value is particularly useful for the cross-fade effects, as explained in the specification itself and [in this article](https://jakearchibald.com/2021/dom-cross-fade/) by Jake Archibald

### Related issues and pull requests

This PR doesn't depend on other issues or PRs

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
