### PR TITLE
it's -> its

### DIFF
--- a/files/en-us/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/en-us/web/javascript/guide/iterators_and_generators/index.md
@@ -120,7 +120,7 @@ console.log(it[Symbol.iterator]() === it); // true
 // which has the @@iterator method return the it (itself),
 // and consequently, the it object can iterate only _once_.
 
-// If we change it's @@iterator method to a function/generator
+// If we change its @@iterator method to a function/generator
 // which returns a new iterator/generator object, (it)
 // can iterate many times
 


### PR DESCRIPTION
Pronouns don't have possessive apostrophes. It's is short for it is.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences --> fixed bad grsammar

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? --> Bad grammar is cringeworthy in published code.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
