### PR TITLE
Remove mention of ARIAMixin

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
@@ -38,7 +38,7 @@ If changes to a rendered widget would create a state where the widget is missing
 - true
   - : The element is being updated.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaBusy")}}
   - : The [`ariaBusy`](/en-US/docs/Web/API/Element/ariaBusy) property, part of each element's interface, reflects the value of the `aria-busy` attribute, which indicates whether an element is being modified.

--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -62,7 +62,7 @@ Used in roles:
 - [`radio`](/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role)
 - [`switch`](/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role)
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaChecked")}}
   - : The [`ariaChecked`](/en-US/docs/Web/API/Element/ariaChecked) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-checked` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -62,7 +62,7 @@ Used in roles:
 - [`radio`](/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role)
 - [`switch`](/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role)
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaChecked")}}
   - : The [`ariaChecked`](/en-US/docs/Web/API/Element/ariaChecked) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-checked` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindex/index.md
@@ -80,7 +80,7 @@ If all the columns are in the DOM, neither `aria-colcount` nor `aria-colindex` a
 - `<integer>`
   - : Integer greater than or equal to 1 and less than or equal to the total number of columns if all were present.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaColIndex")}}
   - : The [`ariaColIndex`](/en-US/docs/Web/API/Element/ariaColIndex) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-colindex` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindex/index.md
@@ -80,7 +80,7 @@ If all the columns are in the DOM, neither `aria-colcount` nor `aria-colindex` a
 - `<integer>`
   - : Integer greater than or equal to 1 and less than or equal to the total number of columns if all were present.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaColIndex")}}
   - : The [`ariaColIndex`](/en-US/docs/Web/API/Element/ariaColIndex) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-colindex` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -68,7 +68,7 @@ See related [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/
 - `<string>`
   - The human-readable text alternative of the numeric [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaColIndexText")}}
   - : The [`ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-colindextext` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -68,7 +68,7 @@ See related [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/
 - `<string>`
   - The human-readable text alternative of the numeric [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaColIndexText")}}
   - : The [`ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-colindextext` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
@@ -139,10 +139,10 @@ If we had used a {{HTMLElement('table')}} and semantic table elements our markup
 - `<integer>`
   - : An integer greater than or equal to the default value of 1 defining the number of columns spanned by the cell. The value must be less than what would cause a cell to overlap the next cell in the same row.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaColSpan")}}
-  - : The [`ariaColSpan`](/en-US/docs/Web/API/Element/ariaColSpan) property, part of the {{domxref("ARIAMixin")}} interface, reflects the value of the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : The [`ariaColSpan`](/en-US/docs/Web/API/Element/ariaColSpan) property, part of each element's interface, reflects the value of the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
@@ -139,7 +139,7 @@ If we had used a {{HTMLElement('table')}} and semantic table elements our markup
 - `<integer>`
   - : An integer greater than or equal to the default value of 1 defining the number of columns spanned by the cell. The value must be less than what would cause a cell to overlap the next cell in the same row.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaColSpan")}}
   - : The [`ariaColSpan`](/en-US/docs/Web/API/Element/ariaColSpan) property, part of each element's interface, reflects the value of the `aria-colspan` attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.

--- a/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
@@ -78,12 +78,12 @@ In this tabs example, each tab controls one tabpanel:
 ## Values
 
 - `id` list
-  - : Space separated list of one or more ID values referencing the elements being controlled by the current element
+  - : A space-separated list of one or more ID values referencing the elements being controlled by the current element
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaBusy")}}
-  - : The [`ariaControls`](/en-US/docs/Web/API/Element/ariaBusy) property, part of the {{domxref("ARIAMixin")}} interface, reflects the value of the `aria-controls` attribute, which indicates whether an element is being modified.
+  - : The [`ariaControls`](/en-US/docs/Web/API/Element/ariaBusy) property, part of each element's interface, reflects the value of the `aria-controls` attribute, which indicates whether an element is being modified.
 
 ## Associated roles
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
@@ -80,7 +80,7 @@ In this tabs example, each tab controls one tabpanel:
 - `id` list
   - : A space-separated list of one or more ID values referencing the elements being controlled by the current element
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaBusy")}}
   - : The [`ariaControls`](/en-US/docs/Web/API/Element/ariaBusy) property, part of each element's interface, reflects the value of the `aria-controls` attribute, which indicates whether an element is being modified.

--- a/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
@@ -66,7 +66,7 @@ If the element representing the current page in the breadcrumb was not a link, t
 - `false` (default)
   - : Does not represent the current item within a set.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaCurrent")}}
   - : The [`ariaCurrent`](/en-US/docs/Web/API/Element/ariaCurrent) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-current` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
@@ -66,7 +66,7 @@ If the element representing the current page in the breadcrumb was not a link, t
 - `false` (default)
   - : Does not represent the current item within a set.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaCurrent")}}
   - : The [`ariaCurrent`](/en-US/docs/Web/API/Element/ariaCurrent) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-current` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
@@ -36,7 +36,7 @@ The content of the description, whether set by `aria-description` or `aria-descr
 - `<string>`
   - : The value is a string, an unconstrained value type, that is intended to be conveyed to the assistive technology user.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaDescription")}}
   - : The [`ariaDescription`](/en-US/docs/Web/API/Element/ariaDescription) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-description` attribute, which defines a string value that describes or annotates the current element.

--- a/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
@@ -36,7 +36,7 @@ The content of the description, whether set by `aria-description` or `aria-descr
 - `<string>`
   - : The value is a string, an unconstrained value type, that is intended to be conveyed to the assistive technology user.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaDescription")}}
   - : The [`ariaDescription`](/en-US/docs/Web/API/Element/ariaDescription) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-description` attribute, which defines a string value that describes or annotates the current element.

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -91,7 +91,7 @@ If you used just CSS to style the disabled state using an attribute selector, th
 - `false`
   - : The element is not disabled
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaDisabled")}}
   - : The [`ariaDisabled`](/en-US/docs/Web/API/Element/ariaDisabled) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-disabled` attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -91,7 +91,7 @@ If you used just CSS to style the disabled state using an attribute selector, th
 - `false`
   - : The element is not disabled
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaDisabled")}}
   - : The [`ariaDisabled`](/en-US/docs/Web/API/Element/ariaDisabled) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-disabled` attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.

--- a/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
@@ -77,7 +77,7 @@ A parent row in a [`treegrid`](/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid
 - `undefined` (default)
   - : The element does not own or control a grouping element that is expandable.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaExpanded")}}
   - : The [`ariaExpanded`](/en-US/docs/Web/API/Element/ariaExpanded) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-expanded` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
@@ -77,7 +77,7 @@ A parent row in a [`treegrid`](/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid
 - `undefined` (default)
   - : The element does not own or control a grouping element that is expandable.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaExpanded")}}
   - : The [`ariaExpanded`](/en-US/docs/Web/API/Element/ariaExpanded) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-expanded` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
@@ -42,7 +42,7 @@ When creating a [`menubar`](/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_rol
 - `dialog`
   - : The popup is a dialog.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaHasPopup")}}
   - : The [`ariaHasPopup`](/en-US/docs/Web/API/Element/ariaHasPopup) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-haspopup` attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.

--- a/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
@@ -42,7 +42,7 @@ When creating a [`menubar`](/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_rol
 - `dialog`
   - : The popup is a dialog.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaHasPopup")}}
   - : The [`ariaHasPopup`](/en-US/docs/Web/API/Element/ariaHasPopup) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-haspopup` attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.

--- a/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
@@ -66,7 +66,7 @@ We have a button with [a Font Awesome icon](https://fontawesome.com/). We hide t
 - `undefined` (default)
   - : The element's hidden state is determined by the user agent based on whether it is rendered.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaHidden")}}
   - : The [`ariaHidden`](/en-US/docs/Web/API/Element/ariaHidden) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-hidden` attribute, which Indicates whether the element is exposed to an accessibility API.

--- a/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
@@ -66,7 +66,7 @@ We have a button with [a Font Awesome icon](https://fontawesome.com/). We hide t
 - `undefined` (default)
   - : The element's hidden state is determined by the user agent based on whether it is rendered.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaHidden")}}
   - : The [`ariaHidden`](/en-US/docs/Web/API/Element/ariaHidden) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-hidden` attribute, which Indicates whether the element is exposed to an accessibility API.

--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -113,7 +113,7 @@ In this example, the `aria-keyshortcuts` attribute on the element is set to "Alt
 <a href="#content" aria-keyshortcuts="Alt+Shift+A">Skip to content</a>
 ```
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaKeyShortcuts")}}
   - : The [`ariaKeyShortcuts`](/en-US/docs/Web/API/Element/ariaKeyShortcuts) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-keyshortcuts` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -113,7 +113,7 @@ In this example, the `aria-keyshortcuts` attribute on the element is set to "Alt
 <a href="#content" aria-keyshortcuts="Alt+Shift+A">Skip to content</a>
 ```
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaKeyShortcuts")}}
   - : The [`ariaKeyShortcuts`](/en-US/docs/Web/API/Element/ariaKeyShortcuts) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-keyshortcuts` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -57,7 +57,7 @@ If you give your {{HTMLElement('iframe')}}s a `title`, your images an `alt` attr
 - `<string>`
   - : A string of text that will be the accessible name for the object.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaLabel")}}
   - : The [`ariaLabel`](/en-US/docs/Web/API/Element/ariaLabel) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-label` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -57,7 +57,7 @@ If you give your {{HTMLElement('iframe')}}s a `title`, your images an `alt` attr
 - `<string>`
   - : A string of text that will be the accessible name for the object.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaLabel")}}
   - : The [`ariaLabel`](/en-US/docs/Web/API/Element/ariaLabel) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-label` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
@@ -38,7 +38,7 @@ If a complete set of available nodes is not present in the DOM due to dynamic lo
 - `<integer>`
   - : An integer greater than or equal to 1
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaLevel")}}
   - : The [`ariaLevel`](/en-US/docs/Web/API/Element/ariaLevel) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-level` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
@@ -38,7 +38,7 @@ If a complete set of available nodes is not present in the DOM due to dynamic lo
 - `<integer>`
   - : An integer greater than or equal to 1
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaLevel")}}
   - : The [`ariaLevel`](/en-US/docs/Web/API/Element/ariaLevel) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-level` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
@@ -64,7 +64,7 @@ A live region includes the element and all its descendants. When not set on upda
 - `polite`
   - : Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaLive")}}
   - : The [`ariaLive`](/en-US/docs/Web/API/Element/ariaLive) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-live` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
@@ -64,7 +64,7 @@ A live region includes the element and all its descendants. When not set on upda
 - `polite`
   - : Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaLive")}}
   - : The [`ariaLive`](/en-US/docs/Web/API/Element/ariaLive) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-live` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -69,7 +69,7 @@ The `aria-modal` attribute exposes the existence of the modal to assistive techn
 - `true`
   - : Element is modal.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaModal")}}
   - : The [`ariaModal`](/en-US/docs/Web/API/Element/ariaModal) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-modal` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -69,7 +69,7 @@ The `aria-modal` attribute exposes the existence of the modal to assistive techn
 - `true`
   - : Element is modal.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaModal")}}
   - : The [`ariaModal`](/en-US/docs/Web/API/Element/ariaModal) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-modal` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
@@ -28,7 +28,7 @@ Be aware of focus and keystrokes when designing text boxes. ARIA only modifies t
 - `false`
   - : The text box only accepts a single line of input.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaMultiLine")}}
   - : The [`ariaMultiLine`](/en-US/docs/Web/API/Element/ariaMultiLine) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-multiline` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
@@ -28,7 +28,7 @@ Be aware of focus and keystrokes when designing text boxes. ARIA only modifies t
 - `false`
   - : The text box only accepts a single line of input.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaMultiLine")}}
   - : The [`ariaMultiLine`](/en-US/docs/Web/API/Element/ariaMultiLine) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-multiline` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -130,7 +130,7 @@ Instead of `aria-selected="true"`, include the [`checked`](/en-US/docs/Web/HTML/
 - `false`
   - : Only one item can be selected
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaMultiSelectable")}}
   - : The [`ariaMultiSelectable`](/en-US/docs/Web/API/Element/ariaMultiSelectable) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-multiselectable` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -130,7 +130,7 @@ Instead of `aria-selected="true"`, include the [`checked`](/en-US/docs/Web/HTML/
 - `false`
   - : Only one item can be selected
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaMultiSelectable")}}
   - : The [`ariaMultiSelectable`](/en-US/docs/Web/API/Element/ariaMultiSelectable) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-multiselectable` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-orientation/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-orientation/index.md
@@ -44,7 +44,7 @@ Always remember that ARIA only modifies how assistive technology presents conten
 - `vertical`
   - : The element is oriented vertically.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaOrientation")}}
   - : The [`ariaOrientation`](/en-US/docs/Web/API/Element/ariaOrientation) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-orientation` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-orientation/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-orientation/index.md
@@ -44,7 +44,7 @@ Always remember that ARIA only modifies how assistive technology presents conten
 - `vertical`
   - : The element is oriented vertically.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaOrientation")}}
   - : The [`ariaOrientation`](/en-US/docs/Web/API/Element/ariaOrientation) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-orientation` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
@@ -39,7 +39,7 @@ The `aria-placeholder` is used in addition to, not instead of, a label. They hav
 - `<string>`
   - : The word or short phrase to display in a control when the control has no value.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaPlaceholder")}}
   - : The [`ariaPlaceholder`](/en-US/docs/Web/API/Element/ariaPlaceholder) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-placeholder` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
@@ -39,7 +39,7 @@ The `aria-placeholder` is used in addition to, not instead of, a label. They hav
 - `<string>`
   - : The word or short phrase to display in a control when the control has no value.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaPlaceholder")}}
   - : The [`ariaPlaceholder`](/en-US/docs/Web/API/Element/ariaPlaceholder) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-placeholder` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
@@ -38,7 +38,7 @@ In a [`feed`](/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role), each {{HTMLEl
 - `<integer>`
   - : Integer greater than or equal to 1, and less than or equal to the value of `aria-setsize`.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaPosInSet")}}
   - : The [`ariaPosInSet`](/en-US/docs/Web/API/Element/ariaPosInSet) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-posinset` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
@@ -38,7 +38,7 @@ In a [`feed`](/en-US/docs/Web/Accessibility/ARIA/Roles/feed_role), each {{HTMLEl
 - `<integer>`
   - : Integer greater than or equal to 1, and less than or equal to the value of `aria-setsize`.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaPosInSet")}}
   - : The [`ariaPosInSet`](/en-US/docs/Web/API/Element/ariaPosInSet) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-posinset` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-pressed/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-pressed/index.md
@@ -38,7 +38,7 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
 - `undefined` (default)
   - : The element does not support being pressed.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaPressed")}}
   - : The [`ariaPressed`](/en-US/docs/Web/API/Element/ariaPressed) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-pressed` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-pressed/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-pressed/index.md
@@ -38,7 +38,7 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
 - `undefined` (default)
   - : The element does not support being pressed.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaPressed")}}
   - : The [`ariaPressed`](/en-US/docs/Web/API/Element/ariaPressed) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-pressed` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
@@ -32,7 +32,7 @@ If the non-changeable value shouldn't be able to receive focus, use [`aria-disab
 - `false` (default)
   - : The element is not readonly.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaReadOnly")}}
   - : The [`ariaReadOnly`](/en-US/docs/Web/API/Element/ariaReadOnly) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-readonly` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
@@ -32,7 +32,7 @@ If the non-changeable value shouldn't be able to receive focus, use [`aria-disab
 - `false` (default)
   - : The element is not readonly.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaReadOnly")}}
   - : The [`ariaReadOnly`](/en-US/docs/Web/API/Element/ariaReadOnly) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-readonly` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
@@ -34,7 +34,7 @@ The values of `removals` and `all` should be used sparingly. For example, when a
 - `additions text` (default)
   - : Element nodes are added to the accessibility tree within the live region AND text content or a text alternative is added to any descendant in the accessibility tree of the live region.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRelevant")}}
   - : The [`ariaRelevant`](/en-US/docs/Web/API/Element/ariaRelevant) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-relevant` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
@@ -34,7 +34,7 @@ The values of `removals` and `all` should be used sparingly. For example, when a
 - `additions text` (default)
   - : Element nodes are added to the accessibility tree within the live region AND text content or a text alternative is added to any descendant in the accessibility tree of the live region.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRelevant")}}
   - : The [`ariaRelevant`](/en-US/docs/Web/API/Element/ariaRelevant) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-relevant` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
@@ -55,7 +55,7 @@ This could be written semantically, without the need for JavaScript:
 - `false`
   - : The element is not required.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRequired")}}
   - : The [`ariaRequired`](/en-US/docs/Web/API/Element/ariaRequired) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-required` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
@@ -55,7 +55,7 @@ This could be written semantically, without the need for JavaScript:
 - `false`
   - : The element is not required.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRequired")}}
   - : The [`ariaRequired`](/en-US/docs/Web/API/Element/ariaRequired) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-required` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
@@ -53,7 +53,7 @@ In the previous examples, a screen reader user may hear "Quarterly Report, slide
 - `<string>`
   - : A non-empty string, an unconstrained value type, containing more than just white space.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRoleDescription")}}
   - : The [`ariaRoleDescription`](/en-US/docs/Web/API/Element/ariaRoleDescription) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-roledescription` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
@@ -53,7 +53,7 @@ In the previous examples, a screen reader user may hear "Quarterly Report, slide
 - `<string>`
   - : A non-empty string, an unconstrained value type, containing more than just white space.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRoleDescription")}}
   - : The [`ariaRoleDescription`](/en-US/docs/Web/API/Element/ariaRoleDescription) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-roledescription` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
@@ -53,7 +53,7 @@ The following example shows a grid with 24 rows, of which the first row and rows
 - `<integer>`
   - : The number of rows in the full table or `-1` is the table size is not known.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRowCount")}}
   - : The [`ariaRowCount`](/en-US/docs/Web/API/Element/ariaRowCount) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowcount` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
@@ -53,7 +53,7 @@ The following example shows a grid with 24 rows, of which the first row and rows
 - `<integer>`
   - : The number of rows in the full table or `-1` is the table size is not known.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRowCount")}}
   - : The [`ariaRowCount`](/en-US/docs/Web/API/Element/ariaRowCount) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowcount` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
@@ -67,7 +67,7 @@ Note both `aria-rowspan` and `aria-rowindex` are present on the Goalkeeper cell,
 - `<integer>`
   - : An integer greater than or equal to 1, greater than the `aria-rowindex` of the previous row, if any, and less than or equal to the value of [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount).
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRowIndex")}}
   - : The [`ariaRowIndex`](/en-US/docs/Web/API/Element/ariaRowIndex) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindex` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
@@ -67,7 +67,7 @@ Note both `aria-rowspan` and `aria-rowindex` are present on the Goalkeeper cell,
 - `<integer>`
   - : An integer greater than or equal to 1, greater than the `aria-rowindex` of the previous row, if any, and less than or equal to the value of [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount).
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRowIndex")}}
   - : The [`ariaRowIndex`](/en-US/docs/Web/API/Element/ariaRowIndex) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindex` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -20,7 +20,7 @@ The `aria-rowindextext` is added to each {{HTMLElement('tr')}} or to elements wi
 - `<string>`
   - The human-readable text alternative of the numeric [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRowIndexText")}}
   - : The [`ariaRowIndexText`](/en-US/docs/Web/API/Element/ariaRowIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindextext` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -20,7 +20,7 @@ The `aria-rowindextext` is added to each {{HTMLElement('tr')}} or to elements wi
 - `<string>`
   - The human-readable text alternative of the numeric [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRowIndexText")}}
   - : The [`ariaRowIndexText`](/en-US/docs/Web/API/Element/ariaRowIndexText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowindextext` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
@@ -22,7 +22,7 @@ The value of `aria-rowspan` is an integer greater than or equal to 0 and less th
 - `<integer>`
   - : An integer greater than or equal to `0` and less than would cause a cell to overlap the next cell in the same column.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaRowSpan")}}
   - : The [`ariaRowSpan`](/en-US/docs/Web/API/Element/ariaRowSpan) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowspan` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
@@ -22,7 +22,7 @@ The value of `aria-rowspan` is an integer greater than or equal to 0 and less th
 - `<integer>`
   - : An integer greater than or equal to `0` and less than would cause a cell to overlap the next cell in the same column.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaRowSpan")}}
   - : The [`ariaRowSpan`](/en-US/docs/Web/API/Element/ariaRowSpan) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-rowspan` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
@@ -96,7 +96,7 @@ In this `tablist` example, the first `tab` is selected:
 - `undefined` (default)
   - : The element is not selectable.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaSelected")}}
   - : The [`ariaSelected`](/en-US/docs/Web/API/Element/ariaSelected) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-selected` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
@@ -96,7 +96,7 @@ In this `tablist` example, the first `tab` is selected:
 - `undefined` (default)
   - : The element is not selectable.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaSelected")}}
   - : The [`ariaSelected`](/en-US/docs/Web/API/Element/ariaSelected) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-selected` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
@@ -48,7 +48,7 @@ To orient the user, assistive technologies would list the bananas above as "item
 - `<integer>`
   - : The number of items in the full set or `-1` is the set size is unknown.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaSetSize")}}
   - : The [`ariaSetSize`](/en-US/docs/Web/API/Element/ariaSetSize) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-setsize` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
@@ -48,7 +48,7 @@ To orient the user, assistive technologies would list the bananas above as "item
 - `<integer>`
   - : The number of items in the full set or `-1` is the set size is unknown.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaSetSize")}}
   - : The [`ariaSetSize`](/en-US/docs/Web/API/Element/ariaSetSize) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-setsize` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
@@ -59,7 +59,7 @@ We provided instructions in the caption for assistive technology who may not see
 - `other`
   - : A sorting algorithm other than ascending or descending has been applied.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaSort")}}
   - : The [`ariaSort`](/en-US/docs/Web/API/Element/ariaSort) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-sort` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
@@ -59,7 +59,7 @@ We provided instructions in the caption for assistive technology who may not see
 - `other`
   - : A sorting algorithm other than ascending or descending has been applied.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaSort")}}
   - : The [`ariaSort`](/en-US/docs/Web/API/Element/ariaSort) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-sort` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
@@ -37,7 +37,7 @@ The code below shows a simple slider with a maximum value of 9.
 - `<number>`
   - : An integer or decimal number that is greater than the minimum value.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaValueMax")}}
   - : The [`ariaValueMax`](/en-US/docs/Web/API/Element/ariaValueMax) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuemax` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
@@ -37,7 +37,7 @@ The code below shows a simple slider with a maximum value of 9.
 - `<number>`
   - : An integer or decimal number that is greater than the minimum value.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaValueMax")}}
   - : The [`ariaValueMax`](/en-US/docs/Web/API/Element/ariaValueMax) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuemax` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
@@ -24,7 +24,7 @@ The maximum value is defined with [`aria-valuemax`](/en-US/docs/Web/Accessibilit
 - `<number>`
   - : A decimal number, below the maximum value.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaValueMin")}}
   - : The [`ariaValueMin`](/en-US/docs/Web/API/Element/ariaValueMin) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuemin` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
@@ -24,7 +24,7 @@ The maximum value is defined with [`aria-valuemax`](/en-US/docs/Web/Accessibilit
 - `<number>`
   - : A decimal number, below the maximum value.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaValueMin")}}
   - : The [`ariaValueMin`](/en-US/docs/Web/API/Element/ariaValueMin) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuemin` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -86,7 +86,7 @@ If we employ native HTML semantics with {{HTMLElement('input')}} we get styles a
 - `<number>`
   - : A decimal number, between the minimum and maximum values.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaValueNow")}}
   - : The [`ariaValueNow`](/en-US/docs/Web/API/Element/ariaValueNow) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuenow` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -86,7 +86,7 @@ If we employ native HTML semantics with {{HTMLElement('input')}} we get styles a
 - `<number>`
   - : A decimal number, between the minimum and maximum values.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaValueNow")}}
   - : The [`ariaValueNow`](/en-US/docs/Web/API/Element/ariaValueNow) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuenow` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
@@ -24,7 +24,7 @@ When both the `aria-valuetext` and `aria-valuenow` are included, the `aria-value
 - `<string>`
   - : A human-readable text alternative of the `aria-valuenow` value.
 
-## API
+## Associated interfaces
 
 - {{domxref("Element.ariaValueText")}}
   - : The [`ariaValueText`](/en-US/docs/Web/API/Element/ariaValueText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuetext` attribute.

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
@@ -24,7 +24,7 @@ When both the `aria-valuetext` and `aria-valuenow` are included, the `aria-value
 - `<string>`
   - : A human-readable text alternative of the `aria-valuenow` value.
 
-## ARIAMixin API
+## API
 
 - {{domxref("Element.ariaValueText")}}
   - : The [`ariaValueText`](/en-US/docs/Web/API/Element/ariaValueText) property, part of the {{domxref("Element")}} interface, reflects the value of the `aria-valuetext` attribute.

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -88,7 +88,7 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 
 ### Instance properties included from ARIA
 
-_The `Element` interface includes the following properties, defined on the `ARIAMixin` mixin._
+_The `Element` interface also includes the following properties._
 
 - {{domxref("Element.ariaAtomic")}}
   - : A string reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -33,7 +33,7 @@ This interface has no constructor. An `ElementInternals` object is returned when
 
 ### Instance properties included from ARIA
 
-The `ElementInternals` interface includes the following properties, defined on the `ARIAMixin` mixin.
+The `ElementInternals` interface also includes the following properties.
 
 > **Note:** These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 


### PR DESCRIPTION
There still were a few mentions of the `ARIAMixin` dictionary.

We don't mention dictionaries: they are a spec detail and invisible to web developers.

(Follow-up of #31298)