### PR TITLE
Remove broken link to long-gone WebRTC feature

### DIFF
--- a/files/en-us/mozilla/firefox/releases/66/index.md
+++ b/files/en-us/mozilla/firefox/releases/66/index.md
@@ -95,7 +95,7 @@ No changes.
 
 #### Removals
 
-- The legacy WebRTC {{domxref("PeerConnection.getStats()")}} method has been removed, along with associated types ([Firefox bug 1328194](https://bugzil.la/1328194)).
+- The legacy WebRTC `PeerConnection.getStats()` method has been removed, along with associated types ([Firefox bug 1328194](https://bugzil.la/1328194)).
 
 ### Networking
 


### PR DESCRIPTION
Was never documented, non-standard, Gecko-speciic, gone since 2019.