### PR TITLE
fix(docs): add selecteditem keywords to system-color list

### DIFF
--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -53,6 +53,10 @@ Note that these keywords are _case insensitive_, but are listed here with mixed 
   - : Background of text that has been specially marked (such as by the HTML `mark` element)
 - `MarkText`
   - : Text that has been specially marked (such as by the HTML `mark` element)
+- `SelectedItem`
+  - : Background of selected items, for example a selected checkbox
+- `SelectedItemText`
+  - : Text of selected items
 - `VisitedText`
   - : Text of visited links
 

--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -54,7 +54,7 @@ Note that these keywords are _case insensitive_, but are listed here with mixed 
 - `MarkText`
   - : Text that has been specially marked (such as by the HTML `mark` element)
 - `SelectedItem`
-  - : Background of selected items, for example a selected checkbox
+  - : Background of selected items, for example, a selected checkbox
 - `SelectedItemText`
   - : Text of selected items
 - `VisitedText`


### PR DESCRIPTION
### Description

Adds two system colors from the [CSS Color Module Level 4](https://drafts.csswg.org/css-color/#css-system-colors) specification that were missing from the list on the [system-color documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/system-color):

- `SelectedItem`
- `SelectedItemText`

The descriptions included are directly from the specification.

### Motivation

These system colors were missing from the list.

### Related issues and pull requests

It looks like these had previously been added to a list in #22555 , that used to exist on the [color data type page](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), before system-color had it's own data type page and was linked to.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
