### PR TITLE
Remove bash tags from the console API tutorial

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -89,7 +89,7 @@ console.log(someObject);
 
 The output looks something like this:
 
-```
+```text
 {str:"Some text", id:5}
 ```
 
@@ -105,7 +105,7 @@ console.info("My first car was a", car, ". The object is:", someObject);
 
 The output will look like this:
 
-```
+```text
 My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
 ```
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -89,7 +89,7 @@ console.log(someObject);
 
 The output looks something like this:
 
-```bash
+```
 {str:"Some text", id:5}
 ```
 
@@ -105,7 +105,7 @@ console.info("My first car was a", car, ". The object is:", someObject);
 
 The output will look like this:
 
-```bash
+```
 My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
 ```
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -105,7 +105,7 @@ console.info("My first car was a", car, ". The object is:", someObject);
 
 The output will look like this:
 
-```text
+```plain
 My first car was a Dodge Charger. The object is: {str:"Some text", id:5}
 ```
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -89,7 +89,7 @@ console.log(someObject);
 
 The output looks something like this:
 
-```text
+```plain
 {str:"Some text", id:5}
 ```
 


### PR DESCRIPTION
This output certainly isn't bash, but is labeled and highlighted as such in the rendered doc.  Seems best to remove it.

### Related issues and pull requests
The bash tag originates from a mass conversion commit https://github.com/mdn/content/commit/2279e5ae6c229c707a014a22aa1ec4635a0f981f.
