### PR TITLE
Remove template literals from formData entries example

### DIFF
--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -34,15 +34,15 @@ formData.append("key2", "value2");
 
 // Display the key/value pairs
 for (const pair of formData.entries()) {
-  console.log(`${pair[0]}, ${pair[1]}`);
+  console.log(pair[0], pair[1]);
 }
 ```
 
 The result is:
 
 ```plain
-key1, value1
-key2, value2
+key1 value1
+key2 value2
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove template literals from formData entries example

### Motivation

Keep examples as simple as possible. 

### Additional details

There is no need for template literals to show the example, to avoid confusion for beginners we can remove them here.

### Related issues and pull requests

No related issue.
