### PR TITLE
Clarify default value of cookie Path attribute

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -51,8 +51,7 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
 
   - `;partitioned`: Indicates that the cookie should be stored using partitioned storage. See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Partitioned_cookies) for more details.
 
-  - `;path=path`: Indicates the path that must exist in the requested URL for the browser to send the {{httpheader("Cookie")}} header (e.g., '`/`',
-    '`/mydir`'). If not specified, it defaults to the "directory" of the current document URI's path component.
+  - `;path=path`: The value of the cookie's [`Path` attribute](/en-US/docs/Web/HTTP/Cookies#path_attribute).
 
   - `;samesite`: [SameSite](/en-US/docs/Web/HTTP/Cookies#samesite_cookies) prevents the browser from sending this cookie along with cross-site
     requests. Possible values are `lax`, `strict` or `none`.

--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -122,6 +122,16 @@ But these request paths don't:
 - `/docsets`
 - `/fr/docs`
 
+##### Path default value
+
+If the `Path` attribute is not set, its default value is computed from the [path](/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#path_to_resource) of the URI that set the cookie, as follows:
+
+- If the path is empty, does not start with `"/"`, or contains no more than one `"/"` character, then the default value for `Path` is `"/"`.
+- Otherwise, the default value for `Path` is the path from the start up to but not including the final `"/"` character.
+
+For example, if the cookie was set from `"https://example.org/a/b/c`, then the default value of `Path`
+would be `"/a/b"`.
+
 #### SameSite attribute
 
 The [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) attribute lets servers specify whether/when cookies are sent with cross-site requests (where {{Glossary("Site")}} is defined by the registrable domain and the _scheme_: http or https).


### PR DESCRIPTION
Follow-up to https://github.com/mdn/content/pull/29558.

This attempts to address https://github.com/mdn/content/pull/29558#issuecomment-1760096380, explaining how the default value of `Path` is computed, based on https://www.rfc-editor.org/rfc/rfc6265#section-5.1.4.
