### PR TITLE
Harmonize the usage of `<section>` in document

### DIFF
--- a/files/en-us/web/css/grid-template-areas/index.md
+++ b/files/en-us/web/css/grid-template-areas/index.md
@@ -55,12 +55,12 @@ grid-template-areas: unset;
 #### HTML
 
 ```html
-<section id="page">
+<div id="page">
   <header>Header</header>
   <nav>Navigation</nav>
   <main>Main area</main>
   <footer>Footer</footer>
-</section>
+</div>
 ```
 
 #### CSS

--- a/files/en-us/web/css/grid-template/index.md
+++ b/files/en-us/web/css/grid-template/index.md
@@ -115,12 +115,12 @@ footer {
 #### HTML
 
 ```html
-<section id="page">
+<div id="page">
   <header>Header</header>
   <nav>Navigation</nav>
   <main>Main area</main>
   <footer>Footer</footer>
-</section>
+</div>
 ```
 
 #### Result


### PR DESCRIPTION
### Description

Replace `<section>` to `<div>` somewhere in the documentation related to grid layouts.

### Motivation

These places should not semantically use `<section>`.
I think it should be standardized in the one document, though it's not necessary to make this distinction in modern frontend.

Here are some quotes on why `<section>` is not appropriate in these two code snippet examples:

> main content: \<main\>, with various content subsections represented by \<article\>, \<section\>, and \<div\> elements.

In the [MDN Document_and_website_structure](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure#html_for_structuring_content)

> \<section\> is similar to \<article\>, but it is more for grouping together a single part of the page that constitutes one single piece of functionality (e.g., a mini map, or a set of article headlines and summaries), or a theme. It's considered best practice to begin each section with a heading; also note that you can break \<article\>s up into different \<section\>s, or \<section\>s up into different \<article\>s, depending on the context.

In the [MDN Document_and_website_structure](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Document_and_website_structure#html_layout_elements_in_more_detail)

> Sectioning content, a subset of flow content, creates a section in the current outline defining the scope of \<header\> elements, \<footer\> elements, and heading content.
>
> Elements belonging to this category are \<article\>, \<aside\>, \<nav\>, and \<section\>.

In the [MDN Content_categories](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#sectioning_content).

> If you are only using the element as a styling wrapper, use a `div` instead.

In the [MDN section](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section#usage_notes).