### PR TITLE
SVG: Add link to svg-tutorial.com

### DIFF
--- a/files/en-us/web/svg/index.md
+++ b/files/en-us/web/svg/index.md
@@ -41,5 +41,6 @@ See also, [SVG Tutorial](/en-US/docs/Web/SVG/Tutorial).
 - [SVG authoring guidelines](https://jwatt.org/svg/authoring/)
 - [SVG as an image](/en-US/docs/Web/SVG/SVG_as_an_Image)
 - [SVG animation with SMIL](/en-US/docs/Web/SVG/SVG_animation_with_SMIL)
+- [SVG Tutorial Advent Calendar](https://svg-tutorial.com)
 - [SVG art gallery](https://www1.plurib.us/svg_gallery/)
 - [D3](https://d3js.org) (JavaScript library for visualizing data with HTML, SVG, and CSS)

--- a/files/en-us/web/svg/tutorial/index.md
+++ b/files/en-us/web/svg/tutorial/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 Scalable Vector Graphics, [SVG](/en-US/docs/Web/SVG), is a W3C XML dialect to mark up graphics.
 
-This tutorial aims to explain the internals of SVG and is packed with technical details. If you just want to draw beautiful images, you might find more useful resources at [Inkscape's documentation page](https://inkscape.org/learn/). Another good introduction to SVG is provided by the W3C's [SVG Primer](https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html).
+This tutorial aims to explain the internals of SVG and is packed with technical details. If you just want to draw beautiful images, you might find more useful resources at [Inkscape's documentation page](https://inkscape.org/learn/). Another good introduction to SVG is provided by the W3C's [SVG Primer](https://www.w3.org/Graphics/SVG/IG/resources/svgprimer.html). Also check out this advent calendar-themed [SVG Tutorial](https://svg-tutorial.com) that walks you through coding 25 festive SVGs.
 
 ## Introducing SVG from Scratch
 


### PR DESCRIPTION
### Description

I created an advent calendar-themed [SVG tutorial](https://svg-tutorial.com). I plan to update it in the future with more interactive examples (integrate [this demo](https://hunormarton.github.io/svg-curves) for instance), but first I wanted to see if it finds its audience this way. 

Is it too soon to link it in the MDN docs? Also, if you have any ideas on how to find its audience, and rank it in Google, or have any feedback, I'd highly appreciate it.

### Motivation

I'm working on an interactive SVG tutorial and I'd like to find its audience.

### Additional details

\-

### Related issues and pull requests

\-
