### PR TITLE
Clarify HTTP request types that do or do not use a body

### DIFF
--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -64,7 +64,7 @@ Many different headers can appear in requests. They can be divided in several gr
 
 ### Body
 
-The final part of the request is its body. Not all requests have one: requests fetching resources like `GET` or `HEAD` usually don't need a body. Requests that send data to the server in order to update it such as `PUT` or `POST` typically require a body containing the data which is to be used in fulfilling the request (for instance HTML form data).
+The final part of the request is its body. Not all requests have one: requests fetching resources like `GET` or `HEAD` usually don't need a body. Requests that send data to the server to create a resource, such as `PUT` or `POST` requests, typically require a body with the data used to fulfill the request (for instance, HTML form data).
 
 Bodies can be broadly divided into two categories:
 

--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -64,7 +64,7 @@ Many different headers can appear in requests. They can be divided in several gr
 
 ### Body
 
-The final part of the request is its body. Not all requests have one: requests fetching resources like `GET` or `HEAD` usually don't need a body. Requests which send data to the server in order to update it such as `PUT` or `POST` typically require a body containing the data which is to be used in fulfilling the request (for instance HTML form data).
+The final part of the request is its body. Not all requests have one: requests fetching resources like `GET` or `HEAD` usually don't need a body. Requests that send data to the server in order to update it such as `PUT` or `POST` typically require a body containing the data which is to be used in fulfilling the request (for instance HTML form data).
 
 Bodies can be broadly divided into two categories:
 

--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -64,7 +64,7 @@ Many different headers can appear in requests. They can be divided in several gr
 
 ### Body
 
-The final part of the request is its body. Not all requests have one: requests fetching resources, like `GET`, `HEAD`, `DELETE`, or `OPTIONS`, usually don't need one. Some requests send data to the server in order to update it: as often the case with `POST` requests (containing HTML form data).
+The final part of the request is its body. Not all requests have one: requests fetching resources like `GET` or `HEAD` usually don't need a body. Requests which send data to the server in order to update it such as `PUT` or `POST` typically require a body containing the data which is to be used in fulfilling the request (for instance HTML form data).
 
 Bodies can be broadly divided into two categories:
 


### PR DESCRIPTION
### Description

This change is a clarification of the [HTTP Messages guide section which talks about request bodies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#body).  It reduces the number of example methods but by removing the attempt to be comprehensive, it (hopefully) clarifies the purpose of the request body and its typical usage.

### Motivation

The list of examples of requests not requiring bodies cited "fetching resources" but included `DELETE`, which set off my pedantry alarm because that's not, strictly speaking, a method that is intended to fetch a resource.

Therefore, I tried to break out the list of example methods which don't require body to be more technically accurate by saying something like "requests fetching resources like `GET` or `HEAD`, completing singular operations like `DELETE`, or exploring server capabilities like `OPTIONS`, usually don't need a request body."  That led me to realize that we're itemizing nearly _all_ the HTTP methods which don't require a body and so I briefly considered adding the last few but discarded that in favor of keeping `GET` and `HEAD`, which I suspect are the most well known "fetching" methods and left it at that.  I then tried to make the examples of methods requiring more explicit in explaining why a body might be needed.


### Additional details

[https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)