### PR TITLE
fix(html): Add advice on object element with data attr instead of param element

### DIFF
--- a/files/en-us/web/html/element/param/index.md
+++ b/files/en-us/web/html/element/param/index.md
@@ -12,7 +12,7 @@ browser-compat: html.elements.param
 The **`<param>`** [HTML](/en-US/docs/Web/HTML) element defines parameters for an {{HTMLElement("object")}} element.
 
 > **Note:**
-> It's recommended to use the {{HTMLElement("object")}} element with a [data attribute](/en-US/docs/Web/HTML/Element/object#data) to set the URL of an external resource instead.
+> It's recommended to use the {{HTMLElement("object")}} element with a [`data` attribute](/en-US/docs/Web/HTML/Element/object#data) to set the URL of an external resource instead.
 
 ## Attributes
 

--- a/files/en-us/web/html/element/param/index.md
+++ b/files/en-us/web/html/element/param/index.md
@@ -12,7 +12,7 @@ browser-compat: html.elements.param
 The **`<param>`** [HTML](/en-US/docs/Web/HTML) element defines parameters for an {{HTMLElement("object")}} element.
 
 > **Note:**
-> It's recommended to use the {{HTMLElement("object")}} element with a [`data` attribute](/en-US/docs/Web/HTML/Element/object#data) to set the URL of an external resource instead.
+> Use the {{HTMLElement("object")}} element with a [`data`](/en-US/docs/Web/HTML/Element/object#data) attribute to set the URL of an external resource.
 
 ## Attributes
 

--- a/files/en-us/web/html/element/param/index.md
+++ b/files/en-us/web/html/element/param/index.md
@@ -11,6 +11,9 @@ browser-compat: html.elements.param
 
 The **`<param>`** [HTML](/en-US/docs/Web/HTML) element defines parameters for an {{HTMLElement("object")}} element.
 
+> **Note:**
+> It's recommended to use the {{HTMLElement("object")}} element with a [data attribute](/en-US/docs/Web/HTML/Element/object#data) to set the URL of an external resource instead.
+
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).


### PR DESCRIPTION
### Description

The feature is deprecated and https://github.com/mdn/content/issues/31523 asks for rationale for this status.

As linked in the issue, https://github.com/mdn/content/pull/15225 is the PR that introduces this status change in the docs.

__Additions:__

* Note that points to an alternative 

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/31523