### PR TITLE
Removed line about perspective() needing to be listed first

### DIFF
--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -61,8 +61,6 @@ transform: unset;
 
 The `transform` property may be specified as either the keyword value `none` or as one or more `<transform-function>` values.
 
-If {{cssxref("transform-function/perspective", "perspective()")}} is one of multiple function values, it must be listed first.
-
 ### Values
 
 - {{cssxref("&lt;transform-function&gt;")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This line is not correct.
It does need to come before functions in 3D to properly apply to them, but the transform will still work if it's not listed first.
In some cases it's even necessary to insert other functions before it. E.g. manually applying a transform-origin without using `transform-origin`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
