### PR TITLE
Fix a link target in FontFaceSet

### DIFF
--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -50,7 +50,7 @@ This property is available as {{domxref("Document.fonts")}}, or `self.fonts` in 
 - {{domxref("FontFaceSet.has","FontFaceSet.has()")}}
   - : Returns a {{jsxref("Boolean")}} asserting whether an element is present with the given value.
 - {{domxref("FontFaceSet.keys","FontFaceSet.keys()")}}
-  - : An alias for {{domxref("CustomStateSet.values()")}}.
+  - : An alias for {{domxref("FontFaceSet.values()")}}.
 - {{domxref("FontFaceSet.load","FontFaceSet.load()")}}
   - : Returns a {{jsxref("Promise")}} which resolves to a list of font-faces for a requested font.
 - {{domxref("FontFaceSet.values","FontFaceSet.values()")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The link target should be incorrect.
`FontFaceSet.keys()` is an alias of `FontFaceSet.values()` rather than `CustomStateSet.values()`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
