### PR TITLE
relnote(122): Enable LargestContentfulPaint in stable

### DIFF
--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -51,6 +51,9 @@ This article provides information about the changes in Firefox 122 that affect d
 
 ### APIs
 
+- The [LargestContentfulPaint API](/en-US/docs/Web/API/LargestContentfulPaint) is now supported.
+  This API is part of the [Performance APIs](/en-US/docs/Web/API/Performance_API) and provides timing information about the largest image or text paint before users interact with a web page ([Firefox bug 1866266](https://bugzil.la/1866266)).
+
 #### DOM
 
 ### showPicker() method for HTML select elements


### PR DESCRIPTION
__Preference:__

`dom.enable_largest_contentful_paint`, [see revision](https://hg.mozilla.org/mozilla-central/rev/5dc051006d87)

```diff
--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -2409,17 +2409,17 @@
 - name: dom.enable_event_timing
   type: RelaxedAtomicBool
   value: true
   mirror: always
 
 # Whether the LargestContentfulPaint API will be gathered and returned by performance observer*
 - name: dom.enable_largest_contentful_paint
   type: RelaxedAtomicBool
-  value: @IS_NIGHTLY_BUILD@
+  value: true
   mirror: always
```

__Bugzilla:__

- [bugzilla.mozilla.org/show_bug.cgi?id=1866266](https://bugzilla.mozilla.org/show_bug.cgi?id=1866266)



__Related issues and pull requests:__

- [x] Parent issue https://github.com/mdn/content/issues/31110
- [x] BCD: https://github.com/mdn/browser-compat-data/pull/21678

__Existing docs:__

- https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint
- https://developer.mozilla.org/en-US/docs/Glossary/Largest_contentful_paint

