### PR TITLE
docs: fix paste evnet link

### DIFF
--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -48,7 +48,7 @@ The Clipboard API extends the following APIs, adding the listed features.
   - : An event fired whenever the user initiates a copy action.
 - [`Element: cut`](/en-US/docs/Web/API/Element/cut_event) event
   - : An event fired whenever the user initiates a cut action.
-- [`Element: paste`](/en-US/docs/Web/API/Element/cut_event) event
+- [`Element: paste`](/en-US/docs/Web/API/Element/paste_event) event
   - : An event fired whenever the user initiates a paste action.
 
 <!-- Note `Window: clipboardchange` event is in spec but not implemented -->


### PR DESCRIPTION
Fixes `paste event` link in the clipboard api. It is pointing to cut event right now.
[
cut event](https://developer.mozilla.org/en-US/docs/Web/API/Element/cut_event)
[paste event](https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event)