### PR TITLE
"List of all color notations" should be linked to "/Web/CSS/color_value"

### DIFF
--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -154,6 +154,6 @@ div {
 
 ## See also
 
-- [List of all color notations](/en-US/docs/Web/CSS/color)
+- [List of all color notations](/en-US/docs/Web/CSS/color_value)
 - {{CSSXref("&lt;hue&gt;")}} data type
 - [LCH colors in CSS: what, why, and how?](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/)

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -151,7 +151,7 @@ div {
 
 ## See also
 
-- [List of all color notations](/en-US/docs/Web/CSS/color)
+- [List of all color notations](/en-US/docs/Web/CSS/color_value)
 - {{CSSXref("&lt;hue&gt;")}} data type
 - [A perceptual color space for image processing](https://bottosson.github.io/posts/oklab/)
 - [OKLCH in CSS](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

"List of all color notations" should be linked to `<color_value>` ("Web/CSS/color_value") rather than the `color` property ("Web/CSS/color").

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
