### PR TITLE
Typo fix in index.md

### DIFF
--- a/files/en-us/web/css/basic-shape/polygon/index.md
+++ b/files/en-us/web/css/basic-shape/polygon/index.md
@@ -63,7 +63,7 @@ Applying those coordinates to the CSS {{cssxref("clip-path")}} property using th
 clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
 ```
 
-This would create a rectangle shape the size of its parent content by specifying the coordinates of its four corners: top-left (`0% 0%`), top-right (`100% 0%`), bottom-right (`100% 100%`), and bottom-right (`0% 100%`).
+This would create a rectangle shape the size of its parent content by specifying the coordinates of its four corners: top-left (`0% 0%`), top-right (`100% 0%`), bottom-right (`100% 100%`), and bottom-left (`0% 100%`).
 
 ## Formal syntax
 


### PR DESCRIPTION
Typo correction in example code's explanation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The example code provided was this:
clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
The explanation for the above code was this:
"This would create a rectangle shape the size of its parent content by specifying the coordinates of its four corners: top-left (0% 0%), top-right (100% 0%), bottom-right (100% 100%), and bottom-right (0% 100%)."
Changed:
this "bottom-right (0% 100%)." to "bottom-left (0% 100%)."
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Readers who are beginners may get confused a bit with this example.
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
