### PR TITLE
FF122 Relnote CSS -moz-user-focus removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -47,7 +47,7 @@ This article provides information about the changes in Firefox 122 that affect d
 
 #### Removals
 
-- Removed support for the CSS [`-moz-user-focus`](/en-US/docs/Web/CSS/-moz-user-focus) property in website code (see [Firefox bug 1871745](https://bugzil.la/1871745) and [Firefox bug 1868552](https://bugzil.la/1868552)).
+- Removed support for the CSS [`-moz-user-focus`](/en-US/docs/Web/CSS/-moz-user-focus) property ([Firefox bug 1871745](https://bugzil.la/1871745) and [Firefox bug 1868552](https://bugzil.la/1868552)).
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -45,6 +45,10 @@ This article provides information about the changes in Firefox 122 that affect d
 
 - The {{domxref("HTMLSelectElement.showPicker()")}} method is now supported, allowing the browser picker for a {{HTMLElement("select")}} element to be programmatically launched when triggered by user interaction ([Firefox bug 1865207](https://bugzil.la/1865207)).
 
+#### Removals
+
+- Removed support for the CSS [`-moz-user-focus`](/en-US/docs/Web/CSS/-moz-user-focus) property in website code (see [Firefox bug 1871745](https://bugzil.la/1871745) and [Firefox bug 1868552](https://bugzil.la/1868552)).
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### General

--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -7,16 +7,18 @@ status:
 browser-compat: css.properties.-moz-user-focus
 ---
 
-{{CSSRef}} {{Non-standard_header}}
+{{CSSRef}} {{deprecated_header}}
 
 The **`-moz-user-focus`** [CSS](/en-US/docs/Web/CSS) property is used to indicate whether an element can have the focus.
 
-By setting its value to `ignore`, you can disable focusing the element, which means that the user will not be able to activate the element. The element will be skipped in the tab sequence.
+By setting its value to `ignore`, you can disable focusing the element, which means that the user will not be able to activate the element, and the element will be skipped in the tab sequence.
+The default is `none`, which disables focussing on the element and removes focus on other elements if there is an attempt to select the element.
 
 ## Syntax
 
 ```css
 /* Keyword values */
+-moz-user-focus: none;
 -moz-user-focus: normal;
 -moz-user-focus: ignore;
 
@@ -33,7 +35,8 @@ By setting its value to `ignore`, you can disable focusing the element, which me
 - `normal`
   - : The element can accept keyboard focus.
 - `none`
-  - : ?
+  - : The element does not accept keyboard focus.
+    Attempting to select the element removes focus from any other element.
 
 ## Formal definition
 

--- a/files/en-us/web/css/-moz-user-focus/index.md
+++ b/files/en-us/web/css/-moz-user-focus/index.md
@@ -3,6 +3,7 @@ title: "-moz-user-focus"
 slug: Web/CSS/-moz-user-focus
 page-type: css-property
 status:
+  - deprecated
   - non-standard
 browser-compat: css.properties.-moz-user-focus
 ---


### PR DESCRIPTION
FF122 removes CSS [`-moz-user-focus`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-user-focus) for use in content https://bugzilla.mozilla.org/show_bug.cgi?id=1871745 so it can only be used in browser chrome. (and in https://bugzilla.mozilla.org/show_bug.cgi?id=1868552 the default value also changes to `normal` from `none`.

Because MDN is for web developers, the fact it can be used in chrome seems irrelevant. I have therefore added a release note in 122 that remove this. Also updated the property page with deprecated (rather than non-standard)

Related docs work can be tracked in https://github.com/mdn/content/issues/31928