### PR TITLE
Minor: Add `name` attribute to checkboxes

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -18,7 +18,7 @@ The `checkbox` role is for checkable interactive controls. Elements containing `
 > **Note:** The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML checkbox of `<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox) (with an associated {{HTMLElement('label')}}), which natively provides all the functionality required:
 
 ```html
-<input type="checkbox" id="chk1-label" />
+<input type="checkbox" id="chk1-label" name="RememberPreferences" />
 <label for="chk1-label">Remember my preferences</label>
 ```
 

--- a/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
@@ -109,7 +109,7 @@ When the dialog is correctly labeled and focus is moved to an element (often an 
       <textarea id="interests"></textarea>
     </p>
     <p>
-      <input type="checkbox" id="autoLogin" />
+      <input type="checkbox" id="autoLogin" name="autoLogin" />
       <label for="autoLogin">Auto-login?</label>
     </p>
     <p>

--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -41,7 +41,7 @@ If the `value` attribute was omitted, the default value for the checkbox is `on`
 
 ## Additional attributes
 
-In addition to the common attributes shared by all {{HTMLElement("input")}} elements, "`checkbox`" inputs support the following attributes.
+In addition to the [common attributes](/en-US/docs/Web/HTML/Element/input#attributes) shared by all {{HTMLElement("input")}} elements, "`checkbox`" inputs support the following attributes.
 
 - `checked`
 


### PR DESCRIPTION
checkboxes should have a name. The name of the element is use for [form submission](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-2) and in the [form.elements](https://html.spec.whatwg.org/multipage/forms.html#dom-form-elements) API

Part of https://github.com/openwebdocs/project/issues/134