### PR TITLE
Remove closing slashes in example

### DIFF
--- a/files/en-us/web/html/element/br/index.md
+++ b/files/en-us/web/html/element/br/index.md
@@ -37,11 +37,11 @@ You can set a {{cssxref("margin")}} on `<br>` elements themselves to increase th
 In the following example we use `<br>` elements to create line breaks between the different lines of a postal address:
 
 ```html
-Mozilla<br />
-331 E. Evelyn Avenue<br />
-Mountain View, CA<br />
-94041<br />
-USA<br />
+Mozilla<br>
+331 E. Evelyn Avenue<br>
+Mountain View, CA<br>
+94041<br>
+USA<br>
 ```
 
 #### Result


### PR DESCRIPTION
### Description
Changed for consistency and because the examples above also don’t have closing slashes.

### Motivation
Consitency and real world HTML, how most people write it these days.

These templates for PRs and Issues are great, but they are so big and intimidating, it took me months to finally open a pull request.