### PR TITLE
initial documentation for HtmlLinkElement.hreflang

### DIFF
--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -19,7 +19,12 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 ## Example
 
 ```html
-<link rel="alternate" href="www.example.com/fr/html" hreflang="fr" type="text/html" title="French HTML">
+<link
+  rel="alternate"
+  href="www.example.com/fr/html"
+  hreflang="fr"
+  type="text/html"
+  title="French HTML" />
 <p></p>
 ```
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -28,9 +28,17 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 <p class="tag"></p>
 ```
 
+```css
+.tag {
+  margin-left: 20px;
+  font: bold;
+  font-size: 24px;
+}
+```
+
 ```js
 const myLink = document.querySelector("link");
-const pTag = document.querySelector("tag");
+const pTag = document.querySelector(".tag");
 pTag.textContent = myLink.hreflang;
 ```
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -25,5 +25,3 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 {{Compat}}
 
 ## See also
-
-- {{domxref("HTMLAnchorElement.hreflang")}} property

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -10,11 +10,11 @@ browser-compat: api.HTMLLinkElement.hreflang
 
 The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} is used to indicate the language and the geographical targeting of a page. This improves SEO(Search Engine Optimization).
 
-It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` element.
+It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` attribute.
 
 ## Value
 
-A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` element.
+A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` attribute.
 
 ## Example
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -25,4 +25,5 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 {{Compat}}
 
 ## See also
+
 - {{domxref("HTMLAnchorElement.hreflang")}} property

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLLinkElement.hreflang
 
 {{ApiRef("HTML DOM")}}
 
-The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} is used to indicate the language and the geographical targeting of a page. This improves SEO(Search Engine Optimization).  
+The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} is used to indicate the language and the geographical targeting of a page. This improves SEO(Search Engine Optimization).
 
 It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` element.
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -28,7 +28,7 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 <p></p>
 ```
 
-```JavaScript
+```javascript
 const myLink = document.querySelector("link");
 const pTag = document.querySelector("p");
 pTag.textContent = myLink.hreflang

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -25,3 +25,4 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 {{Compat}}
 
 ## See also
+- {{domxref("HTMLAnchorElement.hreflang")}} property

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -25,12 +25,12 @@ A string that contains a language tag, or the empty string (`""`) if there is no
   hreflang="fr"
   type="text/html"
   title="French HTML" />
-<p></p>
+<p class="tag"></p>
 ```
 
 ```javascript
 const myLink = document.querySelector("link");
-const pTag = document.querySelector("p");
+const pTag = document.querySelector("tag");
 pTag.textContent = myLink.hreflang;
 ```
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -28,7 +28,7 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 <p class="tag"></p>
 ```
 
-```javascript
+```js
 const myLink = document.querySelector("link");
 const pTag = document.querySelector("tag");
 pTag.textContent = myLink.hreflang;

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -18,6 +18,21 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 
 ## Example
 
+```html
+<link rel="alternate" href="www.example.com/fr/html" hreflang="fr" type="text/html" title="French HTML">
+<p></p>
+```
+
+```JavaScript
+const myLink = document.querySelector("link");
+const pTag = document.querySelector("p");
+pTag.textContent = myLink.hreflang
+```
+
+## Results
+
+{{EmbedLiveSample("Example",100,100)}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -8,13 +8,15 @@ browser-compat: api.HTMLLinkElement.hreflang
 
 {{ApiRef("HTML DOM")}}
 
-The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} interface has the same semantics as the {{domxref("HTMLAnchorElement.hreflang")}} property.
+The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} is used to indicate the language and the geographical targeting of a page. This improves SEO(Search Engine Optimization).  
 
 It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` element.
 
 ## Value
 
 A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` element.
+
+## Example
 
 ## Specifications
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -1,0 +1,30 @@
+---
+title: "HTMLLinkElement: hreflang property"
+short-title: hreflang
+slug: Web/API/HTMLLinkElement/hreflang
+page-type: web-api-instance-property
+browser-compat: api.HTMLLinkElement.hreflang
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} interface has same semantics as {{domxref("HTMLAnchorElement.hreflang")}} property.
+
+It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` element.
+
+## Value
+
+A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` element.
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLAnchorElement.hreflang")}} property

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLLinkElement.hreflang
 
 {{ApiRef("HTML DOM")}}
 
-The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} is used to indicate the language and the geographical targeting of a page. This improves SEO(Search Engine Optimization).
+The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} is used to indicate the language and the geographical targeting of a page. This hint can be used by browsers to select the more appropriate page or to improve {{Glossary("SEO")}}.
 
 It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` attribute.
 

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -16,7 +16,6 @@ It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and 
 
 A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` element.
 
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -31,7 +31,7 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 ```javascript
 const myLink = document.querySelector("link");
 const pTag = document.querySelector("p");
-pTag.textContent = myLink.hreflang
+pTag.textContent = myLink.hreflang;
 ```
 
 ## Results

--- a/files/en-us/web/api/htmllinkelement/hreflang/index.md
+++ b/files/en-us/web/api/htmllinkelement/hreflang/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLLinkElement.hreflang
 
 {{ApiRef("HTML DOM")}}
 
-The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} interface has same semantics as {{domxref("HTMLAnchorElement.hreflang")}} property.
+The **`hreflang`** property of the {{domxref("HTMLLinkElement")}} interface has the same semantics as the {{domxref("HTMLAnchorElement.hreflang")}} property.
 
 It reflects the `hreflang` attribute of the {{HTMLElement("link")}} element and is the empty string (`""`) if there is no `hreflang` element.
 


### PR DESCRIPTION
This adds the missing HTMLLinkElement.hreflang page.

resource link
[hreflang](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-hreflang)

Part of the project to document all interoperable features ([mdn/discussions#476](https://github.com/orgs/mdn/discussions/476))