### PR TITLE
Make it more clear what happens when IntersectionObserver's options.root is not specified

### DIFF
--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
@@ -37,13 +37,13 @@ new IntersectionObserver(callback, options)
 
 - `options` {{optional_inline}}
 
-  - : An optional object which customizes the observer.
-    If `options` isn't specified, the observer uses the document's viewport as the root, with no margin, and a 0% threshold (meaning that even a one-pixel change is enough to trigger a callback).
+  - : An optional object which customizes the observer. All properties are optional.
     You can provide any combination of the following options:
 
     - `root`
       - : An {{domxref("Element")}} or {{domxref("Document")}} object which is an ancestor of the intended target, whose bounding rectangle will be considered the viewport.
-        Any part of the target not visible in the visible area of the `root` is not considered visible.
+        Any part of the target not visible in the visible area of the `root` is not considered visible. If not specified, the observer uses the document's
+        viewport as the root, with no margin, and a 0% threshold (meaning that even a one-pixel change is enough to trigger a callback).
     - `rootMargin`
       - : A string which specifies a set of offsets to add to the root's {{Glossary('bounding_box')}} when calculating intersections, effectively shrinking
         or growing the root for calculation purposes.


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Motivation


This makes it more clear that if the object is supplied, the options are optional, and makes it clear that the viewport is used specifically in the absence of options.root (not just the absence of options).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
