### PR TITLE
`MediaStreamTrack.getCapabilities()` | add detail return value & fix incorrect usage of macros

### DIFF
--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A `MediaTrackCapabilities` object containing the following members:
+A `MediaTrackCapabilities` object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties, containing the following members:
 
 - `deviceId`
   - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the device ID.

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -84,3 +84,7 @@ navigator.mediaDevices.enumerateDevices().then((devices) => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("MediaStreamTrack.getCapabilities()")}}, which also return a `MediaTrackCapabilities` object.

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -28,7 +28,7 @@ A `MediaTrackCapabilities` object which specifies the value or range of values w
   - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the device ID.
 - `groupId`
   - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing a group ID.
-- `autoGainControl`>
+- `autoGainControl`
   - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do auto gain control.
     If the feature can be controlled by a script the source will report both true and false as possible values.
 - `channelCount`

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -10,9 +10,8 @@ browser-compat: api.MediaStreamTrack.getCapabilities
 
 The **`getCapabilities()`** method of
 the {{domxref("MediaStreamTrack")}} interface returns a
-{{domxref('MediaTrackCapabilities')}} object which specifies the values or range of
-values which each constrainable property, based upon the platform and {{Glossary("user
-    agent")}}.
+`MediaTrackCapabilities` object which specifies the values or range of
+values which each constrainable property, based upon the platform and {{Glossary("user agent")}}.
 
 Once you know what the browser's capabilities are, your script can use
 {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} to ask for the
@@ -30,7 +29,41 @@ None.
 
 ### Return value
 
-A {{domxref('MediaTrackCapabilities')}} object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties.
+A `MediaTrackCapabilities` object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties, containing the following members:
+
+- `deviceId`
+  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the device ID.
+- `groupId`
+  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing a group ID.
+- `autoGainControl`
+  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do auto gain control.
+    If the feature can be controlled by a script the source will report both true and false as possible values.
+- `channelCount`
+  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the channel count or range of channel counts.
+- `echoCancellation`
+  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do echo cancellation.
+    If the feature can be controlled by a script the source will report both true and false as possible values.
+- `latency`
+  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the latency or range of latencies.
+- `noiseSuppression`
+  - : A [`ConstrainBoolean`](/en-US/docs/Web/API/MediaTrackConstraints#constrainboolean) object reporting if the source can do noise suppression.
+    If the feature can be controlled by a script the source will report both true and false as possible values.
+- `sampleRate`
+  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the sample rate or range of sample rates.
+- `sampleSize`
+  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the sample size or range of sample sizes.
+- `aspectRatio`
+  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the video aspect ratio (width in pixels divided by height in pixels) or range of aspect ratios.
+- `facingMode`
+  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the camera facing mode. A camera may report multiple facings, for example "left" and "user".
+- `frameRate`
+  - : A [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble) containing the frame rate or range of frame rates which are acceptable.
+- `height`
+  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the video height or range of heights in pixels.
+- `width`
+  - : A [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong) containing the video width or range of widths in pixels.
+- `resizeMode`
+  - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the mode or an array of modes the UA can use to derive the resolution of the video track.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -72,3 +72,7 @@ A `MediaTrackCapabilities` object which specifies the value or range of values w
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("InputDeviceInfo.getCapabilities()")}}, which also return a `MediaTrackCapabilities` object.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

add details for `MediaStreamTrack.getCapabilities()`, that is list all members of `MediaTrackCapabilities` object

also remove the usage of {{domxref("MediaTrackCapabilities")}} object

add a link to indicate that `InputDeviceInfo.getCapabilities()` and `MediaStreamTrack.getCapabilities()` returns the same structure of data

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

see https://w3c.github.io/mediacapture-main/ and https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
