### PR TITLE
Fix hex value of DOM_VK_DOUBLE_QUOTE

### DIFF
--- a/files/en-us/web/api/keyboardevent/keycode/index.md
+++ b/files/en-us/web/api/keyboardevent/keycode/index.md
@@ -2971,7 +2971,7 @@ Gecko defines a lot of `keyCode` values in `KeyboardEvent` for making the mappin
     </tr>
     <tr>
       <td><code>DOM_VK_DOUBLE_QUOTE</code></td>
-      <td>0xA3 (162)</td>
+      <td>0xA2 (162)</td>
       <td>Double quote (""") key.</td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Off by one in the HEX value. See https://github.com/mozilla/gecko-dev/blob/f961e5f2a22f4d41733545190892296e64c06858/dom/webidl/KeyEvent.webidl#L166.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
