### PR TITLE
remove outdated link of Clipboard API

### DIFF
--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -118,5 +118,4 @@ async function pasteImage() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboard/readtext/index.md
+++ b/files/en-us/web/api/clipboard/readtext/index.md
@@ -61,7 +61,6 @@ navigator.clipboard
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)
 - {{domxref("Clipboard.writeText()")}}
 - {{domxref("Clipboard.write()")}}

--- a/files/en-us/web/api/clipboard/readtext/index.md
+++ b/files/en-us/web/api/clipboard/readtext/index.md
@@ -62,5 +62,3 @@ navigator.clipboard
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)
-- {{domxref("Clipboard.writeText()")}}
-- {{domxref("Clipboard.write()")}}

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -103,5 +103,4 @@ function copyCanvasContentsToClipboard(canvas, onDone, onError) {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboard/writetext/index.md
+++ b/files/en-us/web/api/clipboard/writetext/index.md
@@ -62,5 +62,4 @@ navigator.clipboard.writeText("<empty clipboard>").then(
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -54,5 +54,4 @@ This snippet fetches the text from the clipboard and appends it to the first ele
 
 ## See also
 
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/index.md
@@ -39,5 +39,4 @@ _No specific methods; inherits methods from its parent {{domxref("Event")}}_.
 
 - Copy-related events: {{domxref("Element/copy_event", "copy")}}, {{domxref("Element/cut_event", "cut")}}, {{domxref("Element/paste_event", "paste")}}
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -67,5 +67,4 @@ async function writeClipImg() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboarditem/gettype/index.md
+++ b/files/en-us/web/api/clipboarditem/gettype/index.md
@@ -68,5 +68,4 @@ async function getClipboardContents() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/index.md
@@ -95,5 +95,4 @@ async function getClipboardContents() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboarditem/presentationstyle/index.md
+++ b/files/en-us/web/api/clipboarditem/presentationstyle/index.md
@@ -45,5 +45,4 @@ async function getClipboardContents() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)

--- a/files/en-us/web/api/clipboarditem/types/index.md
+++ b/files/en-us/web/api/clipboarditem/types/index.md
@@ -53,5 +53,4 @@ async function getClipboardContents() {
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Async Clipboard API demo on Glitch](https://async-clipboard-api.glitch.me/)
 - [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the link to the demp does not existed now

following up https://github.com/mdn/content/pull/31483

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
