### PR TITLE
fix: React Fragments doc has new URL

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -313,7 +313,7 @@ function App() {
 
 The `App()` function returns a JSX expression. This expression defines what your browser ultimately renders to the DOM.
 
-Just under the `return` keyword is a special bit of syntax: `<>`. This is a [fragment](https://react.dev/docs/fragments). React components have to return a single JSX element, and fragments allow us to do that without rendering arbitrary `<div>`s in the browser. You'll see fragments in many React applications.
+Just under the `return` keyword is a special bit of syntax: `<>`. This is a [fragment](https://react.dev/reference/react/Fragment). React components have to return a single JSX element, and fragments allow us to do that without rendering arbitrary `<div>`s in the browser. You'll see fragments in many React applications.
 
 ### The `export` statement
 


### PR DESCRIPTION
Point to new react.dev URL about Fragments

Looks like https://react.dev/docs is completely gone now, the new scheme is https://react.dev/reference/react