### PR TITLE
fix: Reflect.construct() vs. Object.create() example error

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -89,6 +89,8 @@ function OtherClass() {
   this.name = "other";
 }
 
+const args = [];
+const obj1 = Reflect.construct(OneClass,args,OtherClass);
 const obj2 = Object.create(OtherClass.prototype);
 OneClass.apply(obj2, args);
 
@@ -112,6 +114,8 @@ function func2(d, e, f, g) {
 }
 
 const obj1 = Reflect.construct(func1, ["I", "Love", "my", "country"]);
+const obj2 = Object.create(func1.prototype);
+func2.apply(obj2,["I", "Love", "my", "country"])
 ```
 
 However, while the end result is the same, there is one important difference in the process. When using `Object.create()` and {{jsxref("Function.prototype.apply()")}}, the `new.target` operator will point to `undefined` within the function used as the constructor, since the `new` keyword is not being used to create the object. (In fact, it uses the [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply) semantic, not `construct`, although normal functions happen to operate nearly the same.)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -90,7 +90,7 @@ function OtherClass() {
 }
 
 const args = [];
-const obj1 = Reflect.construct(OneClass,args,OtherClass);
+const obj1 = Reflect.construct(OneClass, args, OtherClass);
 const obj2 = Object.create(OtherClass.prototype);
 OneClass.apply(obj2, args);
 
@@ -115,7 +115,7 @@ function func2(d, e, f, g) {
 
 const obj1 = Reflect.construct(func1, ["I", "Love", "my", "country"]);
 const obj2 = Object.create(func1.prototype);
-func2.apply(obj2,["I", "Love", "my", "country"])
+func2.apply(obj2, ["I", "Love", "my", "country"])
 ```
 
 However, while the end result is the same, there is one important difference in the process. When using `Object.create()` and {{jsxref("Function.prototype.apply()")}}, the `new.target` operator will point to `undefined` within the function used as the constructor, since the `new` keyword is not being used to create the object. (In fact, it uses the [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply) semantic, not `construct`, although normal functions happen to operate nearly the same.)

--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -102,20 +102,6 @@ console.log(obj2 instanceof OneClass); // false
 
 console.log(obj1 instanceof OtherClass); // true
 console.log(obj2 instanceof OtherClass); // true
-
-// Another example to demonstrate below:
-
-function func1(a, b, c, d) {
-  console.log(arguments[3]);
-}
-
-function func2(d, e, f, g) {
-  console.log(arguments[3]);
-}
-
-const obj1 = Reflect.construct(func1, ["I", "Love", "my", "country"]);
-const obj2 = Object.create(func1.prototype);
-func2.apply(obj2, ["I", "Love", "my", "country"])
 ```
 
 However, while the end result is the same, there is one important difference in the process. When using `Object.create()` and {{jsxref("Function.prototype.apply()")}}, the `new.target` operator will point to `undefined` within the function used as the constructor, since the `new` keyword is not being used to create the object. (In fact, it uses the [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply) semantic, not `construct`, although normal functions happen to operate nearly the same.)


### PR DESCRIPTION
### Description
Fix "Reflect.construct() vs. Object.create()" example which is incomplete;

### Motivation
The  example is missing some variable declarations,so I want to fix it;

### Additional details

### Related issues and pull requests
