### PR TITLE
remove the documentation of "Read-Only" tag

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -229,7 +229,6 @@ If the keyword `readonly` is present, the property can't be modified. It must be
 
 - In the interface, by adding the \\{{ReadOnlyInline}} macro next to its definition term.
 - In the first sentence of its own page, by starting the description with: _The read-only **`HTMLMediaElement.error`** property…_
-- By adding the `Read-only` tag to its own page.
 - By starting its description in the interface page with _Returns…_
 
 > **Note:** Only read-only properties can be described as 'returning' a value. Non read-only properties can also be used to set a value.


### PR DESCRIPTION
### Description

We no longer use the `Read-only` tag.
