### PR TITLE
docs: robots meta tag vs robots.txt file

### DIFF
--- a/files/en-us/web/html/element/meta/name/index.md
+++ b/files/en-us/web/html/element/meta/name/index.md
@@ -241,7 +241,7 @@ The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtension
   >
   > - Only cooperative robots follow these rules. Do not expect to prevent email harvesters with them.
   > - The robot still needs to access the page in order to read these rules. To prevent bandwidth consumption, consider if using a _{{Glossary("robots.txt")}}_ file is more appropriate.
-  > - The `robots` meta tag and `robots.txt` file serve different purposes, as `robots.txt` is exclusively for the crawling of pages, and does not determine the indexing of pages. A page that can't be crawled may still be indexed if it is referenced by another document.
+  > - The `robots` `<meta>` tag and `robots.txt` file serve different purposes: `robots.txt` controls the crawling of pages, and does not affect indexing or other behavior controlled by `robots` meta. A page that can't be crawled may still be indexed if it is referenced by another document.
   > - If you want to remove a page, `noindex` will work, but only after the robot visits the page again. Ensure that the `robots.txt` file is not preventing revisits.
   > - Some values are mutually exclusive, like `index` and `noindex`, or `follow` and `nofollow`. In these cases the robot's behavior is undefined and may vary between them.
   > - Some crawler robots, like Google, Yahoo and Bing, support the same values for the HTTP header `X-Robots-Tag`; this allows non-HTML documents like images to use these rules.

--- a/files/en-us/web/html/element/meta/name/index.md
+++ b/files/en-us/web/html/element/meta/name/index.md
@@ -240,7 +240,8 @@ The [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtension
   > **Note:**
   >
   > - Only cooperative robots follow these rules. Do not expect to prevent email harvesters with them.
-  > - The robot still needs to access the page in order to read these rules. To prevent bandwidth consumption, use a _{{Glossary("robots.txt")}}_ file.
+  > - The robot still needs to access the page in order to read these rules. To prevent bandwidth consumption, consider if using a _{{Glossary("robots.txt")}}_ file is more appropriate.
+  > - The `robots` meta tag and `robots.txt` file serve different purposes, as `robots.txt` is exclusively for the crawling of pages, and does not determine the indexing of pages. A page that can't be crawled may still be indexed if it is referenced by another document.
   > - If you want to remove a page, `noindex` will work, but only after the robot visits the page again. Ensure that the `robots.txt` file is not preventing revisits.
   > - Some values are mutually exclusive, like `index` and `noindex`, or `follow` and `nofollow`. In these cases the robot's behavior is undefined and may vary between them.
   > - Some crawler robots, like Google, Yahoo and Bing, support the same values for the HTTP header `X-Robots-Tag`; this allows non-HTML documents like images to use these rules.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This PR brings more attention to the difference between the `robots` meta tags and `robots.txt` file, and clarifies explicitly that these are not alternatives.

* Instead of instructing users to use `robots.txt`, propose that users should investigate if it may be a more appropriate solution for them.
* Explicitly note that the `robots.txt` is for crawling, and does not determine if a page should be indexed on its own, and that pages may still get indexed even if it can't be crawled.

I believe the changes pair well with the existing points above and below where I added it, which bring more clarity to how it works.

### Motivation

When I was first reading about if I should use `robots` or `robots.txt`, I was under the impression that these were alternatives.

This was solidified by the explanation on MDN, which instructed users to use `robots.txt` to reduce bandwidth, though it's worth noting MDN did not explicitly state the relationship it had with indexing.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

> **Warning**: Don't use a robots.txt file as a means to hide your web pages (including PDFs and other text-based formats supported by Google) from Google search results. 
> 
> If other pages point to your page with descriptive text, Google could still index the URL without visiting the page. If you want to block your page from search results, use another method such as password protection or [**noindex**](https://developers.google.com/search/docs/crawling-indexing/block-indexing).
> 
> **If your web page is blocked with a robots.txt file**, its URL can still appear in search results, but the search result will [not have a description](https://support.google.com/webmasters/answer/7489871).
> 
> — https://developers.google.com/search/docs/crawling-indexing/robots/intro#what-is-a-robots.txt-file-used-for

### Related issues and pull requests

* Fixes https://github.com/mdn/content/issues/30955
