### PR TITLE
Fix links to table's insertCell() and insertRow() methods

### DIFF
--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -21,7 +21,7 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 - Support for the `WeakMap.prototype.clear()` method, recently added to the Harmony (ECMAScript 2015) draft proposal has been added ([Firefox bug 814562](https://bugzil.la/814562)).
 - Support for the [`Math.imul()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul) method, a C-style 32-bit multiplication function. Though proposed for Harmony (ECMAScript 2015) it has not yet been accepted and still is non-standard ([Firefox bug 808148](https://bugzil.la/808148)).
 - Web apps using draggable text with Kinetic 3.x are working, even when using the Cairo canvas backend ([Firefox bug 835064](https://bugzil.la/835064)).
-- The [`for each...in`](/en-US/docs/JavaScript/Reference/Statements/for_each...in) statement has been deprecated and should not be used. Consider using the new [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) statement ([Firefox bug 804834](https://bugzil.la/804834)).
+- The [`for each...in`](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#statements_2) statement has been deprecated and should not be used. Consider using the new [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) statement ([Firefox bug 804834](https://bugzil.la/804834)).
 - Support for the {{jsxref("Map.prototype.keys()")}}, {{jsxref("Map.prototype.values()")}}, and {{jsxref("Map.prototype.entries()")}} has been added ([Firefox bug 817368](https://bugzil.la/817368)).
 
 ### CSS

--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -19,22 +19,22 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 ### JavaScript
 
 - Support for the `WeakMap.prototype.clear()` method, recently added to the Harmony (ECMAScript 2015) draft proposal has been added ([Firefox bug 814562](https://bugzil.la/814562)).
-- Support for the [`Math.imul()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul) method, a C-style 32-bit multiplication function. Though proposed for Harmony (ECMAScript 2015) it has not yet accepted and still is non-standard ([Firefox bug 808148](https://bugzil.la/808148)).
+- Support for the [`Math.imul()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul) method, a C-style 32-bit multiplication function. Though proposed for Harmony (ECMAScript 2015) it has not yet been accepted and still is non-standard ([Firefox bug 808148](https://bugzil.la/808148)).
 - Web apps using draggable text with Kinetic 3.x are working, even when using the Cairo canvas backend ([Firefox bug 835064](https://bugzil.la/835064)).
 - The [`for each...in`](/en-US/docs/JavaScript/Reference/Statements/for_each...in) statement has been deprecated and should not be used. Consider using the new [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) statement ([Firefox bug 804834](https://bugzil.la/804834)).
 - Support for the {{jsxref("Map.prototype.keys()")}}, {{jsxref("Map.prototype.values()")}}, and {{jsxref("Map.prototype.entries()")}} has been added ([Firefox bug 817368](https://bugzil.la/817368)).
 
 ### CSS
 
-- [CSS Flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox) is now available by default in pre-release builds only (excluding beta versions). It can be enabled in release and beta version by setting the `layout.css.flexbox.enabled` about:config preference to `true`.
+- [CSS Flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox) is now available by default in pre-release builds only (excluding beta versions). It can be enabled in release and beta versions by setting the `layout.css.flexbox.enabled` about:config preference to `true`.
 - The `mask-type` property from the [CSS Masking specification](https://www.w3.org/TR/css-masking-1/#the-mask-type) has been added ([Firefox bug 793617](https://bugzil.la/793617)).
-- Experimental support for the {{cssxref(":scope")}} pseudo-class has been added. Enabled by default in Aurora and Nightly, it can be enabled in release and beta version by setting the `layout.css.scope-pseudo.enabled` about:config preference to `true` ([Firefox bug 648722](https://bugzil.la/648722)).
+- Experimental support for the {{cssxref(":scope")}} pseudo-class has been added. Enabled by default in Aurora and Nightly, it can be enabled in release and beta versions by setting the `layout.css.scope-pseudo.enabled` about:config preference to `true` ([Firefox bug 648722](https://bugzil.la/648722)).
 
 ### DOM/APIs
 
 - {{domxref("HTMLMediaElement")}} supports now `playbackRate` (both read and write), with pitch correction. Pitch correction can be controlled using the property `mozPreservesPitch` ([Firefox bug 495040](https://bugzil.la/495040)).
 - CSSOM: Support for the new {{domxref("CSSGroupingRule")}} and {{domxref("CSSConditionRule")}} has been added ([Firefox bug 814907](https://bugzil.la/814907)).
-- CSSOM: On {{domxref("CSSRule")}} the constant CSSRule.MOZ_KEYFRAME_RULE and CSSRule.MOZ_KEYFRAMES_RULE have been unprefixed to CSSRule.KEYFRAME_RULE and CSSRule.KEYFRAMES_RULE. The prefixed version are temporarily kept for helping Web author to transition their code [Firefox bug 816431](https://bugzil.la/816431)).
+- CSSOM: On {{domxref("CSSRule")}} the constant CSSRule.MOZ_KEYFRAME_RULE and CSSRule.MOZ_KEYFRAMES_RULE have been unprefixed to CSSRule.KEYFRAME_RULE and CSSRule.KEYFRAMES_RULE. The prefixed version is temporarily kept for helping Web author to transition their code [Firefox bug 816431](https://bugzil.la/816431)).
 - CSSOM: It is now possible to set the value of `conditionText` for {{domxref("CSSMediaRule")}} ([Firefox bug 815021](https://bugzil.la/815021)).
 - The {{domxref("DOMParser")}} `parseFromStream` and `parseFromBuffer` methods are no longer available from web content ([Firefox bug 816410](https://bugzil.la/816410)).
 - The [`XMLSerializer`](/en-US/docs/Web/API/XMLSerializer) `serializeToStream` method is no longer available from web content ([Firefox bug 816410](https://bugzil.la/816410)).
@@ -42,10 +42,10 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 - Support for the `CSS.supports()` method has been added, behind the `layout.css.supports-rule.enabled` pref (off by default) ([Firefox bug 779917](https://bugzil.la/779917)).
 - Support for UndoManager has been added ([Firefox bug 617532](https://bugzil.la/617532)).
 - The CSSOM {{domxref("Document.caretPositionFromPoint()")}} method, which returns a {{domxref("CaretPosition")}} has been implemented.
-- The index argument of the {{domxref("tableRow.insertCell")}} and {{domxref("table.insertRow")}} methods has been made optional as per HTML specification.
+- The index argument of the {{domxref("HTMLTableRowElement.insertCell()")}} and {{domxref("HTMLTableElement.insertRow()")}} methods has been made optional as per HTML specification.
 - {{domxref("Navigator.getUserMedia")}}, still prefixed as `Navigator.mozGetUserMedia` is now activated by default.
-- The third, optional, `transfer` argument of {{domxref("Window.postMessage")}} is now supported. It allows to transfer a sequence of {{domxref("Transferable")}} objects to the destination ([Firefox bug 822094](https://bugzil.la/822094)).
-- The non-standard {{domxref("Window.sizeToContent()")}} method now clamps the minimal size: the window cannot be forced anymore to small sizes preventing the user to interact with ([Firefox bug 764240](https://bugzil.la/764240)).
+- The third, optional, `transfer` argument of {{domxref("Window.postMessage")}} is now supported. It allows to transfer a sequence of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to the destination ([Firefox bug 822094](https://bugzil.la/822094)).
+- The non-standard {{domxref("Window.sizeToContent()")}} method now clamps the minimal size: the window cannot be forced anymore to small sizes preventing the user from interacting with ([Firefox bug 764240](https://bugzil.la/764240)).
 - Blend modes, such as `overlay`, `color-burn`, `hue`, etc. have been added to the Canvas {{domxref("CanvasRenderingContext2D.globalCompositeOperation")}} property ([Firefox bug 748433](https://bugzil.la/748433)).
 - The prefixed version of [`window.indexedDB`](/en-US/docs/Web/API/indexedDB) — `window.mozIndexedDB` — was reintroduced to Gecko, so that bad cross-browser prefixing code (such as `var indexedDB = window.indexedDB || window.webkitIndexedDB …`) doesn't break in Firefox. A better approach is `window.indexedDB = window.indexedDB || window.webkitIndexedDB …` (see [Firefox bug 770844](https://bugzil.la/770844).)
 
@@ -55,7 +55,7 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 
 ### MathML
 
-- To help MathML authors debugging "invalid-markup" errors in their documents, MathML parsing errors (such as having too many / too few child elements) and warnings about deprecated attributes or wrong attribute values are now reported to the [Error Console](/en-US/docs/Error_Console).
+- To help MathML authors debugging "invalid-markup" errors in their documents, MathML parsing errors (such as having too many / too few child elements) and warnings about deprecated attributes or wrong attribute values are now reported to the error console.
 - The `scriptminsize` attribute now accepts unitless values and percent values. They are interpreted as multiples of the default value ("`8pt`").
 - Unitless values are now also allowed for the `mathsize` and `fontsize` attributes; they multiply the default value.
 


### PR DESCRIPTION
Both links (+ transferable) were broken, though the pages do exist.

(+ minor grammar fixes)