### PR TITLE
bookmark api: add missing parameters in example code

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -12,7 +12,7 @@ Fired when a bookmark item (a bookmark or a folder) is created.
 ## Syntax
 
 ```js-nolint
-browser.bookmarks.onCreated.addListener()
+browser.bookmarks.onCreated.addListener(listener)
 browser.bookmarks.onCreated.removeListener(listener)
 browser.bookmarks.onCreated.hasListener(listener)
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In [bookmark.onCreated api page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/onCreated), example code misses a parameter which is included in the following part of the document.

### Motivation


### Additional details



### Related issues and pull requests

