### PR TITLE
Update sectioning content to fit spec

### DIFF
--- a/files/en-us/web/html/content_categories/index.md
+++ b/files/en-us/web/html/content_categories/index.md
@@ -122,7 +122,7 @@ A few other elements belong to this category, but only if a specific condition i
 
 ### Sectioning content
 
-Sectioning content, a subset of flow content, creates a [section in the current outline](/en-US/docs/Web/HTML/Element/Heading_Elements) defining the scope of {{HTMLElement("header")}} elements, {{HTMLElement("footer")}} elements, and [heading content](#heading_content).
+Sectioning content, a subset of flow content, creates a [section in the current outline](/en-US/docs/Web/HTML/Element/Heading_Elements) defining the scope of {{HTMLElement("header")}} and {{HTMLElement("footer")}} elements.
 
 Elements belonging to this category are {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("nav")}}, and {{HTMLElement("section")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

As of https://github.com/whatwg/html/pull/7829, sectioning content no longer defines the scope of heading content. This can also be seen in [the spec](https://html.spec.whatwg.org/multipage/dom.html#sectioning-content-2):

> Sectioning content is content that defines the scope of [header](https://html.spec.whatwg.org/multipage/sections.html#the-header-element) and [footer](https://html.spec.whatwg.org/multipage/sections.html#the-footer-element) elements.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

We should not confuse readers about the fictional Document Outline Algorithm, especially since it is no longer in the spec.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://github.com/whatwg/html/pull/7829
https://html.spec.whatwg.org/multipage/dom.html#sectioning-content-2
https://adrianroselli.com/2016/08/there-is-no-document-outline-algorithm.html

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
