### PR TITLE
add document for HTMLButtonElement.type

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/type/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/type/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLButtonElement.type
 
 {{ApiRef("HTML DOM")}}
 
-The **`type`** property of the {{domxref("HTMLButtonElement")}} interface is a string that indicates behaviour type of the {{HTMLElement("button")}} element.
+The **`type`** property of the {{domxref("HTMLButtonElement")}} interface is a string that indicates the behavior type of the {{HTMLElement("button")}} element.
 
 It reflects the [`type`](/en-US/docs/Web/HTML/Element/button#type) attribute of the {{HTMLElement("button")}} element.
 
@@ -30,7 +30,7 @@ Its possible values are listed in the attribute's [button types](/en-US/docs/Web
 
 ```js
 const buttonElement = document.querySelector("#buttton");
-console.log(buttonElement.type); // Output: "reset"
+console.log(buttonElement.type); // "reset"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlbuttonelement/type/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/type/index.md
@@ -43,5 +43,5 @@ console.log(buttonElement.type); // Output: "reset"
 
 ## See also
 
-- {{domxref("HTMLTextAreaElement.type")}} property.
+- {{domxref("HTMLTextAreaElement.type")}} property
 - {{domxref("HTMLInputElement.type")}} property

--- a/files/en-us/web/api/htmlbuttonelement/type/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/type/index.md
@@ -16,7 +16,7 @@ It reflects the [`type`](/en-US/docs/Web/HTML/Element/button#type) attribute of 
 
 A string representing the type.
 
-Its possible values are listed in the attribute's [buttom types](/en-US/docs/Web/API/HTMLButtonElement#htmlbuttonelement.type) section.
+Its possible values are listed in the attribute's [button types](/en-US/docs/Web/API/HTMLButtonElement#htmlbuttonelement.type) section.
 
 ## Example
 

--- a/files/en-us/web/api/htmlbuttonelement/type/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/type/index.md
@@ -1,0 +1,47 @@
+---
+title: "HTMLButtonElement: type property"
+short-title: type
+slug: Web/API/HTMLButtonElement/type
+page-type: web-api-instance-property
+browser-compat: api.HTMLButtonElement.type
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`type`** property of the {{domxref("HTMLButtonElement")}} interface is a string that indicates behaviour type of the {{HTMLElement("button")}} element.
+
+It reflects the [`type`](/en-US/docs/Web/HTML/Element/button#type) attribute of the {{HTMLElement("button")}} element.
+
+## Value
+
+A string representing the type.
+
+Its possible values are listed in the attribute's [buttom types](/en-US/docs/Web/API/HTMLButtonElement#htmlbuttonelement.type) section.
+
+## Example
+
+### HTML
+
+```html
+<button id="button" type="reset">type</button>
+```
+
+### JavaScript
+
+```js
+const buttonElement = document.querySelector("#buttton");
+console.log(buttonElement.type); // Output: "reset"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.type")}} property.
+- {{domxref("HTMLInputElement.type")}} property


### PR DESCRIPTION
This PR add documentation for HTMLButtonElement.type

It is part of https://github.com/mdn/mdn/issues/520

Resource
[type](https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-type) 