### PR TITLE
fix(streams): erroneous code in WritableStreamDefaultWriter examples

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -31,8 +31,8 @@ abort(reason)
 
 ### Return value
 
-A {{jsxref("Promise")}}, which fulfills with the value given in the `reason`
-parameter.
+A {{jsxref("Promise")}}, which fulfills to `undefined` when the stream is aborted, or
+rejects with an error if the writer was inactive or the receiver stream is invalid.
 
 ### Exceptions
 
@@ -65,9 +65,7 @@ const writer = writableStream.getWriter();
 // ...
 
 // abort the stream when desired
-writer.abort.then((reason) => {
-  console.log(reason);
-});
+await writer.abort("WritableStream aborted. Reason: ...");
 ```
 
 ## Specifications

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -46,7 +46,7 @@ function it calls the stream's `getWriter()` method, which returns an
 instance of {{domxref("WritableStreamDefaultWriter")}}. Each chunk of the
 encoded string is written to the stream using the `write()` method, and the
 `forEach()` method of the encoded `Uint8Array` to process it byte-by-byte.
-Finally, `close()` is called and the Promise is returns is handled to deal
+Finally, `close()` is called and the Promise it returns is handled to deal
 with success (or any failures) of the chunked write operations.
 
 ```js

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -43,7 +43,7 @@ The following example shows the creation of a `WritableStream` with a custom
 sink and an API-supplied queuing strategy. It then calls a function called
 `sendMessage()`, passing the newly created stream and a string. Inside this
 function it calls the stream's `getWriter()` method, which returns an
-instance of {{domxref("WritableStreamDefaultWriter")}}. Each chunk of the 
+instance of {{domxref("WritableStreamDefaultWriter")}}. Each chunk of the
 encoded string is written to the stream using the `write()` method, and the
 `forEach()` method of the encoded `Uint8Array` to process it byte-by-byte.
 Finally, `close()` is called and the Promise is returns is handled to deal

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -43,10 +43,11 @@ The following example shows the creation of a `WritableStream` with a custom
 sink and an API-supplied queuing strategy. It then calls a function called
 `sendMessage()`, passing the newly created stream and a string. Inside this
 function it calls the stream's `getWriter()` method, which returns an
-instance of {{domxref("WritableStreamDefaultWriter")}}. A `forEach()` call is
-used to write each chunk of the string to the stream. Finally, `write()` and
-`close()` return promises that are processed to deal with success or failure
-of chunks and streams.
+instance of {{domxref("WritableStreamDefaultWriter")}}. Each chunk of the 
+encoded string is written to the stream using the `write()` method, and the
+`forEach()` method of the encoded `Uint8Array` to process it byte-by-byte.
+Finally, `close()` is called and the Promise is returns is handled to deal
+with success (or any failures) of the chunked write operations.
 
 ```js
 const list = document.querySelector("ul");
@@ -55,7 +56,7 @@ function sendMessage(message, writableStream) {
   // defaultWriter is of type WritableStreamDefaultWriter
   const defaultWriter = writableStream.getWriter();
   const encoder = new TextEncoder();
-  const encoded = encoder.encode(message, { stream: true });
+  const encoded = encoder.encode(message);
   encoded.forEach((chunk) => {
     defaultWriter.ready
       .then(() => {
@@ -116,7 +117,7 @@ const writableStream = new WritableStream(
 sendMessage("Hello, world.", writableStream);
 ```
 
-You can find the full code in our [Simple writer example](https://mdn.github.io/dom-examples/streams/simple-writer/).
+You can view a live demonstration of this at our [simple writer example](https://mdn.github.io/dom-examples/streams/simple-writer/).
 
 ## Specifications
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
@@ -30,7 +30,7 @@ function sendMessage(message, writableStream) {
   // defaultWriter is of type WritableStreamDefaultWriter
   const defaultWriter = writableStream.getWriter();
   const encoder = new TextEncoder();
-  const encoded = encoder.encode(message, { stream: true });
+  const encoded = encoder.encode(message);
   encoded.forEach((chunk) => {
     // Make sure the stream and its writer are able to
     //   receive data.

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -58,7 +58,7 @@ function sendMessage(message, writableStream) {
   // defaultWriter is of type WritableStreamDefaultWriter
   const defaultWriter = writableStream.getWriter();
   const encoder = new TextEncoder();
-  const encoded = encoder.encode(message, { stream: true });
+  const encoded = encoder.encode(message);
   encoded.forEach((chunk) => {
     defaultWriter.ready
       .then(() => defaultWriter.write(chunk))


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is a quick PR that mostly just fixed some erroneous usage of the TextEncoder.encode API  in the example code. It had an imaginary second parameter of `{ stream: true }`, which is only available on the _TextDecoder.decode_ API. After knocking that out of there I just reworded a couple of things in some of the page's prose, for some added clarity.

### Motivation

I really value accurate documentation, type annotations, and examples. A wise man once told me that incorrect types and examples are **far worse** than no types and examples at all 😉 

### Additional details

N/A

### Related issues and pull requests

Sorry, no related issue for this one. Just kind of did it on the fly.
