### PR TITLE
Remove unnecessary template string from example.

### DIFF
--- a/files/en-us/web/api/element/keydown_event/index.md
+++ b/files/en-us/web/api/element/keydown_event/index.md
@@ -95,7 +95,7 @@ const log = document.getElementById("log");
 input.addEventListener("keydown", logKey);
 
 function logKey(e) {
-  log.textContent += ` ${e.code}`;
+  log.textContent += " " + e.code;
 }
 ```
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I've replaced the line
```js
log.textContent += ` ${e.code}`;
```
with a simpler
```js
log.textContent += " " + e.code;
```

### Motivation

The template string is completely unnecessary here and can cause additional confusion for people who are still new to programming or javascript in general.

### Additional details

This was motivated by my brother learning programming and getting hung up on completely unrelated notation while trying to understand event listeners. (after already having to figure out what an arrow function is)

### Related issues and pull requests

none
