### PR TITLE
Remove mention of ARIAMixin in aria-busy

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
@@ -15,7 +15,7 @@ When multiple parts of a live region need to be loaded before changes are announ
 
 There is a section of content that updates. The updates are important and you want to let the user know when it has been modified, so you have converted it into an [ARIA live region](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) with the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute. You may want to update several components of that section at the same time, but you can't be sure that everything will update simultaneously. Even if it is a very important live region with `aria-live="assertive"`, you don't want to interrupt the user multiple times as different parts of the content load. This is where `aria-busy` can help.
 
-The `aria-busy` property is an optional property of live regions that can have the value `true` or `false`. The `aria-busy` attribute with a value of `true` can be added to an element currently being updated or modified, to inform the assistive technology that it should wait until the modifications or changes are complete before exposing the content to the user. Use the [`ariaBusy`](/en-US/docs/Web/API/Element/ariaBusy) property of the {{domxref("ARIAMixin")}} interface to change the value to `false` when downloading is complete.
+The `aria-busy` property is an optional property of live regions that can have the value `true` or `false`. The `aria-busy` attribute with a value of `true` can be added to an element currently being updated or modified, to inform the assistive technology that it should wait until the modifications or changes are complete before exposing the content to the user. Use the [`ariaBusy`](/en-US/docs/Web/API/Element/ariaBusy) property of the object to change the value to `false` when downloading is complete.
 
 ```js
 ariaLiveElement.ariaBusy = "false";
@@ -29,7 +29,7 @@ If an element with [`feed`](/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role) 
 
 ### Within a `widget`
 
-If changes to a rendered widget would create a state where the widget is missing required owned elements during script execution, set `aria-busy` to `true` on the widget during the update process. For example, if a rendered tree grid updates multiple branches not necessarily rendered simultaneously, an alternative to replacing the whole tree in a single update would be to mark the tree busy while each of the branches are modified.
+If changes to a rendered widget would create a state where the widget is missing required owned elements during script execution, set `aria-busy` to `true` on the widget during the update process. For example, if a rendered tree grid updates multiple branches not necessarily rendered simultaneously, an alternative to replacing the whole tree in a single update would be to mark the tree busy while each of the branches is modified.
 
 ## Values
 
@@ -38,10 +38,10 @@ If changes to a rendered widget would create a state where the widget is missing
 - true
   - : The element is being updated.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaBusy")}}
-  - : The [`ariaBusy`](/en-US/docs/Web/API/Element/ariaBusy) property, part of the {{domxref("ARIAMixin")}} interface, reflects the value of the `aria-busy` attribute, which indicates whether an element is being modified.
+  - : The [`ariaBusy`](/en-US/docs/Web/API/Element/ariaBusy) property, part of each element's interface, reflects the value of the `aria-busy` attribute, which indicates whether an element is being modified.
 
 ```html
 <div


### PR DESCRIPTION
We don't mention ARIAMixin as they are a specification shorthand (= not displayed to developers + instable–the spec writer can change them or modify them without notifying anybody).