### PR TITLE
Change Atomics to Math

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/index.md
@@ -13,7 +13,7 @@ The **`Math`** namespace object contains static properties and methods for mathe
 
 ## Description
 
-Unlike most global objects, `Math` is not a constructor. You cannot use it with the [`new` operator](/en-US/docs/Web/JavaScript/Reference/Operators/new) or invoke the `Atomics` object as a function. All properties and methods of `Math` are static.
+Unlike most global objects, `Math` is not a constructor. You cannot use it with the [`new` operator](/en-US/docs/Web/JavaScript/Reference/Operators/new) or invoke the `Math` object as a function. All properties and methods of `Math` are static.
 
 > **Note:** Many `Math` functions have a precision that's _implementation-dependent_.
 >


### PR DESCRIPTION
### Description

The word "Atomics" was used instead of "Math", probably due to a copy-paste from the Atomics documentation page.

### Motivation

Mentioning "Atomics" in the Math page is confusing and most likely a typo.

