### PR TITLE
Correct reference to non-existent header

### DIFF
--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -57,7 +57,7 @@ HTTP requests are messages sent by the client to initiate an action on the serve
 Many different headers can appear in requests. They can be divided in several groups:
 
 - {{glossary("General header", "General headers")}}, like {{HTTPHeader("Via")}}, apply to the message as a whole.
-- {{glossary("Request header", "Request headers")}}, like {{HTTPHeader("User-Agent")}} or {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None")}}).
+- {{glossary("Request header", "Request headers")}}, like {{HTTPHeader("User-Agent")}} or {{HTTPHeader("Accept")}}, modify the request by specifying it further (like {{HTTPHeader("Accept-Language")}}), by giving context (like {{HTTPHeader("Referer")}}), or by conditionally restricting it (like {{HTTPHeader("If-None-Match")}}).
 - {{glossary("Representation header", "Representation headers")}} like {{HTTPHeader("Content-Type")}} that describe the original format of the message data and any encoding applied (only present if the message has a body).
 
 ![Example of headers in an HTTP request](http_request_headers3.png)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the HTTP Messages Guide, the "If-None" header is used as an example of a request header which provides conditional constraints on the request.  Unfortunately, this header doesn't actually exist, which means the link points to a URL which `404`s. This change updates the example to use "If-None-Match", which is a good example of the same preconditional functionality (and is actually what I suspect was originally intended anyway).

### Motivation

Avoiding bad links & non-existent examples :-)

### Additional details

* Exists: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
* Does not exist: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None
* "IF-None" wasn't in the original RFC where precondition headers were defined: https://datatracker.ietf.org/doc/html/rfc7232#section-3