### PR TITLE
fix broken links and update the description of iterators

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -19,11 +19,11 @@ WebIDL can be found in multiple locations:
 
   - For Gecko, all WebIDL files are grouped in a single directory: <https://dxr.mozilla.org/mozilla-central/source/dom/webidl/>. Their extension is `.webidl`. There are other `*.idl` files in the Gecko source tree but they are not WebIDL, so you can ignore them. Older versions of Gecko have some of their WebIDL scattered around somewhat, and may even use Mozilla's IDL instead of WebIDL to describe some Web interfaces, but this won't be a problem in any recent Gecko code.
   - For Chromium, they are located in two locations, both subtrees of the source code's [`renderer/`](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/) directory: [`core/`](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/) and [`modules/`](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/). Chromium source code has IDL files in other locations, but these are part of the testing system and not relevant to API implementations.
-  - For WebCore, they are scattered around the source code, so you need to dig a bit more: E.g. <https://github.com/WebKit/webkit/blob/master/Source/WebCore/html/DOMTokenList.idl>
+  - For WebCore, they are scattered around the source code, so you need to dig a bit more: E.g. <https://github.com/WebKit/webkit/blob/main/Source/WebCore/html/DOMTokenList.idl>
 
 ## Different dialects of WebIDL
 
-WebIDL is defined in [its specification](https://heycam.github.io/webidl/). But it has been designed to be extended to convey more information, and browser vendors have done so:
+WebIDL is defined in [its specification](https://webidl.spec.whatwg.org/). But it has been designed to be extended to convey more information, and browser vendors have done so:
 
 - For Gecko, Mozilla created the [documentation](https://firefox-source-docs.mozilla.org/dom/webIdlBindings/index.html) of its dialectal WebIDL.
 - For Chromium, Google also created a [document](https://www.chromium.org/blink/webidl/) to describe its extensions.
@@ -243,7 +243,7 @@ If the keyword `readonly` is present, the property can't be modified. It must be
 
 In some cases, like when some values are illegal, setting a new value can lead to an exception being raised. This is marked using the `[SetterThrows]` annotation. When this happens, the Syntax section of the property page _must_ have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.
 
-Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://heycam.github.io/webidl/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) raises a {{jsxref('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.
+Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://webidl.spec.whatwg.org/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) raises a {{jsxref('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.
 
 It is uncommon to have getters throwing exceptions, though it happens in a few cases. In this case the `[GetterThrows]` annotation is used. Here also, the Syntax section of the property page _must_ have an Exceptions subsection.
 
@@ -355,9 +355,9 @@ The parameters of a method are listed in the Syntax section of the method sub-pa
 DOMString canPlayType(DOMString type);
 ```
 
-The return value type is indicated first inside the parentheses — in the above case the value is an object of type `DOMString`. if followed by a question mark (`'?'`), a value of `null` can be returned too, and the documentation must explain _when_ this may happen. If no question mark is present, like here, the return value can't be `null`.
+The return value type is indicated before the method name — in the above case the value is an object of type `DOMString`. If followed by a question mark (`'?'`), a value of `null` can be returned too, and the documentation must explain _when_ this may happen. If no question mark is present, like here, the return value can't be `null`.
 
-The keyword `void` means that there is no return value. It is not a return value type. If the WebIDL entry reads `void`, the _Return value_ section in the docs should contain only a simple "None.".
+The keyword `void` means that there is no return value. It is not a return value type. If the WebIDL entry reads `void`, the _Return value_ section in the docs should simply contain a sentence "None (\{{jsxref("undefined")}}).".
 
 ### Throwing exceptions
 
@@ -368,7 +368,7 @@ The keyword `void` means that there is no return value. It is not a return value
 
 Some methods can throw exceptions. This is marked using the `[Throws]` annotation. When this happens, the Syntax section of the method page _must_ have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.
 
-Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://heycam.github.io/webidl/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{jsxref('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.
+Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://webidl.spec.whatwg.org/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{jsxref('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.
 
 Have a look at one of these [_Exceptions_ sections](/en-US/docs/Web/API/SubtleCrypto/importKey#exceptions).
 
@@ -382,7 +382,7 @@ For the documentation, the sub-page must contain a sentence indicating if it is 
 
 > **Note:** this information is specific to Gecko and should only be used in the Browser compatibility section.
 
-In Gecko, the availability of some properties may be controlled by a preference. This is marked in the WebIDL too.
+In Gecko, the availability of some methods may be controlled by a preference. This is marked in the WebIDL too.
 
 ```webidl
 [Pref="media.webvtt.enabled"]
@@ -437,14 +437,15 @@ The iterator will iterate over values of type _valueType_. The generated methods
 - `entries()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the indexes (that are `unsigned long`).
 - `values()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values.
 - `keys()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys, that are its indexes (that are `unsigned long`). In the case of value iterators, `keys()` and `entries()` are identical.
-- `forEach()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys that calls a given callback function one for each entry in the list.
+- `forEach()`, which generates an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values, and then calls a given callback function one for each entry in the list.
 
 Such an iterator allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`. We add a sentence about it in the interface description.
 
-> **Note:** the value pairs to iterate over can be defined in two different ways:
+> **Note:** the value pairs to iterate over can be defined in three different ways:
 >
-> 1. Outside the webidl file, in the prose accompanying it. Such a prose is in the spec and usually starts with: _"The [values to iterate over](https://heycam.github.io/webidl/#dfn-values-to-iterate-over)…"_.
+> 1. In the webidl file, use the `iterable<valueType>` notation. E.g. {{domxref('DOMTokenList')}}.
 > 2. In the webidl file, implicitly, if the interface supports indexed properties, that is when the interface has a `getter` methods with a parameter of type `unsigned long`.
+> 3. Outside the webidl file, in the prose accompanying it. Such a prose is in the spec and usually starts with: _"The [values to iterate over](https://webidl.spec.whatwg.org/#dfn-value-iterator)…"_.
 
 #### Pair iterator
 
@@ -452,18 +453,19 @@ Such an iterator allows to use the syntax `for (const p in object)` as a shortha
 iterable<keyType, valueType>
 ```
 
-The iterator will iterate over values of type _valueType_, with keys of type _keyType_. The generated methods will be:
+The iterator will iterate over values of type _valueType_ with keys of type _keyType_, that is the value pairs. The generated methods will be:
 
-- `entries()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the indexes (of type _keyType_). E.g. {{domxref('FormData.entries()')}}
+- `entries()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the value pairs. E.g. {{domxref('FormData.entries()')}}
 - `values()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values. E.g. {{domxref('FormData.values()')}}
 - `keys()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys. E.g. {{domxref('FormData.keys()')}}
-- Once [Firefox bug 1216751](https://bugzil.la/1216751) lands, `forEach()`.
+- `forEach()` that generates an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the value pairs, and then calls a given callback function one for each entry in the list. E.g. {{domxref('Headers.forEach()')}}
 
 Such an iterator allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`. We add a sentence about it in the interface description. E.g. {{domxref('FormData')}}.
 
-> **Note:** the value pairs to iterate over are _not_ defined in the webidl file, but in the prose accompanying it. Such a prose is in the spec and usually starts with: _"The [value pairs to iterate over](https://heycam.github.io/webidl/#dfn-value-pairs-to-iterate-over)…"_
+> **Note:** the value pairs to iterate over can be defined in two different ways:
 >
-> E.g, for {{domxref('FormData')}} you find in the spec: _"The [value pairs to iterate over](https://heycam.github.io/webidl/#dfn-value-pairs-to-iterate-over) are the [entries](https://xhr.spec.whatwg.org/#concept-formdata-entry) with the key being the [name](https://xhr.spec.whatwg.org/#concept-formdata-entry-name) and the value the [value](https://xhr.spec.whatwg.org/#concept-formdata-entry-value). "_
+> 1. In the webidl file, use the `iterable<keyType, valueType>` notation. E.g. {{domxref('FormData')}}.
+> 2. Outside the webidl file, in the prose accompanying it. Such a prose is in the spec and usually has a sentence like this: _"The [value pairs to iterate over](https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over) are the list of value pairs with the [key](https://webidl.spec.whatwg.org/#value-pair-key) bein...and the [value](https://webidl.spec.whatwg.org/#value-pair-value) being..."_.
 
 ### Set-like methods
 

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -355,9 +355,9 @@ The parameters of a method are listed in the Syntax section of the method sub-pa
 DOMString canPlayType(DOMString type);
 ```
 
-The return value type is indicated before the method name — in the above case the value is an object of type `DOMString`. If followed by a question mark (`'?'`), a value of `null` can be returned too, and the documentation must explain _when_ this may happen. If no question mark is present, like here, the return value can't be `null`.
+The return value type is indicated before the method name — in the above case the value is an object of type `DOMString`. If the return type is followed by a question mark (`'?'`), a value of `null` can be returned too, and the documentation must explain _when_ this may happen. If no question mark is present, like here, the return value can't be `null`.
 
-The keyword `void` means that there is no return value. It is not a return value type. If the WebIDL entry reads `void`, the _Return value_ section in the docs should simply contain a sentence "None (\{{jsxref("undefined")}}).".
+If the return value is the `void` keyword, it means that there is no return value. It is not a return value type. If the WebIDL entry reads `void`, the _Return value_ section in the docs should simply state "None (\{{jsxref("undefined")}}).".
 
 ### Throwing exceptions
 
@@ -437,15 +437,15 @@ The iterator will iterate over values of type _valueType_. The generated methods
 - `entries()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the indexes (that are `unsigned long`).
 - `values()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values.
 - `keys()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys, that are its indexes (that are `unsigned long`). In the case of value iterators, `keys()` and `entries()` are identical.
-- `forEach()`, which generates an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values, and then calls a given callback function one for each entry in the list.
+- `forEach()`, which executes a given callback function once for each entry in the list.
 
 Such an iterator allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`. We add a sentence about it in the interface description.
 
-> **Note:** the value pairs to iterate over can be defined in three different ways:
->
-> 1. In the webidl file, use the `iterable<valueType>` notation. E.g. {{domxref('DOMTokenList')}}.
-> 2. In the webidl file, implicitly, if the interface supports indexed properties, that is when the interface has a `getter` methods with a parameter of type `unsigned long`.
-> 3. Outside the webidl file, in the prose accompanying it. Such a prose is in the spec and usually starts with: _"The [values to iterate over](https://webidl.spec.whatwg.org/#dfn-value-iterator)…"_.
+The values to iterate over can be defined in one of the following ways:
+
+- In the WebIDL file, using the `iterable<valueType>` notation. For example, see {{domxref('DOMTokenList')}}.
+- Implicitly in the WebIDL file, if the interface supports indexed properties. This is indicated when the interface includes `getter` methods with a parameter of type `unsigned long`.
+- Outside the WebIDL file, in the accompanying prose. Such a prose is typically found in the specification and usually starts with: _"The [values to iterate over](https://webidl.spec.whatwg.org/#dfn-value-iterator)…"_.
 
 #### Pair iterator
 
@@ -455,17 +455,17 @@ iterable<keyType, valueType>
 
 The iterator will iterate over values of type _valueType_ with keys of type _keyType_, that is the value pairs. The generated methods will be:
 
-- `entries()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the value pairs. E.g. {{domxref('FormData.entries()')}}
-- `values()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values. E.g. {{domxref('FormData.values()')}}
-- `keys()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys. E.g. {{domxref('FormData.keys()')}}
-- `forEach()` that generates an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the value pairs, and then calls a given callback function one for each entry in the list. E.g. {{domxref('Headers.forEach()')}}
+- `entries()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the value pairs. For example, see {{domxref('FormData.entries()')}}.
+- `values()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values. For example, see {{domxref('FormData.values()')}}.
+- `keys()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys. For example, see {{domxref('FormData.keys()')}}.
+- `forEach()`, which executes a given callback function once for each entry in the list. For example, see {{domxref('Headers.forEach()')}}.
 
 Such an iterator allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`. We add a sentence about it in the interface description. E.g. {{domxref('FormData')}}.
 
-> **Note:** the value pairs to iterate over can be defined in two different ways:
->
-> 1. In the webidl file, use the `iterable<keyType, valueType>` notation. E.g. {{domxref('FormData')}}.
-> 2. Outside the webidl file, in the prose accompanying it. Such a prose is in the spec and usually has a sentence like this: _"The [value pairs to iterate over](https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over) are the list of value pairs with the [key](https://webidl.spec.whatwg.org/#value-pair-key) bein...and the [value](https://webidl.spec.whatwg.org/#value-pair-value) being..."_.
+The value pairs to iterate over can be defined in one of the following ways:
+
+- In the WebIDL file, using the `iterable<keyType, valueType>` notation. For example, see {{domxref('FormData')}}.
+- Outside the WebIDL file, in the accompanying prose. Such a prose is typically found in the specification and usually starts with: _"The [value pairs to iterate over](https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over)…"_.
 
 ### Set-like methods
 
@@ -477,10 +477,10 @@ setlike<valueType>
 
 The generated properties will be:
 
-- `entries()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the indexes. E.g. {{domxref('NodeList.entries()')}}.
-- `values()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values. E.g. {{domxref('NodeList.values()')}}.
-- `keys()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys. E.g. {{domxref('NodeList.keys()')}},
-- `forEach()`.
+- `entries()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the indexes. For example, see {{domxref('NodeList.entries()')}}.
+- `values()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the values. For example, see {{domxref('NodeList.values()')}}.
+- `keys()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys. For example, see {{domxref('NodeList.keys()')}}.
+- `forEach()`, which executes a given callback function once for each entry in the list. For example, see {{domxref('NodeList.forEach()')}}.
 
 In cases where the set-like declaration is not prefixed by read-only, the following methods are also generated:
 


### PR DESCRIPTION
### Description

fix broken links and update the description of iterators.

In WebIDL, some iterators have been marked using `iterator<>` notation.
