### PR TITLE
Minor: fix link in SVG to "media query"

### DIFF
--- a/files/en-us/web/svg/attribute/media/index.md
+++ b/files/en-us/web/svg/attribute/media/index.md
@@ -7,7 +7,7 @@ browser-compat: svg.elements.style.media
 
 {{SVGRef}}
 
-The **`media`** attribute specifies a {{Glossary("media query")}} that must be matched for a style sheet to apply.
+The **`media`** attribute specifies a [media query](/en-US/docs/Web/CSS/CSS_media_queries) that must be matched for a style sheet to apply.
 
 You can use this attribute with the following SVG elements:
 


### PR DESCRIPTION
There is not glossary entry for media query.
https://developer.mozilla.org/en-US/docs/Glossary/Media/CSS was not a good match. but, the link at the bottom of that page.....
