### PR TITLE
Use the mimeType property in the dataavailable example

### DIFF
--- a/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
@@ -62,7 +62,7 @@ mediaRecorder.onstop = (e) => {
 
   const audio = document.createElement("audio");
   audio.controls = true;
-  const blob = new Blob(chunks, { type: "audio/ogg; codecs=opus" });
+  const blob = new Blob(chunks, { type: mediaRecorder.mimeType });
   const audioURL = window.URL.createObjectURL(blob);
   audio.src = audioURL;
   console.log("recorder stopped");


### PR DESCRIPTION
The current uses the hardcoded mime type ""audio/ogg; codecs=opus", which may not be the actual type recorded. Use the `MediaRecorder.mimeType` for better portability.
