### PR TITLE
Add info about the "r" attribute when set in percentage

### DIFF
--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -16,6 +16,8 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("circle")}}
 - {{SVGElement("radialGradient")}}
 
+When the value is set in percentage, it refers to the normalized diagonal of the current SVG viewport.
+
 ## Example
 
 ```css hidden
@@ -56,7 +58,6 @@ svg {
 ## circle
 
 For {{SVGElement('circle')}}, `r` defines the radius of the circle and therefor its size. With a value lower or equal to zero the circle won't be drawn at all.
-
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -58,6 +58,7 @@ svg {
 ## circle
 
 For {{SVGElement('circle')}}, `r` defines the radius of the circle and therefor its size. With a value lower or equal to zero the circle won't be drawn at all.
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -16,7 +16,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("circle")}}
 - {{SVGElement("radialGradient")}}
 
-When the value is set in percentage, it refers to the normalized diagonal of the current SVG viewport.
+When the value is set as a percentage, it refers to the normalized diagonal of the current SVG viewport.
 
 ## Example
 


### PR DESCRIPTION
It could be helpful to add here that when set in percentage, it refers to the normalized diagonal of the SVG viewport (and not the width).
I added the information about how t "r" value is calculated when set in percentage: https://www.w3.org/TR/SVG2/coords.html#Units
https://www.w3.org/TR/SVG2/geometry.html#R

I'm making this changes because I struggled to understand why I didn't get the results I was expecting when setting a percentage value in the "r" attribute. I didn't find the info in the MDN page about the "r" attritbute.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
