### PR TITLE
fix(css): update 'text-underline-position' content

### DIFF
--- a/files/en-us/web/css/text-underline-position/index.md
+++ b/files/en-us/web/css/text-underline-position/index.md
@@ -41,9 +41,9 @@ text-underline-position: unset;
 - `under`
   - : Forces the line to be set below the alphabetic baseline, at a position where it won't cross any descenders. This is useful for ensuring legibility with chemical and mathematical formulas, which make a large use of subscripts.
 - `left`
-  - : In vertical writing-modes, this keyword forces the line to be placed on the _left_ side of the text. In horizontal writing-modes, it is a synonym of `under`.
+  - : In vertical writing-modes, this keyword forces the line to be placed on the _left_ side of the text. In horizontal writing-modes, it is a synonym of `auto`.
 - `right`
-  - : In vertical writing-modes, this keyword forces the line to be placed on the _right_ side of the text. In horizontal writing-modes, it is a synonym of `under`.
+  - : In vertical writing-modes, this keyword forces the line to be placed on the _right_ side of the text. In horizontal writing-modes, it is a synonym of `auto`.
 
 ## Formal definition
 


### PR DESCRIPTION
- fixes #31683 

Current specs does say it's `auto` in horizontal writing mode:
> In vertical [typographic modes](https://drafts.csswg.org/css-writing-modes-4/#typographic-mode), the [text-underline-position](https://drafts.csswg.org/css-text-decor/#propdef-text-underline-position) values [left](https://drafts.csswg.org/css-text-decor/#underline-left) and [right](https://drafts.csswg.org/css-text-decor/#underline-right) allow placing the underline on either side of the text. (In horizontal typographic modes, both values are treated as [auto](https://drafts.csswg.org/css-text-decor/#underline-auto).)