### PR TITLE
RSA: Update importKey 

### DIFF
--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -260,7 +260,7 @@ function importPrivateKey(pem) {
   const pemFooter = "-----END PRIVATE KEY-----";
   const pemContents = pem.substring(
     pemHeader.length,
-    pem.length - pemFooter.length,
+    pem.length - pemFooter.length - 1,
   );
   // base64 decode the string to get the binary data
   const binaryDerString = window.atob(pemContents);


### PR DESCRIPTION
importPrivateKey and importRSAKey had different code for extracting the key from between headers. The RSA one was correct, i.e. `pem.length - pemFooter.length - 1` rather than `pem.length - pemFooter.length`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
