### PR TITLE
chore(ci): Add 'issue: write' perms to workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,6 +4,7 @@ on:
   - pull_request_target
 
 permissions:
+  issues: write
   pull-requests: write
   contents: read
 


### PR DESCRIPTION
We do indeed need `issue: write` perms, see https://github.com/mdn/content/pull/31738