### PR TITLE
Fix incorrect example in Cache add() doc

### DIFF
--- a/files/en-us/web/api/cache/add/index.md
+++ b/files/en-us/web/api/cache/add/index.md
@@ -17,7 +17,7 @@ fetch(url).then((response) => {
   if (!response.ok) {
     throw new TypeError("bad response status");
   }
-  return cache.add(url);
+  return cache.put(url, response);
 });
 ```
 


### PR DESCRIPTION
The documentation for the Cache add() method says: "The add() method is functionally equivalent to the following:", then gives a code block example which uses the add() function -- this doesn't make sense, functionally equivalent with itself? It's supposed to be functionally equivalent to the put() function.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed a mistake in the "functionally equivalent" code block.

### Motivation

I'm making this change because it's a mistake that should be fixed 😁 

### Additional details

N/A

### Related issues and pull requests

N/A
