### PR TITLE
Update /web/http/methods/trace/index.md

### DIFF
--- a/files/en-us/web/http/methods/trace/index.md
+++ b/files/en-us/web/http/methods/trace/index.md
@@ -21,7 +21,7 @@ Note that the client must not send content in the request, or generate fields th
     </tr>
     <tr>
       <th scope="row">Successful response has body</th>
-      <td>No</td>
+      <td>Yes</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>


### PR DESCRIPTION
### Description

Updates "Successful response has body" row value to "Yes" in characteristics table in TRACE method docs.

### Motivation

AFAIK Trace method successful responses always should have a body with loop-back data for debugging purposes.

### Additional details

https://http.dev/trace#example
