### PR TITLE
autocapitalise - make it clear you need a voice/virtual keyboard

### DIFF
--- a/files/en-us/web/html/global_attributes/autocapitalize/index.md
+++ b/files/en-us/web/html/global_attributes/autocapitalize/index.md
@@ -105,6 +105,8 @@ div {
 
 ## Result
 
+Test the effect on each input using a virtual keyboard or voice entry (keyboard entry will not work).
+
 {{ EmbedLiveSample("Examples", "100%", "500") }}
 
 ## Specifications


### PR DESCRIPTION
Fixes #31450

The description clearly states that the property does not work for keyboard entry, but by the time you get to the example that may not be obvious. This adds a note at the point that you test the example that you must use voice or virtual keyboard.