### PR TITLE
HTMLDialogElement - cancel event defined in parent

### DIFF
--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -33,8 +33,10 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 
 ## Events
 
-- {{domxref("HTMLElement/cancel_event", "cancel")}}
-  - : Fired when the user dismisses the current open dialog with the escape key.
+_Also inherits events from its parent interface, `\{{DOMxRef("NameOfParentInterface")}}`._ (Note: If the interface doesn't inherit from another interface, remove this whole line.)
+
+Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
 - {{domxref("HTMLDialogElement/close_event", "close")}}
   - : Fired when the dialog is closed, whether with the escape key, the `HTMLDialogElement.close()` method, or via submitting a form within the dialog with [`method="dialog"`](/en-US/docs/Web/HTML/Element/form#method).
 

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -33,7 +33,7 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 
 ## Events
 
-_Also inherits events from its parent interface, `\{{DOMxRef("NameOfParentInterface")}}`._
+_Also inherits events from its parent interface, `{{DOMxRef("HTMLElement")}}`._
 
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -33,7 +33,7 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 
 ## Events
 
-_Also inherits events from its parent interface, `\{{DOMxRef("NameOfParentInterface")}}`._ (Note: If the interface doesn't inherit from another interface, remove this whole line.)
+_Also inherits events from its parent interface, `\{{DOMxRef("NameOfParentInterface")}}`._
 
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 


### PR DESCRIPTION
Update to remove a cancel event from `HTMLDialogElement` as it is defined in HTMLElement. Also update as per the new template https://github.com/mdn/content/pull/31126