### PR TITLE
Update properties sections of Webkit extensions

### DIFF
--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -1,5 +1,5 @@
 ---
-title: WebKit vendor-prefixed CSS extensions
+title: "-webkit-prefixed CSS extensions"
 slug: Web/CSS/WebKit_Extensions
 page-type: landing-page
 status:
@@ -8,7 +8,7 @@ status:
 
 {{CSSRef}}
 
-Applications based on WebKit or Blink, such as Safari and Chrome, support several special extensions to [CSS](/en-US/docs/Web/CSS). These extensions are generally prefixed with `-webkit-`. Most `-webkit-` prefixed properties also work with an `-apple-` prefix. A few are prefixed with `-epub-`.
+User agents based on WebKit or Blink, such as Safari and Chrome, support several special extensions to [CSS](/en-US/docs/Web/CSS). These extensions are prefixed with `-webkit-`.
 
 ## -webkit-prefixed properties without standard equivalents
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -12,7 +12,7 @@ Applications based on WebKit or Blink, such as Safari and Chrome, support severa
 
 ## -webkit-prefixed properties without standard equivalents
 
-> **Note:** Avoid using on websites. These properties will only work in WebKit-based browsers.
+> **Note:** Avoid using on websites. These properties will only work in WebKit- or Blink-based browsers except where specified.
 
 ### A-C
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -8,451 +8,176 @@ status:
 
 {{CSSRef}}
 
-Applications based on WebKit or Blink, such as Safari and Chrome, support a number of special **WebKit extensions to [CSS](/en-US/docs/Web/CSS)**. These extensions are generally prefixed with `-webkit-`. Most `-webkit-` prefixed properties also work with an `-apple-` prefix. A few are prefixed with `-epub-`.
+Applications based on WebKit or Blink, such as Safari and Chrome, support several special extensions to [CSS](/en-US/docs/Web/CSS). These extensions are generally prefixed with `-webkit-`. Most `-webkit-` prefixed properties also work with an `-apple-` prefix. A few are prefixed with `-epub-`.
 
-## WebKit-only properties
+## WebKit-only properties without standard equivalents
 
-> **Note:** Avoid using on websites. These properties will only work in WebKit applications.
+> **Note:** Avoid using on websites. These properties will only work in WebKit-based browsers.
 
-### A
+### A-C
 
-- {{CSSxRef("-webkit-animation-trigger", "-webkit-animation-trigger")}}
-- {{CSSxRef("-webkit-app-region", "-webkit-app-region")}}
-
-### B
-
-- {{CSSxRef("backdrop-filter", "-webkit-backdrop-filter")}}\*\*
-- {{CSSxRef("border-block-end","-webkit-border-after")}}\*\*
-- {{CSSxRef("border-block-end-color","-webkit-border-after-color")}}\*\*
-- {{CSSxRef("border-block-end-style","-webkit-border-after-style")}}\*\*
-- {{CSSxRef("border-block-end-width","-webkit-border-after-width")}}\*\*
-- {{CSSxRef("border-block-start","-webkit-border-before")}}\*\*
-- {{CSSxRef("border-block-start-color","-webkit-border-before-color")}}\*\*
-- {{CSSxRef("border-block-start-style","-webkit-border-before-style")}}\*\*
-- {{CSSxRef("border-block-start-width","-webkit-border-before-width")}}\*\*
-- {{CSSxRef("border-inline-end", "-webkit-border-end")}}\*\*
-- {{CSSxRef("border-inline-end-color","-webkit-border-end-color")}}\*\*
-- {{CSSxRef("border-inline-end-style","-webkit-border-end-style")}}\*\*
-- {{CSSxRef("border-inline-end-width","-webkit-border-end-width")}}\*\*
-- {{CSSxRef("-webkit-border-horizontal-spacing", "-webkit-border-horizontal-spacing")}}
-- {{CSSxRef("border-inline-start", "-webkit-border-start")}}\*\*
-- {{CSSxRef("border-inline-start-color", "-webkit-border-start-color")}}\*\*
-- {{CSSxRef("border-inline-start-style", "-webkit-border-start-style")}}\*\*
-- {{CSSxRef("border-inline-start-width", "-webkit-border-start-width")}}\*\*
-- {{CSSxRef("-webkit-border-vertical-spacing", "-webkit-border-vertical-spacing")}}
-- {{CSSxRef("align-items","-webkit-box-align")}}\*\*
-- {{CSSxRef("flex-direction", "-webkit-box-direction")}}\*\*
-- {{CSSxRef("box-flex-group", "-webkit-box-flex-group")}}
-- {{CSSxRef("flex-grow", "-webkit-box-flex")}}\*\*
-- {{CSSxRef("flex-flow", "-webkit-box-lines")}}\*\*
-- {{CSSxRef("order", "-webkit-box-ordinal-group")}}\*\*
-- {{CSSxRef("flex-direction","-webkit-box-orient")}}\*\*
-- {{CSSxRef("justify-content", "-webkit-box-pack")}}\*\*
-- {{CSSxRef("-webkit-box-reflect", "-webkit-box-reflect")}}\*\*
-
-### C
-
-- {{CSSxRef("-webkit-column-axis", "-webkit-column-axis")}}
-- {{CSSxRef("-webkit-column-break-after", "-webkit-column-break-after")}}
-- {{CSSxRef("-webkit-column-break-before", "-webkit-column-break-before")}}
-- {{CSSxRef("-webkit-column-break-inside", "-webkit-column-break-inside")}}
-- {{CSSxRef("-webkit-column-progression", "-webkit-column-progression")}}
-- {{CSSxRef("-webkit-cursor-visibility", "-webkit-cursor-visibility")}}
+- {{CSSxRef("-webkit-app-region")}}
+- {{CSSxRef("-webkit-border-horizontal-spacing")}}
+- {{CSSxRef("-webkit-border-vertical-spacing")}}
+- {{CSSxRef("-webkit-box-reflect")}} (Supported with `-webkit` by every browser, for compatibility reasons)
+- {{CSSxRef("-webkit-column-axis")}}
+- {{CSSxRef("-webkit-column-progression")}}
+- {{CSSxRef("-webkit-cursor-visibility")}}
 
 ### D-I
 
-- {{CSSxRef("-webkit-dashboard-region", "-webkit-dashboard-region")}}
-- {{CSSxRef("-webkit-font-size-delta", "-webkit-font-size-delta")}}
 - {{CSSxRef("font-smooth", "-webkit-font-smoothing")}}
-- {{CSSxRef("hyphenate-character", "-webkit-hyphenate-character")}} \*\*
-- {{CSSxRef("-webkit-hyphenate-limit-after", "-webkit-hyphenate-limit-after")}}
-- {{CSSxRef("-webkit-hyphenate-limit-before", "-webkit-hyphenate-limit-before")}}
-- {{CSSxRef("-webkit-hyphenate-limit-lines", "-webkit-hyphenate-limit-lines")}}
-- {{CSSxRef("initial-letter", "-webkit-initial-letter")}}\*\*
+- {{CSSxRef("-webkit-hyphenate-limit-after")}}
+- {{CSSxRef("-webkit-hyphenate-limit-before")}}
+- {{CSSxRef("-webkit-hyphenate-limit-lines")}}
 
 ### L
 
-- {{CSSxRef("-webkit-line-align", "-webkit-line-align")}}
-- {{CSSxRef("-webkit-line-box-contain", "-webkit-line-box-contain")}}
-- {{CSSxRef("-webkit-line-clamp", "-webkit-line-clamp")}}
-- {{CSSxRef("-webkit-line-grid", "-webkit-line-grid")}}
-- {{CSSxRef("-webkit-line-snap", "-webkit-line-snap")}}
-- {{CSSxRef("-webkit-locale", "-webkit-locale")}}
-- {{CSSxRef("-webkit-logical-height", "-webkit-logical-height")}}
-- {{CSSxRef("-webkit-logical-width", "-webkit-logical-width")}}
+- {{CSSxRef("-webkit-line-align")}}
+- {{CSSxRef("-webkit-line-box-contain")}}
+- {{CSSxRef("-webkit-line-clamp")}}
+- {{CSSxRef("-webkit-line-grid")}}
+- {{CSSxRef("-webkit-line-snap")}}
+- {{CSSxRef("-webkit-locale")}}
+- {{CSSxRef("-webkit-logical-height")}}
+- {{CSSxRef("-webkit-logical-width")}}
 
 ### M
 
-- {{CSSxRef("-webkit-margin-after", "-webkit-margin-after")}}
-- {{CSSxRef("-webkit-margin-before", "-webkit-margin-before")}}
-- {{CSSxRef("margin-block-end", "-webkit-margin-end")}}\*\*
-- {{CSSxRef("margin-block-start", "-webkit-margin-start")}}\*\*
-- {{CSSxRef("-webkit-marquee-direction", "-webkit-marquee-direction")}}
-- {{CSSxRef("-webkit-marquee-increment", "-webkit-marquee-increment")}}
-- {{CSSxRef("-webkit-marquee-repetition", "-webkit-marquee-repetition")}}
-- {{CSSxRef("-webkit-marquee-speed", "-webkit-marquee-speed")}}
-- {{CSSxRef("-webkit-marquee-style", "-webkit-marquee-style")}}
-- {{CSSxRef("-webkit-marquee", "-webkit-marquee")}}
-- {{CSSxRef("-webkit-mask-box-image-outset", "-webkit-mask-box-image-outset")}}
-- {{CSSxRef("-webkit-mask-box-image-repeat", "-webkit-mask-box-image-repeat")}}
-- {{CSSxRef("-webkit-mask-box-image-slice", "-webkit-mask-box-image-slice")}}
-- {{CSSxRef("-webkit-mask-box-image-source", "-webkit-mask-box-image-source")}}
-- {{CSSxRef("-webkit-mask-box-image-width", "-webkit-mask-box-image-width")}}
-- {{CSSxRef("-webkit-mask-box-image", "-webkit-mask-box-image")}}
-- {{CSSxRef("-webkit-mask-position-x", "-webkit-mask-position-x")}}
-- {{CSSxRef("-webkit-mask-position-y", "-webkit-mask-position-y")}}
-- {{CSSxRef("-webkit-mask-repeat-x", "-webkit-mask-repeat-x")}}\*\*\*
-- {{CSSxRef("-webkit-mask-repeat-y", "-webkit-mask-repeat-y")}}\*\*\*
-- {{CSSxRef("-webkit-mask-source-type", "-webkit-mask-source-type")}}
-- {{CSSxRef("-webkit-max-logical-height", "-webkit-max-logical-height")}}
-- {{CSSxRef("-webkit-max-logical-width", "-webkit-max-logical-width")}}
-- {{CSSxRef("-webkit-min-logical-height", "-webkit-min-logical-height")}}
-- {{CSSxRef("-webkit-min-logical-width", "-webkit-min-logical-width")}}
+- {{CSSxRef("-webkit-margin-after")}}
+- {{CSSxRef("-webkit-margin-before")}}
+- {{CSSxRef("-webkit-mask-attachment")}}
+- {{CSSxRef("-webkit-mask-box-image-outset")}}
+- {{CSSxRef("-webkit-mask-box-image-repeat")}}
+- {{CSSxRef("-webkit-mask-box-image-slice")}}
+- {{CSSxRef("-webkit-mask-box-image-source")}}
+- {{CSSxRef("-webkit-mask-box-image-width")}}
+- {{CSSxRef("-webkit-mask-box-image")}}
+- {{cssxref("-webkit-mask-composite")}}
+- {{CSSxRef("-webkit-mask-position-x")}} (Supported with `-webkit` by every browser, for compatibility reasons)
+- {{CSSxRef("-webkit-mask-position-y")}} (Supported with `-webkit` by every browser, for compatibility reasons)
+- {{CSSxRef("-webkit-mask-repeat-x")}} (Also supported without prefix)
+- {{CSSxRef("-webkit-mask-repeat-y")}} (Also supported without prefix)
+- {{CSSxRef("-webkit-mask-source-type")}}
+- {{CSSxRef("-webkit-max-logical-height")}}
+- {{CSSxRef("-webkit-max-logical-width")}}
+- {{CSSxRef("-webkit-min-logical-height")}}
+- {{CSSxRef("-webkit-min-logical-width")}}
 
-### N
+### N-R
 
-- {{CSSxRef("-webkit-nbsp-mode", "-webkit-nbsp-mode")}}
-
-### P
-
-- {{CSSxRef("padding-block-end","-webkit-padding-after")}}\*\*
-- {{CSSxRef("padding-block-start","-webkit-padding-before")}}\*\*
-- {{CSSxRef("padding-inline-end","-webkit-padding-end")}}\*\*
-- {{CSSxRef("padding-inline-start","-webkit-padding-start")}}\*\*
-- {{CSSxRef("-webkit-perspective-origin-x", "-webkit-perspective-origin-x")}}
-- {{CSSxRef("-webkit-perspective-origin-y", "-webkit-perspective-origin-y")}}
-
-### R-S
-
-- {{CSSxRef("-webkit-rtl-ordering", "-webkit-rtl-ordering")}}
-- {{CSSxRef("-webkit-svg-shadow", "-webkit-svg-shadow")}}
+- {{CSSxRef("-webkit-nbsp-mode")}}
+- {{CSSxRef("-webkit-perspective-origin-x")}}
+- {{CSSxRef("-webkit-perspective-origin-y")}}
+- {{CSSxRef("-webkit-rtl-ordering")}}
 
 ### T
 
-- {{CSSxRef("-webkit-tap-highlight-color", "-webkit-tap-highlight-color")}}
-- {{CSSxRef("-webkit-text-decoration-skip", "-webkit-text-decoration-skip")}}
-- {{CSSxRef("-webkit-text-decorations-in-effect", "-webkit-text-decorations-in-effect")}}
-- {{CSSxRef("-webkit-text-fill-color", "-webkit-text-fill-color")}}
-- {{CSSxRef("-webkit-text-security", "-webkit-text-security")}}
-- {{CSSxRef("-webkit-text-stroke-color", "-webkit-text-stroke-color")}}
-- {{CSSxRef("-webkit-text-stroke-width", "-webkit-text-stroke-width")}}
-- {{CSSxRef("-webkit-text-stroke", "-webkit-text-stroke")}}
-- {{CSSxRef("-webkit-text-zoom", "-webkit-text-zoom")}}
-- {{CSSxRef("-webkit-transform-origin-x", "-webkit-transform-origin-x")}}
-- {{CSSxRef("-webkit-transform-origin-y", "-webkit-transform-origin-y")}}
-- {{CSSxRef("-webkit-transform-origin-z", "-webkit-transform-origin-z")}}
+- {{CSSxRef("-webkit-tap-highlight-color")}}
+- {{CSSxRef("-webkit-text-decoration-skip")}}
+- {{CSSxRef("-webkit-text-decorations-in-effect")}}
+- {{CSSxRef("-webkit-text-fill-color")}}
+- {{CSSxRef("-webkit-text-security")}}
+- {{CSSxRef("-webkit-text-stroke-color")}}
+- {{CSSxRef("-webkit-text-stroke-width")}}
+- {{CSSxRef("-webkit-text-stroke")}}
+- {{CSSxRef("-webkit-text-zoom")}}
+- {{cssxref("-webkit-touch-callout")}}
+- {{CSSxRef("-webkit-transform-origin-x")}}
+- {{CSSxRef("-webkit-transform-origin-y")}}
+- {{CSSxRef("-webkit-transform-origin-z")}}
 
-### U
+### U-Z
 
-- {{CSSxRef("-webkit-user-drag", "-webkit-user-drag")}}
-- {{CSSxRef("-webkit-user-modify", "-webkit-user-modify")}}
+- {{CSSxRef("-webkit-user-drag")}}
+- {{CSSxRef("-webkit-user-modify")}}
 
-\* A few are on the standards, unprefixed track
+## Webkit-prefixed properties with standard equivalent
 
-\*\* New syntax has been standardized. Property links to the new syntax. The old, prefixed syntax is still supported in some browsers.
+Several old Webkit-prefixed properties have standard equivalents. Even if the name and syntax may be different, they shouldn't be used anymore at all.
 
-\*\*\* WebKit supports without `-webkit` prefix, but not standard or on standards track
+For each of them, use the standard equivalent provided.
 
-## WebKit-prefixed properties on the standards track
+### A-B
 
-- {{CSSxRef("appearance", "-webkit-appearance")}}
-- {{CSSxRef("-webkit-font-size-delta", "-webkit-font-size-delta")}}
+- `-webkit-border-after`
+  - : Use the standard {{CSSxRef("border-block-end")}} property instead.
+- `-webkit-border-after-color`
+  - : Use the standard {{CSSxRef("border-block-end-color")}} property instead.
+- `-webkit-border-after-style`
+  - : Use the standard {{CSSxRef("border-block-end-style")}} property instead.
+- `-webkit-border-after-width`
+  - : Use the standard {{CSSxRef("border-block-end-width")}} property instead.
+- `-webkit-border-before`
+  - : Use the standard {{CSSxRef("border-block-start")}} property instead.
+- `-webkit-border-before-color`
+  - : Use the standard {{CSSxRef("border-block-start-color")}} property instead.
+- `-webkit-border-before-style`
+  - : Use the standard {{CSSxRef("border-block-start-style")}} property instead.
+- `-webkit-border-before-width`
+  - : Use the standard {{CSSxRef("border-block-start-width")}} property instead.
+- `-webkit-border-end`
+  - : Use the standard {{CSSxRef("border-inline-end")}} proprety instead.
+- `-webkit-border-end-color`
+  - : Use the standard {{CSSxRef("border-inline-end-color")}} property instead.
+- `-webkit-border-end-style`
+  - : Use the standard {{CSSxRef("border-inline-end-style")}} property instead.
+- `-webkit-border-end-width`
+  - : Use the standard {{CSSxRef("border-inline-end-width")}} property instead.
+- `-webkit-border-start`
+  - : Use the standard {{CSSxRef("border-inline-start")}} property instead.
+- `-webkit-border-start-color`
+  - : Use the standard {{CSSxRef("border-inline-start-color")}} property instead.
+- `-webkit-border-start-style`
+  - : Use the standard {{CSSxRef("border-inline-start-style")}} property instead.
+- `-webkit-border-start-width`
+  - : Use the standard {{CSSxRef("border-inline-start-width")}} property instead.
+- `-webkit-box-align`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("align-items")}} property instead.
+- `-webkit-box-direction`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("flex-direction")}} property instead.
+- {{CSSxRef("box-flex-group", "-webkit-box-flex-group")}}
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{cssxref("flex-basis")}}, {{cssxref("flex-grow")}}, and {{cssxref("flex-shrink")}} properties instead.
+- `-webkit-box-flex`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("flex-grow")}} property instead.
+- `-webkit-box-lines`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("flex-flow")}} property instead.
+- `-webkit-box-ordinal-group`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("order")}} property instead.
+- `-webkit-box-orient`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("flex-direction")}} property instead.
+- `-webkit-box-pack`
+  - : Use the [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) with the standard {{CSSxRef("justify-content")}} property instead.
 
-## Formerly proprietary properties that are now standard
+### C-I
 
-> **Note:** To maximize the compatibility of your CSS, you should use the unprefixed standard properties instead of the prefixed ones listed below.
+- `-webkit-column-break-after`
+  - : Use the [CSS multicolumn layout](/en-US/docs/Web/CSS/CSS_multicol_layout) with the standard {{cssxref("break-after")}} property instead.
+- `-webkit-column-break-before`
+  - : Use the [CSS multicolumn layout](/en-US/docs/Web/CSS/CSS_multicol_layout) with the standard {{cssxref("break-before")}} property instead.
+- `-webkit-column-break-inside`
+  - : Use the [CSS multicolumn layout](/en-US/docs/Web/CSS/CSS_multicol_layout) with the standard {{cssxref("break-inside")}} property instead.
+- `-webkit-hyphenate-character`
+  - : Use the standard {{cssxref("hyphenate-character")}} property instead.
+- `-webkit-initial-letter`
+  - : Use the standard {{cssxref("initial-letter")}} property instead.
 
-### A
+### J-Z
 
-- {{CSSxRef("align-content","-webkit-align-content")}}
-- {{CSSxRef("align-items","-webkit-align-items")}}
-- {{CSSxRef("align-self","-webkit-align-self")}}
-- {{CSSxRef("animation","-webkit-animation")}}
-- {{CSSxRef("animation-delay","-webkit-animation-delay")}}
-- {{CSSxRef("animation-direction","-webkit-animation-direction")}}
-- {{CSSxRef("animation-duration","-webkit-animation-duration")}}
-- {{CSSxRef("animation-fill-mode","-webkit-animation-fill-mode")}}
-- {{CSSxRef("animation-iteration-count","-webkit-animation-iteration-count")}}
-- {{CSSxRef("animation-name","-webkit-animation-name")}}
-- {{CSSxRef("animation-play-state","-webkit-animation-play-state")}}
-- {{CSSxRef("animation-timing-function","-webkit-animation-timing-function")}}
-- {{CSSxRef("appearance", "-webkit-appearance")}}
-- {{CSSxRef("aspect-ratio", "-webkit-aspect-ratio")}}
+- `webkit-margin-end`
+  - : Use the standard {{CSSxRef("margin-block-end")}} property instead.
+- `-webkit-margin-start`
 
-### B
+  - : Use the standard {{CSSxRef("margin-block-start")}} property instead.
 
-- {{CSSxRef("backface-visibility","-webkit-backface-visibility")}}
-- {{CSSxRef("background-clip","-webkit-background-clip")}}
-- {{CSSxRef("background-origin","-webkit-background-origin")}}
-- {{CSSxRef("background-size","-webkit-background-size")}}
-- {{CSSxRef("border-bottom-left-radius","-webkit-border-bottom-left-radius")}}
-- {{CSSxRef("border-bottom-right-radius","-webkit-border-bottom-right-radius")}}
-- {{CSSxRef("border-image","-webkit-border-image")}}
-- {{CSSxRef("border-radius","-webkit-border-radius")}}
-- {{CSSxRef("border-top-left-radius","-webkit-border-top-left-radius")}}
-- {{CSSxRef("border-top-right-radius","-webkit-border-top-right-radius")}}
-- {{CSSxRef("box-decoration-break","-webkit-box-decoration-break")}}
-- {{CSSxRef("box-shadow","-webkit-box-shadow")}}
-- {{CSSxRef("box-sizing","-webkit-box-sizing")}}
-
-### C
-
-- {{CSSxRef("clip-path","-webkit-clip-path")}}
-- {{CSSxRef("column-count","-webkit-column-count")}}
-- {{CSSxRef("column-fill","-webkit-column-fill")}}
-- {{CSSxRef("column-gap","-webkit-column-gap")}}
-- {{CSSxRef("column-rule","-webkit-column-rule")}}
-- {{CSSxRef("column-rule-color","-webkit-column-rule-color")}}
-- {{CSSxRef("column-rule-style","-webkit-column-rule-style")}}
-- {{CSSxRef("column-rule-width","-webkit-column-rule-width")}}
-- {{CSSxRef("column-span","-webkit-column-span")}}
-- {{CSSxRef("column-width","-webkit-column-width")}}
-- {{CSSxRef("columns","-webkit-columns")}}
-
-### F
-
-- {{CSSxRef("filter","-webkit-filter")}}
-- {{CSSxRef("flex","-webkit-flex")}}
-- {{CSSxRef("flex-basis","-webkit-flex-basis")}}
-- {{CSSxRef("flex-direction","-webkit-flex-direction")}}
-- {{CSSxRef("flex-flow","-webkit-flex-flow")}}
-- {{CSSxRef("flex-grow","-webkit-flex-grow")}}
-- {{CSSxRef("flex-shrink","-webkit-flex-shrink")}}
-- {{CSSxRef("flex-wrap","-webkit-flex-wrap")}}
-- {{CSSxRef("font-feature-settings", "-webkit-font-feature-settings")}}
-- {{CSSxRef("font-kerning", "-webkit-font-kerning")}}
-- {{CSSxRef("font-variant-ligatures", "-webkit-font-variant-ligatures")}}
-
-### G-J
-
-- {{CSSxRef("grid","-webkit-grid")}}
-- {{CSSxRef("grid-area","-webkit-grid-area")}}
-- {{CSSxRef("grid-auto-columns","-webkit-grid-auto-columns")}}
-- {{CSSxRef("grid-auto-flow","-webkit-grid-auto-flow")}}
-- {{CSSxRef("grid-auto-rows","-webkit-grid-auto-rows")}}
-- {{CSSxRef("grid-column","-webkit-grid-column")}}
-- {{CSSxRef("grid-column-end","-webkit-grid-column-end")}}
-- {{CSSxRef("column-gap","-webkit-grid-column-gap")}}
-- {{CSSxRef("grid-column-start","-webkit-grid-column-start")}}
-- {{CSSxRef("gap","-webkit-grid-gap")}}
-- {{CSSxRef("grid-row","-webkit-grid-row")}}
-- {{CSSxRef("grid-row-end","-webkit-grid-row-end")}}
-- {{CSSxRef("row-gap","-webkit-grid-row-gap")}}
-- {{CSSxRef("grid-row-start","-webkit-grid-row-start")}}
-- {{CSSxRef("grid-template","-webkit-grid-template")}}
-- {{CSSxRef("grid-template-areas","-webkit-grid-template-areas")}}
-- {{CSSxRef("grid-template-columns","-webkit-grid-template-columns")}}
-- {{CSSxRef("grid-template-rows","-webkit-grid-template-rows")}}
-
-### H-L
-
-- {{CSSxRef("hyphens","-webkit-hyphens")}}
-- {{CSSxRef("justify-content","-webkit-justify-content")}}
-- {{CSSxRef("justify-items","-webkit-justify-items")}}
-- {{CSSxRef("justify-self","-webkit-justify-self")}}
-- {{CSSxRef("line-break","-webkit-line-break")}}
-
-### M
-
-- {{CSSxRef("mask","-webkit-mask")}}
-- {{CSSxRef("mask-clip","-webkit-mask-clip")}}
-- {{CSSxRef("mask-composite","-webkit-mask-composite")}}
-- {{CSSxRef("mask-image","-webkit-mask-image")}}
-- {{CSSxRef("mask-origin","-webkit-mask-origin")}}
-- {{CSSxRef("mask-position","-webkit-mask-position")}}
-- {{CSSxRef("mask-repeat","-webkit-mask-repeat")}}
-- {{CSSxRef("mask-size","-webkit-mask-size")}}
-
-### O-R
-
-- {{CSSxRef("opacity","-webkit-opacity")}}
-- {{CSSxRef("order","-webkit-order")}}
-- {{CSSxRef("perspective","-webkit-perspective")}}
-- {{CSSxRef("perspective-origin","-webkit-perspective-origin")}}
-- {{CSSxRef("print-color-adjust", "-webkit-print-color-adjust")}}
-- {{CSSxRef("ruby-position","-webkit-ruby-position")}}
-
-### S
-
-- {{CSSxRef("scroll-snap-type","-webkit-scroll-snap-type")}}
-- {{CSSxRef("shape-image-threshold","-webkit-shape-image-threshold")}}
-- {{CSSxRef("shape-margin","-webkit-shape-margin")}}
-- {{CSSxRef("shape-outside","-webkit-shape-outside")}}
-
-### T
-
-- {{CSSxRef("text-combine-upright", "-webkit-text-combine")}}
-- {{CSSxRef("text-decoration", "-epub-text-decoration")}}
-- {{CSSxRef("text-decoration-color", "-webkit-text-color-decoration")}}
-- {{CSSxRef("text-decoration-line", "-webkit-text-decoration-line")}}
-- {{CSSxRef("text-decoration-style", "-webkit-text-decoration-style")}}
-- {{CSSxRef("text-emphasis", "-epub-text-emphasis")}}
-- {{CSSxRef("text-emphasis","-webkit-text-emphasis")}}
-- {{CSSxRef("text-emphasis-color", "-epub-text-emphasis-color")}}
-- {{CSSxRef("text-emphasis-color","-webkit-text-emphasis-color")}}
-- {{CSSxRef("text-emphasis-position","-webkit-text-emphasis-position")}}
-- {{CSSxRef("text-emphasis-style","-epub-text-emphasis-style")}}
-- {{CSSxRef("text-emphasis-style","-webkit-text-emphasis-style")}}
-- {{CSSxRef("text-justify","-webkit-text-justify")}}
-- {{CSSxRef("text-orientation","-webkit-text-orientation")}}
-- {{CSSxRef("text-size-adjust","-webkit-text-size-adjust")}}
-- {{CSSxRef("text-underline-position","-webkit-text-underline-position")}}
-- {{CSSxRef("transform","-webkit-transform")}}
-- {{CSSxRef("transform-origin","-webkit-transform-origin")}}
-- {{CSSxRef("transform-style","-webkit-transform-style")}}
-- {{CSSxRef("transition","-webkit-transition")}}
-- {{CSSxRef("transition-delay","-webkit-transition-delay")}}
-- {{CSSxRef("transition-duration","-webkit-transition-duration")}}
-- {{CSSxRef("transition-property","-webkit-transition-property")}}
-- {{CSSxRef("transition-timing-function","-webkit-transition-timing-function")}}
-
-### U-W
-
-- {{CSSxRef("user-select","-webkit-user-select")}}
-- {{CSSxRef("word-break", "-epub-word-break")}}
-- {{CSSxRef("writing-mode", "-epub-writing-mode")}}
-
-## Supported in non-webkit browsers without a prefix, but not standard
-
-The following properties are supported in at least one browser without a prefix, but are not on the standards track.
-
-- {{CSSxRef("mask-position-x","-webkit-mask-position-x")}}\*
-- {{CSSxRef("mask-position-y","-webkit-mask-position-y")}}\*
-
-\* Supported unprefixed in Firefox, with prefix in Safari.
-
-## Supported in Firefox with `-webkit-` prefix
-
-The following properties are supported with the `-webkit-` prefix in Firefox. Many of these are supported with no prefix as well: see [Formerly proprietary properties that are now standard](#formerly_proprietary_properties_that_are_now_standard) above.
-
-> **Note:** Due to the legacy code in a multitude of websites that used -webkit- prefixed properties, Edge and Firefox redirect many -webkit- prefixed properties to -moz-, -ms-, and unprefixed equivalents.
-
-### A
-
-- {{CSSxRef("align-content", "-webkit-align-content")}}
-- {{CSSxRef("align-items", "-webkit-align-items")}}
-- {{CSSxRef("align-self", "-webkit-align-self")}}
-- {{CSSxRef("animation", "-webkit-animation")}}
-- {{CSSxRef("animation-delay", "-webkit-animation-delay")}}
-- {{CSSxRef("animation-direction", "-webkit-animation-direction")}}
-- {{CSSxRef("animation-duration", "-webkit-animation-duration")}}
-- {{CSSxRef("animation-fill-mode", "-webkit-animation-fill-mode")}}
-- {{CSSxRef("animation-iteration-count", "-webkit-animation-iteration-count")}}
-- {{CSSxRef("animation-name", "-webkit-animation-name")}}
-- {{CSSxRef("animation-play-state", "-webkit-animation-play-state")}}
-- {{CSSxRef("animation-timing-function", "-webkit-animation-timing-function")}}
-- {{CSSxRef("appearance", "-webkit-appearance")}}\*
-
-### B
-
-- {{CSSxRef("backface-visibility", "-webkit-backface-visibility")}}
-- {{CSSxRef("background-clip", "-webkit-background-clip")}}
-- {{CSSxRef("background-origin", "-webkit-background-origin")}}
-- {{CSSxRef("background-size", "-webkit-background-size")}}
-- {{CSSxRef("border-bottom-left-radius", "-webkit-border-bottom-left-radius")}}
-- {{CSSxRef("border-bottom-right-radius", "-webkit-border-bottom-right-radius")}}
-- {{CSSxRef("border-image", "-webkit-border-image")}}
-- {{CSSxRef("border-radius", "-webkit-border-radius")}}
-- {{CSSxRef("box-align", "-webkit-box-align")}}\*\*, \*\*\*
-- {{CSSxRef("box-direction", "-webkit-box-direction")}}\*\*, \*\*\*
-- {{CSSxRef("box-flex", "-webkit-box-flex")}}\*\*, \*\*\*
-- {{CSSxRef("box-orient", "-webkit-box-orient")}}\*\*, \*\*\*
-- {{CSSxRef("box-pack", "-webkit-box-pack")}}\*\*, \*\*\*
-- {{CSSxRef("box-shadow", "-webkit-box-shadow")}}
-- {{CSSxRef("box-sizing", "-webkit-box-sizing")}}
-- {{CSSxRef("border-top-left-radius", "-webkit-border-top-left-radius")}}
-- {{CSSxRef("border-top-right-radius", "-webkit-border-top-right-radius")}}
-
-### F
-
-- {{CSSxRef("filter", "-webkit-filter")}}
-- {{CSSxRef("flex", "-webkit-flex")}}
-- {{CSSxRef("flex-basis", "-webkit-flex-basis")}}
-- {{CSSxRef("flex-direction", "-webkit-flex-direction")}}
-- {{CSSxRef("flex-flow", "-webkit-flex-flow")}}
-- {{CSSxRef("flex-grow", "-webkit-flex-grow")}}
-- {{CSSxRef("flex-shrink", "-webkit-flex-shrink")}}
-- {{CSSxRef("flex-wrap", "-webkit-flex-wrap")}}
-
-### J
-
-- {{CSSxRef("justify-content", "-webkit-justify-content")}}
-
-### M
-
-- {{CSSxRef("mask", "-webkit-mask")}}
-- {{CSSxRef("mask-clip", "-webkit-mask-clip")}}
-- {{CSSxRef("-webkit-mask-composite", "-webkit-mask-composite")}}\*
-- {{CSSxRef("mask-image", "-webkit-mask-image")}}
-- {{CSSxRef("mask-origin", "-webkit-mask-origin")}}
-- {{CSSxRef("mask-position", "-webkit-mask-position")}}
-- {{CSSxRef("-webkit-mask-position-x", "-webkit-mask-position-x")}}\*\*
-- {{CSSxRef("-webkit-mask-position-y", "-webkit-mask-position-y")}}\*\*
-- {{CSSxRef("mask-repeat", "-webkit-mask-repeat")}}
-- {{CSSxRef("mask-size", "-webkit-mask-size")}}
-
-### O-P
-
-- {{CSSxRef("order", "-webkit-order")}}
-- {{CSSxRef("perspective", "-webkit-perspective")}}
-- {{CSSxRef("perspective-origin", "-webkit-perspective-origin")}}
-
-### T
-
-- {{CSSxRef("-webkit-text-fill-color", "-webkit-text-fill-color")}}\*\*
-- {{CSSxRef("text-size-adjust", "-webkit-text-size-adjust")}}
-- {{CSSxRef("-webkit-text-stroke", "-webkit-text-stroke")}}\*\*
-- {{CSSxRef("-webkit-text-stroke-color", "-webkit-text-stroke-color")}}\*\*
-- {{CSSxRef("-webkit-text-stroke-width", "-webkit-text-stroke-width")}}\*\*
-- {{CSSxRef("transform", "-webkit-transform")}}
-- {{CSSxRef("transform-origin", "-webkit-transform-origin")}}
-- {{CSSxRef("transition", "-webkit-transition")}}
-- {{CSSxRef("transition-delay", "-webkit-transition-delay")}}
-- {{CSSxRef("transition-duration", "-webkit-transition-duration")}}
-- {{CSSxRef("transition-property", "-webkit-transition-property")}}
-- {{CSSxRef("transition-timing-function", "-webkit-transition-timing-function")}}
-
-### U
-
-- {{CSSxRef("user-select", "-webkit-user-select")}}
-
-\* Supported with `-moz-` and `-webkit-` prefix in Firefox, but not supported without a prefix.
-\*\* These values are supported even though they are not standard and are not on track to becoming standard.
-\*\*\* Use flex-box properties instead.
-
-## Deprecated `-webkit-` properties
-
-The following properties were once supported with the -webkit- prefix but are no longer supported in evergreen browsers, with or without the `-webkit-` prefix.
-
-- `-webkit-alt*`
-- `-webkit-background-composite`
-- `-webkit-border-fit`
-- `-webkit-color-correction`
-- `-webkit-flow-from`
-- `-webkit-flow-into`
-- `-webkit-grid-columns` (See [`grid-column`](/en-US/docs/Web/CSS/grid-column))
-- `-webkit-grid-rows` (See [`grid-row`](/en-US/docs/Web/CSS/grid-row))
-- `-webkit-highlight`
-- `-webkit-hyphenate-charset`
-- `-webkit-image-set` (See {{CSSxRef("image/image-set", "image-set")}})
-- `-webkit-mask-attachment`
-- `-webkit-match-nearest-mail-blockquote-color`
-- `-webkit-margin-collapse`
-- `-webkit-margin-after-collapse`
-- `-webkit-margin-before-collapse`
-- `-webkit-margin-bottom-collapse`
-- `-webkit-margin-top-collapse`
-- {{CSSxRef("-webkit-overflow-scrolling", "-webkit-overflow-scrolling")}}
-- `-webkit-region-break-after`
-- `-webkit-region-break-before`
-- `-webkit-region-break-inside`
-- `-webkit-region-fragment`
-- `-webkit-shape-inside`
-- [`-webkit-touch-callout`](/en-US/docs/Web/CSS/-webkit-touch-callout) (See {{cssxref("touch-action")}})
-- `background-origin-x` (unprefixed!)
-- `background-origin-y` (unprefixed!)
-
-\* Still supported in the Safari Technology Preview, but not in a generally released browser.
+- `-webkit-padding-after`
+  - : Use the standard {{CSSxRef("padding-block-end")}} property instead.
+- `-webkit-padding-before`
+  - : Use the standard {{CSSxRef("padding-block-start")}} property instead.
+- `-webkit-padding-end`
+  - : Use the standard {{CSSxRef("padding-inline-end")}} property instead.
+- `-webkit-padding-start`
+  - : Use the standard {{CSSxRef("padding-inline-start")}} property instead.
 
 ## Pseudo-classes
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -19,7 +19,7 @@ User agents based on WebKit or Blink, such as Safari and Chrome, support several
 - {{CSSxRef("-webkit-app-region")}}
 - {{CSSxRef("-webkit-border-horizontal-spacing")}}
 - {{CSSxRef("-webkit-border-vertical-spacing")}}
-- {{CSSxRef("-webkit-box-reflect")}} (Supported with `-webkit` by every browser, for compatibility reasons)
+- {{CSSxRef("-webkit-box-reflect")}} (supported with `-webkit-` by every browser, for compatibility reasons)
 - {{CSSxRef("-webkit-column-axis")}}
 - {{CSSxRef("-webkit-column-progression")}}
 - {{CSSxRef("-webkit-cursor-visibility")}}
@@ -54,10 +54,10 @@ User agents based on WebKit or Blink, such as Safari and Chrome, support several
 - {{CSSxRef("-webkit-mask-box-image-width")}}
 - {{CSSxRef("-webkit-mask-box-image")}}
 - {{cssxref("-webkit-mask-composite")}}
-- {{CSSxRef("-webkit-mask-position-x")}} (Supported with `-webkit` by every browser, for compatibility reasons)
-- {{CSSxRef("-webkit-mask-position-y")}} (Supported with `-webkit` by every browser, for compatibility reasons)
-- {{CSSxRef("-webkit-mask-repeat-x")}} (Also supported without prefix)
-- {{CSSxRef("-webkit-mask-repeat-y")}} (Also supported without prefix)
+- {{CSSxRef("-webkit-mask-position-x")}} (supported with `-webkit-` by every browser, for compatibility reasons)
+- {{CSSxRef("-webkit-mask-position-y")}} (supported with `-webkit-` by every browser, for compatibility reasons)
+- {{CSSxRef("-webkit-mask-repeat-x")}} (also supported without prefix)
+- {{CSSxRef("-webkit-mask-repeat-y")}} (also supported without prefix)
 - {{CSSxRef("-webkit-mask-source-type")}}
 - {{CSSxRef("-webkit-max-logical-height")}}
 - {{CSSxRef("-webkit-max-logical-width")}}

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -117,7 +117,7 @@ For each of them, use the standard equivalent provided.
 - `-webkit-border-before-width`
   - : Use the standard {{CSSxRef("border-block-start-width")}} property instead.
 - `-webkit-border-end`
-  - : Use the standard {{CSSxRef("border-inline-end")}} proprety instead.
+  - : Use the standard {{CSSxRef("border-inline-end")}} property instead.
 - `-webkit-border-end-color`
   - : Use the standard {{CSSxRef("border-inline-end-color")}} property instead.
 - `-webkit-border-end-style`

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -94,7 +94,7 @@ Applications based on WebKit or Blink, such as Safari and Chrome, support severa
 
 ## -webkit-prefixed properties with standard equivalents
 
-Several old Webkit-prefixed properties have standard equivalents. Even if the name and syntax may be different, they shouldn't be used anymore at all.
+Several old `-webkit-`prefixed properties have standard equivalents. Even if the name and syntax may be different, they shouldn't be used anymore at all.
 
 For each of them, use the standard equivalent provided.
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -10,7 +10,7 @@ status:
 
 Applications based on WebKit or Blink, such as Safari and Chrome, support several special extensions to [CSS](/en-US/docs/Web/CSS). These extensions are generally prefixed with `-webkit-`. Most `-webkit-` prefixed properties also work with an `-apple-` prefix. A few are prefixed with `-epub-`.
 
-## WebKit-only properties without standard equivalents
+## -webkit-prefixed properties without standard equivalents
 
 > **Note:** Avoid using on websites. These properties will only work in WebKit-based browsers.
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -92,7 +92,7 @@ Applications based on WebKit or Blink, such as Safari and Chrome, support severa
 - {{CSSxRef("-webkit-user-drag")}}
 - {{CSSxRef("-webkit-user-modify")}}
 
-## Webkit-prefixed properties with standard equivalent
+## -webkit-prefixed properties with standard equivalents
 
 Several old Webkit-prefixed properties have standard equivalents. Even if the name and syntax may be different, they shouldn't be used anymore at all.
 


### PR DESCRIPTION
The Webkit CSS extension page is unusable because there is too much information, and it is poorly maintained (because it is more complicated than it is worth).

This PR takes care of the property sections (not the selectors and media query sections, which will be for other PRs).

The conditions for inclusion are:
- the prefixed extension does something in at least one browser.
- it isn't just an alias for the non-prefixed standard property (same name).

So we include:
- properties with no unprefixed equivalent
- properties with unprefixed equivalents that have different names or values.

The first section is a list, and we expect the red links to be written at some point
The second section is a `<dl>` so that what to use instead is clearly stated (pedagogy: it was hidden before).

Note: this PR was made possible because of mdn/browser-compat-data#21621, which tested what prefixed properties existed, and is part of openwebdocs/project#187