### PR TITLE
Inexistent parameter removed from the Example

### DIFF
--- a/files/en-us/web/api/treewalker/filter/index.md
+++ b/files/en-us/web/api/treewalker/filter/index.md
@@ -31,7 +31,6 @@ const treeWalker = document.createTreeWalker(
       return NodeFilter.FILTER_ACCEPT;
     },
   },
-  false,
 );
 nodeFilter = treeWalker.filter; // document.body in this case
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

✍️ The example of creating a `TreeWalker` contains an inexistent parameter.

### Additional details

🔗 https://dom.spec.whatwg.org/#dom-document-createtreewalker

