### PR TITLE
docs: adding missing WebSocket.terminate method

### DIFF
--- a/files/en-us/web/api/websocket/index.md
+++ b/files/en-us/web/api/websocket/index.md
@@ -39,6 +39,8 @@ To construct a `WebSocket`, use the [`WebSocket()`](/en-US/docs/Web/API/WebSocke
 
 - {{domxref("WebSocket.close()")}}
   - : Closes the connection.
+- {{domxref("WebSocket.terminate()")}}
+  - : Terminates the connection.
 - {{domxref("WebSocket.send()")}}
   - : Enqueues data to be transmitted.
 

--- a/files/en-us/web/api/websocket/terminate/index.md
+++ b/files/en-us/web/api/websocket/terminate/index.md
@@ -1,0 +1,37 @@
+---
+title: "WebSocket: terminate() method"
+short-title: terminate()
+slug: Web/API/WebSocket/terminate
+page-type: web-api-instance-method
+browser-compat: api.WebSocket.terminate
+---
+
+{{APIRef("Web Sockets API")}}
+
+The **`WebSocket.terminate()`** method closes the
+{{domxref("WebSocket")}} connection or connection attempt, if any. If the connection is
+already `CLOSED`, this method does nothing.
+
+> **Note:** The process of closing the connection begins with a [closing handshake](https://www.rfc-editor.org/rfc/rfc6455.html#section-1.4), and the `close()` method does not discard previously-sent messages before starting that closing handshake; even if the user agent is still busy sending those messages, the handshake will only start after the messages are sent.
+
+## Syntax
+
+```js-nolint
+terminate()
+```
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455.html) (the WebSocket Protocol specification)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

While searching for some info about WebSocket.terminate method, I noticed the `@types/ws` package has a definition for `WebSocket.terminate()` and found here and there some info about the method which is effectively an alias for `WebSocket.close()`, but I didn't find any mention in MDN.

Even in the [RFC-6455](https://www.rfc-editor.org/rfc/rfc6455.html) there seem to be no explicit mention about this.

### Motivation

As I did, many people could search on MDN for .terminate and wouldn't find it.

### Additional details



### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
