### PR TITLE
Declare color-scheme using HTML meta tag

### DIFF
--- a/files/en-us/web/css/color-scheme/index.md
+++ b/files/en-us/web/css/color-scheme/index.md
@@ -58,7 +58,13 @@ The `color-scheme` property's value must be one of the following keywords.
 
 ### Declaring color scheme preferences
 
-To opt the entire page into the user's color scheme preferences, declare `color-scheme` on the {{cssxref(":root")}} element.
+To opt the entire page into the user's color scheme preferences, declare `color-scheme` on HTML {{HTMLElement("meta")}} tag.
+
+```html
+<meta name="color-scheme" content="light dark">
+```
+
+To opt the entire page into the user's color scheme preferences, declare `color-scheme` on the CSS {{cssxref(":root")}} element.
 
 ```css
 :root {

--- a/files/en-us/web/css/color-scheme/index.md
+++ b/files/en-us/web/css/color-scheme/index.md
@@ -61,7 +61,7 @@ The `color-scheme` property's value must be one of the following keywords.
 To opt the entire page into the user's color scheme preferences, declare `color-scheme` on HTML {{HTMLElement("meta")}} tag.
 
 ```html
-<meta name="color-scheme" content="light dark">
+<meta name="color-scheme" content="light dark" />
 ```
 
 To opt the entire page into the user's color scheme preferences, declare `color-scheme` on the CSS {{cssxref(":root")}} element.


### PR DESCRIPTION
### Description

Add another method to declare color-scheme using HTML meta tag.

### Motivation

MDN should provide the reader all the available methods to declare color-scheme. The user will choose which method to use. But the article should list all the methods.

### Additional details

Related: https://github.com/mdn/content/pull/30712

