### PR TITLE
Elaborate on matchAll's return value

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -29,7 +29,7 @@ matchAll(regexp)
 
 ### Return value
 
-An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each iterator value has the same shape as  {{jsxref("RegExp.prototype.exec()")}}'s return value.
+An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each iterator value has the same shape as {{jsxref("RegExp.prototype.exec()")}}'s return value.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -29,7 +29,7 @@ matchAll(regexp)
 
 ### Return value
 
-An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches. Each match is an array with the same shape as the return value of {{jsxref("RegExp.prototype.exec()")}}.
+An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of successful matches or an empty iterator if no matches are found. Each match is an array with the same shape as the return value of {{jsxref("RegExp.prototype.exec()")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -29,7 +29,7 @@ matchAll(regexp)
 
 ### Return value
 
-An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each value yielded by the iterator has the same shape as {{jsxref("RegExp.prototype.exec()")}}'s return value.
+An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each value yielded by the iterator is an array with the same shape as the return value of {{jsxref("RegExp.prototype.exec()")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -29,7 +29,7 @@ matchAll(regexp)
 
 ### Return value
 
-An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of successful matches or an empty iterator if no matches are found. Each match is an array with the same shape as the return value of {{jsxref("RegExp.prototype.exec()")}}.
+An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each iterator value has the same shape as  {{jsxref("RegExp.prototype.exec()")}}'s return value.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/matchall/index.md
@@ -29,7 +29,7 @@ matchAll(regexp)
 
 ### Return value
 
-An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each iterator value has the same shape as {{jsxref("RegExp.prototype.exec()")}}'s return value.
+An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each value yielded by the iterator has the same shape as {{jsxref("RegExp.prototype.exec()")}}'s return value.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Original vs Modification
```
- An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches. Each match is an array with the same shape as the return value of {{jsxref("RegExp.prototype.exec()")}}.
+ An [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) (which is not restartable) of matches or an empty iterator if no matches are found. Each iterator value has the same shape as {{jsxref("RegExp.prototype.exec()")}}'s return value.
```

### Motivation

I don't necessarily think this is an improvement. It's more about starting a conversation around the topic of, "What does `matchAll` return when there are no matches?" After reading this sentence, that was unclear to me so I had to experiment with developer tools to learn. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

1. I'm not sure if the term "empty iterator" is technically correct. 
1. I think the link to `RegExp.prototype.exec()` should be changed to go to `RegExp.prototype.exec()`'s [Return value section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#return_value), but I couldn't figure out how to do this nor find a similar example.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
