### PR TITLE
De-XHRify miscellaneous pages

### DIFF
--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
@@ -86,17 +86,11 @@ const ttmlUrl = myVideo.getElementsByTagName("track")[0].src;
 
 ## Retrieving the IMSC file
 
-The browser will not retrieve the document automatically for us. In most browsers only [WebVTT](/en-US/docs/Web/API/WebVTT_API) is implemented at the moment. Therefore, these browsers expect that the value of the `src` attribute points to a WebVTT file. If it doesn't, they don't use it, and we also have no direct access to the file the `src` attribute is pointing to. We use the `src` attribute therefore just to store the URL of the IMSC file. We need to do the work to retrieve the file and read it into a JavaScript string. In the example we use the `XMLHttpRequest` method for this task:
+The browser will not retrieve the document automatically for us. In most browsers only [WebVTT](/en-US/docs/Web/API/WebVTT_API) is implemented at the moment. Therefore, these browsers expect that the value of the `src` attribute points to a WebVTT file. If it doesn't, they don't use it, and we also have no direct access to the file the `src` attribute is pointing to. We use the `src` attribute therefore just to store the URL of the IMSC file. We need to do the work to retrieve the file and read it into a JavaScript string. In the example we use the {{domxref("fetch()")}} API for this task:
 
 ```js
-const client = new XMLHttpRequest();
-
-client.open("GET", ttmlUrl);
-client.onreadystatechange = function () {
-  initTrack(client.responseText);
-};
-
-client.send();
+const response = await fetch(ttmlUrl);
+initTrack(await response.text());
 ```
 
 ## Setting the text track mode

--- a/files/en-us/web/accessibility/aria/roles/form_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/form_role/index.md
@@ -41,7 +41,7 @@ No role specific keyboard interactions
 ### Required JavaScript features
 
 - `onsubmit`
-  - : The onSubmit event handler handles the event raised when the form is submitted. Anything that is not a `<form>` cannot be submitted, therefore you would have to use JavaScript to build an alternative data submission mechanism, for example with {{domxref("XMLHTTPRequest")}}.
+  - : The onSubmit event handler handles the event raised when the form is submitted. Anything that is not a `<form>` cannot be submitted, therefore you would have to use JavaScript to build an alternative data submission mechanism, for example with {{domxref("fetch()")}}.
 
 ## Examples
 

--- a/files/en-us/web/guide/index.md
+++ b/files/en-us/web/guide/index.md
@@ -41,7 +41,7 @@ There are a number of guides within MDN docs. These articles aim to add addition
 ## APIs
 
 - [Using FormData objects](/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects)
-  - : The [`FormData`](/en-US/docs/Web/API/FormData) object lets you compile a set of key/value pairs to send using `XMLHttpRequest`. It's primarily intended for sending form data, but can be used independently of forms to transmit keyed data. The transmission is in the same format that the form's `submit()` method would use to send the data if the form's encoding type were set to "multipart/form-data".
+  - : The [`FormData`](/en-US/docs/Web/API/FormData) object lets you compile a set of key/value pairs to send using {{domxref("fetch()")}}. It's primarily intended for sending form data, but can be used independently of forms to transmit keyed data. The transmission is in the same format that the form's `submit()` method would use to send the data if the form's encoding type were set to "multipart/form-data".
 - [Progressive web apps](/en-US/docs/Web/Progressive_web_apps#core_pwa_guides)
   - : Progressive web apps (PWAs) use modern web APIs along with traditional progressive enhancement strategy to create cross-platform web applications. These apps work everywhere and provide several features that give them the same user experience advantages as native apps. This set of guides tells you all you need to know about PWAs.
 - [Parsing and serializing XML](/en-US/docs/Web/XML/Parsing_and_serializing_XML)

--- a/files/en-us/web/media/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/index.md
@@ -119,38 +119,41 @@ We set the source of the video depending on the type of video file the browser s
 
 ## Web Audio API
 
+In this example we retrieve an MP3 file using the {{domxref("fetch()")}} API, load it into a source, and play it.
+
 ```js
-let context;
-let request;
+let audioCtx;
+let buffer;
 let source;
 
-try {
-  context = new AudioContext();
-  request = new XMLHttpRequest();
-  request.open(
-    "GET",
-    "http://jplayer.org/audio/mp3/RioMez-01-Sleep_together.mp3",
-    true,
-  );
-  request.responseType = "arraybuffer";
-
-  request.onload = () => {
-    context.decodeAudioData(request.response, (buffer) => {
-      source = context.createBufferSource();
-      source.buffer = buffer;
-      source.connect(context.destination);
-      // autoplay
-      source.start(0); // start was previously noteOn
-    });
-  };
-
-  request.send();
-} catch (e) {
-  alert("web audio api not supported");
+async function loadAudio() {
+  try {
+    // Load an audio file
+    const response = await fetch("viper.mp3");
+    // Decode it
+    buffer = await audioCtx.decodeAudioData(await response.arrayBuffer());
+  } catch (err) {
+    console.error(`Unable to fetch the audio file. Error: ${err.message}`);
+  }
 }
+
+const play = document.getElementById("play");
+play.addEventListener("click", async () => {
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+    await loadAudio();
+  }
+  source = audioCtx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(audioCtx.destination);
+  source.start();
+  play.disabled = true;
+});
 ```
 
-In this example we retrieve an MP3 file via XHR, load it into a source and play it ([Try it for yourself](https://jsbin.com/facutone/1/edit?js)). Find more about Web Audio API basics in [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API).
+You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/promise/).
+
+Find more about Web Audio API basics in [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API).
 
 ## getUserMedia / Stream API
 

--- a/files/en-us/web/security/mixed_content/index.md
+++ b/files/en-us/web/security/mixed_content/index.md
@@ -40,8 +40,8 @@ This section lists some types of HTTP requests which are considered active conte
 - {{HTMLElement("script")}} (`src` attribute)
 - {{HTMLElement("link")}} (`href` attribute) (this includes CSS stylesheets)
 - {{HTMLElement("iframe")}} (`src` attribute)
-- {{domxref("XMLHttpRequest")}} requests
 - {{domxref("fetch()")}} requests
+- {{domxref("XMLHttpRequest")}} requests
 - All cases in CSS where a {{cssxref("url", "url()")}} value is used ({{cssxref("@font-face")}}, {{cssxref("cursor")}}, {{cssxref("background-image")}}, and so forth).
 - {{HTMLElement("object")}} (`data` attribute)
 - {{domxref("Navigator.sendBeacon")}} (`url` attribute)

--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -61,7 +61,7 @@ The mechanism has some limitations. For example, it will throw a "`SecurityError
 
 ## Cross-origin network access
 
-The same-origin policy controls interactions between two different origins, such as when you use {{domxref("XMLHttpRequest")}} or an {{htmlelement("img")}} element. These interactions are typically placed into three categories:
+The same-origin policy controls interactions between two different origins, such as when you use {{domxref("fetch()")}} or an {{htmlelement("img")}} element. These interactions are typically placed into three categories:
 
 - Cross-origin _writes_ are typically allowed. Examples are links, redirects, and form submissions. Some HTTP requests require [preflight](/en-US/docs/Web/HTTP/CORS#preflighted_requests).
 - Cross-origin _embedding_ is typically allowed. (Examples are listed below.)

--- a/files/en-us/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/xml/parsing_and_serializing_xml/index.md
@@ -12,8 +12,10 @@ At times, you may need to parse {{Glossary("XML")}} content and convert it into 
   - : Serializes DOM trees, converting them into strings containing XML.
 - {{domxref("DOMParser")}}
   - : Constructs a DOM tree by parsing a string containing XML, returning a {{domxref("XMLDocument")}} or {{domxref("Document")}} as appropriate based on the input data.
+- {{domxref("fetch()")}}
+  - : Loads content from a URL. XML content is returned as a text string which you can parse using `DOMParser`.
 - {{domxref("XMLHttpRequest")}}
-  - : Loads content from a URL; XML content is returned as an XML {{domxref("Document")}} object with a DOM tree built from the XML itself.
+  - : The precursor to `fetch()`. Unlike the `fetch()` API, `XMLHttpRequest` can return a resource as a `Document`, via its {{domxref("XMLHttpRequest.responseXML", "responseXML")}} property.
 - [XPath](/en-US/docs/Web/XPath)
   - : A technology for creating strings that contain addresses for specific portions of an XML document, and locating XML nodes based on those addresses.
 
@@ -45,24 +47,18 @@ if (errorNode) {
 Here is sample code that reads and parses a URL-addressable XML file into a DOM tree:
 
 ```js
-const xhr = new XMLHttpRequest();
-
-xhr.onload = () => {
-  dump(xhr.responseXML.documentElement.nodeName);
-};
-
-xhr.onerror = () => {
-  dump("Error while getting XML.");
-};
-
-xhr.open("GET", "example.xml");
-xhr.responseType = "document";
-xhr.send();
+fetch("example.xml")
+  .then((response) => response.text())
+  .then((text) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, "text/xml");
+    console.log(doc.documentElement.nodeName);
+  });
 ```
 
-The value in the `xhr` object's {{domxref("XMLHttpRequest.responseXML", "responseXML")}} field is a {{domxref("Document")}} constructed by parsing the XML.
+This code fetches the resource as a text string, then uses {{domxref("DOMParser.parseFromString()")}} to construct an {{domxref("XMLDocument")}}.
 
-If the document is {{Glossary("HTML")}}, the code shown above will return a {{domxref("Document")}}. If the document is XML, the resulting object is actually a {{domxref("XMLDocument")}}. The two types are essentially the same; the difference is largely historical, although differentiating has some practical benefits as well.
+If the document is {{Glossary("HTML")}}, the code shown above will return a {{domxref("Document")}}. If the document is XML, the resulting object is actually an `XMLDocument`. The two types are essentially the same; the difference is largely historical, although differentiating has some practical benefits as well.
 
 > **Note:** There is in fact an {{domxref("HTMLDocument")}} interface as well, but it is not necessarily an independent type. In some browsers it is, while in others it is an alias for the `Document` interface.
 
@@ -74,7 +70,7 @@ Use the following approaches to serialize the contents of the XML document you c
 
 ### Serializing DOM trees to strings
 
-First, create a DOM tree as described in [How to Create a DOM tree](/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree). Alternatively, use a DOM tree obtained from {{ domxref("XMLHttpRequest") }}.
+First, create a DOM tree as described in [How to Create a DOM tree](/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree). Alternatively, use a DOM tree obtained from {{ domxref("fetch()") }}.
 
 To serialize the DOM tree `doc` into XML text, call {{domxref("XMLSerializer.serializeToString()")}}:
 
@@ -102,5 +98,6 @@ const docOuterHtml = document.documentElement.outerHTML;
 ## See also
 
 - [XPath](/en-US/docs/Web/XPath)
+- {{domxref("fetch()")}}
 - {{domxref("XMLHttpRequest")}}
 - {{domxref("Document")}}, {{domxref("XMLDocument")}}, and {{domxref("HTMLDocument")}}

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{XsltSidebar}}
 
-This document describes the interface for using [XPath](/en-US/docs/Web/XPath) in JavaScript internally, in extensions, and from websites. Mozilla implements a fair amount of the [DOM 3 XPath](https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/), which means that XPath expressions can be run against both HTML and XML documents.
+This document describes the interface for using [XPath](/en-US/docs/Web/XPath) in JavaScript. Mozilla implements a fair amount of the [DOM 3 XPath](https://www.w3.org/TR/2004/NOTE-DOM-Level-3-XPath-20040226/), which means that XPath expressions can be run against both HTML and XML documents.
 
 The main interface to using XPath is the [evaluate](/en-US/docs/Web/API/Document/evaluate) function of the [document](/en-US/docs/Web/API/Document) object.
 
@@ -264,53 +264,6 @@ while (thisHeading) {
 ```
 
 Once we iterate to a node, we have access to all the standard DOM interfaces on that node. After iterating through all the `h2` elements returned from our expression, any further calls to `iterateNext()` will return `null`.
-
-### Evaluating against an XML document within an Extension
-
-The following uses an XML document located at `chrome://yourextension/content/peopleDB.xml` as an example.
-
-```xml
-<?xml version="1.0"?>
-<people xmlns:xul = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" >
-  <person>
-    <name first="george" last="bush" />
-    <address street="1600 pennsylvania avenue" city="washington" country="usa"/>
-    <phoneNumber>202-456-1111</phoneNumber>
-  </person>
-  <person>
-    <name first="tony" last="blair" />
-    <address street="10 downing street" city="london" country="uk"/>
-    <phoneNumber>020 7925 0918</phoneNumber>
-  </person>
-</people>
-```
-
-To make the contents of the XML document available within the extension, we create an [`XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) object to load the document synchronously, the variable `xmlDoc` will contain the document as an [`XMLDocument`](/en-US/docs/Web/API/XMLDocument) object against which we can use the `evaluate` method
-
-JavaScript used in the extensions xul/js documents.
-
-```js
-const req = new XMLHttpRequest();
-
-req.open("GET", "chrome://yourextension/content/peopleDB.xml", false);
-req.send(null);
-
-const xmlDoc = req.responseXML;
-
-const nsResolver = xmlDoc.createNSResolver(
-  xmlDoc.ownerDocument === null
-    ? xmlDoc.documentElement
-    : xmlDoc.ownerDocument.documentElement,
-);
-
-const personIterator = xmlDoc.evaluate(
-  "//person",
-  xmlDoc,
-  nsResolver,
-  XPathResult.ANY_TYPE,
-  null,
-);
-```
 
 ## Appendix
 

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -36,8 +36,6 @@ function evaluateXPath(aNode, aExpr) {
 
 Note that `createNSResolver` should only be used if you are sure the namespace prefixes in the XPath expression match those in the document you want to query (and that no default namespace is being used (though see [document.createNSResolver](/en-US/docs/Web/API/Document/createNSResolver) for a workaround)). Otherwise, you have to provide your own implementation of XPathNSResolver.
 
-If you are using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) to read a local or remote XML file into a DOM tree (as described in [Parsing and serializing XML](/en-US/docs/Web/XML/Parsing_and_serializing_XML)), the first argument to `evaluateXPath()` should be `req.responseXML`.
-
 #### Sample usage
 
 Assume we have the following XML document (see also [How to Create a DOM tree](/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree) and [Parsing and serializing XML](/en-US/docs/Web/XML/Parsing_and_serializing_XML)):


### PR DESCRIPTION
Part of https://github.com/openwebdocs/project/issues/156.

This is everything left over except /JavaScript and /Mozilla.

- the IMSC change has https://github.com/mdn/imsc-examples/pull/14 to accompany it, although I don't think it needs to block on that
- in "using XPath in JavaScript", I just deleted the section on "Evaluating against an XML document within an Extension", I'm pretty sure that the stuff there is no longer possible in extensions (and hasn't been for about 6 years)