### PR TITLE
Adding details for browserAction.getUserSettings

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getusersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getusersettings/index.md
@@ -54,4 +54,3 @@ gettingUserSettings.then(gotSettings);
 ## Browser compatibility
 
 {{Compat}}
-

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getusersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getusersettings/index.md
@@ -39,9 +39,9 @@ This code logs a message indicating whether the browser action is pinned or not:
 ```js
 function gotSettings(userSettings) {
   if (userSettings.isOnToolbar) {
-    console.log("Action is pinned to toolbar.");
+    console.log("Browser action is pinned to toolbar.");
   } else {
-    console.log("Action is not pinned to toolbar.");
+    console.log("Browser action is not pinned to toolbar.");
   }
 }
 
@@ -55,34 +55,3 @@ gettingUserSettings.then(gotSettings);
 
 {{Compat}}
 
-> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getUserSettings) API.
-
-<!--
-// Copyright 2015 The Chromium Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//    * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//    * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getusersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getusersettings/index.md
@@ -1,0 +1,88 @@
+---
+title: browserAction.getUserSettings()
+slug: Mozilla/Add-ons/WebExtensions/API/browserAction/getUserSettings
+page-type: webextension-api-function
+browser-compat: webextensions.api.browserAction.getUserSettings
+---
+
+{{AddonSidebar}}
+
+Gets the user-specified settings for the browser action.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js-nolint
+let userSettings = await browser.browserAction.getUserSettings();
+```
+
+### Parameters
+
+This function takes no parameters.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that fulfills with an object with these properties:
+
+- `userSettings`
+
+  - : An object containing the user-specified settings for the browser action with these properties:
+
+    - `isOnToolbar` {{optional_inline}}
+      - : `boolean`. Whether the user has pinned the action's icon to the browser UI. This setting does not indicate whether the action icon is visible. The icon's visibility depends on the size of the browser window and the layout of the browser UI.
+
+## Examples
+
+This code logs a message indicating whether the browser action is pinned or not:
+
+```js
+function gotSettings(userSettings) {
+  if (userSettings.isOnToolbar) {
+    console.log("Action is pinned to toolbar.");
+  } else {
+    console.log("Action is not pinned to toolbar.");
+  }
+}
+
+let gettingUserSettings = browser.browserAction.getUserSettings();
+gettingUserSettings.then(gotSettings);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getUserSettings) API.
+
+<!--
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -57,6 +57,8 @@ With the `browserAction` API, you can:
   - : Sets the badge's text color.
 - {{WebExtAPIRef("browserAction.getBadgeTextColor()")}}
   - : Gets the badge's text color.
+- {{WebExtAPIRef("browserAction.getUserSettings()")}}
+  - : Gets the user-specified settings for the browser action.
 - {{WebExtAPIRef("browserAction.enable()")}}
   - : Enables the browser action for a tab. By default, browser actions are enabled for all tabs.
 - {{WebExtAPIRef("browserAction.disable()")}}

--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -72,7 +72,7 @@ This article provides information about the changes in Firefox 116 that affect d
 ## Changes for add-on developers
 
 - The URL of a page visited when an extension is uninstalled, provided in {{WebExtAPIRef("runtime.setUninstallURL")}}, can now be up to 1023 characters instead of 255 ([Firefox bug 1835723](https://bugzil.la/1835723)).
-- Adds {{WebExtAPIRef("action.getUserSettings")}} providing the user-specified settings for an extension's browser action ([Firefox bug 1814905](https://bugzil.la/1814905)).
+- Adds {{WebExtAPIRef("action.getUserSettings")}} and {{WebExtAPIRef("browserAction.getUserSettings")}} providing the user-specified settings for an extension's browser action ([Firefox bug 1814905](https://bugzil.la/1814905)).
 - `autoDiscardable` is now supported in {{WebExtAPIRef("tabs.Tab")}}, {{WebExtAPIRef("tabs.onUpdated")}}, {{WebExtAPIRef("tabs.update")}}, and {{WebExtAPIRef("tabs.query")}} ([Firefox bug 1809094](https://bugzil.la/1809094)).
 
 ## Developer Tools


### PR DESCRIPTION
### Description

Documentation for browserAction.getUserSetting which was added in [Bug 1814905](https://bugzilla.mozilla.org/show_bug.cgi?id=1814905) "Implement chrome.action.getUserSettings" but missed from the original documentation update.
