### PR TITLE
Add note re:sharedWorker in browser devtools

### DIFF
--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -54,7 +54,7 @@ myWorker.port.start();
 
 When the port is started, both scripts post messages to the worker and handle messages sent from it using `port.postMessage()` and `port.onmessage`, respectively:
 
-> **Note:** You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome devtools, the URL [`chrome://inspect/#workers`](chrome://inspect/#workers), and in FireFox, the URL [`about:debugging#workers`](about:debugging#workers).
+> **Note:** You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome devtools, the URL `chrome://inspect/#workers`, and in FireFox, the URL `about:debugging#workers`.
 
 ```js
 first.onchange = () => {

--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -54,7 +54,7 @@ myWorker.port.start();
 
 When the port is started, both scripts post messages to the worker and handle messages sent from it using `port.postMessage()` and `port.onmessage`, respectively:
 
-> **Note:** You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome devtools, the URL `chrome://inspect/#workers`, and in FireFox, the URL `about:debugging#workers`.
+> **Note:** You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome, the URL `chrome://inspect/#workers`, and in FireFox, the URL `about:debugging#workers`.
 
 ```js
 first.onchange = () => {

--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -54,7 +54,7 @@ myWorker.port.start();
 
 When the port is started, both scripts post messages to the worker and handle messages sent from it using `port.postMessage()` and `port.onmessage`, respectively:
 
-> **Note:** In order to debug your SharedWorker you need to navigate to the correct inspector. For example in Chrome web worker inspection can be opened from `chrome://inspect/#workers` and in FireFox the location is `about:debugging#workers`
+> **Note:** You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome devtools, the URL [`chrome://inspect/#workers`](chrome://inspect/#workers), and in FireFox, the URL [`about:debugging#workers`](about:debugging#workers).
 
 ```js
 first.onchange = () => {

--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -54,6 +54,8 @@ myWorker.port.start();
 
 When the port is started, both scripts post messages to the worker and handle messages sent from it using `port.postMessage()` and `port.onmessage`, respectively:
 
+> **Note:** In order to debug your SharedWorker you need to navigate to the correct inspector. For example in Chrome web worker inspection can be opened from `chrome://inspect/#workers` and in FireFox the location is `about:debugging#workers`
+
 ```js
 first.onchange = () => {
   myWorker.port.postMessage([first.value, second.value]);


### PR DESCRIPTION
### Description / Motivation

I added debugging info for chrome and firefox because I personally found it elusive starting out with `SharedWorkers`. I can not confirm on Safari so I left that out.

### Additional details

I tried to user hyperlinks but my markdown is weak so I resorted to codeblocks instead which I now regret as it feels unconventional. Please reformat if you feel so inclined. 

Cheers!