### PR TITLE
CookieChangeEvent | add `partitioned` option & add optional for param & fix event name

### DIFF
--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -39,6 +39,9 @@ An array of objects containing the changed cookie(s). Each object contains the f
     - `"none"`
       - : Cookies will be sent in all contexts.
 
+- `partitioned`
+  - : A boolean indicating whether the cookie is a partitioned cookie (`true`) or not (`false`). See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more information.
+
 ## Examples
 
 In this example when the cookie is set, the event listener logs the `changed` property to the console. The first item in that array contains an object representing the cookie that has just been set.

--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -25,7 +25,7 @@ An array of objects containing the changed cookie(s). Each object contains the f
 - `path`
   - : A string containing the path of the cookie.
 - `expires`
-  - : A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, containing the expiration date of the cookie.
+  - : A timestamp, given as {{glossary("Unix time")}} in milliseconds, containing the expiration date of the cookie.
 - `secure`
   - : A {{jsxref("boolean")}} indicating whether the cookie is from a site with a secure context (HTTPS rather than HTTP).
 - `sameSite`
@@ -44,7 +44,7 @@ An array of objects containing the changed cookie(s). Each object contains the f
 
 ## Examples
 
-In this example when the cookie is set, the event listener logs the `changed` property to the console. The first item in that array contains an object representing the cookie that has just been set.
+In this example, when the cookie is set, the event listener logs the `changed` property to the console. The first item in that array contains an object representing the cookie that has just been set.
 
 ```js
 cookieStore.addEventListener("change", (event) => {

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CookieChangeEvent.CookieChangeEvent
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
 
 The **`CookieChangeEvent()`** constructor creates a new {{domxref("CookieChangeEvent")}} object
-which is the event type passed to {{domxref("CookieStore/change_event", "CookieStore.onchange()")}}.
+which is the event type of the {{domxref("CookieStore/change_event", "change")}} event fired at a {{domxref("CookieStore")}} when any cookie changes occur.
 This constructor is called by the browser when a change event occurs.
 
 > **Note:** This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -30,9 +30,9 @@ new CookieChangeEvent(type, options)
     It is case-sensitive and browsers always set it to `cookiechange`.
 - `options` {{Optional_Inline}}
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
-    - `changed`
+    - `changed`{{Optional_Inline}}
       - : An array containing the changed cookies.
-    - `deleted`
+    - `deleted`{{Optional_Inline}}
       - : An array containing the deleted cookies.
 
 ### Return value

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -26,8 +26,7 @@ new CookieChangeEvent(type, options)
 ### Parameters
 
 - `type`
-  - : A string with the name of the event.
-    It is case-sensitive and browsers always set it to `cookiechange`.
+  - : A string with the name of the event. It is case-sensitive and browsers always set it to `change`.
 - `options` {{Optional_Inline}}
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `changed`{{Optional_Inline}}

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -25,7 +25,7 @@ An array of objects containing the deleted cookie(s). Each object contains the f
 - `path`
   - : A string containing the path of the cookie.
 - `expires`
-  - : A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, containing the expiration date of the cookie.
+  - : A timestamp, given as {{glossary("Unix time")}} in milliseconds, containing the expiration date of the cookie.
 - `secure`
   - : A {{jsxref("boolean")}} indicating whether the cookie is from a site with a secure context (HTTPS rather than HTTP).
 - `sameSite`
@@ -44,7 +44,7 @@ An array of objects containing the deleted cookie(s). Each object contains the f
 
 ## Examples
 
-In this example when the cookie is deleted the event listener logs the first item in the `CookieChangeEvent.deleted` property to the console. It contains an object representing the cookie that has just been deleted.
+In this example, when the cookie is deleted, the event listener logs the first item in the `CookieChangeEvent.deleted` property to the console. It contains an object representing the cookie that has just been deleted.
 
 ```js
 cookieStore.addEventListener("change", (event) => {

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -39,6 +39,9 @@ An array of objects containing the deleted cookie(s). Each object contains the f
     - `"none"`
       - : Cookies will be sent in all contexts.
 
+- `partitioned`
+  - : A boolean indicating whether the cookie is a partitioned cookie (`true`) or not (`false`). See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more information.
+
 ## Examples
 
 In this example when the cookie is deleted the event listener logs the first item in the `CookieChangeEvent.deleted` property to the console. It contains an object representing the cookie that has just been deleted.

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -35,6 +35,10 @@ _This interface also inherits properties from {{domxref("Event")}}._
 - {{domxref("CookieChangeEvent.deleted")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an array containing one or more deleted cookies.
 
+## Instance methods
+
+_This interface also inherits methods from {{domxref("Event")}}._
+
 ## Examples
 
 In this example when the cookie is set, the event listener logs the event to the console. This is a `CookieChangeEvent` object with the {{domxref("CookieChangeEvent.changed","changed")}} property containing an object representing the cookie that has just been set.

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -9,12 +9,12 @@ browser-compat: api.CookieChangeEvent
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
 
-The **`CookieChangeEvent`** interface of the ['Cookie Store API'](/en-US/docs/Web/API/Cookie_Store_API) is the event type of the {{domxref("CookieStore.change_event", "change")}} event fired at a {{domxref("CookieStore")}} when any cookie changes occur. A cookie change consists of a cookie and a type (either "changed" or "deleted").
+The **`CookieChangeEvent`** interface of the {{domxref("Cookie Store API", "", "", "nocode")}} is the event type of the {{domxref("CookieStore/change_event", "change")}} event fired at a {{domxref("CookieStore")}} when any cookie changes occur. A cookie change consists of a cookie and a type (either "changed" or "deleted").
 
 Cookie changes that will cause the `CookieChangeEvent` to be dispatched are:
 
 - A cookie is newly created and not immediately removed. In this case `type` is "changed".
-- A cookie is newly created and immediately removed. In this case `type` is "deleted"
+- A cookie is newly created and immediately removed. In this case `type` is "deleted".
 - A cookie is removed. In this case `type` is "deleted".
 
 > **Note:** A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

also add the `partitioned` option to `CookieChangeEvent.changed` and `CookieChangeEvent.deleted`, which is not added in #23495 and https://github.com/mdn/browser-compat-data/pull/18591

fix the event name in `CookieChangeEvent()` constructor - should be `change` instead of `cookiechange`, which is related with `CookieStore: change` event; and mark the two params as {{Optional_Inline}}

some other small update

see spec https://wicg.github.io/cookie-store/ , also https://developer.mozilla.org/en-US/docs/Web/API/Cookie_Store_API

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
