### PR TITLE
Show how to access private properties in syntax section

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_properties/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_properties/index.md
@@ -10,7 +10,7 @@ browser-compat:
 
 {{jsSidebar("Classes")}}
 
-**Private properties** are counterparts of the regular class properties which are public, including [class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields), class methods, etc. Private properties get created by using a hash `#` prefix and cannot be legally referenced outside of the class. The privacy encapsulation of these class properties is enforced by JavaScript itself.
+**Private properties** are counterparts of the regular class properties which are public, including [class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields), class methods, etc. Private properties get created by using a hash `#` prefix and cannot be legally referenced outside of the class. The privacy encapsulation of these class properties is enforced by JavaScript itself. The only way to access a private property is via [dot notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#dot_notation), and you can only do so within the class that defines the private property.
 
 Private properties were not native to the language before this syntax existed. In prototypal inheritance, its behavior may be emulated with [`WeakMap`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) objects or [closures](/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
 
@@ -22,8 +22,6 @@ class ClassWithPrivate {
   #privateFieldWithInitializer = 42;
 
   #privateMethod() {
-    this.#privateField = "private string";
-    this.#privateFieldWithInitializer++;
     // …
   }
 
@@ -31,8 +29,6 @@ class ClassWithPrivate {
   static #privateStaticFieldWithInitializer = 42;
 
   static #privateStaticMethod() {
-    ClassWithPrivate.#privateStaticField = "private string";
-    ClassWithPrivate.#privateStaticFieldWithInitializer++;
     // …
   }
 }

--- a/files/en-us/web/javascript/reference/classes/private_properties/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_properties/index.md
@@ -22,6 +22,8 @@ class ClassWithPrivate {
   #privateFieldWithInitializer = 42;
 
   #privateMethod() {
+    this.#privateField = "private string";
+    this.#privateFieldWithInitializer++;
     // …
   }
 
@@ -29,6 +31,8 @@ class ClassWithPrivate {
   static #privateStaticFieldWithInitializer = 42;
 
   static #privateStaticMethod() {
+    ClassWithPrivate.#privateStaticField = "private string";
+    ClassWithPrivate.#privateStaticFieldWithInitializer++;
     // …
   }
 }

--- a/files/en-us/web/javascript/reference/operators/property_accessors/index.md
+++ b/files/en-us/web/javascript/reference/operators/property_accessors/index.md
@@ -16,6 +16,7 @@ browser-compat: javascript.operators.property_accessors
 ```js-nolint
 object.propertyName
 object[expression]
+object.#privateProperty
 ```
 
 ## Description
@@ -66,6 +67,8 @@ If you use a method for a numeric literal, and the numeric literal has no expone
 77.0.toExponential();
 // because 77. === 77.0, no ambiguity
 ```
+
+In addition, [private properties](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties) can only be accessed using dot notation within the class that defines them.
 
 ### Bracket notation
 


### PR DESCRIPTION
- The reader has to scroll 1/4th of the way down this article to see a (valid) example of accessing private properties. I personally visit this page as a refresher, so it saves me time to know how to define *and* use private properties as early as possible. I may not be the intended audience, but I think it would benefit those learning the concept for the first time too: this change gives them enough information to experiment on their own, if that's the way they prefer to learn.
- My biggest concern with my changes is introducing code beyond private property syntax. i.e., `= "private string";` and `++;` have nothing to do with private properties.
- It might be useful to show how to use a static private field within the `#privateMethod`, but I didn't want to change too much at once: I'd want to group all the fields together at the top if I were to show that here.
