### PR TITLE
Improve the example in Presentation API

### DIFF
--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -41,7 +41,7 @@ Depending on the connection mechanism provided by the presentation device, any c
 
 ## Example
 
-Example codes below highlight the usage of main features of the Presentation API: `controller.html` implements the controller and `presentation.html` implements the presentation. Both pages are served from the domain `http://example.org` (`http://example.org/controller.html` and `http://example.org/presentation.html`). These examples assume that the controlling page is managing one presentation at a time. Please refer to the comments in the code examples for further details.
+Example codes below highlight the usage of main features of the Presentation API: `controller.html` implements the controller and `presentation.html` implements the presentation. Both pages are served from the domain `https://example.org` (`https://example.org/controller.html` and `https://example.org/presentation.html`). These examples assume that the controlling page is managing one presentation at a time. Please refer to the comments in the code examples for further details.
 
 ### Monitor availability of presentation displays
 
@@ -55,8 +55,8 @@ In `controller.html`:
 
   // It is also possible to use relative presentation URL e.g. "presentation.html"
   const presUrls = [
-    "http://example.com/presentation.html",
-    "http://example.net/alternate.html",
+    "https://example.com/presentation.html",
+    "https://example.net/alternate.html",
   ];
 
   // Show or hide present button depending on display availability


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Use `https` instead of `http` in the example of the Presentation API.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The Presentation API is available only in secure context, so `https` should be used instead of `http` with non-local domain `example.org`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
