### PR TITLE
Writing Guidelines: surface content

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/index.md
@@ -10,3 +10,8 @@ Throughout MDN there are document structures that are used to provide consistent
 This page lists articles describing these structures so that you can modify page content appropriately for the documents you write, edit, or translate.
 
 {{LandingPageListSubPages()}}
+
+## See also
+
+- [Page templates](files/en-us/mdn/writing_guidelines/page_structures/page_types/#page_templates)
+- [Page components](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#page_components)

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/index.md
@@ -35,3 +35,8 @@ Macros are heavily cached; for any set of input values (both parameters and envi
 Macros can be as simple as just inserting a larger block of text or swapping in contents from another part of MDN, or as complex as building an entire index of content by searching through parts of the site, styling the output, and adding links.
 
 You can read up on our most commonly-used macros on the [Commonly-used macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros) page; also, you can browse through the [complete sources for all macros](https://github.com/mdn/yari/tree/main/kumascript/macros). Most of the macro sources have documentation built into them, as comments at the top.
+
+## See also
+
+- [Quicklinks](/en-US/docs/MDN/Writing_guidelines/Page_structures/Quicklinks)
+- [List of macros](https://github.com/mdn/yari/tree/main/kumascript/macros) on Github

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -51,7 +51,25 @@ We have defined a front matter key `page-type` to clearly identify the type of M
 
 For the complete list of page types see [The page-type front matter key](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key).
 
-## API landing page
+## Page templates
+
+Below are examples of the various pages you'll find on MDN along with templates that can be used to create new content based on the type of content you will be presenting, including the following pages:
+
+    - [API langding pages](#api_landing_page)
+    - [API reference page](#api_reference_page)
+    - [API reference subpage](#api_reference_subpage)
+    - [Conceptual pages](#conceptual_page)
+    - [CSS feature reference](#css_feature_reference_page)
+    - [CSS module landing page](#css_module_landing_page)
+    - [Glossary entry](#glossary_page)
+    - [HTML element](#html_element_reference_page)
+    - [HTTP header](#http_header_reference_page)
+    - [Landing page](#landing_page)
+    - [SVG element](#svg_element_reference_page)
+
+Each section includes links to live example pages for that page type.
+
+### API landing page
 
 An **{{Glossary("API")}} landing page** provides an overview of what a particular API does, as well as links to the documentation for each of the interfaces, globals, functions, etc. offered by the API.
 It does not link directly to specific methods or properties within the API's classes, except in the context of the overview text.
@@ -62,15 +80,15 @@ For example, the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/) cov
 In such cases, many of the high level concepts are the same, so it makes no sense to repeat those over multiple landing pages.
 In such a case, it would make more sense in terms of repetition and findability to cover them all under a single "Web sensors" landing page.
 
-### Example
+#### Example
 
 - [WebVR API](/en-US/docs/Web/API/WebVR_API)
 
-### Templates
+#### Templates
 
 - [API landing page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_landing_page_template)
 
-## API reference page
+### API reference page
 
 > **Note:** Also known as an _Interface landing page_.
 
@@ -78,58 +96,58 @@ An **API reference page** lists all the methods, properties, events, and so fort
 It provides an overview of what the class or interface does or is used for, and gives links to the documentation for each of these members.
 It is more granular than an API landing page, which typically links to multiple API reference pages.
 
-### Example
+#### Example
 
 - [Request interface](/en-US/docs/Web/API/Request) of the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
-### Templates
+#### Templates
 
 - [API reference page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_reference_page_template)
 
-## API reference subpage
+### API reference subpage
 
 An **API reference subpage** is a child of an API reference page.
 It documents a single interface member in detail.
 
-### Examples
+#### Examples
 
 - [`count()` method](/en-US/docs/Web/API/IDBIndex/count) of the [IDBIndex](/en-US/docs/Web/API/IDBIndex) interface (part of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API))
 - [capabilities property](/en-US/docs/Web/API/VRDisplay/capabilities) of the [VRDisplay](/en-US/docs/Web/API/VRDisplay) interface (part of the [WebVR API](/en-US/docs/Web/API/WebVR_API))
 - [Request() constructor](/en-US/docs/Web/API/Request/Request) of the [Request](/en-US/docs/Web/API/Request) interface (part of the [Fetch API](/en-US/docs/Web/API/Fetch_API))
 - [vrdisplaypresentchange event](/en-US/docs/Web/API/Window/vrdisplaypresentchange_event) (part of the [WebVR API](/en-US/docs/Web/API/WebVR_API), hangs off the [Window](/en-US/docs/Web/API/Window)) interface
 
-### Templates
+#### Templates
 
 - [API method subpage template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_method_subpage_template)
 - [API property subpage template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_property_subpage_template)
 - [API constructor subpage template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_constructor_subpage_template)
 - [API event subpage template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/API_event_subpage_template)
 
-## HTML element reference page
+### HTML element reference page
 
 An **HTML reference page** lists all the attributes that are available on an HTML element, explains the element's purpose and usage, and provides examples, browser compatibility information, and other important data.
 
-### Example
+#### Example
 
 - [`<video>` element](/en-US/docs/Web/HTML/Element/video)
 
-### Templates
+#### Templates
 
 - [HTML element page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/HTML_element_page_template)
 
-## SVG element reference page
+### SVG element reference page
 
 An **SVG reference page** lists all the attributes that are available on an SVG element, explains the element's purpose and usage, and provides examples, browser compatibility information, and other important data.
 
-### Example
+#### Example
 
 - [\<g> element](/en-US/docs/Web/SVG/Element/g)
 
-### Templates
+#### Templates
 
 - [SVG element page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/SVG_element_page_template)
 
-## CSS module landing page
+### CSS module landing page
 
 Every **[CSS](/en-US/docs/Web/CSS) module** represents a CSS specification that provides support for certain features and implementations in CSS. For example, the [CSS box model](/en-US/docs/Web/CSS/CSS_box_model) module represents the [specification](/en-US/docs/Web/CSS/CSS_box_model#specifications) that describes the margin and padding properties that let you create spacing in and around a CSS box.
 
@@ -139,76 +157,76 @@ The module landing page serves primarily as a _navigation_ page, but also functi
 Some related properties and features that belong in other modules, but that are closely related to the functionality offered by the module you are documenting, can also be covered in a _Related concepts_ section.
 For example, the `<easing-function>` data type and the `prefers-reduced-motion` media query are not covered in the CSS animations module, but because they are closely related with CSS animations, it is a good idea to highlight them in the [Related concepts](/en-US/docs/Web/CSS/CSS_animations#related_concepts) section of the CSS animations module landing page.
 
-### Examples
+#### Examples
 
 - [CSS animations](/en-US/docs/Web/CSS/CSS_animations)
 - [CSS basic user interface](/en-US/docs/Web/CSS/CSS_basic_user_interface)
 - [CSS filter effects](/en-US/docs/Web/CSS/CSS_filter_effects)
 - [CSS scroll snap](/en-US/docs/Web/CSS/CSS_scroll_snap)
 
-### Templates
+#### Templates
 
 - [CSS module landing page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_module_landing_page_template)
 
-## CSS feature reference page
+### CSS feature reference page
 
 A **CSS reference page** lists all the available syntax for a CSS feature such as a selector or property, and explains the feature's purpose and usage. It also provides examples, browser compatibility information, and other important data.
 
-### Examples
+#### Examples
 
 - [background-color property](/en-US/docs/Web/CSS/background-color)
 - [:hover pseudo-class](/en-US/docs/Web/CSS/:hover)
 - [@media at-rule](/en-US/docs/Web/CSS/@media)
 
-### Templates
+#### Templates
 
 - [CSS property page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template)
 - [CSS selector page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_selector_page_template)
 - [CSS function page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_function_page_template)
 
-## HTTP header reference page
+### HTTP header reference page
 
 An **HTTP header reference page** lists all the available directives that an HTTP header can contain, and explains the header's purpose and usage.
 It also provides examples, browser compatibility information, and other important explanations.
 
-### Example
+#### Example
 
 - [Cache-Control header](/en-US/docs/Web/HTTP/Headers/Cache-Control)
 
-### Templates
+#### Templates
 
 - [HTTP header page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/HTTP_header_page_template)
 
-## Conceptual page
+### Conceptual page
 
 A **conceptual page** is a _guide_ page that explains or teaches something.
 Generally, if a page contains primarily prose, and doesn't fall into another page type, it's probably a conceptual page.
 An extended discussion of a topic might be spread across multiple conceptual pages, and linked using [Next](https://github.com/mdn/yari/blob/main/kumascript/macros/Next.ejs) and [Previous](https://github.com/mdn/yari/blob/main/kumascript/macros/Previous.ejs) macros.
 
-### Examples
+#### Examples
 
 - [Using the WebVR API](/en-US/docs/Web/API/WebVR_API/Using_the_WebVR_API)
 - [Visualizations with Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API)
 - [Cascade and inheritance in CSS](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance)
 
-## Glossary page
+### Glossary page
 
 A **glossary page** contains a brief explanation of a term, topic, or concept.
 The first paragraph should be a simple, self-contained description of the term, no more than a couple sentences.
 This can be followed by links to further information in the **See also** section.
 If the page grows to more than a screenful or so, it's too long and should be converted to a conceptual page. See [How to write and reference an entry in the glossary](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary) for more details.
 
-### Examples
+#### Examples
 
 - [DOM](/en-US/docs/Glossary/DOM)
 - [Exception](/en-US/docs/Glossary/Exception)
 - [Hyperlink](/en-US/docs/Glossary/Hyperlink)
 
-### Templates
+#### Templates
 
 - [Glossary page template](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/Glossary_page_template)
 
-## Landing page
+### Landing page
 
 A **landing page** serves as a menu, of sorts, for its subpages, and is therefore primarily a _navigation_ page.
 A landing page layout is typically used for the root page of a tree of pages about a particular topic.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -242,3 +242,8 @@ The list of subpages can be generated automatically using the templates [`Subpag
 - [JavaScript](/en-US/docs/Web/JavaScript)
 - [Learning area](/en-US/docs/Learn)
 - [Contributing to MDN](/en-US/docs/MDN/Contribute)
+
+## See also
+
+- [Page components](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#page_components)
+- [Creating code examples in markdown](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide)

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -20,6 +20,7 @@ Any time you need to use the same set of quicklinks on more than one page, you s
 Every page has a sidebar. These sidebars are created by quicklink macros added after the frontmatter and before the content on every page. Here are a few, with what they do:
 
 - `\{{CSSRef}}`
+
   - : Present on every CSS page, it generates different CSS sidebars depending on tags, like "properties", "selectors", "at-rules", "descriptors", etc., included in the page.
 
 - `\{{ListSubpagesForSidebar(<parameters>)}}`

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -99,6 +99,7 @@ The following macros are included on all reference pages, but are also supported
 ### Banner macros
 
 - `\{{SeeCompatTable}}`
+
   - : Generates a **This is an experimental technology** banner indicating the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental) with a link to the [Browser compatibility](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) that every [reference page](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types) contains.
 
 - `\{{Deprecated_Header}}` 

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -37,7 +37,7 @@ The appropriate macro to use depends on the page type and is listed in the templ
 
 #### Including extra content in a sidebar
 
-To include a sidebar with additional content and not be limited to the macro's output, include the macro at the end of the page (instead of right after the frontmatter) and nest the macro in a {{htmlelement("section")}} element with `id="Quick_links"` set. 
+To include a sidebar with additional content and not be limited to the macro's output, include the macro at the end of the page (instead of right after the frontmatter) and nest the macro in a {{htmlelement("section")}} element with `id="Quick_links"` set.
 
 For example:
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -91,6 +91,7 @@ In addition to quicklinks, there are a several other macros that you can include
 The following macros are included on all reference pages, but are also supported by all page types:
 
 - `\{{Compat}}` / `\{{Compat(&lt;feature>)}}` / `\{{Compat(&lt;feature>, &lt;depth>)}}`
+
   - : Generates a [compatibility table](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) for the feature passed as the parameter. If no parameter is included, it defaults to the features defined by `browser-compat` in the frontmatter. An optional depth parameter sets how deep sub features should be added to the table. The depth, if omitted, defaults to 1, meaning only the first level of sub feature data from BCD will be included.
 
 - `\{{Specifications}}` / `\{{Specifications(&lt;feature>)}}`

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -23,6 +23,7 @@ Every page has a sidebar. These sidebars are created by quicklink macros added a
   - : Present on every CSS page, it generates different CSS sidebars depending on tags, like "properties", "selectors", "at-rules", "descriptors", etc., included in the page.
 
 - `\{{ListSubpagesForSidebar(<parameters>)}}`
+
   - : Inserts a tree of subpages of the slug of the pages specified as the first parameter. Include two parameters, with the second being `true`, to display the links as plain text instead of like code. Include a third parameter, set to `true`, to include the parent page at the top of the list with the link text "Overview".
 
 - `\{{DefaultAPISidebar("<API_Title>")}}`

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -20,9 +20,9 @@ For example, your quicklinks HTML might look like this:
 ```html
 <section id="Quick_links">
   <ol>
-    <li><a href="http://docs.ckeditor.com/">CKEditor documentation site</a></li>
+    <li><a href="https://www.markdownguide.org">Markdown guide</a></li>
     <li>
-      <a href="http://mxr.mozilla.org/">MXR: Mozilla source cross-reference</a>
+      <a href="https://github.com/mdn/content/">Github repository for MDN</a>
     </li>
     <li class="toggle">
       <details>

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -27,6 +27,7 @@ Every page has a sidebar. These sidebars are created by quicklink macros added a
   - : Inserts a tree of subpages of the slug of the pages specified as the first parameter. Include two parameters, with the second being `true`, to display the links as plain text instead of like code. Include a third parameter, set to `true`, to include the parent page at the top of the list with the link text "Overview".
 
 - `\{{DefaultAPISidebar("<API_Title>")}}`
+
   - : The API sidebar displayed for overview pages; the single parameter is the name of the API group in GroupData.
 
 - Other sidebar macros

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -6,70 +6,69 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-MDN supports adding quicklinks to pages; these are boxes containing a potentially hierarchical list of links to other pages on MDN or to pages off-site.
-This article describes how to create quicklinks boxes.
+MDN supports adding quicklinks to pages. **Quicklinks** are boxes containing a potentially hierarchical list of links to other pages on MDN or off-site. This article describes how to create quicklinks boxes.
 
-## Quicklinks syntax
+When a quicklink is included, the server creates a section of content containing an unordered list of links.
 
-The quicklinks for a page are provided by creating a {{HTMLElement("section")}} block with the ID "Quick_links".
-Then you place the contents that go into the quicklinks box within the section.
-These should be formatted as an {{HTMLElement("ol")}} ordered list (optionally nested).
-You can do this by using the numbered list button in the editor toolbar.
-For example, your quicklinks HTML might look like this:
+The contents of the section depend on if the quicklinks include links based on a directory's structure, a page type, or a list of predefined pages hard-coded in Yari, and where the quicklinks macro is located.
 
-```html
+You can and often **should** use macros to generate quicklinks.
+Any time you need to use the same set of quicklinks on more than one page, you should turn them into a macro.
+
+### Quicklink sidebars
+
+Every page has a sidebar. These sidebars are created by quicklink macros added after the frontmatter and before the content on every page. Here are a few, with what they do:
+
+- `\{{CSSRef}}`
+  - : Present on every CSS page, it generates different CSS sidebars depending on tags, like "properties", "selectors", "at-rules", "descriptors", etc., included in the page.
+
+- `\{{ListSubpagesForSidebar(<parameters>)}}`
+  - : Inserts a tree of subpages of the slug of the pages specified as the first parameter. Include two parameters, with the second being `true`, to display the links as plain text instead of like code. Include a third parameter, set to `true`, to include the parent page at the top of the list with the link text "Overview".
+
+- `\{{DefaultAPISidebar("<API_Title>")}}`
+  - : The API sidebar displayed for overview pages; the single parameter is the name of the API group in GroupData.
+
+- Other sidebar macros
+  - : Other sidebar generating macro calls include `\{{GlossarySidebar}}`, `\{{LearnSidebar}}`,`\{{HTMLSidebar}}`, `\{{HTTPSidebar}}`, `\{{PWASidebar}}`, etc.
+
+The appropriate macro to use depends on the page type and is listed in the template for each page type.
+
+#### Including extra content in a sidebar
+
+To include a sidebar with additional content and not be limited to the macro's output, include the macro at the end of the page (instead of right after the frontmatter) and nest the macro in a {{htmlelement("section")}} element with `id="Quick_links"` set. 
+
+For example:
+
+```md
 <section id="Quick_links">
-  <ol>
-    <li><a href="https://www.markdownguide.org">Markdown guide</a></li>
-    <li>
-      <a href="https://github.com/mdn/content/">Github repository for MDN</a>
-    </li>
-    <li class="toggle">
-      <details>
-        <summary>Style guides</summary>
-        <ol>
-          <li>
-            <a href="http://www.economist.com/research/StyleGuide/"
-              >The Economist style guide</a
-            >
-          </li>
-          <li>
-            <a href="https://www.amazon.com/gp/product/0226104036/"
-              >The Chicago manual of style</a
-            >
-          </li>
-          <li>
-            <a href="http://www.answers.com/library/Dictionary"
-              >Answers.com dictionary</a
-            >
-          </li>
-          <li>
-            <a href="http://www.wsu.edu/~brians/errors/"
-              >Common Errors in English</a
-            >
-          </li>
-        </ol>
-      </details>
-    </li>
-  </ol>
+
+1. [**WAI-ARIA roles**](/en-US/docs/Web/Accessibility/ARIA/Roles)
+
+   \{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles", "true")}}
+
 </section>
 ```
 
-The important things to note:
+### Quicklinks in content
 
-- The list **should** be an ordered list.
-- You may have nested lists by using a {{HTMLElement("details")}} containing another ordered list **inside** the same {{HTMLElement("li")}} block.
+- `\{{LandingPageListSubPages()}}`
+  - : Inserts a definition list ({{HTMLelement("dl")}}) of the subpages of the current page, with each page's title as the {{HTMLelement("dt")}} term and its SEO summary as the {{HTMLelement("dd")}} term. The optional parameter accepts the slug list of pages to output instead of the subpages of the current page.
 
-## Using macros to create quicklinks
+There is a [list of commonly used macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros) which output links in content, including:
 
-It's worth noting that you can (and often **should**) use macros to generate quicklinks.
-Any time you need to use the same set of quicklinks on more than one page, you should turn them into a macro.
+- `\{{CSSxRef("")}}`
+- `\{{DOMxRef("")}}`
+- `\{{HTMLElement("")}}`
+- `\{{JSxRef("")}}`
+- `\{{SVGAttr("")}}`
+- `\{{SVGElement("")}}`
+- `\{{HTTPHeader("")}}`
+- `\{{HTTPMethod("")}}`
+- `\{{HTTPStatus("")}}`
 
-Your macro can be as simple or as complex as necessary; it needs to output HTML similar to what's shown in [Quicklinks syntax](#quicklinks_syntax) above.
+### Underlying code for MDN macros
 
-### Standard quicklinks macros
-
-Here's a list of our standard macros for generating quicklinks.
+There are around 100 [available macros](https://github.com/mdn/yari/tree/main/kumascript/macros). Here's are a few standard macros for generating quicklinks and an example of a hardcoded Yari macro list.
 
 - [`CSSRef`](https://github.com/mdn/yari/blob/main/kumascript/macros/CSSRef.ejs)
   - : Builds the standard quicklinks for CSS Reference pages.
@@ -79,3 +78,37 @@ Here's a list of our standard macros for generating quicklinks.
   - : Creates a set of quicklinks using the current page's (or the specified page's) children as the destinations.
     This creates hierarchical lists up to two levels deep.
     The pages' titles are used as the link text and their summaries as tooltips.
+
+
+### Additional macros
+
+In addition to quicklinks, there are a several other macros that you can include.
+
+#### Page sections
+
+The following macros are included on all reference pages, but are also supported by all page types:
+
+- `\{{Compat}}` / `\{{Compat(&lt;feature>)}}` / `\{{Compat(&lt;feature>, &lt;depth>)}}`
+  - : Generates a [compatibility table](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) for the feature passed as the parameter. If no parameter is included, it defaults to the features defined by `browser-compat` in the frontmatter. An optional depth parameter sets how deep sub features should be added to the table. The depth, if omitted, defaults to 1, meaning only the first level of sub feature data from BCD will be included.
+
+- `\{{Specifications}}` / `\{{Specifications(&lt;feature>)}}`
+  - : Includes the specification for the feature specified in the parameter. If no parameter is passed, the specification listed is defined by the value for `spec_urls` in the frontmatter, if present, or from the specification listed in browser compatibility data defined by `browser-compat` in the frontmatter. The specification is rendered as an external link.
+
+### Banner macros
+
+- `\{{SeeCompatTable}}`
+  - : Generates a **This is an experimental technology** banner indicating the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental) with a link to the [Browser compatibility](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) that every [reference page](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types) contains.
+
+- `\{{Deprecated_Header}}` 
+  - : Generates a **Deprecated** banner indicating the technology is [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated) and should not be used.
+
+- `\{{SecureContext_Header}}`
+  - : Generates a **Secure context** banner indicating a [secure context](/en-US/docs/Web/Security/Secure_Contexts) is required for the feature.
+
+For more information, see the [banners and notices guide](/en-US/docs/MDN/Writing_guidelines/Page_structures/Banners_and_notices)
+
+## See also
+
+- [Using macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros)
+- [Macros](https://github.com/mdn/yari/tree/main/kumascript/macros) on Github
+- [Commonly used macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros)

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -103,7 +103,8 @@ The following macros are included on all reference pages, but are also supported
 
   - : Generates a **This is an experimental technology** banner indicating the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental) with a link to the [Browser compatibility](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) that every [reference page](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types) contains.
 
-- `\{{Deprecated_Header}}` 
+- `\{{Deprecated_Header}}`
+
   - : Generates a **Deprecated** banner indicating the technology is [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated) and should not be used.
 
 - `\{{SecureContext_Header}}`

--- a/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/quicklinks/index.md
@@ -82,7 +82,6 @@ There are around 100 [available macros](https://github.com/mdn/yari/tree/main/ku
     This creates hierarchical lists up to two levels deep.
     The pages' titles are used as the link text and their summaries as tooltips.
 
-
 ### Additional macros
 
 In addition to quicklinks, there are a several other macros that you can include.

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -511,6 +511,7 @@ If you include images or other media on a page, follow these guidelines:
 - Make sure the media license allows you to use them. Try to use media that has a very permissive license such as [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/) or at least one that is compatible with our general content license — [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA).
 - For images, run them through <https://tinypng.com> or <https://imageoptim.com> to reduce the page weight.
 - For `SVG`, run the code through [SVGOMG](https://jakearchibald.github.io/svgomg/), and ensure that the `SVG` file has an empty line at the end of the file.
+- Every image must [include descriptive `alt` text](/en-US/docs/MDN/Writing_guidelines/Howto/Images_media#adding_alternative_text_to_images).
 
 ### Lists
 


### PR DESCRIPTION
Added a lot of links between pages within the guidelines to improve searchability.
Removed some wiki-related content
Rewrote quicklinks (not 100% perfect, but the old stuff was for the wiki)