### PR TITLE
Bugfix : pass prog to getProgramParameter instead of vs (vertex shader)

### DIFF
--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
@@ -260,7 +260,7 @@ if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS)) {
 }
 
 gl.linkProgram(prog);
-if (!gl.getProgramParameter(vs, gl.LINK_STATUS)) {
+if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
   console.error(`Link failed: ${gl.getProgramInfoLog(prog)}`);
 }
 ```
@@ -271,7 +271,7 @@ Consider:
 gl.compileShader(vs);
 gl.compileShader(fs);
 gl.linkProgram(prog);
-if (!gl.getProgramParameter(vs, gl.LINK_STATUS)) {
+if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
   console.error(`Link failed: ${gl.getProgramInfoLog(prog)}`);
   console.error(`vs info-log: ${gl.getShaderInfoLog(vs)}`);
   console.error(`fs info-log: ${gl.getShaderInfoLog(fs)}`);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
WebGLProgram requires a WebGLProgram. Instead, your code provides a WebGLShader

<!-- ✍️ Summarize your changes in one or two sentences -->
I changed the first parameter of WebGLProgram from vs to prog

### Motivation
Bug fix
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
[getProgramParameter documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getProgramParameter)

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Not applicable

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
