### PR TITLE
fix(html): add missing properties pages for HTMLProgressElement

### DIFF
--- a/files/en-us/web/api/htmlprogresselement/max/index.md
+++ b/files/en-us/web/api/htmlprogresselement/max/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.HTMLProgressElement.max
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
-The **`HTMLProgressElement.max`** represents the upper bound of the {{HTMLElement("progress")}} element's range.
+The **`max`** property of the {{DOMxRef("HTMLProgressElement")}} interface represents the upper bound of the {{HTMLElement("progress")}} element's range.
 
 ## Value
 

--- a/files/en-us/web/api/htmlprogresselement/max/index.md
+++ b/files/en-us/web/api/htmlprogresselement/max/index.md
@@ -28,6 +28,8 @@ Progress: <progress id="pBar"></progress> <span>0</span>%
 const pBar = document.getElementById("pBar");
 const span = document.getElementsByTagName("span")[0];
 
+console.log(`Default value of max: ${pBar.max}`);
+
 pBar.max = 100;
 pBar.value = 0;
 

--- a/files/en-us/web/api/htmlprogresselement/max/index.md
+++ b/files/en-us/web/api/htmlprogresselement/max/index.md
@@ -1,0 +1,49 @@
+---
+title: "HTMLProgressElement: max property"
+short-title: max
+slug: Web/API/HTMLProgressElement/max
+page-type: web-api-instance-property
+browser-compat: api.HTMLProgressElement.max
+---
+
+{{APIRef("DOM")}}
+
+The **`HTMLProgressElement.max`** sets the upper bound of the {{HTMLElement("progress")}} element's range.
+
+## Value
+
+A floating point number that is greater than zero. The default value is 1.0.
+
+## Examples
+
+### HTML
+
+```html
+Progress: <progress id="pBar"></progress> <span>0</span>%
+```
+
+### JavaScript
+
+```js
+const pBar = document.getElementById("pBar");
+const span = document.getElementsByTagName("span")[0];
+
+pBar.max = 100;
+pBar.value = 0;
+
+setInterval(() => {
+  pBar.value = pBar.value < pBar.max ? pBar.value + 1 : 0;
+
+  span.textContent = Math.trunc(pBar.position * 100);
+}, 100);
+```
+
+{{EmbedLiveSample("Examples", "100%", 30)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmlprogresselement/max/index.md
+++ b/files/en-us/web/api/htmlprogresselement/max/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLProgressElement.max
 
 {{APIRef("DOM")}}
 
-The **`HTMLProgressElement.max`** sets the upper bound of the {{HTMLElement("progress")}} element's range.
+The **`HTMLProgressElement.max`** represents the upper bound of the {{HTMLElement("progress")}} element's range.
 
 ## Value
 

--- a/files/en-us/web/api/htmlprogresselement/position/index.md
+++ b/files/en-us/web/api/htmlprogresselement/position/index.md
@@ -1,0 +1,52 @@
+---
+title: "HTMLProgressElement: position property"
+short-title: position
+slug: Web/API/HTMLProgressElement/position
+page-type: web-api-instance-property
+browser-compat: api.HTMLProgressElement.position
+---
+
+{{APIRef("DOM")}}
+
+The **`HTMLProgressElement.position`** read-only value returns current progress of the {{HTMLElement("progress")}} element.
+
+## Value
+
+For determinate progress bar returns the result of current value decided by max value, i.e., a fraction between `0.0` and `1.0`.
+
+For indeterminate progress bar the value is always `-1`.
+
+## Examples
+
+### HTML
+
+```html
+Determinate Progress bar: <progress id="pBar"></progress> Position:
+<span>0</span>
+```
+
+### JavaScript
+
+```js
+const pBar = document.getElementById("pBar");
+const span = document.getElementsByTagName("span")[0];
+
+pBar.max = 100;
+pBar.value = 0;
+
+setInterval(() => {
+  pBar.value = pBar.value < pBar.max ? pBar.value + 1 : 0;
+
+  span.textContent = pBar.position;
+}, 100);
+```
+
+{{EmbedLiveSample("Examples", "100%", 30)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmlprogresselement/position/index.md
+++ b/files/en-us/web/api/htmlprogresselement/position/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.HTMLProgressElement.position
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
-The **`HTMLProgressElement.position`** read-only value returns current progress of the {{HTMLElement("progress")}} element.
+The **`position`** read-only property of the {{DOMxRef("HTMLProgressElement")}} interface returns current progress of the {{HTMLElement("progress")}} element.
 
 ## Value
 

--- a/files/en-us/web/api/htmlprogresselement/value/index.md
+++ b/files/en-us/web/api/htmlprogresselement/value/index.md
@@ -6,15 +6,15 @@ page-type: web-api-instance-property
 browser-compat: api.HTMLProgressElement.value
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
-The **`HTMLProgressElement.value`** represents the current progress of the {{HTMLElement("progress")}} element.
+The **`value`** property of the {{DOMxRef("HTMLProgressElement")}} interface represents the current progress of the {{HTMLElement("progress")}} element.
 
 ## Value
 
-A floating point number. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and 1.0. If the `max` value is set then the `value` ranges between `0` and the `max` value.
+A floating point number. If {{DOMxRef("HTMLProgressElement.max", "max")}} value is not set on the progress bar then value ranges between 0.0 and 1.0. If the `max` value is set then the `value` ranges between `0` and the `max` value.
 
-If the `value` property is not set on [`HTMLProgressElement`](/en-US/docs/Web/API/HTMLProgressElement) object, then the progress bar remains indeterminate.
+If the `value` property is not set on {{DOMxRef("HTMLProgressElement")}} object, then the progress bar remains indeterminate.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlprogresselement/value/index.md
+++ b/files/en-us/web/api/htmlprogresselement/value/index.md
@@ -8,11 +8,11 @@ browser-compat: api.HTMLProgressElement.value
 
 {{APIRef("DOM")}}
 
-The **`HTMLProgressElement.value`** sets the current progress of the {{HTMLElement("progress")}} element.
+The **`HTMLProgressElement.value`** represents the current progress of the {{HTMLElement("progress")}} element.
 
 ## Value
 
-A floating point number with default value 0.0. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and 1.0. If the `max` value is set then the `value` ranges between `0` and the `max` value.
+A floating point number. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and  the {{domxref("HTMLProgressElement.max")}} value.
 
 If the `value` is not set or removed then the progress bar becomes indeterminate.
 

--- a/files/en-us/web/api/htmlprogresselement/value/index.md
+++ b/files/en-us/web/api/htmlprogresselement/value/index.md
@@ -12,7 +12,7 @@ The **`HTMLProgressElement.value`** represents the current progress of the {{HTM
 
 ## Value
 
-A floating point number. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and the {{domxref("HTMLProgressElement.max")}} value.
+A floating point number. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and 1.0. If the `max` value is set then the `value` ranges between `0` and the `max` value.
 
 If the `value` property is not set on [`HTMLProgressElement`](/en-US/docs/Web/API/HTMLProgressElement) object, then the progress bar remains indeterminate.
 

--- a/files/en-us/web/api/htmlprogresselement/value/index.md
+++ b/files/en-us/web/api/htmlprogresselement/value/index.md
@@ -12,9 +12,9 @@ The **`HTMLProgressElement.value`** represents the current progress of the {{HTM
 
 ## Value
 
-A floating point number. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and  the {{domxref("HTMLProgressElement.max")}} value.
+A floating point number. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and the {{domxref("HTMLProgressElement.max")}} value.
 
-If the `value` is not set or removed then the progress bar becomes indeterminate.
+If the `value` property is not set on [`HTMLProgressElement`](/en-US/docs/Web/API/HTMLProgressElement) object, then the progress bar remains indeterminate.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlprogresselement/value/index.md
+++ b/files/en-us/web/api/htmlprogresselement/value/index.md
@@ -1,0 +1,53 @@
+---
+title: "HTMLProgressElement: value property"
+short-title: value
+slug: Web/API/HTMLProgressElement/value
+page-type: web-api-instance-property
+browser-compat: api.HTMLProgressElement.value
+---
+
+{{APIRef("DOM")}}
+
+The **`HTMLProgressElement.value`** sets the current progress of the {{HTMLElement("progress")}} element.
+
+## Value
+
+A floating point number with default value 0.0. If [`max`](Web/API/HTMLProgressElement/max) value is not set on the progress bar then value ranges between 0.0 and 1.0. If the `max` value is set then the `value` ranges between `0` and the `max` value.
+
+If the `value` is not set or removed then the progress bar becomes indeterminate.
+
+## Examples
+
+### HTML
+
+```html
+Determinate Progress bar: <progress id="pBar"></progress> <span>0</span>%
+<br />
+Indeterminate Progress bar: <progress></progress>
+```
+
+### JavaScript
+
+```js
+const pBar = document.getElementById("pBar");
+const span = document.getElementsByTagName("span")[0];
+
+pBar.max = 100;
+pBar.value = 0;
+
+setInterval(() => {
+  pBar.value = pBar.value < pBar.max ? pBar.value + 1 : 0;
+
+  span.textContent = Math.trunc(pBar.position * 100);
+}, 100);
+```
+
+{{EmbedLiveSample("Examples", "100%", 30)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
- part of the fix for https://github.com/orgs/mdn/discussions/476

The PR adds `max`, `position`, and `value` pages. BCD entries for these already exist.