### PR TITLE
Update `Element.setAttribute` exception description

### DIFF
--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -49,7 +49,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `InvalidCharacterError` {{domxref("DOMException")}}
-  - : Thrown if the [`name`](#name) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
+  - : Thrown if the [`name`](#name) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, a hyphen, or a period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
 
 ## Examples
 

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -49,8 +49,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `InvalidCharacterError` {{domxref("DOMException")}}
-  - : The specified attribute `name` contains one or more characters which are
-    not valid in attribute names.
+  - : Thrown if the [`name`](#name) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
 
 ## Examples
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I copied the error description from [`Document.createAttribute`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute) to `Element.setAttribute`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The new explanation clearly links to the [XML specification](https://www.w3.org/TR/REC-xml/#dt-name), while the old explanation confusingly said "not valid in attribute names" while [attribute names allowed by `HTML` (e.g. `@click`)](https://html.spec.whatwg.org/multipage/syntax.html#syntax-attribute-name) aren't allowed in this method.

### Additional details

- [XML name specification](https://www.w3.org/TR/REC-xml/#dt-name)
- [HTML attribute specification](https://html.spec.whatwg.org/multipage/syntax.html#syntax-attribute-name)
- [`Element.setAttribute` specification](https://dom.spec.whatwg.org/#dom-element-setattribute)
- [`Document.createAttribute` specification](https://dom.spec.whatwg.org/#dom-document-createattribute)
