### PR TITLE
Guide project: move Houdini

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12156,6 +12156,7 @@
 /en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines	/en-US/docs/Web/HTML/Element/Heading_Elements
 /en-US/docs/Web/Guide/HTML/Using_data_attributes	/en-US/docs/Learn/HTML/Howto/Use_data_attributes
 /en-US/docs/Web/Guide/HTML/XHTML	/en-US/docs/Glossary/XHTML
+/en-US/docs/Web/Guide/Houdini	/en-US/docs/Web/API/Houdini
 /en-US/docs/Web/Guide/Index	/en-US/docs/Web/Guide
 /en-US/docs/Web/Guide/Introduction_to_Web_development	/en-US/docs/Learn
 /en-US/docs/Web/Guide/Mobile	/en-US/docs/Learn/CSS/CSS_layout/Responsive_Design
@@ -12335,7 +12336,7 @@
 /en-US/docs/Web/HTTP/X-Frame-Options	/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 /en-US/docs/Web/HTTP/data_URIs	/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 /en-US/docs/Web/HTTP/www_and_non-www_URLs	/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs
-/en-US/docs/Web/Houdini	/en-US/docs/Web/Guide/Houdini
+/en-US/docs/Web/Houdini	/en-US/docs/Web/API/Houdini
 /en-US/docs/Web/Houdini/CSS_Painting_API	/en-US/docs/Web/API/CSS_Painting_API/Guide
 /en-US/docs/Web/Houdini/CSS_Typed_OM	/en-US/docs/Web/API/CSS_Typed_OM_API
 /en-US/docs/Web/Houdini/Learn/CSS_Painting_API	/en-US/docs/Web/API/CSS_Painting_API/Guide

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -42344,6 +42344,18 @@
     "modified": "2019-03-18T20:56:26.488Z",
     "contributors": ["wbamberg", "chrisdavidmills", "rugk"]
   },
+  "Web/API/Houdini": {
+    "modified": "2020-07-16T03:51:08.991Z",
+    "contributors": [
+      "Wind1808",
+      "enva-2-7-1-2",
+      "estelle",
+      "chrisdavidmills",
+      "SphinxKnight",
+      "jason2477",
+      "Sheppy"
+    ]
+  },
   "Web/API/IDBCursor": {
     "modified": "2020-10-15T21:09:31.954Z",
     "contributors": [
@@ -92040,18 +92052,6 @@
       "Sheppy",
       "illourr",
       "jswisher"
-    ]
-  },
-  "Web/Guide/Houdini": {
-    "modified": "2020-07-16T03:51:08.991Z",
-    "contributors": [
-      "Wind1808",
-      "enva-2-7-1-2",
-      "estelle",
-      "chrisdavidmills",
-      "SphinxKnight",
-      "jason2477",
-      "Sheppy"
     ]
   },
   "Web/Guide/Parsing_and_serializing_XML": {

--- a/files/en-us/glossary/houdini/index.md
+++ b/files/en-us/glossary/houdini/index.md
@@ -14,7 +14,7 @@ While many of the features Houdini enables can be created with JavaScript, inter
 
 ## See also
 
-- [Houdini](/en-US/docs/Web/Guide/Houdini)
+- [Houdini](/en-US/docs/Web/API/Houdini)
 - [CSSOM](/en-US/docs/Web/API/CSS_Object_Model)
 - [CSS Paint API](/en-US/docs/Web/API/CSS_Painting_API)
 - [CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/css/paintworklet_static/index.md
+++ b/files/en-us/web/api/css/paintworklet_static/index.md
@@ -40,4 +40,4 @@ if ("paintWorklet" in CSS) {
 ## See also
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)
+- [Houdini APIs](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/api/css_object_model/index.md
+++ b/files/en-us/web/api/css_object_model/index.md
@@ -112,4 +112,4 @@ All these features have been added little by little over the years to the differ
 ## See also
 
 - [Document Object Model (DOM)](/en-US/docs/Web/API/Document_Object_Model)
-- [Houdini](/en-US/docs/Web/Guide/Houdini)
+- [Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -9,7 +9,7 @@ browser-compat: api.PaintWorkletGlobalScope
 
 {{DefaultAPISidebar("CSS Painting API")}}{{SeeCompatTable}}
 
-The CSS Painting API — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs — allows developers to write JavaScript functions that can draw directly into an element's background, border, or content.
+The CSS Painting API — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini) umbrella of APIs — allows developers to write JavaScript functions that can draw directly into an element's background, border, or content.
 
 ## Concepts and usage
 
@@ -157,4 +157,4 @@ While you can't play with the worklet's script, you can alter the custom propert
 
 - [Using the CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API/Guide)
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/api/css_properties_and_values_api/guide/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/guide/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSS.registerProperty_static
 
 {{DefaultAPISidebar("CSS Properties and Values API")}}
 
-The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs — allows the registration of {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
+The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini) umbrella of APIs — allows the registration of {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
 
 ## Registering a custom property
 

--- a/files/en-us/web/api/css_properties_and_values_api/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/index.md
@@ -9,7 +9,7 @@ browser-compat:
 
 {{DefaultAPISidebar("CSS Properties and Values API")}}
 
-The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs — allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
+The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini) umbrella of APIs — allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
 
 ## Interfaces
 
@@ -54,4 +54,4 @@ The same registration can take place in [CSS](/en-US/docs/Web/CSS) using the {{c
 - [Using the CSS properties and values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API/guide)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/api/css_typed_om_api/index.md
+++ b/files/en-us/web/api/css_typed_om_api/index.md
@@ -119,4 +119,4 @@ CSSStyleValue is the base class through which all CSS values are expressed. Subc
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [Using the CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/api/houdini/index.md
+++ b/files/en-us/web/api/houdini/index.md
@@ -1,6 +1,6 @@
 ---
-title: CSS Houdini
-slug: Web/Guide/Houdini
+title: Houdini
+slug: Web/API/Houdini
 page-type: guide
 ---
 

--- a/files/en-us/web/api/paintworkletglobalscope/devicepixelratio/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/devicepixelratio/index.md
@@ -29,5 +29,5 @@ A double-precision integer.
 - [CSS.paintWorklet](/en-US/docs/Web/API/CSS/paintWorklet_static)
 - [Worklet](/en-US/docs/Web/API/Worklet)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)
+- [Houdini APIs](/en-US/docs/Web/API/Houdini)
 - [window.devicePixelRatio](/en-US/docs/Web/API/Window/devicePixelRatio)

--- a/files/en-us/web/api/paintworkletglobalscope/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/index.md
@@ -110,4 +110,4 @@ You can also use the {{cssxref('@supports')}} at-rule.
 ## See also
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)
+- [Houdini APIs](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
@@ -100,4 +100,4 @@ li {
 ## See also
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)
+- [Houdini APIs](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.property
 
 {{CSSRef}}
 
-The **`@property`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) is part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs. It allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking and constraining, setting default values, and defining whether a custom property can inherit values or not.
+The **`@property`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) is part of the [CSS Houdini](/en-US/docs/Web/API/Houdini) umbrella of APIs. It allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking and constraining, setting default values, and defining whether a custom property can inherit values or not.
 
 The `@property` rule represents a custom property registration directly in a stylesheet without having to run any JS. Valid `@property` rules result in a registered custom property, as if {{domxref('CSS.registerProperty_static', 'registerProperty()')}} had been called with equivalent parameters.
 
@@ -136,6 +136,6 @@ For item three, the `--item-size` value gets set to `1000px`. While `1000px` is 
 - [CSS Properties and Values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)
 - [Using CSS custom properties (variables)](/en-US/docs/Web/CSS/Using_CSS_custom_properties) guide
 - [CSS custom properties for cascading variables](/en-US/docs/Web/CSS/CSS_cascading_variables) module

--- a/files/en-us/web/css/@property/inherits/index.md
+++ b/files/en-us/web/css/@property/inherits/index.md
@@ -78,4 +78,4 @@ window.CSS.registerProperty({
 - [CSS Properties and Values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/css/@property/initial-value/index.md
+++ b/files/en-us/web/css/@property/initial-value/index.md
@@ -77,4 +77,4 @@ window.CSS.registerProperty({
 - [CSS Properties and Values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -102,4 +102,4 @@ window.CSS.registerProperty({
 - [CSS Properties and Values API](/en-US/docs/Web/API/CSS_Properties_and_Values_API)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)

--- a/files/en-us/web/css/css_properties_and_values_api/index.md
+++ b/files/en-us/web/css/css_properties_and_values_api/index.md
@@ -84,7 +84,7 @@ The value of `--stop-color` is set to `cornflowerblue` at first, but when you ho
 
   - : Explains how to register custom properties in CSS and JavaScript, with hints on handling undefined and invalid values, fallbacks, and inheritance.
 
-- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)
+- [CSS Houdini](/en-US/docs/Web/API/Houdini)
   - : Explains what CSS Houdini is and its advantages, along with a list of available APIs and their statuses.
 
 ## Related concepts

--- a/files/en-us/web/guide/houdini/index.md
+++ b/files/en-us/web/guide/houdini/index.md
@@ -4,10 +4,6 @@ slug: Web/Guide/Houdini
 page-type: guide
 ---
 
-<section id="Quick_links">
-  {{ListSubpagesForSidebar("/en-US/docs/Web/Guide")}}
-</section>
-
 Houdini is a set of low-level APIs that exposes parts of the CSS engine,
 giving developers the power to extend CSS by hooking into the styling and layout process of a browser's rendering engine.
 Houdini is a group of APIs that give developers direct access to the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) (CSSOM),

--- a/files/en-us/web/guide/houdini/index.md
+++ b/files/en-us/web/guide/houdini/index.md
@@ -4,6 +4,8 @@ slug: Web/Guide/Houdini
 page-type: guide
 ---
 
+{{DefaultAPISidebar("Houdini API")}}
+
 Houdini is a set of low-level APIs that exposes parts of the CSS engine,
 giving developers the power to extend CSS by hooking into the styling and layout process of a browser's rendering engine.
 Houdini is a group of APIs that give developers direct access to the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) (CSSOM),

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -597,7 +597,7 @@
       "events": ["Window: popstate"]
     },
     "Houdini API": {
-      "overview": ["Houdini API"],
+      "overview": ["Houdini APIs"],
       "guides": [
         "/docs/Web/API/CSS_Properties_and_Values_API/guide",
         "/docs/Web/API/CSS_Typed_OM_API/Guide",

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -596,6 +596,31 @@
       "properties": [],
       "events": ["Window: popstate"]
     },
+    "Houdini API": {
+      "overview": ["Houdini API"],
+      "guides": [
+        "/docs/Web/API/CSS_Properties_and_Values_API/guide",
+        "/docs/Web/API/CSS_Typed_OM_API/Guide",
+        "/docs/Web/API/CSS_Painting_API/Guide"
+      ],
+      "interfaces": [
+        "CSSImageValue",
+        "CSSKeywordValue",
+        "CSSMathValue",
+        "CSSNumericValue",
+        "CSSPositionValue",
+        "CSSStyleValue",
+        "CSSTransformValue",
+        "CSSUnitValue",
+        "CSSUnparsedValue",
+        "PaintWorkletGlobalScope",
+        "StylePropertyMap",
+        "Worklet"
+      ],
+      "methods": ["CSS.registerProperty", "Worklet.addModule"],
+      "properties": [],
+      "events": []
+    },
     "HTML DOM": {
       "overview": ["HTML DOM API"],
       "interfaces": [


### PR DESCRIPTION
Create a new sidebar for Houdini APIs
Move Houdini from guides to apis
Update all links from /guide/ to /API/

fixes https://github.com/openwebdocs/project/issues/185