### PR TITLE
Call super first in custom element constructor

### DIFF
--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -192,8 +192,8 @@ The dashed identifier is just a string preceded by two dashes: in this case we c
 ```js
 class MyCustomElement extends HTMLElement {
   constructor() {
-    this._internals = this.attachInternals();
     super();
+    this._internals = this.attachInternals();
   }
 
   get collapsed() {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`super()` was not called first in the constructor of a custom element, so I fixed it.

### Motivation

The current code snippet results in a reference error. I'd like to contribute to the readers' learning experience by proposing a change to the code snippet.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
