### PR TITLE
Fix broken link (+ minor grammar)

### DIFF
--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -15,7 +15,7 @@ This allows UIs to differentiate timeout errors, which typically require user no
 
 The timeout is based on active rather than elapsed time, and will effectively be paused if the code is running in a suspended worker, or while the document is in a back-forward cache ("[bfcache](https://web.dev/articles/bfcache)").
 
-To combine multiple signals, you can use {{domxref("AbortSignal.any()")}}, for example, to directly abort a download using either a timeout signal or by calling {{domxref("AbortController.abort()")}}.
+To combine multiple signals, you can use {{domxref("AbortSignal/any_static", "AbortSignal.any()")}}, for example, to directly abort a download using either a timeout signal or by calling {{domxref("AbortController.abort()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/abortsignal/timeout_static/index.md
+++ b/files/en-us/web/api/abortsignal/timeout_static/index.md
@@ -11,7 +11,7 @@ browser-compat: api.AbortSignal.timeout_static
 The **`AbortSignal.timeout()`** static method returns an {{domxref("AbortSignal")}} that will automatically abort after a specified time.
 
 The signal aborts with a `TimeoutError` {{domxref("DOMException")}} on timeout, or with `AbortError` {{domxref("DOMException")}} due to pressing a browser stop button (or some other inbuilt "stop" operation).
-This allow UIs to differentiate timeout errors, which typically require user notification, from user-triggered aborts that do not.
+This allows UIs to differentiate timeout errors, which typically require user notification, from user-triggered aborts that do not.
 
 The timeout is based on active rather than elapsed time, and will effectively be paused if the code is running in a suspended worker, or while the document is in a back-forward cache ("[bfcache](https://web.dev/articles/bfcache)").
 
@@ -36,8 +36,8 @@ The signal will abort with its {{domxref("AbortSignal.reason")}} property set to
 
 ## Examples
 
-A simple example showing a fetch operation that will timeout if unsuccessful after 5 seconds, is shown below.
-Note that this may also fail if the method is not supported, if a browser "stop" button is pressed, or for some other reason.
+Below is a simple example showing a fetch operation that will timeout if unsuccessful after 5 seconds.
+Note that this may also fail if the method is not supported, if a browser "stop" button is pressed, or for another reason.
 
 ```js
 const url = "https://path_to_large_file.mp4";


### PR DESCRIPTION
`any()` is a static method and need a special link.