### PR TITLE
add document for HTMLInputElement.type

### DIFF
--- a/files/en-us/web/api/htmlinputelement/type/index.md
+++ b/files/en-us/web/api/htmlinputelement/type/index.md
@@ -8,17 +8,17 @@ browser-compat: api.HTMLInputElement.type
 
 {{ApiRef("HTML DOM")}}
 
-The **`type`** property of the {{domxref("HTMLInputElement")}} interface is a string that indicates behaviour and rendering type of the {{HTMLElement("input")}} element.
+The **`type`** property of the {{domxref("HTMLInputElement")}} interface is a string that indicates behaviour type of the {{HTMLElement("input")}} element.
 
 It reflects the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of the {{HTMLElement("input")}} element.
 
 ## Value
 
-A string representing type values. Default value is a `text`.
+A string representing the type.
 
-It's possible values are listed in [input types](/en-US/docs/Web/HTML/Element/input#input_types).
+Its possible values are listed in the attribute's [input types](/en-US/docs/Web/HTML/Element/input#input_types) section.
 
-## Examples
+## Example
 
 ### HTML
 
@@ -43,5 +43,5 @@ console.log(inputElement.type); // Output: "date"
 
 ## See also
 
-- {{domxref("HTMLTextAreaElement.type")}} property that returns the string "textarea".
+- {{domxref("HTMLTextAreaElement.type")}} property.
 - {{domxref("HTMLButtonElement.type")}} property

--- a/files/en-us/web/api/htmlinputelement/type/index.md
+++ b/files/en-us/web/api/htmlinputelement/type/index.md
@@ -43,5 +43,5 @@ console.log(inputElement.type); // Output: "date"
 
 ## See also
 
-- {{domxref("HTMLTextAreaElement.type")}} property.
+- {{domxref("HTMLTextAreaElement.type")}} property
 - {{domxref("HTMLButtonElement.type")}} property

--- a/files/en-us/web/api/htmlinputelement/type/index.md
+++ b/files/en-us/web/api/htmlinputelement/type/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLInputElement.type
 
 {{ApiRef("HTML DOM")}}
 
-The **`type`** property of the {{domxref("HTMLInputElement")}} interface is a string that indicates behaviour type of the {{HTMLElement("input")}} element.
+The **`type`** property of the {{domxref("HTMLInputElement")}} interface indicates the kind of data allowed in the {{HTMLElement("input")}} element, or example a number, a date, or an email. Browsers will select the appropriate widget and behavior to help users to enter a valid value.
 
 It reflects the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of the {{HTMLElement("input")}} element.
 

--- a/files/en-us/web/api/htmlinputelement/type/index.md
+++ b/files/en-us/web/api/htmlinputelement/type/index.md
@@ -1,0 +1,47 @@
+---
+title: "HTMLInputElement: type property"
+short-title: type
+slug: Web/API/HTMLInputElement/type
+page-type: web-api-instance-property
+browser-compat: api.HTMLInputElement.type
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`type`** property of the {{domxref("HTMLInputElement")}} interface is a string that indicates behaviour and rendering type of the {{HTMLElement("input")}} element.
+
+It reflects the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of the {{HTMLElement("input")}} element.
+
+## Value
+
+A string representing type values. Default value is a `text`.
+
+It's possible values are listed in [input types](/en-US/docs/Web/HTML/Element/input#input_types).
+
+## Examples
+
+### HTML
+
+```html
+<input id="input1" type="date" />
+```
+
+### JavaScript
+
+```js
+const inputElement = document.querySelector("#input1");
+console.log(inputElement.type); // Output: "date"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.type")}} property that returns the string "textarea".
+- {{domxref("HTMLButtonElement.type")}} property


### PR DESCRIPTION
This PR add documentation for HTMLInputElement.type property.

It is part of https://github.com/mdn/mdn/issues/520

Resource
[type](https://html.spec.whatwg.org/#dom-input-type)