### PR TITLE
Import django.urls.reverse in Genre, not Book

### DIFF
--- a/files/en-us/learn/server-side/django/models/index.md
+++ b/files/en-us/learn/server-side/django/models/index.md
@@ -290,6 +290,8 @@ Copy the `Genre` model code shown below and paste it into the bottom of your `mo
 As mentioned above, we've created the genre as a model rather than as free text or a selection list so that the possible values can be managed through the database rather than being hard coded.
 
 ```python
+from django.urls import reverse # Used to generate URLs by reversing the URL patterns
+
 class Genre(models.Model):
     """Model representing a book genre."""
     name = models.CharField(
@@ -323,8 +325,6 @@ Unlike for the `isbn` (and the genre name), the `title` is is not set to be uniq
 The model uses `TextField` for the `summary`, because this text may need to be quite long.
 
 ```python
-from django.urls import reverse # Used to generate URLs by reversing the URL patterns
-
 class Book(models.Model):
     """Model representing a book (but not a specific copy of a book)."""
     title = models.CharField(max_length=200)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Import django.urls.reverse in first model shown in the guide, "Genre", instead of waiting until the second model, "Book".

### Motivation

The first model definition, "Genre", calls the method django.urls.reverse, but the guide does not indicate to the user to import this method until the second model definition, "Book".


### Additional details

None

### Related issues and pull requests

None


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
