### PR TITLE
Update index.md: remove redundant 's' letter

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -54,7 +54,7 @@ function safeRedactName(text, name) {
 const report =
   "A hacker called ha.*er used special characters in their name to breach the system.";
 
-console.log(unsafeRedactName(report, "ha.*er")); // "A [REDACTED]s in their name to breach the system."
+console.log(unsafeRedactName(report, "ha.*er")); // "A [REDACTED] in their name to breach the system."
 console.log(safeRedactName(report, "ha.*er")); // "A hacker called [REDACTED] used special characters in their name to breach the system."
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes a grammatical error in the comment for the `unsafeRedactName` function. Removed the redundant "s" at the end of "[REDACTED]s."

### Motivation

The correction improves the accuracy and clarity of the comment, ensuring that it is grammatically correct and more understandable for readers.

### Additional details

N/A

### Related issues and pull requests

N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

