### PR TITLE
Fix BCD in yaml for RTC*Stats.* that have a page and an entry

### DIFF
--- a/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: availableOutgoingBitrate property"
 short-title: availableOutgoingBitrate
 slug: Web/API/RTCIceCandidatePairStats/availableOutgoingBitrate
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.availableOutgoingBitrate
+browser-compat: api.RTCStatsReport.type_candidate-pair.availableOutgoingBitrate
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: bytesReceived property"
 short-title: bytesReceived
 slug: Web/API/RTCIceCandidatePairStats/bytesReceived
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.bytesReceived
+browser-compat: api.RTCStatsReport.type_candidate-pair.bytesReceived
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: bytesSent property"
 short-title: bytesSent
 slug: Web/API/RTCIceCandidatePairStats/bytesSent
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.bytesSent
+browser-compat: api.RTCStatsReport.type_candidate-pair.bytesSent
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: currentRoundTripTime property"
 short-title: currentRoundTripTime
 slug: Web/API/RTCIceCandidatePairStats/currentRoundTripTime
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.currentRoundTripTime
+browser-compat: api.RTCStatsReport.type_candidate-pair.currentRoundTripTime
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: lastPacketReceivedTimestamp property"
 short-title: lastPacketReceivedTimestamp
 slug: Web/API/RTCIceCandidatePairStats/lastPacketReceivedTimestamp
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.lastPacketReceivedTimestamp
+browser-compat: api.RTCStatsReport.type_candidate-pair.lastPacketReceivedTimestamp
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: lastPacketSentTimestamp property"
 short-title: lastPacketSentTimestamp
 slug: Web/API/RTCIceCandidatePairStats/lastPacketSentTimestamp
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.lastPacketSentTimestamp
+browser-compat: api.RTCStatsReport.type_candidate-pair.lastPacketSentTimestamp
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: localCandidateId property"
 short-title: localCandidateId
 slug: Web/API/RTCIceCandidatePairStats/localCandidateId
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.localCandidateId
+browser-compat: api.RTCStatsReport.type_candidate-pair.localCandidateId
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: nominated property"
 short-title: nominated
 slug: Web/API/RTCIceCandidatePairStats/nominated
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.nominated
+browser-compat: api.RTCStatsReport.type_candidate-pair.nominated
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/priority/index.md
@@ -5,7 +5,7 @@ slug: Web/API/RTCIceCandidatePairStats/priority
 page-type: web-api-instance-property
 status:
   - deprecated
-browser-compat: api.RTCIceCandidatePairStats.priority
+browser-compat: api.RTCStatsReport.type_candidate-pair.priority
 ---
 
 {{APIRef("WebRTC")}}{{deprecated_header}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: remoteCandidateId property"
 short-title: remoteCandidateId
 slug: Web/API/RTCIceCandidatePairStats/remoteCandidateId
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.remoteCandidateId
+browser-compat: api.RTCStatsReport.type_candidate-pair.remoteCandidateId
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: requestsReceived property"
 short-title: requestsReceived
 slug: Web/API/RTCIceCandidatePairStats/requestsReceived
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.requestsReceived
+browser-compat: api.RTCStatsReport.type_candidate-pair.requestsReceived
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: requestsSent property"
 short-title: requestsSent
 slug: Web/API/RTCIceCandidatePairStats/requestsSent
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.requestsSent
+browser-compat: api.RTCStatsReport.type_candidate-pair.requestsSent
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: responsesReceived property"
 short-title: responsesReceived
 slug: Web/API/RTCIceCandidatePairStats/responsesReceived
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.responsesReceived
+browser-compat: api.RTCStatsReport.type_candidate-pair.responsesReceived
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: responsesSent property"
 short-title: responsesSent
 slug: Web/API/RTCIceCandidatePairStats/responsesSent
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.responsesSent
+browser-compat: api.RTCStatsReport.type_candidate-pair.responsesSent
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/state/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/state/index.md
@@ -3,12 +3,12 @@ title: "RTCIceCandidatePairStats: state property"
 short-title: state
 slug: Web/API/RTCIceCandidatePairStats/state
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.state
+browser-compat: api.RTCStatsReport.type_candidate-pair.state
 ---
 
 {{APIRef("WebRTC")}}
 
-The **`state`** property in a string that indicates the state of the check list of which the candidate pair is a member.
+The **`state`** property is a string that indicates the state of the checklist of which the candidate pair is a member.
 
 ## Value
 
@@ -27,24 +27,23 @@ A string whose value is one of the following:
 
 ## ICE check lists
 
-During ICE negotiation, the ICE layer builds up a **check list**, which is
+During ICE negotiation, the ICE layer builds up a _checklist_, which is
 a list of potential pairings of ICE candidates. Each pair has a state, represented by a string literal.
 
-![A diagram showing how ICE candidate pairs change state as the check list is analyzed](ice-check-list-states.svg)
+![A diagram showing how ICE candidate pairs change state as the checklist is analyzed](ice-check-list-states.svg)
 
-When a candidate pair is added to the check list, it begins in the `frozen`
-state. As soon as there are no checks ongoing which block the pair from being analyzed,
+When a candidate pair is added to the checklist, it begins in the `frozen`
+state. As soon as there are no checks ongoing that block the pair from being analyzed,
 it is unfrozen and moves into the `waiting` state. This may happen
-immediately upon being added to the check list.
+immediately upon being added to the checklist.
 
-Each time a candidate pair is done being checked, the next-highest priority candidate
-pair remaining on the check list moves from the `waiting` state to the
+Each time a candidate pair is checked, the next-highest priority candidate
+pair remaining on the checklist moves from the `waiting` state to the
 `in-progress` state, and its check begins. If the check fails for any reason,
 the pair moves into its final state, `failed`. If the check succeeds, the
 pair ends up in the `succeeded` state.
-
-The ICE check list state for any given pair of ICE candidates can be found in the
-corresponding the `state` property.
+The ICE checklist state for any given pair of ICE candidates can be found in the
+corresponding `state` property.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: totalRoundTripTime property"
 short-title: totalRoundTripTime
 slug: Web/API/RTCIceCandidatePairStats/totalRoundTripTime
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.totalRoundTripTime
+browser-compat: api.RTCStatsReport.type_candidate-pair.totalRoundTripTime
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidatePairStats: transportId property"
 short-title: transportId
 slug: Web/API/RTCIceCandidatePairStats/transportId
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidatePairStats.transportId
+browser-compat: api.RTCStatsReport.type_candidate-pair.transportId
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/address/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/address/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: address property"
 short-title: address
 slug: Web/API/RTCIceCandidateStats/address
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidateStats.address
+browser-compat: api.RTCStatsReport.type_local-candidate.address
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.md
@@ -3,13 +3,13 @@ title: "RTCIceCandidateStats: candidateType property"
 short-title: candidateType
 slug: Web/API/RTCIceCandidateStats/candidateType
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidateStats.candidateType
+browser-compat: api.RTCStatsReport.type_local-candidate.candidateType
 ---
 
 {{APIRef("WebRTC")}}
 
 The {{domxref("RTCIceCandidateStats")}} interface's
-**`candidateType`** property is a string which indicates the
+**`candidateType`** property is a string that indicates the
 type of {{Glossary("ICE")}} candidate the object represents.
 
 ## Syntax

--- a/files/en-us/web/api/rtcicecandidatestats/port/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/port/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: port property"
 short-title: port
 slug: Web/API/RTCIceCandidateStats/port
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidateStats.port
+browser-compat: api.RTCStatsReport.type_local-candidate.port
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/priority/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: priority property"
 short-title: priority
 slug: Web/API/RTCIceCandidateStats/priority
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidateStats.priority
+browser-compat: api.RTCStatsReport.type_local-candidate.priority
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: protocol property"
 short-title: protocol
 slug: Web/API/RTCIceCandidateStats/protocol
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidateStats.protocol
+browser-compat: api.RTCStatsReport.type-local-candidate.protocol
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: protocol property"
 short-title: protocol
 slug: Web/API/RTCIceCandidateStats/protocol
 page-type: web-api-instance-property
-browser-compat: api.RTCStatsReport.type-local-candidate.protocol
+browser-compat: api.RTCIceCandidateStats.protocol
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
@@ -3,7 +3,7 @@ title: "RTCIceCandidateStats: transportId property"
 short-title: transportId
 slug: Web/API/RTCIceCandidateStats/transportId
 page-type: web-api-instance-property
-browser-compat: api.RTCIceCandidateStats.transportId
+browser-compat: api.RTCStatsReport.type_local-candidate.transportId
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.md
@@ -3,7 +3,7 @@ title: "RTCInboundRtpStreamStats: bytesReceived property"
 short-title: bytesReceived
 slug: Web/API/RTCInboundRtpStreamStats/bytesReceived
 page-type: web-api-instance-property
-browser-compat: api.RTCInboundRtpStreamStats.bytesReceived
+browser-compat: api.RTCStatsReport.type_inbound-rtp.bytesReceived
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.md
@@ -3,7 +3,7 @@ title: "RTCInboundRtpStreamStats: fecPacketsDiscarded property"
 short-title: fecPacketsDiscarded
 slug: Web/API/RTCInboundRtpStreamStats/fecPacketsDiscarded
 page-type: web-api-instance-property
-browser-compat: api.RTCInboundRtpStreamStats.fecPacketsDiscarded
+browser-compat: api.RTCStatsReport.type_inbound-rtp.fecPacketsDiscarded
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.md
@@ -3,7 +3,7 @@ title: "RTCInboundRtpStreamStats: fecPacketsReceived property"
 short-title: fecPacketsReceived
 slug: Web/API/RTCInboundRtpStreamStats/fecPacketsReceived
 page-type: web-api-instance-property
-browser-compat: api.RTCInboundRtpStreamStats.fecPacketsReceived
+browser-compat: api.RTCStatsReport.type_inbound-rtp.fecPacketsReceived
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.md
@@ -3,7 +3,7 @@ title: "RTCInboundRtpStreamStats: nackCount property"
 short-title: nackCount
 slug: Web/API/RTCInboundRtpStreamStats/nackCount
 page-type: web-api-instance-property
-browser-compat: api.RTCInboundRtpStreamStats.nackCount
+browser-compat: api.RTCStatsReport.type_inbound-rtp.nackCount
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.md
@@ -3,7 +3,7 @@ title: "RTCOutboundRtpStreamStats: nackCount property"
 short-title: nackCount
 slug: Web/API/RTCOutboundRtpStreamStats/nackCount
 page-type: web-api-instance-property
-browser-compat: api.RTCOutboundRtpStreamStats.nackCount
+browser-compat: api.RTCStatsReport.type_outbound-rtp.nackCount
 ---
 
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.md
@@ -3,7 +3,7 @@ title: "RTCOutboundRtpStreamStats: remoteId property"
 short-title: remoteId
 slug: Web/API/RTCOutboundRtpStreamStats/remoteId
 page-type: web-api-instance-property
-browser-compat: api.RTCOutboundRtpStreamStats.remoteId
+browser-compat: api.RTCStatsReport.type_outbound-rtp.remoteId
 ---
 
 {{APIRef("WebRTC")}}


### PR DESCRIPTION
We have many RTC*Stats.* pages with broken specs and compat tables (red tables).

This PR fixes the cases where we actually have entries in mdn/browser-compat-table, but we weren't linking to the right places.

I also fixed a few obvious orthographic or grammar errors.