### PR TITLE
Content update & fix of Notification in Service Worker

### DIFF
--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Notification.Notification
 The **`Notification()`** constructor creates a new
 {{domxref("Notification")}} object instance, which represents a user notification.
 
-> **Note:** Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`.
+> **Note:** Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`, you should use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -11,6 +11,8 @@ browser-compat: api.Notification.Notification
 The **`Notification()`** constructor creates a new
 {{domxref("Notification")}} object instance, which represents a user notification.
 
+> **Note:** Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`.
+
 {{AvailableInWorkers}}
 
 ## Syntax

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Notification.Notification
 The **`Notification()`** constructor creates a new
 {{domxref("Notification")}} object instance, which represents a user notification.
 
-> **Note:** Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`, you should use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
+> **Note:** Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`. Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -2,11 +2,6 @@
 title: Using the Notifications API
 slug: Web/API/Notifications_API/Using_the_Notifications_API
 page-type: guide
-browser-compat:
-  - api.Notification
-  - api.ServiceWorkerRegistration.showNotification
-  - api.ServiceWorkerRegistration.getNotifications
-spec-urls: https://notifications.spec.whatwg.org/
 ---
 
 {{DefaultAPISidebar("Web Notifications")}}{{securecontext_header}}
@@ -225,14 +220,6 @@ window.addEventListener("load", () => {
 ### Result
 
 {{ EmbedLiveSample('Tag_example', '100%', 30) }}
-
-## Specifications
-
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -2,7 +2,11 @@
 title: Using the Notifications API
 slug: Web/API/Notifications_API/Using_the_Notifications_API
 page-type: guide
-browser-compat: api.Notification
+browser-compat:
+  - api.Notification
+  - api.ServiceWorkerRegistration.showNotification
+  - api.ServiceWorkerRegistration.getNotifications
+spec-urls: https://notifications.spec.whatwg.org/
 ---
 
 {{DefaultAPISidebar("Web Notifications")}}{{securecontext_header}}

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -92,7 +92,7 @@ self.onnotificationclick = (event) => {
 };
 ```
 
-You can handle event actions using `event.action` within a {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event handler:
+You can handle event actions using `event.action` within a `notificationclick` event handler:
 
 ```js
 navigator.serviceWorker.register("sw.js");

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ServiceWorkerGlobalScope.notificationclick_event
 
 {{APIRef("Web Notifications")}}
 
-The **`notificationclick`** event is fired to indicate that a system notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}} has been clicked.
+The **`notificationclick`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired to indicate that a system notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}} has been clicked.
 
 Notifications created on the main thread or in workers which aren't service workers
 using the {{domxref("Notification.Notification","Notification()")}} constructor will

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -10,6 +10,11 @@ browser-compat: api.ServiceWorkerGlobalScope.notificationclick_event
 
 The **`notificationclick`** event is fired to indicate that a system notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}} has been clicked.
 
+Notifications created on the main thread or in workers which aren't service workers
+using the {{domxref("Notification.Notification","Notification()")}} constructor will
+instead receive a {{domxref("Notification/click_event", "click")}} event on the {{domxref("Notification")}} object
+itself.
+
 This event is not cancelable and does not bubble.
 
 ## Syntax

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -35,7 +35,7 @@ A {{domxref("NotificationEvent")}}. Inherits from {{domxref("ExtendableEvent")}}
 
 ## Event properties
 
-_Inherits properties from its ancestor, {{domxref("ExtendableEvent")}} and {{domxref("Event")}}_.
+_Inherits properties from its ancestors, {{domxref("ExtendableEvent")}} and {{domxref("Event")}}_.
 
 - {{domxref("NotificationEvent.notification")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Notification")}} object representing the notification that was clicked to fire the event.

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -29,13 +29,13 @@ onnotificationclick = (event) => {};
 
 ## Event type
 
-A {{domxref("NotificationEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("NotificationEvent")}}. Inherits from {{domxref("ExtendableEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("NotificationEvent")}}
 
 ## Event properties
 
-_Inherits properties from its ancestor, {{domxref("Event")}}_.
+_Inherits properties from its ancestor, {{domxref("ExtendableEvent")}} and {{domxref("Event")}}_.
 
 - {{domxref("NotificationEvent.notification")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Notification")}} object representing the notification that was clicked to fire the event.

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
@@ -29,13 +29,13 @@ onnotificationclose = (event) => {};
 
 ## Event type
 
-A {{domxref("NotificationEvent")}}. Inherits from {{domxref("Event")}}.
+A {{domxref("NotificationEvent")}}. Inherits from {{domxref("ExtendableEvent")}} and {{domxref("Event")}}.
 
 {{InheritanceDiagram("NotificationEvent")}}
 
 ## Event properties
 
-_Inherits properties from its ancestor, {{domxref("Event")}}_.
+_Inherits properties from its ancestor, {{domxref("ExtendableEvent")}} and {{domxref("Event")}}_.
 
 - {{domxref("NotificationEvent.notification")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Notification")}} object representing the notification that was clicked to fire the event.

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
@@ -12,13 +12,8 @@ The **`notificationclose`** event fires when a user closes a displayed notificat
 
 Notifications created on the main thread or in workers which aren't service workers
 using the {{domxref("Notification.Notification","Notification()")}} constructor will
-instead receive a {{domxref("Notification/close_event", "close")}} event on the `Notification` object
+instead receive a {{domxref("Notification/close_event", "close")}} event on the {{domxref("Notification")}} object
 itself.
-
-> **Note:** Trying to create a notification inside the
-> {{domxref("ServiceWorkerGlobalScope")}} using the
-> {{domxref("Notification.Notification","Notification()")}} constructor will throw an
-> error.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ServiceWorkerGlobalScope.notificationclose_event
 
 {{APIRef("Web Notifications")}}
 
-The **`notificationclose`** event fires when a user closes a displayed notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}}.
+The **`notificationclose`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface fires when a user closes a displayed notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}}.
 
 Notifications created on the main thread or in workers which aren't service workers
 using the {{domxref("Notification.Notification","Notification()")}} constructor will

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
@@ -45,7 +45,7 @@ _Inherits properties from its ancestor, {{domxref("ExtendableEvent")}} and {{dom
 ## Example
 
 ```js
-//Inside a service worker.
+// Inside a service worker.
 self.onnotificationclose = (event) => {
   console.log("On notification close: ", event.notification.tag);
 };

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -24,7 +24,7 @@ showNotification(title, options)
 ### Parameters
 
 - `title`
-  - : The title that must be shown within the notification
+  - : The title that must be shown within the notification.
 - `options` {{optional_inline}}
 
   - : An object that allows configuring the notification. It can have the following
@@ -45,7 +45,7 @@ showNotification(title, options)
         {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.
 
     - `badge` {{optional_inline}} {{experimental_inline}}
-      - : a string containing the URL of an image
+      - : A string containing the URL of an image
         to represent the notification when there is not enough space to display the
         notification itself such as for example, the Android Notification Bar. On Android
         devices, the badge should accommodate devices up to 4x resolution, about 96 by 96
@@ -59,10 +59,10 @@ showNotification(title, options)
     - `dir` {{optional_inline}}
       - : The direction of the notification; it can be `auto`, `ltr` or `rtl`.
     - `icon` {{optional_inline}}
-      - : a string containing the URL of an image to
+      - : A string containing the URL of an image to
         be used as an icon by the notification.
     - `image` {{optional_inline}} {{experimental_inline}}
-      - : a string containing the URL of an image to
+      - : A string containing the URL of an image to
         be displayed in the notification.
     - `lang` {{optional_inline}}
       - : Specify the lang used within the notification. This string

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -128,8 +128,8 @@ function showNotification() {
 }
 ```
 
-To invoke the above function at an appropriate time, you could use the
-{{domxref("ServiceWorkerGlobalScope.notificationclick_event", "onnotificationclick")}} event handler.
+To invoke the above function at an appropriate time, you could listen to the
+{{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.
 
 You can also retrieve details of the {{domxref("Notification")}}s that have been fired
 from the current service worker using

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -38,7 +38,7 @@ showNotification(title, options)
           - : A string identifying a user action to be displayed on the notification.
         - `title`
           - : A string containing action text to be shown to the user.
-        - `icon`
+        - `icon` {{optional_inline}}
           - : A string containing the URL of an icon to display with the action.
 
         Appropriate responses are built using `event.action` within the

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -71,19 +71,19 @@ showNotification(title, options)
     - `renotify` {{optional_inline}} {{experimental_inline}}
       - : A boolean that indicates whether to suppress vibrations
         and audible alerts when reusing a `tag` value.
-        If _options_'s `renotify` is true
-        and _options_'s `tag` is the empty string a TypeError will be
+        If _options_'s `renotify` is `true`
+        and _options_'s `tag` is the empty string a `TypeError` will be
         thrown. The default is `false`.
     - `requireInteraction` {{optional_inline}} {{experimental_inline}}
       - : Indicates that on devices with sufficiently
         large screens, a notification should remain active until the user clicks or
-        dismisses it. If this value is absent or false, the desktop version of Chrome will
+        dismisses it. If this value is absent or `false`, the desktop version of Chrome will
         auto-minimize notifications after approximately twenty seconds. The default value
         is `false`.
     - `silent` {{optional_inline}}
       - : When set indicates that no sounds or vibrations should be
-        made. If _options_'s `silent` is true
-        and _options_'s `vibrate` is present a TypeError exception
+        made. If _options_'s `silent` is `true`
+        and _options_'s `vibrate` is present a `TypeError` exception
         will be thrown. The default value is `false`.
     - `tag` {{optional_inline}}
       - : An ID for a given notification that allows you to find,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

move the note in `ServiceWorkerGlobalScope.notificationclose` event to `Notification()` constructor

and update content indicating relative event on `Notification` in `ServiceWorkerGlobalScope.notificationclick`

also update example description by replacing event handler property usage to event

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
