### PR TITLE
Remove mention of IDBDatabase.setVersion()

### DIFF
--- a/files/en-us/web/api/idbtransaction/mode/index.md
+++ b/files/en-us/web/api/idbtransaction/mode/index.md
@@ -28,10 +28,9 @@ The following values are available:
 - `readwrite`
   - : Allows reading and writing of data in existing data stores to be changed.
 - `versionchange`
-  - : Allows any operation to be performed, including ones that delete and
+  - : Allows any operation, including ones that delete and
     create object stores and indexes.
-    This mode is for updating the version number of transactions
-    that were started using {{domxref("IDBDatabase.setVersion()")}}.
+    This mode is for updating the version number of transactions if the need is detected when calling {{domxref("IDBDatabase.open()")}}.
     Transactions of this mode cannot run concurrently with other transactions.
     Transactions in this mode are known as _upgrade transactions_.
 

--- a/files/en-us/web/api/idbtransaction/mode/index.md
+++ b/files/en-us/web/api/idbtransaction/mode/index.md
@@ -30,7 +30,7 @@ The following values are available:
 - `versionchange`
   - : Allows any operation, including ones that delete and
     create object stores and indexes.
-    This mode is for updating the version number of transactions if the need is detected when calling {{domxref("IDBDatabase.open()")}}.
+    This mode is for updating the version number of transactions if the need is detected when calling {{domxref("IDBFactory.open()")}}.
     Transactions of this mode cannot run concurrently with other transactions.
     Transactions in this mode are known as _upgrade transactions_.
 


### PR DESCRIPTION
`IDBInterface.setVersion()` is long gone.

The mode is set if a version DB upgrade is needed when opening a DB.