### PR TITLE
Swap `setAppBadge` and `clearAppBadge` methods in the Badging API doc

### DIFF
--- a/files/en-us/web/api/badging_api/index.md
+++ b/files/en-us/web/api/badging_api/index.md
@@ -64,13 +64,13 @@ None.
 To set a notification badge on the current app with a value of 12:
 
 ```js
-navigator.clearAppBadge(12);
+navigator.setAppBadge(12);
 ```
 
 To clear a notification badge on the current app:
 
 ```js
-navigator.setAppBadge();
+navigator.clearAppBadge();
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

In the [Badging API doc](https://developer.mozilla.org/en-US/docs/Web/API/Badging_API#examples), `setAppBadge` and `clearAppBadge` methods were displayed in the wrong place.

### Motivation

The current information is wrong and this PR aims to fix it.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Badging_API#examples