### PR TITLE
Remove link to -moz-touch-enabled media query

### DIFF
--- a/files/en-us/mozilla/firefox/releases/73/index.md
+++ b/files/en-us/mozilla/firefox/releases/73/index.md
@@ -25,7 +25,7 @@ _No changes._
 
 #### Removals
 
-- The proprietary [`-moz-touch-enabled`](/en-US/docs/Web/CSS/@media/-moz-touch-enabled) media query has been removed ([Firefox bug 1486964](https://bugzil.la/1486964)). You should use [`pointer: coarse`](/en-US/docs/Web/CSS/@media/pointer) instead.
+- The proprietary `-moz-touch-enabled` media query has been removed ([Firefox bug 1486964](https://bugzil.la/1486964)). You should use [`pointer: coarse`](/en-US/docs/Web/CSS/@media/pointer) instead.
 
 ### SVG
 


### PR DESCRIPTION
- gone
- never documented and will never.

The Bugzilla link + the link to the alternative are enough