### PR TITLE
Document for HTMLAnchorElement.text

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.text
 
 {{ApiRef("HTML DOM")}}
 
-The **`text`** property of the {{domxref("HTMLAnchorElement")}} represents the text inside the the element. 
+The **`text`** property of the {{domxref("HTMLAnchorElement")}} represents the text inside the the element.
 This property is the same as {{domxref("Node.textContent")}}.
 
 ## Value

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -30,8 +30,8 @@ A string.
 
 ```js
 const anchorElement = document.getElementById("exampleLink");
-const pTag = document.querySelector(".text);
-pTag.text = anchorElement.text + " " + "text property";
+const pTag = document.querySelector(".text");
+pTag.textContent = anchorElement.text + " " + "text property";
 ```
 
 ## Result

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -9,7 +9,7 @@ browser-compat: api.HTMLAnchorElement.text
 {{ApiRef("HTML DOM")}}
 
 The **`text`** property of the {{domxref("HTMLAnchorElement")}} represents the text inside the the element.
-This property is the same as {{domxref("Node.textContent")}}.
+This property represents the same information as {{domxref("Node.textContent")}}.
 
 ## Value
 

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -1,0 +1,52 @@
+---
+title: "HTMLAnchorElement: text property"
+short-title: text
+slug: Web/API/HTMLAnchorElement/text
+page-type: web-api-instance-property
+browser-compat: api.HTMLAnchorElement.text
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`text`** property of the {{domxref("HTMLAnchorElement")}} gets the {{HTMLElement("a")}} element text content.
+This property is same as {{domxref("Node.textContent")}}.
+
+## Value
+
+A string.
+
+## Example
+
+```html
+<a id="exampleLink" href="https://example.com" >Example Link</a>
+<p class="text"></p>
+```
+
+```css
+#exampleLink {
+  font-size: 1.5rem;
+}
+```
+
+```js
+const anchorElement = document.getElementById("exampleLink");
+const pTag = document.querySelector(".text);
+pTag.text = anchorElement.text + " " + "text property";
+```
+
+## Result
+
+{{EmbedLiveSample("Example",100,100)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLScriptElement.text")}} property
+- {{domxref("HTMLOptionElement.text")}} property

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -9,7 +9,7 @@ browser-compat: api.HTMLAnchorElement.text
 {{ApiRef("HTML DOM")}}
 
 The **`text`** property of the {{domxref("HTMLAnchorElement")}} reflects the {{HTMLElement("a")}} element text content.
-This property is same as {{domxref("Node.textContent")}}.
+This property is the same as {{domxref("Node.textContent")}}.
 
 ## Value
 

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.text
 
 {{ApiRef("HTML DOM")}}
 
-The **`text`** property of the {{domxref("HTMLAnchorElement")}} gets the {{HTMLElement("a")}} element text content.
+The **`text`** property of the {{domxref("HTMLAnchorElement")}} reflects the {{HTMLElement("a")}} element text content.
 This property is same as {{domxref("Node.textContent")}}.
 
 ## Value

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -31,7 +31,7 @@ A string.
 ```js
 const anchorElement = document.getElementById("exampleLink");
 const pTag = document.querySelector(".text");
-pTag.textContent = anchorElement.text + " " + "text property";
+pTag.textContent =  `Text property: ${anchorElement.text}`;
 ```
 
 ### Result

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -34,7 +34,7 @@ const pTag = document.querySelector(".text");
 pTag.textContent = anchorElement.text + " " + "text property";
 ```
 
-## Result
+### Result
 
 {{EmbedLiveSample("Example",100,100)}}
 

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -18,7 +18,7 @@ A string.
 ## Example
 
 ```html
-<a id="exampleLink" href="https://example.com" >Example Link</a>
+<a id="exampleLink" href="https://example.com">Example Link</a>
 <p class="text"></p>
 ```
 

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -31,7 +31,7 @@ A string.
 ```js
 const anchorElement = document.getElementById("exampleLink");
 const pTag = document.querySelector(".text");
-pTag.textContent =  `Text property: ${anchorElement.text}`;
+pTag.textContent = `Text property: ${anchorElement.text}`;
 ```
 
 ### Result

--- a/files/en-us/web/api/htmlanchorelement/text/index.md
+++ b/files/en-us/web/api/htmlanchorelement/text/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.text
 
 {{ApiRef("HTML DOM")}}
 
-The **`text`** property of the {{domxref("HTMLAnchorElement")}} reflects the {{HTMLElement("a")}} element text content.
+The **`text`** property of the {{domxref("HTMLAnchorElement")}} represents the text inside the the element. 
 This property is the same as {{domxref("Node.textContent")}}.
 
 ## Value


### PR DESCRIPTION
This PR add documentation for HTMLAnchorElement.text property.

It is part of the discussion to document all interoperable features ([mdn/discussions#476](https://github.com/orgs/mdn/discussions/476))

### Resource
[text property](https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-text)