### PR TITLE
De-XHRify JavaScript

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -139,7 +139,7 @@ It can be tempting to use strings to represent complex data. Doing this comes wi
 
 - It is easy to build complex strings with concatenation.
 - Strings are easy to debug (what you see printed is always what is in the string).
-- Strings are the common denominator of a lot of APIs ([input fields](/en-US/docs/Web/API/HTMLInputElement), [local storage](/en-US/docs/Web/API/Web_Storage_API) values, [`XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) responses when using `responseText`, etc.) and it can be tempting to only work with strings.
+- Strings are the common denominator of a lot of APIs ([input fields](/en-US/docs/Web/API/HTMLInputElement), [local storage](/en-US/docs/Web/API/Web_Storage_API) values, [`fetch()`](/en-US/docs/Web/API/fetch) responses when using {{domxref("Response.text()")}}, etc.) and it can be tempting to only work with strings.
 
 With conventions, it is possible to represent any data structure in a string. This does not make it a good idea. For instance, with a separator, one could emulate a list (while a JavaScript array would be more suitable). Unfortunately, when the separator is used in one of the "list" elements, then, the list is broken. An escape character can be chosen, etc. All of this requires conventions and creates an unnecessary maintenance burden.
 

--- a/files/en-us/web/javascript/event_loop/index.md
+++ b/files/en-us/web/javascript/event_loop/index.md
@@ -137,7 +137,7 @@ A web worker or a cross-origin `iframe` has its own stack, heap, and message que
 
 ## Never blocking
 
-A very interesting property of the event loop model is that JavaScript, unlike a lot of other languages, never blocks. Handling I/O is typically performed via events and callbacks, so when the application is waiting for an [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) query to return or an [XHR](/en-US/docs/Web/API/XMLHttpRequest) request to return, it can still process other things like user input.
+A very interesting property of the event loop model is that JavaScript, unlike a lot of other languages, never blocks. Handling I/O is typically performed via events and callbacks, so when the application is waiting for an [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) query to return or a [`fetch()`](/en-US/docs/Web/API/fetch) request to return, it can still process other things like user input.
 
 Legacy exceptions exist like `alert` or synchronous XHR, but it is considered good practice to avoid them. Beware: [exceptions to the exception do exist](https://stackoverflow.com/questions/2734025/is-javascript-guaranteed-to-be-single-threaded/2734311#2734311) (but are usually implementation bugs, rather than anything else).
 

--- a/files/en-us/web/javascript/guide/typed_arrays/index.md
+++ b/files/en-us/web/javascript/guide/typed_arrays/index.md
@@ -131,7 +131,7 @@ These are some examples of APIs that make use of typed arrays; there are others,
 - [`FileReader.prototype.readAsArrayBuffer()`](/en-US/docs/Web/API/FileReader/readAsArrayBuffer)
   - : The `FileReader.prototype.readAsArrayBuffer()` method starts reading the contents of the specified [`Blob`](/en-US/docs/Web/API/Blob) or [`File`](/en-US/docs/Web/API/File).
 - [`fetch()`](/en-US/docs/Web/API/fetch)
-  - : The [`body`](/en-US/docs/Web/API/fetch#body) option to `fetch()` can be a typed array or {{jsxref("ArrayBuffer")}}, enabling you to send these objects as the payload of a {{httpmethod("POST")}} request.
+  - : The [`body`](/en-US/docs/Web/API/fetch#body) option to `fetch()` can be a typed array or {{jsxref("ArrayBuffer")}}, enabling you to send these objects as the payload of a {{HTTPMethod("POST")}} request.
 - [`ImageData.data`](/en-US/docs/Web/API/ImageData)
   - : Is a {{jsxref("Uint8ClampedArray")}} representing a one-dimensional array containing the data in the RGBA order, with integer values between `0` and `255` inclusive.
 

--- a/files/en-us/web/javascript/guide/typed_arrays/index.md
+++ b/files/en-us/web/javascript/guide/typed_arrays/index.md
@@ -130,8 +130,8 @@ These are some examples of APIs that make use of typed arrays; there are others,
 
 - [`FileReader.prototype.readAsArrayBuffer()`](/en-US/docs/Web/API/FileReader/readAsArrayBuffer)
   - : The `FileReader.prototype.readAsArrayBuffer()` method starts reading the contents of the specified [`Blob`](/en-US/docs/Web/API/Blob) or [`File`](/en-US/docs/Web/API/File).
-- [`XMLHttpRequest.prototype.send()`](/en-US/docs/Web/API/XMLHttpRequest/send)
-  - : `XMLHttpRequest` instances' `send()` method now supports typed arrays and {{jsxref("ArrayBuffer")}} objects as argument.
+- [`fetch()`](/en-US/docs/Web/API/fetch)
+  - : The [`body`](/en-US/docs/Web/API/fetch#body) option to `fetch()` can be a typed array or {{jsxref("ArrayBuffer")}}, enabling you to send these objects as the payload of a {{httpmethod("POST")}} request.
 - [`ImageData.data`](/en-US/docs/Web/API/ImageData)
   - : Is a {{jsxref("Uint8ClampedArray")}} representing a one-dimensional array containing the data in the RGBA order, with integer values between `0` and `255` inclusive.
 


### PR DESCRIPTION
(The last) Part of https://github.com/openwebdocs/project/issues/156.

There are a few other pages that reference XMLHttpRequest, but I thought they were OK:

[web/javascript/reference/statements/switch/](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/switch/)
[web/javascript/reference/global_objects/promise/promise/](https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/promise/promise/)
[web/javascript/reference/global_objects/promise/](https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/promise/)
[web/javascript/javascript_technologies_overview/](https://developer.mozilla.org/en-US/docs/web/javascript/javascript_technologies_overview/)

I was a bit surprised to read in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Event_loop that "JavaScript... never blocks". I'm not sure in what sense this is true.

