### PR TITLE
Add media type to not

### DIFF
--- a/files/en-us/web/css/@media/scan/index.md
+++ b/files/en-us/web/css/@media/scan/index.md
@@ -42,22 +42,22 @@ p {
   border: solid;
 }
 
-@media (scan: interlace) {
+@media screen and (scan: interlace) {
   p {
     background: #f4ae8a;
   }
 }
-@media (scan: progressive) {
+@media screen and (scan: progressive) {
   p {
     text-decoration: underline;
   }
 }
-@media not (scan: progressive) {
+@media not screen and (scan: progressive) {
   p {
     border-style: dashed;
   }
 }
-@media not (scan: interlaced) {
+@media not screen and (scan: interlaced) {
   p {
     color: purple;
   }


### PR DESCRIPTION
when using `not` in a media query, we generally include a media type. I didn't. So fixing that. I included it in the examples without `not` for consistency. It's not a requirement, just an old practice due to browsers not supporting feature queries.