### PR TITLE
document for HTMLAnchorElement.type

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/type/index.md
+++ b/files/en-us/web/api/htmlanchorelement/type/index.md
@@ -51,6 +51,5 @@ pTag.textContent = anchorElement.type;
 ## See also
 
 - {{domxref("HTMLLinkElement.type")}} property
-- {{domxref("HTMLOListElement.type")}} property
 - {{domxref("HTMLSourceElement.type")}} property
 - {{domxref("HTMLEmbedElement.type")}} property

--- a/files/en-us/web/api/htmlanchorelement/type/index.md
+++ b/files/en-us/web/api/htmlanchorelement/type/index.md
@@ -36,8 +36,6 @@ console.log(anchorElement.type); // Output: "text/html"
 pTag.textContent = anchorElement.type;
 ```
 
-## Result
-
 {{EmbedLiveSample("Example",100,100)}}
 
 ## Specifications

--- a/files/en-us/web/api/htmlanchorelement/type/index.md
+++ b/files/en-us/web/api/htmlanchorelement/type/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.type
 
 {{ApiRef("HTML DOM")}}
 
-The **`type`** property of the {{domxref("HTMLAnchorElement")}} interface is a string that is the MIME type of the linked resource.
+The **`type`** property of the {{domxref("HTMLAnchorElement")}} interface is a string that indicates the MIME type of the linked resource.
 
 It reflects the `type` attribute of the {{HTMLElement("a")}} element.
 

--- a/files/en-us/web/api/htmlanchorelement/type/index.md
+++ b/files/en-us/web/api/htmlanchorelement/type/index.md
@@ -1,0 +1,57 @@
+---
+title: "HTMLAnchorElement: type property"
+short-title: type
+slug: Web/API/HTMLAnchorElement/type
+page-type: web-api-instance-property
+browser-compat: api.HTMLAnchorElement.type
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`type`** property of the {{domxref("HTMLAnchorElement")}} interface is a string that is the MIME type of the linked resource.
+
+It reflects the `type` attribute of the {{HTMLElement("a")}} element.
+
+
+## Value
+
+A string.
+
+## Example
+
+```html
+<a id="exampleLink" href="https://example.com" type="text/html">Example Link</a>
+<p class="type"></p>
+```
+
+```css
+#exampleLink {
+  font-size: 1.5rem;
+}
+```
+
+```js
+const anchorElement = document.getElementById("exampleLink");
+const pTag = document.querySelector(".type");
+console.log(anchorElement.type); // Output: "text/html"
+pTag.textContent = anchorElement.type;
+```
+
+## Result
+
+{{EmbedLiveSample("Example",100,100)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLLinkElement.type")}} property
+- {{domxref("HTMLOListElement.type")}} property
+- {{domxref("HTMLSourceElement.type")}} property
+- {{domxref("HTMLEmbedElement.type")}} property

--- a/files/en-us/web/api/htmlanchorelement/type/index.md
+++ b/files/en-us/web/api/htmlanchorelement/type/index.md
@@ -12,7 +12,6 @@ The **`type`** property of the {{domxref("HTMLAnchorElement")}} interface is a s
 
 It reflects the `type` attribute of the {{HTMLElement("a")}} element.
 
-
 ## Value
 
 A string.


### PR DESCRIPTION
This PR add documentation for HTMLAnchorElement.type property.

It is part of the discussion to document all interoperable features ([mdn/discussions#476](https://github.com/orgs/mdn/discussions/476))

### Resource
[type property](https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-type)