### PR TITLE
Remove mention of onDOMContentLoaded

### DIFF
--- a/files/en-us/web/api/document/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.md
@@ -22,8 +22,6 @@ Use the event name in methods like {{domxref("EventTarget.addEventListener", "ad
 
 ```js
 addEventListener("DOMContentLoaded", (event) => {});
-
-onDOMContentLoaded = (event) => {};
 ```
 
 ## Event type


### PR DESCRIPTION
There is no such `onDOMContentLoaded` event attribute. This was mistakenly added as part of a bulk change in https://github.com/mdn/content/commit/95d6c222f9aba9a60dee4adc738d741a28c8b83a

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This removes a code example that makes it look like `window.onDOMContentLoaded` would be a thing.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This event attribute doesn't exist. The only way to register to the `DOMContentLoaded` event is through `document.addEventListener("DOMContentLoaded", cb)` (or on `window` since the event bubbles).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
[List of event handlers on window](https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects:event-afterprint), where `onDOMContentLoaded` is not listed. 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
