### PR TITLE
Remove mention of SMIL being deprecated in Chrome

### DIFF
--- a/files/en-us/web/svg/svg_animation_with_smil/index.md
+++ b/files/en-us/web/svg/svg_animation_with_smil/index.md
@@ -6,8 +6,6 @@ page-type: guide
 
 {{SVGRef}}
 
-> **Warning:** Although Chrome 45 deprecated SMIL in favor of CSS animations and Web animations, the Chrome developers have since [suspended](https://groups.google.com/a/chromium.org/d/msg/blink-dev/5o0yiO440LM/YGEJBsjUAwAJ) that deprecation.
-
 Firefox 4 introduced support for animating [SVG](/en-US/docs/Web/SVG) using [Synchronized Multimedia Integration Language](https://www.w3.org/TR/REC-smil/) (SMIL). SMIL allows you to:
 
 - animate the numeric attributes of an element (x, y, …)

--- a/files/en-us/web/svg/svg_animation_with_smil/index.md
+++ b/files/en-us/web/svg/svg_animation_with_smil/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{SVGRef}}
 
-Firefox 4 introduced support for animating [SVG](/en-US/docs/Web/SVG) using [Synchronized Multimedia Integration Language](https://www.w3.org/TR/REC-smil/) (SMIL). SMIL allows you to:
+[Synchronized Multimedia Integration Language](https://www.w3.org/TR/REC-smil/) (SMIL) is an extension of [SVG](/en-US/docs/Web/SVG) allowing to animating SVG elements. SMIL allows you to:
 
 - animate the numeric attributes of an element (x, y, …)
 - animate transform attributes (translation or rotation)


### PR DESCRIPTION
### Description
Removed SMIL warning.

### Motivation
SMIL was never deprecated by Chrome or it's not even something not recommended.

Given thread itself is deprecated & 8 years old:
https://groups.google.com/a/chromium.org/g/blink-dev/c/5o0yiO440LM/m/YGEJBsjUAwAJ