### PR TITLE
Replace 'attribute' with 'property' for 'indeterminate'

### DIFF
--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.indeterminate
 
 {{CSSRef}}
 
-The **`:indeterminate`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any form element whose state is indeterminate, such as checkboxes which have their [`indeterminate`](/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) JavaScript property set to `true`, radio buttons which are members of a group in which all radio buttons are unchecked, and indeterminate {{HTMLElement("progress")}} elements.
+The **`:indeterminate`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any form element whose state is indeterminate, such as checkboxes that have been set to an [`indeterminate`](/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) state with JavaScript, radio buttons which are members of a group in which all radio buttons are unchecked, and {{HTMLElement("progress")}} elements with no `value` attribute.
 
 ```css
 /* Selects any <input> whose state is indeterminate */

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.indeterminate
 
 {{CSSRef}}
 
-The **`:indeterminate`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any form element whose state is indeterminate, such as checkboxes which have their HTML [`indeterminate`](/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) attribute set to `true`, radio buttons which are members of a group in which all radio buttons are unchecked, and indeterminate {{HTMLElement("progress")}} elements.
+The **`:indeterminate`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any form element whose state is indeterminate, such as checkboxes which have their [`indeterminate`](/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) JavaScript property set to `true`, radio buttons which are members of a group in which all radio buttons are unchecked, and indeterminate {{HTMLElement("progress")}} elements.
 
 ```css
 /* Selects any <input> whose state is indeterminate */
@@ -131,6 +131,6 @@ progress:indeterminate {
 
 - [Web forms — Working with user data](/en-US/docs/Learn/Forms)
 - [Styling web forms](/en-US/docs/Learn/Forms/Styling_web_forms)
-- The [`<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox) element's [`indeterminate`](/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxe) attribute
+- The [`<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox) element's [`indeterminate`](/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) property
 - {{HTMLElement("input")}} and the {{domxref("HTMLInputElement")}} interface which implements it.
 - The {{cssxref(":checked")}} CSS selector lets you style checkboxes based on whether they're checked or not


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

- Replace 'attribute' with 'property' to accurately reflect that `indeterminate` is a JavaScript property (IDL attribute) of the element, not an HTML attribute.
- Fix a broken link in the "See also" section.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It makes more clear that the `indeterminate` is not an HTML attribute so that there are no misunderstandings for the readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
