### PR TITLE
Add example for string lengths/sizes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -23,7 +23,7 @@ This property returns the number of code units in the string. JavaScript uses [U
 
 The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~1GiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
 - In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
 - In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -23,7 +23,7 @@ This property returns the number of code units in the string. JavaScript uses [U
 
 The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~512MiB) on 64 bit platforms.
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~512MiB) on 64 bit platforms. On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~256MiB).
 - In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
 - In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -23,7 +23,7 @@ This property returns the number of code units in the string. JavaScript uses [U
 
 The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~512MiB) on 64 bit platforms.
 - In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
 - In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -23,9 +23,19 @@ This property returns the number of code units in the string. JavaScript uses [U
 
 The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~512MiB) on 64 bit platforms. On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~256MiB).
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~1GiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
 - In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
 - In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
+
+If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the encoding always becomes UTF-16. The size of the string may be different from the size of the source file.
+
+```js
+const str1 = "a".repeat(2 ** 29 - 24); // Success
+const str2 = "a".repeat(2 ** 29 - 23); // RangeError: Invalid string length
+
+const buffer = new Uint8Array(2 ** 29 - 24).fill("a".codePointAt(0)); // This buffer is 512MiB in size
+const str = new TextDecoder().decode(buffer); // This string is 1GiB in size
+```
 
 For an empty string, `length` is 0.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the latest versions of Chrome and Node.js, the maximum string length to my knowledge is 512MB irrespective of 32 vs 64 bit

### Motivation

Correct info

### Additional details

Me running this code locally in node.js on ubuntu

```
% node
Welcome to Node.js v20.10.0.
Type ".help" for more information.
> const len = 536_870_889
undefined
> const buf = new Uint8Array(len)
undefined
> for (let i = 0; i < len; i++) {
...   buf[i] = 'a'.charCodeAt(0)
... }

> const str = new TextDecoder().decode(buf)
Uncaught Error: Cannot create a string longer than 0x1fffffe8 characters
    at TextDecoder.decode (node:internal/encoding:449:16) {
  code: 'ERR_STRING_TOO_LONG'
}
> console.log(str.length)
Uncaught ReferenceError: str is not defined
>

```

in Chrome Version 120.0.6099.129 (Official Build) (64-bit) ubuntu

```
const len = 536_870_889
const buf = new Uint8Array(len)
for (let i = 0; i < len; i++) {
  buf[i] = 'a'.charCodeAt(0)
}
const str = new TextDecoder().decode(buf)
console.log(str.length)
VM80:7 0
```

random related thing: i wrote about this awhile back but was notified that the docs here said otherwise https://cmdcolin.github.io/posts/2021-10-30-spooky

### Related issues and pull requests
N/A
