### PR TITLE
JS Guide: Improve switch fall-through summary

### DIFF
--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -228,7 +228,7 @@ The optional `break` statement associated with each `case` clause
 ensures that the program breaks out of `switch` once the matched statement is
 executed, and then continues execution at the statement following `switch`.
 If `break` is omitted, the program continues execution inside the
-`switch` statement (and will evaluate the next `case`, and so on).
+`switch` statement (and will execute the next `case`, and so on).
 
 ##### Example
 

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -228,7 +228,7 @@ The optional `break` statement associated with each `case` clause
 ensures that the program breaks out of `switch` once the matched statement is
 executed, and then continues execution at the statement following `switch`.
 If `break` is omitted, the program continues execution inside the
-`switch` statement (and will execute the next `case`, and so on).
+`switch` statement (and will execute statements under the next `case`, and so on).
 
 ##### Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replace "and will evaluate the next `case`" with "and will execute the next `case`" when `break` is omitted.

### Motivation

The page currently states:

> If break is omitted, the program continues execution inside the switch statement (and will evaluate the next case, and so on).

The wording "will evaluate the next `case`" might be read as "will evaluate the next `case` and execute the statements only if it matches".

Also, `break` is part of the statements to be executed, so I wouldn't use the verb "evaluate" for something that happens during or after statement execution (evaluation already happend at this point and a match was found).

The example right below demonstrates switch fall-through in more detail. 

### Additional details

As defined in the [switch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch#breaking_and_fall-through) reference page:

> The clause expressions are only evaluated when necessary — if a match is already found, subsequent case clause expressions will not be evaluated, even when they will be visited by fall-through.

> If `break` is omitted, execution will proceed to the next `case` clause, even to the `default` clause, regardless of whether the value of that clause's expression matches. This behavior is called "fall-through".



<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
