### PR TITLE
pageAction API edits

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.pageAction
 
 {{AddonSidebar}}
 
-The API to control [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions), which is a clickable icon inside the browser's address bar.
+The API to control [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions).
 
 ![Paw print icon representing a page action](page-action.png)
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -19,7 +19,7 @@ The button also has a context menu, and you can add items to this menu with the 
 
 You can define most of a page action's properties declaratively using the [`page_action` key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) in your [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json), and redefine them programmatically using this API.
 
-Page actions are for actions that are only relevant to particular pages (such as "bookmark the current tab"). If they are relevant to the browser as a whole (such as "show all bookmarks"), use a [browser action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) instead.
+Page actions are for actions that are only relevant to particular pages (such as "bookmark the current tab"). If they are relevant to the browser as a whole (such as "show all bookmarks"), use a [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) instead.
 
 ## Types
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -7,19 +7,19 @@ browser-compat: webextensions.api.pageAction
 
 {{AddonSidebar}}
 
-A [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions) is a clickable icon inside the browser's address bar.
+The API to create [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions), which is a clickable icon inside the browser's address bar.
 
 ![Paw print icon representing a page action](page-action.png)
 
-You can listen for clicks on the icon or specify a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups) that opens when the icon is clicked.
+You can listen for clicks on the icon in a background script, or specify a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups) that opens when the icon is clicked.
 
-If you specify a popup, you define its contents and behavior using HTML, CSS, and JavaScript, like a normal web page. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts.
+If you specify a popup, you define its contents and behavior using HTML, CSS, and JavaScript. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts. Despite being named pageAction, the action code doesn't get access to web page content. To access web page DOM, you need to add [content script](en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) and interact with it.
 
 The button also has a context menu, and you can add items to this menu with the {{WebExtAPIRef("menus")}} API using the `page_action` {{WebExtAPIRef("menus.ContextType")}}.
 
 You can define most of a page action's properties declaratively using the [`page_action` key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) in your [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json), and redefine them programmatically using this API.
 
-Page actions are for actions that are only relevant to particular pages (such as "bookmark the current tab"). If they are relevant to the browser as a whole (such as "show all bookmarks"), use a browser action instead.
+Page actions are for actions that are only relevant to particular pages (such as "bookmark the current tab"). If they are relevant to the browser as a whole (such as "show all bookmarks"), use a [browser action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) instead.
 
 ## Types
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -13,7 +13,7 @@ The API to create [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtensions
 
 You can listen for clicks on the icon in a background script, or specify a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups) that opens when the icon is clicked.
 
-If you specify a popup, you define its contents and behavior using HTML, CSS, and JavaScript. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts. Despite being named pageAction, the action code doesn't get access to web page content. To access web page DOM, you need to add [content script](en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) and interact with it.
+If you specify a popup, you define its contents and behavior using HTML, CSS, and JavaScript. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts. Despite being named pageAction, the action code doesn't get access to web page content. To access web page DOM, you need to add [content script](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) and interact with it.
 
 The button also has a context menu, and you can add items to this menu with the {{WebExtAPIRef("menus")}} API using the `page_action` {{WebExtAPIRef("menus.ContextType")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -13,7 +13,7 @@ The API to control [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtension
 
 You can listen for clicks on the icon in a background script, or specify a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups) that opens when the icon is clicked.
 
-If you specify a popup, you define its contents and behavior using HTML, CSS, and JavaScript. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts. Despite being named pageAction, the action code doesn't get access to web page content. To access web page DOM, you need to add [content script](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) and interact with it.
+If you specify a popup, you define its contents and behavior using HTML, CSS, and JavaScript. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts. Despite being named `pageAction`, the action code doesn't get access to web page content. To access web page DOM, you need to add a [content script](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) and interact with it.
 
 The button also has a context menu, and you can add items to this menu with the {{WebExtAPIRef("menus")}} API using the `page_action` {{WebExtAPIRef("menus.ContextType")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.pageAction
 
 {{AddonSidebar}}
 
-The API to create [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions), which is a clickable icon inside the browser's address bar.
+The API to control [address bar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions), which is a clickable icon inside the browser's address bar.
 
 ![Paw print icon representing a page action](page-action.png)
 


### PR DESCRIPTION
* pageAction is used to create Address bar button
* HTML, JavaScript and CSS is not the same (no ESM if I remember correctly)
* Listening for clicks is in a background script
* Access to web page DOM is only possible with a content script
* Link to browser action
* Link to content scripts

### Description

Adds missing information and clarifications.

### Motivation

I've created Page Action extension to interact with web page, and then discovered that Page Action code can not do this. Spent quite a lot of time discovering that, so I want to make these changes so that others can save this time.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
