### PR TITLE
Show that objects usually inherit the `constructor` property

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -46,7 +46,7 @@ Note that `constructor` usually comes from the constructor's [`prototype`](/en-U
 const o = new TypeError(); // Inheritance: TypeError -> Error -> Object
 const proto = Object.getPrototypeOf;
 
-o.hasOwnProperty("constructor"); // false
+Object.hasOwn(o, "constructor"); // false
 proto(o).constructor === TypeError; // true
 proto(proto(o)).constructor === Error; // true
 proto(proto(proto(o))).constructor === Object; // true

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -45,6 +45,8 @@ Note that `constructor` usually comes from the constructor's [`prototype`](/en-U
 ```js
 const o = new TypeError(); // Inheritance: TypeError -> Error -> Object
 const proto = Object.getPrototypeOf;
+
+o.hasOwnProperty("constructor"); // false
 proto(o).constructor === TypeError; // true
 proto(proto(o)).constructor === Error; // true
 proto(proto(proto(o))).constructor === Object; // true


### PR DESCRIPTION
The paragraph above my change says this in its first sentence:

> Note that `constructor` usually comes from the constructor's [`prototype`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/prototype) property.

But the example that follows doesn't *show* that. Therefore, I added `o.hasOwnProperty("constructor"); // false` to the example. It might make more sense to put it as the second line instead of where I placed it? 

I initially wrote `o.constructor === proto(o).constructor // true` but removed it later: prototypical inheritance can be tricky to people like me, and I felt that this line didn't document its intention as well as `o.hasOwnProperty`. Let me know if that's a better line or if both should be in the example.
