### PR TITLE
Remove HTML comment

### DIFF
--- a/files/en-us/web/api/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/index.md
@@ -35,8 +35,6 @@ The **`WebTransport`** interface of the {{domxref("WebTransport API", "WebTransp
 - {{domxref("WebTransport.reliability", "reliability")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a string that indicates whether the connection supports reliable transports only, or whether it also supports unreliable transports (such as UDP).
 
-<!-- {{domxref("WebTransport.draining", "draining")}} {{ReadOnlyInline}} {{Experimental_Inline}} : Returns a promise that resolves if a server wants the client to gracefully close the connection. -->
-
 ## Instance methods
 
 - {{domxref("WebTransport.close", "close()")}}


### PR DESCRIPTION
However still in the spec, the `draining` property is not implemented. No need to keep it there, it will be readded once implemented (if ever), and we have it in the history.