### PR TITLE
Duration cannot be optional

### DIFF
--- a/files/en-us/web/api/mediasession/setpositionstate/index.md
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.md
@@ -34,7 +34,7 @@ setPositionState(stateDict)
     state information is cleared. This object can contain the following
     parameters:
 
-    - `duration` {{optional_inline}}
+    - `duration`
       - : A floating-point value giving the total duration of the current media in seconds. This should always be a positive number, with positive infinity ({{jsxref("Infinity")}}) indicating media without a defined end, such as a live stream.
     - `playbackRate` {{optional_inline}}
       - : A floating-point value indicating the rate at which the media is being played, as a ratio relative to its normal playback speed. Thus, a value of 1 is playing at normal speed, 2 is playing at double speed, and so forth. Negative values indicate that the media is playing in reverse; -1 indicates playback at the normal speed but backward, -2 is double speed in reverse, and so on.


### PR DESCRIPTION
According to the spec, if the duration is missing or null, an error is raised: https://w3c.github.io/mediasession/#dom-mediasession-setpositionstate

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removed "optional" from `setPositionState` `stateDict` property `duration`.

### Motivation

The property cannot be optional as it says later (and in the spec) that if the property is missing or null, an error is raised.
