### PR TITLE
Accessible description: link to glossary term

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -382,7 +382,7 @@ It is possible to render external images onto your canvas. These can be simple i
    - Parameters 6 and 7 define the coordinates at which you want to draw the top-left corner of the cut-out portion of the image, relative to the top-left corner of the canvas.
    - Parameters 8 and 9 define the width and height to draw the cut-out area of the image. In this case, we have specified the same dimensions as the original slice, but you could resize it by specifying different values.
 
-5. When the image is meaningfully updated, the accessible description must also be updated.
+5. When the image is meaningfully updated, the {{glossary("accessible description")}} must also be updated.
 
    ```js
    canvas.setAttribute("aria-label", "Firefox Logo");

--- a/files/en-us/web/accessibility/aria/annotations/index.md
+++ b/files/en-us/web/accessibility/aria/annotations/index.md
@@ -71,7 +71,7 @@ We have already alluded to the difference between these two above — `aria-desc
 <p id="description-id">An extended text description of some kind.</p>
 
 <div aria-describedby="description-id">
-  <!-- Some kind of UI feature that needs an accessible description -->
+  <!-- Some kind of UI feature that needs an {{glossary("accessible description")}} -->
 </div>
 ```
 
@@ -93,7 +93,7 @@ This difference becomes apparent when you get to how the content is interpreted 
 
 Content associated via `aria-describedby` becomes part of the accessible description and is flattened into a simple string (lists, links, etc. are not exposed). Generally it is announced after the accessible name. ARIA 1.3 also identifies [which roles _disallow_ its use](https://w3c.github.io/aria/#namefromprohibited) (such as `generic`, which maps to `<div>`).
 
-Content associated via `aria-details` is _not_ factored into the accessible description computation. A screen reader would ideally make the user aware the content is available and then let the user navigate directly to that content. As such, it can contain rich content. The role of the referenced element (eg: `comment`, `definition`) may affect how a screen reader exposes or references the content. `aria-details` has no restrictions on which roles may use it.
+Content associated via `aria-details` is _not_ factored into the {{glossary("accessible description")}} computation. A screen reader would ideally make the user aware the content is available and then let the user navigate directly to that content. As such, it can contain rich content. The role of the referenced element (eg: `comment`, `definition`) may affect how a screen reader exposes or references the content. `aria-details` has no restrictions on which roles may use it.
 
 ## A basic description
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
@@ -27,7 +27,7 @@ The `aria-description` attribute is similar to [`aria-label`](/en-US/docs/Web/Ac
 
 The `aria-description` and `aria-describedby` properties have the same purpose; both provide the user with additional descriptive text for the object on which it is set. If descriptive text is available in the DOM, use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) instead.
 
-The `aria-description` property should only be used when providing a visible description is not the desired user experience. The `aria-describedby` attribute takes as its value a list of `id`s of the elements that contain descriptive text about the object. The `aria-description` is used when there is no appropriate descriptive text that can be associated with the object by `id` reference. If both attributes are present, `aria-describedby` takes precedence in defining the accessible description property.
+The `aria-description` property should only be used when providing a visible description is not the desired user experience. The `aria-describedby` attribute takes as its value a list of `id`s of the elements that contain descriptive text about the object. The `aria-description` is used when there is no appropriate descriptive text that can be associated with the object by `id` reference. If both attributes are present, `aria-describedby` takes precedence in defining the {{glossary("accessible description")}} property.
 
 The content of the description, whether set by `aria-description` or `aria-describedby`, should be flat text. If the content is very long, has semantic meaning requirements, or has a navigational structure, use [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details) instead.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -56,7 +56,7 @@ If a dialog is not modal — there is no inert background and focus isn't confin
 
 This partial example includes an `alertdialog` nested in a full-screen, non-scrollable backdrop.
 
-The [`role="alertdialog"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) identifies the element that serves as the alert dialog container. The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) provides the alert dialog an accessible name by referring to the element that provides the alert dialog title. The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute gives the alert dialog an accessible description by referring to the alert dialog content that describes the primary message or purpose of the alert dialog.
+The [`role="alertdialog"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) identifies the element that serves as the alert dialog container. The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) provides the alert dialog an accessible name by referring to the element that provides the alert dialog title. The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute gives the alert dialog an {{glossary("accessible description")}} by referring to the alert dialog content that describes the primary message or purpose of the alert dialog.
 
 The `aria-modal="true"` informs the assistive technology user that the content underneath the dialog is not interactive so long as the element with a declaration of `role="alertdialog"` has focus.
 

--- a/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -30,7 +30,7 @@ Adding `role="alertdialog"` alone is not sufficient to make an alert dialog acce
 - The alert dialog must be properly labeled
 - Keyboard focus must be managed correctly
 
-The `alertdialog` must have an accessible name, defined with [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label). The alert dialog text must have an accessible description using [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby).
+The `alertdialog` must have an accessible name, defined with [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label). The alert dialog text must have an {{glossary("accessible description")}} using [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby).
 
 ## Examples
 

--- a/files/en-us/web/html/element/caption/index.md
+++ b/files/en-us/web/html/element/caption/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.caption
 
 {{HTMLSidebar}}
 
-The **`<caption>`** [HTML](/en-US/docs/Web/HTML) element specifies the caption (or title) of a table.
+The **`<caption>`** [HTML](/en-US/docs/Web/HTML) element specifies the caption (or title) of a table, providing the table an {{glossary("accessible description")}}.
 
 {{EmbedInteractiveExample("pages/tabbed/caption.html", "tabbed-taller")}}
 

--- a/files/en-us/web/html/element/details/index.md
+++ b/files/en-us/web/html/element/details/index.md
@@ -9,7 +9,7 @@ browser-compat: html.elements.details
 
 The **`<details>`** [HTML](/en-US/docs/Web/HTML) element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the {{HTMLElement("summary")}} element.
 
-A disclosure widget is typically presented onscreen using a small triangle which rotates (or twists) to indicate open/closed status, with a label next to the triangle. The contents of the `<summary>` element are used as the label for the disclosure widget.
+A disclosure widget is typically presented onscreen using a small triangle that rotates (or twists) to indicate open/closed status, with a label next to the triangle. The contents of the `<summary>` element are used as the label for the disclosure widget. The contents of the `<details>` provide the {{glossary("accessible description")}} for the `<summary>`.
 
 {{EmbedInteractiveExample("pages/tabbed/details.html", "tabbed-shorter")}}
 

--- a/files/en-us/web/html/element/figcaption/index.md
+++ b/files/en-us/web/html/element/figcaption/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.figcaption
 
 {{HTMLSidebar}}
 
-The **`<figcaption>`** [HTML](/en-US/docs/Web/HTML) element represents a caption or legend describing the rest of the contents of its parent {{HTMLElement("figure")}} element.
+The **`<figcaption>`** [HTML](/en-US/docs/Web/HTML) element represents a caption or legend describing the rest of the contents of its parent {{HTMLElement("figure")}} element, providing the `<figure>` an {{glossary("accessible description")}}.
 
 {{EmbedInteractiveExample("pages/tabbed/figcaption.html","tabbed-shorter")}}
 

--- a/files/en-us/web/html/element/figure/index.md
+++ b/files/en-us/web/html/element/figure/index.md
@@ -19,6 +19,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 - Usually a `<figure>` is an image, illustration, diagram, code snippet, etc., that is referenced in the main flow of a document, but that can be moved to another part of the document or to an appendix without affecting the main flow.
 - A caption can be associated with the `<figure>` element by inserting a {{HTMLElement("figcaption")}} inside it (as the first or the last child). The first `<figcaption>` element found in the figure is presented as the figure's caption.
+- The `<figcaption>` provides the {{glossary("accessible description")}} for the parent `<figure>`.
 
 ## Examples
 

--- a/files/en-us/web/html/element/input/button/index.md
+++ b/files/en-us/web/html/element/input/button/index.md
@@ -17,7 +17,7 @@ browser-compat: html.elements.input.type_button
 
 ### Button with a value
 
-An `<input type="button">` elements' [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string that is used as the button's label.
+An `<input type="button">` elements' [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string that is used as the button's label. The `value` provides the {{glossary("accessible description")}} for the button.
 
 ```html
 <input type="button" value="Click Me" />

--- a/files/en-us/web/html/element/input/reset/index.md
+++ b/files/en-us/web/html/element/input/reset/index.md
@@ -15,7 +15,7 @@ browser-compat: html.elements.input.type_reset
 
 ## Value
 
-An `<input type="reset">` element's [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string that is used as the button's label. Buttons such as `reset` don't have a value otherwise.
+An `<input type="reset">` element's [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string that is used as the button's label providing the button with an {{glossary("accessible description")}}. Buttons such as `reset` don't have a value otherwise.
 
 ### Setting the value attribute
 

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -11,7 +11,7 @@ browser-compat: html.elements.input.type_submit
 
 ## Value
 
-An `<input type="submit">` element's [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string which is displayed as the button's label. Buttons do not have a true value otherwise.
+An `<input type="submit">` element's [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string which is displayed as the button's label. Buttons do not have a true value otherwise. The `value` provides the {{glossary("accessible description")}} for the button.
 
 ### Setting the value attribute
 

--- a/files/en-us/web/html/element/summary/index.md
+++ b/files/en-us/web/html/element/summary/index.md
@@ -21,6 +21,8 @@ The `<summary>` element's contents can be any heading content, plain text, or HT
 
 A `<summary>` element may _only_ be used as the first child of a `<details>` element. When the user clicks on the summary, the parent `<details>` element is toggled open or closed, and then a {{domxref("HTMLDetailsElement/toggle_event", "toggle")}} event is sent to the `<details>` element, which can be used to let you know when this state change occurs.
 
+The content of the `<details>` provides the {{glossary("accessible description")}} for the `<summary>`.
+
 ### Default label text
 
 If a `<details>` element's first child is not a `<summary>` element, the {{Glossary("user agent")}} will use a default string (typically "Details") as the label for the disclosure box.

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/manifest_file/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/manifest_file/index.md
@@ -43,7 +43,7 @@ To identify your PWA, the JSON must include a `name` or `short_name` member, or 
 When both the `name` and `short_name` are present, the `name` is used in most instances, with the `short_name` used when there is a limited space to display the application name.
 
 - [`description`](/en-US/docs/Web/Manifest/description)
-  - : Explanation of what the application does. It provides an [accessible description](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) of the application's purpose and function.
+  - : Explanation of what the application does. It provides an {{glossary("accessible description")}} of the application's purpose and function.
 
 ### Task
 


### PR DESCRIPTION
updated occurrences of accessible description to point to the new glossary term.
A few elements provide accessible descriptions. These elements were updated to reflect that, except table, which is currently being rewritten in an open PR