### PR TITLE
ServiceWorkerContainer.register: point type=module to compat data

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -56,7 +56,7 @@ register(scriptURL, options)
           - : The loaded service worker is in an
             [ES module](/en-US/docs/Web/JavaScript/Guide/Modules)
             and the import statement is available on
-            worker contexts. For ES module compatibility info, see the [browser compatibility data table for the ServiceWorker API](/en-US/docs/Web/API/ServiceWorker#browser_compatibility).
+            worker contexts. For ES module compatibility info, see the [browser compatibility data table for the `ServiceWorker` interface](/en-US/docs/Web/API/ServiceWorker#browser_compatibility).
 
     - `updateViaCache`
 

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -56,7 +56,7 @@ register(scriptURL, options)
           - : The loaded service worker is in an
             [ES module](/en-US/docs/Web/JavaScript/Guide/Modules)
             and the import statement is available on
-            worker contexts. For ES module compatibility info, see the [browser compatibility data table for the ServiceWorker API](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker#browser_compatibility).
+            worker contexts. For ES module compatibility info, see the [browser compatibility data table for the ServiceWorker API](/en-US/docs/Web/API/ServiceWorker#browser_compatibility).
 
     - `updateViaCache`
 

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -56,7 +56,7 @@ register(scriptURL, options)
           - : The loaded service worker is in an
             [ES module](/en-US/docs/Web/JavaScript/Guide/Modules)
             and the import statement is available on
-            worker contexts.
+            worker contexts. For ES module compatibility info, see the [browser compatibility data table for the ServiceWorker API](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker#browser_compatibility).
 
     - `updateViaCache`
 


### PR DESCRIPTION
This PR adds a link to the compatibility table on the ServiceWorker API page to determine if modules are supported.  Fixes https://github.com/mdn/browser-compat-data/issues/17023.