### PR TITLE
Neutralize red links

### DIFF
--- a/files/en-us/mozilla/firefox/releases/37/index.md
+++ b/files/en-us/mozilla/firefox/releases/37/index.md
@@ -23,7 +23,7 @@ Highlights:
 ### CSS
 
 - `display: contents` is now activated by default ([Firefox bug 1102374](https://bugzil.la/1102374) and [Firefox bug 1105369](https://bugzil.la/1105369)).
-- [CSS multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts) is now working on element with `display: table-caption` ([Firefox bug 1109571](https://bugzil.la/1109571)).
+- [CSS multi-column layout](/en-US/docs/Web/CSS/CSS_multicol_layout/Using_multicol_layouts) is now working on elements with `display: table-caption` ([Firefox bug 1109571](https://bugzil.la/1109571)).
 - Relative positioning (`position: relative`) of table cells has been implemented ([Firefox bug 35168](https://bugzil.la/35168)).
 - The quirks mode behavior of {{cssxref("empty-cells")}} has been removed: it now defaults to `show` like in standard mode ([Firefox bug 1020400](https://bugzil.la/1020400)).
 
@@ -36,7 +36,7 @@ Highlights:
 
 - The {{jsxref("Map")}}, {{jsxref("Set")}}, {{jsxref("WeakMap")}} and {{jsxref("WeakSet")}} constructors now ignore null iterable ([Firefox bug 1092538](https://bugzil.la/1092538)).
 - The {{jsxref("Map")}}, {{jsxref("Set")}}, {{jsxref("WeakMap")}} and {{jsxref("WeakSet")}} constructors now supports monkey-patched `prototype.set` or `prototype.add` ([Firefox bug 804279](https://bugzil.la/804279)).
-- The Non-standard {{jsxref("String.quote","String.prototype.quote()")}} method has been removed ([Firefox bug 1103181](https://bugzil.la/1103181)).
+- The Non-standard `String.prototype.quote()` method has been removed ([Firefox bug 1103181](https://bugzil.la/1103181)).
 - The {{jsxref("RegExp.prototype.flags")}} property has been implemented ([Firefox bug 1108467](https://bugzil.la/1108467)).
 - Several {{jsxref("Array")}} methods have been implemented for [typed arrays](/en-US/docs/Web/JavaScript/Guide/Typed_arrays) as well:
 
@@ -49,7 +49,7 @@ Highlights:
   - The {{jsxref("TypedArray.reverse", "reverse()")}} method ([Firefox bug 1111516](https://bugzil.la/1111516)).
   - The {{jsxref("TypedArray.keys", "keys()")}}, {{jsxref("TypedArray.values", "values()")}}, and {{jsxref("TypedArray.entries", "entries()")}} methods ([Firefox bug 1119217](https://bugzil.la/1119217)).
 
-- ES2015 Proxy {{jsxref("Global_Objects/Proxy/handler/enumerate", "enumerate")}} trap is implemented ([Firefox bug 783829](https://bugzil.la/783829)).
+- The ES2015 {{jsxref("Proxy")}} enumerate trap for [`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) statements is implemented ([Firefox bug 783829](https://bugzil.la/783829)).
 - The `configurable` attribute of the {{jsxref("Function.length")}} property is now `true` per the ES2015 specification ([Firefox bug 911142](https://bugzil.la/911142)).
 - The development of [ParallelJS (PJS)](https://web.archive.org/web/20161113115816/http://wiki.ecmascript.org/doku.php?id=strawman:data_parallelism) has been discontinued due to the limited future prospects, little attention and code complexity. The experimental implementation that had been enabled only on the Nightly channel, including the `Array.prototype.mapPar`, `filterPar` and `reducePar` methods, has been completely removed.
 


### PR DESCRIPTION
`quote()` has never been documented

And for the enumerate trap, I use the same format as in Firefox 47 for developers, where it got removed.