### PR TITLE
Remove link to CanvasRendringContext2D.drawSystemFocusRing()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/28/index.md
+++ b/files/en-us/mozilla/firefox/releases/28/index.md
@@ -39,7 +39,7 @@ More details in [this post](https://hacks.mozilla.org/2013/12/split-console-pret
 
 ### JavaScript
 
-- [ECMAScript 2015](/en-US/docs/Web/JavaScript/ECMAScript_6_support_in_Mozilla) implementation continues:
+- ECMAScript 2015 implementation continues:
 
   - New `Array` methods have been implemented: {{jsxref("Array.prototype.entries()")}} and {{jsxref("Array.prototype.keys()")}} ([Firefox bug 894658](https://bugzil.la/894658)).
 
@@ -53,7 +53,7 @@ More details in [this post](https://hacks.mozilla.org/2013/12/split-console-pret
 - The {{domxref("File")}} constructor, e.g. `new File(["foo"], "foo.txt")` has been implemented. ([Firefox bug 819900](https://bugzil.la/819900)).
 - The {{domxref("Navigator.plugins")}} is no more enumerable, for privacy reasons ([Firefox bug 757726](https://bugzil.la/757726)).
 - The two attributes {{domxref("Window.screenX")}} and {{domxref("Window.screenY")}} now return CSS pixels (and no more device pixels) ([Firefox bug 943668](https://bugzil.la/943668)).
-- The two methods {{domxref("CanvasRenderingContext2D.drawSystemFocusRing()")}} and {{domxref("CanvasRenderingContext2D/drawFocusIfNeeded", "CanvasRenderingContext2D.drawCustomFocusRing()")}} have been implemented. The preference `canvas.focusring.enabled` must be set to `true` to activate both ([Firefox bug 540456](https://bugzil.la/540456)).
+- The two methods `CanvasRenderingContext2D.drawSystemFocusRing()` and {{domxref("CanvasRenderingContext2D/drawFocusIfNeeded", "CanvasRenderingContext2D.drawCustomFocusRing()")}} have been implemented. The preference `canvas.focusring.enabled` must be set to `true` to activate both ([Firefox bug 540456](https://bugzil.la/540456)).
 - The `willReadFrequently` context attribute for "`2d`" canvas contexts has been implemented (see {{domxref("HTMLCanvasElement.getContext()")}}) ([Firefox bug 884226](https://bugzil.la/884226)).
 - The following attributes and methods of `NavigatorID` have been implemented on {{domxref("WorkerNavigator")}} to allow their use in workers: {{domxref("Navigator.appCodeName")}}, {{domxref("Navigator.product")}}, and {{domxref("Navigator.taintEnabled")}} ([Firefox bug 925847](https://bugzil.la/925847)).
 - The {{domxref("Element/previousElementSibling", "previousElementSibling")}} and {{domxref("Element/nextElementSibling", "nextElementSibling")}} properties has been removed from {{domxref("DocumentType")}}, because of compatibility problems ([Firefox bug 932501](https://bugzil.la/932501)).
@@ -75,9 +75,9 @@ _No change._
 
 - Support of `SPDY/2` has been removed.
 
-## Changes for addon and Mozilla developers
+## Changes for add-ons and Mozilla developers
 
-- The interface of [DeferredTask.jsm](/en-US/docs/Mozilla/JavaScript_code_modules/DeferredTask.jsm) has been changed, and the `isPending()`, `start()`, `flush()`, and `cancel()` methods have been removed ([Firefox bug 940408](https://bugzil.la/940408)).
+- The interface of `DeferredTask.jsm` has been changed, and the `isPending()`, `start()`, `flush()`, and `cancel()` methods have been removed ([Firefox bug 940408](https://bugzil.la/940408)).
 
 ## Security
 


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1120371 (5 years ago) 

> This feature was removed from the spec years ago. Support from it was removed from other browsers then too. We never pref'd it on either. The original implementer of the feature is also long gone. It was also suggested years ago that we remove this. The tests are already skipped on most platforms except Linux. Let's just nuke this from orbit already so we can resolve the intermittent in [bug 1005846](https://bugzilla.mozilla.org/show_bug.cgi?id=1005846) from these obsolete tests.