### PR TITLE
document for HTMLAreaElement.ping

### DIFF
--- a/files/en-us/web/api/htmlareaelement/index.md
+++ b/files/en-us/web/api/htmlareaelement/index.md
@@ -38,7 +38,7 @@ _Inherits properties from its parent {{domxref("HTMLElement")}}._
 - {{domxref("HTMLAreaElement.pathname")}}
   - : A string containing the path name component, if any, of the referenced URL.
 - {{domxref("HTMLAreaElement.ping")}}
-  - : A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
+  - : A space-separated list of URLs. When the link is followed, the browser will send {{HTTPMethod("POST")}} requests with the body PING to the URLs.
 - {{domxref("HTMLAreaElement.port")}}
   - : A string containing the port component, if any, of the referenced URL.
 - {{domxref("HTMLAreaElement.protocol")}}

--- a/files/en-us/web/api/htmlareaelement/index.md
+++ b/files/en-us/web/api/htmlareaelement/index.md
@@ -38,7 +38,7 @@ _Inherits properties from its parent {{domxref("HTMLElement")}}._
 - {{domxref("HTMLAreaElement.pathname")}}
   - : A string containing the path name component, if any, of the referenced URL.
 - {{domxref("HTMLAreaElement.ping")}}
-  - : A space-separated list of URLs.
+  - : A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
 - {{domxref("HTMLAreaElement.port")}}
   - : A string containing the port component, if any, of the referenced URL.
 - {{domxref("HTMLAreaElement.protocol")}}

--- a/files/en-us/web/api/htmlareaelement/index.md
+++ b/files/en-us/web/api/htmlareaelement/index.md
@@ -37,6 +37,8 @@ _Inherits properties from its parent {{domxref("HTMLElement")}}._
   - : A string containing the password specified before the domain name.
 - {{domxref("HTMLAreaElement.pathname")}}
   - : A string containing the path name component, if any, of the referenced URL.
+- {{domxref("HTMLAreaElement.ping")}}
+  - : A space-separated list of URLs.
 - {{domxref("HTMLAreaElement.port")}}
   - : A string containing the port component, if any, of the referenced URL.
 - {{domxref("HTMLAreaElement.protocol")}}

--- a/files/en-us/web/api/htmlareaelement/ping/index.md
+++ b/files/en-us/web/api/htmlareaelement/ping/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAreaElement.ping
 
 {{ApiRef("HTML DOM")}}
 
-The **`ping`** property of the {{domxref("HTMLAreaElement")}} interface is a space-separated list of URLs.
+The **`ping`** property of the {{domxref("HTMLAreaElement")}} interface is a space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
 
 It reflects the `ping` attribute of the {{HTMLElement("area")}} element.
 
@@ -20,14 +20,14 @@ It reflects the `ping` attribute of the {{HTMLElement("area")}} element.
 <map>
   <area
     href="https://example.com"
-    ping="https://example-tracking.com"
+    ping="https://example-tracking.com https://example-analytics.com"
     alt="example" />
 </map>
 ```
 
 ```js
 const areaCollection = document.getElementsByTagName("map")[0].areas;
-console.log(areaCollection[0].ping); // Output: "https://example-tracking.com"
+console.log(areaCollection[0].ping); // Output: "https://example-tracking.com https://example-analytics.com"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlareaelement/ping/index.md
+++ b/files/en-us/web/api/htmlareaelement/ping/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAreaElement.ping
 
 {{ApiRef("HTML DOM")}}
 
-The **`ping`** property of the {{domxref("HTMLAreaElement")}} interface is a space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs.
+The **`ping`** property of the {{domxref("HTMLAreaElement")}} interface is a space-separated list of URLs. When the link is followed, the browser will send {{HTTPMethod("POST")}} requests with the body PING to the URLs.
 
 It reflects the `ping` attribute of the {{HTMLElement("area")}} element.
 

--- a/files/en-us/web/api/htmlareaelement/ping/index.md
+++ b/files/en-us/web/api/htmlareaelement/ping/index.md
@@ -1,0 +1,43 @@
+---
+title: "HTMLAreaElement: ping property"
+short-title: ping
+slug: Web/API/HTMLAreaElement/ping
+page-type: web-api-instance-property
+browser-compat: api.HTMLAreaElement.ping
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`ping`** property of the {{domxref("HTMLAreaElement")}} interface is a space-separated list of URLs.
+
+It reflects the `ping` attribute of the {{HTMLElement("area")}} element.
+
+> **Note:** This property is not effective in Firefox and its usage may be limited due to privacy and security concerns.
+
+## Example
+
+```html
+<map>
+  <area
+    href="https://example.com"
+    ping="https://example-tracking.com"
+    alt="example" />
+</map>
+```
+
+```js
+const areaCollection = document.getElementsByTagName("map")[0].areas;
+console.log(areaCollection[0].ping); // Output: "https://example-tracking.com"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLAnchorElement.ping")}} property


### PR DESCRIPTION
This PR add documentation for HTMLAreaElement.ping property.

It is part of the discussion to document all interoperable features ([mdn/discussions#476](https://github.com/orgs/mdn/discussions/476))

Resource
[ping](https://html.spec.whatwg.org/multipage/image-maps.html#dom-area-ping)