### PR TITLE
Document the ClipboardUnsanitizedFormats parameter to the Clipboard.read() method

### DIFF
--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -23,8 +23,11 @@ read(formats)
 ### Parameters
 
 - `formats` {{optional_inline}}
+
   - : An optional object with the following properties:
+
     - `unsanitized` {{optional_inline}}
+
       - : An {{jsxref("Array")}} of strings containing MIME types of data formats that should not be sanitized when reading from the clipboard.
 
         Certain browsers may sanitize the clipboard data when it is read, to prevent malicious content from being pasted into the document. For example, Chrome (and other Chromium-based browsers) sanitizes HTML data by stripping `<script>` tags and other potentially dangerous content. Use the `unsanitized` array to specify a list of MIME types that should not be sanitized.
@@ -250,14 +253,15 @@ Notes:
 
 This example uses the `formats` parameter to read HTML data from the clipboard and get the code in its original form, without the browser sanitizing it first.
 
-Note that, currently, only Chromium-based browsers support the `formats` parameter.
-
 #### HTML
 
 ```html
 <textarea id="source" rows="5">
-<style>h1 {color: red;} p {color: blue;}</style><h1>Hello world!</h1><p>This is a test.</p><script>alert('Hello world!');</script></textarea
->
+  <style>h1 {color: red;} p {color: blue;}</style>
+  <h1>Hello world!</h1>
+  <p>This is a test.</p>
+  <script>alert('Hello world!');</script>
+</textarea>
 <button id="copy">Copy HTML</button>
 <button id="paste_normal">Paste HTML</button>
 <button id="paste_unsanitized">Paste unsanitized HTML</button>
@@ -309,18 +313,15 @@ async function getHTMLFromClipboardContents(clipboardContents) {
     }
   }
 
-  destinationTextarea.value =
-    "Could not find HTML data in the clipboard. Please use the copy button first.";
-  return "";
+  return null;
 }
 
 pasteButton.addEventListener("click", async () => {
   try {
     const clipboardContents = await navigator.clipboard.read();
     const html = await getHTMLFromClipboardContents(clipboardContents);
-    if (html) {
-      destinationTextarea.value = html;
-    }
+    destinationTextarea.value =
+      html || "Could not find HTML data in the clipboard.";
   } catch (error) {
     destinationTextarea.value = `Clipboard read failed: ${error}`;
   }
@@ -332,9 +333,8 @@ pasteUnsanitizedButton.addEventListener("click", async () => {
       unsanitized: ["text/html"],
     });
     const html = await getHTMLFromClipboardContents(clipboardContents);
-    if (html) {
-      destinationTextarea.value = html;
-    }
+    destinationTextarea.value =
+      html || "Could not find HTML data in the clipboard.";
   } catch (error) {
     destinationTextarea.value = `Clipboard read failed: ${error}`;
   }

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -17,11 +17,15 @@ Browsers commonly support reading text, HTML, and PNG image data — see [browse
 
 ```js-nolint
 read()
+read(formats)
 ```
 
 ### Parameters
 
-None.
+- `formats` {{optional_inline}}
+  - : An optional object with the following properties:
+    - `unsanitized`
+      - : An {{jsxref("Array")}} of strings specifying the data formats that should not be sanitized when reading from the clipboard. Certain browsers may sanitize the clipboard data when it is read, to prevent malicious content from being pasted into the document. For example, Chrome (and other Chromium-based browsers) sanitizes HTML data by stripping `<script>` tags and other potentially dangerous content. Use the `unsanitized` array to specify a list of MIME types that should not be sanitized.
 
 ### Return value
 
@@ -240,6 +244,107 @@ Notes:
 - If prompted, you will need to grant permission in order to paste the image.
 - This may not work on chromium browsers as the sample frame is not granted the [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) `clipboard-read` and `clipboard-write` permissions ([required by Chromium browsers](/en-US/docs/Web/API/Clipboard_API#security_considerations)).
 
+### Reading unsanitized HTML from the clipboard
+
+This example uses the `read(formats)` method to read HTML data from the clipboard and get the code in its original form, without the browser sanitizing it first.
+
+Note that, currently, only Chromium-based browsers support the `formats` parameter.
+
+#### HTML
+
+```html
+<textarea id="source" rows="5">
+<style>h1 {color: red;} p {color: blue;}</style><h1>Hello world!</h1><p>This is a test.</p><script>alert('Hello world!');</script></textarea
+>
+<button id="copy">Copy HTML</button>
+<button id="paste_normal">Paste HTML</button>
+<button id="paste_unsanitized">Paste unsanitized HTML</button>
+<textarea id="destination" rows="5"></textarea>
+```
+
+#### CSS
+
+```css
+body {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+}
+
+textarea {
+  grid-column: 1 / span 3;
+}
+```
+
+#### JavaScript
+
+```js
+const copyButton = document.getElementById("copy");
+const pasteButton = document.getElementById("paste_normal");
+const pasteUnsanitizedButton = document.getElementById("paste_unsanitized");
+const sourceTextarea = document.getElementById("source");
+const destinationTextarea = document.getElementById("destination");
+
+copyButton.addEventListener("click", async () => {
+  const text = sourceTextarea.value;
+  const type = "text/html";
+  const blob = new Blob([text], { type });
+  const data = [new ClipboardItem({ [type]: blob })];
+
+  try {
+    await navigator.clipboard.write(data);
+  } catch (e) {
+    destinationTextarea.value = `Clipboard write failed: ${e}`;
+  }
+});
+
+async function getHTMLFromClipboardContents(clipboardContents) {
+  for (const item of clipboardContents) {
+    if (item.types.includes("text/html")) {
+      const blob = await item.getType("text/html");
+      const blobText = await blob.text();
+      return blobText;
+    }
+  }
+
+  destinationTextarea.value =
+    "Could not find HTML data in the clipboard. Please use the copy button first.";
+  return "";
+}
+
+pasteButton.addEventListener("click", async () => {
+  try {
+    const clipboardContents = await navigator.clipboard.read();
+    const html = await getHTMLFromClipboardContents(clipboardContents);
+    if (html) {
+      destinationTextarea.value = html;
+    }
+  } catch (error) {
+    destinationTextarea.value = `Clipboard read failed: ${e}`;
+  }
+});
+
+pasteUnsanitizedButton.addEventListener("click", async () => {
+  try {
+    const clipboardContents = await navigator.clipboard.read({
+      unsanitized: ["text/html"],
+    });
+    const html = await getHTMLFromClipboardContents(clipboardContents);
+    if (html) {
+      destinationTextarea.value = html;
+    }
+  } catch (error) {
+    destinationTextarea.value = `Clipboard read failed: ${e}`;
+  }
+});
+```
+
+#### Result
+
+First click the "Copy HTML" button to write the HTML code from the first textarea to the clipboard. Then either click the "Paste HTML" button or the "Paste unsanitized HTML" button to paste the sanitized or unsanitized HTML code into the second textarea.
+
+{{EmbedLiveSample("Reading unsanitized HTML from the clipboard", "100%", "220")}}
+
 ## Specifications
 
 {{Specifications}}
@@ -251,7 +356,8 @@ Notes:
 ## See also
 
 - [Clipboard API](/en-US/docs/Web/API/Clipboard_API)
-- [Image support for Async Clipboard article](https://web.dev/articles/async-clipboard)
+- [Unblocking clipboard access](https://web.dev/articles/async-clipboard) on web.dev
+- [Unsanitized HTML in the Async Clipboard API](https://developer.chrome.com/docs/web-platform/unsanitized-html-async-clipboard) on developer.chrome.com
 - {{domxref("Clipboard.readText()")}}
 - {{domxref("Clipboard.writeText()")}}
 - {{domxref("Clipboard.write()")}}

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -24,8 +24,10 @@ read(formats)
 
 - `formats` {{optional_inline}}
   - : An optional object with the following properties:
-    - `unsanitized`
-      - : An {{jsxref("Array")}} of strings specifying the data formats that should not be sanitized when reading from the clipboard. Certain browsers may sanitize the clipboard data when it is read, to prevent malicious content from being pasted into the document. For example, Chrome (and other Chromium-based browsers) sanitizes HTML data by stripping `<script>` tags and other potentially dangerous content. Use the `unsanitized` array to specify a list of MIME types that should not be sanitized.
+    - `unsanitized` {{optional_inline}}
+      - : An {{jsxref("Array")}} of strings containing MIME types of data formats that should not be sanitized when reading from the clipboard.
+
+        Certain browsers may sanitize the clipboard data when it is read, to prevent malicious content from being pasted into the document. For example, Chrome (and other Chromium-based browsers) sanitizes HTML data by stripping `<script>` tags and other potentially dangerous content. Use the `unsanitized` array to specify a list of MIME types that should not be sanitized.
 
 ### Return value
 
@@ -246,7 +248,7 @@ Notes:
 
 ### Reading unsanitized HTML from the clipboard
 
-This example uses the `read(formats)` method to read HTML data from the clipboard and get the code in its original form, without the browser sanitizing it first.
+This example uses the `formats` parameter to read HTML data from the clipboard and get the code in its original form, without the browser sanitizing it first.
 
 Note that, currently, only Chromium-based browsers support the `formats` parameter.
 
@@ -293,8 +295,8 @@ copyButton.addEventListener("click", async () => {
 
   try {
     await navigator.clipboard.write(data);
-  } catch (e) {
-    destinationTextarea.value = `Clipboard write failed: ${e}`;
+  } catch (error) {
+    destinationTextarea.value = `Clipboard write failed: ${error}`;
   }
 });
 
@@ -320,7 +322,7 @@ pasteButton.addEventListener("click", async () => {
       destinationTextarea.value = html;
     }
   } catch (error) {
-    destinationTextarea.value = `Clipboard read failed: ${e}`;
+    destinationTextarea.value = `Clipboard read failed: ${error}`;
   }
 });
 
@@ -334,7 +336,7 @@ pasteUnsanitizedButton.addEventListener("click", async () => {
       destinationTextarea.value = html;
     }
   } catch (error) {
-    destinationTextarea.value = `Clipboard read failed: ${e}`;
+    destinationTextarea.value = `Clipboard read failed: ${error}`;
   }
 });
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Recently, a new optional parameter was added to the `read()` method of the Clipboard interface. This parameter allows developers to specify the mime-types for which they do not want the browser to sanitize the content. In certain cases, browsers may sanitize the clipboard content when reading it. For example, when reading HTML code, chrome inlines CSS styles and removes script tags to avoid pasting malicious content.

In some situations, this can be a problem, for example when building an HTML editor.

To work around this, the new optional parameter was added.

### Motivation

The spec changed, and Chromium browsers now support the parameter. So it's time to update the documentation.

### Additional details

Apple and Mozilla might not actually ever implement this. Even though it's standardized and implemented in chromium, not all browsers are going to agree with it. Mozilla and Apple have said they want the behavior to be consistent whether you use the new async clipboard API or the old one, and that the HTML should either always be sanitized, or never, but that having an option makes no sense to them.

Mozilla: https://github.com/mozilla/standards-positions/issues/769#issuecomment-1852250385
Apple: I couldn't find a standards position for webkit.

### See also

https://developer.chrome.com/docs/web-platform/unsanitized-html-async-clipboard
https://chromium-review.googlesource.com/c/chromium/src/+/3828553