### PR TITLE
fix HTML <image> reference to <img> in Sec-Fetch-Dest docs

### DIFF
--- a/files/en-us/web/http/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.md
@@ -79,7 +79,7 @@ Servers should ignore this header if it contains any other value.
 - `iframe`
   - : The destination is an iframe. This might originate from an HTML {{HTMLElement("iframe")}} tag.
 - `image`
-  - : The destination is an image. This might originate from an HTML {{HTMLElement("image")}}, SVG {{SVGElement("image")}}, CSS {{cssxref("background-image")}}, CSS {{cssxref("cursor")}}, CSS {{cssxref("list-style-image")}}, etc.
+  - : The destination is an image. This might originate from an HTML {{HTMLElement("img")}}, SVG {{SVGElement("image")}}, CSS {{cssxref("background-image")}}, CSS {{cssxref("cursor")}}, CSS {{cssxref("list-style-image")}}, etc.
 - `manifest`
   - : The destination is a manifest. This might originate from an HTML [\<link rel=manifest>](/en-US/docs/Web/HTML/Attributes/rel/manifest).
 - `object`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `Sec-Fetch-Dest: image` header value refers (I assume erroneously) to the `<image>` HTML element rather than the `<img>` element.

### Motivation

Currently clicking this links brings you to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/image for the deprecated `<image>` tag, which is unhelpful.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
