### PR TITLE
CustomEvent note re sharing objects

### DIFF
--- a/files/en-us/web/api/customevent/index.md
+++ b/files/en-us/web/api/customevent/index.md
@@ -9,6 +9,8 @@ browser-compat: api.CustomEvent
 
 The **`CustomEvent`** interface represents events initialized by an application for any purpose.
 
+> **Note:** If used to attempt to communicate between a web extension content script and a web page script, a non-string `detail` property throws with "Permission denied to access property" in Firefox. To avoid this issue clone the object. See [Share objects with page scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts) for more information.
+
 {{AvailableInWorkers}}
 
 {{InheritanceDiagram}}


### PR DESCRIPTION
### Description

Adds a small note stating the to clone objects when used in WebExtensions' content scripts to communicate with the web page, with a link to the extension documentation on share objects with page scripts.

### Related issues and pull requests

Fixes #29232