### PR TITLE
Fix incorrect statement about dialog top-layer placement

### DIFF
--- a/files/en-us/web/api/popover_api/index.md
+++ b/files/en-us/web/api/popover_api/index.md
@@ -16,7 +16,7 @@ A very common pattern on the web is to show content over the top of other conten
 - **modal**, meaning that while a popover is being shown, the rest of the page is rendered non-interactive until the popover is actioned in some way (for example an important choice is made).
 - **non-modal**, meaning that the rest of the page can be interacted with while the popover is being shown.
 
-Popovers which are created using the popover API are always non-modal. If you want to create a modal popover, a {{htmlelement("dialog")}} element is the right way to go, although bear in mind that `<dialog>` elements are not put in the {{glossary("top layer")}} by default — popovers are. There is significant overlap between the two — you might for example want to create a popover that persists, but control it using declarative HTML. You can even turn a `<dialog>` element into a popover if you want to combine popover control and top level placement with dialog semantics.
+Popovers created using the Popover API are always non-modal. If you want to create a modal popover, a {{htmlelement("dialog")}} element is the right way to go. There is significant overlap between the two — you might for example want to create a popover that persists, but control it using declarative HTML. You can turn a `<dialog>` element into a popover (`<dialog popover>` is perfectly valid) if you want to combine popover control with dialog semantics.
 
 Typical use cases for the popover API include user-interactive elements like action menus, custom "toast" notifications, form element suggestions, content pickers, or teaching UI.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR fixes an incorrect statement on the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) landing page ("bear in mind that <dialog> elements are not put in the [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) by default").

Fixes https://github.com/mdn/content/issues/31757

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
