### PR TITLE
OVR_multiview2.: three.js demo link

### DIFF
--- a/files/en-us/web/api/ovr_multiview2/index.md
+++ b/files/en-us/web/api/ovr_multiview2/index.md
@@ -13,7 +13,6 @@ The `OVR_multiview2` extension is part of the [WebGL API](/en-US/docs/Web/API/We
 For more information, see also:
 
 - [Multiview on WebXR](https://blog.mozvr.com/multiview-on-webxr/)
-- [three.js multiview demo](https://threejs.org/examples/webgl_multiple_views.html)
 - [Multiview in babylon.js](https://doc.babylonjs.com/divingDeeper/cameras/multiViewsPart1)
 - [Optimizing Virtual Reality: Understanding Multiview](https://community.arm.com/arm-community-blogs/b/graphics-gaming-and-vr-blog/posts/optimizing-virtual-reality-understanding-multiview)
 - [Multiview WebGL Rendering for Oculus Browser 6.0+](https://developer.oculus.com/documentation/oculus-browser/latest/concepts/browser-multiview/)
@@ -112,4 +111,3 @@ Also, see this [three.js](https://threejs.org/examples/?q=mult#webgl_multiple_vi
 - {{domxref("WebGLRenderingContext.getExtension()")}}
 - {{domxref("WebGLRenderingContext.getParameter()")}}
 - [WebXR](/en-US/docs/Web/API/WebXR_Device_API)
-- [three.js multiview demo](https://threejs.org/examples/webgl_multiple_views.html)


### PR DESCRIPTION
### Description

Remove links to `three.js` since the engine does not support `OVR_multiview2`. Support for this extension has been removed with the release `r114`, see https://github.com/mrdoob/three.js/pull/18750. The mentioned multiview demo `webgl_multiple_views` renders its views without the extension (so it was never a valid demo).

### Motivation

Make sure readers do not assume `three.js` supports `OVR_multiview2`.

### Additional details

None.

### Related issues and pull requests

Relates to https://github.com/mrdoob/three.js/pull/18750

