### PR TITLE
Add `download` attribute for `<a>` on `<video>` element page's examples

### DIFF
--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -373,11 +373,7 @@ This example plays a video when activated, providing the user with the browser's
   poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
   width="620">
   Sorry, your browser doesn't support embedded videos, but don't worry, you can
-  <a
-    href="https://archive.org/details/BigBuckBunny_124"
-    download="BigBuckBunny_124"
-    >download it</a
-  >
+  <a href="https://archive.org/details/BigBuckBunny_124">download it</a>
   and watch it with your favorite video player!
 </video>
 ```

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -373,7 +373,11 @@ This example plays a video when activated, providing the user with the browser's
   poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
   width="620">
   Sorry, your browser doesn't support embedded videos, but don't worry, you can
-  <a href="https://archive.org/details/BigBuckBunny_124" download="BigBuckBunny_124">download it</a>
+  <a
+    href="https://archive.org/details/BigBuckBunny_124"
+    download="BigBuckBunny_124"
+    >download it</a
+  >
   and watch it with your favorite video player!
 </video>
 ```
@@ -409,7 +413,9 @@ This example builds on the last one, offering three different sources for the me
     type="video/mp4" />
 
   Sorry, your browser doesn't support embedded videos, but don't worry, you can
-  <a href="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4" download="ed_1024_512kb.mp4">
+  <a
+    href="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
+    download="ed_1024_512kb.mp4">
     download the MP4
   </a>
   and watch it with your favorite video player!

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -282,7 +282,7 @@ Browsers don't all support the same video formats; you can provide multiple sour
   <source src="myVideo.mp4" type="video/mp4" />
   <p>
     Your browser doesn't support HTML video. Here is a
-    <a href="myVideo.mp4">link to the video</a> instead.
+    <a href="myVideo.mp4" download="myVideo.mp4">link to the video</a> instead.
   </p>
 </video>
 ```
@@ -373,7 +373,7 @@ This example plays a video when activated, providing the user with the browser's
   poster="https://peach.blender.org/wp-content/uploads/title_anouncement.jpg?x11217"
   width="620">
   Sorry, your browser doesn't support embedded videos, but don't worry, you can
-  <a href="https://archive.org/details/BigBuckBunny_124">download it</a>
+  <a href="https://archive.org/details/BigBuckBunny_124" download="BigBuckBunny_124">download it</a>
   and watch it with your favorite video player!
 </video>
 ```
@@ -409,7 +409,7 @@ This example builds on the last one, offering three different sources for the me
     type="video/mp4" />
 
   Sorry, your browser doesn't support embedded videos, but don't worry, you can
-  <a href="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4">
+  <a href="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4" download="ed_1024_512kb.mp4">
     download the MP4
   </a>
   and watch it with your favorite video player!


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

inspired by #29287 

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
