### PR TITLE
Minor clarification

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -36,7 +36,7 @@ The object that was passed to the function, with the specified property added or
 
 Property descriptors present in objects come in two main flavors: data descriptors and accessor descriptors. A **data descriptor** is a property with a value that may or may not be writable. An **accessor descriptor** is a property described by a getter-setter pair of functions. A descriptor must be one of these two flavors; it cannot be both.
 
-Both data and accessor descriptors are objects. They share the following optional keys (please note: the **defaults** mentioned here are in the case of defining properties using `Object.defineProperty()`):
+Both data and accessor descriptors are objects. They share the following optional keys (please note: the **defaults** mentioned here are in the case of defining properties using `Object.defineProperty()`, not when defining using simple assignment, and not when modifying an existing property):
 
 - `configurable`
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

An average reader wouldn't pay attention that the word "*defining*" here means a **new** property, as opposed to "*defining or modifiying*".

### Additional details

```
const object1 = {};

object1.property1 = 10;

Object.defineProperty(object1, 'property1', {
  value: 200,
});

// defaults didn't apply when defineProperty was used to modify

console.log(Object.getOwnPropertyDescriptor(object1,"property1").writable);     // true
console.log(Object.getOwnPropertyDescriptor(object1,"property1").configurable); // true
console.log(Object.getOwnPropertyDescriptor(object1,"property1").enumerable);   // true

```
