### PR TITLE
HTTP Client Hints: remove reference to deprecated DPR header

### DIFF
--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -121,7 +121,7 @@ Headers include: {{HTTPHeader("Sec-CH-Prefers-Reduced-Motion")}}, {{HTTPHeader("
 ### Device client hints
 
 Device client hints allow a server to vary responses based on device characteristics including available memory and screen properties.
-Headers include: {{HTTPHeader("Device-Memory")}}, {{HTTPHeader("DPR")}}, {{HTTPHeader("Width")}}, {{HTTPHeader("Viewport-Width")}}.
+Headers include: {{HTTPHeader("Device-Memory")}}, {{HTTPHeader("Width")}}, {{HTTPHeader("Viewport-Width")}}.
 
 ### Network client hints
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The HTTP Client Hints page includes the DPR header in an example of headers which might serve as device client hints.  The DPR header is now deprecated, so should no longer be used as an example here.

### Motivation

Removing the deprecated header from the list included as examples avoids inadvertently encouraging its use and helps users avoid going down a "dead end".

### Additional details

[(https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR) shows the deprecated warning.
