### PR TITLE
Content:JS  Clarify shallow copy definition  

### DIFF
--- a/files/en-us/glossary/shallow_copy/index.md
+++ b/files/en-us/glossary/shallow_copy/index.md
@@ -10,7 +10,7 @@ A **shallow copy** of an object is a copy whose properties share the same [refer
 
 More formally, two objects `o1` and `o2` are shallow copies if:
 
-1. They are not the same object (`o1 !== o2`).
+1. They are not the same object but they refer to same object (`o1 === o2`).
 2. The properties of `o1` and `o2` have the same names in the same order.
 3. The values of their properties are equal.
 4. Their prototype chains are equal.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed an error where  wrong comparison operator was used in the definition of shallow copies. 
In shallow copies, `o1` and `o2` reference the same object (`o1 === o2`), not distinct ones (`o1 !== o2`).


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Improves clarity in the documentation about shallow copies, ensuring that readers understand the correct relationship between shallow copies.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
