### PR TITLE
Ff123 createindex locale depr

### DIFF
--- a/files/en-us/web/api/idbobjectstore/createindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/createindex/index.md
@@ -45,7 +45,7 @@ createIndex(indexName, keyPath, options)
       - : If `true`, the index will add an entry in the index for each array element when the `keyPath` resolves to an array.
         If `false`, it will add one single entry containing the array. Defaults to `false`.
     - `locale` {{non-standard_inline}} {{deprecated_inline}}
-      - : Currently Firefox-only (43+), this allows you to specify a locale for the index.
+      - : Allows you to specify a locale for the index.
         Any sorting operations performed on the data via key ranges will then obey sorting rules of that locale
         (see [locale-aware sorting](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#locale-aware_sorting)).
         You can specify its value in one of three ways:

--- a/files/en-us/web/api/idbobjectstore/createindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/createindex/index.md
@@ -32,12 +32,9 @@ createIndex(indexName, keyPath, options)
 ### Parameters
 
 - `indexName`
-  - : The name of the index to create. Note that it is possible to create an index with an
-    empty name.
+  - : The name of the index to create. Note that it is possible to create an index with an empty name.
 - `keyPath`
-  - : The key path for the index to use. Note that it is possible to create an index with
-    an empty `keyPath`, and also to pass in a sequence (array) as a
-    `keyPath`.
+  - : The key path for the index to use. Note that it is possible to create an index with an empty `keyPath`, and also to pass in a sequence (array) as a `keyPath`.
 - `options` {{optional_inline}}
 
   - : An object which can include the following
@@ -47,7 +44,7 @@ createIndex(indexName, keyPath, options)
     - `multiEntry`
       - : If `true`, the index will add an entry in the index for each array element when the `keyPath` resolves to an array.
         If `false`, it will add one single entry containing the array. Defaults to `false`.
-    - `locale` {{non-standard_inline}}
+    - `locale` {{non-standard_inline}} {{deprecated_inline}}
       - : Currently Firefox-only (43+), this allows you to specify a locale for the index.
         Any sorting operations performed on the data via key ranges will then obey sorting rules of that locale
         (see [locale-aware sorting](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#locale-aware_sorting)).


### PR DESCRIPTION
The Firefox-only `options.locale` argument to [`IDBObjectStore.createIndex()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/createIndex) is now deprecated by https://bugzilla.mozilla.org/show_bug.cgi?id=1872675 in FF123.

This adds deprecated inline to mention of the property. Also removes the version 43+ which I will add to BCD.

Related docs work can be tracked in #31915