### PR TITLE
Remove mention of overconstrained event

### DIFF
--- a/files/en-us/web/api/media_capture_and_streams_api/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/index.md
@@ -44,7 +44,6 @@ In these reference articles, you'll find the fundamental information you'll need
 - {{domxref("MediaStream/addtrack_event", "addtrack")}}
 - {{domxref("MediaStreamTrack/ended_event", "ended")}}
 - {{domxref("MediaStreamTrack/mute_event", "mute")}}
-- {{domxref("MediaStreamTrack.overconstrained_event", "overconstrained")}}
 - {{domxref("MediaStream/removetrack_event", "removetrack")}}
 - {{domxref("MediaStreamTrack/unmute_event", "unmute")}}
 


### PR DESCRIPTION
We deleted its documentation as browsers did not support it for over 2 years.

(The deletion tool missed this one)