### PR TITLE
Add spec-urls to sec-websocket-accept

### DIFF
--- a/files/en-us/web/http/headers/sec-websocket-accept/index.md
+++ b/files/en-us/web/http/headers/sec-websocket-accept/index.md
@@ -3,6 +3,7 @@ title: Sec-WebSocket-Accept
 slug: Web/HTTP/Headers/Sec-WebSocket-Accept
 page-type: http-header
 browser-compat: http.headers.Sec-WebSocket-Accept
+spec-urls: https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.3
 ---
 
 {{HTTPSidebar}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Previously, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-WebSocket-Accept displays the following:

<img width="808" alt="image" src="https://github.com/mdn/content/assets/13301/d5513966-04d6-4ae9-a4d9-96b2e866c249">

Although the long term fix likely involves adding an entry to browser-compat-data, this PR presents an improvement from the status quo.

### Motivation

I wanted to click through to the relevant section of the websockets specification and could not do so.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
