### PR TITLE
FF122 Relnote HTMLSelectElement.showPicker

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -59,47 +59,6 @@ Layout for `input type="search"` has been updated. This causes a search field to
   </tbody>
 </table>
 
-### showPicker() method for HTML select elements
-
-The {{domxref("HTMLSelectElement.showPicker()")}} method programmatically launches the browser picker for a {{HTMLElement("select")}} element, triggered by user interaction.
-(See [Firefox bug 1854112](https://bugzil.la/1854112) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>121</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.select.showPicker.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Toggle password display
 
 HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/Element/input/password)) include an "eye" icon that can be toggled to display or obscure the password text ([Firefox bug 502258](https://bugzil.la/502258)).

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -44,6 +44,10 @@ This article provides information about the changes in Firefox 122 that affect d
 
 #### DOM
 
+### showPicker() method for HTML select elements
+
+- The {{domxref("HTMLSelectElement.showPicker()")}} method is now supported, allowing the browser picker for a {{HTMLElement("select")}} element to be programmatically launched when triggered by user interaction ([Firefox bug 1865207](https://bugzil.la/1865207)).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
FF122 enabled support for `Relnote HTMLSelectElement.showPicker()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1865207. This adds release note, and removes form experimental features. 

Related docs work can be tracked in https://github.com/mdn/content/issues/31106