### PR TITLE
Fixed a mistake in code example

### DIFF
--- a/files/en-us/web/css/cssom_view/coordinate_systems/index.md
+++ b/files/en-us/web/css/cssom_view/coordinate_systems/index.md
@@ -77,7 +77,7 @@ const inner = document.querySelector(".inner");
 
 function setCoords(e) {
   log.innerText = `
-    Offset X/Y: ${e.screenX}, ${e.screenY}
+    Offset X/Y: ${e.offsetX}, ${e.offsetY}
     Viewport X/Y: ${e.clientX}, ${e.clientY}
     Page X/Y: ${e.pageX}, ${e.pageY}
     Screen X/Y: ${e.screenX}, ${e.screenY}`;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Found a mistake in JavaScript code example on https://developer.mozilla.org/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems.
It's showing screen coordinate values instead of offset coordinate values.

### Motivation

I learned about offset coordinates in the docs and was confused about why it was not working as expected in the example.
It took me some time to figure out what was wrong, so I don't want others to also waste their time.
