### PR TITLE
CSS :where() - move up sentence comparing to :is()

### DIFF
--- a/files/en-us/web/css/_colon_where/index.md
+++ b/files/en-us/web/css/_colon_where/index.md
@@ -9,9 +9,9 @@ browser-compat: css.selectors.where
 
 The **`:where()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) function takes a selector list as its argument, and selects any element that can be selected by one of the selectors in that list.
 
-{{EmbedInteractiveExample("pages/tabbed/pseudo-class-where.html", "tabbed-shorter")}}
-
 The difference between `:where()` and {{CSSxRef(":is", ":is()")}} is that `:where()` always has 0 [specificity](/en-US/docs/Web/CSS/Specificity), whereas `:is()` takes on the specificity of the most specific selector in its arguments.
+
+{{EmbedInteractiveExample("pages/tabbed/pseudo-class-where.html", "tabbed-shorter")}}
 
 ### Forgiving Selector Parsing
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

On the [CSS :where() page](https://developer.mozilla.org/en-US/docs/Web/CSS/:where), move up the sentence comparing it to [:is()](https://developer.mozilla.org/en-US/docs/Web/CSS/:is).

### Motivation

The two pages have the same introductory sentence before the first example. At first I thought there must be a mistake, until I googled "css is vs where", which brought me to the sentence I moved up.

Seems I'm not the only one, as there is also [this StackOverflow answer](https://stackoverflow.com/a/67450559):

> As mentioned, the difference is specificity. This is mentioned on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:where), though not prominently for some reason.