### PR TITLE
Ff122 expr intl segmenter

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1170,6 +1170,48 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ## JavaScript
 
+### Intl.Segmenter
+
+The {{jsxref("Intl.Segmenter")}} is supported in nightly builds, allowing developers to perform locale-sensitive text segmentation.
+This enables splitting a string into meaningful items (graphemes, words or sentences) in different locales.
+(See [Firefox bug 1423593](https://bugzil.la/1423593) for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>122</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>NA</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>NA</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>NA</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">None</td>
+    </tr>
+  </tbody>
+</table>
+
 ## APIs
 
 ### Graphics: Canvas, WebGL, and WebGPU


### PR DESCRIPTION
FF122 supports the [Intl/Segmenter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1423593.

This updates the Experimental features page with that information.

Related docs work can be tracked in #31098