### PR TITLE
IntallEvent vs install event

### DIFF
--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -44,7 +44,7 @@ You can access `CacheStorage` through the global {{domxref("caches")}} property.
 ## Examples
 
 This code snippet is from the MDN [simple service worker example](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker) (see [simple service worker running live](https://bncb2v.csb.app/).)
-This service worker script waits for an [`install event`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) to fire, then runs {{domxref("ExtendableEvent.waitUntil","waitUntil")}} to handle the install process for the app. This consists of calling {{domxref("CacheStorage.open")}} to create a new cache, then using {{domxref("Cache.addAll")}} to add a series of assets to it.
+This service worker script waits for an {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event to fire, then runs {{domxref("ExtendableEvent.waitUntil","waitUntil")}} to handle the install process for the app. This consists of calling {{domxref("CacheStorage.open")}} to create a new cache, then using {{domxref("Cache.addAll")}} to add a series of assets to it.
 
 In the second code block, we wait for a {{domxref("FetchEvent")}} to fire. We construct a custom response like so:
 

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -44,7 +44,7 @@ You can access `CacheStorage` through the global {{domxref("caches")}} property.
 ## Examples
 
 This code snippet is from the MDN [simple service worker example](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker) (see [simple service worker running live](https://bncb2v.csb.app/).)
-This service worker script waits for an {{domxref("InstallEvent")}} to fire, then runs {{domxref("ExtendableEvent.waitUntil","waitUntil")}} to handle the install process for the app. This consists of calling {{domxref("CacheStorage.open")}} to create a new cache, then using {{domxref("Cache.addAll")}} to add a series of assets to it.
+This service worker script waits for an [`install event`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) to fire, then runs {{domxref("ExtendableEvent.waitUntil","waitUntil")}} to handle the install process for the app. This consists of calling {{domxref("CacheStorage.open")}} to create a new cache, then using {{domxref("Cache.addAll")}} to add a series of assets to it.
 
 In the second code block, we wait for a {{domxref("FetchEvent")}} to fire. We construct a custom response like so:
 

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.InstallEvent
 ---
 
-> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall()` handler to catch events of this type, instead handle the (non-deprecated) [`install`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) using a listener added with [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener).
+> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall()` handler to catch events of this type, instead handle the (non-deprecated) {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event using a listener added with {{domxref("EventTarget/addEventListener", "addEventListener")}}.
 
 {{APIRef("Service Workers API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.InstallEvent
 ---
 
-> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall()` handler to catch events of this type, instead handle the (non-deprecated) {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event using a listener added with {{domxref("EventTarget/addEventListener", "addEventListener")}}.
+> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall` handler to catch events of this type, handle the (non-deprecated) {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event using a listener added with {{domxref("EventTarget/addEventListener", "addEventListener")}}.
 
 {{APIRef("Service Workers API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -8,9 +8,9 @@ status:
 browser-compat: api.InstallEvent
 ---
 
-> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall` handler to catch events of this type, handle the (non-deprecated) {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event using a listener added with {{domxref("EventTarget/addEventListener", "addEventListener")}}.
-
 {{APIRef("Service Workers API")}}{{Deprecated_Header}}{{Non-standard_Header}}
+
+> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall` handler to catch events of this type, handle the (non-deprecated) {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event using a listener added with {{domxref("EventTarget/addEventListener", "addEventListener")}}.
 
 The parameter passed into the {{domxref("ServiceWorkerGlobalScope.install_event", "oninstall")}} handler, the `InstallEvent` interface represents an install action that is dispatched on the {{domxref("ServiceWorkerGlobalScope")}} of a {{domxref("ServiceWorker")}}. As a child of {{domxref("ExtendableEvent")}}, it ensures that functional events such as {{domxref("FetchEvent")}} are not dispatched during installation.
 

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -8,6 +8,8 @@ status:
 browser-compat: api.InstallEvent
 ---
 
+> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall()` handler to catch events of this type, instead handle the (non-deprecated) [`install`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) using a listener added with [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener).
+
 {{APIRef("Service Workers API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The parameter passed into the {{domxref("ServiceWorkerGlobalScope.install_event", "oninstall")}} handler, the `InstallEvent` interface represents an install action that is dispatched on the {{domxref("ServiceWorkerGlobalScope")}} of a {{domxref("ServiceWorker")}}. As a child of {{domxref("ExtendableEvent")}}, it ensures that functional events such as {{domxref("FetchEvent")}} are not dispatched during installation.
@@ -15,8 +17,6 @@ The parameter passed into the {{domxref("ServiceWorkerGlobalScope.install_event"
 This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 
 {{InheritanceDiagram}}
-
-> **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall()` handler to catch events of this type, instead handle the (non-deprecated) [`install`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/install_event) using a listener added with [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener).
 
 ## Constructor
 


### PR DESCRIPTION
CacheStorage page: InstallEvent is deprecated. I replaced it with what I hope is the correct text, "install event", and what I'm sure is the correct link.

InstallEvent page: The blue Note is the most important thing users need to know and is specific to this page, whereas the red warning boxes are generic text, thus I put the Note at the top of the page.
