### PR TITLE
`ImageCapture` | fix apiref & add exception section & fix a property description

### DIFF
--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ImageCapture.getPhotoCapabilities
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`getPhotoCapabilities()`**
 method of the {{domxref("ImageCapture")}} interface returns a {{jsxref("Promise")}}

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -38,6 +38,13 @@ A {{jsxref("Promise")}} that resolves with an object containing the following pr
 - `fillLightMode`
   - : Returns an array of available fill light options. Options include `auto`, `off`, or `flash`.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `readyState` property of the `MediaStreamTrack` passing in the constructor is not `live`.
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown if the operation can't complete for any reason.
+
 ## Examples
 
 The following example, extracted from [Chrome's Image Capture / Photo Resolution Sample](https://googlechrome.github.io/samples/image-capture/photo-resolution.html), uses the results from

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -27,8 +27,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with an object
-containing the following properties:
+A {{jsxref("Promise")}} that resolves with an object containing the following properties:
 
 - `fillLightMode`
   - : The flash setting of the capture device, one of `"auto"`, `"off"`, or `"flash"`.

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -39,6 +39,13 @@ containing the following properties:
 - `redEyeReduction`
   - : A boolean indicating whether the red-eye reduction should be used if it is available.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `readyState` property of the `MediaStreamTrack` passing in the constructor is not `live`.
+- `OperationError` {{domxref("DOMException")}}
+  - : Thrown if the operation can't complete for any reason.
+
 ## Examples
 
 The following example, extracted from [Chrome's Image Capture / Photo Resolution Sample](https://googlechrome.github.io/samples/image-capture/photo-resolution.html), uses the results from

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ImageCapture.getPhotoSettings
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`getPhotoSettings()`** method of
 the {{domxref("ImageCapture")}} interface returns a {{jsxref("Promise")}} that

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -31,7 +31,7 @@ A {{jsxref("Promise")}} that resolves with an object
 containing the following properties:
 
 - `fillLightMode`
-  - : The flash setting of the capture device, one of `"auto"`, `"off"`, or `"on"`.
+  - : The flash setting of the capture device, one of `"auto"`, `"off"`, or `"flash"`.
 - `imageHeight`
   - : The desired image height as an integer. The browser selects the closest width value to this setting if it only supports discrete heights.
 - `imageWidth`

--- a/files/en-us/web/api/imagecapture/grabframe/index.md
+++ b/files/en-us/web/api/imagecapture/grabframe/index.md
@@ -29,6 +29,13 @@ None.
 
 A {{jsxref("Promise")}} that resolves to an {{domxref("ImageBitmap")}} object.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `readyState` property of the `MediaStreamTrack` passing in the constructor is not `live`.
+- `UnknownError` {{domxref("DOMException")}}
+  - : Thrown if the operation can't complete for any reason.
+
 ## Examples
 
 This example is extracted from this [Simple Image Capture demo](https://simpl.info/imagecapture/). It shows how to use the {{jsxref("Promise")}} returned by

--- a/files/en-us/web/api/imagecapture/grabframe/index.md
+++ b/files/en-us/web/api/imagecapture/grabframe/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ImageCapture.grabFrame
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`grabFrame()`** method of the
 {{domxref("ImageCapture")}} interface takes a snapshot of the live video in a

--- a/files/en-us/web/api/imagecapture/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/imagecapture/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ImageCapture.ImageCapture
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`ImageCapture()`** constructor
 creates a new {{domxref("ImageCapture")}} object.

--- a/files/en-us/web/api/imagecapture/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/imagecapture/index.md
@@ -31,6 +31,11 @@ new ImageCapture(videoTrack)
 A new `ImageCapture` object which can be used to capture still frames from
 the specified video track.
 
+### Exceptions
+
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : Thrown if the `videoTrack` parameter's `kind` property is not `video`.
+
 ## Examples
 
 The following example shows how to use a call to

--- a/files/en-us/web/api/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/index.md
@@ -23,8 +23,6 @@ The **`ImageCapture`** interface of the [MediaStream Image Capture API](/en-US/d
 
 ## Instance methods
 
-The `ImageCapture` interface is based on {{domxref("EventTarget")}}, so it includes the methods defined by that interface as well as the ones listed below.
-
 - {{domxref("ImageCapture.takePhoto()")}} {{Experimental_Inline}}
   - : Takes a single exposure using the video capture device sourcing a {{domxref("MediaStreamTrack")}} and returns a {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}} containing the data.
 - {{domxref("ImageCapture.getPhotoCapabilities()")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.ImageCapture
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`ImageCapture`** interface of the [MediaStream Image Capture API](/en-US/docs/Web/API/MediaStream_Image_Capture_API) provides methods to enable the capture of images or photos from a camera or other photographic device. It provides an interface for capturing images from a photographic device referenced through a valid {{domxref("MediaStreamTrack")}}.
 

--- a/files/en-us/web/api/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/index.md
@@ -26,7 +26,7 @@ The **`ImageCapture`** interface of the [MediaStream Image Capture API](/en-US/d
 - {{domxref("ImageCapture.takePhoto()")}} {{Experimental_Inline}}
   - : Takes a single exposure using the video capture device sourcing a {{domxref("MediaStreamTrack")}} and returns a {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}} containing the data.
 - {{domxref("ImageCapture.getPhotoCapabilities()")}} {{Experimental_Inline}}
-  - : Returns a {{jsxref("Promise")}} that resolves with a `PhotoCapabilities` object containing the ranges of available configuration options.
+  - : Returns a {{jsxref("Promise")}} that resolves with an object containing the ranges of available configuration options.
 - {{domxref("ImageCapture.getPhotoSettings()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with an object containing the current photo configuration settings.
 - {{domxref("ImageCapture.grabFrame()")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/imagecapture/takephoto/index.md
+++ b/files/en-us/web/api/imagecapture/takephoto/index.md
@@ -47,6 +47,13 @@ takePhoto(photoSettings)
 
 A {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}}.
 
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if `readyState` property of the `MediaStreamTrack` passing in the constructor is not `live`.
+- `UnknownError` {{domxref("DOMException")}}
+  - : Thrown if the operation can't complete for any reason.
+
 ## Examples
 
 This example is extracted from this [Simple Image Capture demo](https://simpl.info/imagecapture/). It shows how to use the {{jsxref("Promise")}} returned by

--- a/files/en-us/web/api/imagecapture/takephoto/index.md
+++ b/files/en-us/web/api/imagecapture/takephoto/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ImageCapture.takePhoto
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`takePhoto()`** method of the
 {{domxref("ImageCapture")}} interface takes a single exposure using the video capture

--- a/files/en-us/web/api/imagecapture/track/index.md
+++ b/files/en-us/web/api/imagecapture/track/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ImageCapture.track
 ---
 
-{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
+{{APIRef("Image Capture API")}}{{SeeCompatTable}}
 
 The **`track`** read-only property of the
 {{domxref("ImageCapture")}} interface returns a reference to the


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

see https://w3c.github.io/mediacapture-image/ and https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Image_Capture_API

fix apiref for pages in `ImageCapture` interface and its properties, also add ezeption sections

fix the `fillLightMode` property in return value description of `ImageCapture.getPhotoSettings()`, which should be one of `"auto"`, `"off"`, or `"flash"`

some other text update

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
