### PR TITLE
Clarify single-colon use case

### DIFF
--- a/files/en-us/web/css/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/_doublecolon_first-line/index.md
@@ -13,7 +13,7 @@ The **`::first-line`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/W
 
 The effects of `::first-line` are limited by the length and content of the first line of text in the element. The length of the first line depends on many factors, including the width of the element, the width of the document, and the font size of the text. `::first-line` has no effect when the first child of the element, which would be the first part of the first line, is an inline block-level element, such as an inline table.
 
-> **Note:** [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) introduced the double-colon notation (`::`) to differentiate [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) from the single-colon (`:`) [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes). Browsers accept both `::first-line` and `:first-line`, which was introduced in CSS2.
+> **Note:** [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) introduced the double-colon notation (`::`) to distinguish [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) from the single-colon (`:`) [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes). Browsers accept both `::first-line` and `:first-line`, which was introduced in CSS2.
 
 For the purposes of CSS {{CSSXref("background")}}, the `::first-line` pseudo-element is like an inline-level element meaning that in a left-justified first line, the background may not extend all the way to the right margin.
 

--- a/files/en-us/web/css/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/_doublecolon_first-line/index.md
@@ -13,7 +13,7 @@ The **`::first-line`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/W
 
 The effects of `::first-line` are limited by the length and content of the first line of text in the element. The length of the first line depends on many factors, including the width of the element, the width of the document, and the font size of the text. `::first-line` has no effect when the first child of the element, which would be the first part of the first line, is an inline block-level element, such as an inline table.
 
-> **Note:** [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) introduced the double-colon notation (`::`) to distinguish [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) from [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements), which are single-colon `:`. Browsers accept both `::first-line` and `:first-line`, which was introduced in CSS2.
+> **Note:** [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) introduced the double-colon notation (`::`) to differentiate [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) from the single-colon (`:`) [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes). Browsers accept both `::first-line` and `:first-line`, which was introduced in CSS2.
 
 For the purposes of CSS {{CSSXref("background")}}, the `::first-line` pseudo-element is like an inline-level element meaning that in a left-justified first line, the background may not extend all the way to the right margin.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR proposes a reword to the psuedo-element vs. psuedo-class note on the ::first-line CSS selector documentation. 

### Motivation

The note currently reads: 

> Note: Selectors Level 3 introduced the double-colon notation (`::`) to distinguish pseudo-classes from pseudo-elements, which are single-colon `:`. 

_To me, this read that psuedo-elements are single-colon, but it's the other way around in reality._

I've simply switched the wording to read: 

> Note: Selectors Level 3 introduced the double-colon notation (`::`) to distinguish pseudo-elements from the single-colon (`:`) pseudo-classes. Browsers accept both ::first-line and :first-line, which was introduced in CSS2.

This way, it's unmistakeable that single-colons correspond with pseudo classes. 

Additionally, I moved the single-colon into parentheses since this seems to match the rest of the site. 

Let me know if this makes sense, and thanks for your time!

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
