### PR TITLE
document for HTMLMapElement.name

### DIFF
--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -9,9 +9,9 @@ browser-compat: api.HTMLMapElement.name
 {{ApiRef("HTML DOM")}}
 
 The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
-This property is used for referencing `useMap` attribute of the {{HTMLElement("img")}} element. We
-can not set this property empty or with whitespaces. If `id` is given to a {{HTMLElement("map")}} element 
-then `name` property should be same as `id`.
+This property is used for referencing `useMap` attribute of the {{HTMLElement("img")}} element. 
+The `name` property can not set to empty or with whitespaces. 
+If `id` is given to a {{HTMLElement("map")}} element then `name` property should be same as `id`.
 
 ## Value
 

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -9,7 +9,7 @@ browser-compat: api.HTMLMapElement.name
 {{ApiRef("HTML DOM")}}
 
 The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
-This property is used for referencing `useMap` attribute of the {{HTMLElement("img")}} element. 
+Its value can be used with the `useMap` attribute of the {{HTMLElement("img")}} element to reference a `<map>` element.
 If `id` is given to a {{HTMLElement("map")}} element then `name` property should be same as `id`.
 
 ## Value

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -31,11 +31,6 @@ const mapElement = document.getElementsByName("image-map")[0];
 console.log(mapElement.name); //output: "image-map"
 ```
 
-
-## Results
-
-{{EmbedLiveSample("Example",100,100)}}
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -21,9 +21,7 @@ A non-empty string without whitespaces.
 
 ```html
 <map name="image-map">
-    <area
-        shape="circle"
-        coords="15,15,5"/>
+  <area shape="circle" coords="15,15,5" />
 </map> 
 ```
 

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -10,7 +10,6 @@ browser-compat: api.HTMLMapElement.name
 
 The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
 This property is used for referencing `useMap` attribute of the {{HTMLElement("img")}} element. 
-The `name` property can not be set to empty or with whitespaces. 
 If `id` is given to a {{HTMLElement("map")}} element then `name` property should be same as `id`.
 
 ## Value

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -1,15 +1,15 @@
 ---
-title: "HTMLLinkElement: hreflang property"
-short-title: hreflang
-slug: Web/API/HTMLLinkElement/hreflang
+title: "HTMLMapElement: name property"
+short-title: name
+slug: Web/API/HTMLMapElement/name
 page-type: web-api-instance-property
-browser-compat: api.HTMLLinkElement.hreflang
+browser-compat: api.HTMLMapElement.name
 ---
 
 {{ApiRef("HTML DOM")}}
 
 The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
-This property is used for referencing `useMap` attribute of the {{HTMLElement("image")}} element. We
+This property is used for referencing `useMap` attribute of the {{HTMLElement("img")}} element. We
 can not set this property empty or with whitespaces. If `id` is given to a {{HTMLElement("map")}} element 
 then `name` property should be same as `id`.
 
@@ -18,6 +18,23 @@ A non-empty string without whitespaces.
 
 ## Example
 
+```html
+<map name="image-map">
+    <area
+        shape="circle"
+        coords="15,15,5"/>
+</map> 
+```
+
+```js
+const mapElement = document.getElementsByName("image-map")[0];
+console.log(mapElement.name); //output: "image-map"
+```
+
+
+## Results
+
+{{EmbedLiveSample("Example",100,100)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -14,6 +14,7 @@ can not set this property empty or with whitespaces. If `id` is given to a {{HTM
 then `name` property should be same as `id`.
 
 ## Value
+
 A non-empty string without whitespaces.
 
 ## Example
@@ -28,7 +29,7 @@ A non-empty string without whitespaces.
 
 ```js
 const mapElement = document.getElementsByName("image-map")[0];
-console.log(mapElement.name); //output: "image-map"
+console.log(mapElement.name); // output: "image-map"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -8,6 +8,16 @@ browser-compat: api.HTMLLinkElement.hreflang
 
 {{ApiRef("HTML DOM")}}
 
+The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
+This property is used for referencing `useMap` attribute of the {{HTMLElement("image")}} element. We
+can not set this property empty or with whitespaces. If `id` is given to a {{HTMLElement("map")}} element 
+then `name` property should be same as `id`.
+
+## Value
+A non-empty string without whitespaces.
+
+## Example
+
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -1,0 +1,23 @@
+---
+title: "HTMLLinkElement: hreflang property"
+short-title: hreflang
+slug: Web/API/HTMLLinkElement/hreflang
+page-type: web-api-instance-property
+browser-compat: api.HTMLLinkElement.hreflang
+---
+
+{{ApiRef("HTML DOM")}}
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLImageElement.useMap")}} property
+- {{domxref("HTMLAreaElement")}} element

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -10,7 +10,7 @@ browser-compat: api.HTMLMapElement.name
 
 The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
 This property is used for referencing `useMap` attribute of the {{HTMLElement("img")}} element. 
-The `name` property can not set to empty or with whitespaces. 
+The `name` property can not be set to empty or with whitespaces. 
 If `id` is given to a {{HTMLElement("map")}} element then `name` property should be same as `id`.
 
 ## Value

--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -8,7 +8,7 @@ browser-compat: api.HTMLMapElement.name
 
 {{ApiRef("HTML DOM")}}
 
-The **`name`** property of the {{domxref("HTMLMapElement")}} is a string gives the map unique name. 
+The **`name`** property of the {{domxref("HTMLMapElement")}} represents the unique name `<map>`  element. 
 Its value can be used with the `useMap` attribute of the {{HTMLElement("img")}} element to reference a `<map>` element.
 If `id` is given to a {{HTMLElement("map")}} element then `name` property should be same as `id`.
 


### PR DESCRIPTION
### Description
This adds new documentation for the HTMLMapElement.name property. 
A description of a property is added with an example.

### Discussion 
Part of the project to document all interoperable features ([mdn/discussions#476](https://github.com/orgs/mdn/discussions/476))

### Resources
[name property](https://html.spec.whatwg.org/multipage/image-maps.html#dom-map-name
)
