### PR TITLE
Add: Primitive value reassigned image

### DIFF
--- a/files/en-us/glossary/primitive/index.md
+++ b/files/en-us/glossary/primitive/index.md
@@ -18,6 +18,8 @@ In {{Glossary("JavaScript")}}, a **primitive** (primitive value, primitive data 
 
 Most of the time, a primitive value is represented directly at the lowest level of the language implementation.
 
+![Primitive reassigned](https://github.com/mdn/content/assets/57232813/d96539ed-1cd1-430d-8c55-336652733869)
+
 All primitives are _immutable_; that is, they cannot be altered. It is important not to confuse a primitive itself with a variable assigned a primitive value. The variable may be reassigned to a new value, but the existing value can not be changed in the ways that objects, arrays, and functions can be altered. The language does not offer utilities to mutate primitive values.
 
 Primitives have no methods but still behave as if they do. When properties are accessed on primitives, JavaScript _auto-boxes_ the value into a wrapper object and accesses the property on that object instead. For example, `"foo".includes("f")` implicitly creates a [`String`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) wrapper object and calls `String.prototype.includes()` on that object. This auto-boxing behavior is not observable in JavaScript code but is a good mental model of various behaviors — for example, why "mutating" primitives does not work (because `str.foo = 1` is not assigning to the property `foo` of `str` itself, but to an ephemeral wrapper object).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Hi,

I was learning TypeScript Quickly today and got interested in Symbols type. I learned about primitive types and that the value of primitive types is immutable, but the reference of the variable can be changed.

I found it a bit confusing, so I went to MDN and saw similar descriptions, but they didn't really illustrate the concept of primitive types well either. So I drew a diagram of primitive type changes.

Please let me know if there are any mistakes. I think it was a great learning experience.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I think many people who are learning about ECMAScript proposals and standards are interested in understanding what it means for a new object or type to become a primitive data type. They may come to MDN to learn more, and I want to provide them with a visual aid to help them understand.

### Additional details

![image](https://github.com/mdn/content/assets/57232813/4ad4e936-0271-4455-888f-02367b18e3c6)

Do you notice the small dashed line and a solid "1" in the second line of the code? It indicates that the variable "a" has been assigned to a new value.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
