### PR TITLE
Add search as optional permission

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -85,6 +85,7 @@ You can include any of the following here, but not in all browsers: check the co
 - `privacy`
 - `proxy`
 - `scripting`
+- `search`
 - `sessions`
 - `tabHide`
 - `tabs`


### PR DESCRIPTION
### Description

As noted in [feedback on a BCD change](https://github.com/mdn/browser-compat-data/pull/22034#discussion_r1469473500), search is an optional permission in Firefox. See also https://searchfox.org/mozilla-central/rev/3c72de9280ec57dc55c24886c6334d9e340500e8/browser/components/extensions/schemas/search.json#10,14

