### PR TITLE
Remove spec/browser section for HTML attribute

### DIFF
--- a/files/en-us/web/html/attributes/required/index.md
+++ b/files/en-us/web/html/attributes/required/index.md
@@ -2,7 +2,6 @@
 title: "HTML attribute: required"
 slug: Web/HTML/Attributes/required
 page-type: html-attribute
-browser-compat: html.elements.attributes.required
 ---
 
 {{HTMLSidebar}}
@@ -58,14 +57,6 @@ Provide an indication to users informing them the form control is required. Ensu
 ### Result
 
 {{EmbedLiveSample('Example')}}
-
-## Specifications
-
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
"required" is not a true subfeature; this page is a kind of summary for the three subfeatures called `required`, so there is no single BCD entries.

We could have added all the tables, but this would have bloated the page.