### PR TITLE
backface-visibility property

### DIFF
--- a/files/en-us/web/css/css_transforms/using_css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/using_css_transforms/index.md
@@ -171,7 +171,6 @@ The CSS establishes classes that can be used to set the perspective to different
 .cube {
   width: 100%;
   height: 100%;
-  backface-visibility: visible;
   perspective-origin: 150% 150%;
   transform-style: preserve-3d;
 }
@@ -187,6 +186,7 @@ The CSS establishes classes that can be used to set the perspective to different
   font-size: 60px;
   color: white;
   text-align: center;
+  backface-visibility: visible;
 }
 
 /* Define each face based on direction */
@@ -468,7 +468,6 @@ This example shows cubes with popular `perspective-origin` values.
 .cube {
   width: 100%;
   height: 100%;
-  backface-visibility: visible;
   perspective: 300px;
   transform-style: preserve-3d;
 }
@@ -484,6 +483,7 @@ This example shows cubes with popular `perspective-origin` values.
   font-size: 60px;
   color: white;
   text-align: center;
+  backface-visibility: visible;
 }
 
 /* Define each face based on direction */


### PR DESCRIPTION
Hi. backface-visibility has no effect when declared for .cube class. It must be declared for .face class elements instead. Try "hidden" instead of "visible", so that you can check that out.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
