### PR TITLE
Unify length, percentage and length-percentage links with `{{cssxref}}` macro usage

### DIFF
--- a/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -88,7 +88,7 @@ The {{cssxref("background-repeat")}} property is used to control the tiling beha
 
 #### Sizing the background image
 
-The _balloons.jpg_ image used in the initial background images example, is a large image that was cropped due to being larger than the element it is a background of. In this case we could use the {{cssxref("background-size")}} property, which can take [length](/en-US/docs/Web/CSS/length) or [percentage](/en-US/docs/Web/CSS/percentage) values, to size the image to fit inside the background.
+The _balloons.jpg_ image used in the initial background images example, is a large image that was cropped due to being larger than the element it is a background of. In this case we could use the {{cssxref("background-size")}} property, which can take {{cssxref("length")}} or {{cssxref("percentage")}} values, to size the image to fit inside the background.
 
 You can also use keywords:
 
@@ -123,7 +123,7 @@ You can use keywords such as `top` and `right` (look up the others on the {{cssx
 }
 ```
 
-And [Lengths](/en-US/docs/Web/CSS/length), and [percentages](/en-US/docs/Web/CSS/percentage):
+And {{cssxref("length", "lengths")}}, and {{cssxref("percentage", "percentages")}}:
 
 ```css
 .box {

--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -43,7 +43,7 @@ In this lesson, we will take a look at some of the most frequently used value ty
 
 ## What is a CSS value?
 
-In CSS specifications and on the property pages here on MDN you will be able to spot value types as they will be surrounded by angle brackets, such as [`<color>`](/en-US/docs/Web/CSS/color_value) or [`<length>`](/en-US/docs/Web/CSS/length). When you see the value type `<color>` as valid for a particular property, that means you can use any valid color as a value for that property, as listed on the [`<color>`](/en-US/docs/Web/CSS/color_value) reference page.
+In CSS specifications and on the property pages here on MDN you will be able to spot value types as they will be surrounded by angle brackets, such as [`<color>`](/en-US/docs/Web/CSS/color_value) or {{cssxref("length")}}. When you see the value type `<color>` as valid for a particular property, that means you can use any valid color as a value for that property, as listed on the [`<color>`](/en-US/docs/Web/CSS/color_value) reference page.
 
 > **Note:** You'll see CSS value types referred to as _data types_. The terms are basically interchangeable — when you see something in CSS referred to as a data type, it is really just a fancy way of saying value type. The term _value_ refers to any particular expression supported by a value type that you choose to use.
 
@@ -105,9 +105,7 @@ There are various numeric value types that you might find yourself using in CSS.
         A <code>&#x3C;dimension></code> is a <code>&#x3C;number></code> with a
         unit attached to it. For example, <code>45deg</code>, <code>5s</code>,
         or <code>10px</code>. <code>&#x3C;dimension></code> is an umbrella
-        category that includes the
-        <code><a href="/en-US/docs/Web/CSS/length">&#x3C;length></a></code
-        >, <code><a href="/en-US/docs/Web/CSS/angle">&#x3C;angle></a></code
+        category that includes the {{cssxref("length")}}, <code><a href="/en-US/docs/Web/CSS/angle">&#x3C;angle></a></code
         >, <code><a href="/en-US/docs/Web/CSS/time">&#x3C;time></a></code
         >, and
         <code
@@ -117,11 +115,7 @@ There are various numeric value types that you might find yourself using in CSS.
       </td>
     </tr>
     <tr>
-      <td>
-        <code
-          ><a href="/en-US/docs/Web/CSS/percentage">&#x3C;percentage></a></code
-        >
-      </td>
+      <td>{{cssxref("percentage")}}</td>
       <td>
         A <code>&#x3C;percentage></code> represents a fraction of some other
         value. For example, <code>50%</code>. Percentage values are always
@@ -134,7 +128,7 @@ There are various numeric value types that you might find yourself using in CSS.
 
 ### Lengths
 
-The numeric type you will come across most frequently is [`<length>`](/en-US/docs/Web/CSS/length). For example, `10px` (pixels) or `30em`. There are two types of lengths used in CSS — relative and absolute. It's important to know the difference in order to understand how big things will become.
+The numeric type you will come across most frequently is {{cssxref("length")}}. For example, `10px` (pixels) or `30em`. There are two types of lengths used in CSS — relative and absolute. It's important to know the difference in order to understand how big things will become.
 
 #### Absolute length units
 
@@ -336,7 +330,7 @@ The next example has font sizes set in percentages. Each `<li>` has a `font-size
 
 {{EmbedGHLiveSample("css-examples/learn/values-units/percentage-fonts.html", '100%', 800)}}
 
-Note that, while many value types accept a length or a percentage, there are some that only accept length. You can see which values are accepted on the MDN property reference pages. If the allowed value includes [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) then you can use a length or a percentage. If the allowed value only includes `<length>`, it is not possible to use a percentage.
+Note that, while many value types accept a length or a percentage, there are some that only accept length. You can see which values are accepted on the MDN property reference pages. If the allowed value includes {{cssxref("length-percentage")}} then you can use a length or a percentage. If the allowed value only includes `<length>`, it is not possible to use a percentage.
 
 ### Numbers
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -28,7 +28,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ### SVG
 
-- The [SVG attributes](/en-US/docs/Web/SVG/Attribute) that accept a [`<length>`](/en-US/docs/Web/SVG/Content_type#length) value now support [level 3](https://www.w3.org/TR/css-values-3/#lengths) [length](/en-US/docs/Web/CSS/length) [CSS data types](/en-US/docs/Web/CSS/CSS_Types) for all SVG elements. This enables the sizing of SVG elements based on font sizes (`cap`, `rem`, etc.), viewport (`vh`, `vw`, `vmin`, etc.), or absolute lengths (`px`, `cm`, etc.), e.g. `<line x1="10vw" y1="10vh" x2="50vw" y2="50vh"/>`. (See [Firefox bug 1287054](https://bugzil.la/1287054) for more details).
+- The [SVG attributes](/en-US/docs/Web/SVG/Attribute) that accept a [`<length>`](/en-US/docs/Web/SVG/Content_type#length) value now support [level 3](https://www.w3.org/TR/css-values-3/#lengths) {{cssxref("length")}} [CSS data types](/en-US/docs/Web/CSS/CSS_Types) for all SVG elements. This enables the sizing of SVG elements based on font sizes (`cap`, `rem`, etc.), viewport (`vh`, `vw`, `vmin`, etc.), or absolute lengths (`px`, `cm`, etc.), e.g. `<line x1="10vw" y1="10vh" x2="50vw" y2="50vh"/>`. (See [Firefox bug 1287054](https://bugzil.la/1287054) for more details).
 
 ### HTTP
 

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -55,7 +55,7 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
 - [CSS transitions](/en-US/docs/Web/CSS/CSS_transitions/Using_CSS_transitions)
   - : New CSS transitions support is available in Firefox 4.
 - Computed values in CSS
-  - : Support for `-moz-calc` has been added. This lets you specify `{{cssxref("&lt;length&gt;")}}` values as mathematical expressions.
+  - : Support for `-moz-calc` has been added. This lets you specify {{cssxref("length")}} values as mathematical expressions.
 - Selector grouping
   - : Support for `:-moz-any` to group selectors and factorize combinators.
 - Background image subrectangle support
@@ -187,7 +187,7 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
       <td><code>-moz-calc</code></td>
       <td>
         Lets you specify
-        {{cssxref("&lt;length&gt;")}} values as
+        {{cssxref("length")}} values as
         mathematical expressions.
       </td>
     </tr>
@@ -224,7 +224,7 @@ The following changes were made to the {{domxref("CanvasRenderingContext2D")}} i
 - The {{cssxref("overflow")}} property no longer applies to table-group elements (`<thead>`, `<tbody>`, and `<tfoot>`).
 - The `-moz-appearance` property now supports the `-moz-win-borderless-glass` value, which applies a borderless Aero Glass look to an element.
 - The [`-moz-device-pixel-ratio`](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#-moz-device-pixel-ratio) media feature has been added, allowing the use of the device pixels per CSS pixel ratio to be used in [Media Queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).
-- Gecko's handling of [CSS units](/en-US/docs/Web/CSS/length) has been revised to better match other browsers, and to more accurately translate absolute lengths into screen pixel counts based on the device's DPI.
+- Gecko's handling of CSS {{cssxref("length")}} units has been revised to better match other browsers, and to more accurately translate absolute lengths into screen pixel counts based on the device's DPI.
 
 ### Graphics and video
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/letterspacing/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/letterspacing/index.md
@@ -14,7 +14,7 @@ This corresponds to the CSS [`letter-spacing`](/en-US/docs/Web/CSS/letter-spacin
 
 ## Value
 
-The letter spacing as a string in the [CSS length](/en-US/docs/Web/CSS/length) data format.
+The letter spacing as a string in the CSS {{cssxref("length")}} data format.
 The default is `0px`.
 
 The property can be used to get or set the spacing.

--- a/files/en-us/web/api/canvasrenderingcontext2d/wordspacing/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/wordspacing/index.md
@@ -14,7 +14,7 @@ This corresponds to the CSS [`word-spacing`](/en-US/docs/Web/CSS/word-spacing) p
 
 ## Value
 
-The word spacing as a string in the [CSS length](/en-US/docs/Web/CSS/length) data format.
+The word spacing as a string in the CSS {{cssxref("length")}} data format.
 The default is `0px`.
 
 The property can be used to get or set the spacing.

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -37,7 +37,7 @@ details on how to construct a media condition.
 
 ### Source size values
 
-The source size value is a [CSS length](/en-US/docs/Web/CSS/length). It may
+The source size value is a CSS {{cssxref("length")}}. It may
 be specified using font-relative units (such as `em` or `ex`),
 absolute units (such as `px` or `cm`), or the `vw`
 unit, which lets you specify the width as a percentage of the viewport width

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -58,7 +58,7 @@ In this example, we define two custom properties, `--item-size` and `--item-colo
 </div>
 ```
 
-The following code uses the CSS `@property` at-rule to define a custom property named `--item-size`. The property sets the initial value to `40%`, limiting valid values to [percentage](/en-US/docs/Web/CSS/percentage) values only. This means, when used as the value for an item's size, its size will always be relative to its parent's size. The property is inheritable.
+The following code uses the CSS `@property` at-rule to define a custom property named `--item-size`. The property sets the initial value to `40%`, limiting valid values to {{cssxref("percentage")}} values only. This means, when used as the value for an item's size, its size will always be relative to its parent's size. The property is inheritable.
 
 ```css
 @property --item-size {

--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -11,7 +11,7 @@ The **`<alpha-value>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/C
 
 ## Syntax
 
-The value of an `<alpha-value>` is given as either a [`<number>`](/en-US/docs/Web/CSS/number) or a [`<percentage>`](/en-US/docs/Web/CSS/percentage).
+The value of an `<alpha-value>` is given as either a [`<number>`](/en-US/docs/Web/CSS/number) or a {{cssxref("percentage")}}.
 
 If given as a number, the useful range is 0 (fully transparent) to 1.0 (fully opaque), with decimal values in between; that is, 0.5 indicates that half of the foreground color is used and half of the background color is used. Values outside the range of 0 to 1 are permitted, but are [clamped](<https://en.wikipedia.org/wiki/Clamping_(graphics)>) to lie within the range 0 to 1.
 

--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -52,7 +52,7 @@ box-shadow: unset;
 
 Specify a single box-shadow using:
 
-- Two, three, or four [`<length>`](/en-US/docs/Web/CSS/length) values.
+- Two, three, or four {{cssxref("length")}} values.
 
   - If only two values are given, they are interpreted as `<offset-x>` and `<offset-y>` values.
   - If a third value is given, it is interpreted as a `<blur-radius>`.
@@ -87,7 +87,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
 
 ### Interpolation
 
-When animating shadows, such as when multiple shadow values on a box transition to new values on hover, the values are interpolated. {{Glossary("Interpolation")}} determines intermediate values of properties, such as the blur radius, spread radius, and color, as shadows transition. For each shadow in a list of shadows, the color, x, y, blur, and spread transition; the color as [`<color>`](/en-US/docs/Web/CSS/color_value), and the other values as [`<length>`](/en-US/docs/Web/CSS/length)s.
+When animating shadows, such as when multiple shadow values on a box transition to new values on hover, the values are interpolated. {{Glossary("Interpolation")}} determines intermediate values of properties, such as the blur radius, spread radius, and color, as shadows transition. For each shadow in a list of shadows, the color, x, y, blur, and spread transition; the color as [`<color>`](/en-US/docs/Web/CSS/color_value), and the other values as {{cssxref("length")}}s.
 
 In interpolating multiple shadows between two comma-separated lists of multiple box shadows, the shadows are paired, in order, with interpolation occurring between paired shadows. If the lists of shadows have different lengths, then the shorter list is padded at the end with shadows whose color is `transparent`, and X, Y, and blur are `0`, with the inset, or lack of inset, being set to match. If in any pair of shadows, one has `inset` set and the other does not, the entire shadow list is uninterpolated; the shadows will change to the new values without an animating effect.
 

--- a/files/en-us/web/css/clamp/index.md
+++ b/files/en-us/web/css/clamp/index.md
@@ -74,7 +74,7 @@ The example adjusts the sizes of page elements in three ways:
 - the font size of paragraph text
 - the font size of heading text
 
-In all three cases, the page uses a combination of a viewport-relative units ([`vw`](/en-US/docs/Web/CSS/length#vw) and [`<percentage>`](/en-US/docs/Web/CSS/percentage)), to set a size that varies with the viewport width, and a value that is not viewport relative ([`rem`](/en-US/docs/Web/CSS/length#rem) and [`px`](/en-US/docs/Web/CSS/length#px)) to implement minimum and/or maximum sizes.
+In all three cases, the page uses a combination of a viewport-relative units ([`vw`](/en-US/docs/Web/CSS/length#vw) and {{cssxref("percentage")}}), to set a size that varies with the viewport width, and a value that is not viewport relative ([`rem`](/en-US/docs/Web/CSS/length#rem) and [`px`](/en-US/docs/Web/CSS/length#px)) to implement minimum and/or maximum sizes.
 
 The example is at <https://mdn.github.io/css-examples/min-max-clamp/>. Open it in a new window and try adjusting the window width.
 

--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_axis/index.md
@@ -34,7 +34,7 @@ There are a few concepts worth digging into before looking at how the flex prope
 
 In order to work out how much space there is available to lay out flex items, the browser needs to know how big the item is to start with. How is this worked out for items that don't have a width or a height applied using an absolute length unit?
 
-There is a concept in CSS of {{CSSxRef('min-content')}} and {{CSSxRef('max-content')}}; these keywords can be used in place of a [length unit](/en-US/docs/Web/CSS/length).
+There is a concept in CSS of {{CSSxRef('min-content')}} and {{CSSxRef('max-content')}}; these keywords can be used in place of a {{cssxref("length")}} unit.
 
 In the live example below for instance I have two paragraph elements that contain a string of text. The first paragraph has a width of `min-content`. You should be able to see that the text has taken all of the soft wrapping opportunities available to it, becoming as small as it can be without overflowing. This then, is the `min-content` size of that string. Essentially, the longest word in the string is dictating the size.
 

--- a/files/en-us/web/css/css_images/using_css_gradients/index.md
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.md
@@ -557,7 +557,7 @@ div {
 
 #### Example: length for circles
 
-For circles the size may be given as a [\<length>](/en-US/docs/Web/CSS/length), which is the size of the circle.
+For circles the size may be given as a {{cssxref("length")}}, which is the size of the circle.
 
 ```html hidden
 <div class="radial-circle-size"></div>

--- a/files/en-us/web/css/css_transforms/index.md
+++ b/files/en-us/web/css/css_transforms/index.md
@@ -103,10 +103,10 @@ You can [view this example's source on GitHub](https://github.com/mdn/css-exampl
   - [`visibility`](/en-US/docs/Web/CSS/visibility)
 - Data types:
   - [`<angle>`](/en-US/docs/Web/CSS/angle)
-  - [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage)
-  - [`<length>`](/en-US/docs/Web/CSS/length)
+  - {{cssxref("length-percentage")}}
+  - {{cssxref("length")}}
   - [`<number>`](/en-US/docs/Web/CSS/number)
-  - [`<percentage>`](/en-US/docs/Web/CSS/percentage)
+  - {{cssxref("percentage")}}
   - [`<position>`](/en-US/docs/Web/CSS/position_value)
 - Glossary terms:
   - [Interpolation](/en-US/docs/Glossary/Interpolation)

--- a/files/en-us/web/css/gradient/conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/conic-gradient/index.md
@@ -70,7 +70,7 @@ The conic-gradient syntax is similar to the radial-gradient syntax, but the colo
 
 ![color stops along the circumference of a conic gradient and the axis of a radial gradient.](screenshot_2018-11-29_21.09.19.png)
 
-A conic gradient is specified by indicating a rotation angle, the center of the gradient, and then specifying a list of color-stops. Unlike linear and radial gradients, whose color-stops are placed by specifying a [length](/en-US/docs/Web/CSS/length), the color-stops of a conic gradient are specified with an [angle](/en-US/docs/Web/CSS/angle). Units include `deg` for degrees, `grad` for gradients, `rad` for radians, and `turn` for turns. There are 360 degrees, 400 gradians, 2π radians, and 1 turn in a circle. Browsers supporting conic gradients also accept percent values, with 100% equaling 360 degrees, but this is not in the specification.
+A conic gradient is specified by indicating a rotation angle, the center of the gradient, and then specifying a list of color-stops. Unlike linear and radial gradients, whose color-stops are placed by specifying a {{cssxref("length")}}, the color-stops of a conic gradient are specified with an [angle](/en-US/docs/Web/CSS/angle). Units include `deg` for degrees, `grad` for gradients, `rad` for radians, and `turn` for turns. There are 360 degrees, 400 gradians, 2π radians, and 1 turn in a circle. Browsers supporting conic gradients also accept percent values, with 100% equaling 360 degrees, but this is not in the specification.
 
 Similar to radial gradients, the conic gradient syntax provides for positioning the center of the gradient anywhere within, or even outside, the image. The values for the position are similar to the syntax for 2-value background-position.
 

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -43,9 +43,9 @@ A radial gradient is specified by indicating the center of the gradient (where t
     | `farthest-side`   | Similar to `closest-side`, except the ending shape is sized to meet the side of the box farthest from its center (or vertical and horizontal sides).                            |
     | `farthest-corner` | The default value, the gradient's ending shape is sized so that it exactly meets the farthest corner of the box from its center.                                                |
 
-    If `<ending-shape>` is specified as `circle`, the size may be given explicitly as a [`<length>`](/en-US/docs/Web/CSS/length), which provides an explicit circle radius. Negative values are invalid.
+    If `<ending-shape>` is specified as `circle`, the size may be given explicitly as a {{cssxref("length")}}, which provides an explicit circle radius. Negative values are invalid.
 
-    If `<ending-shape>` is specified as `ellipse`, the size may be given as a [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) with two values to provide an explicit ellipse size. The first value represents the horizontal radius and the second is the vertical radius. Percentage values are relative to the corresponding dimension of the gradient box. Negative values are invalid.
+    If `<ending-shape>` is specified as `ellipse`, the size may be given as a {{cssxref("length-percentage")}} with two values to provide an explicit ellipse size. The first value represents the horizontal radius and the second is the vertical radius. Percentage values are relative to the corresponding dimension of the gradient box. Negative values are invalid.
 
     When the `<ending-shape>` keyword is omitted, the gradient shape is determined by the size given. One `<length>` value provides a circle, while two values in `<length-percentage>`units provide an ellipse. A single `<percentage>` value is not valid.
 

--- a/files/en-us/web/css/mod/index.md
+++ b/files/en-us/web/css/mod/index.md
@@ -40,7 +40,7 @@ transition-duration: mod(20s / 2, 3000ms * 2); /* 4s */
 
 ### Parameter
 
-The `mod(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or [percentage](/en-US/docs/Web/CSS/percentage), for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
+The `mod(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or {{cssxref("percentage")}}, for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
 
 - `dividend`
 

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -40,7 +40,7 @@ transition-duration: rem(20s / 2, 3000ms * 2); /* 4s */
 
 ### Parameter
 
-The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or [percentage](/en-US/docs/Web/CSS/percentage), for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
+The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or {{cssxref("percentage")}}, for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
 
 - `dividend`
 

--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -117,7 +117,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td><code>depth</code></td>
       <td>{{ MathMLElement("mpadded") }}</td>
       <td>
-       A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired depth (below the baseline).
+       A {{cssxref("length-percentage")}} indicating the desired depth (below the baseline).
       </td>
     </tr>
     <tr>
@@ -209,7 +209,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mspace") }}
       </td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired height (above the baseline).
+        A {{cssxref("length-percentage")}} indicating the desired height (above the baseline).
       </td>
     </tr>
     <tr>
@@ -225,7 +225,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>linethickness</code></td>
       <td>{{ MathMLElement("mfrac") }}</td>
-      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the thickness of the horizontal fraction line.</td>
+      <td>A {{cssxref("length-percentage")}} indicating the thickness of the horizontal fraction line.</td>
     </tr>
     <tr>
       <td><code>lspace</code></td>
@@ -233,7 +233,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mo") }}
       </td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating amount of space before the operator.
+        A {{cssxref("length-percentage")}} indicating amount of space before the operator.
       </td>
     </tr>
     <tr>
@@ -242,7 +242,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mpadded") }}
       </td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the element.
+        A {{cssxref("length-percentage")}} indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the element.
       </td>
     </tr>
     <tr>
@@ -270,7 +270,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
       <td><code>mathsize</code></td>
       <td><a href="/en-US/docs/Web/MathML/Global_attributes">All MathML elements</a></td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> used as a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> for the element.
+        A {{cssxref("length-percentage")}} used as a <a href="/en-US/docs/Web/CSS/font-size"><code>font-size</code></a> for the element.
       </td>
     </tr>
     <tr>
@@ -281,12 +281,12 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>maxsize</code></td>
       <td>{{ MathMLElement("mo") }}</td>
-      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the maximum size of the operator when it is stretchy.</td>
+      <td>A {{cssxref("length-percentage")}} indicating the maximum size of the operator when it is stretchy.</td>
     </tr>
     <tr>
       <td><code>minsize</code></td>
       <td>{{ MathMLElement("mo") }}</td>
-      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum size of the operator when it is stretchy.</td>
+      <td>A {{cssxref("length-percentage")}} indicating the minimum size of the operator when it is stretchy.</td>
     </tr>
     <tr>
       <td><code>movablelimits</code></td>
@@ -343,7 +343,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>rspace</code></td>
       <td>{{ MathMLElement("mo") }}</td>
-      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the amount of space after the operator.</td>
+      <td>A {{cssxref("length-percentage")}} indicating the amount of space after the operator.</td>
     </tr>
     <tr>
       <td><code>rquote</code> {{deprecated_inline}}</td>
@@ -412,7 +412,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mmultiscripts") }}
       </td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the subscript down.
+        A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the subscript down.
       </td>
     </tr>
     <tr>
@@ -423,7 +423,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mmultiscripts") }}
       </td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the minimum amount to shift the baseline of the superscript up.
+        A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the superscript up.
       </td>
     </tr>
     <tr>
@@ -436,7 +436,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
     <tr>
       <td><code>voffset</code></td>
       <td>{{ MathMLElement("mpadded") }}</td>
-      <td>A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the vertical location of the positioning point of the child content with respect to the positioning point of the element.
+      <td>A {{cssxref("length-percentage")}} indicating the vertical location of the positioning point of the child content with respect to the positioning point of the element.
 </td>
     </tr>
     <tr>
@@ -447,7 +447,7 @@ This is an alphabetical list of MathML attributes. More details for each attribu
         {{ MathMLElement("mtable") }}
       </td>
       <td>
-        A <a href="/en-US/docs/Web/CSS/length-percentage"><code>&lt;length-percentage&gt;</code></a> indicating the desired width.
+        A {{cssxref("length-percentage")}} indicating the desired width.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -25,7 +25,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `denomalign` {{deprecated_inline}} {{Non-standard_Inline}}
   - : The alignment of the denominator under the fraction. Possible values are: `left`, `center` (default), and `right`.
 - `linethickness`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the thickness of the horizontal fraction line.
+  - : A {{cssxref("length-percentage")}} indicating the thickness of the horizontal fraction line.
 - `numalign` {{deprecated_inline}} {{Non-standard_Inline}}
   - : The alignment of the numerator over the fraction. Possible values are: `left`, `center` (default), and `right`.
 

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -33,9 +33,9 @@ MathML uses the syntax below, that is a base expression, followed by an arbitrar
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
 - `subscriptshift` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the subscript down.
+  - : A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the subscript down.
 - `superscriptshift` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the superscript up.
+  - : A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the superscript up.
 
 > **Note:** For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -20,15 +20,15 @@ In addition to the [global MathML attributes](/en-US/docs/Web/MathML/Global_attr
 - `largeop`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator should be drawn bigger when [`math-style`](/en-US/docs/Web/CSS/math-style) is set to `normal`.
 - `lspace`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the amount of space before the operator.
+  - : A {{cssxref("length-percentage")}} indicating the amount of space before the operator.
 - `maxsize`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the maximum size of the operator when it is stretchy.
+  - : A {{cssxref("length-percentage")}} indicating the maximum size of the operator when it is stretchy.
 - `minsize`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum size of the operator when it is stretchy.
+  - : A {{cssxref("length-percentage")}} indicating the minimum size of the operator when it is stretchy.
 - `movablelimits`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether attached under- and overscripts move to sub- and superscript positions when [`math-style`](/en-US/docs/Web/CSS/math-style) is set to `compact`.
 - `rspace`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the amount of space after the operator.
+  - : A {{cssxref("length-percentage")}} indicating the amount of space after the operator.
 - `separator`
   - : A [`<boolean>`](/en-US/docs/Web/MathML/Values#mathml-specific_types) indicating whether the operator is a separator (such as commas). There is no visual effect for this attribute.
 - `stretchy`

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -14,15 +14,15 @@ The **`<mpadded>`** [MathML](/en-US/docs/Web/MathML) element is used to add extr
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `depth`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired depth (below the baseline) of the `<mpadded>` element.
+  - : A {{cssxref("length-percentage")}} indicating the desired depth (below the baseline) of the `<mpadded>` element.
 - `height`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired height (above the baseline) of the `<mpadded>` element.
+  - : A {{cssxref("length-percentage")}} indicating the desired height (above the baseline) of the `<mpadded>` element.
 - `lspace`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the `<mpadded>` element.
+  - : A {{cssxref("length-percentage")}} indicating the horizontal location of the positioning point of the child content with respect to the positioning point of the `<mpadded>` element.
 - `voffset`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the vertical location of the positioning point of the child content with respect to the positioning point of the `<mpadded>` element.
+  - : A {{cssxref("length-percentage")}} indicating the vertical location of the positioning point of the child content with respect to the positioning point of the `<mpadded>` element.
 - `width`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired horizontal length of the `<mpadded>` element.
+  - : A {{cssxref("length-percentage")}} indicating the desired horizontal length of the `<mpadded>` element.
 
 ### Legacy syntax
 

--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -14,11 +14,11 @@ The **`<mspace>`** [MathML](/en-US/docs/Web/MathML) element is used to display a
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `depth`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired depth (below the baseline) of the space.
+  - : A {{cssxref("length-percentage")}} indicating the desired depth (below the baseline) of the space.
 - `height`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired height (above the baseline) of the space.
+  - : A {{cssxref("length-percentage")}} indicating the desired height (above the baseline) of the space.
 - `width`
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the desired width of the space.
+  - : A {{cssxref("length-percentage")}} indicating the desired width of the space.
 
 > **Note:** For the `depth`, `height`, `width` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -16,7 +16,7 @@ It uses the following syntax: `<msub> base subscript </msub>`.
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attribute:
 
 - `subscriptshift` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the subscript down.
+  - : A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the subscript down.
 
 > **Note:** For the `subscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -16,9 +16,9 @@ It uses the following syntax: `<msubsup> base subscript superscript </msubsup>`.
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
 - `subscriptshift` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the subscript down.
+  - : A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the subscript down.
 - `superscriptshift` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the superscript up.
+  - : A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the superscript up.
 
 > **Note:** For the `subscriptshift` and `superscriptshift` attributes, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -16,7 +16,7 @@ It uses the following syntax: `<msup> base superscript </msup>`.
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attribute:
 
 - `superscriptshift` {{deprecated_inline}} {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the minimum amount to shift the baseline of the superscript up.
+  - : A {{cssxref("length-percentage")}} indicating the minimum amount to shift the baseline of the superscript up.
 
 > **Note:** For the `superscriptshift` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -31,19 +31,19 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 - `columnlines` {{Non-standard_Inline}}
   - : Specifies column borders. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnlines="none none solid"`). Possible values are: `none` (default), `solid` and `dashed`.
 - `columnspacing` {{Non-standard_Inline}}
-  - : Specifies the space between table columns. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnspacing="1em 2em"`). Possible values are [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage).
+  - : Specifies the space between table columns. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnspacing="1em 2em"`). Possible values are {{cssxref("length-percentage")}}.
 - `frame` {{Non-standard_Inline}}
   - : Specifies borders of the entire table. Possible values are: `none` (default), `solid` and `dashed`.
 - `framespacing` {{Non-standard_Inline}}
-  - : Specifies additional space added between the table and frame. The first value specifies the spacing on the right and left; the second value specifies the spacing above and below. Possible values are [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage).
+  - : Specifies additional space added between the table and frame. The first value specifies the spacing on the right and left; the second value specifies the spacing above and below. Possible values are {{cssxref("length-percentage")}}.
 - `rowalign` {{Non-standard_Inline}}
   - : Specifies the vertical alignment of the cells. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowalign="top bottom axis"`). Possible values are: `axis`, `baseline` (default), `bottom`, `center` and `top`.
 - `rowlines` {{Non-standard_Inline}}
   - : Specifies row borders. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowlines="none none solid"`). Possible values are: `none` (default), `solid` and `dashed`.
 - `rowspacing` {{Non-standard_Inline}}
-  - : Specifies the space between table rows. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowspacing="1em 2em"`). Possible values are [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage).
+  - : Specifies the space between table rows. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowspacing="1em 2em"`). Possible values are {{cssxref("length-percentage")}}.
 - `width` {{Non-standard_Inline}}
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) indicating the width of the entire table.
+  - : A {{cssxref("length-percentage")}} indicating the width of the entire table.
 
 > **Note:** For the `width` attribute, some browsers may also accept [legacy MathML lengths](/en-US/docs/Web/MathML/Values#legacy_mathml_lengths).
 

--- a/files/en-us/web/mathml/global_attributes/index.md
+++ b/files/en-us/web/mathml/global_attributes/index.md
@@ -49,7 +49,7 @@ In addition to the basic MathML global attributes, the following global attribut
 
 - [`mathsize`](/en-US/docs/Web/MathML/Global_attributes/mathsize)
 
-  - : A [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) used as a [font-size](/en-US/docs/Web/CSS/font-size) for the element.
+  - : A {{cssxref("length-percentage")}} used as a [font-size](/en-US/docs/Web/CSS/font-size) for the element.
 
 - [`nonce`](/en-US/docs/Web/HTML/Global_attributes/nonce)
 

--- a/files/en-us/web/mathml/values/index.md
+++ b/files/en-us/web/mathml/values/index.md
@@ -18,7 +18,7 @@ In addition to [CSS data types](/en-US/docs/Web/CSS/CSS_Types), some MathML attr
 
 {{deprecated_header}}
 
-Instead of [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage), MathML used to define its own [type to describe lengths](https://www.w3.org/TR/MathML3/chapter2.html#type.length). Accepted values included non-zero unitless length values (e.g. `5` to mean `500%`), values containing numbers ending with a dot (e.g. `34.px`), or named spaces (e.g. `thinmathspace`). For compatibility reasons, it is recommended to replace non-zero unitless length values with equivalent [`<percentage>`](/en-US/docs/Web/CSS/percentage) values, to remove unnecessary dots in numbers, and to use the following replacement for named lengths:
+Instead of {{cssxref("length-percentage")}}, MathML used to define its own [type to describe lengths](https://www.w3.org/TR/MathML3/chapter2.html#type.length). Accepted values included non-zero unitless length values (e.g. `5` to mean `500%`), values containing numbers ending with a dot (e.g. `34.px`), or named spaces (e.g. `thinmathspace`). For compatibility reasons, it is recommended to replace non-zero unitless length values with equivalent {{cssxref("percentage")}} values, to remove unnecessary dots in numbers, and to use the following replacement for named lengths:
 
 ```plain
 veryverythinmathspace  => 0.05555555555555555em

--- a/files/en-us/web/svg/attribute/transform-origin/index.md
+++ b/files/en-us/web/svg/attribute/transform-origin/index.md
@@ -42,17 +42,17 @@ If two or more values are defined and either no value is a keyword, or the only 
 
 - One-value syntax:
 
-  - The value must be a [`<length>`](/en-US/docs/Web/CSS/length), or one of the keywords `left`, `center`, `right`, `top`, and `bottom`.
+  - The value must be a {{cssxref("length")}}, or one of the keywords `left`, `center`, `right`, `top`, and `bottom`.
 
 - Two-value syntax:
 
-  - One value must be a [`<length>`](/en-US/docs/Web/CSS/length), a [`<percentage>`](/en-US/docs/Web/CSS/percentage), or one of the keywords `left`, `center`, and `right`.
-  - The other value must be a [`<length>`](/en-US/docs/Web/CSS/length), a [`<percentage>`](/en-US/docs/Web/CSS/percentage), or one of the keywords `top`, `center`, and `bottom`.
+  - One value must be a {{cssxref("length")}}, a {{cssxref("percentage")}}, or one of the keywords `left`, `center`, and `right`.
+  - The other value must be a {{cssxref("length")}}, a {{cssxref("percentage")}}, or one of the keywords `top`, `center`, and `bottom`.
 
 - Three-value syntax:
 
   - The first two values are the same as for the two-value syntax.
-  - The third value must be a [`<length>`](/en-US/docs/Web/CSS/length). It always represents the Z offset.
+  - The third value must be a {{cssxref("length")}}. It always represents the Z offset.
 
 ## Example
 

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -197,7 +197,7 @@ SVG makes use of a number of data types. This article lists these types along wi
 - \<length>
 
   - : A length is a distance measurement, given as a number along with a unit.
-    The SVG2 specification aligns with CSS [`<length>`](/en-US/docs/Web/CSS/length) data types and units for the attribute syntax and values.
+    The SVG2 specification aligns with CSS {{cssxref("length")}} data types and units for the attribute syntax and values.
     A length unit identifier must be provided and the values of the length unit identifiers are case-insensitive.
     The syntax follows the CSS `<length>` syntax:
 


### PR DESCRIPTION
### Description

This PR unifies length, percentage and length-percentage links with `{{cssxref}}` macro usage where it is possible.

### Motivation

The desire to improve the markup and bring it to a unified look.

### Related issues and pull requests

Relates to #31003