### PR TITLE
fix(ci): migrate to husky v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-#!/bin/sh
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:json": "prettier -c \"**/*.json(c)?\"",
     "lint:md": "markdownlint-cli2 \"**/*.md\" && prettier -c \"**/*.md\"",
     "lint:yml": "prettier -c \"**/*.yml\"",
-    "prepare": "husky install",
+    "prepare": "husky || true",
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build yari-server",
     "up-to-date-check": "node scripts/up-to-date-check.js",
     "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",


### PR DESCRIPTION
Husky was updated to V9 yesterday. Migrating as instructed in the [release notes](https://github.com/typicode/husky/releases/tag/v9.0.1).

`husky install` is deprecated. Using `husky || true` [as suggested in their docs](https://typicode.github.io/husky/how-to.html#ci-server-and-docker).

Sourcing `husky.sh` is redundant now. Because the auto generated file, during husky installation, is empty.

:warning: I suggest all to run `yarn install` and `yarn prepare` after pulling this change.
