### PR TITLE
feat(ci): add post pull script to run install

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -7,10 +7,8 @@ if [ -f ".husky/_/history" ]; then
   lastHash=$(cat ./.husky/_/history)
   isUpdated=$(git diff $lastHash HEAD -- ./package.json)
   if [ "$isUpdated" != "" ]; then
-    yarn install
+    echo ⚠🔥 package.json has been modified please run 'yarn install'! 🔥
   fi
 else
   yarn install
 fi
-
-echo $(git rev-parse HEAD) > ./.husky/_/history

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -7,7 +7,7 @@ if [ -f ".husky/_/history" ]; then
   lastHash=$(cat ./.husky/_/history)
   isUpdated=$(git diff $lastHash HEAD -- ./package.json)
   if [ "$isUpdated" != "" ]; then
-    echo ⚠🔥 package.json has been modified please run 'yarn install'! 🔥
+    echo -e "\n⚠🔥 package.json has been modified please run 'yarn install'! 🔥"
   fi
 else
   yarn install

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,16 @@
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "main" ]]; then
+  exit 0
+fi
+
+if [ -f ".husky/_/history" ]; then
+  lastHash=$(cat ./.husky/_/history)
+  isUpdated=$(git diff $lastHash HEAD -- ./package.json)
+  if [ "$isUpdated" != "" ]; then
+    yarn install
+  fi
+else
+  yarn install
+fi
+
+echo $(git rev-parse HEAD) > ./.husky/_/history

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -7,7 +7,7 @@ if [ -f ".husky/_/history" ]; then
   lastHash=$(cat ./.husky/_/history)
   isUpdated=$(git diff $lastHash HEAD -- ./package.json)
   if [ "$isUpdated" != "" ]; then
-    echo -e "\n⚠🔥 package.json has been modified please run 'yarn install'! 🔥"
+    echo -e "\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
   fi
 else
   yarn install

--- a/.husky/update-history
+++ b/.husky/update-history
@@ -1,0 +1,7 @@
+# The script updates main branche's HEAD commit number.
+# The stored commit number is used by post-merge script.
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" == "main" ]]; then
+  echo $(git rev-parse HEAD) > ./.husky/_/history
+fi

--- a/.husky/update-history
+++ b/.husky/update-history
@@ -1,5 +1,5 @@
-# The script updates main branche's HEAD commit number.
-# The stored commit number is used by post-merge script.
+# This script stores the 'main' branch's HEAD commit hash in .husky/_/history
+# The stored commit hash is used by the post-merge script .husky/post-merge
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$BRANCH" == "main" ]]; then

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "type": "module",
   "scripts": {
+    "postinstall": "sh ./.husky/update-history",
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build yari-build",
     "content": "env-cmd --silent cross-env CONTENT_ROOT=files yari-tool",
     "filecheck": "env-cmd --silent cross-env CONTENT_ROOT=files yari-filecheck --cwd=.",


### PR DESCRIPTION
People have faced issues after pulling new code from origin or base and they have spent hours figuring out what was wrong. Almost all the time simple `yarn install` makes thing right again.

The PR adds post-merge script which runs when a contributor runs `git pull` or `git pull upstream main`. The script has following properties:
- it works only if the branch is `main`
- do `yarn install` on very first run
- when pulled code has `package.json` modified then run `yarn install` <-- this is the main feature
- do nothing if `package.json` hasn't been modified since last pull

Yari does `yarn install` [on every precommit](https://github.com/mdn/yari/blob/main/.husky/pre-commit), which will be very annoying in content. Next best thing is to do it immediately after pull/merge in `main` branch.