### PR TITLE
feat(husky): force to update moved file links

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -31,13 +31,12 @@ jobs:
           yarn content fix-flaws
           yarn fix:md
           yarn fix:fm
-          node scripts/update-moved-file-links.js
 
       - name: Create PR with only fixable issues
         if: success()
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "chore: auto-fix Markdownlint, Prettier, front-matter, redirects issues"
+          commit-message: "chore: auto-fix Markdownlint, Prettier, and front-matter issues"
           branch: markdownlint-auto-cleanup
           title: "fix: auto-cleanup by bot"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
@@ -49,7 +48,7 @@ jobs:
         if: failure()
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "chore: auto-fix Markdownlint issues"
+          commit-message: "chore: auto-fix Markdownlint, Prettier, and front-matter issues"
           branch: markdownlint-auto-cleanup
           title: "fix: auto-cleanup by bot"
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -3,6 +3,7 @@
   "*.md": [
     "markdownlint-cli2 --fix",
     "node scripts/front-matter_linter.js --fix true",
+    "node scripts/update-moved-file-links.js --check",
     "prettier --write"
   ],
   "tests/**/*.*": "yarn test:front-matter-linter",

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -2,7 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import childProcess from "node:child_process";
 
-const IMG_RX = /(\.png|\.jpg|\.svg|\.gif)$/gim;
+export const IMG_RX = /(\.png|\.jpg|\.svg|\.gif)$/gim;
+export const SLUG_RX = /(?<=\nslug: ).*?$/gm;
 
 export async function* walkSync(dir) {
   const files = await fs.readdir(dir, { withFileTypes: true });


### PR DESCRIPTION
- follow up of: https://github.com/mdn/content/pull/31091

The PR moves moved URL auto updates from nightly Github workflow to local husky. The move operation is only possible from local environment so it makes sense to have it enforced locally.

When you move a file and try to make a git commit, the husky precommit hook will execute `node scripts/update-moved-file-links.js --check`. If there are URLs to update then the commit operation will fail asking the user to run `node scripts/update-moved-file-links.js` to update all the URLs before trying the commit again.

ping @teoli2003 