### PR TITLE
Unpluralize "servers" when referring to a class of response codes

### DIFF
--- a/files/en-us/web/http/session/index.md
+++ b/files/en-us/web/http/session/index.md
@@ -147,7 +147,7 @@ X-Cache: Error from cloudfront
 
 ### Response status codes
 
-[HTTP response status codes](/en-US/docs/Web/HTTP/Status) indicate if a specific HTTP request has been successfully completed. Responses are grouped into five classes: informational responses, successful responses, redirects, client errors, and servers errors.
+[HTTP response status codes](/en-US/docs/Web/HTTP/Status) indicate if a specific HTTP request has been successfully completed. Responses are grouped into five classes: informational responses, successful responses, redirects, client errors, and server errors.
 
 - {{HTTPStatus(200)}}: OK. The request has succeeded.
 - {{HTTPStatus(301)}}: Moved Permanently. This response code means that the URI of requested resource has been changed.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The [Response status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Session#response_status_codes) section of the "Typical HTTP Session" guide talks about "client errors" and "servers errors".  The two should be consistently pluralized (or not) and to my American English-speaker's ear, the singular version sounds correct.

### Motivation

Grammatical correctness.