### PR TITLE
Display -> VRDisplay

### DIFF
--- a/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/maxlayers/index.md
@@ -11,7 +11,7 @@ browser-compat: api.VRDisplayCapabilities.maxLayers
 
 {{APIRef("WebVR API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
-The **`maxLayers`** read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a number indicating the maximum number of {{domxref("VRLayerInit")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("Display.requestPresent()")}} can accept.)
+The **`maxLayers`** read-only property of the {{domxref("VRDisplayCapabilities")}} interface returns a number indicating the maximum number of {{domxref("VRLayerInit")}}s that the VR display can present at once (e.g. the maximum length of the array that {{domxref("VRDisplay.requestPresent()")}} can accept.)
 
 > **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 


### PR DESCRIPTION
The name of the interface was wrong, hence the red link (and the flaw)