### PR TITLE
Mention that freeze/seal have no effect on private props

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -38,6 +38,8 @@ that are objects can still be modified, unless they are also frozen. As an objec
 array can be frozen; after doing so, its elements cannot be altered and no elements can
 be added to or removed from the array.
 
+[Private properties](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties) do not have the concept of property descriptors. Freezing an object with private properties does not prevent the values of these private properties from being changed. (Freezing objects is usually meant as a security measure against external code, but external code cannot access private properties anyway.) Private properties cannot be added or removed from the object, whether the object is frozen or not.
+
 `freeze()` returns the same object that was passed into the function. It
 _does not_ create a frozen copy.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/seal/index.md
@@ -36,6 +36,8 @@ to accessor or vice versa, will fail, either silently or by throwing a
 {{jsxref("TypeError")}} (most commonly, although not exclusively, when in
 {{jsxref("Strict_mode", "strict mode", "", 1)}} code).
 
+[Private properties](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties) do not have the concept of property descriptors. Private properties cannot be added or removed from the object, whether the object is sealed or not.
+
 The prototype chain remains untouched. However, due to the effect of [preventing extensions](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions), the `[[Prototype]]` cannot be reassigned.
 
 Unlike {{jsxref("Object.freeze()")}}, objects sealed with `Object.seal()` may have their existing


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/31177. This information is already present on the private properties page.