### PR TITLE
document DOMParser.parseFromString includeShadowRoots option

### DIFF
--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -13,7 +13,7 @@ The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface par
 ## Syntax
 
 ```js-nolint
-parseFromString(string, mimeType)
+parseFromString(string, mimeType, options)
 ```
 
 ### Parameters
@@ -37,6 +37,14 @@ parseFromString(string, mimeType)
     The other valid values (`text/xml`, `application/xml`, `application/xhtml+xml`, and `image/svg+xml`) are functionally equivalent. They all invoke the XML parser, and the method will return a {{domxref("XMLDocument")}}.
 
     Any other value is invalid and will cause a [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) to be thrown.
+
+- `options` (Optional)
+
+  - : An object. This object allows for additional configuration of the `parseFromString` method. Supported properties are:
+
+    - `includeShadowRoots`
+
+    A value of `includeShadowRoots` enabled parsing of HTML with Declarative Shadow Roots applied. This avoids some important security considerations as fragment parsing APIs like `innerHTML` or `insertAdjacentHTML()` don't support creation of Declarative Shadow Roots.
 
 ### Return value
 
@@ -92,6 +100,24 @@ if (errorNode) {
 ```
 
 Additionally, the parsing error may be reported to the browser's JavaScript console.
+
+### includeShadowRoots
+
+The below shows an example of passing `includeShadowRoots` as an option to `parseFromString`.
+
+```js
+<script>
+  const html = `
+    <div>
+      <template shadowrootmode="open"></template>
+    </div>
+  `;
+
+  const fragment = new DOMParser().parseFromString(html, 'text/html', {
+    includeShadowRoots: true
+  });
+</script>
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -42,9 +42,11 @@ parseFromString(string, mimeType, options)
 
   - : An object. This object allows for additional configuration of the `parseFromString` method. Supported properties are:
 
-    - `includeShadowRoots`
+    - `includeShadowRoots` {{Non-standard_Inline}}
 
     A value of `includeShadowRoots` enabled parsing of HTML with Declarative Shadow Roots applied. This avoids some important security considerations as fragment parsing APIs like `innerHTML` or `insertAdjacentHTML()` don't support creation of Declarative Shadow Roots.
+
+> As `includeShadowRoots` is non-standard, once available [`setHTMLUnsafe` and `parseHTMLUnsafe`](https://github.com/mdn/mdn/issues/459) should be used instead.
 
 ### Return value
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -44,7 +44,7 @@ parseFromString(string, mimeType, options)
 
     - `includeShadowRoots` {{Non-standard_Inline}}
 
-    A value of `includeShadowRoots` enabled parsing of HTML with Declarative Shadow Roots applied. This avoids some important security considerations as fragment parsing APIs like `innerHTML` or `insertAdjacentHTML()` don't support creation of Declarative Shadow Roots.
+    A value of `includeShadowRoots` enables parsing of HTML with Declarative Shadow Roots applied. This avoids some important security considerations as fragment parsing APIs like `innerHTML` or `insertAdjacentHTML()` don't support creation of Declarative Shadow Roots.
 
 > As `includeShadowRoots` is non-standard, once available [`setHTMLUnsafe` and `parseHTMLUnsafe`](https://github.com/mdn/mdn/issues/459) should be used instead.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

1. Document `includeShadowRoots` option of the `DOMParser.parseFromString` method
1. Include relevant historical / deprecation related context and alternatives

(credit to the [Chrome Developer Docs](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom#parser-only) for the reference)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Add historical documentation about the `includeShadowRoots` option of the `DOMParser.parseFromString` method.

### Additional details

- https://developer.chrome.com/docs/css-ui/declarative-shadow-dom#parser-only
- https://github.com/whatwg/dom/issues/912#issuecomment-732476002
- https://github.com/whatwg/html/pull/9538
- https://github.com/mdn/mdn/issues/459

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

- Fixes #31501
- (?) Depends on #459 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->