### PR TITLE
FF123 Relnote: Deprecation of custom local support in IndexDB API

### DIFF
--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -40,9 +40,14 @@ This article provides information about the changes in Firefox 123 that affect d
 
 #### DOM
 
+- Custom locale support for the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) has been deprecated, including the [`options.locale`](/en-US/docs/Web/API/IDBObjectStore/createIndex#locale) parameter to `IDBObjectStore.createIndex()`, and the `IDBIndex` properties [`isAutoLocale`](/en-US/docs/Web/API/IDBIndex/isAutoLocale) and [`locale`](/en-US/docs/Web/API/IDBIndex/locale).
+  (See [Firefox bug 1872675](https://bugzil.la/1872675) and [Firefox bug 1730706](https://bugzil.la/1730706)).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals
+
+The `IDBLocaleAwareKeyRange` interface has been removed ([Firefox bug 1730706](https://bugzil.la/1730706)).
 
 ### WebAssembly
 

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -41,7 +41,7 @@ This article provides information about the changes in Firefox 123 that affect d
 #### DOM
 
 - Custom locale support for the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) has been deprecated, including the [`options.locale`](/en-US/docs/Web/API/IDBObjectStore/createIndex#locale) parameter to `IDBObjectStore.createIndex()`, and the `IDBIndex` properties [`isAutoLocale`](/en-US/docs/Web/API/IDBIndex/isAutoLocale) and [`locale`](/en-US/docs/Web/API/IDBIndex/locale).
-  (See [Firefox bug 1872675](https://bugzil.la/1872675) and [Firefox bug 1730706](https://bugzil.la/1730706)).
+  ([Firefox bug 1872675](https://bugzil.la/1872675) and [Firefox bug 1730706](https://bugzil.la/1730706)).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
FF123 started the process of removing (experimental) custom locale support for IndexDB. This adds a release note indicating what is now deprecated and what has been removed. Note, everything deprecated is expected to be removed after testing to see what will be affected.

Related docs work in #31912 and #31915