### PR TITLE
ExtendableCookieChangeEvent | add {{AvailableInWorkers}} macros & add the `partitioned` option

### DIFF
--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -10,6 +10,8 @@ browser-compat: api.ExtendableCookieChangeEvent.changed
 
 The **`changed`** read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been changed by the given `ExtendableCookieChangeEvent` instance.
 
+{{AvailableInWorkers}}
+
 ## Value
 
 An array of objects containing the changed cookie(s). Each object contains the following properties:

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -37,6 +37,9 @@ An array of objects containing the changed cookie(s). Each object contains the f
     - `"none"`
       - : Cookies will be sent in all contexts.
 
+- `partitioned`
+  - : A boolean indicating whether the cookie is a partitioned cookie (`true`) or not (`false`). See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more information.
+
 ## Examples
 
 In this example when the cookie is set, the event listener logs the `changed` property to the console. The first item in that array contains an object representing the cookie that has just been set.

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -10,6 +10,8 @@ browser-compat: api.ExtendableCookieChangeEvent.deleted
 
 The **`deleted`** read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been deleted by the given `ExtendableCookieChangeEvent` instance.
 
+{{AvailableInWorkers}}
+
 ## Value
 
 An array of objects containing the deleted cookie(s). Each object contains the following properties:

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -37,6 +37,9 @@ An array of objects containing the deleted cookie(s). Each object contains the f
     - `"none"`
       - : Cookies will be sent in all contexts.
 
+- `partitioned`
+  - : A boolean indicating whether the cookie is a partitioned cookie (`true`) or not (`false`). See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more information.
+
 ## Examples
 
 In this example when the cookie is deleted the event listener logs the first item in the `deleted` property to the console. It contains an object representing the cookie that has just been deleted.

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -9,7 +9,7 @@ browser-compat: api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent
 {{securecontext_header}}{{APIRef("Cookie Store API")}}
 
 The **`ExtendableCookieChangeEvent()`** constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object
-which is the event type passed to {{domxref("ServiceWorkerRegistration/cookiechange_event", "ServiceWorkerRegistration.oncookiechange()")}}.
+which is the event type passed to {{domxref("ServiceWorkerGlobalScope/cookiechange_event", "cookiechange")}} event fired at the {{domxref("ServiceWorkerGlobalScope")}} when any cookie changes occur which match the service worker's cookie change subscription list.
 This constructor is called by the browser when a change event occurs.
 
 > **Note:** This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -14,6 +14,8 @@ This constructor is called by the browser when a change event occurs.
 
 > **Note:** This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.
 
+{{AvailableInWorkers}}
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -30,9 +30,9 @@ new ExtendableCookieChangeEvent(type, options)
     It is case-sensitive and browsers always set it to `cookiechange`.
 - `options` {{optional_inline}}
   - : An object that, _in addition of the properties defined in {{domxref("ExtendableEvent/ExtendableEvent", "ExtendableEvent()")}}_, can have the following properties:
-    - `changed`
+    - `changed` {{optional_inline}}
       - : An array containing a changed cookie.
-    - `deleted`
+    - `deleted` {{optional_inline}}
       - : An array containing a deleted cookie.
 
 ### Return value

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -19,6 +19,8 @@ Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are
 
 {{InheritanceDiagram}}
 
+{{AvailableInWorkers}}
+
 ## Constructor
 
 - {{domxref("ExtendableCookieChangeEvent.ExtendableCookieChangeEvent", "ExtendableCookieChangeEvent()")}}

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -35,6 +35,10 @@ _This interface also inherits properties from {{domxref("ExtendableEvent")}}._
 - {{domxref("ExtendableCookieChangeEvent.deleted")}} {{ReadOnlyInline}}
   - : Returns an array containing the deleted cookies.
 
+## Instance methods
+
+_This interface also inherits methods from {{domxref("ExtendableEvent")}}._
+
 ## Examples
 
 In the below example, we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. (In service workers, a subscription is required in order to listen for events.) We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an `ExtendableCookieChangeEvent` object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.ExtendableCookieChangeEvent
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}
 
-The **`ExtendableCookieChangeEvent`** interface of the['Cookie Store API'](/en-US/docs/Web/API/Cookie_Store_API) is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes occur. A cookie change event consists of a cookie and a type (either "changed" or "deleted".)
+The **`ExtendableCookieChangeEvent`** interface of the {{domxref("Cookie Store API", "", "", "nocode")}} is the event type passed to {{domxref("ServiceWorkerGlobalScope/cookiechange_event", "cookiechange")}} event fired at the {{domxref("ServiceWorkerGlobalScope")}} when any cookie changes occur which match the service worker's cookie change subscription list. A cookie change event consists of a cookie and a type. (either "changed" or "deleted")
 
 Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are:
 
@@ -37,12 +37,13 @@ _This interface also inherits properties from {{domxref("ExtendableEvent")}}._
 
 ## Examples
 
-In the below example we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. (In service workers, a subscription is required in order to listen for events.) We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an `ExtendableCookieChangeEvent` object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.
+In the below example, we use {{domxref("CookieStoreManager.getSubscriptions()")}} to get a list of existing subscriptions. (In service workers, a subscription is required in order to listen for events.) We unsubscribe from existing subscriptions using {{domxref("CookieStoreManager.unsubscribe()")}}, then subscribe to the cookie with a name of 'COOKIE_NAME' using {{domxref("CookieStoreManager.subscribe()")}}. If that cookie is changed, the event listener logs the event to the console. This will be an `ExtendableCookieChangeEvent` object, with the {{domxref("ExtendableCookieChangeEvent.changed","changed")}} or {{domxref("ExtendableCookieChangeEvent.deleted","deleted")}} property containing the modified cookie.
 
 ```js
 self.addEventListener("activate", (event) => {
   event.waitUntil(async () => {
     const subscriptions = await self.registration.cookies.getSubscriptions();
+
     await self.registration.cookies.unsubscribe(subscriptions);
 
     await self.registration.cookies.subscribe([

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -17,9 +17,9 @@ Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are
 
 > **Note:** A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
 
-{{InheritanceDiagram}}
-
 {{AvailableInWorkers}}
+
+{{InheritanceDiagram}}
 
 ## Constructor
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

also add the `partitioned` option to `ExtendableCookieChangeEvent.changed` and `ExtendableCookieChangeEvent.deleted`, which is not added in #23495 and https://github.com/mdn/browser-compat-data/pull/18591

add {{AvailableInWorkers}} macros to `ExtendableCookieChangeEvent`

some other small update

see spec https://wicg.github.io/cookie-store/ , also https://developer.mozilla.org/en-US/docs/Web/API/Cookie_Store_API

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
