### PR TITLE
remove outdated link in ClipboardItem

### DIFF
--- a/files/en-us/web/api/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/index.md
@@ -95,5 +95,4 @@ async function getClipboardContents() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

https://async-clipboard-api.glitch.me now returns 403 error

(Not running because node.js it relies on is too old.)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Remove an outdated link.
Thus it won't waste readers time if they follow the link.

<!-- ❓ Why are you making these changes and how do they help readers? -->



<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
