### PR TITLE
New page: @media scan feature

### DIFF
--- a/files/en-us/web/css/@media/scan/index.md
+++ b/files/en-us/web/css/@media/scan/index.md
@@ -7,7 +7,7 @@ browser-compat: css.at-rules.media.scan
 
 {{CSSRef}}
 
-The **`scan`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to apply CSS styles based on scanning process of the output device.
+The **`scan`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to apply CSS styles based on the scanning process of the output device.
 
 ## Syntax
 
@@ -20,7 +20,7 @@ The `scan` feature is specified as one of the following keyword values:
 
 ## Description
 
-Most modern screens, and all computer screens, use progressive rendering, displaying each screen fully with no special treatment.
+Most modern screens (and all computer screens) use progressive rendering, displaying each screen fully with no special treatment.
 
 Interlacing was used by CRT monitors and some plasma TVs to enable the appearance of faster frames per second (FPS) while reducing bandwidth. With interlacing, video frames alternate between rendering the even lines and the odd lines on the screen, downloading and rendering only half the screen for each frame, exploiting the human image-smoothing ability so the brain simulates a higher FPS broadcast at half the bandwidth cost.
 
@@ -78,5 +78,5 @@ p {
 
 ## See also
 
-- [@media](/en-US/docs/Web/CSS/@media) at-rule that is used to specify the scan expression.
+- The [@media](/en-US/docs/Web/CSS/@media) at-rule, which is used to specify the scan expression.
 - [Using media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to understand when and how to use a media query.

--- a/files/en-us/web/css/@media/scan/index.md
+++ b/files/en-us/web/css/@media/scan/index.md
@@ -1,0 +1,82 @@
+---
+title: scan
+slug: Web/CSS/@media/scan
+page-type: css-media-feature
+browser-compat: css.at-rules.media.scan
+---
+
+{{CSSRef}}
+
+The **`scan`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/@media#media_features) is used to apply CSS styles based on scanning process of the output device.
+
+## Syntax
+
+The `scan` feature is specified as one of the following keyword values:
+
+- `interlace`
+  - : The output device uses "interlaced" rendering, where video frames alternate between specifying only the "even" lines on the screen and only the "odd" lines.
+- `progressive`
+  - : The output device renders content to the screen with no special treatment.
+
+## Description
+
+Most modern screens, and all computer screens, use progressive rendering, displaying each screen fully with no special treatment.
+
+Interlacing was used by CRT monitors and some plasma TVs to enable the appearance of faster frames per second (FPS) while reducing bandwidth. With interlacing, video frames alternate between rendering the even lines and the odd lines on the screen, downloading and rendering only half the screen for each frame, exploiting the human image-smoothing ability so the brain simulates a higher FPS broadcast at half the bandwidth cost.
+
+When targeting interlaced screens, avoid very fast movement across the screen and ensure animated details are wider than 1px to reduce flickering.
+
+## Examples
+
+### HTML
+
+```html
+<p>This is a test.</p>
+```
+
+### CSS
+
+```css
+p {
+  padding: 10px;
+  border: solid;
+}
+
+@media (scan: interlace) {
+  p {
+    background: #f4ae8a;
+  }
+}
+@media (scan: progressive) {
+  p {
+    text-decoration: underline;
+  }
+}
+@media not (scan: progressive) {
+  p {
+    border-style: dashed;
+  }
+}
+@media not (scan: interlaced) {
+  p {
+    color: purple;
+  }
+}
+```
+
+### Result
+
+{{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [@media](/en-US/docs/Web/CSS/@media) at-rule that is used to specify the scan expression.
+- [Using media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to understand when and how to use a media query.


### PR DESCRIPTION
this creates a new page.
the scan feature has been around since CSS 2, and is in media queries 3, 4 and 5. 


Note that no links to this page have been added to this PR. This PR is part of the much larger Media query module update project. Links to this scan page will be added in a separate PR. This page addition was made in a small PR in hopes of avoiding creating a huge PR. The links will be in the large PR  to prevent merge conflicts.

BCD issue made: https://github.com/mdn/browser-compat-data/issues/21990

Larger project: https://github.com/openwebdocs/project/issues/192