### PR TITLE
Fix DOM structure in Shadow DOM page

### DIFF
--- a/files/en-us/web/api/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/api/web_components/using_shadow_dom/index.md
@@ -46,7 +46,7 @@ This fragment produces the following DOM structure (excluding whitespace-only te
             - P
                 - #text: Here we will add a link to the
                 - A href="https://www.mozilla.org/"
-                - #text: Mozilla homepage
+                    - #text: Mozilla homepage
 ```
 
 _Shadow_ DOM allows hidden DOM trees to be attached to elements in the regular DOM tree — this shadow DOM tree starts with a shadow root, underneath which you can attach any element, in the same way as the normal DOM.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This fixes the DOM structure of the given HTML snippet. Instead of showing that the text was a child of the link, it incorrectly showed that it was a sibling.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

The previous structure was incorrect

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
