### PR TITLE
Fix broken links

### DIFF
--- a/files/en-us/mozilla/firefox/releases/33/index.md
+++ b/files/en-us/mozilla/firefox/releases/33/index.md
@@ -34,7 +34,7 @@ For details please [see the hacks post](https://hacks.mozilla.org/2014/07/event-
 - Added support for `mongolian`, `disclosure-open` and `disclosure-closed` counter styles in {{cssxref("list-style-type")}} ([Firefox bug 982355](https://bugzil.la/982355) and [Firefox bug 1063856](https://bugzil.la/1063856)).
 - Fixed CSS animations with empty keyframes rule so they also dispatch events ([Firefox bug 1004377](https://bugzil.la/1004377)).
 - Added support for `rebeccapurple`, a new {{cssxref("&lt;color&gt;")}} name defined in CSS Colors level 4 ([Firefox bug 1024642](https://bugzil.la/1024642)).
-- Our experimental implementation of CSS Fonts Level 3 progresses. Its activation is governed by the `layout.css.font-features.enabled` preference, enabled by default in Nightly. Newly implemented features are:
+- Our experimental implementation of CSS Fonts Level 3 is progressing. Its activation is governed by the `layout.css.font-features.enabled` preference, enabled by default in Nightly. Newly implemented features are:
 
   - The fallback algorithm of {{cssxref("font-variant-caps")}}, creating synthetic alternates for missing glyphs ([Firefox bug 961558](https://bugzil.la/961558)).
   - The {{cssxref("font-synthesis")}} CSS property has been implemented ([Firefox bug 871453](https://bugzil.la/871453)).
@@ -42,8 +42,8 @@ For details please [see the hacks post](https://hacks.mozilla.org/2014/07/event-
 ### HTML
 
 - Added the experimental support for {{htmlelement("picture")}} element ([Firefox bug 870022](https://bugzil.la/870022)), behind the `dom.image.picture.enabled` preference (off by default).
-- The {{HTMLElement("label")}}, especially without a [`for`](/en-US/docs/Web/HTML/Element/label#for) attribute, doesn't apply anymore to a `<input type=hidden>` field ([Firefox bug 597650](https://bugzil.la/597650)). The previous behavior wasn't spec compliant.
-- The link annotation `noreferrer` has been implemented on {{HTMLElement("a")}} elements. `<a rel="noreferrer">` will not include the URL of the referrer in the HTTP request sent to fetch it ([Firefox bug 530396](https://bugzil.la/530396)). Note that this work only for in-page links, not for linked clicked via the UI, like via contextual menus.
+- The {{HTMLElement("label")}}, especially without a [`for`](/en-US/docs/Web/HTML/Element/label#for) attribute, doesn't apply anymore to a `<input type=hidden>` field ([Firefox bug 597650](https://bugzil.la/597650)). The previous behavior wasn't spec-compliant.
+- The link annotation `noreferrer` has been implemented on {{HTMLElement("a")}} elements. `<a rel="noreferrer">` will not include the URL of the referrer in the HTTP request sent to fetch it ([Firefox bug 530396](https://bugzil.la/530396)). Note that this works only for in-page links, not for links clicked via the UI, like via contextual menus.
 - On Android, support for two new values for the [`name`](/en-US/docs/Web/HTML/Element/meta#name) attribute of {{HTMLElement("meta")}} has been added: `msapplication-TileImage` and `msapplication-TileColor` ([Firefox bug 1014712](https://bugzil.la/1014712)). Example:
 
   ```html
@@ -53,9 +53,9 @@ For details please [see the hacks post](https://hacks.mozilla.org/2014/07/event-
 
 ### JavaScript
 
-- The non-standard method {{jsxref("Number.toInteger()")}} has been removed ([Firefox bug 1022396](https://bugzil.la/1022396)).
+- The non-standard method `Number.toInteger()` has been removed ([Firefox bug 1022396](https://bugzil.la/1022396)).
 - The {{jsxref("Map.prototype.set()")}}, {{jsxref("WeakMap.prototype.set()")}} and {{jsxref("Set.prototype.add()")}} methods are now chainable, return their equivalent objects and no longer `undefined` ([Firefox bug 1031632](https://bugzil.la/1031632)).
-- A [default parameter](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) is evaluated before function declarations inside the function body, so those functions cannot be referred from default parameter ([Firefox bug 1022962](https://bugzil.la/1022962)).
+- A [default parameter](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) is evaluated before function declarations inside the function body, so those functions cannot be referred from the default parameter ([Firefox bug 1022962](https://bugzil.la/1022962)).
 - Shorthand properties are now allowed in object literals: if not explicitly defined, property keys are initialized by variables of the same name. E.g. `function f(x, y) { return {x, y}; }` is equivalent to `function f(x, y) { return {x: x, y: y}; }` ([Firefox bug 875002](https://bugzil.la/875002)).
 - The parsing of [`yield`](/en-US/docs/Web/JavaScript/Reference/Operators/yield) and [`yield*`](/en-US/docs/Web/JavaScript/Reference/Operators/yield*) has been updated to conform with the latest ES2015 specification ([Firefox bug 981599](https://bugzil.la/981599)).
 - The non-standard `hasOwn` trap has been removed ([Firefox bug 980565](https://bugzil.la/980565)).
@@ -73,7 +73,7 @@ For details please [see the hacks post](https://hacks.mozilla.org/2014/07/event-
 - The formerly called `loaded` event, sent on a {{domxref("HTMLTrackElement")}} has been renamed {{domxref("Window/load_event", "load")}} to match the specification ([Firefox bug 1035505](https://bugzil.la/1035505)).
 - The IndexedDB interface `FileHandle` has been renamed in `IDBMutableFile` ([Firefox bug 1006485](https://bugzil.la/1006485)).
 - The IndexedDB interface `LockedFile` has been renamed in `IDBFileHandle` ([Firefox bug 1006485](https://bugzil.la/1006485)).
-- The {{domxref("ServiceWorker")}} interface has been implemented, behind the `dom.serviceWorkers.enabled` flag ([Firefox bug 903441](https://bugzil.la/903441)).
+- The {{domxref("ServiceWorker")}} interface has been implemented behind the `dom.serviceWorkers.enabled` flag ([Firefox bug 903441](https://bugzil.la/903441)).
 - The {{domxref("NetworkInformation.type")}} now also support the `"unknown"` value ([Firefox bug 1023029](https://bugzil.la/1023029)).
 
 ### MathML
@@ -99,16 +99,16 @@ _No change._
 
 ## Changes for add-on and Mozilla developers
 
-- The [JavaScript Debugger Service (JSD)](/en-US/docs/Mozilla/Add-ons/Code_snippets/JavaScript_Debugger_Service) has been removed in favor of the new [Debugger API](https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/index.html) ([Firefox bug 800200](https://bugzil.la/800200)).
+- The JavaScript Debugger Service (JSD)) has been removed in favor of the new [Debugger API](https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/index.html) ([Firefox bug 800200](https://bugzil.la/800200)).
 - The interface nsIX509CertDB2 has been removed and the methods from that interface have been moved to the nsIX509CertDB interface.
 
 ### Add-on SDK
 
 #### Highlights
 
-- Added support for context menus in panels via a new option in the [`Panel` constructor](</en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/panel#panel(options)>).
-- Added [`tab.readyState`](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/tabs#readystate).
-- Added a [`BrowserWindow`](/en-US/docs/Mozilla/Add-ons/SDK/High-Level_APIs/windows#browserwindow) parameter to [`sidebar.show()`](</en-US/docs/Mozilla/Add-ons/SDK/Low-Level_APIs/ui_sidebar#show(window)>) and [`sidebar.hide()`](</en-US/docs/Mozilla/Add-ons/SDK/Low-Level_APIs/ui_sidebar#hide(window)>), to control the window for which the sidebar will be shown or hidden.
+- Added support for context menus in panels via a new option in the `Panel` constructor.
+- Added `tab.readyState`.
+- Added a `BrowserWindow` parameter to `sidebar.show()` and `sidebar.hide()`, to control the window for which the sidebar will be shown or hidden.
 
 #### Details
 


### PR DESCRIPTION
I neutralized them as they were links to never-written or long-gone documents about deleted features (old add-on interfaces, …)