### PR TITLE
Add information on `ric`, `rex`, `rch` , and `rcap` units and regroup the relative units.

### DIFF
--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -137,7 +137,6 @@ Where a distance unit, also known as a length, is allowed as a value for a prope
 
 There are two types of relative lengths: font-relative lengths and viewport-percentage lengths. These both come in two types. Font-relative length units are either local font-relative or root font-relative. Viewport percentage lengths are either relative to the viewport height or width size or, as defined in the [CSS Containment module](/en-US/docs/Web/CSS/CSS_Containment), relative to a [container](/en-US/docs/Web/CSS/CSS_container_queries#container_query_length_units).
 
-
 ##### Font-relative lengths
 
 Local font-relative lengths are relative to the "local" font size or line height, specifying a length in relation to a computed size of a feature of the [element](/en-US/docs/Web/HTML/Element) itself, or relative to the element's inherited value in the case of a circular reference, such as the `em` value for a {{cssxref("font-size")}} property or a `lh` value for a {{cssxref("line-height")}} property.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -146,20 +146,20 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 | `ex`   | x-height of the element's font.                                                                                                        |
 | `cap`  | Cap height (the nominal height of capital letters) of the element's font.                                                              |
 | `ch`   | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
-| `ic`   | Average character advance of a full width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
+| `ic`   | Average character advance of a full-width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
 | `lh`   | Line height of the element.                                                                                                            |
 
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.
 
-| Unit   | Relative to                                                                                                                  |         |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `rem`  | Font size of the root element.                                                                                               |         |
-| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               |         |
-| `rex`  | x-height of the root element's font.                                                                                         |         |
-| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |         |
-| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, | U+6C34) |
-| `rlh`  | Line height of the root element.                                                                                             |         |
+| Unit   | Relative to                                                                                                                  |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `rem`  | Font size of the root element.                                                                                               |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               |
+| `rex`  | x-height of the root element's font.                                                                                         |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |
+| `ric`  | Average character advance of a full-width glyph in the root element's font, as represented by the "水" (CJK water ideograph, (U+6C34)). |
+| `rlh`  | Line height of the root element.                                                                                             |
 
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -152,14 +152,14 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.
 
-| Unit   | Relative to                                                                                                                  |
+| Unit   | Relative to                                                                                                                  | |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `rem`  | Font size of the root element.                                                                                               |
-| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               |
-| `rex`  | x-height of the root element's font.                                                                                         |
-| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |
+| `rem`  | Font size of the root element.                                                                                               | |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               | |
+| `rex`  | x-height of the root element's font.                                                                                         | |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      | |
 | `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, | U+6C34) |
-| `rlh`  | Line height of the root element.                                                                                             |
+| `rlh`  | Line height of the root element.                                                                                             | |
 
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -165,6 +165,8 @@ For example, `rem` is relative to the font size on the root element and `rex` is
 | `ric`  | Average character advance of a full-width glyph in the root element's font, as represented by the "水" (CJK water ideograph, (U+6C34)). |
 | `rlh`  | Line height of the root element.                                                                                                        |
 
+##### Viewport and container relative units
+
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.
 

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -137,7 +137,6 @@ Where a distance unit, also known as a length, is allowed as a value for a prope
 
 There are two types of relative lengths: font-relative lengths and viewport-percentage lengths. These both come in two types. Font-relative length units are either local font-relative or root font-relative. Viewport percentage lengths are either relative to the viewport height or width size or, as defined in the [CSS Containment module](/en-US/docs/Web/CSS/CSS_Containment), relative to a [container](/en-US/docs/Web/CSS/CSS_container_queries#container_query_length_units).
 
-Relative length units specify a length in relation to something else.
 
 ##### Font-relative lengths
 

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -142,14 +142,14 @@ There are two types of relative lengths: font-relative lengths and viewport-perc
 Local font-relative lengths are relative to the "local" font size or line height, specifying a length in relation to a computed size of a feature of the [element](/en-US/docs/Web/HTML/Element) itself, or relative to the element's inherited value in the case of a circular reference, such as the `em` value for a {{cssxref("font-size")}} property or a `lh` value for a {{cssxref("line-height")}} property.
 For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the element's font.
 
-| Unit   | Relative to                                                                                                                            |
-| ------ | ------------ |
-| `em`   | Font size of the element.                                                                                                              |
-| `ex`   | x-height of the element's font.                                                                                                        |
-| `cap`  | Cap height (the nominal height of capital letters) of the element's font.                                                              |
-| `ch`   | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
-| `ic`   | Average character advance of a full-width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
-| `lh`   | Line height of the element.                                                                                                            |
+| Unit  | Relative to                                                                                                                            |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `em`  | Font size of the element.                                                                                                              |
+| `ex`  | x-height of the element's font.                                                                                                        |
+| `cap` | Cap height (the nominal height of capital letters) of the element's font.                                                              |
+| `ch`  | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
+| `ic`  | Average character advance of a full-width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
+| `lh`  | Line height of the element.                                                                                                            |
 
 Root font-relative lengths specify a length in relation to the element's {{CSSxRef(":root", "root element")}} ancestor, such as {{HTMLElement("HTML")}} or {{HTMLElement("SVG")}}.
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -141,13 +141,13 @@ Local font-relative lengths specify a length in relation to an [element](/en-US/
 For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the element's font.
 
 | Unit   | Relative to                                                                                                                            |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| ------ | ------------ |
 | `em`   | Font size of the element.                                                                                                              |
 | `ex`   | x-height of the element's font.                                                                                                        |
 | `cap`  | Cap height (the nominal height of capital letters) of the element's font.                                                              |
 | `ch`   | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
 | `ic`   | Average character advance of a full width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
-| `lh`   | Line height of the element.  
+| `lh`   | Line height of the element.                                                                                                            |
 
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -136,7 +136,9 @@ These are all covered in subsections below.
 Where a distance unit, also known as a length, is allowed as a value for a property, this is described as the {{cssxref("&lt;length&gt;")}} type. There are two types of lengths in CSS: relative and absolute.
 
 Relative length units specify a length in relation to something else.
-For example, `em` is relative to the font size on the element and `vh` is relative to the viewport height.
+
+Local font-relative lengths specify a length in relation to an element.
+For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the elemen'ts font.
 
 | Unit   | Relative to                                                                                                                            |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -147,21 +149,33 @@ For example, `em` is relative to the font size on the element and `vh` is relati
 | `ic`   | Average character advance of a full width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
 | `lh`   | Line height of the element.  
       |    
-| `rem`  | Font size of the root element.                                                                                                         |                                                                                                     |
+
+Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
+For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.    
+
+| Unit   | Relative to                                                                                                                            |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `rem`  | Font size of the root element.                                                                                                         |                                                
 | `rcap` | Cap height (the nominal height of capital letters) of the root element's font.  
       |
 | `rex`  | x-height of the root element's font.    
       |
 | `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph. 
       |
-| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, U+6C34) |
+| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, |U+6C34) |
 | `rlh`  | Line height of the root element.                                                                                                       |
-| `vw`   | 1% of viewport's width.                                                                                                                |
-| `vh`   | 1% of viewport's height.                                                                                                               |
-| `vi`   | 1% of viewport's size in the root element's inline axis.                                                                               |
-| `vb`   | 1% of viewport's size in the root element's block axis.                                                                                |
-| `vmin` | 1% of viewport's smaller dimension.                                                                                                    |
-| `vmax` | 1% of viewport's larger dimension.                                                                                                     |
+
+Viewport unit lengths specify a length relative to the dimensions of the [viewport](en-US/docs/Glossary/Viewport).
+For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.
+
+| Unit   | Relative to                                             |
+| -------| --------------------------------------------------------|
+| `vw`   | 1% of viewport's width.                                 |                                             
+| `vh`   | 1% of viewport's height.                                |
+| `vi`   | 1% of viewport's size in the root element's inline axis.|
+| `vb`   | 1% of viewport's size in the root element's block axis. | 
+| `vmin` | 1% of viewport's smaller dimension.                     |
+| `vmax` | 1% of viewport's larger dimension.                      |
 
 Container query length units specify a length relative to the dimensions of a [query container](/en-US/docs/Web/CSS/CSS_container_queries).
 For example, `cqw` is relative to the width of the query container and `cqh` is relative to the height of the query container.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -148,7 +148,6 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 | `ch`   | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
 | `ic`   | Average character advance of a full width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
 | `lh`   | Line height of the element.  
-      |    
 
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.    
@@ -156,14 +155,11 @@ For example, `rem` is relative to the font size on the root element and `rex` is
 | Unit   | Relative to                                                                                                                            |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `rem`  | Font size of the root element.                                                                                                         |                                                
-| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.  
-      |
-| `rex`  | x-height of the root element's font.    
-      |
-| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph. 
-      |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.  |
+| `rex`  | x-height of the root element's font.     |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph. |
 | `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, |U+6C34) |
-| `rlh`  | Line height of the root element.                                                                                                       |
+| `rlh`  | Line height of the root element.    |
 
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -159,7 +159,7 @@ For example, `rem` is relative to the font size on the root element and `rex` is
 | `rex`  | x-height of the root element's font.                                                                                         |
 | `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |
 | `ric`  | Average character advance of a full-width glyph in the root element's font, as represented by the "水" (CJK water ideograph, (U+6C34)). |
-| `rlh`  | Line height of the root element.                                                                                             |
+| `rlh`  | Line height of the root element.                                                                                                        |
 
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -153,7 +153,7 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 | `ic`   | Average character advance of a full-width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
 | `lh`   | Line height of the element.                                                                                                            |
 
-Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
+Root font-relative lengths specify a length in relation to the element's {{CSSxRef(":root", "root element")}} ancestor, such as {{HTMLElement("HTML")}} or {{HTMLElement("SVG")}}.
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.
 
 | Unit   | Relative to                                                                                                                             |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -139,7 +139,9 @@ There are two types of relative lengths: font-relative lengths and viewport-perc
 
 Relative length units specify a length in relation to something else.
 
-Local font-relative lengths specify a length in relation to an [element](/en-US/docs/Web/HTML/Element)'s styles.
+##### Font-relative lengths
+
+Local font-relative lengths are relative to the "local" font size or line height, specifying a length in relation to a computed size of a feature of the [element](/en-US/docs/Web/HTML/Element) itself, or relative to the element's inherited value in the case of a circular reference, such as the `em` value for a {{cssxref("font-size")}} property or a `lh` value for a {{cssxref("line-height")}} property.
 For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the element's font.
 
 | Unit   | Relative to                                                                                                                            |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -135,7 +135,7 @@ These are all covered in subsections below.
 
 Where a distance unit, also known as a length, is allowed as a value for a property, this is described as the {{cssxref("&lt;length&gt;")}} type. There are two types of lengths in CSS: relative and absolute. Relative length units specify a length in relation to something else.
 
-There are two types of relative lengths: font-relative lengths and viewport-percentage lengths. These both come in two types. Font-relative length units also are either local font-relative and root font-relative. Viewport percentage lengths are either relative to the viewport height size or, as defined in the [CSS Containment module](/en-US/docs/Web/CSS/CSS_Containment), relative to a [container](/en-US/docs/Web/CSS/CSS_container_queries#container_query_length_units)
+There are two types of relative lengths: font-relative lengths and viewport-percentage lengths. These both come in two types. Font-relative length units are either local font-relative or root font-relative. Viewport percentage lengths are either relative to the viewport height or width size or, as defined in the [CSS Containment module](/en-US/docs/Web/CSS/CSS_Containment), relative to a [container](/en-US/docs/Web/CSS/CSS_container_queries#container_query_length_units).
 
 Relative length units specify a length in relation to something else.
 

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -159,7 +159,7 @@ For example, `rem` is relative to the font size on the root element and `rex` is
 | `rex`  | x-height of the root element's font.                                                                                         |         |
 | `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |         |
 | `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, | U+6C34) |
-| `rlh`  | Line height of the root element.                                                                                             | |
+| `rlh`  | Line height of the root element.                                                                                             |         |
 
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -137,7 +137,7 @@ Where a distance unit, also known as a length, is allowed as a value for a prope
 
 Relative length units specify a length in relation to something else.
 
-Local font-relative lengths specify a length in relation to an [element](/en-US/docs/Web/HTML/Element).
+Local font-relative lengths specify a length in relation to an [element](/en-US/docs/Web/HTML/Element)'s styles.
 For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the element's font.
 
 | Unit   | Relative to                                                                                                                            |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -152,12 +152,12 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.
 
-| Unit   | Relative to                                                                                                                  |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `rem`  | Font size of the root element.                                                                                               |
-| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               |
-| `rex`  | x-height of the root element's font.                                                                                         |
-| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |
+| Unit   | Relative to                                                                                                                             |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `rem`  | Font size of the root element.                                                                                                          |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                                          |
+| `rex`  | x-height of the root element's font.                                                                                                    |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.                 |
 | `ric`  | Average character advance of a full-width glyph in the root element's font, as represented by the "水" (CJK water ideograph, (U+6C34)). |
 | `rlh`  | Line height of the root element.                                                                                                        |
 

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -154,10 +154,10 @@ For example, `rem` is relative to the font size on the root element and `rex` is
 
 | Unit   | Relative to                                                                                                                  |         |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `rem`  | Font size of the root element.                                                                                               | |
-| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               | |
-| `rex`  | x-height of the root element's font.                                                                                         | |
-| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      | |
+| `rem`  | Font size of the root element.                                                                                               |         |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               |         |
+| `rex`  | x-height of the root element's font.                                                                                         |         |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |         |
 | `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, | U+6C34) |
 | `rlh`  | Line height of the root element.                                                                                             | |
 

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -137,7 +137,7 @@ Where a distance unit, also known as a length, is allowed as a value for a prope
 
 Relative length units specify a length in relation to something else.
 
-Local font-relative lengths specify a length in relation to an element.
+Local font-relative lengths specify a length in relation to an [element](/en-US/docs/Web/HTML/Element).
 For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the element's font.
 
 | Unit   | Relative to                                                                                                                            |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -145,7 +145,8 @@ For example, `em` is relative to the font size on the element and `vh` is relati
 | `cap`  | Cap height (the nominal height of capital letters) of the element's font.                                                              |
 | `ch`   | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
 | `ic`   | Average character advance of a full width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
-| `lh`   | Line height of the element.       
+| `lh`   | Line height of the element.  
+      |    
 | `rem`  | Font size of the root element.                                                                                                         |                                                                                                     |
 | `rcap` | Cap height (the nominal height of capital letters) of the root element's font.  
       |
@@ -153,8 +154,7 @@ For example, `em` is relative to the font size on the element and `vh` is relati
       |
 | `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph. 
       |
-| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, U+6C34)
-      |
+| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, U+6C34) |
 | `rlh`  | Line height of the root element.                                                                                                       |
 | `vw`   | 1% of viewport's width.                                                                                                                |
 | `vh`   | 1% of viewport's height.                                                                                                               |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -152,7 +152,7 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
 For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.
 
-| Unit   | Relative to                                                                                                                  | |
+| Unit   | Relative to                                                                                                                  |         |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `rem`  | Font size of the root element.                                                                                               | |
 | `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               | |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -164,14 +164,14 @@ For example, `rem` is relative to the font size on the root element and `rex` is
 Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.
 
-| Unit   | Relative to                                             |
-| -------| --------------------------------------------------------|
-| `vw`   | 1% of viewport's width.                                 |                                             
-| `vh`   | 1% of viewport's height.                                |
-| `vi`   | 1% of viewport's size in the root element's inline axis.|
-| `vb`   | 1% of viewport's size in the root element's block axis. | 
-| `vmin` | 1% of viewport's smaller dimension.                     |
-| `vmax` | 1% of viewport's larger dimension.                      |
+| Unit   | Relative to                                              |
+| ------ | -------------------------------------------------------- |
+| `vw`   | 1% of viewport's width.                                  |
+| `vh`   | 1% of viewport's height.                                 |
+| `vi`   | 1% of viewport's size in the root element's inline axis. |
+| `vb`   | 1% of viewport's size in the root element's block axis.  |
+| `vmin` | 1% of viewport's smaller dimension.                      |
+| `vmax` | 1% of viewport's larger dimension.                       |
 
 Container query length units specify a length relative to the dimensions of a [query container](/en-US/docs/Web/CSS/CSS_container_queries).
 For example, `cqw` is relative to the width of the query container and `cqh` is relative to the height of the query container.

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -150,18 +150,18 @@ For example, `em` is relative to the font size on the element and `ex` is relati
 | `lh`   | Line height of the element.  
 
 Root font-relative lengths specify a length in relation to a [root element](/en-US/docs/Web/HTML/Element/html)
-For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.    
+For example, `rem` is relative to the font size on the root element and `rex` is the x-height of the root element's font.
 
-| Unit   | Relative to                                                                                                                            |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `rem`  | Font size of the root element.                                                                                                         |                                                
-| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.  |
-| `rex`  | x-height of the root element's font.     |
-| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph. |
-| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, |U+6C34) |
-| `rlh`  | Line height of the root element.    |
+| Unit   | Relative to                                                                                                                  |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `rem`  | Font size of the root element.                                                                                               |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.                                               |
+| `rex`  | x-height of the root element's font.                                                                                         |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph.      |
+| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, | U+6C34) |
+| `rlh`  | Line height of the root element.                                                                                             |
 
-Viewport unit lengths specify a length relative to the dimensions of the [viewport](en-US/docs/Glossary/Viewport).
+Viewport unit lengths specify a length relative to the dimensions of the [viewport](/en-US/docs/Glossary/Viewport).
 For example, `vw` is relative to the width of the viewport and `vh` is relative to the height of the viewport.
 
 | Unit   | Relative to                                             |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -138,7 +138,7 @@ Where a distance unit, also known as a length, is allowed as a value for a prope
 Relative length units specify a length in relation to something else.
 
 Local font-relative lengths specify a length in relation to an element.
-For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the elemen'ts font.
+For example, `em` is relative to the font size on the element and `ex` is relative to the x-height of the element's font.
 
 | Unit   | Relative to                                                                                                                            |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -145,8 +145,16 @@ For example, `em` is relative to the font size on the element and `vh` is relati
 | `cap`  | Cap height (the nominal height of capital letters) of the element's font.                                                              |
 | `ch`   | Average character advance of a narrow glyph in the element's font, as represented by the "0" (ZERO, U+0030) glyph.                     |
 | `ic`   | Average character advance of a full width glyph in the element's font, as represented by the "水" (CJK water ideograph, U+6C34) glyph. |
-| `rem`  | Font size of the root element.                                                                                                         |
-| `lh`   | Line height of the element.                                                                                                            |
+| `lh`   | Line height of the element.       
+| `rem`  | Font size of the root element.                                                                                                         |                                                                                                     |
+| `rcap` | Cap height (the nominal height of capital letters) of the root element's font.  
+      |
+| `rex`  | x-height of the root element's font.    
+      |
+| `rch`  | Average character advance of a narrow glyph in the root element's font, as represented by the "0" (ZERO, U+0030) glyph. 
+      |
+| `ric`  | Average character advance of a full width glyph in the root element's font, as represented by the "水" (CJK water ideograph, U+6C34)
+      |
 | `rlh`  | Line height of the root element.                                                                                                       |
 | `vw`   | 1% of viewport's width.                                                                                                                |
 | `vh`   | 1% of viewport's height.                                                                                                               |

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -133,7 +133,9 @@ These are all covered in subsections below.
 
 #### Distance units
 
-Where a distance unit, also known as a length, is allowed as a value for a property, this is described as the {{cssxref("&lt;length&gt;")}} type. There are two types of lengths in CSS: relative and absolute.
+Where a distance unit, also known as a length, is allowed as a value for a property, this is described as the {{cssxref("&lt;length&gt;")}} type. There are two types of lengths in CSS: relative and absolute. Relative length units specify a length in relation to something else.
+
+There are two types of relative lengths: font-relative lengths and viewport-percentage lengths. These both come in two types. Font-relative length units also are either local font-relative and root font-relative. Viewport percentage lengths are either relative to the viewport height size or, as defined in the [CSS Containment module](/en-US/docs/Web/CSS/CSS_Containment), relative to a [container](/en-US/docs/Web/CSS/CSS_container_queries#container_query_length_units)
 
 Relative length units specify a length in relation to something else.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add `ric`, `rex`, `rch` , and `rcap` units.
Rearrange relative units in order to categorize and group them according to spec.
Add examples and a short description for each category.
Link: https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units

### Motivation

I am making changes because it is easier to find more information about the relative units by grouping. Also provides readers with more information about the `ric`, `rex`, `rch` , and `rcap` units.

### Additional details
The spec: https://www.w3.org/TR/css-values-3/#relative-lengths

### Related issues and pull requests

Fixes mdn/mdn#509.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
