### PR TITLE
Fix link to the message property on the RTCError interface

### DIFF
--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -20,7 +20,7 @@ occurred on an {{domxref("RTCPeerConnection")}}. The possible values are:
   - : The connection's {{domxref("RTCDataChannel")}} has failed.
 - `dtls-failure`
   - : The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was
-    terminated with a fatal error. The error's {{domxref("RTCError.message", "message")}}
+    terminated with a fatal error. The error's {{domxref("DOMException.message", "message")}}
     contains details about the nature of the error. If a fatal error is _received_,
     the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is
     set to the value of the DTLSL alert received. If, on the other hand, a fatal error was


### PR DESCRIPTION
The `message` property is not on `RTCError` but on `DOMException`, its parent interface. (This was correct on the `RTCError` interface page).