### PR TITLE
Remove dead tutorial link for porting legacy Firefox add-ons

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/what_are_webextensions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/what_are_webextensions/index.md
@@ -46,7 +46,7 @@ Examples: [Web Developer](https://addons.mozilla.org/en-US/firefox/addon/web-dev
 
 Extensions for Firefox are built using the [WebExtensions APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions), a cross-browser system for developing extensions. To a large extent, the API is compatible with the [extension API](https://developer.chrome.com/docs/extensions/reference/) supported by Google Chrome and Opera. Extensions written for these browsers will in most cases run in Firefox or Microsoft Edge with just a few [changes](https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/).
 
-If you have ideas or questions, or need help [migrating a legacy add-on to WebExtensions APIs](https://extensionworkshop.com/documentation/develop/porting-a-legacy-firefox-extension/), you can reach us on the [Add-ons Discourse](https://discourse.mozilla.org/c/add-ons/35) or in the [Add-ons room](https://chat.mozilla.org/#/room/#addons:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+If you have ideas or questions, you can reach us on the [Add-ons Discourse](https://discourse.mozilla.org/c/add-ons/35) or in the [Add-ons room](https://chat.mozilla.org/#/room/#addons:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
 ## What's next?
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes dead link along with the legacy add-ons mention. 

### Motivation

Link is dead. There is a version saved through [Internet Archive](https://web.archive.org/web/20230320142028/https://extensionworkshop.com/documentation/develop/porting-a-legacy-firefox-extension/) that could be used, but legacy Firefox add-ons haven't been supported for a really long time now, so mentioning them in 2023 seems to make little sense anyway.

### Additional details

Dead link: https://extensionworkshop.com/documentation/develop/porting-a-legacy-firefox-extension/
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

None

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
