### PR TITLE
Firefox 122 release notes for WebDriver conformance

### DIFF
--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -67,9 +67,22 @@ This article provides information about the changes in Firefox 122 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
+#### General
+
+- Fixed a bug that prevented [Perform Actions](https://w3c.github.io/webdriver/#perform-actions) to correctly synthesize double and other multi-click events for the `mouse` input source ([Firefox bug 1864614](https://bugzil.la/1864614)). Additionally, these events will only be emitted when the actual mouse position has changed since the last click action ([Firefox bug 1681076](https://bugzil.la/1681076)).
+- The definitions for the `Pause` and `Equal` (Numpad block) keys have been updated to align with the WebDriver specification ([Firefox bug 1863687](https://bugzil.la/1863687)).
+
 #### WebDriver BiDi
 
+- The serialization of `WindowProxy` remote objects now also work correctly for out-of-process iframes ([Firefox bug 1867667](https://bugzil.la/1867667)).
+- The `browsingContext.setViewport` command now distinguishes between `undefined` and `null` as values for the `viewport` argument. If set to `undefined`, it signifies that the viewport should remain unchanged, while using `null` will reset it to its original dimensions ([Firefox bug 1865618](https://bugzil.la/1865618)).
+- Support for the `browsingContext.traverseHistory` command has been introduced, enabling navigations backward and forward in the browser history ([Firefox bug 1841018](https://bugzil.la/1841018)).
+- Fixed a bug in all supported network events where the `context` id consistently reported the top-level browsing context, even when the navigation occurred within an iframe ([Firefox bug 1869735](https://bugzil.la/1869735)).
+
+
 #### Marionette
+
+- Fixed a bug with [Get Element Text](https://w3c.github.io/webdriver/#dfn-get-element-text), where the command was incorrectly returning an empty text when the element was located within a ShadowRoot's slot ([Firefox bug 1824664](https://bugzil.la/1824664)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -79,7 +79,6 @@ This article provides information about the changes in Firefox 122 that affect d
 - Support for the `browsingContext.traverseHistory` command has been introduced, enabling navigations backward and forward in the browser history ([Firefox bug 1841018](https://bugzil.la/1841018)).
 - Fixed a bug in all supported network events where the `context` id consistently reported the top-level browsing context, even when the navigation occurred within an iframe ([Firefox bug 1869735](https://bugzil.la/1869735)).
 
-
 #### Marionette
 
 - Fixed a bug with [Get Element Text](https://w3c.github.io/webdriver/#dfn-get-element-text), where the command was incorrectly returning an empty text when the element was located within a ShadowRoot's slot ([Firefox bug 1824664](https://bugzil.la/1824664)).

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -75,8 +75,8 @@ This article provides information about the changes in Firefox 122 that affect d
 #### WebDriver BiDi
 
 - The serialization of `WindowProxy` remote objects now also work correctly for out-of-process iframes ([Firefox bug 1867667](https://bugzil.la/1867667)).
-- The `browsingContext.setViewport` command now distinguishes between `undefined` and `null` as values for the `viewport` argument. If set to `undefined`, it signifies that the viewport should remain unchanged, while using `null` will reset it to its original dimensions ([Firefox bug 1865618](https://bugzil.la/1865618)).
-- Support for the `browsingContext.traverseHistory` command has been introduced, enabling navigations backward and forward in the browser history ([Firefox bug 1841018](https://bugzil.la/1841018)).
+- The [browsingContext.setViewport](https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport) command now distinguishes between `undefined` and `null` as values for the `viewport` argument. If set to `undefined`, it signifies that the viewport should remain unchanged, while using `null` will reset it to its original dimensions ([Firefox bug 1865618](https://bugzil.la/1865618)).
+- Support for the [browsingContext.traverseHistory](https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory) command has been introduced, enabling navigations backward and forward in the browser history ([Firefox bug 1841018](https://bugzil.la/1841018)).
 - Fixed a bug in all supported network events where the `context` id consistently reported the top-level browsing context, even when the navigation occurred within an iframe ([Firefox bug 1869735](https://bugzil.la/1869735)).
 
 #### Marionette

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -74,7 +74,7 @@ This article provides information about the changes in Firefox 122 that affect d
 
 #### WebDriver BiDi
 
-- The serialization of `WindowProxy` remote objects now also work correctly for out-of-process iframes ([Firefox bug 1867667](https://bugzil.la/1867667)).
+- The serialization of `WindowProxy` remote objects now also works correctly for out-of-process iframes ([Firefox bug 1867667](https://bugzil.la/1867667)).
 - The [browsingContext.setViewport](https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport) command now distinguishes between `undefined` and `null` as values for the `viewport` argument. If set to `undefined`, it signifies that the viewport should remain unchanged, while using `null` will reset it to its original dimensions ([Firefox bug 1865618](https://bugzil.la/1865618)).
 - Support for the [browsingContext.traverseHistory](https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory) command has been introduced, enabling navigations backward and forward in the browser history ([Firefox bug 1841018](https://bugzil.la/1841018)).
 - Fixed a bug in all supported network events where the `context` id consistently reported the top-level browsing context, even when the navigation occurred within an iframe ([Firefox bug 1869735](https://bugzil.la/1869735)).

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -69,7 +69,7 @@ This article provides information about the changes in Firefox 122 that affect d
 
 #### General
 
-- Fixed a bug that prevented [Perform Actions](https://w3c.github.io/webdriver/#perform-actions) to correctly synthesize double and other multi-click events for the `mouse` input source ([Firefox bug 1864614](https://bugzil.la/1864614)). Additionally, these events will only be emitted when the actual mouse position has changed since the last click action ([Firefox bug 1681076](https://bugzil.la/1681076)).
+- Fixed a bug that prevented [Perform Actions](https://w3c.github.io/webdriver/#perform-actions) to correctly synthesize double and other multi-click events for the `mouse` input source ([Firefox bug 1864614](https://bugzil.la/1864614)). Additionally, these events will only be emitted when the actual mouse position has not changed since the last click action ([Firefox bug 1681076](https://bugzil.la/1681076)).
 - The definitions for the `Pause` and `Equal` (Numpad block) keys have been updated to align with the WebDriver specification ([Firefox bug 1863687](https://bugzil.la/1863687)).
 
 #### WebDriver BiDi

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -50,6 +50,8 @@ This article provides information about the changes in Firefox 123 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
+#### General
+
 #### WebDriver BiDi
 
 #### Marionette


### PR DESCRIPTION
Here the [list of fixed bugs](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox121&query_format=advanced&o1=equals&f1=cf_status_firefox122&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=16864857) worth a release note on MDN.

CC @lutien and @juliandescottes for review.