### PR TITLE
FF122 ArrayBuffer.transfer() and friends - remove experimental tagging

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/detached/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/detached/index.md
@@ -35,6 +35,7 @@ console.log(newBuffer.detached); // false
 
 ## See also
 
+- [Polyfill of `ArrayBuffer.prototype.detached` in `core-js`](https://github.com/zloirock/core-js#arraybufferprototypetransfer-and-friends)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("ArrayBuffer.prototype.transfer()")}}
 - {{jsxref("ArrayBuffer.prototype.transferToFixedLength()")}}

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/detached/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/detached/index.md
@@ -2,12 +2,10 @@
 title: ArrayBuffer.prototype.detached
 slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached
 page-type: javascript-instance-accessor-property
-status:
-  - experimental
 browser-compat: javascript.builtins.ArrayBuffer.detached
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 The **`detached`** accessor property of {{jsxref("ArrayBuffer")}} instances returns a boolean indicating whether or not this buffer has been detached (transferred).
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -57,7 +57,7 @@ These properties are defined on `ArrayBuffer.prototype` and shared by all `Array
   - : The size, in bytes, of the `ArrayBuffer`. This is established when the array is constructed and can only be changed using the {{jsxref("ArrayBuffer.prototype.resize()")}} method if the `ArrayBuffer` is resizable.
 - {{jsxref("Object/constructor", "ArrayBuffer.prototype.constructor")}}
   - : The constructor function that created the instance object. For `ArrayBuffer` instances, the initial value is the {{jsxref("ArrayBuffer/ArrayBuffer", "ArrayBuffer")}} constructor.
-- {{jsxref("ArrayBuffer.prototype.detached")}} {{experimental_inline}}
+- {{jsxref("ArrayBuffer.prototype.detached")}}
   - : Read-only. Returns `true` if the `ArrayBuffer` has been detached (transferred), or `false` if not.
 - {{jsxref("ArrayBuffer.prototype.maxByteLength")}}
   - : The read-only maximum length, in bytes, that the `ArrayBuffer` can be resized to. This is established when the array is constructed and cannot be changed.
@@ -72,9 +72,9 @@ These properties are defined on `ArrayBuffer.prototype` and shared by all `Array
   - : Resizes the `ArrayBuffer` to the specified size, in bytes.
 - {{jsxref("ArrayBuffer.prototype.slice()")}}
   - : Returns a new `ArrayBuffer` whose contents are a copy of this `ArrayBuffer`'s bytes from `begin` (inclusive) up to `end` (exclusive). If either `begin` or `end` is negative, it refers to an index from the end of the array, as opposed to from the beginning.
-- {{jsxref("ArrayBuffer.prototype.transfer()")}} {{experimental_inline}}
+- {{jsxref("ArrayBuffer.prototype.transfer()")}}
   - : Creates a new `ArrayBuffer` with the same byte content as this buffer, then detaches this buffer.
-- {{jsxref("ArrayBuffer.prototype.transferToFixedLength()")}} {{experimental_inline}}
+- {{jsxref("ArrayBuffer.prototype.transferToFixedLength()")}}
   - : Creates a new non-resizable `ArrayBuffer` with the same byte content as this buffer, then detaches this buffer.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
@@ -116,6 +116,7 @@ buffer3.transfer(20); // RangeError: Invalid array buffer length
 
 ## See also
 
+- [Polyfill of `ArrayBuffer.prototype.transfer()` in `core-js`](https://github.com/zloirock/core-js#arraybufferprototypetransfer-and-friends)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("ArrayBuffer.prototype.detached")}}
 - {{jsxref("ArrayBuffer.prototype.transferToFixedLength()")}}

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfer/index.md
@@ -2,12 +2,10 @@
 title: ArrayBuffer.prototype.transfer()
 slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer
 page-type: javascript-instance-method
-status:
-  - experimental
 browser-compat: javascript.builtins.ArrayBuffer.transfer
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 The **`transfer()`** method of {{jsxref("ArrayBuffer")}} instances creates a new `ArrayBuffer` with the same byte content as this buffer, then detaches this buffer.
 

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
@@ -80,6 +80,7 @@ console.log(view2[7]); // 4
 
 ## See also
 
+- [Polyfill of `ArrayBuffer.prototype.transferToFixedLength()` in `core-js`](https://github.com/zloirock/core-js#arraybufferprototypetransfer-and-friends)
 - {{jsxref("ArrayBuffer")}}
 - {{jsxref("ArrayBuffer.prototype.detached")}}
 - {{jsxref("ArrayBuffer.prototype.transfer()")}}

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/transfertofixedlength/index.md
@@ -2,12 +2,10 @@
 title: ArrayBuffer.prototype.transferToFixedLength()
 slug: Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength
 page-type: javascript-instance-method
-status:
-  - experimental
 browser-compat: javascript.builtins.ArrayBuffer.transferToFixedLength
 ---
 
-{{JSRef}} {{SeeCompatTable}}
+{{JSRef}}
 
 The **`transferToFixedLength()`** method of {{jsxref("ArrayBuffer")}} instances creates a new non-resizable `ArrayBuffer` with the same byte content as this buffer, then detaches this buffer.
 


### PR DESCRIPTION
FF122 ships support for [`ArrayBuffer.prototype.transfer()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer), [`ArrayBuffer.prototype.transferToFixedLength()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength),[`ArrayBuffer.prototype.detached`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached) in https://bugzilla.mozilla.org/show_bug.cgi?id=1865103

This removes the experimental status markup. Other docs look fine.

Related docs work can be tracked in #31101