### PR TITLE
Neutralize link to navigator.registerContentHandler()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
@@ -14,7 +14,7 @@ Starting with Firefox 2, Firefox has support for selecting different RSS or Atom
 
 Support for adding feed readers from the web was removed from the HTML5 spec, and Firefox support is scheduled for removal in Firefox 62. {{Deprecated_Inline}}
 
-In older versions, JavaScript code on the web can add a feed reader easily, using the `navigator.registerContentHandler()` function, like this:
+In older versions, JavaScript code on the web can add a feed reader using the `navigator.registerContentHandler()` function, like this:
 
 ```js
 navigator.registerContentHandler(

--- a/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/adding_feed_readers_to_firefox/index.md
@@ -14,7 +14,7 @@ Starting with Firefox 2, Firefox has support for selecting different RSS or Atom
 
 Support for adding feed readers from the web was removed from the HTML5 spec, and Firefox support is scheduled for removal in Firefox 62. {{Deprecated_Inline}}
 
-In older versions, JavaScript code on the web can add a feed reader easily, using the {{domxref("window.navigator.registerContentHandler", "navigator.registerContentHandler()")}} function, like this:
+In older versions, JavaScript code on the web can add a feed reader easily, using the `navigator.registerContentHandler()` function, like this:
 
 ```js
 navigator.registerContentHandler(
@@ -50,7 +50,3 @@ You can add these preferences by hand, by visiting `about:config`.
 ### Adding a new feed reader application
 
 The easiest way to do this is to use the provided user interface, by using the Feeds panel in the Preferences (or Options, depending on your platform) window.
-
-### See also
-
-- {{ domxref("window.navigator.registerContentHandler()") }}


### PR DESCRIPTION
This _was_ a non-standard proprietary method, long gone (and never documented).