### PR TITLE
fix: correct CSS.escape() example results

### DIFF
--- a/files/en-us/web/api/css/escape_static/index.md
+++ b/files/en-us/web/api/css/escape_static/index.md
@@ -32,10 +32,10 @@ The escaped string.
 ### Basic results
 
 ```js-nolint
-CSS.escape(".foo#bar"); // "\.foo\#bar"
-CSS.escape("()[]{}"); // "\(\)\[\]\\{\\}"
+CSS.escape(".foo#bar"); // "\\.foo\\#bar"
+CSS.escape("()[]{}"); // "\\(\\)\\[\\]\\{\\}"
 CSS.escape('--a'); // "--a"
-CSS.escape(0); // "\30 ", the Unicode code point of '0' is 30
+CSS.escape(0); // "\\30 ", the Unicode code point of '0' is 30
 CSS.escape('\0'); // "\ufffd", the Unicode REPLACEMENT CHARACTER
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct the `CSS.escape(...)` example results.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
When reviewing the documentation for a project I was working on, I discovered the examples did not match the output within the browser Console.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
