### PR TITLE
async runtime.onMessage listeners clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -214,7 +214,7 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
-> **Warning:** Do not prepend `async` to the function. Prepend `async` changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
+> **Warning:** Do not prepend `async` to the function. Prepending `async` changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
 
 ### Sending an asynchronous response using a Promise
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -32,7 +32,7 @@ You can send a synchronous response to the message by calling the `sendResponse(
 To send an asynchronous response, there are two options:
 
 - return `true` from the event listener. This keeps the `sendResponse()` function valid after the listener returns, so you can call it later. [See an example](#sending_an_asynchronous_response_using_sendresponse).
-  > **Warning:** Do not prepend `async` to the function that returns `true`, because that causes the return value to be a Promise (that resolves to `true`). `sendResponse` can only be called asynchronously when the listener returns `true` synchronously.
+  > **Warning:** Do not prepend `async` to the function. Prepend `async` changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
 - return a `Promise` from the event listener, and resolve when you have the response (or reject it in case of an error). [See an example](#sending_an_asynchronous_response_using_a_promise).
 
 > **Note:** You can also use a [connection-based approach to exchange messages](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging).
@@ -214,7 +214,7 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
-> **Warning:** Do not prepend `async` to the function, because that causes the return value to be a Promise (that resolves to `true`). `sendResponse` can only be called asynchronously when the listener returns `true` synchronously.
+> **Warning:** Do not prepend `async` to the function. Prepend `async` changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
 
 ### Sending an asynchronous response using a Promise
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -32,7 +32,7 @@ You can send a synchronous response to the message by calling the `sendResponse(
 To send an asynchronous response, there are two options:
 
 - return `true` from the event listener. This keeps the `sendResponse()` function valid after the listener returns, so you can call it later. [See an example](#sending_an_asynchronous_response_using_sendresponse).
-  > **Warning:** Do not prepend `async` to the function. The function won't work as expected because prepending `async` causes the function to return a Promise that resolves to `true`.
+  > **Warning:** Do not prepend `async` to the function that returns `true`, because that causes the return value to be a Promise (that resolves to `true`). `sendResponse` can only be called asynchronously when the listener returns `true` synchronously.
 - return a `Promise` from the event listener, and resolve when you have the response (or reject it in case of an error). [See an example](#sending_an_asynchronous_response_using_a_promise).
 
 > **Note:** You can also use a [connection-based approach to exchange messages](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging).

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -32,6 +32,7 @@ You can send a synchronous response to the message by calling the `sendResponse(
 To send an asynchronous response, there are two options:
 
 - return `true` from the event listener. This keeps the `sendResponse()` function valid after the listener returns, so you can call it later. [See an example](#sending_an_asynchronous_response_using_sendresponse).
+  > **Warning:** Do not prepend `async` to the function. The function won't work as expected because prepending `async` causes the function to return a Promise that resolves to `true`.
 - return a `Promise` from the event listener, and resolve when you have the response (or reject it in case of an error). [See an example](#sending_an_asynchronous_response_using_a_promise).
 
 > **Note:** You can also use a [connection-based approach to exchange messages](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging).
@@ -213,7 +214,7 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
-> **Warning:** Do not prepend `async` to the function. That changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
+> **Warning:** Do not prepend `async` to the function. The function won't work as expected because prepending `async` causes the function to return a Promise that resolves to `true`.
 
 ### Sending an asynchronous response using a Promise
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -32,7 +32,7 @@ You can send a synchronous response to the message by calling the `sendResponse(
 To send an asynchronous response, there are two options:
 
 - return `true` from the event listener. This keeps the `sendResponse()` function valid after the listener returns, so you can call it later. [See an example](#sending_an_asynchronous_response_using_sendresponse).
-  > **Warning:** Do not prepend `async` to the function. Prepend `async` changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
+  > **Warning:** Do not prepend `async` to the function. Prepending `async` changes the meaning to [sending an asynchronous response using a promise](#sending_an_asynchronous_response_using_a_promise), which is effectively the same as `sendResponse(true)`.
 - return a `Promise` from the event listener, and resolve when you have the response (or reject it in case of an error). [See an example](#sending_an_asynchronous_response_using_a_promise).
 
 > **Note:** You can also use a [connection-based approach to exchange messages](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging).

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -214,7 +214,7 @@ function handleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(handleMessage);
 ```
 
-> **Warning:** Do not prepend `async` to the function. The function won't work as expected because prepending `async` causes the function to return a Promise that resolves to `true`.
+> **Warning:** Do not prepend `async` to the function, because that causes the return value to be a Promise (that resolves to `true`). `sendResponse` can only be called asynchronously when the listener returns `true` synchronously.
 
 ### Sending an asynchronous response using a Promise
 


### PR DESCRIPTION
### Description

Addresses the documentation needs of [Bug 1877223](https://bugzilla.mozilla.org/show_bug.cgi?id=1877223) "syntax and handling of async runtime.onMessage listeners is confusing" by clarifying that appending `async` to the function when using the option to return `true` from the event listener doesn't work as expected.