### PR TITLE
Fix incorrect CustomStateSet method set() to the correct one add()

### DIFF
--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -298,7 +298,7 @@ class CompatibleStateElement extends HTMLElement {
     const internals = this.attachInternals();
     // The double dash is required in browsers with the
     // legacy syntax, but works with the modern syntax
-    internals.states.set("--loaded");
+    internals.states.add("--loaded");
   }
 }
 ```
@@ -324,9 +324,9 @@ class CompatibleStateElement extends HTMLElement {
     // The double dash is required in browsers with the
     // legacy syntax, not supplying it will throw
     try {
-      internals.states.set("loaded");
+      internals.states.add("loaded");
     } catch {
-      internals.states.set("--loaded");
+      internals.states.add("--loaded");
     }
   }
 }


### PR DESCRIPTION
### Description

This PR fixes incorrect ``CustomStateSet`` method ``set()`` in the examples to the correct one ``add()``

### Motivation

``CustomStateSet`` has no method ``set()`` for adding a state to the set. The correct method to add a state is ``add()``

### Additional details

[https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet](https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet)
