### PR TITLE
docs: Add link to MDN Blog post about border images

### DIFF
--- a/files/en-us/web/css/border-image-outset/index.md
+++ b/files/en-us/web/css/border-image-outset/index.md
@@ -100,3 +100,4 @@ The `border-image-outset` property may be specified as one, two, three, or four 
 
 - [Backgrounds and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders)
 - [Learn CSS: Backgrounds and borders](/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
+- [Border images in CSS: A key focus area for Interop 2023](/en-US/blog/border-images-interop-2023/) on MDN blog (2023)

--- a/files/en-us/web/css/border-image-repeat/index.md
+++ b/files/en-us/web/css/border-image-repeat/index.md
@@ -109,3 +109,4 @@ repetition.addEventListener("change", (evt) => {
 
 - [Backgrounds and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders)
 - [Learn CSS: Backgrounds and borders](/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
+- [Border images in CSS: A key focus area for Interop 2023](/en-US/blog/border-images-interop-2023/) on MDN blog (2023)

--- a/files/en-us/web/css/border-image-slice/index.md
+++ b/files/en-us/web/css/border-image-slice/index.md
@@ -179,3 +179,4 @@ sliceSlider.addEventListener("input", () => {
 ## See also
 
 - [Illustrated description of the 1-to-4-value syntax](/en-US/docs/Web/CSS/Shorthand_properties#tricky_edge_cases)
+- [Border images in CSS: A key focus area for Interop 2023](/en-US/blog/border-images-interop-2023/) on MDN blog (2023)

--- a/files/en-us/web/css/border-image-source/index.md
+++ b/files/en-us/web/css/border-image-source/index.md
@@ -71,3 +71,4 @@ border-image-source: unset;
 - {{cssxref("box-shadow")}}
 - {{cssxref("background-image")}}
 - {{cssxref("url", "url()")}} function
+- [Border images in CSS: A key focus area for Interop 2023](/en-US/blog/border-images-interop-2023/) on MDN blog (2023)

--- a/files/en-us/web/css/border-image-width/index.md
+++ b/files/en-us/web/css/border-image-width/index.md
@@ -117,3 +117,4 @@ p {
 
 - [Backgrounds and borders](/en-US/docs/Web/CSS/CSS_backgrounds_and_borders)
 - [Learn CSS: Backgrounds and borders](/en-US/docs/Learn/CSS/Building_blocks/Backgrounds_and_borders)
+- [Border images in CSS: A key focus area for Interop 2023](/en-US/blog/border-images-interop-2023/) on MDN blog (2023)

--- a/files/en-us/web/css/border-image/index.md
+++ b/files/en-us/web/css/border-image/index.md
@@ -156,3 +156,4 @@ To match the size of a single diamond, we will use a value of 81 divided by 3, o
 - {{cssxref("background-image")}}
 - {{cssxref("url", "url()")}} function
 - Gradient functions: {{CSSxRef("gradient/conic-gradient", "conic-gradient()")}}, {{CSSxRef("gradient/repeating-conic-gradient", "repeating-conic-gradient()")}}, {{CSSxRef("gradient/linear-gradient", "linear-gradient()")}}, {{CSSxRef("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}}, {{CSSxRef("gradient/radial-gradient", "radial-gradient()")}}, {{CSSxRef("gradient/repeating-radial-gradient", "repeating-radial-gradient()")}}
+- [Border images in CSS: A key focus area for Interop 2023](/en-US/blog/border-images-interop-2023/) on MDN blog (2023)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds links in the "See also" section of all `border-image` properties to the blog post on this topic. 

### Motivation

The blog post takes the reader through all the properties using a single example. It will be beneficial when learning about these properties.

