### PR TITLE
Replace comma with "or" in prose list of two

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/join/index.md
@@ -32,7 +32,7 @@ A string with all array elements joined. If `array.length` is `0`, the empty str
 
 ## Description
 
-The string conversions of all array elements are joined into one string. If an element is `undefined`, `null`, it is converted to an empty string instead of the string `"null"` or `"undefined"`.
+The string conversions of all array elements are joined into one string. If an element is `undefined` or `null`, it is converted to an empty string instead of the string `"null"` or `"undefined"`.
 
 The `join` method is accessed internally by [`Array.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString) with no arguments. Overriding `join` of an array instance will override its `toString` behavior as well.
 


### PR DESCRIPTION
Note the \*'s around changes.

### Before:

> If an element is `undefined`\*,\* `null`, it is converted to an empty string instead of the string `"null"` or `"undefined"`.

### After:

> If an element is `undefined` \*or\* `null`, it is converted to an empty string instead of the string `"null"` or `"undefined"`.

