### PR TITLE
Improve page title

### DIFF
--- a/files/en-us/web/css/css_syntax/error_handling/index.md
+++ b/files/en-us/web/css/css_syntax/error_handling/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS syntax errors
+title: CSS error handling
 slug: Web/CSS/CSS_syntax/Error_handling
 page-type: guide
 ---


### PR DESCRIPTION
This page is about error handing. Yes, handling syntax errors is a large part of it, but people are going to look for the word "error" not the word "syntax", so let's make this page findable while matching the slug,