### PR TITLE
Mention AbortSignal.any() in AbortSignal.timeout()

### DIFF
--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -15,8 +15,7 @@ This allow UIs to differentiate timeout errors, which typically require user not
 
 The timeout is based on active rather than elapsed time, and will effectively be paused if the code is running in a suspended worker, or while the document is in a back-forward cache ("[bfcache](https://web.dev/articles/bfcache)").
 
-> **Note:** At time of writing there is no way to combine multiple signals.
-> This means that you can't directly abort a download using either a timeout signal or by calling {{domxref("AbortController.abort()")}}.
+If you want to combine multiple signals, you can use {{domxref("AbortSignal.any()")}}., for example directly abort a download using either a timeout signal or by calling {{domxref("AbortController.abort()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -15,7 +15,7 @@ This allow UIs to differentiate timeout errors, which typically require user not
 
 The timeout is based on active rather than elapsed time, and will effectively be paused if the code is running in a suspended worker, or while the document is in a back-forward cache ("[bfcache](https://web.dev/articles/bfcache)").
 
-If you want to combine multiple signals, you can use {{domxref("AbortSignal.any()")}}., for example directly abort a download using either a timeout signal or by calling {{domxref("AbortController.abort()")}}.
+To combine multiple signals, you can use {{domxref("AbortSignal.any()")}}, for example, to directly abort a download using either a timeout signal or by calling {{domxref("AbortController.abort()")}}.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It replaces an outdated note with a link to the proper API.

### Motivation

The note is outdated (at least for Chrome/Node). There's a way to combine signals now

### Additional details

- https://chromestatus.com/feature/5202879349522432
- https://bugs.webkit.org/show_bug.cgi?id=256176
- https://github.com/mozilla/standards-positions/issues/774

