### PR TITLE
Remove prefixed :read-only selectors

### DIFF
--- a/files/en-us/web/css/_colon_read-only/index.md
+++ b/files/en-us/web/css/_colon_read-only/index.md
@@ -28,8 +28,6 @@ One use of `readonly` form controls is to allow the user to check and verify inf
 The `:read-only` pseudo-class is used to remove all the styling that makes the inputs look like clickable fields, making them look more like read-only paragraphs. The `:read-write` pseudo-class on the other hand is used to provide some nicer styling to the editable `<textarea>`.
 
 ```css
-input:-moz-read-only,
-textarea:-moz-read-only,
 input:read-only,
 textarea:read-only {
   border: 0;
@@ -37,7 +35,6 @@ textarea:read-only {
   background-color: white;
 }
 
-textarea:-moz-read-write,
 textarea:read-write {
   box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;


### PR DESCRIPTION
If a browser supports either `:read-only` or `:-moz-read-only`, but not both, then the entire ruleset was discarded, as the selector list is unforgiving.

Actually, Firefox is the only browser that supports both. All other browsers were discarding the ruleset.

Possible fixes are:
* Use two separate rulesets (one with the prefixed selectors, another with the unprefixed selectors).
* Enclose the selectors in a `:is()` pseudo-class, as its selector list is forgiving.

Though, Firefox supports the unprefixed selector since version 78, released on June 2020. So we may just drop the prefixed selectors.