### PR TITLE
fix: add bcd data to trusted types api

### DIFF
--- a/files/en-us/web/api/trusted_types_api/index.md
+++ b/files/en-us/web/api/trusted_types_api/index.md
@@ -2,6 +2,7 @@
 title: Trusted Types API
 slug: Web/API/Trusted_Types_API
 page-type: web-api-overview
+browser-compat: api.trustedTypes
 spec-urls: https://w3c.github.io/trusted-types/dist/spec/
 ---
 
@@ -74,7 +75,7 @@ Read more about this example, and discover other ways to sanitize input in the a
 
 ## Browser compatibility
 
-See the compatibility data for each of the Trusted Types API interfaces.
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The [Trusted Types API page](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) has no BCD data shown on it, instead showing the string "See the compatibility data for each of the Trusted Types API interfaces."
This PR adds the same BCD key as on https://developer.mozilla.org/en-US/docs/Web/API/trustedTypes.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

https://github.com/mdn/ai-feedback/issues/37
