### PR TITLE
Fix inherit information for some ui events

### DIFF
--- a/files/en-us/web/api/element/blur_event/index.md
+++ b/files/en-us/web/api/element/blur_event/index.md
@@ -32,7 +32,7 @@ onblur = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/blur_event/index.md
+++ b/files/en-us/web/api/element/blur_event/index.md
@@ -32,7 +32,7 @@ onblur = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/compositionend_event/index.md
+++ b/files/en-us/web/api/element/compositionend_event/index.md
@@ -24,7 +24,7 @@ oncompositionend = (event) => {};
 
 ## Event type
 
-A {{domxref("CompositionEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("CompositionEvent")}}
 

--- a/files/en-us/web/api/element/compositionend_event/index.md
+++ b/files/en-us/web/api/element/compositionend_event/index.md
@@ -24,7 +24,7 @@ oncompositionend = (event) => {};
 
 ## Event type
 
-A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("CompositionEvent")}}
 

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -24,7 +24,7 @@ oncompositionstart = (event) => {};
 
 ## Event type
 
-A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("CompositionEvent")}}
 

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -24,7 +24,7 @@ oncompositionstart = (event) => {};
 
 ## Event type
 
-A {{domxref("CompositionEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("CompositionEvent")}}
 

--- a/files/en-us/web/api/element/compositionupdate_event/index.md
+++ b/files/en-us/web/api/element/compositionupdate_event/index.md
@@ -24,7 +24,7 @@ oncompositionupdate = (event) => {};
 
 ## Event type
 
-A {{domxref("CompositionEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("CompositionEvent")}}
 

--- a/files/en-us/web/api/element/compositionupdate_event/index.md
+++ b/files/en-us/web/api/element/compositionupdate_event/index.md
@@ -24,7 +24,7 @@ oncompositionupdate = (event) => {};
 
 ## Event type
 
-A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("CompositionEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("CompositionEvent")}}
 

--- a/files/en-us/web/api/element/dblclick_event/index.md
+++ b/files/en-us/web/api/element/dblclick_event/index.md
@@ -24,7 +24,7 @@ ondblclick = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/dblclick_event/index.md
+++ b/files/en-us/web/api/element/dblclick_event/index.md
@@ -24,7 +24,7 @@ ondblclick = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/domactivate_event/index.md
+++ b/files/en-us/web/api/element/domactivate_event/index.md
@@ -24,7 +24,7 @@ onDOMActivate = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/domactivate_event/index.md
+++ b/files/en-us/web/api/element/domactivate_event/index.md
@@ -24,7 +24,7 @@ onDOMActivate = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -31,7 +31,7 @@ onDOMMouseScroll = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -31,7 +31,7 @@ onDOMMouseScroll = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}, {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/focus_event/index.md
+++ b/files/en-us/web/api/element/focus_event/index.md
@@ -26,7 +26,7 @@ onfocus = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/focus_event/index.md
+++ b/files/en-us/web/api/element/focus_event/index.md
@@ -26,7 +26,7 @@ onfocus = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/focusin_event/index.md
+++ b/files/en-us/web/api/element/focusin_event/index.md
@@ -24,7 +24,7 @@ addEventListener("focusin", (event) => {});
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/focusin_event/index.md
+++ b/files/en-us/web/api/element/focusin_event/index.md
@@ -24,7 +24,7 @@ addEventListener("focusin", (event) => {});
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/focusout_event/index.md
+++ b/files/en-us/web/api/element/focusout_event/index.md
@@ -24,7 +24,7 @@ addEventListener("focusout", (event) => {});
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/focusout_event/index.md
+++ b/files/en-us/web/api/element/focusout_event/index.md
@@ -24,7 +24,7 @@ addEventListener("focusout", (event) => {});
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/element/keydown_event/index.md
+++ b/files/en-us/web/api/element/keydown_event/index.md
@@ -39,7 +39,7 @@ onkeydown = (event) => {};
 
 ## Event type
 
-A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("KeyboardEvent")}}
 

--- a/files/en-us/web/api/element/keydown_event/index.md
+++ b/files/en-us/web/api/element/keydown_event/index.md
@@ -39,7 +39,7 @@ onkeydown = (event) => {};
 
 ## Event type
 
-A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("KeyboardEvent")}}
 

--- a/files/en-us/web/api/element/keypress_event/index.md
+++ b/files/en-us/web/api/element/keypress_event/index.md
@@ -28,7 +28,7 @@ onkeypress = (event) => {};
 
 ## Event type
 
-A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("KeyboardEvent")}}
 

--- a/files/en-us/web/api/element/keypress_event/index.md
+++ b/files/en-us/web/api/element/keypress_event/index.md
@@ -28,7 +28,7 @@ onkeypress = (event) => {};
 
 ## Event type
 
-A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("KeyboardEvent")}}
 

--- a/files/en-us/web/api/element/keyup_event/index.md
+++ b/files/en-us/web/api/element/keyup_event/index.md
@@ -37,7 +37,7 @@ onkeyup = (event) => {};
 
 ## Event type
 
-A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("KeyboardEvent")}}
 

--- a/files/en-us/web/api/element/keyup_event/index.md
+++ b/files/en-us/web/api/element/keyup_event/index.md
@@ -37,7 +37,7 @@ onkeyup = (event) => {};
 
 ## Event type
 
-A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("KeyboardEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("KeyboardEvent")}}
 

--- a/files/en-us/web/api/element/mousedown_event/index.md
+++ b/files/en-us/web/api/element/mousedown_event/index.md
@@ -24,7 +24,7 @@ onmousedown = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mousedown_event/index.md
+++ b/files/en-us/web/api/element/mousedown_event/index.md
@@ -24,7 +24,7 @@ onmousedown = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -22,7 +22,7 @@ onmouseenter = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -22,7 +22,7 @@ onmouseenter = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseleave_event/index.md
+++ b/files/en-us/web/api/element/mouseleave_event/index.md
@@ -24,7 +24,7 @@ onmouseleave = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseleave_event/index.md
+++ b/files/en-us/web/api/element/mouseleave_event/index.md
@@ -24,7 +24,7 @@ onmouseleave = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mousemove_event/index.md
+++ b/files/en-us/web/api/element/mousemove_event/index.md
@@ -22,7 +22,7 @@ onmousemove = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mousemove_event/index.md
+++ b/files/en-us/web/api/element/mousemove_event/index.md
@@ -22,7 +22,7 @@ onmousemove = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseout_event/index.md
+++ b/files/en-us/web/api/element/mouseout_event/index.md
@@ -24,7 +24,7 @@ onmouseout = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseout_event/index.md
+++ b/files/en-us/web/api/element/mouseout_event/index.md
@@ -24,7 +24,7 @@ onmouseout = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseover_event/index.md
+++ b/files/en-us/web/api/element/mouseover_event/index.md
@@ -22,7 +22,7 @@ onmouseover = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseover_event/index.md
+++ b/files/en-us/web/api/element/mouseover_event/index.md
@@ -22,7 +22,7 @@ onmouseover = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseup_event/index.md
+++ b/files/en-us/web/api/element/mouseup_event/index.md
@@ -24,7 +24,7 @@ onmouseup = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mouseup_event/index.md
+++ b/files/en-us/web/api/element/mouseup_event/index.md
@@ -24,7 +24,7 @@ onmouseup = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/mousewheel_event/index.md
+++ b/files/en-us/web/api/element/mousewheel_event/index.md
@@ -27,7 +27,7 @@ onmousewheel = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}, {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/mousewheel_event/index.md
+++ b/files/en-us/web/api/element/mousewheel_event/index.md
@@ -27,7 +27,7 @@ onmousewheel = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
+++ b/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
@@ -27,7 +27,7 @@ onMozMousePixelScroll = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}, {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
+++ b/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
@@ -27,7 +27,7 @@ onMozMousePixelScroll = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
@@ -28,7 +28,7 @@ onwebkitmouseforcechanged = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
@@ -28,7 +28,7 @@ onwebkitmouseforcechanged = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
@@ -26,7 +26,7 @@ onwebkitmouseforcedown = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
@@ -26,7 +26,7 @@ onwebkitmouseforcedown = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforceup_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforceup_event/index.md
@@ -26,7 +26,7 @@ onwebkitmouseforceup = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforceup_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforceup_event/index.md
@@ -26,7 +26,7 @@ onwebkitmouseforceup = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
@@ -30,7 +30,7 @@ onwebkitmouseforceup = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
@@ -30,7 +30,7 @@ onwebkitmouseforceup = (event) => {};
 
 ## Event type
 
-A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("MouseEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("MouseEvent")}}
 

--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -26,7 +26,7 @@ onwheel = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}, {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -26,7 +26,7 @@ onwheel = (event) => {};
 
 ## Event type
 
-A {{domxref("WheelEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("WheelEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("WheelEvent")}}
 

--- a/files/en-us/web/api/window/blur_event/index.md
+++ b/files/en-us/web/api/window/blur_event/index.md
@@ -26,7 +26,7 @@ onblur = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/window/blur_event/index.md
+++ b/files/en-us/web/api/window/blur_event/index.md
@@ -26,7 +26,7 @@ onblur = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/window/focus_event/index.md
+++ b/files/en-us/web/api/window/focus_event/index.md
@@ -26,7 +26,7 @@ onfocus = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 

--- a/files/en-us/web/api/window/focus_event/index.md
+++ b/files/en-us/web/api/window/focus_event/index.md
@@ -26,7 +26,7 @@ onfocus = (event) => {};
 
 ## Event type
 
-A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}}.
+A {{domxref("FocusEvent")}}. Inherits from {{domxref("UIEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("FocusEvent")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- `FocusEvent` should inherit from `UIEvent`, not `Event`
- `MouseEvent` should inherit from `UIEvent`, not `Event`
- `KeyboardEvent` should inherit from `UIEvent`, not `Event`
- `CompositionEvent` should inherit from `UIEvent`, not `Event`
- `WheelEvent` should inherit from `MouseEvent`, not `Event`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events and spec https://w3c.github.io/uievents/

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
