### PR TITLE
chore(ci): Disable XL comment on PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -42,9 +42,7 @@ jobs:
           l_max_size: "100"
           xl_label: "size/xl"
           fail_if_xl: "false"
-          # message_if_xl: >
-          #   This PR exceeds the recommended size of 1000 lines.
-          #   ...
+          message_if_xl: ""
           files_to_ignore: |
             "files/en-us/_redirects.txt"
             "files/en-us/_wikihistory.json"


### PR DESCRIPTION
While we're evaluating this workflow, we can disable adding comments to `size/xl` PRs.

### Related issues and pull requests

- https://github.com/mdn/content/pull/31658#issuecomment-1896062287