### PR TITLE
Fix typo in canvas api tutorial

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/index.md
@@ -126,7 +126,7 @@ function draw() {
 
     // Clipping path
     ctx.beginPath();
-    ctx.rect(-75, -75, 150, 150); // Outter rectangle
+    ctx.rect(-75, -75, 150, 150); // Outer rectangle
     ctx.arc(0, 0, 60, 0, Math.PI * 2, true); // Hole anticlockwise
     ctx.clip();
 


### PR DESCRIPTION
### Description

"Outer" was misspelt as "Outter" in the codeblock's comment.

### Motivation

Fixing a minor spelling mistake.

### Additional details

None

### Related issues and pull requests

None
