### PR TITLE
Fix mistake in example code

### DIFF
--- a/files/en-us/web/manifest/file_handlers/index.md
+++ b/files/en-us/web/manifest/file_handlers/index.md
@@ -94,7 +94,7 @@ In the following example, {{domxref("LaunchQueue.setConsumer", "window.launchQue
 
 ```js
 async function playSong(handledFile) {
-  const blob = await file.getFile();
+  const blob = await handledFile.getFile();
   const url = window.URL.createObjectURL(blob);
   const audio = new Audio(url);
   audio.play();


### PR DESCRIPTION
### Description

Pretty sure this is just a typo in the example code, since there is no ``file`` variable defined anywhere and the function gets ``handledFile`` passed to it.

### Motivation

Because the current code is wrong.

### Additional details

no

### Related issues and pull requests

Have not seen any.