### PR TITLE
Remove redundant word in SVG Attribute Reference: fill

### DIFF
--- a/files/en-us/web/svg/attribute/fill/index.md
+++ b/files/en-us/web/svg/attribute/fill/index.md
@@ -335,7 +335,7 @@ For {{SVGElement('set')}}, `fill` defines the final state of the animation.
 
 ## text
 
-For {{SVGElement('text')}}, `fill` is a presentation attribute that defines what the color of the text.
+For {{SVGElement('text')}}, `fill` is a presentation attribute that defines the color of the text.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
### Description

Removed a redundant word in the text section.

### Motivation

Current sentence is incorrect.

### Additional details

--

### Related issues and pull requests

--
