### PR TITLE
Remove mention of the PaymentMethodData dictionary

### DIFF
--- a/files/en-us/web/api/paymentrequestevent/index.md
+++ b/files/en-us/web/api/paymentrequestevent/index.md
@@ -23,7 +23,7 @@ The **`PaymentRequestEvent`** interface of the {{domxref("Payment Handler API", 
 - {{domxref("PaymentRequestEvent.instrumentKey","instrumentKey")}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : Returns a {{domxref("PaymentInstrument")}} object reflecting the payment instrument selected by the user or an empty string if the user has not registered or chosen a payment instrument.
 - {{domxref("PaymentRequestEvent.methodData","methodData")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns an array of {{domxref("PaymentMethodData")}} objects containing payment method identifiers for the payment methods that the website accepts and any associated payment method specific data.
+  - : Returns an array of objects containing payment method identifiers for the payment methods that the website accepts and any associated payment method specific data.
 - {{domxref("PaymentRequestEvent.modifiers","modifiers")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an array of objects containing changes to payment details.
 - {{domxref("PaymentRequestEvent.paymentRequestId","paymentRequestId")}} {{ReadOnlyInline}} {{Experimental_Inline}}


### PR DESCRIPTION
We won't document this dictionary separately, no need to have this red link.