### PR TITLE
Remove IE mentioned from React tutorial

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_getting_started/index.md
@@ -129,7 +129,7 @@ You may use the Yarn package manager as an alternative to npm but we'll assume y
 
 If you're using Windows, you will need to install some software to give you parity with Unix/macOS terminal in order to use the terminal commands mentioned in this tutorial. **Gitbash** (which comes as part of the [git for Windows toolset](https://gitforwindows.org/)) or **[Windows Subsystem for Linux](https://docs.microsoft.com/windows/wsl/about)** (**WSL**) are both suitable. See [Command line crash course](/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line) for more information on these, and on terminal commands in general.
 
-Also bear in mind that React and ReactDOM produce apps that only work on a fairly modern set of browsers — IE9+ by way of some polyfills. It is recommended that you use a modern browser like Firefox, Microsoft Edge, Safari, or Chrome when working through these tutorials.
+Also bear in mind that React and ReactDOM produce apps that only work on a fairly modern set of browsers like Firefox, Microsoft Edge, Safari, or Chrome when working through these tutorials.
 
 See the following for more information:
 


### PR DESCRIPTION
This pull request fixes #30603 
It removes the IE mentioned in the tutorial and refactors that sentence as per @jfc3-dol's comment.

(This is a very tiny PR, but the whole tutorial is outdated in several places already and could use some refreshment indeed.)