### PR TITLE
fix: Remove duplicate words

### DIFF
--- a/files/en-us/web/api/editcontext/updateselection/index.md
+++ b/files/en-us/web/api/editcontext/updateselection/index.md
@@ -30,7 +30,7 @@ If the `start` and `end` values are the same, the selection is equivalent to a c
 ### Exceptions
 
 - If only one argument is provided, a `TypeError` {{domxref("DOMException")}} is thrown.
-- If either either argument is not a positive number, a {{domxref("DOMException")}} is thrown.
+- If either argument is not a positive number, a {{domxref("DOMException")}} is thrown.
 - If `start` is greater than `end`, a {{domxref("DOMException")}} is thrown.
 
 ## Examples


### PR DESCRIPTION

### Motivation

I ran a check for duplicate words and found one recent addition.

```bash
grep -rEo '\s([a-zA-Z]{2,})\s\1\s' files/**/*.md
```