### PR TITLE
getUserMedia() | remove from GroupData & update exception section

### DIFF
--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -55,6 +55,10 @@ object when the requested media has successfully been obtained.
     and no hardware issues occurred that would cause a `NotReadableError` {{domxref("DOMException")}}, throw if some
     problem occurred which prevented the device from being used.
 
+- `InvalidStateError` {{domxref("DOMException")}}
+
+  - : Thrown of current document is not fully active.
+
 - `NotAllowedError` {{domxref("DOMException")}}
 
   - : Thrown if one or more of the requested source devices cannot be used at this time. This will
@@ -86,10 +90,6 @@ object when the requested media has successfully been obtained.
     > permission to use the underlying device, it can potentially be used as a
     > [fingerprinting](/en-US/docs/Glossary/Fingerprinting) surface.
 
-- `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if user media support is disabled on the {{domxref("Document")}} on which
-    `getUserMedia()` was called. The mechanism by which user media support is
-    enabled and disabled is left up to the individual user agent.
 - {{jsxref("TypeError")}}
   - : Thrown if the list of constraints specified is empty, or has all constraints set to
     `false`. This can also happen if you try to call

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MediaDevices.getUserMedia
 
 {{securecontext_header}}{{APIRef("Media Capture and Streams")}}
 
-The {{domxref("MediaDevices")}}**`.getUserMedia()`** method prompts the user for permission to use a media input which produces a {{domxref("MediaStream")}} with tracks containing the requested types of media.
+The **`getUserMedia()`** method of the {{domxref("MediaDevices")}} interface prompts the user for permission to use a media input which produces a {{domxref("MediaStream")}} with tracks containing the requested types of media.
 
 That stream can include, for example, a video track (produced by either a hardware or virtual video source such as a camera, video recording device, screen sharing service, and so forth), an audio track (similarly, produced by a physical or virtual audio source like a microphone, A/D converter, or the like), and possibly other track types.
 
@@ -145,8 +145,7 @@ is over.
 
 ### Security
 
-There are a number of ways security management and controls in a {{Glossary("user
-  agent")}} can cause `getUserMedia()` to return a security-related error.
+There are a number of ways security management and controls in a {{Glossary("user agent")}} can cause `getUserMedia()` to return a security-related error.
 
 #### Permissions Policy
 
@@ -432,13 +431,10 @@ const constraints = {
 
 ## See also
 
-- The older {{domxref("navigator.getUserMedia()")}} legacy API
-- {{domxref("mediaDevices.enumerateDevices()")}}: Listing available media devices
-- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)
-- [Media Capture and Streams API (Media Streams)](/en-US/docs/Web/API/Media_Capture_and_Streams_API)
-- [Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API): Capturing
-  screen contents as a {{domxref("MediaStream")}}
-- {{domxref("mediaDevices.getDisplayMedia()")}}: Getting a stream containing screen
-  contents
-- [Taking webcam photos](/en-US/docs/Web/API/Media_Capture_and_Streams_API/Taking_still_photos): A tutorial on using `getUserMedia()` to take still photos
-  rather than video
+- The older {{domxref("Navigator.getUserMedia()")}} legacy API
+- {{domxref("MediaDevices.enumerateDevices()")}}: Listing available media devices
+- {{domxref("WebRTC API", "", "", "nocode")}}
+- {{domxref("Media Capture and Streams API", "", "", "nocode")}}
+- {{domxref("Screen Capture API", "", "", "nocode")}}: Capturing screen contents as a {{domxref("MediaStream")}}
+- {{domxref("MediaDevices.getDisplayMedia()")}}: Getting a stream containing screen contents
+- {{domxref("Media Capture and Streams API/Taking Still Photos", "Taking webcam photos", "", "nocode")}}: A tutorial on using `getUserMedia()` to take still photos rather than video

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -57,7 +57,7 @@ object when the requested media has successfully been obtained.
 
 - `InvalidStateError` {{domxref("DOMException")}}
 
-  - : Thrown of current document is not fully active.
+  - : Thrown if current document is not fully active.
 
 - `NotAllowedError` {{domxref("DOMException")}}
 

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -90,6 +90,10 @@ object when the requested media has successfully been obtained.
     > permission to use the underlying device, it can potentially be used as a
     > [fingerprinting](/en-US/docs/Glossary/Fingerprinting) surface.
 
+- `SecurityError` {{domxref("DOMException")}}
+  - : Thrown if user media support is disabled on the {{domxref("Document")}} on which
+    `getUserMedia()` was called. The mechanism by which user media support is
+    enabled and disabled is left up to the individual user agent.
 - {{jsxref("TypeError")}}
   - : Thrown if the list of constraints specified is empty, or has all constraints set to
     `false`. This can also happen if you try to call

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -894,10 +894,7 @@
         "MediaTrackSettings",
         "MediaTrackSupportedConstraints"
       ],
-      "methods": [
-        "HTMLCanvasElement.captureStream()",
-        "MediaDevices.getUserMedia()"
-      ],
+      "methods": ["HTMLCanvasElement.captureStream()"],
       "properties": ["Navigator.mediaDevices"],
       "events": ["HTMLMediaElement: ended", "HTMLMediaElement: ratechange"]
     },


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

since `MediaDevices` interface is listed in the GroupData, it is not required to keep `getUserMedia()`

add the `InvalidStateError` to exception list, see spec https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
