### PR TITLE
Remove deprecated tota11y from Accessibility Auditing tools

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
@@ -288,7 +288,6 @@ There are a number of auditing tools available that you can feed your web pages 
 
 - [Wave](https://wave.webaim.org/): A rather nice online accessibility testing tool that accepts a web address and returns a useful annotated view of that page with accessibility problems highlighted.
 - [Tenon](https://tenon.io): Another nice online tool that goes through the code at a provided URL and returns results on accessibility errors including metrics, specific errors along with the WCAG criteria they affect, and suggested fixes. It requires a free trial signup to view the results.
-- [tota11y](https://github.com/jdan/tota11y): An accessibility tool from the Khan Academy that takes the form of a JavaScript library that you attach to your page to provide a number of accessibility tools.
 
 Let's look at an example, using Wave.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

When reading the list of Accessibility Auditing tools, I noticed that the [tota11y](https://github.com/jdan/tota11y) project has been deprecated. We should therefore remove it from the list.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To prevent users from being guided to a deprecated project.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

The actual [deprecation notice ](https://github.com/jdan/tota11y?tab=readme-ov-file#deprecation-notice) and [issue that introduced it](https://github.com/jdan/tota11y/issues/200).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
