### PR TITLE
Notification | fix apiref & update exception sections & add missing optional_inline

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.notificationclick_event
 ---
 
-{{APIRef}}
+{{APIRef("Web Notifications")}}
 
 The **`notificationclick`** event is fired to indicate that a system notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}} has been clicked.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.notificationclose_event
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Web Notifications")}}
 
 The **`notificationclose`** event fires when a user closes a displayed notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}}.
 

--- a/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerRegistration.getNotifications
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Web Notifications")}}
 
 The **`getNotifications()`** method of
 the {{domxref("ServiceWorkerRegistration")}} interface returns a list of the

--- a/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
@@ -30,7 +30,7 @@ getNotifications(options)
   - : An object containing options to filter the notifications returned. The available
     options are:
 
-    - `tag`
+    - `tag` {{optional_inline}}
       - : A string representing a notification tag. If
         specified, only notifications that have this tag will be returned.
 

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -30,7 +30,7 @@ showNotification(title, options)
   - : An object that allows configuring the notification. It can have the following
     properties:
 
-    - `actions` {{experimental_inline}}
+    - `actions` {{optional_inline}} {{experimental_inline}}
 
       - : An array of actions to display in the notification. Each element in the array is an object with the following members:
 
@@ -44,51 +44,51 @@ showNotification(title, options)
         Appropriate responses are built using `event.action` within the
         {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.
 
-    - `badge` {{experimental_inline}}
+    - `badge` {{optional_inline}} {{experimental_inline}}
       - : a string containing the URL of an image
         to represent the notification when there is not enough space to display the
         notification itself such as for example, the Android Notification Bar. On Android
         devices, the badge should accommodate devices up to 4x resolution, about 96 by 96
         px, and the image will be automatically masked.
-    - `body`
+    - `body` {{optional_inline}}
       - : A string representing an extra content to display within the
         notification.
-    - `data` {{experimental_inline}}
+    - `data` {{optional_inline}} {{experimental_inline}}
       - : Arbitrary data that you want to be associated with the
         notification. This can be of any data type.
-    - `dir`
+    - `dir` {{optional_inline}}
       - : The direction of the notification; it can be `auto`, `ltr` or `rtl`.
-    - `icon`
+    - `icon` {{optional_inline}}
       - : a string containing the URL of an image to
         be used as an icon by the notification.
-    - `image` {{experimental_inline}}
+    - `image` {{optional_inline}} {{experimental_inline}}
       - : a string containing the URL of an image to
         be displayed in the notification.
-    - `lang`
+    - `lang` {{optional_inline}}
       - : Specify the lang used within the notification. This string
         must be a valid language tag according to
         {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
-    - `renotify` {{experimental_inline}}
+    - `renotify` {{optional_inline}} {{experimental_inline}}
       - : A boolean that indicates whether to suppress vibrations
         and audible alerts when reusing a `tag` value.
         If _options_'s `renotify` is true
         and _options_'s `tag` is the empty string a TypeError will be
         thrown. The default is `false`.
-    - `requireInteraction` {{experimental_inline}}
+    - `requireInteraction` {{optional_inline}} {{experimental_inline}}
       - : Indicates that on devices with sufficiently
         large screens, a notification should remain active until the user clicks or
         dismisses it. If this value is absent or false, the desktop version of Chrome will
         auto-minimize notifications after approximately twenty seconds. The default value
         is `false`.
-    - `silent`
+    - `silent` {{optional_inline}}
       - : When set indicates that no sounds or vibrations should be
         made. If _options_'s `silent` is true
         and _options_'s `vibrate` is present a TypeError exception
         will be thrown. The default value is `false`.
-    - `tag`
+    - `tag` {{optional_inline}}
       - : An ID for a given notification that allows you to find,
         replace, or remove the notification using a script if necessary.
-    - `timestamp`
+    - `timestamp` {{optional_inline}}
       - : A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, representing the time associated with the notification. This could be in the past when a notification is used for a message that couldn't immediately be delivered because the device was offline, or in the future for a meeting that is about to start.
     - `vibrate` {{experimental_inline}}
       - : A vibration pattern to run with the display of the

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ServiceWorkerRegistration.showNotification
 
 {{APIRef("Web Notifications")}}
 
-The `showNotification()` method of the
+The **`showNotification()`** method of the
 {{domxref("ServiceWorkerRegistration")}} interface creates a notification on an active
 service worker.
 
@@ -89,8 +89,8 @@ showNotification(title, options)
       - : An ID for a given notification that allows you to find,
         replace, or remove the notification using a script if necessary.
     - `timestamp` {{optional_inline}}
-      - : A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, representing the time associated with the notification. This could be in the past when a notification is used for a message that couldn't immediately be delivered because the device was offline, or in the future for a meeting that is about to start.
-    - `vibrate` {{experimental_inline}}
+      - : A timestamp, given as {{glossary("Unix time")}} in milliseconds, representing the time associated with the notification. This could be in the past when a notification is used for a message that couldn't immediately be delivered because the device was offline, or in the future for a meeting that is about to start.
+    - `vibrate` {{optional_inline}} {{experimental_inline}}
       - : A vibration pattern to run with the display of the
         notification. A vibration pattern can be an array with as few as one member. The
         values are times in milliseconds where the even indices (0, 2, 4, etc.) indicate

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -102,6 +102,11 @@ showNotification(title, options)
 
 A {{jsxref('Promise')}} that resolves to `undefined`.
 
+### Exceptions
+
+- `TypeError`
+  - : Thrown if current service worker's state is not `activating` or `activated`, or if the user has explicitly denied the browser's permission request to use the API.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerRegistration.showNotification
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Web Notifications")}}
 
 The `showNotification()` method of the
 {{domxref("ServiceWorkerRegistration")}} interface creates a notification on an active


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

update exception sections of `ServiceWorkerRegistration.showNotification()`

add necessary {{optional_inline}} tag to `ServiceWorkerRegistration.showNotification()` and `ServiceWorkerRegistration.getNotifications()`

fix apiref in extensions to service worker api of notification api

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
