### PR TITLE
Remove link to JS expression closure syntax

### DIFF
--- a/files/en-us/mozilla/firefox/releases/60/index.md
+++ b/files/en-us/mozilla/firefox/releases/60/index.md
@@ -116,7 +116,7 @@ _No changes._
 
 ### JavaScript
 
-The non-standard [expression closure](/en-US/docs/Web/JavaScript/Reference/Operators/Expression_closures) syntax has been removed ([Firefox bug 1426519](https://bugzil.la/1426519)).
+The non-standard expression closure syntax has been removed ([Firefox bug 1426519](https://bugzil.la/1426519)).
 
 ### APIs
 

--- a/files/en-us/mozilla/firefox/releases/60/index.md
+++ b/files/en-us/mozilla/firefox/releases/60/index.md
@@ -116,7 +116,7 @@ _No changes._
 
 ### JavaScript
 
-The non-standard expression closure syntax has been removed ([Firefox bug 1426519](https://bugzil.la/1426519)).
+The non-standard [expression closure](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#statements_2) syntax has been removed ([Firefox bug 1426519](https://bugzil.la/1426519)).
 
 ### APIs
 


### PR DESCRIPTION
- non-documented
- non-standard
- long-gone 


The link to Bugzilla is enough for the context.