### PR TITLE
fix: ReadableStream.cancel return value

### DIFF
--- a/files/en-us/web/api/readablestream/cancel/index.md
+++ b/files/en-us/web/api/readablestream/cancel/index.md
@@ -8,15 +8,11 @@ browser-compat: api.ReadableStream.cancel
 
 {{APIRef("Streams")}}
 
-The **`cancel()`** method of the
-{{domxref("ReadableStream")}} interface returns a {{jsxref("Promise")}} that
-resolves when the stream is canceled.
+The **`cancel()`** method of the {{domxref("ReadableStream")}} interface returns a {{jsxref("Promise")}} that resolves when the stream is canceled.
 
-Cancel is used when you've completely finished with the stream and don't need any more
-data from it, even if there are chunks enqueued waiting to be read. That data is lost
-after cancel is called, and the stream is not readable any more. To read those chunks
-still and not completely get rid of the stream, you'd use
-{{domxref("ReadableStreamDefaultController.close()")}}.
+Cancel is used when you've completely finished with the stream and don't need any more data from it, even if there are chunks enqueued waiting to be read.
+That data is lost after cancel is called, and the stream is not readable any more.
+To read those chunks still and not completely get rid of the stream, you'd use {{domxref("ReadableStreamDefaultController.close()")}}.
 
 ## Syntax
 
@@ -28,7 +24,8 @@ cancel(reason)
 ### Parameters
 
 - `reason` {{optional_inline}}
-  - : A human-readable reason for the cancellation. The underlying source may or may not use it.
+  - : A human-readable reason for the cancellation.
+    This is passed to the underlying source, which may or may not use it.
 
 ### Return value
 
@@ -41,8 +38,8 @@ A {{jsxref("Promise")}}, which fulfills with `undefined` value.
 
 ## Examples
 
-In Jake Archibald's [cancelling a fetch](https://jsbin.com/gameboy/edit?js,console) example, a stream is used to fetch the WHATWG HTML spec chunk by chunk; each
-chunk is searched for the string "service workers". When the search terms is found, `cancel()` is used to cancel the stream — the job is finished so it is no longer needed.
+In Jake Archibald's [cancelling a fetch](https://jsbin.com/gameboy/edit?js,console) example, a stream is used to fetch the WHATWG HTML spec chunk by chunk;
+each chunk is searched for the string "service workers". When the search terms is found, `cancel()` is used to cancel the stream — the job is finished so it is no longer needed.
 
 ```js
 const searchTerm = "service workers";

--- a/files/en-us/web/api/readablestream/cancel/index.md
+++ b/files/en-us/web/api/readablestream/cancel/index.md
@@ -32,7 +32,7 @@ cancel(reason)
 
 ### Return value
 
-A {{jsxref("Promise")}}, which fulfills with the value given in the `reason` parameter.
+A {{jsxref("Promise")}}, which fulfills with `undefined` value.
 
 ### Exceptions
 


### PR DESCRIPTION
### Description

Spec doesn't mention any return value.

### Motivation

Browsers return Promise that resolves to `undefined`, users should not rely on returned value. 

### Additional details

https://streams.spec.whatwg.org/#ref-for-rs-cancel%E2%91%A2
