### PR TITLE
Fix typo in tabs section

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
@@ -37,7 +37,7 @@ If the grid supports column selection and a column is selected, all cells in the
 
 In a tablist, `aria-selected` is used on a tab to indicate the currently-displayed [`tabpanel`](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role).
 
-The selected [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) in a [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) should have has its `aria-selected="true"` set. All inactive tabs in the tablist should have `aria-selected="false"` set. Setting the state only impacts the accessibility tree: make sure to style the active tab in a way that visual indicates it's selected state. The default value for `aria-selected` on a `tab` role is `false`.
+The selected [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) in a [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) should have the attribute `aria-selected="true"` set. All inactive tabs in the tablist should have `aria-selected="false"` set. Setting the state only impacts the accessibility tree: make sure to style the active tab in a way that visual indicates it's selected state. The default value for `aria-selected` on a `tab` role is `false`.
 
 If more than one tab is selectable at a time, include `aria-multiselectable` on the `tablist`.
 


### PR DESCRIPTION
### Description

This is a small typo fix to a sentence.

### Motivation

The prior sentence was hard to read because it said, "should have has it."

### Additional details

Not applicable.

### Related issues and pull requests

None.
