### PR TITLE
CSS :state() pseudo class

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1800,10 +1800,10 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
   </tbody>
 </table>
 
-#### Custom element state pseudo-class
+#### Custom element custom states
 
-Custom elements can expose their internal state via the {{domxref("ElementInternals.states","states")}} property as a {{domxref("CustomStateSet")}}. A CSS custom state pseudo-class such as `:--somestate` can match that element's state.
-(See [Firefox bug 1861466](https://bugzil.la/1861466) for more details.)
+Custom elements can expose their internal state by adding and removing an associated custom identifer to their {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) custom state pseudo-class can then match against custom elements within the state by passing the same identifier.
+(See [Firefox bug 1861466](https://bugzil.la/1861466) and [Firefox bug 1866351](https://bugzil.la/1866351) for more details.)
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1802,7 +1802,8 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
 
 #### Custom element custom states
 
-Custom elements can expose their internal state by adding and removing an associated custom identifer to their {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) custom state pseudo-class can then match against custom elements within the state by passing the same identifier.
+Custom elements can now define custom states and match against them using CSS.
+Custom states are represented as custom identifers that can be added to, or removed from, the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument, and matches against custom elements if the identifier is present in their set of `states`, and not otherwise.
 (See [Firefox bug 1861466](https://bugzil.la/1861466) and [Firefox bug 1866351](https://bugzil.la/1866351) for more details.)
 
 <table>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1800,10 +1800,10 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
   </tbody>
 </table>
 
-#### Custom element custom states
+#### CustomStateSet and the :state() pseudo-class: States for custom elements
 
-Custom elements can now define custom states and match against them using CSS.
-Custom states are represented as custom identifers that can be added to, or removed from, the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument, and matches against custom elements if the identifier is present in their set of `states`, and not otherwise.
+You can now define custom states for custom elements and match them using CSS.
+Custom states are represented as custom identifiers that can be added to, or removed from, the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument and matches the custom elements if the identifier is present in their set of states.
 (See [Firefox bug 1861466](https://bugzil.la/1861466) and [Firefox bug 1866351](https://bugzil.la/1866351) for more details.)
 
 <table>

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -63,11 +63,11 @@ The states can be used within the custom element but are not directly accessible
 
 ### Interaction with CSS
 
-Developers can select a custom element with a specific state using the [`:state()`](/en-US/docs/Web/CSS/:state) _custom state pseudo-class_.
+You can select a custom element that is in a specific state using the [`:state()`](/en-US/docs/Web/CSS/:state) _custom state pseudo-class_.
 The format of this pseudo-class is `:state(mystatename)`, where `mystatename` is the state as defined in the element.
-The custom state pseudo-class matches the custom element only if the state is `true` (i.e. if `mystatename` is present in the `CustomStateSet`).
+The custom state pseudo-class matches the custom element only if the state is `true` (i.e., if `mystatename` is present in the `CustomStateSet`).
 
-For example, the following CSS might be used to match a `labeled-checkbox` custom element where the element's `CustomStateSet` contains `checked`, and apply a solid border:
+For example, the following CSS matches a `labeled-checkbox` custom element when the element's `CustomStateSet` contains the `checked` state, and applies a `solid` border to the checkbox:
 
 ```css
 labeled-checkbox:state(checked) {
@@ -75,9 +75,9 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-CSS can also match a custom state [within custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom) by specifying `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function.
+CSS can also be used to match a custom state [within a custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom) by specifying `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function.
 
-`:state()` can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that have a particular state.
+Additionally, the `:state()` pseudo-class can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that are in a particular state.
 
 > **Warning:** Chrome supports a deprecated syntax that selects custom states using a CSS `<dashed-ident>` rather than the `:state()` function.
 > For information about how to support both approaches see the [Compatibility with `<dashed-ident>` syntax](compability_with_dashed-ident_syntax) section below.
@@ -186,9 +186,9 @@ Click the element to see a different border being applied as the checkbox `check
 ### Question box: exposing states in shadow parts
 
 This example, which is adapted from the specification, demonstrates that custom states can be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element for styling.
-These are the parts of the shadow tree that are intentionally exposed to pages that use the custom element.
+Shadow parts are sections of the shadow tree that are intentionally exposed to pages that use the custom element.
 
-The example creates a `<question-box>` custom element, which is an element that displays a question prompt along with a checkbox with the label "Yes".
+The example creates a `<question-box>` custom element that displays a question prompt along with a checkbox labeled "Yes".
 The element uses the `<labeled-checkbox>` defined in the [previous example](#labeled_checkbox) for the checkbox.
 
 #### JavaScript
@@ -257,13 +257,13 @@ class QuestionBox extends HTMLElement {
 ```
 
 The content of the shadow root is set using [`innerHTML`](/en-US/docs/Web/API/ShadowRoot/innerHTML).
-This defines a {{HTMLElement("slot")}} that contains the default prompt text for the element of "Question".
-It then defines a `<labeled-checkbox>` custom element with default text`"Yes"`.
+This defines a {{HTMLElement("slot")}} element that contains the default prompt text "Question" for the element.
+We then define a `<labeled-checkbox>` custom element with the default text `"Yes"`.
 This checkbox is exposed as a shadow part of the question box with the name `checkbox` using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
 
-Note that the code and styling for the `<labeled-checkbox>` is exactly the same as in [previous example](#labeled_checkbox), and is therefore not shown.
+Note that the code and styling for the `<labeled-checkbox>` element are exactly the same as in the [previous example](#labeled_checkbox), and are therefore not repeated here.
 
-We then call the {{domxref("CustomElementRegistry/define", "define()")}} method on the object returned by {{domxref("Window.customElements")}} in order to register the custom element with name `<question-box>`:
+Next, we call the {{domxref("CustomElementRegistry/define", "define()")}} method on the object returned by {{domxref("Window.customElements")}} to register the custom element with the name `question-box`:
 
 ```js
 customElements.define("question-box", QuestionBox);
@@ -271,18 +271,19 @@ customElements.define("question-box", QuestionBox);
 
 #### HTML
 
-After registering the custom element we can use the element in HTML as shown below.
+After registering the custom element, we can use the element in HTML as shown below.
 
 ```html
 <!-- Question box with default prompt "Question" -->
 <question-box></question-box>
+
 <!-- Question box with custom prompt "Continue?" -->
 <question-box>Continue?</question-box>
 ```
 
 #### CSS
 
-The first block of CSS uses the [`::part()`](/en-US/docs/Web/CSS/::part) selector to match on the exposed shadow part named `checkbox`, setting it to be red by default.
+The first block of CSS matches the exposed shadow part named `checkbox` using the [`::part()`](/en-US/docs/Web/CSS/::part) selector, styling it to be `red` by default.
 
 ```css
 question-box::part(checkbox) {
@@ -290,7 +291,7 @@ question-box::part(checkbox) {
 }
 ```
 
-We then use `:state()` after `::part()` to match on `checkbox` parts with the `checked` state:
+The second block follows `::part()` with `:state()`, in order to match `checkbox` parts that are in the `checked` state:
 
 ```css
 question-box::part(checkbox):state(checked) {
@@ -300,7 +301,7 @@ question-box::part(checkbox):state(checked) {
 
 #### Result
 
-Click either of the checkboxes to see the colour change from red to green when the `checked` state is toggled.
+Click either of the checkboxes to see the color change from `red` to `green` when the `checked` state toggles.
 
 {{EmbedLiveSample("Question box", "100%", 100)}}
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -240,10 +240,10 @@ class LabeledCheckbox extends HTMLElement {
 customElements.define("labeled-checkbox", LabeledCheckbox);
 ```
 
-First we define our custom element class `QuestionBox`, which extends `HTMLElement`.
+First, we define the custom element class `QuestionBox`, which extends `HTMLElement`.
 As always, the constructor first calls the `super()` method.
-It then calls [`attachShadow()`](/en-US/docs/Web/API/Element/attachShadow) to attach a shadow DOM tree to the custom element.
-The shadow DOM is attached with `mode: 'closed'` to ensure that nodes within the shadow DOM are not available outside of the element, unless explicitly exposed as a [shadow part](/en-US/docs/Web/CSS/CSS_shadow_parts).
+Next, we attach a shadow DOM tree to the custom element by calling [`attachShadow()`](/en-US/docs/Web/API/Element/attachShadow).
+The shadow DOM is attached with `mode: 'closed'` to ensure that nodes within the shadow DOM are not available from outside the element, unless explicitly exposed as a [shadow part](/en-US/docs/Web/CSS/CSS_shadow_parts).
 
 ```js
 class QuestionBox extends HTMLElement {

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -243,7 +243,6 @@ customElements.define("labeled-checkbox", LabeledCheckbox);
 First, we define the custom element class `QuestionBox`, which extends `HTMLElement`.
 As always, the constructor first calls the `super()` method.
 Next, we attach a shadow DOM tree to the custom element by calling [`attachShadow()`](/en-US/docs/Web/API/Element/attachShadow).
-The shadow DOM is attached with `mode: 'closed'` to ensure that nodes within the shadow DOM are not available from outside the element, unless explicitly exposed as a [shadow part](/en-US/docs/Web/CSS/CSS_shadow_parts).
 
 ```js
 class QuestionBox extends HTMLElement {

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -214,7 +214,7 @@ class LabeledCheckbox extends HTMLElement {
          white-space: pre;
          font-family: monospace;
        }
-       :host(:state(checked))::before { content: '[x]'; background: grey; }
+       :host(:state(checked))::before { content: '[x]'; }
        </style>
        <slot>Label</slot>`;
   }

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -75,7 +75,9 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-CSS can also match a custom state [within custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom) by specifying `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, and can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element to match the state of elements within a shadow tree that have a matching [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
+CSS can also match a custom state [within custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom) by specifying `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function.
+
+`:state()` can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that have a particular state.
 
 > **Warning:** Chrome supports a deprecated syntax that selects custom states using a CSS `<dashed-ident>` rather than the `:state()` function.
 > For information about how to support both approaches see the [Compatibility with `<dashed-ident>` syntax](compability_with_dashed-ident_syntax) section below.

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -249,7 +249,7 @@ The shadow DOM is attached with `mode: 'closed'` to ensure that nodes within the
 class QuestionBox extends HTMLElement {
   constructor() {
     super();
-    const shadowRoot = this.attachShadow({ mode: "closed" });
+    const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<div><slot>Question</slot></div>
        <labeled-checkbox part='checkbox'>Yes</labeled-checkbox>`;
   }

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -84,7 +84,7 @@ Additionally, the `:state()` pseudo-class can be used after the [`::part()`](/en
 
 ## Examples
 
-### Labeled checkbox
+### Matching the custom state of a custom checkbox element
 
 This example, which is adapted from the specification, demonstrates a custom checkbox element that has an internal "checked" state.
 This is mapped to the `checked` custom state, allowing styling to be applied using the `:state(checked)` custom state pseudo class.
@@ -189,7 +189,7 @@ This example, which is adapted from the specification, demonstrates that custom 
 Shadow parts are sections of the shadow tree that are intentionally exposed to pages that use the custom element.
 
 The example creates a `<question-box>` custom element that displays a question prompt along with a checkbox labeled "Yes".
-The element uses the `<labeled-checkbox>` defined in the [previous example](#labeled_checkbox) for the checkbox.
+The element uses the `<labeled-checkbox>` defined in the [previous example](#matching_the_custom_state_of_a_custom_checkbox_element) for the checkbox.
 
 #### JavaScript
 
@@ -260,7 +260,7 @@ This defines a {{HTMLElement("slot")}} element that contains the default prompt 
 We then define a `<labeled-checkbox>` custom element with the default text `"Yes"`.
 This checkbox is exposed as a shadow part of the question box with the name `checkbox` using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
 
-Note that the code and styling for the `<labeled-checkbox>` element are exactly the same as in the [previous example](#labeled_checkbox), and are therefore not repeated here.
+Note that the code and styling for the `<labeled-checkbox>` element are exactly the same as in the [previous example](#matching_the_custom_state_of_a_custom_checkbox_element), and are therefore not repeated here.
 
 Next, we call the {{domxref("CustomElementRegistry/define", "define()")}} method on the object returned by {{domxref("Window.customElements")}} to register the custom element with the name `question-box`:
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -118,7 +118,7 @@ class LabeledCheckbox extends HTMLElement {
          white-space: pre;
          font-family: monospace;
        }
-       :host(:state(checked))::before { content: '[x]'; background: grey; }
+       :host(:state(checked))::before { content: '[x]'; }
        </style>
        <slot>Label</slot>`;
   }

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -183,7 +183,7 @@ Click the element to see a different border being applied as the checkbox `check
 
 {{EmbedLiveSample("Labeled Checkbox", "100%", 50)}}
 
-### Question box: exposing states in shadow parts
+### Matching a custom state in a shadow part of a custom element
 
 This example, which is adapted from the specification, demonstrates that custom states can be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element for styling.
 Shadow parts are sections of the shadow tree that are intentionally exposed to pages that use the custom element.

--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -83,6 +83,9 @@ The basic approach for implementing a web component generally looks something li
       - : Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside (so you can select a custom element from inside its shadow DOM) — but only if the selector given as the function's parameter matches the shadow host.
     - {{cssxref(":host-context", ":host-context()")}}
       - : Selects the shadow host of the [shadow DOM](/en-US/docs/Web/API/Web_components/Using_shadow_DOM) containing the CSS it is used inside (so you can select a custom element from inside its shadow DOM) — but only if the selector given as the function's parameter matches the shadow host's ancestor(s) in the place it sits inside the DOM hierarchy.
+    - {{CSSxRef(":state",":state()")}}
+      - : Matches custom elements that are in a specified custom state.
+        More precisely, it matches anonymous custom elements where the specified state is present in the element's {{domxref("CustomStateSet")}}.
 
 - CSS pseudo-elements
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -227,9 +227,9 @@ my-custom-element:state(hidden) {
 }
 ```
 
-The `:state()` pseudo class can also be used within the [`:host()`](/en-US/docs/Web/CSS/:host_function) CSS pseudo-class function to match a custom state [within custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom), or after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that have a particular state.
+The `:state()` pseudo-class can also be used within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function to match a custom state [within a custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom). Additionally, the `:state()` pseudo-class can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that is in a particular state.
 
-There several live examples in {{domxref("CustomStateSet")}} showing how this works.
+There are several live examples in {{domxref("CustomStateSet")}} showing how this works.
 
 ## Examples
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -215,7 +215,7 @@ class MyCustomElement extends HTMLElement {
 customElements.define("my-custom-element", MyCustomElement);
 ```
 
-After adding `<my-custom-element>` to the HTML we can use the identifier added to the `CustomStateSet`, passed to the `:state()` function, as a custom state pseudo-class for selecting the element state.
+After adding `<my-custom-element>` to the HTML we can use the identifier added to the `CustomStateSet`, passed to the [`:state()`](/en-US/docs/Web/CSS/:state) function, as a custom state pseudo-class for selecting the element state.
 For example, below we select on the `hidden` state being true (and hence the element's `collapsed` state) using the `:hidden` selector, and remove the border.
 
 ```css
@@ -227,7 +227,9 @@ my-custom-element:state(hidden) {
 }
 ```
 
-There is are more complete live example in {{domxref("CustomStateSet")}}.
+The `:state()` pseudo class can also be used within the [`:host()`](/en-US/docs/Web/CSS/:host_function) CSS pseudo-class function to match a custom state [within custom element's shadow DOM](/en-US/docs/Web/CSS/:state#matching_a_custom_state_in_a_custom_elements_shadow_dom), or after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that have a particular state.
+
+There several live examples in {{domxref("CustomStateSet")}} showing how this works.
 
 ## Examples
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -215,7 +215,8 @@ class MyCustomElement extends HTMLElement {
 customElements.define("my-custom-element", MyCustomElement);
 ```
 
-After adding `<my-custom-element>` to the HTML we can use the identifier added to the `CustomStateSet`, passed to the [`:state()`](/en-US/docs/Web/CSS/:state) function, as a custom state pseudo-class for selecting the element state.
+We can use the identifier added to the custom element's `CustomStateSet` (`this._internals.states`) for matching the element's custom state.
+This is matched by passing the identifier to the [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class.
 For example, below we select on the `hidden` state being true (and hence the element's `collapsed` state) using the `:hidden` selector, and remove the border.
 
 ```css

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -181,7 +181,7 @@ Built in HTML elements can have different _states_, such as "hover", "disabled",
 Some of these states can be set as attributes using HTML or JavaScript, while others are internal, and cannot.
 Whether external or internal, commonly these states have corresponding CSS [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) that can be used to select and style the element when it is in a particular state.
 
-Autonomous custom elements (but not elements based on built-in elements) also allow you to define states and select against them using _custom state pseudo-classes_.
+Autonomous custom elements (but not elements based on built-in elements) also allow you to define states and select against them using the [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class function.
 The code below shows how this works using the example of an autonomous custom element that has an internal state "`collapsed`".
 
 The `collapsed` state is represented as a boolean property (with setter and getter methods) that is not visible outside of the element.

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -91,6 +91,7 @@ The `:host-context(h1) { font-style: italic; }` and `:host-context(h1):after { c
 - [Web components](/en-US/docs/Web/API/Web_components)
 - CSS {{cssxref(":host")}} pseudo-class
 - CSS {{cssxref(":host_function", ":host()")}} pseudo-class
+- CSS {{cssxref(":state",":state()")}} pseudo-class
 - CSS {{CSSXref("::slotted")}} pseudo-element
 - HTML {{HTMLElement("template")}} element
 - [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -77,5 +77,6 @@ The `:host { background: rgb(0 0 0 / 10%); padding: 2px 5px; }` rule styles all 
 - [Web components](/en-US/docs/Web/API/Web_components)
 - {{cssxref(":host_function", ":host()")}}
 - {{cssxref(":host-context", ":host-context()")}}
-- {{CSSXref("::slotted")}}
+- {{CSSxref("::slotted")}}
+- {{CSSxRef(":state",":state()")}}
 - [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/css/_colon_host_function/index.md
+++ b/files/en-us/web/css/_colon_host_function/index.md
@@ -80,3 +80,4 @@ The `:host(.footer) { color : red; }` rule styles all instances of the `<context
 - [Web components](/en-US/docs/Web/API/Web_components)
 - {{CSSxRef(":host")}}
 - {{CSSxRef(":host-context", ":host-context()")}}
+- {{CSSxRef(":state",":state()")}}

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -34,9 +34,9 @@ The CSS `:state()` pseudo-class matches an element when the identifier passed as
 
 ## Examples
 
-### Matching a custom element on a state
+### Matching a custom state
 
-This CSS shows how you to change the border of an autonomous custom element `<labeled-checkbox>` to red when it has the "checked" state.
+This CSS shows how to change the border of the autonomous custom element `<labeled-checkbox>` to `red` when it is in the "checked" state.
 
 ```css
 labeled-checkbox {
@@ -47,13 +47,13 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example this code in action.
+See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example of this code in action.
 
 ### Styling with a custom state within a custom element
 
-You can use `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) function pseudo-class to match a state only within the shadow DOM of the current custom element.
+You can use `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function to match a state only within the shadow DOM of the current custom element.
 
-For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) the following CSS is used to inject a grey `[x]` before the element when it is checked.
+For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox), the following CSS is used to inject a grey `[x]` before the element when it is in the "checked" state.
 
 ```css
 :host(:state(checked))::before {

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -35,7 +35,7 @@ The CSS `:state()` pseudo-class matches an element when the identifier, passed a
 The `:state()` pseudo-class can also be used to match custom states within the implementation of a custom element.
 This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, which matches a state only within the shadow DOM of the current custom element.
 
-Additionally, the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element followed by the `:state()` pseudo-class allows matching on the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that are in a particular state (shadow parts are parts of a custom element's shadow tree that are explicitly exposed to a containing page for styling purposes).
+Additionally, the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element followed by the `:state()` pseudo-class allows matching on the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that are in a particular state. (**Shadow parts** are parts of a custom element's shadow tree that are explicitly exposed to a containing page for styling purposes.)
 
 ## Examples
 
@@ -52,7 +52,7 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-For a live example of this code in action, see the ["Labeled checkbox"](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) example on the `CustomStateSet` page.
+For a live example of this code in action, see the [Labeled checkbox](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) example on the `CustomStateSet` page.
 
 ### Matching a custom state in a custom element's shadow DOM
 
@@ -92,7 +92,7 @@ question-box::part(checkbox):state(checked) {
 }
 ```
 
-For a live example of this code in action, see the ["Matching a custom state in a shadow part of a custom element"](/en-US/docs/Web/API/CustomStateSet#matching_a_custom_state_in_a_shadow_part_of_a_custom_element) example on the `CustomStateSet` page.
+For a live example of this code in action, see the [Matching a custom state in a shadow part of a custom element](/en-US/docs/Web/API/CustomStateSet#matching_a_custom_state_in_a_shadow_part_of_a_custom_element) example on the `CustomStateSet` page.
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -15,7 +15,7 @@ The **`:state()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS
 
 ## Syntax
 
-The `:state()` pseudo-class requires a custom identifier representing a state to match as its argument.
+The `:state()` pseudo-class takes as its argument a custom identifier that represents the state of the custom element to match.
 
 ```css-nolint
 :state(<custom identifier>) {

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -1,0 +1,78 @@
+---
+title: ":state()"
+slug: Web/CSS/:state
+page-type: css-pseudo-class
+status:
+  - experimental
+browser-compat: css.selectors.state
+---
+
+{{CSSRef}}{{SeeCompatTable}}
+
+The **`:state()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches [custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) that have the specified custom state.
+
+<!-- {{EmbedInteractiveExample("pages/tabbed/pseudo-class-state.html", "tabbed-shorter")}} -->
+
+## Syntax
+
+The `:state()` pseudo-class requires a custom identifier representing a state to match as its argument.
+
+```css-nolint
+:state(<custom identifier>) {
+  /* ... */
+}
+```
+
+## Description
+
+Elements can have states that change due to user interaction and other factors, such as "hover" when a user hovers over an element, or "visited" for links that the user has clicked.
+Elements provided by user agents can be styled based on these states using CSS pseudo classes such as [`:hover`](/en-US/docs/Web/CSS/:hover) and [`:visited`](/en-US/docs/Web/CSS/:visited).
+[Autonomous custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element) (but not elements derived from built-in elements) can similarly expose their state, allowing the custom elements to be styled using the CSS `:state()` pseudo class.
+
+The states of a custom element are represented by string values that are added to, or removed from, an attached [`CustomStateSet`](/en-US/docs/Web/API/CustomStateSet) object.
+The CSS `:state()` pseudo-class matches an element when the identifier passed as an argument is present in the `CustomStateSet` of the element.
+
+## Examples
+
+### Matching a custom element on a state
+
+This CSS shows how you to change the border of an autonomous custom element `<labeled-checkbox>` to red when it has the "checked" state.
+
+```css
+labeled-checkbox {
+  border: dashed red;
+}
+labeled-checkbox:state(checked) {
+  border: solid;
+}
+```
+
+See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example this code in action.
+
+### Styling with a custom state within a custom element
+
+You can use `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) function pseudo-class to match a state only within the shadow DOM of the current custom element.
+
+For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) the following CSS is used to inject a grey `[x]` before the element when it is checked.
+
+```css
+:host(:state(checked))::before {
+  content: "[x]";
+  background: grey;
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`CustomStateSet`](/en-US/docs/Web/API/CustomStateSet)
+- [Pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)
+- [Pseudo-classes and pseudo-elements](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements)
+- [Custom states and custom state pseudo-class CSS selectors](/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_states_and_custom_state_pseudo-class_css_selectors) in [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements)

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -23,7 +23,8 @@ The `:state()` pseudo-class takes as its argument a custom identifier that repre
 
 ## Description
 
-Elements can transition between states due to user interaction and other factors. For instance, an element can be in the "hover" state when a user hovers over the element, or a link can be in the "visited" state after a user clicks on it.
+Elements can transition between states due to user interaction and other factors.
+For instance, an element can be in the "hover" state when a user hovers over the element, or a link can be in the "visited" state after a user clicks on it.
 Elements provided by browsers can be styled based on these states using CSS pseudo-classes such as [`:hover`](/en-US/docs/Web/CSS/:hover) and [`:visited`](/en-US/docs/Web/CSS/:visited).
 Similarly, [autonomous custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element) (custom elements that are not derived from built-in elements) can expose their states, allowing the custom elements to be styled using the CSS `:state()` pseudo-class.
 
@@ -45,7 +46,7 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example of this code in action.
+See the ["Labeled checkbox" in `CustomStateSet`](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example of this code in action.
 
 ### Matching a custom state in a custom element's shadow DOM
 
@@ -60,6 +61,33 @@ For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/
   background: grey;
 }
 ```
+
+### Matching a custom state against a shadow part
+
+The CSS `:state()` pseudo-class can also be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element.
+
+The shadow parts of a custom element are the parts of its shadow tree that it exposes to a containing page for styling purposes.
+Shadow parts are defined and named using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
+The [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element is used to match against specific parts, and can be followed by `:state()` to match against parts with a particular state.
+
+For example, consider a custom element named `<question-box>` that uses a `<labeled-checkbox>` custom element as part named `checkbox`:
+
+```js
+shadowRoot.innerHTML = `<labeled-checkbox part='checkbox'>Yes</labeled-checkbox>`;
+```
+
+The page CSS can then match against the part, and the part in a particular state, as shown:
+
+```css
+question-box::part(checkbox) {
+  color: red;
+}
+question-box::part(checkbox):state(checked) {
+  color: green;
+}
+```
+
+A full (live) example is shown in the `CustomStateSet` example [Question box: exposing states in shadow parts](/en-US/docs/Web/API/CustomStateSet#question_box_exposing_states_in_shadow_parts).
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -62,21 +62,21 @@ For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/
 }
 ```
 
-### Matching a custom state in shadow parts
+### Matching a custom state in a shadow part
 
 The `:state()` pseudo-class can also be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element.
 
 Shadow parts are parts of a custom element's shadow tree that are exposed to a containing page for styling purposes.
-Shadow parts are defined and named using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
-The [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element is used to match these parts, and can be followed by the `:state()` pseudo-class to match parts that are in the specified state.
+They are defined and named using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
+The [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element is used to match shadow parts, and can be followed by the `:state()` pseudo-class to match parts that are in the specified state.
 
-For example, consider a custom element named `<question-box>` that uses a `<labeled-checkbox>` custom element as a part named `checkbox`:
+For example, consider a custom element named `<question-box>` that uses a `<labeled-checkbox>` custom element as a shadow part named `checkbox`:
 
 ```js
 shadowRoot.innerHTML = `<labeled-checkbox part='checkbox'>Yes</labeled-checkbox>`;
 ```
 
-The page CSS can then match against the part, and the part in a particular state, as shown:
+The page CSS can match the `checkbox` part and style it based on its `checked` state, as shown below:
 
 ```css
 question-box::part(checkbox) {

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -47,7 +47,7 @@ labeled-checkbox:state(checked) {
 
 See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example of this code in action.
 
-### Matching a custom state inside a custom element
+### Matching a custom state in a custom element's shadow DOM
 
 The `:state()` pseudo-class can also be used to match custom states within the implementation of custom elements.
 This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, which matches a state only within the shadow DOM of the current custom element.

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -11,8 +11,6 @@ browser-compat: css.selectors.state
 
 The **`:state()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches [custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) that have the specified custom state.
 
-<!-- {{EmbedInteractiveExample("pages/tabbed/pseudo-class-state.html", "tabbed-shorter")}} -->
-
 ## Syntax
 
 The `:state()` pseudo-class takes as its argument a custom identifier that represents the state of the custom element to match.

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -52,7 +52,7 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-For a live example of this code in action, see the [Labeled checkbox](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) example on the `CustomStateSet` page.
+For a live example of this code in action, see the [Matching the custom state of a custom checkbox element](/en-US/docs/Web/API/CustomStateSet#matching_the_custom_state_of_a_custom_checkbox_element) example on the `CustomStateSet` page.
 
 ### Matching a custom state in a custom element's shadow DOM
 
@@ -66,7 +66,7 @@ The following CSS injects a grey `[x]` before the element when it is in the "che
 }
 ```
 
-For a live example of this code in action, see the ["Labeled checkbox"](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) example on the `CustomStateSet` page.
+For a live example of this code in action, see the [Matching the custom state of a custom checkbox element](/en-US/docs/Web/API/CustomStateSet#matching_the_custom_state_of_a_custom_checkbox_element) example on the `CustomStateSet` page.
 
 ### Matching a custom state in a shadow part
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -49,9 +49,10 @@ labeled-checkbox:state(checked) {
 
 See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example of this code in action.
 
-### Styling with a custom state within a custom element
+### Matching a custom state inside a custom element
 
-You can use `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function to match a state only within the shadow DOM of the current custom element.
+Custom elements can also match against a custom state as part of their implementation.
+This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, which matches a state only within the shadow DOM of the current custom element.
 
 For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox), the following CSS is used to inject a grey `[x]` before the element when it is in the "checked" state.
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -26,10 +26,16 @@ The `:state()` pseudo-class takes as its argument a custom identifier that repre
 Elements can transition between states due to user interaction and other factors.
 For instance, an element can be in the "hover" state when a user hovers over the element, or a link can be in the "visited" state after a user clicks on it.
 Elements provided by browsers can be styled based on these states using CSS pseudo-classes such as [`:hover`](/en-US/docs/Web/CSS/:hover) and [`:visited`](/en-US/docs/Web/CSS/:visited).
-Similarly, [autonomous custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element) (custom elements that are not derived from built-in elements) can expose their states, allowing the custom elements to be styled using the CSS `:state()` pseudo-class.
+Similarly, [autonomous custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element) (custom elements that are not derived from built-in elements) can expose their states, allowing pages that use the elements to style them using the CSS `:state()` pseudo-class.
 
-The states of a custom element are represented by string values. These values are added to or removed from a [`CustomStateSet`](/en-US/docs/Web/API/CustomStateSet) object associated with the element.
+The states of a custom element are represented by string values.
+These values are added to or removed from a [`CustomStateSet`](/en-US/docs/Web/API/CustomStateSet) object associated with the element.
 The CSS `:state()` pseudo-class matches an element when the identifier, passed as an argument, is present in the `CustomStateSet` of the element.
+
+The `:state()` pseudo-class can also be used to match custom states within the implementation of a custom element.
+This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, which matches a state only within the shadow DOM of the current custom element.
+
+Additionally, the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element followed by the `:state()` pseudo-class allows matching on the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that are in a particular state (shadow parts are parts of a custom element's shadow tree that are explicitly exposed to a containing page for styling purposes).
 
 ## Examples
 
@@ -50,32 +56,31 @@ For a live example of this code in action, see the ["Labeled checkbox"](/en-US/d
 
 ### Matching a custom state in a custom element's shadow DOM
 
-The `:state()` pseudo-class can also be used to match custom states within the implementation of custom elements.
-This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, which matches a state only within the shadow DOM of the current custom element.
+This example shows how the `:state()` pseudo-class can be used within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function to match custom states within the implementation of a custom element.
 
-For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox), the following CSS is used to inject a grey `[x]` before the element when it is in the "checked" state.
+The following CSS injects a grey `[x]` before the element when it is in the "checked" state.
 
 ```css
-:host(:state(checked))::before { 
+:host(:state(checked))::before {
   content: "[x]";
 }
 ```
 
+For a live example of this code in action, see the ["Labeled checkbox"](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) example on the `CustomStateSet` page.
+
 ### Matching a custom state in a shadow part
 
-The `:state()` pseudo-class can also be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element.
+This example shows how the `:state()` pseudo-class can be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element.
 
-Shadow parts are parts of a custom element's shadow tree that are exposed to a containing page for styling purposes.
-They are defined and named using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
-The [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element is used to match shadow parts, and can be followed by the `:state()` pseudo-class to match parts that are in the specified state.
-
+Shadow parts are defined and named using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
 For example, consider a custom element named `<question-box>` that uses a `<labeled-checkbox>` custom element as a shadow part named `checkbox`:
 
 ```js
 shadowRoot.innerHTML = `<labeled-checkbox part='checkbox'>Yes</labeled-checkbox>`;
 ```
 
-The page CSS can match the `checkbox` part and style it based on its `checked` state, as shown below:
+The CSS below shows how the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element can be used to match against the `'checkbox'` shadow part.
+It then shows how the `::part()` pseudo-element followed by the `:state()` pseudo-class can be used to match against the same part when it is in the `checked` state.
 
 ```css
 question-box::part(checkbox) {
@@ -87,7 +92,7 @@ question-box::part(checkbox):state(checked) {
 }
 ```
 
-For a live example of this code in action, see the ["Question box"](/en-US/docs/Web/API/CustomStateSet#matching_a_custom_state_in_a_shadow_part_of_a_custom_element) example on the `CustomStateSet` page.
+For a live example of this code in action, see the ["Matching a custom state in a shadow part of a custom element"](/en-US/docs/Web/API/CustomStateSet#matching_a_custom_state_in_a_shadow_part_of_a_custom_element) example on the `CustomStateSet` page.
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -49,7 +49,7 @@ See [CustomStateSet](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a 
 
 ### Matching a custom state inside a custom element
 
-Custom elements can also match against a custom state as part of their implementation.
+The `:state()` pseudo-class can also be used to match custom states within the implementation of custom elements.
 This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/:host_function) pseudo-class function, which matches a state only within the shadow DOM of the current custom element.
 
 For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox), the following CSS is used to inject a grey `[x]` before the element when it is in the "checked" state.

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -56,9 +56,8 @@ This is achieved by using `:state()` within the [`:host()`](/en-US/docs/Web/CSS/
 For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox), the following CSS is used to inject a grey `[x]` before the element when it is in the "checked" state.
 
 ```css
-:host(:state(checked))::before {
+:host(:state(checked))::before { 
   content: "[x]";
-  background: grey;
 }
 ```
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -46,7 +46,7 @@ labeled-checkbox:state(checked) {
 }
 ```
 
-See the ["Labeled checkbox" in `CustomStateSet`](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) for a live example of this code in action.
+For a live example of this code in action, see the ["Labeled checkbox"](/en-US/docs/Web/API/CustomStateSet#labeled_checkbox) example on the `CustomStateSet` page.
 
 ### Matching a custom state in a custom element's shadow DOM
 
@@ -62,15 +62,15 @@ For example, in the [`CustomStateSet` labeled checkbox example](/en-US/docs/Web/
 }
 ```
 
-### Matching a custom state against a shadow part
+### Matching a custom state in shadow parts
 
-The CSS `:state()` pseudo-class can also be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element.
+The `:state()` pseudo-class can also be used to target the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element.
 
-The shadow parts of a custom element are the parts of its shadow tree that it exposes to a containing page for styling purposes.
+Shadow parts are parts of a custom element's shadow tree that are exposed to a containing page for styling purposes.
 Shadow parts are defined and named using the [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute.
-The [`::part()`](/en-US/docs/Web/CSS/::part) pseudo element is used to match against specific parts, and can be followed by `:state()` to match against parts with a particular state.
+The [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element is used to match these parts, and can be followed by the `:state()` pseudo-class to match parts that are in the specified state.
 
-For example, consider a custom element named `<question-box>` that uses a `<labeled-checkbox>` custom element as part named `checkbox`:
+For example, consider a custom element named `<question-box>` that uses a `<labeled-checkbox>` custom element as a part named `checkbox`:
 
 ```js
 shadowRoot.innerHTML = `<labeled-checkbox part='checkbox'>Yes</labeled-checkbox>`;
@@ -82,12 +82,13 @@ The page CSS can then match against the part, and the part in a particular state
 question-box::part(checkbox) {
   color: red;
 }
+
 question-box::part(checkbox):state(checked) {
   color: green;
 }
 ```
 
-A full (live) example is shown in the `CustomStateSet` example [Question box: exposing states in shadow parts](/en-US/docs/Web/API/CustomStateSet#question_box_exposing_states_in_shadow_parts).
+For a live example of this code in action, see the ["Question box"](/en-US/docs/Web/API/CustomStateSet#question_box_exposing_states_in_shadow_parts) example on the `CustomStateSet` page.
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -88,7 +88,7 @@ question-box::part(checkbox):state(checked) {
 }
 ```
 
-For a live example of this code in action, see the ["Question box"](/en-US/docs/Web/API/CustomStateSet#question_box_exposing_states_in_shadow_parts) example on the `CustomStateSet` page.
+For a live example of this code in action, see the ["Question box"](/en-US/docs/Web/API/CustomStateSet#matching_a_custom_state_in_a_shadow_part_of_a_custom_element) example on the `CustomStateSet` page.
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -25,12 +25,12 @@ The `:state()` pseudo-class takes as its argument a custom identifier that repre
 
 ## Description
 
-Elements can have states that change due to user interaction and other factors, such as "hover" when a user hovers over an element, or "visited" for links that the user has clicked.
-Elements provided by user agents can be styled based on these states using CSS pseudo classes such as [`:hover`](/en-US/docs/Web/CSS/:hover) and [`:visited`](/en-US/docs/Web/CSS/:visited).
-[Autonomous custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element) (but not elements derived from built-in elements) can similarly expose their state, allowing the custom elements to be styled using the CSS `:state()` pseudo class.
+Elements can transition between states due to user interaction and other factors. For instance, an element can be in the "hover" state when a user hovers over the element, or a link can be in the "visited" state after a user clicks on it.
+Elements provided by browsers can be styled based on these states using CSS pseudo-classes such as [`:hover`](/en-US/docs/Web/CSS/:hover) and [`:visited`](/en-US/docs/Web/CSS/:visited).
+Similarly, [autonomous custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element) (custom elements that are not derived from built-in elements) can expose their states, allowing the custom elements to be styled using the CSS `:state()` pseudo-class.
 
-The states of a custom element are represented by string values that are added to, or removed from, an attached [`CustomStateSet`](/en-US/docs/Web/API/CustomStateSet) object.
-The CSS `:state()` pseudo-class matches an element when the identifier passed as an argument is present in the `CustomStateSet` of the element.
+The states of a custom element are represented by string values. These values are added to or removed from a [`CustomStateSet`](/en-US/docs/Web/API/CustomStateSet) object associated with the element.
+The CSS `:state()` pseudo-class matches an element when the identifier, passed as an argument, is present in the `CustomStateSet` of the element.
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -109,5 +109,6 @@ globalThis.customElements.define(
 ## See also
 
 - The [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute - Used to define parts which can be selected by the `::part()` selector
+- The {{CSSxRef(":state",":state()")}} pseudo-class function - can follow the `::part()` selector to select custom states.
 - The [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts) attribute - Used to transitively export shadow parts from a nested shadow tree into a containing light tree.
 - [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) module

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -108,7 +108,7 @@ globalThis.customElements.define(
 
 ## See also
 
-- The [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute - Used to define parts which can be selected by the `::part()` selector
-- The {{CSSxRef(":state",":state()")}} pseudo-class function - can follow the `::part()` selector to select custom states.
-- The [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts) attribute - Used to transitively export shadow parts from a nested shadow tree into a containing light tree.
+- [`part`](/en-US/docs/Web/HTML/Global_attributes#part) attribute
+- {{CSSxRef(":state",":state()")}} pseudo-class function
+- [`exportparts`](/en-US/docs/Web/HTML/Global_attributes#exportparts) attribute
 - [CSS shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) module

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -142,6 +142,7 @@ Selectors, whether used in CSS or JavaScript, enable targeting HTML elements bas
 ## Related concepts
 
 - {{CSSXref(":popover-open")}} pseudo-class
+- {{CSSXref(":state","state()")}} pseudo-class
 - [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) module
 
   - : [`&` nesting selector](/en-US/docs/Web/CSS/Nesting_selector)


### PR DESCRIPTION
This add basic docs for the `:state()` pseudo class function. 

This class can be used to match against custom states defined in a custom element. It doesn't make any sense outside of the context of a web component/custom elements. I haven't tried to document/duplicate everything here, but instead just the CSS-ish bits and link to the more full examples.

The BCD for this is here: https://github.com/mdn/browser-compat-data/pull/22083

There isn't a formal CSS spec for this yet (though it is planned and agreed between browser vendors). The docs here currently derive from the definition the HTML live spec here https://html.spec.whatwg.org/multipage/custom-elements.html#exposing-custom-element-states

This is part of doing the work for #31971. I expect more to come, including a definition of the CSS `:part`.

@estelle @dipikabh Would appreciate your review/feedback/advice. This is quite minimalist right now and I am fine with that because I'm mostly hoping to expose the core ideas and provide access to the BCD data. For example, does this "have" to have an interactive example - if so I could perhaps make one similar to the one used for `:defined()`.