### PR TITLE
Remove the overuse of 'basic computer literacy' as a prerequisite.

### DIFF
--- a/files/en-us/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/en-us/learn/accessibility/accessibility_troubleshooting/index.md
@@ -13,7 +13,7 @@ In the assessment for this module, we present to you a simple site with a number
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML, CSS, and
+        A basic understanding of HTML, CSS, and
         JavaScript, an understanding of the
         <a href="/en-US/docs/Learn/Accessibility"
           >previous articles in the course</a

--- a/files/en-us/learn/accessibility/css_and_javascript/index.md
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.md
@@ -13,7 +13,7 @@ CSS and JavaScript, when used properly, also have the potential to allow for acc
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML, CSS, and
+        A basic understanding of HTML, CSS, and
         JavaScript, and understanding of
         <a href="/en-US/docs/Learn/Accessibility/What_is_accessibility"
           >what accessibility is</a

--- a/files/en-us/learn/accessibility/html/index.md
+++ b/files/en-us/learn/accessibility/html/index.md
@@ -13,7 +13,7 @@ A great deal of web content can be made accessible just by making sure the corre
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML (see
+        A basic understanding of HTML (see
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >Introduction to HTML</a
         >), and an understanding of

--- a/files/en-us/learn/accessibility/mobile/index.md
+++ b/files/en-us/learn/accessibility/mobile/index.md
@@ -13,8 +13,8 @@ With web access on mobile devices being so popular and renowned platforms such a
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML, CSS, and
-        JavaScript, and an understanding of the
+        A basic understanding of HTML, CSS, and
+        JavaScript. An understanding of the
         <a href="/en-US/docs/Learn/Accessibility"
           >previous articles in the course</a
         >.

--- a/files/en-us/learn/accessibility/multimedia/index.md
+++ b/files/en-us/learn/accessibility/multimedia/index.md
@@ -13,8 +13,7 @@ Another category of content that can create accessibility problems is multimedia
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML, CSS, and
-        JavaScript, and an understanding of
+        A basic understanding of HTML, CSS, JavaScript, and an understanding of
         <a href="/en-US/docs/Learn/Accessibility/What_is_accessibility"
           >what accessibility is</a
         >.

--- a/files/en-us/learn/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.md
@@ -13,8 +13,8 @@ Following on from the previous article, sometimes making complex UI controls tha
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML, CSS, and
-        JavaScript, an understanding of the
+        A basic understanding of HTML, CSS, and
+        JavaScript. An understanding of the
         <a href="/en-US/docs/Learn/Accessibility"
           >previous articles in the course</a
         >.

--- a/files/en-us/learn/accessibility/what_is_accessibility/index.md
+++ b/files/en-us/learn/accessibility/what_is_accessibility/index.md
@@ -12,7 +12,7 @@ This article starts the module off with a good look at what accessibility is —
   <tbody>
     <tr>
       <th scope="row">Prerequisites:</th>
-      <td>Basic computer literacy, and a basic understanding of HTML and CSS.</td>
+      <td>A basic understanding of HTML and CSS.</td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>

--- a/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -13,10 +13,9 @@ In this lesson, we will take a look at some of the creative things you can do wi
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -15,10 +15,9 @@ While working through this lesson may seem less relevant immediately and a littl
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/debugging_css/index.md
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.md
@@ -13,10 +13,9 @@ Sometimes when writing CSS you will encounter an issue where your CSS doesn't se
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -15,10 +15,9 @@ In recent years however, CSS has evolved in order to better support different di
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/images_media_form_elements/index.md
+++ b/files/en-us/learn/css/building_blocks/images_media_form_elements/index.md
@@ -13,10 +13,9 @@ In this lesson we will take a look at how certain special elements are treated i
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/organizing/index.md
+++ b/files/en-us/learn/css/building_blocks/organizing/index.md
@@ -13,10 +13,9 @@ As you start to work on larger stylesheets and big projects you will discover th
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/overflowing_content/index.md
+++ b/files/en-us/learn/css/building_blocks/overflowing_content/index.md
@@ -13,10 +13,9 @@ Overflow is what happens when there is too much content to fit in an element box
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/selectors/attribute_selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/attribute_selectors/index.md
@@ -13,10 +13,9 @@ As you know from your study of HTML, elements can have attributes that give furt
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/combinators/index.md
@@ -13,10 +13,9 @@ The final selectors we will look at are called combinators, because they combine
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/index.md
@@ -13,10 +13,9 @@ In {{Glossary("CSS")}}, selectors are used to target the {{glossary("HTML")}} el
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/pseudo-classes_and_pseudo-elements/index.md
@@ -13,10 +13,9 @@ The next set of selectors we will look at are referred to as **pseudo-classes** 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/type_class_and_id_selectors/index.md
@@ -13,10 +13,9 @@ In this lesson, we examine some of the simplest selectors, which you will probab
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.md
+++ b/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.md
@@ -13,10 +13,9 @@ In the various lessons so far, you have come across a number of ways to size ite
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/the_box_model/index.md
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.md
@@ -13,10 +13,9 @@ Everything in CSS has a box around it, and understanding these boxes is key to b
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -17,10 +17,9 @@ In this lesson, we will take a look at some of the most frequently used value ty
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/first_steps/getting_started/index.md
+++ b/files/en-us/learn/css/first_steps/getting_started/index.md
@@ -13,10 +13,9 @@ In this article, we will take a simple HTML document and apply CSS to it, learni
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -13,10 +13,9 @@ Now that you are beginning to understand the purpose and use of CSS, let's exami
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/first_steps/how_css_works/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_works/index.md
@@ -14,10 +14,9 @@ We have learned the basics of CSS, what it is for and how to write simple styles
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/first_steps/what_is_css/index.md
+++ b/files/en-us/learn/css/first_steps/what_is_css/index.md
@@ -13,10 +13,9 @@ page-type: learn-module-chapter
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -13,7 +13,7 @@ In this article we'll start you on your journey towards mastering text styling w
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, HTML basics (study
+        HTML basics (study
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >Introduction to HTML</a
         >), CSS basics (study

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -13,7 +13,7 @@ When styling [links](/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperl
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, HTML basics (study
+        HTML basics (study
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >Introduction to HTML</a
         >), CSS basics (study

--- a/files/en-us/learn/css/styling_text/styling_lists/index.md
+++ b/files/en-us/learn/css/styling_text/styling_lists/index.md
@@ -13,7 +13,7 @@ page-type: learn-module-chapter
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, HTML basics (study
+        HTML basics (study
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >Introduction to HTML</a
         >), CSS basics (study

--- a/files/en-us/learn/css/styling_text/web_fonts/index.md
+++ b/files/en-us/learn/css/styling_text/web_fonts/index.md
@@ -13,7 +13,7 @@ In the first article of the module, we explored the basic CSS features available
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, HTML basics (study
+        HTML basics (study
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >Introduction to HTML</a
         >), CSS basics (study

--- a/files/en-us/learn/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn/forms/advanced_form_styling/index.md
@@ -13,7 +13,7 @@ In this article, we will see what can be done with CSS to style the types of for
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic understanding of
+        A basic understanding of
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">HTML</a> and
         <a href="/en-US/docs/Learn/CSS/First_steps">CSS</a>.
       </td>

--- a/files/en-us/learn/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.md
@@ -13,7 +13,7 @@ In the [previous article](/en-US/docs/Learn/Forms/How_to_structure_a_web_form), 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic
+        A basic
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >understanding of HTML</a
         >.

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -13,7 +13,7 @@ With the basics out of the way, we'll now look in more detail at the elements us
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">understanding of HTML</a>.
+        A basic <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">understanding of HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/forms/html5_input_types/index.md
+++ b/files/en-us/learn/forms/html5_input_types/index.md
@@ -13,7 +13,7 @@ In the [previous article](/en-US/docs/Learn/Forms/Basic_native_form_controls) we
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic
+        A basic
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >understanding of HTML</a
         >.

--- a/files/en-us/learn/forms/other_form_controls/index.md
+++ b/files/en-us/learn/forms/other_form_controls/index.md
@@ -13,7 +13,7 @@ We now look at the functionality of non-`<input>` form elements in detail, from 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic
+        A basic
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >understanding of HTML</a
         >.

--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
@@ -13,7 +13,7 @@ Once the form data has been validated on the client-side, it is okay to submit t
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, an
+        An
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >understanding of HTML</a
         >, and basic knowledge of

--- a/files/en-us/learn/forms/styling_web_forms/index.md
+++ b/files/en-us/learn/forms/styling_web_forms/index.md
@@ -13,7 +13,7 @@ In the previous few articles, we showed how to create web forms in HTML. Now, we
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic understanding of
+        A basic understanding of
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">HTML</a> and
         <a href="/en-US/docs/Learn/CSS/First_steps">CSS</a>.
       </td>

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -13,7 +13,7 @@ In the previous articles, we covered the styling of various form controls in a g
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic understanding of
+        A basic understanding of
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML">HTML</a> and
         <a href="/en-US/docs/Learn/CSS/First_steps">CSS</a>, including general
         knowledge of

--- a/files/en-us/learn/forms/your_first_form/index.md
+++ b/files/en-us/learn/forms/your_first_form/index.md
@@ -14,7 +14,7 @@ We'll expand on each of these subtopics in more detail later on in the module.
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, and a basic
+        A basic
         <a href="/en-US/docs/Learn/HTML/Introduction_to_HTML"
           >understanding of HTML</a
         >.

--- a/files/en-us/learn/front-end_web_developer/index.md
+++ b/files/en-us/learn/front-end_web_developer/index.md
@@ -63,7 +63,7 @@ Time to complete: 35–50 hours
 
 #### Prerequisites
 
-Nothing except basic computer literacy, and a basic web development environment.
+A basic web development environment.
 
 #### How will I know I'm ready to move on?
 

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -13,10 +13,9 @@ In this article, we cover the absolute basics of HTML. To get you started, this 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -14,10 +14,9 @@ In the beginning, the Web was just text, and it was really quite boring. Fortuna
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -13,10 +13,9 @@ By now you should really be getting the hang of embedding things into your web p
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -13,10 +13,9 @@ Now that we are comfortable with adding simple images to a webpage, the next ste
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/javascript/asynchronous/implementing_a_promise-based_api/index.md
+++ b/files/en-us/learn/javascript/asynchronous/implementing_a_promise-based_api/index.md
@@ -13,7 +13,7 @@ In the last article we discussed how to use APIs that return promises. In this a
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a reasonable understanding of JavaScript
+        A reasonable understanding of JavaScript
         fundamentals, including event handling and the basics of promises.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/asynchronous/introducing/index.md
+++ b/files/en-us/learn/javascript/asynchronous/introducing/index.md
@@ -13,7 +13,7 @@ In this article, we'll explain what asynchronous programming is, why we need it,
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a reasonable understanding of JavaScript
+        A reasonable understanding of JavaScript
         fundamentals, including functions and event handlers.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
+++ b/files/en-us/learn/javascript/asynchronous/introducing_workers/index.md
@@ -13,7 +13,7 @@ In this final article in our "Asynchronous JavaScript" module, we'll introduce _
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a reasonable understanding of JavaScript
+        A reasonable understanding of JavaScript
         fundamentals, including event handling.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -13,7 +13,7 @@ page-type: learn-module-chapter
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a reasonable understanding of JavaScript
+        A reasonable understanding of JavaScript
         fundamentals, including event handling.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/asynchronous/sequencing_animations/index.md
+++ b/files/en-us/learn/javascript/asynchronous/sequencing_animations/index.md
@@ -13,7 +13,7 @@ In this assessment you'll update a page to play a series of animations in a sequ
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a reasonable understanding of JavaScript
+        A reasonable understanding of JavaScript
         fundamentals, how to use promise-based APIs.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -13,11 +13,10 @@ With most of the essential theory dealt with in the previous article, this artic
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML, CSS, and 
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
-        >,
-        <a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions"
+        >. Also, <a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions"
           >Functions — reusable blocks of code</a
         >.
       </td>

--- a/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.md
+++ b/files/en-us/learn/javascript/building_blocks/build_your_own_function/index.md
@@ -13,7 +13,7 @@ With most of the essential theory dealt with in the previous article, this artic
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        A basic understanding of HTML, CSS, and 
+        A basic understanding of HTML, CSS, and
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >. Also, <a href="/en-US/docs/Learn/JavaScript/Building_blocks/Functions"

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -13,7 +13,7 @@ In any programming language, the code needs to make decisions and carry out acti
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        A basic understanding of HTML, CSS, and 
+        A basic understanding of HTML, CSS, and
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -13,7 +13,7 @@ In any programming language, the code needs to make decisions and carry out acti
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML, CSS, and 
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -17,7 +17,7 @@ This won't be an exhaustive study; just what you need to know at this stage.
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML, CSS, and 
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/events/index.md
@@ -17,7 +17,7 @@ This won't be an exhaustive study; just what you need to know at this stage.
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        A basic understanding of HTML, CSS, and 
+        A basic understanding of HTML, CSS, and
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -13,7 +13,7 @@ Another essential concept in coding is **functions**, which allow you to store a
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML, CSS, and 
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/functions/index.md
+++ b/files/en-us/learn/javascript/building_blocks/functions/index.md
@@ -13,7 +13,7 @@ Another essential concept in coding is **functions**, which allow you to store a
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        A basic understanding of HTML, CSS, and 
+        A basic understanding of HTML, CSS, and
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.md
@@ -13,7 +13,7 @@ Programming languages are very useful for rapidly completing repetitive tasks, f
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML, CSS, and 
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/looping_code/index.md
+++ b/files/en-us/learn/javascript/building_blocks/looping_code/index.md
@@ -13,7 +13,7 @@ Programming languages are very useful for rapidly completing repetitive tasks, f
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        A basic understanding of HTML, CSS, and 
+        A basic understanding of HTML, CSS, and
         <a href="/en-US/docs/Learn/JavaScript/First_steps"
           >JavaScript first steps</a
         >.

--- a/files/en-us/learn/javascript/building_blocks/return_values/index.md
+++ b/files/en-us/learn/javascript/building_blocks/return_values/index.md
@@ -14,7 +14,7 @@ There's one last essential concept about functions for us to discuss — return 
       <th scope="row">Prerequisites:</th>
       <td>
         <p>
-          Basic computer literacy, a basic understanding of HTML and CSS,
+          A basic understanding of HTML and CSS,
           <a href="/en-US/docs/Learn/JavaScript/First_steps"
             >JavaScript first steps</a
           >,

--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
@@ -14,7 +14,7 @@ First up, we'll start by looking at APIs from a high level — what are they, ho
       <th scope="row">Prerequisites:</th>
       <td>
         A basic understanding of
-        <a href="/en-US/docs/Learn/HTML">HTML</a>, 
+        <a href="/en-US/docs/Learn/HTML">HTML</a>,
         <a href="/en-US/docs/Learn/CSS">CSS</a>, and JavaScript basics (see
         <a href="/en-US/docs/Learn/JavaScript/First_steps">first steps</a>,
         <a href="/en-US/docs/Learn/JavaScript/Building_blocks"

--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
@@ -13,9 +13,9 @@ First up, we'll start by looking at APIs from a high level — what are they, ho
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of
-        <a href="/en-US/docs/Learn/HTML">HTML</a> and
-        <a href="/en-US/docs/Learn/CSS">CSS</a>, JavaScript basics (see
+        A basic understanding of
+        <a href="/en-US/docs/Learn/HTML">HTML</a>, 
+        <a href="/en-US/docs/Learn/CSS">CSS</a>, and JavaScript basics (see
         <a href="/en-US/docs/Learn/JavaScript/First_steps">first steps</a>,
         <a href="/en-US/docs/Learn/JavaScript/Building_blocks"
           >building blocks</a

--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -13,7 +13,7 @@ When writing web pages and apps, one of the most common things you'll want to do
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML, CSS, and
+        A basic understanding of HTML, CSS, and
         JavaScript — including JavaScript objects.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -13,7 +13,7 @@ Now you've learned something about the theory of JavaScript and what you can do 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/arrays/index.md
+++ b/files/en-us/learn/javascript/first_steps/arrays/index.md
@@ -13,7 +13,7 @@ In the final article of this module, we'll look at arrays — a neat way of stor
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/math/index.md
+++ b/files/en-us/learn/javascript/first_steps/math/index.md
@@ -13,7 +13,7 @@ At this point in the course, we discuss math in JavaScript — how we can use {{
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -13,7 +13,7 @@ Next, we'll turn our attention to strings — this is what pieces of text are ca
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
@@ -13,7 +13,7 @@ Now that we've looked at the very basics of strings, let's move up a gear and st
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/variables/index.md
+++ b/files/en-us/learn/javascript/first_steps/variables/index.md
@@ -13,7 +13,7 @@ After reading the last couple of articles you should now know what JavaScript is
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
@@ -13,7 +13,7 @@ In this article we will look at JavaScript from a high level, answering question
   <tbody>
     <tr>
       <th scope="row">Prerequisites:</th>
-      <td>Basic computer literacy, a basic understanding of HTML and CSS.</td>
+      <td>A basic understanding of HTML and CSS.</td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>

--- a/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
@@ -13,7 +13,7 @@ When you built up the "Guess the number" game in the previous article, you may h
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, an
+        A basic understanding of HTML and CSS, an
         understanding of what JavaScript is.
       </td>
     </tr>

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -13,7 +13,7 @@ In this article, we'll look at fundamental JavaScript object syntax, and revisit
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML and CSS,
         familiarity with JavaScript basics (see
         <a href="/en-US/docs/Learn/JavaScript/First_steps">First steps</a> and
         <a href="/en-US/docs/Learn/JavaScript/Building_blocks">Building blocks</a>).

--- a/files/en-us/learn/javascript/objects/classes_in_javascript/index.md
+++ b/files/en-us/learn/javascript/objects/classes_in_javascript/index.md
@@ -17,7 +17,7 @@ In this article, we'll go through these features. It's worth keeping in mind tha
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML and CSS,
         familiarity with JavaScript basics (see
         <a href="/en-US/docs/Learn/JavaScript/First_steps">First steps</a> and
         <a href="/en-US/docs/Learn/JavaScript/Building_blocks"

--- a/files/en-us/learn/javascript/objects/json/index.md
+++ b/files/en-us/learn/javascript/objects/json/index.md
@@ -13,7 +13,7 @@ JavaScript Object Notation (JSON) is a standard text-based format for representi
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS, familiarity with JavaScript basics (see <a href="/en-US/docs/Learn/JavaScript/First_steps">First steps</a> and <a href="/en-US/docs/Learn/JavaScript/Building_blocks">Building blocks</a>) and OOJS basics (see <a href="/en-US/docs/Learn/JavaScript/Objects/Basics">Introduction to objects</a>).
+        A basic understanding of HTML and CSS, familiarity with JavaScript basics (see <a href="/en-US/docs/Learn/JavaScript/First_steps">First steps</a> and <a href="/en-US/docs/Learn/JavaScript/Building_blocks">Building blocks</a>) and OOJS basics (see <a href="/en-US/docs/Learn/JavaScript/Objects/Basics">Introduction to objects</a>).
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/javascript/objects/object_building_practice/index.md
+++ b/files/en-us/learn/javascript/objects/object_building_practice/index.md
@@ -13,7 +13,7 @@ In previous articles we looked at all the essential JavaScript object theory and
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, a basic understanding of HTML and CSS,
+        A basic understanding of HTML and CSS,
         familiarity with JavaScript basics (see
         <a href="/en-US/docs/Learn/JavaScript/First_steps">First steps</a> and
         <a href="/en-US/docs/Learn/JavaScript/Building_blocks"

--- a/files/en-us/learn/mathml/first_steps/fractions_and_roots/index.md
+++ b/files/en-us/learn/mathml/first_steps/fractions_and_roots/index.md
@@ -13,10 +13,9 @@ Relying on text containers, this article describes how to build more complex Mat
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/mathml/first_steps/getting_started/index.md
+++ b/files/en-us/learn/mathml/first_steps/getting_started/index.md
@@ -13,10 +13,9 @@ In this article, we will take a simple HTML document and see how to add MathML f
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/mathml/first_steps/scripts/index.md
+++ b/files/en-us/learn/mathml/first_steps/scripts/index.md
@@ -13,10 +13,9 @@ We continue the review of basic math notations and focus on building MathML elem
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/mathml/first_steps/tables/index.md
+++ b/files/en-us/learn/mathml/first_steps/tables/index.md
@@ -13,10 +13,9 @@ Once all basic math notations are known, it remains to consider tabular layout w
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/mathml/first_steps/text_containers/index.md
+++ b/files/en-us/learn/mathml/first_steps/text_containers/index.md
@@ -13,10 +13,9 @@ Now that you get a better idea of MathML, we move focus on text containers (vari
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, basic knowledge of
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"

--- a/files/en-us/learn/performance/business_case_for_performance/index.md
+++ b/files/en-us/learn/performance/business_case_for_performance/index.md
@@ -13,7 +13,7 @@ We've discussed the importance of web performance. You've learned what you need 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy, basic knowledge of
+        Basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a
         >, and a basic understanding of

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -13,10 +13,9 @@ When developing a website, you need to consider how the browser is handling the 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/html/index.md
+++ b/files/en-us/learn/performance/html/index.md
@@ -13,10 +13,9 @@ HTML is by default fast and accessible. It is our job, as developers, to ensure 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/javascript/index.md
+++ b/files/en-us/learn/performance/javascript/index.md
@@ -13,10 +13,9 @@ It is very important to consider how you are using JavaScript on your websites a
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/measuring_performance/index.md
+++ b/files/en-us/learn/performance/measuring_performance/index.md
@@ -17,10 +17,9 @@ This article introduces tools you can use to access web performance metrics, whi
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/multimedia/index.md
+++ b/files/en-us/learn/performance/multimedia/index.md
@@ -13,10 +13,9 @@ Media, namely images and video, account for over 70% of the bytes downloaded for
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/perceived_performance/index.md
+++ b/files/en-us/learn/performance/perceived_performance/index.md
@@ -15,10 +15,9 @@ This article provides a brief introduction to the factors that affect perceived 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -13,10 +13,9 @@ As we learned in the previous section, media, namely images and video, account f
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/what_is_web_performance/index.md
+++ b/files/en-us/learn/performance/what_is_web_performance/index.md
@@ -13,10 +13,9 @@ Web performance is all about making websites fast, including making slow process
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/performance/why_web_performance/index.md
+++ b/files/en-us/learn/performance/why_web_performance/index.md
@@ -13,10 +13,9 @@ Web performance is all about making websites fast, including making slow process
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy,
         <a
           href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >basic software installed</a
+          >Basic software installed</a
         >, and basic knowledge of
         <a href="/en-US/docs/Learn/Getting_started_with_the_web"
           >client-side web technologies</a

--- a/files/en-us/learn/server-side/django/introduction/index.md
+++ b/files/en-us/learn/server-side/django/introduction/index.md
@@ -15,7 +15,6 @@ We'll outline the main features, including some of the advanced functionality th
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy.
         A general understanding of <a href="/en-US/docs/Learn/Server-side/First_steps">server-side website programming</a>, and in particular the mechanics of <a href="/en-US/docs/Learn/Server-side/First_steps/Client-Server_overview">client-server interactions in websites</a>.
       </td>
     </tr>

--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.md
@@ -13,7 +13,7 @@ In this first Express article we answer the questions "What is Node?" and "What 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy. A general understanding of <a href="/en-US/docs/Learn/Server-side/First_steps">server-side website programming</a>, and in particular the mechanics of <a href="/en-US/docs/Learn/Server-side/First_steps/Client-Server_overview">client-server interactions in websites</a>.
+        A general understanding of <a href="/en-US/docs/Learn/Server-side/First_steps">server-side website programming</a>, and in particular the mechanics of <a href="/en-US/docs/Learn/Server-side/First_steps/Client-Server_overview">client-server interactions in websites</a>.
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.md
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.md
@@ -13,7 +13,7 @@ Now that you know the purpose and potential benefits of server-side programming,
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy. A basic understanding of what a web server is.
+        A basic understanding of what a web server is.
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/server-side/first_steps/introduction/index.md
+++ b/files/en-us/learn/server-side/first_steps/introduction/index.md
@@ -13,7 +13,7 @@ Welcome to the MDN beginner's server-side programming course! In this first arti
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy. A basic understanding of what a web server is.
+        A basic understanding of what a web server is.
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/server-side/first_steps/web_frameworks/index.md
+++ b/files/en-us/learn/server-side/first_steps/web_frameworks/index.md
@@ -13,7 +13,7 @@ The previous article showed you what the communication between web clients and s
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Basic computer literacy. Basic understanding of how server-side code
+        Basic understanding of how server-side code
         handles and responds to HTTP requests (see <a
           href="/en-US/docs/Learn/Server-side/First_steps/Client-Server_overview"
           >Client-Server overview</a


### PR DESCRIPTION
### Description

This PR aims to remove what is, in my opinion, the overuse of "Basic computer literacy" as a prerequisite for topics. I feel that this tag can be used in high-level topics when no harder prerequisites are listed, but that that should be the extent of its use. 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

My goal is to make the docs more accurate and inclusive, and more quickly scanned by a reader to determine that they are fit to digest the content. 

While diving into the express docs, I noticed that "Basic computer literacy" was listed as a prerequisite... It felt superfluous at best and slightly arrogant at worst. That led me to look how pervasively the phrase was used throughout MDN docs and I feel that 89/91 instances could probably be removed.

### Additional details

Thanks for reading and reviewing my PR. I'd be happy to discuss my rationale more deeply if this is a contentious topic.

### Related issues and pull requests

~~I'm not sure. I haven't scanned the issues list, nor did I open one for this.~~
After taking a closer look, I don't believe there are any open issues related to this.