### PR TITLE
Fix lazy loading examples

### DIFF
--- a/files/en-us/web/performance/lazy_loading/index.md
+++ b/files/en-us/web/performance/lazy_loading/index.md
@@ -68,8 +68,8 @@ The [`loading`](/en-US/docs/Web/HTML/Element/img#loading) attribute on an {{HTML
 This allows non-critical resources to load only if needed, potentially speeding up initial page loads and reducing network usage.
 
 ```html
-<img src="image.jpg" alt="..." loading="lazy" />
-<iframe src="video-player.html" title="..." loading="lazy"></iframe>
+<img loading="lazy" src="image.jpg" alt="..." />
+<iframe loading="lazy" src="video-player.html" title="..."></iframe>
 ```
 
 The `load` event fires when the eagerly-loaded content has all been loaded. At that time, it's entirely possible (or even likely) that there may be lazily-loaded images or iframes within the {{Glossary("visual viewport")}} that haven't yet loaded.


### PR DESCRIPTION
### Description

Due to [Bug 1647077](https://bugzilla.mozilla.org/show_bug.cgi?id=1647077), `loading="lazy"` must be placed before the `src` attribute for it to work properly on Firefox.