### PR TITLE
chore(ci): Add perms for PR labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  contents: read
 
 jobs:
   # Docs: https://github.com/actions/labeler

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,15 +1,7 @@
 name: Pull request labeler
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches:
-      - "main"
-
-permissions:
-  issues: write
-  pull-requests: write
-  contents: read
+  - pull_request_target
 
 jobs:
   # Docs: https://github.com/actions/labeler

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -3,6 +3,10 @@ name: Pull request labeler
 on:
   - pull_request_target
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   # Docs: https://github.com/actions/labeler
   label-by-path:
@@ -23,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Label PR based on size
         uses: cbrgm/pr-size-labeler-action@main

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - "main"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   # Docs: https://github.com/actions/labeler
   label-by-path:


### PR DESCRIPTION

Action is 403 at the moment, adding perms to the workflow:

- [x] https://github.com/mdn/content/pull/31729
- Logs https://github.com/mdn/content/actions/runs/7541990630/job/20529845639?pr=31684