### PR TITLE
sync_event is experimental like SyncEvent, SyncManager

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.sync_event
 ---
 
-{{APIRef("Background Sync")}}
+{{APIRef("Background Sync")}}{{SeeCompatTable}}
 
 The **`sync`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when the page (or worker) that registered the event with the {{domxref('SyncManager')}} is running and as soon as network connectivity is available.
 


### PR DESCRIPTION
If the `ServiceWorkerGlobalScope` "sync" event is type `SyncEvent` and depends on `SyncManager`, and both of those are experimental technology, then the "sync" event must be experimental too.  