### PR TITLE
URL Pattern API |  add readonly mark for properties & update constructor parameters

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -14,6 +14,8 @@ matchers. These patterns can be matched against URLs or individual URL
 components. The URL Pattern API is used by the {{domxref("URLPattern")}}
 interface.
 
+{{AvailableInWorkers}}
+
 ## Concepts and usage
 
 The pattern syntax is based on the syntax from the

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -31,7 +31,7 @@ can contain:
 You can find details about the syntax in the [pattern syntax](#pattern_syntax)
 section below.
 
-## URL Pattern API interfaces
+## Interfaces
 
 The URL Pattern API only has a single related interface:
 

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -5,6 +5,7 @@ page-type: web-api-overview
 status:
   - experimental
 browser-compat: api.URLPattern
+spec-urls: https://urlpattern.spec.whatwg.org/
 ---
 
 {{DefaultAPISidebar("URL Pattern API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -10,7 +10,7 @@ spec-urls: https://urlpattern.spec.whatwg.org/
 
 {{DefaultAPISidebar("URL Pattern API")}}{{SeeCompatTable}}
 
-The URL Pattern API defines a syntax that is used to create URL pattern
+The **URL Pattern API** defines a syntax that is used to create URL pattern
 matchers. These patterns can be matched against URLs or individual URL
 components. The URL Pattern API is used by the {{domxref("URLPattern")}}
 interface.
@@ -39,6 +39,7 @@ section below.
 The URL Pattern API only has a single related interface:
 
 - {{domxref("URLPattern")}} {{Experimental_Inline}}
+  - : Represents a pattern that can match URLs or parts of URLs. The pattern can contain capturing groups that extract parts of the matched URL.
 
 ## Pattern syntax
 

--- a/files/en-us/web/api/urlpattern/hash/index.md
+++ b/files/en-us/web/api/urlpattern/hash/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.hash
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`hash`** property of the {{domxref("URLPattern")}} interface is a
+The **`hash`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the fragment part
 of a URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/hostname/index.md
+++ b/files/en-us/web/api/urlpattern/hostname/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.hostname
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`hostname`** property of the {{domxref("URLPattern")}} interface is a
+The **`hostname`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the hostname part
 of a URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/index.md
@@ -23,28 +23,28 @@ page: {{domxref("URL Pattern API", "", "", "nocode")}}.
 
 ## Instance properties
 
-- {{domxref("URLPattern.hash", "hash")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.hash", "hash")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _hash_ part
     of a URL.
-- {{domxref("URLPattern.hostname", "hostname")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.hostname", "hostname")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _hostname_
     part of a URL.
-- {{domxref("URLPattern.password", "password")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.password", "password")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _password_
     part of a URL.
-- {{domxref("URLPattern.pathname", "pathname")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.pathname", "pathname")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _pathname_
     part of a URL.
-- {{domxref("URLPattern.port", "port")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.port", "port")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _port_ part
     of a URL.
-- {{domxref("URLPattern.protocol", "protocol")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.protocol", "protocol")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _protocol_
     part of a URL.
-- {{domxref("URLPattern.search", "search")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.search", "search")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _search_ part
     of a URL.
-- {{domxref("URLPattern.username","username")}} {{Experimental_Inline}}
+- {{domxref("URLPattern.username","username")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing a pattern to match the _username_
     part of a URL.
 

--- a/files/en-us/web/api/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/index.md
@@ -9,11 +9,10 @@ browser-compat: api.URLPattern
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`URLPattern`** interface matches URLs or parts of URLs against a pattern.
-The pattern can contain capturing groups that extract parts of the matched URL.
+The **`URLPattern`** interface of the {{domxref("URL Pattern API", "", "", "nocode")}} matches URLs or parts of URLs against a pattern. The pattern can contain capturing groups that extract parts of the matched URL.
 
 More information about the syntax of patterns can be found on the API overview
-page: [URL Pattern API](/en-US/docs/Web/API/URL_Pattern_API)
+page: {{domxref("URL Pattern API", "", "", "nocode")}}.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/urlpattern/password/index.md
+++ b/files/en-us/web/api/urlpattern/password/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.password
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`password`** property of the {{domxref("URLPattern")}} interface is a
+The **`password`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the password part
 of a URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/pathname/index.md
+++ b/files/en-us/web/api/urlpattern/pathname/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.pathname
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`pathname`** property of the {{domxref("URLPattern")}} interface is a
+The **`pathname`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the pathname part
 of a URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/port/index.md
+++ b/files/en-us/web/api/urlpattern/port/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.port
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`port`** property of the {{domxref("URLPattern")}} interface is a
+The **`port`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the port part of a
 URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/protocol/index.md
+++ b/files/en-us/web/api/urlpattern/protocol/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.protocol
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`protocol`** property of the {{domxref("URLPattern")}} interface is a
+The **`protocol`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the protocol part
 of a URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/search/index.md
+++ b/files/en-us/web/api/urlpattern/search/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.search
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`search`** property of the {{domxref("URLPattern")}} interface is a
+The **`search`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the search part of
 a URL. This value may differ from the input to the constructor due to
 normalization.

--- a/files/en-us/web/api/urlpattern/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/urlpattern/index.md
@@ -19,17 +19,16 @@ object representing the url pattern defined by the parameters.
 
 ```js-nolint
 new URLPattern(input)
-new URLPattern(input, baseURL)
+new URLPattern(patternString, baseURL)
 new URLPattern(input, options)
-new URLPattern(input, baseURL, options)
+new URLPattern(patternString, baseURL, options)
 ```
 
 ### Parameters
 
-- `input`
-  - : The input pattern that will be used for matching. This can either be a
-    string, or an object providing patterns for each URL part
-    individually. The object members can be any of:
+- `input` {{Optional_Inline}}
+  - : An object providing patterns for each URL part individually
+    that will be used for matching. The object members can be any of:
     - `protocol`
     - `username`
     - `password`
@@ -40,12 +39,14 @@ new URLPattern(input, baseURL, options)
     - `hash`
     - `baseURL`
       > **Note:** Omitted parts of the object will be treated as wildcards (`*`).
+- `patternString` {{Optional_Inline}}
+  - : A string representing the input pattern that will be used for matching.
 - `baseURL` {{Optional_Inline}}
   - : A string representing the base URL to use in cases where
     `input` is a relative pattern. If not specified, it defaults to `undefined`.
 - `options` {{Optional_Inline}}
   - : An object providing options for matching the given pattern. The possible object members are as follows:
-    - `ignoreCase`
+    - `ignoreCase` {{Optional_Inline}}
       - Enables case-insensitive matching if set to `true`. If omitted or set to `false`, matching will be case-sensitive.
 
 ### Exceptions

--- a/files/en-us/web/api/urlpattern/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/urlpattern/index.md
@@ -19,16 +19,17 @@ object representing the url pattern defined by the parameters.
 
 ```js-nolint
 new URLPattern(input)
-new URLPattern(patternString, baseURL)
+new URLPattern(input, baseURL)
 new URLPattern(input, options)
-new URLPattern(patternString, baseURL, options)
+new URLPattern(input, baseURL, options)
 ```
 
 ### Parameters
 
-- `input` {{Optional_Inline}}
-  - : An object providing patterns for each URL part individually
-    that will be used for matching. The object members can be any of:
+- `input`
+  - : The input pattern that will be used for matching. This can either be a
+    string, or an object providing patterns for each URL part
+    individually. The object members can be any of:
     - `protocol`
     - `username`
     - `password`
@@ -39,15 +40,13 @@ new URLPattern(patternString, baseURL, options)
     - `hash`
     - `baseURL`
       > **Note:** Omitted parts of the object will be treated as wildcards (`*`).
-- `patternString` {{Optional_Inline}}
-  - : A string representing the input pattern that will be used for matching.
 - `baseURL` {{Optional_Inline}}
   - : A string representing the base URL to use in cases where
     `input` is a relative pattern. If not specified, it defaults to `undefined`.
 - `options` {{Optional_Inline}}
   - : An object providing options for matching the given pattern. The possible object members are as follows:
     - `ignoreCase` {{Optional_Inline}}
-      - Enables case-insensitive matching if set to `true`. If omitted or set to `false`, matching will be case-sensitive.
+      - : Enables case-insensitive matching if set to `true`. If omitted or set to `false`, matching will be case-sensitive.
 
 ### Exceptions
 

--- a/files/en-us/web/api/urlpattern/username/index.md
+++ b/files/en-us/web/api/urlpattern/username/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URLPattern.username
 
 {{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
-The **`username`** property of the {{domxref("URLPattern")}} interface is a
+The **`username`** read-only property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the username part
 of a URL. This value may differ from the input to the constructor due to
 normalization.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

see https://urlpattern.spec.whatwg.org/ and https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API

maajor changes:

add {{AvailableInWorkers}} for API landing page, also update section title - *URL Pattern API interfaces* to *Interfaces*, also add a description for `URLPattern` interface

mark properties in `URLPattern` as readonly - add read-only word in API property subpage and {{ReadOnlyInline}} in API reference page

update `URLPattern()` constructor parameters - mark `ignoreCase` as optional

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
