### PR TITLE
update example of using union()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/union/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/union/index.md
@@ -47,7 +47,7 @@ The following example computes the union between the set of even numbers (<10) a
 ```js
 const evens = new Set([2, 4, 6, 8]);
 const squares = new Set([1, 4, 9]);
-console.log(evens.union(squares)); // Set(6) { 1, 2, 4, 6, 8, 9 }
+console.log(evens.union(squares)); // Set(6) { 2, 4, 6, 8, 1, 9 }
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

The description of union states that the order of elements in the returned set is first those in `this` followed by those in `other`.  The example js did not accurately reflect this, showing an element from other as the first element in the new set.

### Motivation

Reading the documentation for the course I am on, I spotted that the example appeared to contradict the explained behaviour.

### Additional details

### Related issues and pull requests
