### PR TITLE
add document for HTMLTextAreaElement.type

### DIFF
--- a/files/en-us/web/api/htmltextareaelement/type/index.md
+++ b/files/en-us/web/api/htmltextareaelement/type/index.md
@@ -10,6 +10,9 @@ browser-compat: api.HTMLTextAreaElement.type
 
 The read-only **`type`** property of the {{domxref("HTMLTextAreaElement")}} represents a string `textarea` of the {{HTMLElement("textarea")}} element.
 
+## Value
+
+A string whose value is always `textarea`.
 ## Example
 
 ### HTML

--- a/files/en-us/web/api/htmltextareaelement/type/index.md
+++ b/files/en-us/web/api/htmltextareaelement/type/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTextAreaElement.type
 
 {{ApiRef("HTML DOM")}}
 
-The read-only **`type`** property of the {{domxref("HTMLTextAreaElement")}} represents a string `textarea` of the {{HTMLElement("textarea")}} element.
+The read-only **`type`** property of the {{domxref("HTMLTextAreaElement")}} always returns `textarea`.
 
 ## Value
 

--- a/files/en-us/web/api/htmltextareaelement/type/index.md
+++ b/files/en-us/web/api/htmltextareaelement/type/index.md
@@ -13,6 +13,7 @@ The read-only **`type`** property of the {{domxref("HTMLTextAreaElement")}} alwa
 ## Value
 
 A string whose value is always `textarea`.
+
 ## Example
 
 ### HTML

--- a/files/en-us/web/api/htmltextareaelement/type/index.md
+++ b/files/en-us/web/api/htmltextareaelement/type/index.md
@@ -1,0 +1,38 @@
+---
+title: "HTMLTextAreaElement: type property"
+short-title: type
+slug: Web/API/HTMLTextAreaElement/type
+page-type: web-api-instance-property
+browser-compat: api.HTMLTextAreaElement.type
+---
+
+{{ApiRef("HTML DOM")}}
+
+The read-only **`type`** property of the {{domxref("HTMLTextAreaElement")}} represents a string `textarea` of the {{HTMLElement("textarea")}} element.
+
+## Example
+
+### HTML
+
+```html
+<textarea id="txtarea"></textarea>
+```
+
+### JavaScript
+
+```js
+const txtAreaElement = document.querySelector("#txtarea");
+console.log(txtAreaElement.type); // Output: "textarea"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLInputElement.type")}} property


### PR DESCRIPTION
This PR add documentation for HTMLTextAreaElement.type property.

It is part of https://github.com/mdn/mdn/issues/520

Resource
[type](https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-type) 