### PR TITLE
Add declarative shadow DOM to Firefox 123 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -99,46 +99,6 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
   </tbody>
 </table>
 
-### Declarative shadow DOM
-
-The {{htmlelement("template")}} element now supports a `shadowrootmode` attribute which can be set to either `open` or `closed`, the same values as the `mode` option of the {{domxref("Element.attachShadow()", "attachShadow()")}} method. It allows the creation of a shadow DOM subtree declaratively. (See [Firefox bug 1712140](https://bugzil.la/1712140) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>122</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>122</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>122</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>122</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.webcomponents.shadowdom.declarative.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## CSS
 
 ### Hex boxes to display stray control characters

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -14,7 +14,7 @@ This article provides information about the changes in Firefox 123 that affect d
 
 ### HTML
 
-- The {{htmlelement("template")}} element now supports a `shadowrootmode` attribute which can be set to either `open` or `closed`, the same values as the `mode` option of the {{domxref("Element.attachShadow()", "attachShadow()")}} method. It allows the creation of a shadow DOM subtree declaratively. ([Firefox bug 1712140](https://bugzil.la/1870052))
+- The {{htmlelement("template")}} element now supports a `shadowrootmode` attribute that allows declarative creation of a shadow DOM subtree. The attribute can be set to either `open` or `closed`, which expose or hide JavaScript in the shadow DOM from external code, respectively. These are the same values as the `mode` option of the {{domxref("Element.attachShadow()", "attachShadow()")}} method. ([Firefox bug 1712140](https://bugzil.la/1870052))
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -14,6 +14,8 @@ This article provides information about the changes in Firefox 123 that affect d
 
 ### HTML
 
+- The {{htmlelement("template")}} element now supports a `shadowrootmode` attribute which can be set to either `open` or `closed`, the same values as the `mode` option of the {{domxref("Element.attachShadow()", "attachShadow()")}} method. It allows the creation of a shadow DOM subtree declaratively. ([Firefox bug 1712140](https://bugzil.la/1870052))
+
 #### Removals
 
 ### CSS


### PR DESCRIPTION
### Description

- Adds declarative shadow DOM to Firefox 123 release notes
- Removes declarative shadow DOM from experimental features

### Motivation

To support [Firefox 123 release project](https://github.com/mdn/content/issues/31865).

### Related issues and pull requests

- [Bugzilla: Enable Declarative ShadowDOM on all channels](https://bugzilla.mozilla.org/show_bug.cgi?id=1870052)