### PR TITLE
fix(css): Removes browser-specifc note from CSS nesting guide

### DIFF
--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -6,13 +6,11 @@ page-type: guide
 
 {{CSSRef}}
 
-The [CSS Nesting](/en-US/docs/Web/CSS/CSS_nesting) module allows you to write your stylesheets so that they are easier to read, more modular, and more maintainable. As you are not constantly repeating selectors, the file size can also be reduced.
+The [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) module allows you to write your stylesheets so that they are easier to read, more modular, and more maintainable. As you are not constantly repeating selectors, the file size can also be reduced.
 
 CSS nesting is different from CSS preprocessors such as [Sass](https://sass-lang.com/) in that it is parsed by the browser rather than being pre-compiled by a CSS preprocessor. Also, in CSS nesting, the [specificity of the `&` nesting selector](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity) is similar to the {{cssxref(':is',':is()')}} function; it is calculated using the highest specificity in the associated selector list.
 
 This guide shows different ways to arrange nesting in CSS.
-
-> **Note:** Early versions of the specification did not allow nesting of [type selectors](/en-US/docs/Web/CSS/Type_selectors) without the [`&` nesting selector](/en-US/docs/Web/CSS/Nesting_selector). This has been updated so the `&` nesting selector is no longer needed. At the time of writing (Aug. 2023) Firefox supports the new version of the specification while Chrome and Safari support the old version of the specification and must use the `&` nesting selector for type selector nesting.
 
 ## Child selectors
 
@@ -436,7 +434,7 @@ In the following example, there is an invalid selector (`%` is not a valid chara
 }
 ```
 
-## See Also
+## See also
 
 - [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) module
 - [`&` nesting selector](/en-US/docs/Web/CSS/Nesting_selector)

--- a/files/en-us/web/css/nesting_selector/index.md
+++ b/files/en-us/web/css/nesting_selector/index.md
@@ -7,11 +7,11 @@ browser-compat: css.selectors.nesting
 
 {{CSSRef}}
 
-The CSS **`&` nesting selector** explicitly states the relationship between parent and child rules when using [CSS Nesting](/en-US/docs/Web/CSS/CSS_nesting). It makes nested child rule selectors _relative to the parent element_. Without the `&` nesting selector the child rule selector selects child elements. The child rule selectors have the same [specificity](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity) weight as if they were within {{cssxref(":is", ":is()")}}.
+The CSS **`&` nesting selector** explicitly states the relationship between parent and child rules when using [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting). It makes the nested child rule selectors _relative to the parent element_. Without the `&` nesting selector, the child rule selector selects child elements. The child rule selectors have the same [specificity](/en-US/docs/Web/CSS/CSS_nesting/Nesting_and_specificity) weight as if they were within {{cssxref(":is", ":is()")}}.
 
 > **Note:** _Child rule_ does not mean _child element selector_. A child rule can target parent element or child elements depending on use of the `&` nesting selector.
 
-If not used in nested style rule the `&` nesting selector represents the [scoping root](/en-US/docs/Web/CSS/:scope).
+If not used in nested style rule, the `&` nesting selector represents the [scoping root](/en-US/docs/Web/CSS/:scope).
 
 ## Syntax
 
@@ -26,7 +26,7 @@ parentRule {
 
 ### `&` nesting selector and whitespace
 
-Consider following code where nesting is done without the **`&` nesting selector**.
+Consider the following code where nesting is done _without_ the `&` nesting selector.
 
 ```css
 .parent-rule {
@@ -37,7 +37,7 @@ Consider following code where nesting is done without the **`&` nesting selector
 }
 ```
 
-When the browser parses the nested selectors, it automatically adds whitespace between the selectors to create a new CSS selector rule. Following code shows non nested equivalent rules:
+When the browser parses the nested selectors, it automatically adds whitespace between the selectors to create a new CSS selector rule. The following code shows the equivalent non-nested rules:
 
 ```css
 .parent-rule {
@@ -49,9 +49,9 @@ When the browser parses the nested selectors, it automatically adds whitespace b
 }
 ```
 
-When the nested rule needs to be attached (with no whitespace) to the parent rule, such as when using a {{cssxref('Pseudo-classes', 'pseudo class')}} or creating [compound selectors](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector), the **`&` nesting selector** must be immediately prepended to achieve the desired effect.
+When the nested rule needs to be attached (with no whitespace) to the parent rule, such as when using a {{cssxref('Pseudo-classes', 'pseudo-class')}} or creating [compound selectors](/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#compound_selector), the `&` nesting selector must be immediately prepended to achieve the desired effect.
 
-Consider an example where we want to style an element, providing styles to be applied at all times, and also nesting some styles to be applied only on hover. If the **`&` nesting selector** is not included, whitespace is added and we end up with a ruleset that applies the nested styles to any _hovered descendant of the parent rule selector_. This is not what we wanted.
+Consider an example where we want to style an element, providing styles to be applied at all times, and also nesting some styles to be applied only on hover. If the `&` nesting selector is not included, whitespace is added and we end up with a ruleset that applies the nested styles to any _hovered descendant of the parent rule selector_. This is, however, not what we want.
 
 ```css
 .parent-rule {
@@ -61,8 +61,7 @@ Consider an example where we want to style an element, providing styles to be ap
   }
 }
 
-/* the browser parses above nested rules as */
-
+/* the browser parses the above nested rules as shown below */
 .parent-rule {
   /* parent rule properties */
 }
@@ -72,7 +71,7 @@ Consider an example where we want to style an element, providing styles to be ap
 }
 ```
 
-With the **`&` nesting selector** added with no whitespace, the elements matched by the parent rule will be styled when hovered.
+With the `&` nesting selector added with no whitespace, the elements matched by the parent rule will be styled when hovered.
 
 ```css
 .parent-rule {
@@ -82,8 +81,7 @@ With the **`&` nesting selector** added with no whitespace, the elements matched
   }
 }
 
-/* the browser parses above nested rules as */
-
+/* the browser parses the above nested rules as shown below */
 .parent-rule {
   /* parent rule properties */
 }
@@ -141,7 +139,7 @@ The `&` nesting selector can be placed multiple times:
 
 Both of the following examples produce the same output. The first one uses normal CSS styles and the second one uses the `&` nesting selector.
 
-### Normal CSS styles
+### Using normal CSS styles
 
 This example uses normal CSS styling.
 
@@ -176,7 +174,7 @@ This example uses normal CSS styling.
 
 {{EmbedLiveSample('Original_CSS_styles','100%','65')}}
 
-### Nested CSS styles
+### Using `&` in nested CSS styles
 
 This example uses nested CSS styling.
 
@@ -209,9 +207,9 @@ This example uses nested CSS styling.
 
 {{EmbedLiveSample('Nested_CSS_styles','100%','65')}}
 
-### Usage outside nested rule
+### Using `&` outside nested rule
 
-If not used in nested style rule the `&` nesting selector represents the [scoping root](/en-US/docs/Web/CSS/:scope).
+If not used in nested style rule, the `&` nesting selector represents the [scoping root](/en-US/docs/Web/CSS/:scope).
 
 ```html
 <p>Hover over the output box to change document's background color.</p>
@@ -230,7 +228,7 @@ If not used in nested style rule the `&` nesting selector represents the [scopin
 
 #### Result
 
-In this case all the styles apply to [document](/en-US/docs/Web/API/Document).
+In this case, all the styles apply to [document](/en-US/docs/Web/API/Document).
 
 {{EmbedLiveSample('Usage_outside_nested_rule','100%','65')}}
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/31019

Removed the note because it is no longer valid; there is cross-browser support for `&` now: https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector#browser_compatibility

This PR also proposes some minor edits like comma additions and removing emphasis around "`&` nesting selector" everywhere except in the intro para.

