### PR TITLE
Rename file from .html to .md

### DIFF
--- a/files/en-us/web/api/htmlmapelement/name/index.html
+++ b/files/en-us/web/api/htmlmapelement/name/index.html
@@ -8,9 +8,10 @@ browser-compat: api.HTMLMapElement.name
 
 {{ApiRef("HTML DOM")}}
 
-The **`name`** property of the {{domxref("HTMLMapElement")}} represents the unique name `<map>`  element. 
+The **`name`** property of the {{domxref("HTMLMapElement")}} represents the unique name `<map>` element. 
 Its value can be used with the `useMap` attribute of the {{HTMLElement("img")}} element to reference a `<map>` element.
-If `id` is given to a {{HTMLElement("map")}} element then `name` property should be same as `id`.
+  
+If an `id` attribute is set on the {{HTMLElement("map")}} element, then this `name` property should be the same as this `id`.
 
 ## Value
 

--- a/files/en-us/web/api/htmlmapelement/name/index.md
+++ b/files/en-us/web/api/htmlmapelement/name/index.md
@@ -8,9 +8,9 @@ browser-compat: api.HTMLMapElement.name
 
 {{ApiRef("HTML DOM")}}
 
-The **`name`** property of the {{domxref("HTMLMapElement")}} represents the unique name `<map>` element. 
+The **`name`** property of the {{domxref("HTMLMapElement")}} represents the unique name `<map>` element.
 Its value can be used with the `useMap` attribute of the {{HTMLElement("img")}} element to reference a `<map>` element.
-  
+
 If an `id` attribute is set on the {{HTMLElement("map")}} element, then this `name` property should be the same as this `id`.
 
 ## Value
@@ -22,7 +22,7 @@ A non-empty string without whitespaces.
 ```html
 <map name="image-map">
   <area shape="circle" coords="15,15,5" />
-</map> 
+</map>
 ```
 
 ```js


### PR DESCRIPTION
There is an unusual sectioning flaw on this page, so I'm trying to fix it; it was caused by the page having the suffix `.html` while being `.md`

(And improving a sentence)