### PR TITLE
`NavigationCurrentEntryChangeEvent` | fix type of `navigationType` property

### DIFF
--- a/files/en-us/web/api/navigationcurrententrychangeevent/from/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/from/index.md
@@ -10,8 +10,7 @@ browser-compat: api.NavigationCurrentEntryChangeEvent.from
 
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
-The **`from`** read-only property of the
-{{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the {{domxref("NavigationHistoryEntry")}} that was navigated from.
+The **`from`** read-only property of the {{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the {{domxref("NavigationHistoryEntry")}} that was navigated from.
 
 ## Value
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
@@ -27,8 +27,8 @@ new NavigationCurrentEntryChangeEvent(type, init)
   - : An object containing the following properties:
     - `destination`
       - : A {{domxref("NavigationHistoryEntry")}} object representing the location being navigated to.
-    - `navigationType`
-      - : The type of the navigation that resulted in the change. Possible values — `push`, `reload`, `replace`, and `traverse`.
+    - `navigationType` {{optional_inline}}
+      - : The type of the navigation that resulted in the change. Possible values are `push`, `reload`, `replace`, and `traverse`. Defaults to `null`.
 
 ## Examples
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationcurrententrychangeevent/index.md
@@ -10,8 +10,7 @@ browser-compat: api.NavigationCurrentEntryChangeEvent.NavigationCurrentEntryChan
 
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
-The **`NavigationCurrentEntryChangeEvent()`** constructor creates a new
-{{domxref("NavigationCurrentEntryChangeEvent")}} object.
+The **`NavigationCurrentEntryChangeEvent()`** constructor creates a new {{domxref("NavigationCurrentEntryChangeEvent")}} object.
 
 ## Syntax
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
@@ -11,7 +11,7 @@ browser-compat: api.NavigationCurrentEntryChangeEvent.navigationType
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
 The **`navigationType`** read-only property of the
-{{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the type of the navigation that resulted in the change.
+{{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the type of the navigation that resulted in the change. The property may return `null` if the change is due to {{domxref("Navigation.updateCurrentEntry()")}}.
 
 ## Value
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
@@ -10,8 +10,7 @@ browser-compat: api.NavigationCurrentEntryChangeEvent.navigationType
 
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
-The **`navigationType`** read-only property of the
-{{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the type of the navigation that resulted in the change. The property may return `null` if the change is due to {{domxref("Navigation.updateCurrentEntry()")}}.
+The **`navigationType`** read-only property of the {{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the type of the navigation that resulted in the change. The property may return `null` if the change is due to {{domxref("Navigation.updateCurrentEntry()")}}.
 
 ## Value
 

--- a/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
+++ b/files/en-us/web/api/navigationcurrententrychangeevent/navigationtype/index.md
@@ -10,7 +10,7 @@ browser-compat: api.NavigationCurrentEntryChangeEvent.navigationType
 
 {{APIRef("Navigation API")}}{{SeeCompatTable}}
 
-The **`navigationType`** read-only property of the {{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the type of the navigation that resulted in the change. The property may return `null` if the change is due to {{domxref("Navigation.updateCurrentEntry()")}}.
+The **`navigationType`** read-only property of the {{domxref("NavigationCurrentEntryChangeEvent")}} interface returns the type of the navigation that resulted in the change. The property may be `null` if the change occurs due to {{domxref("Navigation.updateCurrentEntry()")}}.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

add note for `NavigationCurrentEntryChangeEvent.navigationType` may return `null`

and the `navigationType` option for `NavigationCurrentEntryChangeEvent` is optional and defaults to `null`

see the spec https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationcurrententrychangeevent

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
