### PR TITLE
Remove OPTIONS from Access-Control-Allow-Methods example

### DIFF
--- a/files/en-us/web/http/headers/access-control-allow-methods/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.md
@@ -43,7 +43,7 @@ Access-Control-Allow-Methods: *
 ## Examples
 
 ```http
-Access-Control-Allow-Methods: POST, GET, OPTIONS
+Access-Control-Allow-Methods: GET, POST
 Access-Control-Allow-Methods: *
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove OPTIONS from the example of `Access-Control-Allow-Methods`.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

OPTIONS is never actually necessary to my understanding so I think it is a bad example.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

 - https://www.w3.org/TR/2020/SPSD-cors-20200602/#access-control-allow-methods-response-header
 - https://stackoverflow.com/questions/66926518/should-access-control-allow-methods-include-options

The official spec doesn't explicitly state one way or the other to my knowledge, however it does include examples which do not include OPTIONS.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
