### PR TITLE
change blue to red

### DIFF
--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -166,19 +166,19 @@ div {
 ```css
 @media (color-gamut: p3) {
   div {
-    background-color: color(display-p3 0 0 1);
+    background-color: color(display-p3 1 0 0);
   }
 }
 
 @media (color-gamut: srgb) {
   div:nth-child(2) {
-    background-color: color(srgb 0 0 1);
+    background-color: color(srgb 1 0 0);
   }
 }
 
 @media (color-gamut: rec2020) {
   div:nth-child(3) {
-    background-color: color(rec2020 0 0 1);
+    background-color: color(rec2020 1 0 0);
   }
 }
 ```


### PR DESCRIPTION
Thanks for all the excellent work you do on the mdn documentation!

But I think this example doesn't do a good job of showing the differences between these color spaces, which are more prevalent in reds and greens, not blues.

The example "using_color-gamut_media_queries_with_color" would need to be updated to use red too.