### PR TITLE
Replace [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) with {{jsxref("null")}}

### DIFF
--- a/files/en-us/glossary/falsy/index.md
+++ b/files/en-us/glossary/falsy/index.md
@@ -14,7 +14,7 @@ The following table provides a complete list of JavaScript falsy values:
 
 | Value                       | Type      | Description                                                                                                                                         |
 | --------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{Glossary("null")}}        | Null      | The keyword [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) — the absence of any value.                                               |
+| {{Glossary("null")}}        | Null      | The keyword {{jsxref("null")}} — the absence of any value.                                               |
 | {{Glossary("undefined")}}   | Undefined | [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) — the primitive value.                                                 |
 | `false`                     | Boolean   | The keyword [`false`](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words).                                                         |
 | {{Glossary("NaN")}}         | Number    | [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) — not a number.                                                                    |

--- a/files/en-us/glossary/falsy/index.md
+++ b/files/en-us/glossary/falsy/index.md
@@ -14,7 +14,7 @@ The following table provides a complete list of JavaScript falsy values:
 
 | Value                       | Type      | Description                                                                                                                                         |
 | --------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{Glossary("null")}}        | Null      | The keyword {{jsxref("null")}} — the absence of any value.                                               |
+| {{Glossary("null")}}        | Null      | The keyword {{jsxref("null")}} — the absence of any value.                                                                                          |
 | {{Glossary("undefined")}}   | Undefined | [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) — the primitive value.                                                 |
 | `false`                     | Boolean   | The keyword [`false`](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words).                                                         |
 | {{Glossary("NaN")}}         | Number    | [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN) — not a number.                                                                    |

--- a/files/en-us/glossary/null/index.md
+++ b/files/en-us/glossary/null/index.md
@@ -19,7 +19,7 @@ This is considered [a bug](/en-US/docs/Web/JavaScript/Reference/Operators/typeof
 ## See also
 
 - [JavaScript data types](/en-US/docs/Web/JavaScript/Data_structures)
-- The JavaScript global object: [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+- The JavaScript global object: {{jsxref("null")}}
 - [Null pointer](https://en.wikipedia.org/wiki/Null_pointer) on Wikipedia
 - **[Glossary](/en-US/docs/Glossary)**
 

--- a/files/en-us/glossary/nullish/index.md
+++ b/files/en-us/glossary/nullish/index.md
@@ -6,4 +6,4 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In [JavaScript](/en-US/docs/Glossary/JavaScript), a nullish value is the value which is either [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{JSxRef("undefined")}}. Nullish values are always [falsy](/en-US/docs/Glossary/Falsy).
+In [JavaScript](/en-US/docs/Glossary/JavaScript), a nullish value is the value which is either {{jsxref("null")}} or {{JSxRef("undefined")}}. Nullish values are always [falsy](/en-US/docs/Glossary/Falsy).

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -435,7 +435,7 @@ Next, let's change the page title to a personalized welcome message when the use
 
 ### A user name of null?
 
-When you run the example and get the dialog box that prompts you to enter your user name, try pressing the _Cancel_ button. You should end up with a title that reads _Mozilla is cool, null_. This happens because—when you cancel the prompt—the value is set as [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). _Null_ is a special value in JavaScript that refers to the absence of a value.
+When you run the example and get the dialog box that prompts you to enter your user name, try pressing the _Cancel_ button. You should end up with a title that reads _Mozilla is cool, null_. This happens because—when you cancel the prompt—the value is set as {{jsxref("null")}}. _Null_ is a special value in JavaScript that refers to the absence of a value.
 
 Also, try clicking _OK_ without entering a name. You should end up with a title that reads _Mozilla is cool,_ for fairly obvious reasons.
 

--- a/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_went_wrong/index.md
@@ -117,7 +117,7 @@ Earlier on in the course we got you to type some simple JavaScript commands into
 
    This code will print the value of `lowOrHi` to the console after we tried to set it in line 49. See {{domxref("console/log_static", "console.log()")}} for more information.
 
-7. Save and refresh, and you should now see the `console.log()` result in your console. ![Screenshot of the same demo. One log statement is visible in the console, reading simply "null".](console-log-output.png) Sure enough, `lowOrHi`'s value is `null` at this point, and this matches up with the Firefox error message `lowOrHi is null`. So there is definitely a problem with line 49. The [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) value means "nothing", or "no value". So our code to set `lowOrHi` to an element is going wrong.
+7. Save and refresh, and you should now see the `console.log()` result in your console. ![Screenshot of the same demo. One log statement is visible in the console, reading simply "null".](console-log-output.png) Sure enough, `lowOrHi`'s value is `null` at this point, and this matches up with the Firefox error message `lowOrHi is null`. So there is definitely a problem with line 49. The {{jsxref("null")}} value means "nothing", or "no value". So our code to set `lowOrHi` to an element is going wrong.
 
 8. Let's think about what the problem could be. Line 49 is using a [`document.querySelector()`](/en-US/docs/Web/API/Document/querySelector) method to get a reference to an element by selecting it with a CSS selector. Looking further up our file, we can find the paragraph in question:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
@@ -26,7 +26,7 @@ Utilities related to your extension. Get URLs to resources packages with your ex
 ## Functions
 
 - {{WebExtAPIRef("extension.getBackgroundPage()")}}
-  - : Returns the [`Window`](/en-US/docs/Web/API/Window) object for the background page running inside the current extension. Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the extension has no background page.
+  - : Returns the [`Window`](/en-US/docs/Web/API/Window) object for the background page running inside the current extension. Returns {{jsxref("null")}} if the extension has no background page.
 - {{WebExtAPIRef("extension.getExtensionTabs()")}} {{deprecated_inline}}
   - : Returns an array of the JavaScript [Window](/en-US/docs/Web/API/Window) objects for each of the tabs running inside the current extension.
 - {{WebExtAPIRef("extension.getURL()")}} {{deprecated_inline}}

--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
@@ -47,7 +47,7 @@ None ({{jsxref("undefined")}}).
 
 - If `mode` is not one of the accepted values, a `gl.INVALID_ENUM` error is thrown.
 - If `first`, `count` or `primcount` are negative, a `gl.INVALID_VALUE` error is thrown.
-- if `gl.CURRENT_PROGRAM` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), a `gl.INVALID_OPERATION` error is thrown.
+- if `gl.CURRENT_PROGRAM` is {{jsxref("null")}}, a `gl.INVALID_OPERATION` error is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CanvasRenderingContext2D.canvas
 The **`CanvasRenderingContext2D.canvas`** property, part of the
 [Canvas API](/en-US/docs/Web/API/Canvas_API), is a read-only reference to the
 {{domxref("HTMLCanvasElement")}} object that is associated with a given context. It
-might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if there is no associated {{HTMLElement("canvas")}} element.
+might be {{jsxref("null")}} if there is no associated {{HTMLElement("canvas")}} element.
 
 ## Value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -45,14 +45,14 @@ createPattern(image, repetition)
     - `"repeat-y"` (vertical only)
     - `"no-repeat"` (neither direction)
 
-    If `repetition` is specified as an empty string (`""`) or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) (but not {{jsxref("undefined")}}), a value of `"repeat"` will be used.
+    If `repetition` is specified as an empty string (`""`) or {{jsxref("null")}} (but not {{jsxref("undefined")}}), a value of `"repeat"` will be used.
 
 ### Return value
 
 - {{domxref("CanvasPattern")}}
   - : An opaque object describing a pattern.
 
-If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is `false`), then [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
+If the `image` is not fully loaded ({{domxref("HTMLImageElement.complete")}} is `false`), then {{jsxref("null")}} is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -262,7 +262,7 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
 - {{domxref("CanvasRenderingContext2D.restore()")}}
   - : Restores the drawing style state to the last element on the 'state stack' saved by `save()`.
 - {{domxref("CanvasRenderingContext2D.canvas")}}
-  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
+  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be {{jsxref("null")}} if it is not associated with a {{HTMLElement("canvas")}} element.
 - {{domxref("CanvasRenderingContext2D.getContextAttributes()")}}
   - : Returns an object containing the context attributes used by the browser. Context attributes can be requested when using {{domxref("HTMLCanvasElement.getContext()")}} to create the 2D context.
 - {{domxref("CanvasRenderingContext2D.reset()")}}

--- a/files/en-us/web/api/element/classname/index.md
+++ b/files/en-us/web/api/element/classname/index.md
@@ -34,7 +34,7 @@ the `element` is an {{domxref("SVGElement")}}. It is better to get/set the
 `className` of an element using {{domxref("Element.getAttribute")}} and
 {{domxref("Element.setAttribute")}} if you are dealing with SVG elements. However, take
 into account that {{domxref("Element.getAttribute")}} returns
-[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+{{jsxref("null")}}
 instead of `""` if the `element` has an empty [`class` attribute](/en-US/docs/Web/HTML/Global_attributes/class).
 
 ```js

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -38,7 +38,7 @@ or the attribute's name, with no leading or trailing whitespace. See the [exampl
 
 Since the specified `value` gets converted into a string, specifying
 `null` doesn't necessarily do what you expect. Instead of removing the
-attribute or setting its value to be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), it instead sets the attribute's
+attribute or setting its value to be {{jsxref("null")}}, it instead sets the attribute's
 value to the string `"null"`. If you wish to remove an attribute, call
 {{domxref("Element.removeAttribute", "removeAttribute()")}}.
 

--- a/files/en-us/web/api/federatedcredential/protocol/index.md
+++ b/files/en-us/web/api/federatedcredential/protocol/index.md
@@ -13,7 +13,7 @@ browser-compat: api.FederatedCredential.protocol
 The **`protocol`** property of the
 {{domxref("FederatedCredential")}} interface returns a read-only
 string containing a credential's federated identity protocol. If this
-property is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), the protocol may be inferred from the
+property is {{jsxref("null")}}, the protocol may be inferred from the
 {{domxref("FederatedCredential.provider")}} property.
 
 ## Value

--- a/files/en-us/web/api/formdata/get/index.md
+++ b/files/en-us/web/api/formdata/get/index.md
@@ -28,7 +28,7 @@ get(name)
 
 ### Return value
 
-A value whose key matches the specified `name`. Otherwise, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+A value whose key matches the specified `name`. Otherwise, {{jsxref("null")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/history/state/index.md
+++ b/files/en-us/web/api/history/state/index.md
@@ -14,7 +14,7 @@ a way to look at the state without having to wait for a {{domxref("Window/popsta
 
 ## Value
 
-The state at the top of the history stack. The value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) until the
+The state at the top of the history stack. The value is {{jsxref("null")}} until the
 {{domxref("History.pushState","pushState()")}} or
 {{domxref("History.replaceState","replaceState()")}} method is used.
 

--- a/files/en-us/web/api/htmlallcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlallcollection/nameditem/index.md
@@ -23,7 +23,7 @@ namedItem(name)
 
 ### Return value
 
-The first {{domxref("Element")}} in the {{domxref("HTMLAllCollection")}} matching the `name`, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if there are none.
+The first {{domxref("Element")}} in the {{domxref("HTMLAllCollection")}} matching the `name`, or {{jsxref("null")}}, if there are none.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLCanvasElement.getContext
 
 The
 **`HTMLCanvasElement.getContext()`** method returns a drawing
-context on the canvas, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context identifier is not
+context on the canvas, or {{jsxref("null")}} if the context identifier is not
 supported, or the canvas has already been set to a different context mode.
 
 Later calls to this method on the same canvas element, with the same

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -25,7 +25,7 @@ namedItem(key)
 
 ### Return value
 
-- `item` is the first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching the _key_, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if there are none.
+- `item` is the first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching the _key_, or {{jsxref("null")}}, if there are none.
 
 ## Example
 

--- a/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
@@ -32,7 +32,7 @@ namedItem(name)
 
 ### Return value
 
-- A {{domxref("RadioNodeList")}}, {{domxref("Element")}}, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+- A {{domxref("RadioNodeList")}}, {{domxref("Element")}}, or {{jsxref("null")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -16,10 +16,10 @@ interface represents the text content of the node and its descendants.
 
 ## Value
 
-A string, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). Its value depends on the situation:
+A string, or {{jsxref("null")}}. Its value depends on the situation:
 
 - If the node is a {{domxref("document")}} or a {{glossary("doctype")}},
-  `textContent` returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+  `textContent` returns {{jsxref("null")}}.
 
   > **Note:** To get _all_ of the text and [CDATA data](/en-US/docs/Web/API/CDATASection) for the whole
   > document, use `document.documentElement.textContent`.

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -8,7 +8,7 @@ browser-compat: api.OffscreenCanvas.getContext
 
 {{APIRef("Canvas API")}}
 
-The **`OffscreenCanvas.getContext()`** method returns a drawing context for an offscreen canvas, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context identifier is not supported.
+The **`OffscreenCanvas.getContext()`** method returns a drawing context for an offscreen canvas, or {{jsxref("null")}} if the context identifier is not supported.
 
 ## Syntax
 

--- a/files/en-us/web/api/performanceelementtiming/element/index.md
+++ b/files/en-us/web/api/performanceelementtiming/element/index.md
@@ -14,7 +14,7 @@ The **`element`** read-only property of the {{domxref("PerformanceElementTiming"
 
 ## Value
 
-An {{domxref("Element")}}, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the element is a [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) element.
+An {{domxref("Element")}}, or {{jsxref("null")}} if the element is a [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) element.
 
 ## Examples
 

--- a/files/en-us/web/api/performanceeventtiming/target/index.md
+++ b/files/en-us/web/api/performanceeventtiming/target/index.md
@@ -14,7 +14,7 @@ The read-only **`target`** property returns the associated event's last [`target
 
 A {{domxref("Node")}} onto which the event was last dispatched.
 
-Or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the `Node` is disconnected from the document's DOM or is in the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM).
+Or {{jsxref("null")}} if the `Node` is disconnected from the document's DOM or is in the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM).
 
 ## Examples
 

--- a/files/en-us/web/api/request/body/index.md
+++ b/files/en-us/web/api/request/body/index.md
@@ -16,7 +16,7 @@ and `null` is returned in these cases.
 
 ## Value
 
-A {{domxref("ReadableStream")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+A {{domxref("ReadableStream")}} or {{jsxref("null")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -12,7 +12,7 @@ The **`body`** read-only property of the {{domxref("Response")}} interface is a 
 
 ## Value
 
-A {{domxref("ReadableStream")}}, or else [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) for any `Response` object [constructed](/en-US/docs/Web/API/Response/Response) with a null [`body`](/en-US/docs/Web/API/Response/Response#body) property, or for any actual [HTTP response](/en-US/docs/Web/HTTP/Messages#http_responses) that has no [body](/en-US/docs/Web/HTTP/Messages#body_2).
+A {{domxref("ReadableStream")}}, or else {{jsxref("null")}} for any `Response` object [constructed](/en-US/docs/Web/API/Response/Response) with a null [`body`](/en-US/docs/Web/API/Response/Response#body) property, or for any actual [HTTP response](/en-US/docs/Web/HTTP/Messages#http_responses) that has no [body](/en-US/docs/Web/HTTP/Messages#body_2).
 
 The stream is a [readable byte stream](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams), which supports zero-copy reading using a {{domxref("ReadableStreamBYOBReader")}}.
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
@@ -55,7 +55,7 @@ getActiveUniformBlockParameter(program, uniformBlockIndex, pname)
 ### Return value
 
 Depends on which information is requested using the `pname` parameter. If an
-error occurs, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
+error occurs, {{jsxref("null")}} is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
@@ -73,7 +73,7 @@ An `INVALID_VALUE` error is generated if:
 
 - `offset` + `returnedData.byteLength` would extend beyond the
   end of the buffer
-- `returnedData` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+- `returnedData` is {{jsxref("null")}}
 - `offset` is less than zero.
 
 An `INVALID_OPERATION` error is generated if:

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
@@ -9,7 +9,7 @@ browser-compat: api.WebGL2RenderingContext.getQuery
 {{APIRef("WebGL")}}
 
 The **`WebGL2RenderingContext.getQuery()`** method of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) returns the currently active
-{{domxref("WebGLQuery")}} for the `target`, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+{{domxref("WebGLQuery")}} for the `target`, or {{jsxref("null")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
@@ -104,7 +104,7 @@ texImage3D(target, level, internalformat, width, height, depth, border, format, 
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-      [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
+      {{jsxref("null")}})
 
 - `source`
 

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
@@ -105,7 +105,7 @@ texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, fo
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-      [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
+      {{jsxref("null")}})
 
 - `pixels`
 

--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
@@ -14,7 +14,7 @@ By now you are quite used to seeing the same pieces of {{Glossary("HTML")}}, {{G
 
 Specifically, the HTML has a {{HTMLElement("p")}} element that contains some descriptive text about the page and may also hold error messages; a {{HTMLElement("canvas")}} element; and optionally a {{HTMLElement("button")}}. The CSS contains rules for `body`, `canvas`, and `button`. Any additional non-trivial CSS and HTML will be displayed on the pages of specific examples.
 
-In following examples, we will use a JavaScript helper function, `getRenderingContext()`, to initialize the {{domxref("WebGLRenderingContext","WebGL rendering context", "", 1)}}. By now, you should be able to understand what the function does. Basically, it gets the WebGL rendering context from the canvas element, initializes the drawing buffer, clears it black, and returns the initialized context. In case of error, it displays an error message and returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+In following examples, we will use a JavaScript helper function, `getRenderingContext()`, to initialize the {{domxref("WebGLRenderingContext","WebGL rendering context", "", 1)}}. By now, you should be able to understand what the function does. Basically, it gets the WebGL rendering context from the canvas element, initializes the drawing buffer, clears it black, and returns the initialized context. In case of error, it displays an error message and returns {{jsxref("null")}}.
 
 Finally, all JavaScript code will run within an immediate function, which is a common JavaScript technique (see {{Glossary("Function")}}). The function declaration and invocation will also be hidden.
 

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
@@ -83,7 +83,7 @@ None.
   `countsList`, or `instanceCountsList` are negative,
   a `gl.INVALID_VALUE` error is thrown.
 - if `gl.CURRENT_PROGRAM` is
-  [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null),
+  {{jsxref("null")}},
   a `gl.INVALID_OPERATION` error is thrown.
 
 ## Examples

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
@@ -73,7 +73,7 @@ None.
   `countsList` are negative,
   a `gl.INVALID_VALUE` error is thrown.
 - if `gl.CURRENT_PROGRAM` is
-  [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null),
+  {{jsxref("null")}},
   a `gl.INVALID_OPERATION` error is thrown.
 
 ## Examples

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -36,7 +36,7 @@ bindFramebuffer(target, framebuffer)
       - : Used as a source for reading operations such as `gl.readPixels` and `gl.blitFramebuffer`.
 
 - `framebuffer`
-  - : A {{domxref("WebGLFramebuffer")}} object to bind, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) for binding the {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}} object associated with the rendering context.
+  - : A {{domxref("WebGLFramebuffer")}} object to bind, or {{jsxref("null")}} for binding the {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}} object associated with the rendering context.
 
 ### Return value
 

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.md
@@ -10,7 +10,7 @@ browser-compat: api.WebGLRenderingContext.canvas
 
 The **`WebGLRenderingContext.canvas`** property is a read-only
 reference to the {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}}
-object that is associated with the context. It might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not
+object that is associated with the context. It might be {{jsxref("null")}} if it is not
 associated with a {{HTMLElement("canvas")}} element or an {{domxref("OffscreenCanvas")}}
 object.
 
@@ -23,7 +23,7 @@ gl.canvas
 ### Return value
 
 Either a {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}} object or
-[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+{{jsxref("null")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -47,7 +47,7 @@ None ({{jsxref("undefined")}}).
   `gl.INVALID_ENUM` error is thrown.
 - If `first` or `count` are negative, a
   `gl.INVALID_VALUE` error is thrown.
-- if `gl.CURRENT_PROGRAM` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), a
+- if `gl.CURRENT_PROGRAM` is {{jsxref("null")}}, a
   `gl.INVALID_OPERATION` error is thrown.
 
 ## Examples

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -10,7 +10,7 @@ browser-compat: api.WebGLRenderingContext.getContextAttributes
 
 The **`WebGLRenderingContext.getContextAttributes()`** method
 returns a `WebGLContextAttributes` object that contains the actual context
-parameters. Might return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if the context is lost.
+parameters. Might return {{jsxref("null")}}, if the context is lost.
 
 ## Syntax
 
@@ -25,7 +25,7 @@ None.
 ### Return value
 
 A `WebGLContextAttributes` object that contains the actual context
-parameters, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context is lost.
+parameters, or {{jsxref("null")}} if the context is lost.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -24,7 +24,7 @@ getExtension(name)
 
 ### Return value
 
-A WebGL extension object, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if name does not match
+A WebGL extension object, or {{jsxref("null")}} if name does not match
 (case-insensitive) to one of the strings in
 {{domxref("WebGLRenderingContext.getSupportedExtensions")}}.
 

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
@@ -171,7 +171,7 @@ getTexParameter(target, pname)
 ### Return value
 
 Returns the requested texture information (as specified with `pname`). If an
-error occurs, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
+error occurs, {{jsxref("null")}} is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -72,7 +72,7 @@ getUniformLocation(program, name)
 ### Return value
 
 A {{domxref("WebGLUniformLocation")}} value indicating the location of the named
-variable, if it exists. If the specified variable doesn't exist, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is
+variable, if it exists. If the specified variable doesn't exist, {{jsxref("null")}} is
 returned instead.
 
 The `WebGLUniformLocation` is an opaque value used to uniquely identify the

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -29,13 +29,13 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 The following properties and methods provide general information and functionality to deal with the WebGL context:
 
 - {{domxref("WebGLRenderingContext.canvas")}}
-  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
+  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be {{jsxref("null")}} if it is not associated with a {{HTMLElement("canvas")}} element.
 - {{domxref("WebGLRenderingContext.drawingBufferWidth")}}
   - : The read-only width of the current drawing buffer. Should match the width of the canvas element associated with this context.
 - {{domxref("WebGLRenderingContext.drawingBufferHeight")}}
   - : The read-only height of the current drawing buffer. Should match the height of the canvas element associated with this context.
 - {{domxref("WebGLRenderingContext.getContextAttributes()")}}
-  - : Returns a `WebGLContextAttributes` object that contains the actual context parameters. Might return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if the context is lost.
+  - : Returns a `WebGLContextAttributes` object that contains the actual context parameters. Might return {{jsxref("null")}}, if the context is lost.
 - {{domxref("WebGLRenderingContext.isContextLost()")}}
   - : Returns `true` if the context is lost, otherwise returns `false`.
 - {{domxref("WebGLRenderingContext.makeXRCompatible()")}}

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -798,7 +798,7 @@ texImage2D(target, level, internalformat, width, height, border, format, type, s
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-      [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
+      {{jsxref("null")}})
 
 - `pixels`
 

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
@@ -122,7 +122,7 @@ texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixe
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-      [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
+      {{jsxref("null")}})
 
 - `pixels`
 

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -20,7 +20,7 @@ in which the window is embedded.
 
 The element which the window is embedded into. If the window isn't embedded into
 another document, or if the document into which it's embedded has a different
-{{glossary("origin")}}, the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) instead.
+{{glossary("origin")}}, the value is {{jsxref("null")}} instead.
 
 ## Examples
 

--- a/files/en-us/web/api/window/opener/index.md
+++ b/files/en-us/web/api/window/opener/index.md
@@ -20,7 +20,7 @@ In other words, if window `A` opens window `B`,
 
 A {{domxref("Window")}}-like object referring to the window that opened the current
 window (using {{domxref("window.open()")}}, or by a link with [`target`](/en-US/docs/Web/HTML/Element/a#target) attribute set). If this window was not opened by being linked to or created by
-another, returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+another, returns {{jsxref("null")}}.
 
 If the opener is not on the same origin as the current page, functionality of the
 opener object is limited. For example, variables and functions on the window object are
@@ -30,7 +30,7 @@ phishing attacks possible, where a trusted page that is opened in the original w
 replaced by a phishing page by the newly opened page.
 
 In the following cases, the browser does not populate `window.opener`, but
-leaves it [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null):
+leaves it {{jsxref("null")}}:
 
 - The opener can be omitted by specifying
   [`rel=noopener`](/en-US/docs/Web/HTML/Attributes/rel#noopener) on a link, or passing

--- a/files/en-us/web/api/xrframe/getlightestimate/index.md
+++ b/files/en-us/web/api/xrframe/getlightestimate/index.md
@@ -25,7 +25,7 @@ getLightEstimate(lightProbe)
 
 ### Return value
 
-An {{domxref("XRLightEstimate")}} object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the device cannot estimate lighting for this frame.
+An {{domxref("XRLightEstimate")}} object or {{jsxref("null")}} if the device cannot estimate lighting for this frame.
 
 ## Examples
 

--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -30,7 +30,7 @@ None ({{jsxref("undefined")}}).
 
 ### Unsubscribe from hit test
 
-The `cancel()` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The `cancel()` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
 
 ```js
 hitTestSource.cancel();

--- a/files/en-us/web/api/xrhittestsource/index.md
+++ b/files/en-us/web/api/xrhittestsource/index.md
@@ -54,7 +54,7 @@ function onXRFrame(time, xrFrame) {
 
 ### Unsubscribe from hit test
 
-To unsubscribe from a hit test source, call {{domxref("XRHitTestSource.cancel()")}}. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+To unsubscribe from a hit test source, call {{domxref("XRHitTestSource.cancel()")}}. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to {{jsxref("null")}}.
 
 ```js
 hitTestSource.cancel();

--- a/files/en-us/web/api/xrinputsource/hand/index.md
+++ b/files/en-us/web/api/xrinputsource/hand/index.md
@@ -12,7 +12,7 @@ The read-only **`hand`** property of the {{domxref("XRInputSource")}} interface 
 
 ## Value
 
-An {{domxref("XRHand")}} object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the {{domxref("XRSession")}} has not been [requested](/en-US/docs/Web/API/XRSystem/requestSession) with the `hand-tracking` feature descriptor.
+An {{domxref("XRHand")}} object or {{jsxref("null")}} if the {{domxref("XRSession")}} has not been [requested](/en-US/docs/Web/API/XRSystem/requestSession) with the `hand-tracking` feature descriptor.
 
 ## Examples
 

--- a/files/en-us/web/api/xrpose/angularvelocity/index.md
+++ b/files/en-us/web/api/xrpose/angularvelocity/index.md
@@ -16,7 +16,7 @@ the angular velocity in radians per second relative to the base
 ## Value
 
 A {{DOMxRef("DOMPointReadOnly")}} describing the angular velocity in radians
-per second relative to the base {{DOMxRef("XRSpace")}}. Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+per second relative to the base {{DOMxRef("XRSpace")}}. Returns {{jsxref("null")}}
 if the user agent can't populate this value.
 
 ## Specifications

--- a/files/en-us/web/api/xrpose/linearvelocity/index.md
+++ b/files/en-us/web/api/xrpose/linearvelocity/index.md
@@ -16,7 +16,7 @@ the linear velocity in meters per second relative to the base
 ## Value
 
 A {{DOMxRef("DOMPointReadOnly")}} describing the linear velocity in meters
-per second relative to the base {{DOMxRef("XRSpace")}}. Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+per second relative to the base {{DOMxRef("XRSpace")}}. Returns {{jsxref("null")}}
 if the user agent can't populate this value.
 
 ## Specifications

--- a/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
@@ -30,7 +30,7 @@ Note that some user agents might implement certain levels of foveation, so you m
 - `2/3`: medium foveation
 - `1.0`: maximum foveation
 
-Some devices don't support foveated rendering. In that case `fixedFoveation` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and setting it will not do anything.
+Some devices don't support foveated rendering. In that case `fixedFoveation` is {{jsxref("null")}} and setting it will not do anything.
 
 ## Examples
 

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -15,7 +15,7 @@ The _read-only_ **`domOverlayState`** property of an `immersive-ar`
 
 ## Value
 
-Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the DOM overlay feature is not supported or not enabled or an object containing information about the DOM overlay state with the following properties:
+Returns {{jsxref("null")}} if the DOM overlay feature is not supported or not enabled or an object containing information about the DOM overlay state with the following properties:
 
 - `type`
 

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -30,7 +30,7 @@ None ({{jsxref("undefined")}}).
 
 ### Unsubscribe from hit test
 
-The `cancel()` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The `cancel()` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
 
 ```js
 transientHitTestSource.cancel();

--- a/files/en-us/web/api/xrtransientinputhittestsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/index.md
@@ -56,7 +56,7 @@ function onXRFrame(time, xrFrame) {
 
 ### Unsubscribe from a transient input hit test
 
-To unsubscribe from a transient input hit test source, use the {{domxref("XRTransientInputHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRTransientInputHitTestSource` object to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+To unsubscribe from a transient input hit test source, use the {{domxref("XRTransientInputHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRTransientInputHitTestSource` object to {{jsxref("null")}}.
 
 ```js
 transientHitTestSource.cancel();

--- a/files/en-us/web/api/xrview/index.md
+++ b/files/en-us/web/api/xrview/index.md
@@ -20,7 +20,7 @@ The [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)'s **`XRView`** inte
 - {{domxref("XRView.projectionMatrix", "projectionMatrix")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : The projection matrix that will transform the scene to appear correctly given the point-of-view indicated by `eye`. This matrix should be used directly in order to avoid presentation distortions that may lead to potentially serious user discomfort.
 - {{domxref("XRView.recommendedViewportScale", "recommendedViewportScale")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : The recommended viewport scale value that you can use for `requestViewportScale()` if the user agent has such a recommendation; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
+  - : The recommended viewport scale value that you can use for `requestViewportScale()` if the user agent has such a recommendation; {{jsxref("null")}} otherwise.
 - {{domxref("XRView.transform", "transform")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An {{domxref("XRRigidTransform")}} which describes the current position and orientation of the viewpoint in relation to the {{domxref("XRReferenceSpace")}} specified when {{domxref("XRFrame.getViewerPose", "getViewerPose()")}} was called on the {{domxref("XRFrame")}} being rendered.
 

--- a/files/en-us/web/api/xrview/recommendedviewportscale/index.md
+++ b/files/en-us/web/api/xrview/recommendedviewportscale/index.md
@@ -10,11 +10,11 @@ browser-compat: api.XRView.recommendedViewportScale
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
-The read-only **`recommendedViewportScale`** property of the {{domxref("XRView")}} interface is the recommended viewport scale value that you can use for {{domxref("XRView.requestViewportScale()")}} if the user agent has such a recommendation; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
+The read-only **`recommendedViewportScale`** property of the {{domxref("XRView")}} interface is the recommended viewport scale value that you can use for {{domxref("XRView.requestViewportScale()")}} if the user agent has such a recommendation; {{jsxref("null")}} otherwise.
 
 ## Value
 
-A number greater than 0.0 and less than or equal to 1.0; or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the user agent does not provide a recommended scale.
+A number greater than 0.0 and less than or equal to 1.0; or {{jsxref("null")}} if the user agent does not provide a recommended scale.
 
 ## Examples
 

--- a/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
@@ -30,7 +30,7 @@ Note that some user agents might implement certain levels of foveation, so you m
 - `2/3`: medium foveation
 - `1.0`: maximum foveation
 
-Some devices don't support foveated rendering. In that case `fixedFoveation` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and setting it will not do anything.
+Some devices don't support foveated rendering. In that case `fixedFoveation` is {{jsxref("null")}} and setting it will not do anything.
 
 ## Examples
 

--- a/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
@@ -10,11 +10,11 @@ browser-compat: api.XRWebGLSubImage.imageIndex
 
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
-The read-only **`imageIndex`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the offset into the texture array if the layer was requested with `texture-array`; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
+The read-only **`imageIndex`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the offset into the texture array if the layer was requested with `texture-array`; {{jsxref("null")}} otherwise.
 
 ## Value
 
-A number or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the layer wasn't requested with `texture-array`.
+A number or {{jsxref("null")}} if the layer wasn't requested with `texture-array`.
 
 ### Using `imageIndex`
 

--- a/files/en-us/web/api/xrwebglsubimage/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/index.md
@@ -22,7 +22,7 @@ _Inherits properties from its parent, {{domxref("XRSubImage")}}._
 - {{domxref("XRWebGLSubImage.depthStencilTexture")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A depth/stencil {{domxref("WebGLTexture")}} object for the {{domxref("XRCompositionLayer")}} to render.
 - {{domxref("XRWebGLSubImage.imageIndex")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : A number representing the offset into the texture array if the layer was requested with `texture-array`; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
+  - : A number representing the offset into the texture array if the layer was requested with `texture-array`; {{jsxref("null")}} otherwise.
 - {{domxref("XRWebGLSubImage.colorTextureWidth")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A number representing the width in pixels of the GL attachment.
 - {{domxref("XRWebGLSubImage.colorTextureHeight")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -34,9 +34,9 @@ Implicit coercions are very convenient, but can create subtle bugs when conversi
 
 All types except [Object](#objects) define [immutable](/en-US/docs/Glossary/Immutable) values represented directly at the lowest level of the language. We refer to values of these types as _primitive values_.
 
-All primitive types, except [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), can be tested by the [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) operator. `typeof null` returns `"object"`, so one has to use `=== null` to test for `null`.
+All primitive types, except {{jsxref("null")}}, can be tested by the [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) operator. `typeof null` returns `"object"`, so one has to use `=== null` to test for `null`.
 
-All primitive types, except [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined), have their corresponding object wrapper types, which provide useful methods for working with the primitive values. For example, the [`Number`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) object provides methods like [`toExponential()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential). When a property is accessed on a primitive value, JavaScript automatically wraps the value into the corresponding wrapper object and accesses the property on the object instead. However, accessing a property on `null` or `undefined` throws a `TypeError` exception, which necessitates the introduction of the [optional chaining](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator.
+All primitive types, except {{jsxref("null")}} and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined), have their corresponding object wrapper types, which provide useful methods for working with the primitive values. For example, the [`Number`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) object provides methods like [`toExponential()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential). When a property is accessed on a primitive value, JavaScript automatically wraps the value into the corresponding wrapper object and accesses the property on the object instead. However, accessing a property on `null` or `undefined` throws a `TypeError` exception, which necessitates the introduction of the [optional chaining](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator.
 
 | Type                         | `typeof` return value | Object wrapper        |
 | ---------------------------- | --------------------- | --------------------- |
@@ -52,7 +52,7 @@ The object wrapper classes' reference pages contain more information about the m
 
 ### Null type
 
-The Null type is inhabited by exactly one value: [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The Null type is inhabited by exactly one value: {{jsxref("null")}}.
 
 ### Undefined type
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -765,7 +765,7 @@ The rules of logic guarantee that these evaluations are always correct. Note tha
 _anything_ part of the above expressions is not evaluated, so any side effects of
 doing so do not take effect.
 
-Note that for the second case, in modern code you can use the [Nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) (`??`) that works like `||`, but it only returns the second expression, when the first one is "[nullish](/en-US/docs/Glossary/Nullish)", i.e. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+Note that for the second case, in modern code you can use the [Nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) (`??`) that works like `||`, but it only returns the second expression, when the first one is "[nullish](/en-US/docs/Glossary/Nullish)", i.e. {{jsxref("null")}}
 or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined).
 It is thus the better alternative to provide defaults, when values like `''` or `0` are valid values for the first expression, too.
 

--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -255,7 +255,7 @@ console.log(myCar); // { make: 'Ford', model: 'Mustang' }
 
 However, beware of using square brackets to access properties whose names are given by external input. This may make your code susceptible to [object injection attacks](https://github.com/nodesecurity/eslint-plugin-security/blob/main/docs/the-dangers-of-square-bracket-notation.md).
 
-Nonexistent properties of an object have value {{jsxref("undefined")}} (and not [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
+Nonexistent properties of an object have value {{jsxref("undefined")}} (and not {{jsxref("null")}}).
 
 ```js
 myCar.nonexistentProperty; // undefined

--- a/files/en-us/web/javascript/language_overview/index.md
+++ b/files/en-us/web/javascript/language_overview/index.md
@@ -115,7 +115,7 @@ console.log(`I am ${age} years old.`); // Template literal
 
 ### Other types
 
-JavaScript distinguishes between [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), which indicates a deliberate non-value (and is only accessible through the `null` keyword), and {{jsxref("undefined")}}, which indicates absence of value. There are many ways to obtain `undefined`:
+JavaScript distinguishes between {{jsxref("null")}}, which indicates a deliberate non-value (and is only accessible through the `null` keyword), and {{jsxref("undefined")}}, which indicates absence of value. There are many ways to obtain `undefined`:
 
 - A [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) statement with no value (`return;`) implicitly returns `undefined`.
 - Accessing a nonexistent [object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) property (`obj.iDontExist`) returns `undefined`.

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -42,7 +42,7 @@ class ModernClass {
 class AnotherChildClass extends ModernClass {}
 ```
 
-The `prototype` property of the `ParentClass` must be an {{jsxref("Object")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), but you would rarely worry about this in practice, because a non-object `prototype` doesn't behave as it should anyway. (It's ignored by the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.)
+The `prototype` property of the `ParentClass` must be an {{jsxref("Object")}} or {{jsxref("null")}}, but you would rarely worry about this in practice, because a non-object `prototype` doesn't behave as it should anyway. (It's ignored by the [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) operator.)
 
 ```js
 function ParentClass() {}

--- a/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
@@ -6,7 +6,7 @@ page-type: javascript-error
 
 {{jsSidebar("Errors")}}
 
-The JavaScript exception "x can't be converted to BigInt" occurs when attempting to convert a {{jsxref("Symbol")}}, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), or {{jsxref("undefined")}} value to a {{jsxref("BigInt")}}, or if an operation expecting a BigInt parameter receives a number.
+The JavaScript exception "x can't be converted to BigInt" occurs when attempting to convert a {{jsxref("Symbol")}}, {{jsxref("null")}}, or {{jsxref("undefined")}} value to a {{jsxref("BigInt")}}, or if an operation expecting a BigInt parameter receives a number.
 
 ## Message
 

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -49,7 +49,7 @@ delete x;
 // is deprecated
 ```
 
-To free the contents of a variable, you can set it to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null):
+To free the contents of a variable, you can set it to {{jsxref("null")}}:
 
 ```js example-good
 "use strict";

--- a/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
@@ -50,7 +50,7 @@ Instead you will need to use {{jsxref("String.prototype.includes()")}}, for exam
 
 ### The operand can't be null or undefined
 
-Make sure the object you are inspecting isn't actually [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
+Make sure the object you are inspecting isn't actually {{jsxref("null")}} or
 {{jsxref("undefined")}}.
 
 ```js example-bad

--- a/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -42,7 +42,7 @@ const obj2 = Object.setPrototypeOf({});
 // TypeError: Object.setPrototypeOf requires at least 2 arguments, but only 1 were passed
 ```
 
-You can fix this by setting [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) as the prototype, for example:
+You can fix this by setting {{jsxref("null")}} as the prototype, for example:
 
 ```js example-good
 const obj = Object.create(null);

--- a/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
@@ -7,7 +7,7 @@ page-type: javascript-error
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "is not a non-null object" occurs when an object is expected
-somewhere and wasn't provided. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is not an object and won't work.
+somewhere and wasn't provided. {{jsxref("null")}} is not an object and won't work.
 
 ## Message
 
@@ -27,7 +27,7 @@ TypeError: Attempted to add a non-object value to a WeakSet (Safari)
 
 ## What went wrong?
 
-An object is expected somewhere and wasn't provided. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is not an
+An object is expected somewhere and wasn't provided. {{jsxref("null")}} is not an
 object and won't work. You must provide a proper object in the given situation.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/errors/no_properties/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_properties/index.md
@@ -7,7 +7,7 @@ page-type: javascript-error
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "null (or undefined) has no properties" occurs when you
-attempt to access properties of [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}. They
+attempt to access properties of {{jsxref("null")}} and {{jsxref("undefined")}}. They
 don't have any.
 
 ## Message
@@ -25,7 +25,7 @@ TypeError: undefined is not an object (evaluating 'undefined.x') (Safari)
 
 ## What went wrong?
 
-Both [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}, have no properties you could
+Both {{jsxref("null")}} and {{jsxref("undefined")}}, have no properties you could
 access.
 
 ## Examples
@@ -42,5 +42,5 @@ undefined.bar;
 
 ## See also
 
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+- {{jsxref("null")}}
 - {{jsxref("undefined")}}

--- a/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
@@ -7,7 +7,7 @@ page-type: javascript-error
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "_x_ is (not) _y_" occurs when there was an
-unexpected type. Oftentimes, unexpected {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+unexpected type. Oftentimes, unexpected {{jsxref("undefined")}} or {{jsxref("null")}}
 values.
 
 ## Message
@@ -29,7 +29,7 @@ TypeError: Symbol.keyFor requires that the first argument be a symbol (Safari)
 ## What went wrong?
 
 There was an unexpected type. This occurs oftentimes with {{jsxref("undefined")}} or
-[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) values.
+{{jsxref("null")}} values.
 
 Also, certain methods, such as {{jsxref("Object.create()")}} or
 {{jsxref("Symbol.keyFor()")}}, require a specific type, that must be provided.
@@ -79,4 +79,4 @@ if (foo) {
 ## See also
 
 - {{jsxref("undefined")}}
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+- {{jsxref("null")}}

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -222,7 +222,7 @@ console.log(parsed);
 Many built-in operations that expect BigInts first coerce their arguments to BigInts. [The operation](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tobigint) can be summarized as follows:
 
 - BigInts are returned as-is.
-- [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) throw a {{jsxref("TypeError")}}.
+- [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and {{jsxref("null")}} throw a {{jsxref("TypeError")}}.
 - `true` turns into `1n`; `false` turns into `0n`.
 - Strings are converted by parsing them as if they contain an integer literal. Any parsing failure results in a {{jsxref("SyntaxError")}}. The syntax is a subset of [string numeric literals](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion), where decimal points or exponent indicators are not allowed.
 - [Numbers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) throw a {{jsxref("TypeError")}} to prevent unintended implicit coercion causing loss of precision.

--- a/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.md
@@ -35,7 +35,7 @@ When `Boolean()` is called as a function (without `new`), it coerces the paramet
 
 ## Description
 
-The value passed as the first parameter is [converted to a boolean value](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion). If the value is omitted or is `0`, `-0`, `0n`, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), `false`, {{jsxref("NaN")}}, {{jsxref("undefined")}}, or the empty string (`""`), then the object has an initial value of `false`. All other values, including any object, an empty array (`[]`), or the string `"false"`, create an object with an initial value of `true`.
+The value passed as the first parameter is [converted to a boolean value](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion). If the value is omitted or is `0`, `-0`, `0n`, {{jsxref("null")}}, `false`, {{jsxref("NaN")}}, {{jsxref("undefined")}}, or the empty string (`""`), then the object has an initial value of `false`. All other values, including any object, an empty array (`[]`), or the string `"false"`, create an object with an initial value of `true`.
 
 > **Note:** When the non-standard property [`document.all`](/en-US/docs/Web/API/Document/all) is used as an argument for this constructor, the result is a `Boolean` object with the value `false`. This property is legacy and non-standard and should not be used.
 

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -58,7 +58,7 @@ Many built-in operations that expect booleans first coerce their arguments to bo
 
 - Booleans are returned as-is.
 - [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) turns into `false`.
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `false`.
+- {{jsxref("null")}} turns into `false`.
 - `0`, `-0`, and `NaN` turn into `false`; other numbers turn into `true`.
 - `0n` turns into `false`; other [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) turn into `true`.
 - The empty string `""` turns into `false`; other strings turn into `true`.

--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
@@ -21,9 +21,9 @@ apply(thisArg, argsArray)
 ### Parameters
 
 - `thisArg`
-  - : The value of `this` provided for the call to `func`. If the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) will be replaced with the global object, and primitive values will be converted to objects.
+  - : The value of `this` provided for the call to `func`. If the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), {{jsxref("null")}} and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) will be replaced with the global object, and primitive values will be converted to objects.
 - `argsArray` {{optional_inline}}
-  - : An array-like object, specifying the arguments with which `func` should be called, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) if no arguments should be provided to the function.
+  - : An array-like object, specifying the arguments with which `func` should be called, or {{jsxref("null")}} or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) if no arguments should be provided to the function.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/bind/index.md
@@ -23,7 +23,7 @@ bind(thisArg, arg1, arg2, /* …, */ argN)
 ### Parameters
 
 - `thisArg`
-  - : The value to be passed as the `this` parameter to the target function `func` when the bound function is called. If the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) will be replaced with the global object, and primitive values will be converted to objects. The value is ignored if the bound function is constructed using the {{jsxref("Operators/new", "new")}} operator.
+  - : The value to be passed as the `this` parameter to the target function `func` when the bound function is called. If the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), {{jsxref("null")}} and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) will be replaced with the global object, and primitive values will be converted to objects. The value is ignored if the bound function is constructed using the {{jsxref("Operators/new", "new")}} operator.
 - `arg1`, …, `argN` {{optional_inline}}
   - : Arguments to prepend to arguments provided to the bound function when invoking `func`.
 

--- a/files/en-us/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/call/index.md
@@ -23,7 +23,7 @@ call(thisArg, arg1, arg2, /* …, */ argN)
 ### Parameters
 
 - `thisArg`
-  - : The value to use as `this` when calling `func`. If the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) will be replaced with the global object, and primitive values will be converted to objects.
+  - : The value to use as `this` when calling `func`. If the function is not in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), {{jsxref("null")}} and [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) will be replaced with the global object, and primitive values will be converted to objects.
 - `arg1`, …, `argN` {{optional_inline}}
   - : Arguments for the function.
 

--- a/files/en-us/web/javascript/reference/global_objects/json/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/index.md
@@ -15,7 +15,7 @@ Unlike most global objects, `JSON` is not a constructor. You cannot use it with 
 
 ### JavaScript and JSON differences
 
-JSON is a syntax for serializing objects, arrays, numbers, strings, booleans, and [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). It is based upon JavaScript syntax, but is distinct from JavaScript: most of JavaScript is _not_ JSON. For example:
+JSON is a syntax for serializing objects, arrays, numbers, strings, booleans, and {{jsxref("null")}}. It is based upon JavaScript syntax, but is distinct from JavaScript: most of JavaScript is _not_ JSON. For example:
 
 - Objects and Arrays
   - : Property names must be double-quoted strings; [trailing commas](/en-US/docs/Web/JavaScript/Reference/Trailing_commas) are forbidden.

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -24,7 +24,7 @@ JSON.stringify(value, replacer, space)
 - `value`
   - : The value to convert to a JSON string.
 - `replacer` {{optional_inline}}
-  - : A function that alters the behavior of the stringification process, or an array of strings and numbers that specifies properties of `value` to be included in the output. If `replacer` is an array, all elements in this array that are not strings or numbers (either primitives or wrapper objects), including {{jsxref("Symbol")}} values, are completely ignored. If `replacer` is anything other than a function or an array (e.g. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or not provided), all string-keyed properties of the object are included in the resulting JSON string.
+  - : A function that alters the behavior of the stringification process, or an array of strings and numbers that specifies properties of `value` to be included in the output. If `replacer` is an array, all elements in this array that are not strings or numbers (either primitives or wrapper objects), including {{jsxref("Symbol")}} values, are completely ignored. If `replacer` is anything other than a function or an array (e.g. {{jsxref("null")}} or not provided), all string-keyed properties of the object are included in the resulting JSON string.
 - `space` {{optional_inline}}
 
   - : A string or number that's used to insert white space (including indentation, line break characters, etc.) into the output JSON string for readability purposes.
@@ -33,7 +33,7 @@ JSON.stringify(value, replacer, space)
 
     If this is a string, the string (or the first 10 characters of the string, if it's longer than that) is inserted before every nested object or array.
 
-    If `space` is anything other than a string or number (can be either a primitive or a wrapper object) — for example, is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or not provided — no white space is used.
+    If `space` is anything other than a string or number (can be either a primitive or a wrapper object) — for example, is {{jsxref("null")}} or not provided — no white space is used.
 
 ### Return value
 
@@ -52,8 +52,8 @@ A JSON string representing the given value, or undefined.
 
 - {{jsxref("Boolean")}}, {{jsxref("Number")}}, {{jsxref("String")}}, and {{jsxref("BigInt")}} (obtainable via [`Object()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/Object)) objects are converted to the corresponding primitive values during stringification, in accordance with the traditional conversion semantics. {{jsxref("Symbol")}} objects (obtainable via [`Object()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/Object)) are treated as plain objects.
 - Attempting to serialize {{jsxref("BigInt")}} values will throw. However, if the BigInt has a `toJSON()` method (through monkey patching: `BigInt.prototype.toJSON = ...`), that method can provide the serialization result. This constraint ensures that a proper serialization (and, very likely, its accompanying deserialization) behavior is always explicitly provided by the user.
-- {{jsxref("undefined")}}, {{jsxref("Function")}}, and {{jsxref("Symbol")}} values are not valid JSON values. If any such values are encountered during conversion, they are either omitted (when found in an object) or changed to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) (when found in an array). `JSON.stringify()` can return `undefined` when passing in "pure" values like `JSON.stringify(() => {})` or `JSON.stringify(undefined)`.
-- The numbers {{jsxref("Infinity")}} and {{jsxref("NaN")}}, as well as the value [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), are all considered `null`. (But unlike the values in the previous point, they would never be omitted.)
+- {{jsxref("undefined")}}, {{jsxref("Function")}}, and {{jsxref("Symbol")}} values are not valid JSON values. If any such values are encountered during conversion, they are either omitted (when found in an object) or changed to {{jsxref("null")}} (when found in an array). `JSON.stringify()` can return `undefined` when passing in "pure" values like `JSON.stringify(() => {})` or `JSON.stringify(undefined)`.
+- The numbers {{jsxref("Infinity")}} and {{jsxref("NaN")}}, as well as the value {{jsxref("null")}}, are all considered `null`. (But unlike the values in the previous point, they would never be omitted.)
 - Arrays are serialized as arrays (enclosed by square brackets). Only array indices between 0 and `length - 1` (inclusive) are serialized; other properties are ignored.
 - For other objects:
 

--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -62,7 +62,7 @@ Many built-in operations that expect numbers first coerce their arguments to num
 
 - Numbers are returned as-is.
 - [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) turns into [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `0`.
+- {{jsxref("null")}} turns into `0`.
 - `true` turns into `1`; `false` turns into `0`.
 - Strings are converted by parsing them as if they contain a [number literal](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_literals). Parsing failure results in `NaN`. There are some minor differences compared to an actual number literal:
   - Leading and trailing whitespace/line terminators are ignored.

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -61,7 +61,7 @@ In case of an error, for example if a property is non-writable, a
 changed if any properties are added before the error is raised.
 
 > **Note:** `Object.assign()` does not throw on
-> [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}} sources.
+> {{jsxref("null")}} or {{jsxref("undefined")}} sources.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -32,7 +32,7 @@ A new object with the specified prototype object and properties.
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if `proto` is neither [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) nor an {{jsxref("Object")}}.
+  - : Thrown if `proto` is neither {{jsxref("null")}} nor an {{jsxref("Object")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
@@ -63,7 +63,7 @@ console.log(Object.entries(myObj)); // [ ['foo', 'bar'] ]
 
 ### Using Object.entries() on primitives
 
-Non-object arguments are [coerced to objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion). [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) cannot be coerced to objects and throw a {{jsxref("TypeError")}} upfront. Only strings may have own enumerable properties, while all other primitives return an empty array.
+Non-object arguments are [coerced to objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion). [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and {{jsxref("null")}} cannot be coerced to objects and throw a {{jsxref("TypeError")}} upfront. Only strings may have own enumerable properties, while all other primitives return an empty array.
 
 ```js
 // Strings have indices as enumerable own properties

--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -26,7 +26,7 @@ Object.getPrototypeOf(obj)
 
 ### Return value
 
-The prototype of the given object, which may be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The prototype of the given object, which may be {{jsxref("null")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -156,7 +156,7 @@ The term "`null`-prototype object" often also includes any object without `Objec
 Many built-in operations that expect objects first coerce their arguments to objects. [The operation](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toobject) can be summarized as follows:
 
 - Objects are returned as-is.
-- [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) throw a {{jsxref("TypeError")}}.
+- [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and {{jsxref("null")}} throw a {{jsxref("TypeError")}}.
 - {{jsxref("Number")}}, {{jsxref("String")}}, {{jsxref("Boolean")}}, {{jsxref("Symbol")}}, {{jsxref("BigInt")}} primitives are wrapped into their corresponding object wrappers.
 
 There are two ways to achieve nearly the same effect in JavaScript.

--- a/files/en-us/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/is/index.md
@@ -33,7 +33,7 @@ A boolean indicating whether or not the two arguments are the same value.
 `Object.is()` determines whether two values are [the same value](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#same-value_equality_using_object.is). Two values are the same if one of the following holds:
 
 - both {{jsxref("undefined")}}
-- both [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+- both {{jsxref("null")}}
 - both `true` or both `false`
 - both strings of the same length with the same characters in the same order
 - both the same object (meaning both values reference the same object in memory)

--- a/files/en-us/web/javascript/reference/global_objects/object/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/keys/index.md
@@ -68,7 +68,7 @@ If you want _all_ string-keyed own properties, including non-enumerable ones, se
 
 ### Using Object.keys() on primitives
 
-Non-object arguments are [coerced to objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion). [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) cannot be coerced to objects and throw a {{jsxref("TypeError")}} upfront. Only strings may have own enumerable properties, while all other primitives return an empty array.
+Non-object arguments are [coerced to objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion). [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and {{jsxref("null")}} cannot be coerced to objects and throw a {{jsxref("TypeError")}} upfront. Only strings may have own enumerable properties, while all other primitives return an empty array.
 
 ```js
 // Strings have indices as enumerable own properties

--- a/files/en-us/web/javascript/reference/global_objects/object/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/object/index.md
@@ -30,7 +30,7 @@ Object(value)
 
 When the `Object()` constructor itself is called or constructed, its return value is an object:
 
-- If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it creates and returns an empty object.
+- If the value is {{jsxref("null")}} or {{jsxref("undefined")}}, it creates and returns an empty object.
 - If the value is an object already, it returns the value.
 - Otherwise, it returns an object of a type that corresponds to the given value. For example, passing a {{jsxref("BigInt")}} primitive returns a `BigInt` wrapper object.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Object.setPrototypeOf
 
 {{JSRef}}
 
-The **`Object.setPrototypeOf()`** static method sets the prototype (i.e., the internal `[[Prototype]]` property) of a specified object to another object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The **`Object.setPrototypeOf()`** static method sets the prototype (i.e., the internal `[[Prototype]]` property) of a specified object to another object or {{jsxref("null")}}.
 
 > **Warning:** Changing the `[[Prototype]]` of an object is, by the nature of how modern JavaScript engines optimize property accesses, currently a very slow operation in every browser and JavaScript engine. In addition, the effects of altering inheritance are subtle and far-flung, and are not limited to the time spent in the `Object.setPrototypeOf(...)` statement, but may extend to **_any_** code that has access to any object whose `[[Prototype]]` has been altered. You can read more in [JavaScript engine fundamentals: optimizing prototypes](https://mathiasbynens.be/notes/prototypes).
 >
@@ -26,7 +26,7 @@ Object.setPrototypeOf(obj, prototype)
 - `obj`
   - : The object which is to have its prototype set.
 - `prototype`
-  - : The object's new prototype (an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
+  - : The object's new prototype (an object or {{jsxref("null")}}).
 
 ### Return value
 
@@ -38,7 +38,7 @@ The specified object.
   - : Thrown in one of the following cases:
     - The `obj` parameter is `undefined` or `null`.
     - The `obj` parameter is [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible), or it's an [immutable prototype exotic object](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-immutable-prototype-exotic-objects), such as `Object.prototype` or [`window`](/en-US/docs/Web/API/Window). However, the error is not thrown if the new prototype is the same value as the original prototype of `obj`.
-    - The `prototype` parameter is not an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+    - The `prototype` parameter is not an object or {{jsxref("null")}}.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -55,7 +55,7 @@ Object.prototype.toString.call(arr); // "[object Array]"
 
 The [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object returns `"[object Arguments]"`. Everything else, including user-defined classes, unless with a custom `Symbol.toStringTag`, will return `"[object Object]"`.
 
-`Object.prototype.toString()` invoked on [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}} returns `[object Null]` and `[object Undefined]`, respectively.
+`Object.prototype.toString()` invoked on {{jsxref("null")}} and {{jsxref("undefined")}} returns `[object Null]` and `[object Undefined]`, respectively.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/values/index.md
@@ -66,7 +66,7 @@ console.log(Object.values(myObj)); // ['bar']
 
 ### Using Object.values() on primitives
 
-Non-object arguments are [coerced to objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion). [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) cannot be coerced to objects and throw a {{jsxref("TypeError")}} upfront. Only strings may have own enumerable properties, while all other primitives return an empty array.
+Non-object arguments are [coerced to objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#object_coercion). [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) and {{jsxref("null")}} cannot be coerced to objects and throw a {{jsxref("TypeError")}} upfront. Only strings may have own enumerable properties, while all other primitives return an empty array.
 
 ```js
 // Strings have indices as enumerable own properties

--- a/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
@@ -22,7 +22,7 @@ Reflect.setPrototypeOf(target, prototype)
 - `target`
   - : The target object of which to set the prototype.
 - `prototype`
-  - : The object's new prototype (an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
+  - : The object's new prototype (an object or {{jsxref("null")}}).
 
 ### Return value
 
@@ -31,7 +31,7 @@ A {{jsxref("Boolean")}} indicating whether or not the prototype was successfully
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if `target` is not an object or if `prototype` is neither an object nor [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+  - : Thrown if `target` is not an object or if `prototype` is neither an object nor {{jsxref("null")}}.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -24,7 +24,7 @@ regexp[Symbol.match](str)
 
 ### Return value
 
-An {{jsxref("Array")}} whose contents depend on the presence or absence of the global (`g`) flag, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if no matches are found.
+An {{jsxref("Array")}} whose contents depend on the presence or absence of the global (`g`) flag, or {{jsxref("null")}} if no matches are found.
 
 - If the `g` flag is used, all results matching the complete regular expression will be returned, but capturing groups are not included.
 - If the `g` flag is not used, only the first complete match and its related capturing groups are returned. In this case, `match()` will return the same result as {{jsxref("RegExp.prototype.exec()")}} (an array with some extra properties).

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.RegExp.exec
 
 {{JSRef}}
 
-The **`exec()`** method of {{jsxref("RegExp")}} instances executes a search with this regular expression for a match in a specified string and returns a result array, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The **`exec()`** method of {{jsxref("RegExp")}} instances executes a search with this regular expression for a match in a specified string and returns a result array, or {{jsxref("null")}}.
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-exec.html")}}
 
@@ -24,7 +24,7 @@ exec(str)
 
 ### Return value
 
-If the match fails, the `exec()` method returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), and sets the regex's [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) to `0`.
+If the match fails, the `exec()` method returns {{jsxref("null")}}, and sets the regex's [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) to `0`.
 
 If the match succeeds, the `exec()` method returns an array and updates the [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) property of the regular expression object. The returned array has the matched text as the first item, and then one item for each capturing group of the matched text. The array also has the following additional properties:
 

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -165,7 +165,7 @@ Many built-in operations that expect strings first coerce their arguments to str
 
 - Strings are returned as-is.
 - [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) turns into `"undefined"`.
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) turns into `"null"`.
+- {{jsxref("null")}} turns into `"null"`.
 - `true` turns into `"true"`; `false` turns into `"false"`.
 - Numbers are converted with the same algorithm as [`toString(10)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString).
 - [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) are converted with the same algorithm as [`toString(10)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString).
@@ -402,7 +402,7 @@ The only escaping they do is to replace `"` in the attribute value (for {{jsxref
 
 ### String conversion
 
-The `String()` function is a more reliable way of converting values to strings than calling the `toString()` method of the value, as the former works when used on [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}. For example:
+The `String()` function is a more reliable way of converting values to strings than calling the `toString()` method of the value, as the former works when used on {{jsxref("null")}} and {{jsxref("undefined")}}. For example:
 
 ```js
 // You cannot access properties on null or undefined

--- a/files/en-us/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/match/index.md
@@ -29,7 +29,7 @@ match(regexp)
 
 ### Return value
 
-An {{jsxref("Array")}} whose contents depend on the presence or absence of the global (`g`) flag, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if no matches are found.
+An {{jsxref("Array")}} whose contents depend on the presence or absence of the global (`g`) flag, or {{jsxref("null")}} if no matches are found.
 
 - If the `g` flag is used, all results matching the complete regular expression will be returned, but capturing groups are not included.
 - If the `g` flag is not used, only the first complete match and its related capturing groups are returned. In this case, `match()` will return the same result as {{jsxref("RegExp.prototype.exec()")}} (an array with some extra properties).

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.md
@@ -138,4 +138,4 @@ if (y === void 0) {
 ## See also
 
 - [JavaScript data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)
-- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
+- {{jsxref("null")}}

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -301,7 +301,7 @@ A few identifiers have a special meaning in some contexts without being reserved
 
 ### Null literal
 
-See also [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) for more information.
+See also {{jsxref("null")}} for more information.
 
 ```js-nolint
 null

--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -49,7 +49,7 @@ Left values are the destination of an assignment.
 - {{jsxref("Operators/Property_accessors", "Property accessors", "", 1)}}
   - : Member operators provide access to a property or method of an object (`object.property` and `object["property"]`).
 - {{jsxref("Operators/Optional_chaining", "?.")}}
-  - : The optional chaining operator returns `undefined` instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
+  - : The optional chaining operator returns `undefined` instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ({{jsxref("null")}} or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)).
 - {{jsxref("Operators/new", "new")}}
   - : The `new` operator creates an instance of a constructor.
 - {{jsxref("Operators/new%2Etarget", "new.target")}}

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.md
@@ -107,7 +107,7 @@ false || varObject; // f || object returns varObject
 
 > **Note:** If you use this operator to provide a default value to some
 > variable, be aware that any _falsy_ value will not be used. If you only need to
-> filter out [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, consider using
+> filter out {{jsxref("null")}} or {{jsxref("undefined")}}, consider using
 > [the nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing).
 
 ### Conversion rules for booleans

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -63,7 +63,7 @@ document.getElementById("lyrics").textContent ||= "No lyrics.";
 
 Here the short-circuit is especially beneficial, since the element will not be updated unnecessarily and won't cause unwanted side-effects such as additional parsing or rendering work, or loss of focus, etc.
 
-Note: Pay attention to the value returned by the API you're checking against. If an empty string is returned (a {{Glossary("falsy")}} value), `||=` must be used, so that "No lyrics." is displayed instead of a blank space. However, if the API returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
+Note: Pay attention to the value returned by the API you're checking against. If an empty string is returned (a {{Glossary("falsy")}} value), `||=` must be used, so that "No lyrics." is displayed instead of a blank space. However, if the API returns {{jsxref("null")}} or
 {{jsxref("undefined")}} in case of blank content, [`??=`](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment) should be used instead.
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.nullish_coalescing
 
 The **nullish coalescing (`??`)** operator is a logical
 operator that returns its right-hand side operand when its left-hand side operand is
-[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, and otherwise returns its left-hand side
+{{jsxref("null")}} or {{jsxref("undefined")}}, and otherwise returns its left-hand side
 operand.
 
 {{EmbedInteractiveExample("pages/js/expressions-nullishcoalescingoperator.html")}}

--- a/files/en-us/web/javascript/reference/operators/object_initializer/index.md
+++ b/files/en-us/web/javascript/reference/operators/object_initializer/index.md
@@ -233,7 +233,7 @@ const mergedObj = { ...obj1, ...obj2 };
 
 ### Prototype setter
 
-A property definition of the form `__proto__: value` or `"__proto__": value` does not create a property with the name `__proto__`. Instead, if the provided value is an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), it points the `[[Prototype]]` of the created object to that value. (If the value is not an object or `null`, the object is not changed.)
+A property definition of the form `__proto__: value` or `"__proto__": value` does not create a property with the name `__proto__`. Instead, if the provided value is an object or {{jsxref("null")}}, it points the `[[Prototype]]` of the created object to that value. (If the value is not an object or `null`, the object is not changed.)
 
 Note that the `__proto__` key is standardized syntax, in contrast to the non-standard and non-performant [`Object.prototype.__proto__`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) accessors. It sets the `[[Prototype]]` during object creation, similar to {{jsxref("Object.create")}} — instead of mutating the prototype chain.
 

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.operators.optional_chaining
 
 {{jsSidebar("Operators")}}
 
-The **optional chaining (`?.`)** operator accesses an object's property or calls a function. If the object accessed or function called using this operator is {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), the expression short circuits and evaluates to {{jsxref("undefined")}} instead of throwing an error.
+The **optional chaining (`?.`)** operator accesses an object's property or calls a function. If the object accessed or function called using this operator is {{jsxref("undefined")}} or {{jsxref("null")}}, the expression short circuits and evaluates to {{jsxref("undefined")}} instead of throwing an error.
 
 {{EmbedInteractiveExample("pages/js/expressions-optionalchainingoperator.html", "taller")}}
 
@@ -21,7 +21,7 @@ obj.func?.(args)
 
 ## Description
 
-The `?.` operator is like the `.` chaining operator, except that instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}), the expression short-circuits with a return value of `undefined`. When used with function calls, it returns `undefined` if the given function does not exist.
+The `?.` operator is like the `.` chaining operator, except that instead of causing an error if a reference is [nullish](/en-US/docs/Glossary/Nullish) ({{jsxref("null")}} or {{jsxref("undefined")}}), the expression short-circuits with a return value of `undefined`. When used with function calls, it returns `undefined` if the given function does not exist.
 
 This results in shorter and simpler expressions when accessing chained properties when the possibility exists that a reference may be missing. It can also be helpful while exploring the content of an object when there's no known guarantee as to which properties are required.
 

--- a/files/en-us/web/javascript/reference/statements/while/index.md
+++ b/files/en-us/web/javascript/reference/statements/while/index.md
@@ -89,7 +89,7 @@ The _effect_ of that line is fine — in that, each time a comment node is found
 
 …and then, when there are no more comment nodes in the document:
 
-1. `iterator.nextNode()` returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+1. `iterator.nextNode()` returns {{jsxref("null")}}.
 2. The value of `currentNode = iterator.nextNode()` is therefore also `null`, which is [falsy](/en-US/docs/Glossary/Falsy).
 3. So the loop ends.
 

--- a/files/en-us/webassembly/javascript_interface/table/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/index.md
@@ -34,7 +34,7 @@ The **`WebAssembly.Table`** object is a JavaScript wrapper object — an array-l
 
 ### Creating a new WebAssembly Table instance
 
-The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2 elements. We then print out the table length and contents of the two indexes (retrieved via [`Table.prototype.get()`](/en-US/docs/WebAssembly/JavaScript_interface/Table/get) to show that the length is two and both elements are [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
+The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2 elements. We then print out the table length and contents of the two indexes (retrieved via [`Table.prototype.get()`](/en-US/docs/WebAssembly/JavaScript_interface/Table/get) to show that the length is two and both elements are {{jsxref("null")}}.
 
 ```js
 const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });

--- a/files/en-us/webassembly/javascript_interface/table/set/index.md
+++ b/files/en-us/webassembly/javascript_interface/table/set/index.md
@@ -35,7 +35,7 @@ None ({{jsxref("undefined")}}).
 
 ### Using Table.set
 
-The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of two references. We then print out the table length and contents of the two indexes (retrieved via [`Table.prototype.get()`](/en-US/docs/WebAssembly/JavaScript_interface/Table/get)) to show that the length is two, and the indexes currently contain no function references (they currently return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
+The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of two references. We then print out the table length and contents of the two indexes (retrieved via [`Table.prototype.get()`](/en-US/docs/WebAssembly/JavaScript_interface/Table/get)) to show that the length is two, and the indexes currently contain no function references (they currently return {{jsxref("null")}}).
 
 ```js
 const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

prefer use macros {{jsxref("null")}} than [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) markdown link

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
