### PR TITLE
update proposal in http/methods/options/index.md

### DIFF
--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -17,7 +17,7 @@ The **HTTP `OPTIONS` method** requests permitted communication options for a giv
     </tr>
     <tr>
       <th scope="row">Successful response has body</th>
-      <td>Yes</td>
+      <td>May</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>


### PR DESCRIPTION
### Description

I propose a modification to the properties table concerning the OPTIONS HTTP method.

### Motivation

The initial two rows of the OPTIONS method properties table, namely "Request has body" and "Successful response has body" got me thinking.

If we are to be nit-picky and examine the HTTP specification:

> If the OPTIONS request includes an entity-body [...]
> The response body, if any, SHOULD also include information about the communication options. [...]

then according to this, both rows should indicate "May" mirroring the DELETE method properties table, which already uses "May" values.

However, when we look at the GET method properties table:
> Request has body: No
> Successful response has body: Yes

It becomes apparent that we're taking a more pragmatic and common sense approach to these values, as GET requests may include a request body (in the sense that it isn't explicitly forbid).

In this context, I propose we alter the table to:
> Request has body: No
> Successful response has body: May

As OPTIONS requests typically contain useful information solely in HTTP headers and in practice, many servers may not incorporate a body in the response to an OPTIONS request. So, what do you think, am I overthinking it?

### Additional details

https://www.rfc-editor.org/rfc/rfc2616#section-9.2


