### PR TITLE
Included a link to regex flag descriptions in the regexp document

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -38,6 +38,6 @@ The set accessor of `flags` is `undefined`. You cannot change this property dire
 
 ## See also
 
-- [A table of regular expression flags and their description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags)
+- [A table of regular expression flags and their description](/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags)
 - [Polyfill of `RegExp.prototype.flags` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("RegExp.prototype.source")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -38,5 +38,6 @@ The set accessor of `flags` is `undefined`. You cannot change this property dire
 
 ## See also
 
+- [A table of regular expression flags and their description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags)
 - [Polyfill of `RegExp.prototype.flags` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("RegExp.prototype.source")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -38,6 +38,6 @@ The set accessor of `flags` is `undefined`. You cannot change this property dire
 
 ## See also
 
-- [A table of regular expression flags and their description](/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags)
 - [Polyfill of `RegExp.prototype.flags` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
+- [Advanced searching with flags](/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags) in the Regular expressions guide
 - {{jsxref("RegExp.prototype.source")}}


### PR DESCRIPTION
I think when most people visit this page, they are expecting to find a list with descriptions of regex flags. I've added a link to the document that provides this information. To be honest, I think it would be better to inline this information inside this document (the one I've modified in this PR), but I'm hoping others see this as an improvement, too.