### PR TITLE
webcodecs: Buffer transfer symantics in contructors

### DIFF
--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -42,6 +42,8 @@ new AudioData(init)
       - : An integer indicating the data's time in microseconds .
     - `data`
       - : A typed array of the audio data for this sample.
+    - `transfer`
+      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `AudioData` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
 
 ## Exceptions
 

--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -43,7 +43,7 @@ new AudioData(init)
     - `data`
       - : A typed array of the audio data for this sample.
     - `transfer`
-      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `AudioData` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+      - : An array of {{jsxref("ArrayBuffer")}}s that `AudioData` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `AudioData` will use that buffer directly instead of copying from it.
 
 ## Exceptions
 

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -35,7 +35,7 @@ new EncodedAudioChunk(options)
     - `data`
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing the audio data.
     - `transfer`
-      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `EncodedAudioChunk` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+      - : An array of {{jsxref("ArrayBuffer")}}s that `EncodedAudioChunk` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `EncodedAudioChunk` will use that buffer directly instead of copying from it.
 
 
 ## Examples

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -37,7 +37,6 @@ new EncodedAudioChunk(options)
     - `transfer`
       - : An array of {{jsxref("ArrayBuffer")}}s that `EncodedAudioChunk` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `EncodedAudioChunk` will use that buffer directly instead of copying from it.
 
-
 ## Examples
 
 In the following example a new `EncodedAudioChunk` is created.

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -48,7 +48,7 @@ const init = {
   data: audioBuffer,
   timestamp: 23000000,
   duration: 2000000,
-  transfer: [audioBuffer]
+  transfer: [audioBuffer],
 };
 chunk = new EncodedAudioChunk(init);
 ```

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -34,6 +34,9 @@ new EncodedAudioChunk(options)
       - : An integer representing the length of the audio in microseconds.
     - `data`
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing the audio data.
+    - `transfer`
+      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `EncodedAudioChunk` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+
 
 ## Examples
 
@@ -45,6 +48,7 @@ const init = {
   data: audioBuffer,
   timestamp: 23000000,
   duration: 2000000,
+  transfer: [audioBuffer]
 };
 chunk = new EncodedAudioChunk(init);
 ```

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -32,6 +32,9 @@ new EncodedVideoChunk(options)
       - : An integer representing the length of the video in microseconds.
     - `data`
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing the video data.
+    - `transfer`
+      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `EncodedVideoChunk` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+
 
 ## Examples
 
@@ -43,6 +46,7 @@ const init = {
   data: videoBuffer,
   timestamp: 23000000,
   duration: 2000000,
+  transfer: [videoBuffer]
 };
 chunk = new EncodedVideoChunk(init);
 ```

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -33,7 +33,7 @@ new EncodedVideoChunk(options)
     - `data`
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing the video data.
     - `transfer`
-      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `EncodedVideoChunk` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+      - : An array of {{jsxref("ArrayBuffer")}}s that `EncodedVideoChunk` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `EncodedVideoChunk` will use that buffer directly instead of copying from it.
 
 
 ## Examples

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -46,7 +46,7 @@ const init = {
   data: videoBuffer,
   timestamp: 23000000,
   duration: 2000000,
-  transfer: [videoBuffer]
+  transfer: [videoBuffer],
 };
 chunk = new EncodedVideoChunk(init);
 ```

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -35,7 +35,6 @@ new EncodedVideoChunk(options)
     - `transfer`
       - : An array of {{jsxref("ArrayBuffer")}}s that `EncodedVideoChunk` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `EncodedVideoChunk` will use that buffer directly instead of copying from it.
 
-
 ## Examples
 
 In the following example a new `EncodedVideoChunk` is created.

--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -41,6 +41,8 @@ new ImageDecoder(init)
       - : An integer indicating the desired height for the decoded output. Has no effect unless the image codec supports variable resolution decoding.
     - `preferAnimation` {{optional_inline}}
       - : A {{jsxref("Boolean")}} indicating whether the initial track selection should prefer an animated track.
+    - `transfer`
+      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `ImageDecoder` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
 
 ## Examples
 

--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -44,7 +44,6 @@ new ImageDecoder(init)
     - `transfer`
       - : An array of {{jsxref("ArrayBuffer")}}s that `ImageDecoder` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `ImageDecoder` will use that buffer directly instead of copying from it.
 
-
 ## Examples
 
 The following example creates a new `ImageDecoder` with the required options.

--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -42,7 +42,8 @@ new ImageDecoder(init)
     - `preferAnimation` {{optional_inline}}
       - : A {{jsxref("Boolean")}} indicating whether the initial track selection should prefer an animated track.
     - `transfer`
-      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `ImageDecoder` rather than copied to its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+      - : An array of {{jsxref("ArrayBuffer")}}s that `ImageDecoder` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `ImageDecoder` will use that buffer directly instead of copying from it.
+
 
 ## Examples
 

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -58,7 +58,7 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
 The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{jsxref("ArrayBuffer")}}. Its parameters are:
 
 - `data`
-  - : An {{jsxref("ArrayBuffer")}} containing the data for the new `VideoFrame`.
+  - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing the data for the new `VideoFrame`.
 - `options`
   - : An object containing the following:
     - `format`
@@ -111,6 +111,8 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
           - : A string representing the video color matrix, described on the page for the {{domxref("VideoColorSpace.matrix")}} property.
         - `fullRange`
           - : A Boolean. If `true`, indicates that full-range color values are used.
+    - `transfer`
+      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `VideoFrame` rather than copied to the its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
 
 ## Examples
 
@@ -127,7 +129,7 @@ In the following example a `VideoFrame` is created from a {{jsxref("TypedArray")
 
 ```js
 const pixelSize = 4;
-const init = {
+let init = {
   timestamp: 0,
   codedWidth: 320,
   codedHeight: 200,
@@ -143,6 +145,7 @@ for (let x = 0; x < init.codedWidth; x++) {
     data[offset + 3] = 0x0ff; // Alpha
   }
 }
+init.transfer = [data.buffer]
 let frame = new VideoFrame(data, init);
 ```
 

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -145,7 +145,7 @@ for (let x = 0; x < init.codedWidth; x++) {
     data[offset + 3] = 0x0ff; // Alpha
   }
 }
-init.transfer = [data.buffer]
+init.transfer = [data.buffer];
 let frame = new VideoFrame(data, init);
 ```
 

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -112,7 +112,7 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
         - `fullRange`
           - : A Boolean. If `true`, indicates that full-range color values are used.
     - `transfer`
-      - : An array of {{jsxref("ArrayBuffer")}}s that will be moved to `VideoFrame` rather than copied to the its internal memory. (Usually this array only contains a single element equal to an array buffer backing `data`)
+      - : An array of {{jsxref("ArrayBuffer")}}s that `VideoFrame` will detach and take ownership of. If the array contains the {{jsxref("ArrayBuffer")}} backing `data`, `VideoFrame` will use that buffer directly instead of copying from it.
 
 ## Examples
 


### PR DESCRIPTION

### Description

Add documentation for transfer list usage in constructors of webcodecs objects.

### Motivation

Missing docs for a released feature.

### Additional details

https://www.w3.org/TR/webcodecs/