### PR TITLE
 note for <base> element attributes 

### DIFF
--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -54,7 +54,8 @@ A document's used base URL can be accessed by scripts with {{domxref('Node.baseU
 
 This element's attributes include the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-> **Warning:** If either of the following attributes are specified, this element **must** come before other elements with attribute values of URLs, such as {{HTMLElement("link")}}'s `href` attribute.
+> **Warning:** A `<base>` element must have an `href` attribute, a `target` attribute, or both.
+> If at least one of these attributes are specified, the `<base>` element **must** come before other elements with attribute values that are URLs, such as a {{HTMLElement("link")}}'s `href` attribute.
 
 - `href`
   - : The base URL to be used throughout the document for relative URLs.

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -71,7 +71,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ## Usage notes
 
->**Note:** A `base` element must have either an `href` attribute, a `target` attribute, or both.
+> **Note:** A `base` element must have either an `href` attribute, a `target` attribute, or both.
 
 ### Multiple \<base> elements
 

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -70,8 +70,6 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
     - `_parent`: Show the result in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as `_self`.
     - `_top`: Show the result in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as `_self`.
 
-> **Note:** A `base` element must have either an `href` attribute, a `target` attribute, or both.
-
 ## Usage Notes
 
 ### Multiple \<base> elements

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -70,7 +70,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
     - `_parent`: Show the result in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as `_self`.
     - `_top`: Show the result in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as `_self`.
 
-## Usage Notes
+## Usage notes
 
 ### Multiple \<base> elements
 

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -71,6 +71,8 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ## Usage notes
 
+>**Note:** A `base` element must have either an `href` attribute, a `target` attribute, or both.
+
 ### Multiple \<base> elements
 
 If multiple `<base>` elements are used, only the first `href` and first `target` are obeyed — all others are ignored.

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -69,9 +69,9 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
     - `_parent`: Show the result in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as `_self`.
     - `_top`: Show the result in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as `_self`.
 
-## Usage notes
-
 > **Note:** A `base` element must have either an `href` attribute, a `target` attribute, or both.
+
+## Usage Notes
 
 ### Multiple \<base> elements
 


### PR DESCRIPTION
this note is important in `HTMLBaseElement` Api documentation.

### Related issues and pull requests

[PR #31652](https://github.com/mdn/content/pull/31652)

### Resource
[html base lement](https://html.spec.whatwg.org/multipage/semantics.html#the-base-element)
