### PR TITLE
Remove link to long-gone page

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3/svg_improvements/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/svg_improvements/index.md
@@ -46,5 +46,4 @@ Firefox 3 offers improved [Scalable Vector Graphics](/en-US/docs/Web/SVG) (SVG) 
 ## See also
 
 - [SVG](/en-US/docs/Web/SVG)
-- [SVG in Firefox](/en-US/docs/Web/SVG/SVG_1.1_Support_in_Firefox)
 - [Firefox 3 for developers](/en-US/docs/Mozilla/Firefox/Releases/3)


### PR DESCRIPTION
This page has been gone for 10 years and contains no useful information.