### PR TITLE
Removed type requirements for calc operators

### DIFF
--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -25,9 +25,9 @@ The `calc()` function takes a single expression as its parameter, and the expres
 - `-`
   - : Subtracts the second operand from the first operand.
 - `*`
-  - : Multiplies the specified operands. At least one of the operands must be a {{cssxref("&lt;number&gt;")}}.
+  - : Multiplies the specified operands.
 - `/`
-  - : Divides the left-side operand (dividend) by the right-side operand (divisor). The right-hand operand, the divisor, must be a {{cssxref("&lt;number&gt;")}}.
+  - : Divides the left-side operand (dividend) by the right-side operand (divisor).
 
 All operands, except those of type {{cssxref("&lt;number&gt;")}}, must be suffixed with an appropriate unit string, such as `px`, `em`, or `%`. You can use a different unit with each each operand in your expression. You may also use parentheses to establish computation order when needed.
 


### PR DESCRIPTION
Per Issue #29628: I removed the sentences referencing type requirements for the `*` and `/` operators to match `calc()` specifications.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

I removed the last sentence for the `*` and `/` operator descriptions, which reference a [number](https://developer.mozilla.org/en-US/docs/Web/CSS/number) type requirement. Those types are no longer required per the [calc() specification](https://www.w3.org/TR/css-values-4/#calc-type-checking)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Addresses issue #29628, and helps by bringing the doc up to date.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #29628 
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
