### PR TITLE
CSSStyleRule.selectorText's value must include Space (U+0020) between selectors

### DIFF
--- a/files/en-us/web/api/cssstylerule/index.md
+++ b/files/en-us/web/api/cssstylerule/index.md
@@ -16,7 +16,7 @@ The **`CSSStyleRule`** interface represents a single CSS style rule.
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSStyleRule.selectorText")}}
-  - : Returns the textual representation of the selector for this rule, e.g. `"h1,h2"`.
+  - : Returns the textual representation of the selector for this rule, e.g. `"h1, h2"`.
 - {{domxref("CSSStyleRule.style")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("CSSStyleDeclaration")}} object for the rule.
 - {{domxref("CSSStyleRule.styleMap")}} {{ReadOnlyInline}}


### PR DESCRIPTION
### Description

The `selectorText`'s return value was incorrect, the comma must be follewed by a space.

### Additional details

The [CSSStyleRule](https://drafts.csswg.org/cssom/#cssstylerule) specifies the `selectorText` property, which goes trough on a [serialization ](https://drafts.csswg.org/cssom/#serializing-selectors) process.

> To serialize a group of selectors [serialize](https://drafts.csswg.org/cssom/#serialize-a-selector) each selector in the group of selectors and then [serialize a comma-separated list](https://drafts.csswg.org/cssom/#serialize-a-comma-separated-list)  of these serializations.

> To serialize a comma-separated list concatenate all items of the list in list order while separating them by ", ", i.e., COMMA (U+002C) followed by a single SPACE (U+0020).

