### PR TITLE
fix method name on `Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/tolocaletimestring/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Date.toLocaleTimeString
 
 The **`toLocaleTimeString()`** method of {{jsxref("Date")}} instances returns a string with a language-sensitive representation of the time portion of this date in the local timezone. In implementations with [`Intl.DateTimeFormat` API](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) support, this method simply calls `Intl.DateTimeFormat`.
 
-Every time `toLocaleString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.DateTimeFormat")}} object and use its {{jsxref("Intl/DateTimeFormat/format", "format()")}} method, because a `DateTimeFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
+Every time `toLocaleTimeString` is called, it has to perform a search in a big database of localization strings, which is potentially inefficient. When the method is called many times with the same arguments, it is better to create a {{jsxref("Intl.DateTimeFormat")}} object and use its {{jsxref("Intl/DateTimeFormat/format", "format()")}} method, because a `DateTimeFormat` object remembers the arguments passed to it and may decide to cache a slice of the database, so future `format` calls can search for localization strings within a more constrained context.
 
 {{EmbedInteractiveExample("pages/js/date-tolocaletimestring.html")}}
 


### PR DESCRIPTION
### Description

This PR fixes method name (`toLocaleTimeString` instead of `toLocaleString`) on `Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString` page
