### PR TITLE
Remove Path=/ requirement mentioning from Partitioned Cookies page

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -228,7 +228,7 @@ Set-Cookie: __Host-id=1; Secure; Path=/; Domain=example.com
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure` and `Path=/`. In addition, it is recommended to use the `__Host` prefix when setting partitioned cookies to make them bound to the hostname and not the registrable domain.
+> **Note:** Partitioned cookies must be set with `Secure`. In addition, it is recommended to use the `__Host` prefix when setting partitioned cookies to make them bound to the hostname and not the registrable domain.
 
 ## Specifications
 

--- a/files/en-us/web/privacy/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/partitioned_cookies/index.md
@@ -34,7 +34,7 @@ Browsers with CHIPs support provide a new attribute for the {{httpheader("Set-Co
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure` and `Path=/`. In addition, it is recommended to use the `__Host` prefix when setting partitioned cookies to make them bound to the hostname and not the registrable domain.
+> **Note:** Partitioned cookies must be set with `Secure`. In addition, it is recommended to use the `__Host` prefix when setting partitioned cookies to make them bound to the hostname and not the registrable domain.
 
 With `Partitioned` set, the cookie is stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 


### PR DESCRIPTION
This pull request fixes #29001 
It removes the mention of `Path=/` requirement from the note in the Partitioned Cookies page.
This PR however leaves that parameter in place when it comes to example right above to keep all options mentioned.

There are no other requirements mentioned for `Path=/` in that page.