### PR TITLE
fix: description of `rect()` offset

### DIFF
--- a/files/en-us/web/css/basic-shape/rect/index.md
+++ b/files/en-us/web/css/basic-shape/rect/index.md
@@ -22,7 +22,7 @@ The inset rectangle is defined by specifying four offset values, starting with t
 
 - `<length-percentage>`
 
-  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} value of the distance of the top, right, bottom, or left edge of the rectangle from the top or left edge of the containing block. The first (top) and third (bottom) values are distances from the top edge of the containing block, and the second (right) and fourth (left) values are distances from the left edge of the containing block. The second (right) and third (bottom) values are clamped by the fourth (left) and second (top) values, respectively, to prevent the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` is clamped to `rect(10px 20px 10px 20px)`.
+  - : Specifies the {{cssxref("&lt;length-percentage&gt;")}} value of the distance of the top, right, bottom, or left edge of the rectangle from the top or left edge of the containing block. The first (top) and third (bottom) values are distances from the top edge of the containing block, and the second (right) and fourth (left) values are distances from the left edge of the containing block. The second (right) and third (bottom) values are clamped by the fourth (left) and first (top) values, respectively, to prevent the bottom edge from crossing over the top edge and right edge from crossing over the left edge. For example, `rect(10px 0 0 20px)` is clamped to `rect(10px 20px 10px 20px)`.
 
 - `auto`
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The "top" value of the `rect()` CSS function is the **first** value, not the second value.

