### PR TITLE
See also: related elements, attributes, and selectors re: ShadowRoot.host

### DIFF
--- a/files/en-us/web/api/shadowroot/host/index.md
+++ b/files/en-us/web/api/shadowroot/host/index.md
@@ -35,3 +35,10 @@ let hostElem = shadow.host;
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`part`](/en-US/docs/Web/HTML/Global_attributes#part) and [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts) HTML attributes
+- {{HTMLelement("template")}} and {{HTMLElement("slot")}} HTML elements
+- {{CSSXref(":host")}}, {{CSSXref(":host_function", ":host()")}}, and {{CSSXref(":host-context", ":host-context()")}} CSS pseudo-classes
+- {{CSSXref("::part")}} and {{CSSXref("::slotted")}} CSS pseudo-elements

--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -213,6 +213,10 @@ Since `firstClone` is a `DocumentFragment`, only its children are added to `cont
 
 ## See also
 
-- Web components: {{HTMLElement("slot")}} (and historical: `<shadow>`)
+- [`part`](/en-US/docs/Web/HTML/Global_attributes#part) and [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts) HTML attributes
+- {{HTMLElement("slot")}} HTML element
+- {{CSSXref(":host")}}, {{CSSXref(":host_function", ":host()")}}, and {{CSSXref(":host-context", ":host-context()")}} CSS pseudo-classes
+- {{CSSXref("::part")}} and {{CSSXref("::slotted")}} CSS pseudo-elements
+- [`ShadowRoot`]("/en-US/docs/Web/API/ShadowRoot) interface
 - [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
 - [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module


### PR DESCRIPTION
Added a see also section to shadowRoot host.
Included related elements, attributes, and selectors 