### PR TITLE
Replace deprecated substr() in example code

### DIFF
--- a/files/en-us/web/api/window/launchqueue/index.md
+++ b/files/en-us/web/api/window/launchqueue/index.md
@@ -30,7 +30,7 @@ if ("launchQueue" in window) {
       const track = params.get("track");
       if (track) {
         audio.src = track;
-        title.textContent = new URL(track).pathname.substr(1);
+        title.textContent = new URL(track).pathname.substring(1);
         audio.play();
       }
     }


### PR DESCRIPTION
### Description

Replaced a call to ``substr()`` in example code with an equivalent call to ``substring()``.

### Motivation

``substr()`` is deprecated, ``substring()`` should be used instead.

### Additional details

You can see the [deprecation note for substr in the MDN docs here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr).

### Related issues and pull requests

Didn't see any.