### PR TITLE
Fix confusing wording for timestamp parameter

### DIFF
--- a/files/en-us/web/api/midioutput/send/index.md
+++ b/files/en-us/web/api/midioutput/send/index.md
@@ -22,7 +22,7 @@ send(data, timestamp)
 - `data`
   - : A sequence of one or more [valid MIDI messages](https://www.midi.org/midi-articles/about-midi-part-3-midi-messages). Each entry represents a single byte of data.
 - `timestamp` {{optional_inline}}
-  - : A {{domxref("DOMHighResTimestamp")}} with the time in milliseconds, which is the delay before sending the message.
+  - : A {{domxref("DOMHighResTimestamp")}} with the time in milliseconds when the message should be sent (relative to {{domxref("Performance.timeOrigin")}}).
 
 ### Return value
 


### PR DESCRIPTION
### Description

The current wording implies the "timestamp" value is actually a delay between the function call and the event being sent. This is not the case.

### Motivation

The modification helps readers better understand the meaning of the parameter