### PR TITLE
ExtendableEvent: waitUntil() does not accept anonymous functions

### DIFF
--- a/files/en-us/web/api/extendableevent/waituntil/index.md
+++ b/files/en-us/web/api/extendableevent/waituntil/index.md
@@ -43,7 +43,8 @@ waitUntil(promise)
 
 ### Parameters
 
-A {{jsxref("Promise")}}.
+A {{jsxref("Promise")}}. As illustrated by the example below, `waitUntil()` does
+not accept an anonymous function as the parameter.
 
 ### Return value
 


### PR DESCRIPTION
This is based on my own testing on Chrome and Firefox, not something I saw in the spec or any other documentation.  The [simple-service-worker example](https://github.com/mdn/dom-examples/blob/main/service-worker/simple-service-worker/sw.js) has a two-line function, `addResourcesToCache()` that is called in only one place and is thus ripe for inlining.  But I tried that while adapting the example to my project and it fails.

Prior to merging this change it would be great to confirm with someone knowledgeable that the facts are correct and that I'm not missing anything, like the proper way to structure an anonymous function here.

This might apply to `FetchEvent: respondWith()` too, but I want to confirm that this is for real before expanding the scope of testing and changes.