### PR TITLE
Remove accessKey from the property list of HTMLLegendElement

### DIFF
--- a/files/en-us/web/api/htmllegendelement/index.md
+++ b/files/en-us/web/api/htmllegendelement/index.md
@@ -16,11 +16,9 @@ The **`HTMLLegendElement`** is an interface allowing to access properties of the
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLLegendElement.form")}} {{ReadOnlyInline}}
-  - : A {{domxref("HTMLFormElement")}} representing the form that this legend belongs to. If the legend has a fieldset element as its parent, then this attribute returns the same value as the **form** attribute on the parent fieldset element. Otherwise, it returns null.
-- {{domxref("HTMLLegendElement.accessKey")}}
-  - : A string representing a single-character access key to give access to the element.
+  - : A {{domxref("HTMLFormElement")}} representing the form that this legend belongs to. If the legend has a fieldset element as its parent, then this attribute returns the same value as the **form** attribute on the parent fieldset element. Otherwise, it returns `null`.
 - {{domxref("HTMLLegendElement.align")}} {{deprecated_inline}}
-  - : A string representing the alignment relative to the form set
+  - : A string representing the alignment relative to the form set.
 
 ## Instance methods
 


### PR DESCRIPTION
It actually is defined on HTMLElement.