### PR TITLE
Update bug ref for storage sync in Firefox for Android

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -9,7 +9,7 @@ browser-compat: webextensions.api.storage.sync
 
 Represents the `sync` storage area. Items in `sync` storage are synced by the browser. The data is then available on all instances of the browser the user is logged into (for example, when using a Mozilla account on desktop versions of Firefox or a Google account on Chrome) across different devices.
 
-For desktop Firefox, a user must have `Add-ons` selected in the "Sync" section in `"about:preferences"`. Firefox for Android does not synchronize data with the user's account. See [Firefox bug 1316442](https://bugzil.la/1316442).
+For desktop Firefox, a user must have `Add-ons` selected in the "Sync" section in `"about:preferences"`. Firefox for Android does not synchronize data with the user's account. See [Firefox bug 1625257](https://bugzil.la/1625257).
 
 The implementation of `storage.sync` in Firefox relies on the Add-on ID. If you use `storage.sync`, you must set an ID for your extension using the [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) manifest.json key.
 


### PR DESCRIPTION
### Description

Updates the bug reference for the fix to provide account sync for the sync storage area from the closed (resolved/duplicate) bug ([Bug 1316442](https://bugzilla.mozilla.org/show_bug.cgi?id=1316442)) to the tracking bug ([Bug 1625257](https://bugzilla.mozilla.org/show_bug.cgi?id=1625257)). This also aligns with the information provided on extension workshop and in the BCD.
