### PR TITLE
document for HTMLAnchorElement.ping

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/index.md
+++ b/files/en-us/web/api/htmlanchorelement/index.md
@@ -33,6 +33,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : A string containing the password specified before the domain name.
 - {{domxref("HTMLAnchorElement.pathname")}}
   - : A string containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
+- {{domxref("HTMLAnchorElement.ping")}}
+  - : A space-separated list of URLs.
 - {{domxref("HTMLAnchorElement.port")}}
   - : A string representing the port component, if any, of the referenced URL.
 - {{domxref("HTMLAnchorElement.protocol")}}

--- a/files/en-us/web/api/htmlanchorelement/index.md
+++ b/files/en-us/web/api/htmlanchorelement/index.md
@@ -34,7 +34,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLAnchorElement.pathname")}}
   - : A string containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
 - {{domxref("HTMLAnchorElement.ping")}}
-  - : A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
+  - : A space-separated list of URLs. When the link is followed, the browser will send {{HTTPMethod("POST")}} requests with the body PING to the URLs.
 - {{domxref("HTMLAnchorElement.port")}}
   - : A string representing the port component, if any, of the referenced URL.
 - {{domxref("HTMLAnchorElement.protocol")}}

--- a/files/en-us/web/api/htmlanchorelement/index.md
+++ b/files/en-us/web/api/htmlanchorelement/index.md
@@ -34,7 +34,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLAnchorElement.pathname")}}
   - : A string containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
 - {{domxref("HTMLAnchorElement.ping")}}
-  - : A space-separated list of URLs.
+  - : A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
 - {{domxref("HTMLAnchorElement.port")}}
   - : A string representing the port component, if any, of the referenced URL.
 - {{domxref("HTMLAnchorElement.protocol")}}

--- a/files/en-us/web/api/htmlanchorelement/ping/index.md
+++ b/files/en-us/web/api/htmlanchorelement/ping/index.md
@@ -1,0 +1,38 @@
+---
+title: "HTMLAnchorElement: ping property"
+short-title: ping
+slug: Web/API/HTMLAnchorElement/ping
+page-type: web-api-instance-property
+browser-compat: api.HTMLAnchorElement.ping
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`ping`** property of the {{domxref("HTMLAnchorElement")}} interface is a space-separated list of URLs.
+
+It reflects the `ping` attribute of the {{HTMLElement("a")}} element.
+
+> **Note:** This property is not effective in Firefox and its usage may be limited due to privacy and security concerns. 
+
+## Example
+
+```html
+<a id="exampleLink" href="https://example.com" ping="https://example-tracking.com">Example Link</a>
+```
+
+```js
+const anchorElement = document.getElementById("exampleLink");
+console.log(anchorElement.ping); // Output: "https://example-tracking.com"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLAreaElement.ping")}} property

--- a/files/en-us/web/api/htmlanchorelement/ping/index.md
+++ b/files/en-us/web/api/htmlanchorelement/ping/index.md
@@ -12,7 +12,7 @@ The **`ping`** property of the {{domxref("HTMLAnchorElement")}} interface is a s
 
 It reflects the `ping` attribute of the {{HTMLElement("a")}} element.
 
-> **Note:** This property is not effective in Firefox and its usage may be limited due to privacy and security concerns. 
+> **Note:** This property is not effective in Firefox and its usage may be limited due to privacy and security concerns.
 
 ## Example
 

--- a/files/en-us/web/api/htmlanchorelement/ping/index.md
+++ b/files/en-us/web/api/htmlanchorelement/ping/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.ping
 
 {{ApiRef("HTML DOM")}}
 
-The **`ping`** property of the {{domxref("HTMLAnchorElement")}} interface is a space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
+The **`ping`** property of the {{domxref("HTMLAnchorElement")}} interface is a space-separated list of URLs. When the link is followed, the browser will send {{HTTPMethod("POST")}} requests with the body PING to the URLs.
 
 It reflects the `ping` attribute of the {{HTMLElement("a")}} element.
 

--- a/files/en-us/web/api/htmlanchorelement/ping/index.md
+++ b/files/en-us/web/api/htmlanchorelement/ping/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.ping
 
 {{ApiRef("HTML DOM")}}
 
-The **`ping`** property of the {{domxref("HTMLAnchorElement")}} interface is a space-separated list of URLs.
+The **`ping`** property of the {{domxref("HTMLAnchorElement")}} interface is a space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
 
 It reflects the `ping` attribute of the {{HTMLElement("a")}} element.
 
@@ -20,14 +20,14 @@ It reflects the `ping` attribute of the {{HTMLElement("a")}} element.
 <a
   id="exampleLink"
   href="https://example.com"
-  ping="https://example-tracking.com"
+  ping="https://example-tracking.com https://example-analytics.com"
   >Example Link</a
 >
 ```
 
 ```js
 const anchorElement = document.getElementById("exampleLink");
-console.log(anchorElement.ping); // Output: "https://example-tracking.com"
+console.log(anchorElement.ping); // Output: "https://example-tracking.com https://example-analytics.com"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlanchorelement/ping/index.md
+++ b/files/en-us/web/api/htmlanchorelement/ping/index.md
@@ -17,7 +17,12 @@ It reflects the `ping` attribute of the {{HTMLElement("a")}} element.
 ## Example
 
 ```html
-<a id="exampleLink" href="https://example.com" ping="https://example-tracking.com">Example Link</a>
+<a
+  id="exampleLink"
+  href="https://example.com"
+  ping="https://example-tracking.com"
+  >Example Link</a
+>
 ```
 
 ```js


### PR DESCRIPTION
This PR add documentation for HTMLAnchorElement.ping property.

It is part of the discussion to document all interoperable features ([mdn/discussions#476](https://github.com/orgs/mdn/discussions/476))
### Resource
[ping](https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-ping)