### PR TITLE
Fix flaws in Firefox 30

### DIFF
--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -17,7 +17,7 @@ page-type: firefox-release-notes
 ### CSS
 
 - The property {{cssxref("background-blend-mode")}} has been enabled by default ([Firefox bug 970600](https://bugzil.la/970600)).
-- The non-standard `overflow-clip-box`")}}` property has been implemented for use in UA stylesheets only ([Firefox bug 966992](https://bugzil.la/966992)).
+- The non-standard `overflow-clip-box` property has been implemented for use in UA stylesheets only ([Firefox bug 966992](https://bugzil.la/966992)).
 - The {{cssxref("line-height")}} property now affects single-line text inputs (`<input type=text|password|email|search|tel|url|unknown>` types) although it cannot shrink them below a line height of `1.0` ([Firefox bug 349259](https://bugzil.la/349259)).
 - The {{cssxref("line-height")}} property now also affects `type=button`, with no restrictions ([Firefox bug 697451](https://bugzil.la/697451)).
 - Change to keyframes' name does not affect current elements ([Firefox bug 978648](https://bugzil.la/978648)).
@@ -39,14 +39,14 @@ _No change._
 - {{domxref("Navigator.sendBeacon")}} has been implemented, easing telemetry collection ([Firefox bug 936340](https://bugzil.la/936340)).
 - Added a `relList` property returning a {{domxref("DOMTokenList")}} to {{domxref("HTMLLinkElement")}}, {{domxref("HTMLAreaElement")}} and {{domxref("HTMLAnchorElement")}} ([Firefox bug 968637](https://bugzil.la/968637)).
 - As per the latest specification, the first argument of {{domxref("AudioScheduledSourceNode.start")}} and {{domxref("AudioScheduledSourceNode.stop")}} is now optional and defaults to `0` ([Firefox bug 982541](https://bugzil.la/982541)).
-- The method {{domxref("Navigator.requestWakeLock()")}} and the non-standard {{domxref("MozWakeLock")}} are no longer available from the Web on Desktop ([Firefox bug 963366](https://bugzil.la/963366)).
+- The method `Navigator.requestWakeLock()` and the non-standard `MozWakeLock` are no longer available from the Web on Desktop ([Firefox bug 963366](https://bugzil.la/963366)).
 - The `DOM_VK_ENTER` constant has been removed from {{domxref("KeyboardEvent")}} ([Firefox bug 969247](https://bugzil.la/969247)).
-- Web components' {{domxref("Document.register")}} has been adapted to follow the behavior described in the latest version of the specification ([Firefox bug 856140](https://bugzil.la/856140)).
-- The non-standard, and deprecated since Firefox 15, {{domxref("Blob.mozSlice")}} is no longer supported ([Firefox bug 961804](https://bugzil.la/961804)).
-- The non-standard {{domxref("ArchiveReader")}} and {{domxref("ArchiveRequest")}} are no longer exposed to the Web ([Firefox bug 968883](https://bugzil.la/968883)).
+- Web components' `Document.register()` has been adapted to follow the behavior described in the latest version of the specification ([Firefox bug 856140](https://bugzil.la/856140)).
+- The non-standard, and deprecated since Firefox 15, `Blob.mozSlice` is no longer supported ([Firefox bug 961804](https://bugzil.la/961804)).
+- The non-standard `ArchiveReader` and `ArchiveRequest` are no longer exposed to the Web ([Firefox bug 968883](https://bugzil.la/968883)).
 - [WebIDL constructors](https://searchfox.org/mozilla-central/source/dom/webidl/) cannot be called as functions anymore. They need to be preceded by the keyword `new`. ([Firefox bug 916644](https://bugzil.la/916644))
 - Added support for a new value (`alpha`) for the second, optional, parameter of the {{domxref("HTMLCanvasElement.getContext()")}} method allowing to define if alpha blending must be stored or not for this context. When not, the per-pixel alpha value in this store is always `1.0`. This allows the back-end to implement a fast-track. ([Firefox bug 982480](https://bugzil.la/982480))
-- {{domxref("GlobalWorkerScope.console")}} now returns for the regular {{domxref("console")}}; `WorkerConsole` has been removed ([Firefox bug 965860](https://bugzil.la/965860)).
+- `WorkerGlobalScope.console` now returns for the regular {{domxref("console")}}; `WorkerConsole` has been removed ([Firefox bug 965860](https://bugzil.la/965860)).
 - The {{domxref("WebGL_debug_shaders")}} WebGL extension has been implemented ([Firefox bug 968374](https://bugzil.la/968374)).
 
 ### MathML


### PR DESCRIPTION
Follow-up of #30998.

As I was on it, I fixed the flaws (red links were linking to non-documented features that are not part of the web platform anymore)