### PR TITLE
Remove prefixed :read-only selectors

### DIFF
--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -458,12 +458,8 @@ A fragment of the HTML is as follows — note the readonly attribute:
 If you try the live example, you'll see that the top set of form elements are not focusable, however, the values are submitted when the form is submitted. We've styled the form controls using the `:read-only` and `:read-write` pseudo-classes, like so:
 
 ```css
-:is(
-    input:read-only,
-    input:-moz-read-only,
-    textarea:-moz-read-only,
-    textarea:read-only
-  ) {
+input:read-only,
+textarea:read-only {
   border: 0;
   box-shadow: none;
   background-color: white;


### PR DESCRIPTION
Firefox supports the unprefixed selector since version 78, released on June 2020.

By removing the prefixed selectors, we can in turn remove the `:is()` pseudo-class, which was needed for its forgiving selector list.