### PR TITLE
Adds further detail to image-rendering `crisp-edges` vs `pixelated`

### DIFF
--- a/files/en-us/web/css/image-rendering/index.md
+++ b/files/en-us/web/css/image-rendering/index.md
@@ -38,9 +38,9 @@ image-rendering: unset;
 - `high-quality` {{Experimental_Inline}}
   - : Identical to `smooth`, but with a preference for higher-quality scaling. If system resources are constrained, images with `high-quality` should be prioritized over those with any other value, when considering which images to degrade the quality of and to what degree.
 - `crisp-edges`
-  - : The image is scaled with an algorithm that preserves contrast and edges in the image. Generally intended for images such as pixel art or line drawings, no blurring or color smoothing occurs.
+  - : The image is scaled with an algorithm such as "nearest neighbor" that preserves contrast and edges in the image. Generally intended for images such as pixel art or line drawings, no blurring or color smoothing occurs.
 - `pixelated`
-  - : The image is scaled with the "nearest neighbor" or similar algorithm, preserving a "pixelated" look as the image changes in size.
+  - : The image is scaled with the "nearest neighbor" or similar algorithm to the nearest integer multiple of the original image size, then uses smooth interpolation to bring the image to the final desired size. This is intended to preserve a "pixelated" look without introducing scaling artifacts when the upscaled resolution isn't an integer multiple of the original.
 
 > **Note:** The values `optimizeQuality` and `optimizeSpeed` present in an early draft (and coming from its SVG counterpart {{SVGAttr("image-rendering")}}) are defined as synonyms for the `smooth` and `pixelated` values respectively.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds further details to the differences between `crisp-edges` and `pixelated`.  According to the CSS spec, `pixelated` uses integer scaling to the nearest neighbour and then uses a smooth algorithm to bring the image up to its final scale.  Meanwhile, `crisp-edges` can introduce scaling artifacts at non-integer sizes.

### Motivation

Reading the MDN section on this in the past has left me confused about which one of these I should use.  Only when I went to the [relevent CSS spec section](https://github.com/mdn/content/) (helpfully linked on the page) was I given the information I needed.  This PR brings some of those implementation details into the MDN docs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Commit adding details about `pixelated`'s intended use from Feb 24, 2021: https://github.com/w3c/csswg-drafts/commit/129f7318507b51608f95acfe1620503d01de3c99

### Caveats

While it is linked on the page, officially Images Module Level 3 is still in the editors draft stage and is officially still a work in progress.  It's been years since the referenced section was updated and as far as I'm aware, not all browsers handle the flags this way today.