### PR TITLE
Element.checkVisibility() - docs

### DIFF
--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -95,11 +95,11 @@ The first (default selected) values should result in `checkVisibility()` returni
 </select>
 ```
 
-Next we have a `<div>` that is used to output the result of the `checkVisibility()` check when no options are passed in the parameter, and for each separate option value.
+Next we have a `<pre>` that is used to output the result of the `checkVisibility()` check when no options are passed in the parameter, and for each separate option value.
 At the end we have the element that will be tested (to which we will apply the selected CSS property values).
 
 ```html
-<div id="visibility_check"></div>
+<pre id="output_result"></pre>
 <div id="test_element">The element to be checked for visibility.</div>
 ```
 
@@ -127,7 +127,7 @@ const contentVisibilityCssSelect = document.getElementById(
 const displayCssOpacity = document.getElementById("css_opacity");
 const displayCssVisibility = document.getElementById("css_visibility");
 
-const visibility_check = document.getElementById("visibility_check");
+const outputResult = document.getElementById("output_result");
 const elementToCheck = document.getElementById("test_element");
 
 updateCSS();
@@ -159,13 +159,11 @@ function updateCSS() {
   });
 
   // Output the results of the tests
-  visibility_check.innerHTML = `<p>Checks on element below (may be hidden):</p>
-    <ul>
-      <li>Result of <code>checkVisibility()</code>: ${defaultVisibilityCheck}</li>
-      <li>Result of <code>checkVisibility({opacityProperty: true})</code>: ${opacityVisibilityCheck}</li>
-      <li>Result of <code>checkVisibility({visibilityProperty: true})</code>: ${cssVisibilityCheck}</li>
-      <li>Result of <code>checkVisibility({contentVisibilityAuto: true})</code>: ${contentVisibilityAutoCheck}</li>
-    </ul>`;
+  outputResult.innerText = `Checks on element below (may be hidden):
+- Result of checkVisibility(): ${defaultVisibilityCheck}
+- Result of checkVisibility({opacityProperty: true}): ${opacityVisibilityCheck}
+- Result of checkVisibility({visibilityProperty: true}): ${cssVisibilityCheck}
+- Result of checkVisibility({contentVisibilityAuto: true}): ${contentVisibilityAutoCheck}`;
 }
 ```
 

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -159,12 +159,12 @@ function updateCSS() {
   });
 
   // Output the results of the tests
-  visibility_check.innerHTML = `<p>Result of check on element below (may be hidden):</p>
+  visibility_check.innerHTML = `<p>Checks on element below (may be hidden):</p>
     <ul>
-      <li>default: ${defaultVisibilityCheck}</li>
-      <li>opacity: ${opacityVisibilityCheck}</li>
-      <li>visibility: ${cssVisibilityCheck}</li>
-      <li>contentVisibilityAuto: ${contentVisibilityAutoCheck}</li>
+      <li>Result of <code>checkVisibility()</code>: ${defaultVisibilityCheck}</li>
+      <li>Result of <code>checkVisibility({opacityProperty: true})</code>: ${opacityVisibilityCheck}</li>
+      <li>Result of <code>checkVisibility({visibilityProperty: true})</code>: ${cssVisibilityCheck}</li>
+      <li>Result of <code>checkVisibility({contentVisibilityAuto: true})</code>: ${contentVisibilityAutoCheck}</li>
     </ul>`;
 }
 ```

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -43,9 +43,9 @@ checkVisibility(options)
         > **Note:** Invisible elements include those that have [`visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden), and some element types that have [`visibility: collapse`](/en-US/docs/Web/CSS/visibility#collapse).
 
     - `checkOpacity`
-      - : A historic alias for [`opacityProperty`](#opacityProperty).
+      - : A historic alias for [`opacityProperty`](#opacityproperty).
     - `checkVisibilityCSS`
-      - : A historic alias for [`visibilityProperty`](#visibilityProperty).
+      - : A historic alias for [`visibilityProperty`](#visibilityproperty).
 
 ### Return value
 

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -31,14 +31,14 @@ checkVisibility(options)
     The possible options are:
 
     - `contentVisibilityAuto`
-      - : `true` to check if the element has [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto) and is currently skipping its rendering.
+      - : `true` to check if the element {{cssxref("content-visibility")}} property is set to (or inherits) the value [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and it is currently skipping its rendering.
         `false` by default.
     - `opacityProperty`
       - : `true` to check if the element has an opacity of `0`.
         `false` by default.
     - `visibilityProperty`
 
-      - : `true` to check if the element is invisible due to its CSS [`visibility`](/en-US/docs/Web/CSS/visibility) value.
+      - : `true` to check if the element is invisible due to the value of its {{cssxref("visibility")}} property.
         `false` by default.
 
         > **Note:** Invisible elements include those that have [`visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden), and some element types that have [`visibility: collapse`](/en-US/docs/Web/CSS/visibility#collapse).
@@ -52,10 +52,10 @@ checkVisibility(options)
 
 `false` if any of the following conditions are met, otherwise `true`:
 
-- the element doesn't have an associated box
+- The element doesn't have an associated box.
 - The element has [`content-visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden).
-- `opacityProperty` (or `checkOpacity`) is `true` and the element has an opacity of `0`.
-- `visibilityProperty` (or `checkVisibilityCSS`) is `true` and the element is invisible due to the CSS [`visibility`](/en-US/docs/Web/CSS/visibility) property.
+- `opacityProperty` (or `checkOpacity`) is `true` and the element {{cssxref("opacity ")}} property has (or inherits) a value of `0`.
+- `visibilityProperty` (or `checkVisibilityCSS`) is `true` and the element is invisible due to the value of its {{cssxref("visibility")}} property.
 - `contentVisibilityAuto` is `true` and element rendering is being skipped due to [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto)
 
 ## Examples

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -13,10 +13,10 @@ The **`checkVisibility()`** method of the {{domxref("Element")}} interface check
 The method returns `false` in either of the following situations:
 
 - The element doesn't have an associated box, for example because the CSS {{cssxref("display")}} property is set to [`none`](/en-US/docs/Web/CSS/display#none) or [`contents`](/en-US/docs/Web/CSS/display#contents).
-- The element is not being rendered because the element or an an ancestor element sets the {{cssxref("content-visibility")}} property to [`hidden`](/en-US/docs/Web/CSS/content-visibility#hidden).
+- The element is not being rendered because the element or an ancestor element sets the {{cssxref("content-visibility")}} property to [`hidden`](/en-US/docs/Web/CSS/content-visibility#hidden).
 
 The optional parameter enables additional checks to test for other interpretations of what "visible" means.
-For example, you can further check whether an element has an opacity of `0`, if the CSS [`visibility`](/en-US/docs/Web/CSS/visibility) means that the element is invisible, or if its rendering is currently being skipped because it has the {{cssxref("content-visibility")}} property set to [`auto`](/en-US/docs/Web/CSS/content-visibility#auto).
+For example, you can further check whether an element has an opacity of `0`, if the value of the element [`visibility`](/en-US/docs/Web/CSS/visibility) property makes it invisible, or if the element {{cssxref("content-visibility")}} property has a value of [`auto`](/en-US/docs/Web/CSS/content-visibility#auto) and its rendering is currently being skipped.
 
 ## Syntax
 
@@ -32,10 +32,10 @@ checkVisibility(options)
     The possible options are:
 
     - `contentVisibilityAuto`
-      - : `true` to check if the element {{cssxref("content-visibility")}} property is set to (or inherits) the value [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and it is currently skipping its rendering.
+      - : `true` to check if the element {{cssxref("content-visibility")}} property has (or inherits) the value [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and it is currently skipping its rendering.
         `false` by default.
     - `opacityProperty`
-      - : `true` to check if the element {{cssxref("opacity")}} property is set to (or inherits) a value of `0`.
+      - : `true` to check if the element {{cssxref("opacity")}} property has (or inherits) a value of `0`.
         `false` by default.
     - `visibilityProperty`
 
@@ -54,10 +54,10 @@ checkVisibility(options)
 `false` if any of the following conditions are met, otherwise `true`:
 
 - The element doesn't have an associated box.
-- The element has [`content-visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden).
-- `opacityProperty` (or `checkOpacity`) is `true` and the element {{cssxref("opacity ")}} property has (or inherits) a value of `0`.
+- The element {{cssxref("content-visibility")}} property has (or inherits) a value of [`hidden`](/en-US/docs/Web/CSS/visibility#hidden).
+- `opacityProperty` (or `checkOpacity`) is `true` and the element {{cssxref("opacity")}} property has (or inherits) a value of `0`.
 - `visibilityProperty` (or `checkVisibilityCSS`) is `true` and the element is invisible due to the value of its {{cssxref("visibility")}} property.
-- `contentVisibilityAuto` is `true`, the {{cssxref("content-visibility")}} property is [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and element rendering is being skipped.
+- `contentVisibilityAuto` is `true`, the {{cssxref("content-visibility")}} property has (or inherits) a value of [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and element rendering is being skipped.
 
 ## Examples
 

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -11,6 +11,7 @@ browser-compat: api.Element.checkVisibility
 The **`checkVisibility()`** method of the {{domxref("Element")}} interface checks whether the element is visible.
 
 The method returns `false` in either of the following situations:
+
 - The element doesn't have an associated box, for example because the CSS {{cssxref("display")}} property is set to [`none`](/en-US/docs/Web/CSS/display#none) or [`contents`](/en-US/docs/Web/CSS/display#contents).
 - The element is not being rendered because the element or an an ancestor element sets the {{cssxref("content-visibility")}} property to [`hidden`](/en-US/docs/Web/CSS/content-visibility#hidden).
 
@@ -34,7 +35,7 @@ checkVisibility(options)
       - : `true` to check if the element {{cssxref("content-visibility")}} property is set to (or inherits) the value [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and it is currently skipping its rendering.
         `false` by default.
     - `opacityProperty`
-      - : `true` to check if the element has an opacity of `0`.
+      - : `true` to check if the element {{cssxref("opacity")}} property is set to (or inherits) a value of `0`.
         `false` by default.
     - `visibilityProperty`
 
@@ -56,7 +57,7 @@ checkVisibility(options)
 - The element has [`content-visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden).
 - `opacityProperty` (or `checkOpacity`) is `true` and the element {{cssxref("opacity ")}} property has (or inherits) a value of `0`.
 - `visibilityProperty` (or `checkVisibilityCSS`) is `true` and the element is invisible due to the value of its {{cssxref("visibility")}} property.
-- `contentVisibilityAuto` is `true` and element rendering is being skipped due to [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto)
+- `contentVisibilityAuto` is `true`, the {{cssxref("content-visibility")}} property is [`auto`](/en-US/docs/Web/CSS/content-visibility#auto), and element rendering is being skipped.
 
 ## Examples
 

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -1,0 +1,185 @@
+---
+title: "Element: checkVisibility() method"
+short-title: checkVisibility()
+slug: Web/API/Element/checkVisibility
+page-type: web-api-instance-method
+browser-compat: api.Element.checkVisibility
+---
+
+{{APIRef("DOM")}}
+
+The **`checkVisibility()`** method of the {{domxref("Element")}} interface performs checks to determine whether the element is visible.
+
+The method returns `false` if the element doesn't have an associated box, such as those that have the CSS property [`display: none`](/en-US/docs/Web/CSS/display#none) or [`display: contents`](/en-US/docs/Web/CSS/display#contents).
+The method also returns `false` if the element is not being rendered because the element or an an ancestor element sets the property value as [`content-visibility: hidden`](/en-US/docs/Web/CSS/content-visibility#hidden).
+
+The optional parameter enables additional checks to test for other interpretations of what "visible" means.
+For example, you can further check whether an element has an opacity of `0`, if the CSS [`visibility`](/en-US/docs/Web/CSS/visibility) means that the element is invisible, or if its rendering is currently being skipped because it has the property [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto).
+
+## Syntax
+
+```js-nolint
+checkVisibility(options)
+```
+
+### Parameters
+
+- `options` {{optional_inline}}
+
+  - : An object indicating additional checks to run.
+    The possible options are:
+
+    - `contentVisibilityAuto`
+      - : `true` to check if the element has [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto) and is currently skipping its rendering.
+        `false` by default.
+    - `opacityProperty`
+      - : `true` to check if the element has an opacity of `0`.
+        `false` by default.
+    - `visibilityProperty`
+
+      - : `true` to check if the element is invisible due to its CSS [`visibility`](/en-US/docs/Web/CSS/visibility) value.
+        `false` by default.
+
+        > **Note:** Invisible elements include those that have [`visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden), and some element types that have [`visibility: collapse`](/en-US/docs/Web/CSS/visibility#collapse).
+
+    - `checkOpacity`
+      - : A historic alias for [`opacityProperty`](#opacityProperty).
+    - `checkVisibilityCSS`
+      - : A historic alias for [`visibilityProperty`](#visibilityProperty).
+
+### Return value
+
+`false` if any of the following conditions are met, otherwise `true`:
+
+- the element doesn't have an associated box
+- The element has [`content-visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden).
+- `opacityProperty` (or `checkOpacity`) is `true` and the element has an opacity of `0`.
+- `visibilityProperty` (or `checkVisibilityCSS`) is `true` and the element is invisible due to the CSS [`visibility`](/en-US/docs/Web/CSS/visibility) property.
+- `contentVisibilityAuto` is `true` and element rendering is being skipped due to [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto)
+
+## Examples
+
+### Test checkVisibility() with varied CSS
+
+The following example allows you to test how the result of `checkVisibility()` might change with different values for `display`, `content-visibility`, `visibility`, and `opacity` CSS properties.
+
+#### HTML
+
+The HTML defines a `<select>` element for the CSS properties that affect the results of `checkVisibility()`.
+The first (default selected) values should result in `checkVisibility()` returning `true` when applied to an element, while the other values affect the visibility.
+
+```html
+<select id="css_display" name="css_display">
+  <option value="block" selected>display: block</option>
+  <option value="none">display: none</option>
+  <option value="content">display: content</option>
+</select>
+
+<select id="css_content_visibility" name="css_content_visibility">
+  <option value="visible" selected>content-visibility: visible</option>
+  <option value="hidden">content-visibility: hidden</option>
+  <option value="auto">content-visibility: auto</option>
+</select>
+
+<select id="css_opacity" name="css_opacity">
+  <option value="1" selected>opacity: 1</option>
+  <option value="0">opacity: 0</option>
+</select>
+
+<select id="css_visibility" name="css_visibility">
+  <option value="visible" selected>visibility: visible</option>
+  <option value="hidden">visibility: hidden</option>
+  <option value="collapse">visibility: collapse</option>
+</select>
+```
+
+Next we have a `<div>` that is used to output the result of the `checkVisibility()` check when no options are passed in the parameter, and for each separate option value.
+At the end we have the element that will be tested (to which we will apply the selected CSS property values).
+
+```html
+<div id="visibility_check"></div>
+<div id="test_element">The element to be checked for visibility.</div>
+```
+
+#### CSS
+
+The CSS just highlights the element to be tested.
+
+```css
+#test_element {
+  border: solid;
+  border-color: blue;
+}
+```
+
+#### JavaScript
+
+The code below gets each of the `<select>` elements.
+The `updateCSS()` method is called on start and whenever the select elements change in order to apply the selected CSS to the target element,
+
+```js
+const displayCssSelect = document.getElementById("css_display");
+const contentVisibilityCssSelect = document.getElementById(
+  "css_content_visibility",
+);
+const displayCssOpacity = document.getElementById("css_opacity");
+const displayCssVisibility = document.getElementById("css_visibility");
+
+const visibility_check = document.getElementById("visibility_check");
+const elementToCheck = document.getElementById("test_element");
+
+updateCSS();
+
+const cssSelectors = document.querySelectorAll("select");
+cssSelectors.forEach((select) => {
+  select.addEventListener("change", (event) => {
+    updateCSS();
+  });
+});
+
+function updateCSS() {
+  // Apply selected CSS properties to target element
+  elementToCheck.style.display = displayCssSelect.value;
+  elementToCheck.style.contentVisibility = contentVisibilityCssSelect.value;
+  elementToCheck.style.opacity = displayCssOpacity.value;
+  elementToCheck.style.visibility = displayCssVisibility.value;
+
+  // Call checkVisibility() on element using default and each of options
+  const defaultVisibilityCheck = elementToCheck.checkVisibility();
+  const opacityVisibilityCheck = elementToCheck.checkVisibility({
+    opacityProperty: true,
+  });
+  const cssVisibilityCheck = elementToCheck.checkVisibility({
+    visibilityProperty: true,
+  });
+  const contentVisibilityAutoCheck = elementToCheck.checkVisibility({
+    contentVisibilityAuto: true,
+  });
+
+  // Output the results of the tests
+  visibility_check.innerHTML = `<p>Result of check on element below (may be hidden):</p>
+    <ul>
+      <li>default: ${defaultVisibilityCheck}</li>
+      <li>opacity: ${opacityVisibilityCheck}</li>
+      <li>visibility: ${cssVisibilityCheck}</li>
+      <li>contentVisibilityAuto: ${contentVisibilityAutoCheck}</li>
+    </ul>`;
+}
+```
+
+#### Result
+
+The results are shown below.
+If you change the selection the results will be applied to the test element (blue outline) and the results of the `checkVisibility()` for each setting should be displayed.
+So for example, if you set the `opacity: 0` that test (only) should indicate `false`.
+However if you set `display: none` then all tests should return `false.
+
+{{ EmbedLiveSample('Using hidden to manually manage visibility', "100%", "200" ) }}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -8,13 +8,14 @@ browser-compat: api.Element.checkVisibility
 
 {{APIRef("DOM")}}
 
-The **`checkVisibility()`** method of the {{domxref("Element")}} interface performs checks to determine whether the element is visible.
+The **`checkVisibility()`** method of the {{domxref("Element")}} interface checks whether the element is visible.
 
-The method returns `false` if the element doesn't have an associated box, such as those that have the CSS property [`display: none`](/en-US/docs/Web/CSS/display#none) or [`display: contents`](/en-US/docs/Web/CSS/display#contents).
-The method also returns `false` if the element is not being rendered because the element or an an ancestor element sets the property value as [`content-visibility: hidden`](/en-US/docs/Web/CSS/content-visibility#hidden).
+The method returns `false` in either of the following situations:
+- The element doesn't have an associated box, for example because the CSS {{cssxref("display")}} property is set to [`none`](/en-US/docs/Web/CSS/display#none) or [`contents`](/en-US/docs/Web/CSS/display#contents).
+- The element is not being rendered because the element or an an ancestor element sets the {{cssxref("content-visibility")}} property to [`hidden`](/en-US/docs/Web/CSS/content-visibility#hidden).
 
 The optional parameter enables additional checks to test for other interpretations of what "visible" means.
-For example, you can further check whether an element has an opacity of `0`, if the CSS [`visibility`](/en-US/docs/Web/CSS/visibility) means that the element is invisible, or if its rendering is currently being skipped because it has the property [`content-visibility: auto`](/en-US/docs/Web/CSS/content-visibility#auto).
+For example, you can further check whether an element has an opacity of `0`, if the CSS [`visibility`](/en-US/docs/Web/CSS/visibility) means that the element is invisible, or if its rendering is currently being skipped because it has the {{cssxref("content-visibility")}} property set to [`auto`](/en-US/docs/Web/CSS/content-visibility#auto).
 
 ## Syntax
 
@@ -174,7 +175,7 @@ If you change the selection the results will be applied to the test element (blu
 So for example, if you set the `opacity: 0` that test (only) should indicate `false`.
 However if you set `display: none` then all tests should return `false.
 
-{{ EmbedLiveSample('Using hidden to manually manage visibility', "100%", "200" ) }}
+{{ EmbedLiveSample('Test checkVisibility() with varied CSS', "100%", "200" ) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -185,6 +185,8 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
   - : Attaches a shadow DOM tree to the specified element and returns a reference to its {{DOMxRef("ShadowRoot")}}.
 - {{DOMxRef("Element.before()")}}
   - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the `Element`'s parent, just before the `Element`.
+- {{DOMxRef("Element.checkVisibility()")}}
+  - : Returns whether an element is expected to be visible or not based on configurable checks.
 - {{DOMxRef("Element.closest()")}}
   - : Returns the `Element` which is the closest ancestor of the current element (or the current element itself) which matches the selectors given in parameter.
 - {{DOMxRef("Element.computedStyleMap()")}}


### PR DESCRIPTION
FF122 adds support to get whether an element's rendering is been skipped due to `content-visibility:auto` being set. The support is a new property of the `Element.checkVisibility()` options parameter object named `contentVisibilityAuto`. There are also two other options   `opacityProperty` and `visibilityProperty` created as aliases of other existing options in the same bugzilla https://bugzilla.mozilla.org/show_bug.cgi?id=1859852

This adds docs for the `checkVisibility()` method.

Other docs work for this can be tracked in #31107

Note, the example seems to show some issue with the default behaviour for checkVisibility on Firefox. See https://bugzilla.mozilla.org/show_bug.cgi?id=1859852#c7
