### PR TITLE
Replace outdated reference to <geometry-box> in mask-clip

### DIFF
--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -12,7 +12,7 @@ The **`mask-clip`** [CSS](/en-US/docs/Web/CSS) property determines the area whic
 ## Syntax
 
 ```css
-/* <geometry-box> values */
+/* <coord-box> values */
 mask-clip: content-box;
 mask-clip: padding-box;
 mask-clip: border-box;


### PR DESCRIPTION
Since https://github.com/w3c/fxtf-drafts/issues/439 and the related pull request were closed, mask-clip uses `<coord-box>` instead of `<geometry-box>`. This was mostly fixed in https://github.com/mdn/content/pull/28157 but I forgot to update this comment as well.