### PR TITLE
Added missing full stop in HTTP Messages guide

### DIFF
--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -78,7 +78,7 @@ Bodies can be broadly divided into two categories:
 The start line of an HTTP response, called the _status line_, contains the following information:
 
 1. The _protocol version_, usually `HTTP/1.1`.
-2. A _status code_, indicating success or failure of the request. Common status codes are {{HTTPStatus("200")}}, {{HTTPStatus("404")}}, or {{HTTPStatus("302")}}
+2. A _status code_, indicating success or failure of the request. Common status codes are {{HTTPStatus("200")}}, {{HTTPStatus("404")}}, or {{HTTPStatus("302")}}.
 3. A _status text_. A brief, purely informational, textual description of the status code to help a human understand the HTTP message.
 
 A typical status line looks like: `HTTP/1.1 404 Not Found`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The [HTTP Messages guide section on HTTP responses](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#http_responses) has a list with the middle item missing a full stop at the end of the line.

### Motivation

Consistency