### PR TITLE
fix(tests): remove MDNSidebar from kitchensink

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -5,8 +5,6 @@ page-type: guide
 browser-compat: html.elements.video
 ---
 
-{{MDNSidebar}}
-
 > **Warning:** Don't delete this page. It's used by [mdn/yari](https://github.com/mdn/yari) for its automation.
 
 ## About this page


### PR DESCRIPTION
- related to https://github.com/mdn/yari/pull/10329#issuecomment-1902089458

New `{{MDNSidebar}}` implementation requires `mdn/content` be checkedout in Yari workflows and tests. Better to remove the macro call from kitchensink.