### PR TITLE
Remove mention of CSSOMString

### DIFF
--- a/files/en-us/web/css/css_conditional_rules/index.md
+++ b/files/en-us/web/css/css_conditional_rules/index.md
@@ -96,7 +96,6 @@ There are plans to further extend possible queries by adding the generalized con
   - {{domxref("CSS")}} API
   - {{domxref("CSSGroupingRule")}} API
   - {{domxref("MediaQueryList")}} API
-  - {{domxref("CSSOMString")}} API
   - {{domxref("CSSRule")}} API
   - {{domxref("MediaList")}} interface
     - {{domxref("MediaList.mediaText")}} property


### PR DESCRIPTION
`CSSOMString` is not an API.

It is a WebIDL type that maps to a `string` JavaScript primitive.

We don't mention it, as it is transparent to web developers (like `DOMString` or `USVString`).
![Capture d’écran 2024-01-09 à 11 18 09](https://github.com/mdn/content/assets/1466293/32f81399-2cec-4a19-aa49-19598ae22453)
