### PR TITLE
ServiceWorker.postMessage has more than a single param

### DIFF
--- a/files/en-us/web/api/serviceworker/postmessage/index.md
+++ b/files/en-us/web/api/serviceworker/postmessage/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ServiceWorker.postMessage
 
 {{APIRef("Service Workers API")}}{{securecontext_header}}
 
-The **`postMessage()`** method of the {{domxref("ServiceWorker")}} interface sends a message to the worker. This accepts a single parameter, which is the data to send to the worker. The data may be any JavaScript object which can be handled by the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+The **`postMessage()`** method of the {{domxref("ServiceWorker")}} interface sends a message to the worker. The first parameter is the data to send to the worker. The data may be any JavaScript object which can be handled by the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 
 The service worker can send back information to its clients by using the {{domxref("Client.postMessage", "postMessage()")}} method. The message will not be sent back to this `ServiceWorker` object but to the associated {{domxref("ServiceWorkerContainer")}} available via {{domxref("navigator.serviceWorker")}}.
 


### PR DESCRIPTION
Fixes a misleading sentence that made it sound like there is only a single parameter, to ServiceWorker.postMessage() while the **Parameters** paragraph below clearly shows that it's not true.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Reused the wording from the [Worker.postMessage()](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage) article, since both methods share the same signatures.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This was misleading and confusing. 

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
