### PR TITLE
Fix "See also" link path

### DIFF
--- a/files/en-us/web/manifest/shortcuts/index.md
+++ b/files/en-us/web/manifest/shortcuts/index.md
@@ -99,4 +99,4 @@ The following is a list of shortcuts a calendar app might have:
 
 ## See also
 
-- [Creating shortcut action menus for PWAs](en-US/Web/Progressive_web_apps/How_to/Expose_common_actions_as_shortcuts)
+- [Creating shortcut action menus for PWAs](/en-US/docs/Web/Progressive_web_apps/How_to/Expose_common_actions_as_shortcuts)


### PR DESCRIPTION
This [link](https://developer.mozilla.org/en-US/docs/Web/Manifest/en-US/Web/Progressive_web_apps/How_to/Expose_common_actions_as_shortcuts) is broken.