### PR TITLE
Fix Promise resolution pluralization

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -156,13 +156,13 @@ Promise.resolve(aThenable); // A promise fulfilled with 42
 The `Promise` class offers four static methods to facilitate async task [concurrency](https://en.wikipedia.org/wiki/Concurrent_computing):
 
 - {{jsxref("Promise.all()")}}
-  - : Fulfills when **all** of the promises fulfill; rejects when **any** of the promises rejects.
+  - : Fulfills when **all** of the promises fulfill; rejects when **any** of the promises reject.
 - {{jsxref("Promise.allSettled()")}}
   - : Fulfills when **all** promises settle.
 - {{jsxref("Promise.any()")}}
-  - : Fulfills when **any** of the promises fulfills; rejects when **all** of the promises reject.
+  - : Fulfills when **any** of the promises fulfill; rejects when **all** of the promises reject.
 - {{jsxref("Promise.race()")}}
-  - : Settles when **any** of the promises settles. In other words, fulfills when any of the promises fulfills; rejects when any of the promises rejects.
+  - : Settles when **any** of the promises settle. In other words, fulfills when any of the promises fulfill; rejects when any of the promises reject.
 
 All these methods take an [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) of promises ([thenables](#thenables), to be exact) and return a new promise. They all support subclassing, which means they can be called on subclasses of `Promise`, and the result will be a promise of the subclass type. To do so, the subclass's constructor must implement the same signature as the [`Promise()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise) constructor — accepting a single `executor` function that can be called with the `resolve` and `reject` callbacks as parameters. The subclass must also have a `resolve` static method that can be called like {{jsxref("Promise.resolve()")}} to resolve values to promises.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

When discussing multiple promises the result should be singular, for example:

> rejects when any of the promises reject~s~

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Fixes grammar and makes use of pluralization consistent when discussing multiple promises.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

N/A.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

N/A.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
