### PR TITLE
correct alt info of pictures in typescript svelte

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -199,7 +199,7 @@ In the `App.svelte` component, the `setupTypeScript.js` script has added the `la
 
 And if you pass something that is not a number, it will complain about it:
 
-![Type checking in VS Code - the ms variable has been given an non-numeric value](06-vscode-type-checking-in-components.png)
+![Type checking in VS Code - the ms variable has been given a non-numeric value](06-vscode-type-checking-in-components.png)
 
 The application template has a `check` script configured that runs `svelte-check` against your code. This package allows you to detect errors and warnings normally displayed by a code editor from the command line, which makes it pretty useful for running it in a continuous integration (CI) pipeline. Just run `npm run check` to check for unused CSS, and return A11y hints and TypeScript compile errors.
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -187,7 +187,7 @@ Clicking _Install all_ will install Svelte for VS Code.
 
 We can also see that the `setupTypeScript.js` file made a couple of changes to our project. The `main.js` file has been renamed to `main.ts`, which means that VS Code can provide hover-information on our Svelte components:
 
-![VS Code screenshot showing that when you add type="ts" to a component, it gives you three dot alert hints](03-vscode-hints-in-main-ts.png)
+![VS Code screenshot showing that when hovering on a component, it gives you hints](03-vscode-hints-in-main-ts.png)
 
 We also get type checking for free. If we pass an unknown property in the options parameter of the `App` constructor (for example a typo like `traget` instead of `target`), TypeScript will complain:
 
@@ -199,7 +199,7 @@ In the `App.svelte` component, the `setupTypeScript.js` script has added the `la
 
 And if you pass something that is not a number, it will complain about it:
 
-![Type checking in VS Code - App object has been given an unknown property target](06-vscode-type-checking-in-components.png)
+![Type checking in VS Code - the ms variable has been given an non-numeric value](06-vscode-type-checking-in-components.png)
 
 The application template has a `check` script configured that runs `svelte-check` against your code. This package allows you to detect errors and warnings normally displayed by a code editor from the command line, which makes it pretty useful for running it in a continuous integration (CI) pipeline. Just run `npm run check` to check for unused CSS, and return A11y hints and TypeScript compile errors.
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -191,7 +191,7 @@ We can also see that the `setupTypeScript.js` file made a couple of changes to o
 
 We also get type checking for free. If we pass an unknown property in the options parameter of the `App` constructor (for example a typo like `traget` instead of `target`), TypeScript will complain:
 
-![Type checking in VS Code - App object has been given an unknown property target](04-vscode-type-checking-in-main-ts.png)
+![Type checking in VS Code - App object has been given an unknown property traget](04-vscode-type-checking-in-main-ts.png)
 
 In the `App.svelte` component, the `setupTypeScript.js` script has added the `lang="ts"` attribute to the `<script>` tag. Moreover, thanks to type inference, in many cases we won't even need to specify types to get code assistance. For example, if you start adding an `ms` property to the `Alert` component call, TypeScript will infer from the default value that the `ms` property should be a number:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The alt info of pictures is not right
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
