### PR TITLE
Add a section on basic interactivity for live examples

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -338,7 +338,7 @@ Unlike [Interactive examples](/en-US/docs/MDN/Writing_guidelines/Page_structures
 If you want those features then you have to implement them yourself.
 
 In most cases emulating a basic console log is sufficient for demonstrating the features of an API.
-If you're allowing users to enter values or modify the UI, it also makes sense to provide a "Reset" button to restore the example to it's original state.
+If you're allowing users to enter values or modify the UI, it also makes sense to provide a "Reset" button to restore the example to its original state.
 
 ### Example live sample with reload and logging
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -365,7 +365,7 @@ The CSS sets the height of the logging element.
 }
 ```
 
-#### HTML
+#### Logging test code
 
 This example is designed to show "how to log", so "what is logged" isn't all that important.
 This is therefore trivially implemented as a button that the user can press to iterate a value.
@@ -373,8 +373,6 @@ This is therefore trivially implemented as a button that the user can press to i
 ```html
 <button id="iterate" type="button">Press me many times</button>
 ```
-
-#### JavaScript
 
 ```js
 const iterateButton = document.querySelector("#iterate");
@@ -439,7 +437,7 @@ Note that the JavaScript above ensures that if it does overflow, addition of new
 }
 ```
 
-#### HTML
+#### Logging test code
 
 This example is designed to show "how to log", so "what is logged" isn't all that important.
 This is therefore trivially implemented as a button that the user can press to iterate a value.
@@ -447,8 +445,6 @@ This is therefore trivially implemented as a button that the user can press to i
 ```html
 <button id="iterate" type="button">Press me many times</button>
 ```
-
-#### JavaScript
 
 ```js
 const iterateButton = document.querySelector("#iterate");

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -427,13 +427,15 @@ As with the previous example we set the content using the `innerText` property a
 
 #### CSS
 
-The CSS adds scrollbars if the element content overflows, and also sets the height of the logging element.
+The CSS adds scrollbars if the element content overflows, sets the height of the logging element, and adds a border.
 Note that the JavaScript above ensures that if it does overflow, addition of new log text will scroll the text into view.
 
 ```css
 #log {
   height: 100px;
   overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
 }
 ```
 
@@ -459,7 +461,7 @@ incrementButton.addEventListener("click", () => {
 
 Press the button to add new log content.
 
-{{EmbedLiveSample("Displaying a log that appends items", "100%", "150px")}}
+{{EmbedLiveSample("Displaying a log that appends items", "100%", "180px")}}
 
 ### Displaying a reset button
 
@@ -495,13 +497,15 @@ reload.addEventListener("click", () => {
 #log {
   height: 100px;
   overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
 }
 ```
 
 ```js hidden
 const logElement = document.querySelector("#log");
 function log(text) {
-  logElement.innerText = `${logElement.innerText}\n${text}`;
+  logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
 }
 
@@ -518,7 +522,7 @@ incrementButton.addEventListener("click", () => {
 Click the "Press me many times" button a number of times.
 Reset the example by pressing the "Reset" button.
 
-{{EmbedLiveSample("Displaying a reset button", "100%", "150px")}}
+{{EmbedLiveSample("Displaying a reset button", "100%", "180px")}}
 
 ## Conventions regarding live samples
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -375,9 +375,9 @@ This is therefore trivially implemented as a button that the user can press to i
 ```
 
 ```js
-const iterateButton = document.querySelector("#iterate");
+const incrementButton = document.querySelector("#increment");
 let incrementValue = 0;
-iterateButton.addEventListener("click", () => {
+incrementButton.addEventListener("click", () => {
   incrementValue++;
   log(`The button has been pressed ${incrementValue} time(s)`);
 });

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -368,7 +368,7 @@ The CSS sets the height of the logging element.
 #### Logging test code
 
 This example is designed to show "how to log", so "what is logged" isn't all that important.
-This is therefore trivially implemented as a button that the user can press to iterate a value.
+This is therefore trivially implemented as a button that the user can press to increment a value.
 
 ```html
 <button id="iterate" type="button">Press me many times</button>
@@ -418,7 +418,7 @@ The function also sets the element `scrollTop` to the `scrollHeight` of the elem
 ```js
 const logElement = document.querySelector("#log");
 function log(text) {
-  logElement.innerText = `${logElement.innerText}\n${text}`;
+  logElement.innerText = `${logElement.innerText}${text}\n`;
   logElement.scrollTop = logElement.scrollHeight;
 }
 ```
@@ -440,16 +440,16 @@ Note that the JavaScript above ensures that if it does overflow, addition of new
 #### Logging test code
 
 This example is designed to show "how to log", so "what is logged" isn't all that important.
-This is therefore trivially implemented as a button that the user can press to iterate a value.
+This is therefore trivially implemented as a button that the user can press to increment a value.
 
 ```html
-<button id="iterate" type="button">Press me many times</button>
+<button id="increment" type="button">Press me many times</button>
 ```
 
 ```js
-const iterateButton = document.querySelector("#iterate");
+const incrementButton = document.querySelector("#iterate");
 let iterValue = 0;
-iterateButton.addEventListener("click", () => {
+incrementButton.addEventListener("click", () => {
   iterValue++;
   log(`The button has been pressed ${iterValue} times`);
 });
@@ -466,15 +466,15 @@ Press the button to add new log content.
 A reset button can be helpful for examples that cannot be restored to their initial state without resetting the page.
 For example, [the `Highlight.priority` "setting priority" example](/en-US/docs/Web/API/Highlight/priority#result_2) needs a reset button, because once you've set either priority the initial state is unavailable.
 
-This example shows how to add a reset button to the [Displaying a log that appends item](#displaying_a_log_that_appends_items) example above.
-Note that the JavaScript and CSS for the logging code are the same as in the previous example, so that code has are hidden.
+This example shows how to add a reset button to the [Displaying a log that appends items](#displaying_a_log_that_appends_items) example above.
+Note that the JavaScript and CSS for the logging code are the same as in the previous example, so that code is hidden.
 
 #### HTML
 
 The HTML for the example now includes a reset button.
 
 ```html
-<button id="iterate" type="button">Press me many times</button>
+<button id="increment" type="button">Press me many times</button>
 <button id="reset" type="button">Reset</button>
 <pre id="log"></pre>
 ```
@@ -505,9 +505,9 @@ function log(text) {
   logElement.scrollTop = logElement.scrollHeight;
 }
 
-const iterateButton = document.querySelector("#iterate");
+const incrementButton = document.querySelector("#iterate");
 let iterValue = 0;
-iterateButton.addEventListener("click", () => {
+incrementButton.addEventListener("click", () => {
   iterValue++;
   log(`The button has been press ${iterValue} times`);
 });

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -376,10 +376,10 @@ This is therefore trivially implemented as a button that the user can press to i
 
 ```js
 const iterateButton = document.querySelector("#iterate");
-let iterValue = 0;
+let incrementValue = 0;
 iterateButton.addEventListener("click", () => {
-  iterValue++;
-  log(`The button has been pressed ${iterValue} times`);
+  incrementValue++;
+  log(`The button has been pressed ${incrementValue} time(s)`);
 });
 ```
 
@@ -447,11 +447,11 @@ This is therefore trivially implemented as a button that the user can press to i
 ```
 
 ```js
-const incrementButton = document.querySelector("#iterate");
-let iterValue = 0;
+const incrementButton = document.querySelector("#increment");
+let incrementValue = 0;
 incrementButton.addEventListener("click", () => {
-  iterValue++;
-  log(`The button has been pressed ${iterValue} times`);
+  incrementValue++;
+  log(`The button has been pressed ${incrementValue} time(s)`);
 });
 ```
 
@@ -505,11 +505,11 @@ function log(text) {
   logElement.scrollTop = logElement.scrollHeight;
 }
 
-const incrementButton = document.querySelector("#iterate");
-let iterValue = 0;
+const incrementButton = document.querySelector("#increment");
+let incrementValue = 0;
 incrementButton.addEventListener("click", () => {
-  iterValue++;
-  log(`The button has been press ${iterValue} times`);
+  incrementValue++;
+  log(`The button has been pressed ${incrementValue} time(s)`);
 });
 ```
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -371,7 +371,7 @@ This example is designed to show "how to log", so "what is logged" isn't all tha
 This is therefore trivially implemented as a button that the user can press to increment a value.
 
 ```html
-<button id="iterate" type="button">Press me many times</button>
+<button id="increment" type="button">Press me many times</button>
 ```
 
 ```js


### PR DESCRIPTION
Interactive examples provide and inbuild "framework" for capturing console logging to a window, and resetting examples to their initial state.

Live examples should ideally do so as well. While it is unusual (?) to want to create your own fully functional code editor in a live example, it is common to want to take user input, and to show a simple result. 

This PR updates the Live example page to provide a simple example of how to create a log and also reset an example. Nothing "fancy" but sufficient for 90% of cases. This falls out of https://github.com/mdn/content/pull/31322#discussion_r1445428901

@wbamberg FYI.
In addition, as a follow up PR this doc could also do with a topic on troubleshooting Live samples. Two common problems are
- Because stuff is run in a frame you can run into Permission Policy issuse
- The runner doesn't always load scripts as you would expect, so sometimes you can get errors because dependencies aren't loaded yet.

I won't do this though. I've found live examples near impossible to debug since they added the new runner. ... and I think guidance on debugging these would be useful.