### PR TITLE
docs: update rawgit link to w3c github

### DIFF
--- a/files/en-us/web/api/inputevent/inputtype/index.md
+++ b/files/en-us/web/api/inputevent/inputtype/index.md
@@ -17,7 +17,7 @@ Possible changes include for example inserting, deleting, and formatting text.
 A string containing the type of input that was made. There are many
 possible values, such as `insertText`, `deleteContentBackward`,
 `insertFromPaste`, and `formatBold`. For a complete list of the
-available input types, see the [Attributes section of the Input Events Level 1 spec](https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes).
+available input types, see the [Attributes section of the Input Events Level 2 spec](https://w3c.github.io/input-events/#interface-InputEvent-Attributes).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

update sunset rawgit link to w3c github on InputEvent: inputType property docs

### Motivation

so we don't lead users to wrong places and to maintain the docs updated
