### PR TITLE
FF123 updates for permission publickey-credentials-create

### DIFF
--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -316,7 +316,8 @@ A {{jsxref("Promise")}} that resolves with an {{domxref("PublicKeyCredential")}}
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Possible causes include:
     - Usage was blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy).
-    - The function is called cross-origin when the {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} policy is set by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) (and permitted), but the frame does not also have {{glossary("Transient activation")}}.
+    - The function is called cross-origin but the iframe's [`allow`](/en-US/docs/Web/HTML/Element/iframe#allow) attribute does not set an appropriate {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} policy.
+    - The function is called cross-origin and the `<iframe>` does not have {{glossary("transient activation")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -313,7 +313,7 @@ A {{jsxref("Promise")}} that resolves with an {{domxref("PublicKeyCredential")}}
 
 ### Exceptions
 
-- `SecurityError` {{domxref("DOMException")}}
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Usage was blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy).
 
 ## Examples

--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -314,7 +314,9 @@ A {{jsxref("Promise")}} that resolves with an {{domxref("PublicKeyCredential")}}
 ### Exceptions
 
 - `NotAllowedError` {{domxref("DOMException")}}
-  - : Usage was blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy).
+  - : Possible causes include:
+    - Usage was blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy).
+    - The function is called cross-origin when the {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} policy is set by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) (and permitted), but the frame does not also have {{glossary("Transient activation")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -336,7 +336,7 @@ A {{jsxref("Promise")}} that resolves with an {{domxref("PublicKeyCredential")}}
 
 ### Exceptions
 
-- `SecurityError` {{domxref("DOMException")}}
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Usage was blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-get","publickey-credentials-get")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy).
 
 ### Examples

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -121,9 +121,9 @@ The availability of WebAuthn can be controlled using a [Permissions Policy](/en-
 - {{httpheader("Permissions-Policy/publickey-credentials-create", "publickey-credentials-create")}}: Controls the availability of {{domxref("CredentialsContainer.create", "navigator.credentials.create()")}} with the `publicKey` option.
 - {{httpheader("Permissions-Policy/publickey-credentials-get", "publickey-credentials-get")}}: Controls the availability of {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with the `publicKey` option.
 
-Both directives have a default allowlist value of `"self"`, meaning that by default these methods can be used in top-level document contexts. In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document; `create()` on the other hand cannot be used in {{htmlelement("iframe")}}s.
+Both directives have a default allowlist value of `"self"`, meaning that by default these methods can be used in top-level document contexts. In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document. `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`).
 
-> **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises")}} returned by them will reject with a `SecurityError` {{domxref("DOMException")}}.
+> **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises")}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ### Basic access control
 
@@ -136,26 +136,38 @@ Permissions-Policy: publickey-credentials-create=("https://subdomain.example.com
 
 ### Allowing embedded `get()` calls in an `<iframe>`
 
-If you wish to authenticate with `get()` in an `<iframe>`, there are a couple of steps to follow:
+If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there are a couple of steps to follow:
 
 1. The site embedding the relying party site must provide permission via an `allow` attribute:
+
+   If using `get()`:
+
+   ```html
+   <iframe src="https://auth.provider.com" allow="publickey-credentials-get *">
+   </iframe>
+   ```
+
+   If using `set()`:
 
    ```html
    <iframe
      src="https://auth.provider.com"
-     allow="publickey-credentials-get *" />
+     allow="publickey-credentials-create 'self' https://a.auth.provider.com https://b.auth.provider.com">
+   </iframe>
    ```
 
 2. The relying party site must provide permission for the above access via a `Permissions-Policy` header:
 
    ```http
    Permissions-Policy: publickey-credentials-get=*
+   Permissions-Policy: publickey-credentials-set=*
    ```
 
    Or to allow only a specific URL to embed the relying party site in an `<iframe>`:
 
    ```http
    Permissions-Policy: publickey-credentials-get=("https://subdomain.example.com")
+   Permissions-Policy: publickey-credentials-set=("https://*.auth.provider.com")
    ```
 
 ## Interfaces

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -134,7 +134,7 @@ Permissions-Policy: publickey-credentials-get=("https://subdomain.example.com")
 Permissions-Policy: publickey-credentials-create=("https://subdomain.example.com")
 ```
 
-### Allowing embedded `get()` calls in an `<iframe>`
+### Allowing embedded `create` and `get()` calls in an `<iframe>`
 
 If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there are a couple of steps to follow:
 
@@ -156,7 +156,9 @@ If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there a
    </iframe>
    ```
 
-2. The relying party site must provide permission for the above access via a `Permissions-Policy` header:
+2. The `<iframe>` must also have {{glossary("Transient activation")}} when the methods are called.
+
+3. The relying party site must provide permission for the above access via a `Permissions-Policy` header:
 
    ```http
    Permissions-Policy: publickey-credentials-get=*

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -143,25 +143,25 @@ If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there a
 
 1. The site embedding the relying party site must provide permission via an `allow` attribute:
 
-   If using `get()`:
+   - If using `get()`:
 
-   ```html
-   <iframe src="https://auth.provider.com" allow="publickey-credentials-get *">
-   </iframe>
-   ```
+     ```html
+     <iframe src="https://auth.provider.com" allow="publickey-credentials-get *">
+     </iframe>
+     ```
 
-   If using `create()`:
+   - If using `create()`:
 
-   ```html
-   <iframe
-     src="https://auth.provider.com"
-     allow="publickey-credentials-create 'self' https://a.auth.provider.com https://b.auth.provider.com">
-   </iframe>
-   ```
+     ```html
+     <iframe
+       src="https://auth.provider.com"
+       allow="publickey-credentials-create 'self' https://a.auth.provider.com https://b.auth.provider.com">
+     </iframe>
+     ```
 
-2. The `<iframe>` must also have {{glossary("Transient activation")}} when the methods are called.
+     The `<iframe>` must also have {{glossary("Transient activation")}} if `create()` is called cross-origin.
 
-3. The relying party site must provide permission for the above access via a `Permissions-Policy` header:
+2. The relying party site must provide permission for the above access via a `Permissions-Policy` header:
 
    ```http
    Permissions-Policy: publickey-credentials-get=*

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -162,14 +162,14 @@ If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there a
 
    ```http
    Permissions-Policy: publickey-credentials-get=*
-   Permissions-Policy: publickey-credentials-set=*
+   Permissions-Policy: publickey-credentials-create=*
    ```
 
    Or to allow only a specific URL to embed the relying party site in an `<iframe>`:
 
    ```http
    Permissions-Policy: publickey-credentials-get=("https://subdomain.example.com")
-   Permissions-Policy: publickey-credentials-set=("https://*.auth.provider.com")
+   Permissions-Policy: publickey-credentials-create=("https://*.auth.provider.com")
    ```
 
 ## Interfaces

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -123,10 +123,10 @@ The availability of WebAuthn can be controlled using a [Permissions Policy](/en-
 
 Both directives have a default allowlist value of `"self"`, meaning that by default these methods can be used in top-level document contexts.
 In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document.
-`get()` and `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`), if allowed by the `Permission-Policy`s [`publickey-credentials-get`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) and [`publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create), respectively.
+`get()` and `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`), if allowed by the [`publickey-credentials-get`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) and [`publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) `Permission-Policy` directives, respectively.
 For cross-origin `create()` calls, where the permission was granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes), the frame must also have {{glossary("Transient activation")}}.
 
-> **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises")}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
+> **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises", "", "nocode")}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ### Basic access control
 

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -121,7 +121,8 @@ The availability of WebAuthn can be controlled using a [Permissions Policy](/en-
 - {{httpheader("Permissions-Policy/publickey-credentials-create", "publickey-credentials-create")}}: Controls the availability of {{domxref("CredentialsContainer.create", "navigator.credentials.create()")}} with the `publicKey` option.
 - {{httpheader("Permissions-Policy/publickey-credentials-get", "publickey-credentials-get")}}: Controls the availability of {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with the `publicKey` option.
 
-Both directives have a default allowlist value of `"self"`, meaning that by default these methods can be used in top-level document contexts. In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document. `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`).
+Both directives have a default allowlist value of `"self"`, meaning that by default these methods can be used in top-level document contexts.
+In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document. `get()` and `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`), if allowed by the `Permission-Policy`s [`publickey-credentials-get`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) and [`publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create), respectively.
 
 > **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises")}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -146,7 +146,9 @@ If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there a
    - If using `get()`:
 
      ```html
-     <iframe src="https://auth.provider.com" allow="publickey-credentials-get *">
+     <iframe
+       src="https://auth.provider.com"
+       allow="publickey-credentials-get *">
      </iframe>
      ```
 

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -150,7 +150,7 @@ If you wish to authenticate with `get()` or `create()` in an `<iframe>`, there a
    </iframe>
    ```
 
-   If using `set()`:
+   If using `create()`:
 
    ```html
    <iframe

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -122,7 +122,9 @@ The availability of WebAuthn can be controlled using a [Permissions Policy](/en-
 - {{httpheader("Permissions-Policy/publickey-credentials-get", "publickey-credentials-get")}}: Controls the availability of {{domxref("CredentialsContainer.get", "navigator.credentials.get()")}} with the `publicKey` option.
 
 Both directives have a default allowlist value of `"self"`, meaning that by default these methods can be used in top-level document contexts.
-In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document. `get()` and `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`), if allowed by the `Permission-Policy`s [`publickey-credentials-get`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) and [`publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create), respectively.
+In addition, `get()` can be used in nested browsing contexts loaded from the same origin as the top-most document.
+`get()` and `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`), if allowed by the `Permission-Policy`s [`publickey-credentials-get`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) and [`publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create), respectively.
+For cross-origin `create()` calls, where the permission was granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes), the frame must also have {{glossary("Transient activation")}}.
 
 > **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises")}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -23,6 +23,8 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
   - : Specifies a [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) for the `<iframe>`. The policy defines what features are available to the `<iframe>` (for example, access to the microphone, camera, battery, web-share, etc.) based on the origin of the request.
 
+    See [iframes](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) in the `Permissions-Policy` topic for examples.
+
     > **Note:** A Permissions Policy specified by the `allow` attribute implements a further restriction on top of the policy specified in the {{httpheader("Permissions-Policy")}} header. It doesn't replace it.
 
 - `allowfullscreen`

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-create/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-create/index.md
@@ -11,7 +11,8 @@ browser-compat: http.headers.Permissions-Policy.publickey-credentials-create
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `publickey-credentials-create` directive controls whether the current document is allowed to use the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to create new WebAuthn credentials, i.e., via {{domxref("CredentialsContainer.create","navigator.credentials.create({publicKey})")}}.
 
-Specifically, where a defined policy blocks use of this feature, the {{jsxref("Promise")}} returned by `navigator.credentials.create({publicKey})` will reject with a `SecurityError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks use of this feature, the {{jsxref("Promise")}} returned by `navigator.credentials.create({publicKey})` will reject with a `NotAllowedError` {{domxref("DOMException")}}.
+The {{jsxref("Promise")}} will also reject with a `NotAllowedError` if access to the feature is granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) and the frame does not also have {{glossary("Transient activation")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-create/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-create/index.md
@@ -12,7 +12,7 @@ browser-compat: http.headers.Permissions-Policy.publickey-credentials-create
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `publickey-credentials-create` directive controls whether the current document is allowed to use the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to create new WebAuthn credentials, i.e., via {{domxref("CredentialsContainer.create","navigator.credentials.create({publicKey})")}}.
 
 Specifically, where a defined policy blocks use of this feature, the {{jsxref("Promise")}} returned by `navigator.credentials.create({publicKey})` will reject with a `NotAllowedError` {{domxref("DOMException")}}.
-The {{jsxref("Promise")}} will also reject with a `NotAllowedError` if access to the feature is granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) and the frame does not also have {{glossary("Transient activation")}}.
+If the method is called cross-origin. the {{jsxref("Promise")}} will also reject with a `NotAllowedError` if the feature is granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) and the frame does not also have {{glossary("Transient activation")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
@@ -10,7 +10,6 @@ browser-compat: http.headers.Permissions-Policy.publickey-credentials-get
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `publickey-credentials-get` directive controls whether the current document is allowed to access the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to retrieve public-key credentials, i.e., via {{domxref("CredentialsContainer.get","navigator.credentials.get({publicKey})")}}.
 
 Specifically, where a defined policy blocks the use of this feature, the {{jsxref("Promise")}} returned by `navigator.credentials.get({publicKey})` will reject with a `NotAllowedError` {{domxref("DOMException")}}.
-The {{jsxref("Promise")}} will also reject with a `NotAllowedError` if access to the feature is granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) and the frame does not also have {{glossary("Transient activation")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/publickey-credentials-get/index.md
@@ -9,7 +9,8 @@ browser-compat: http.headers.Permissions-Policy.publickey-credentials-get
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `publickey-credentials-get` directive controls whether the current document is allowed to access the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) to retrieve public-key credentials, i.e., via {{domxref("CredentialsContainer.get","navigator.credentials.get({publicKey})")}}.
 
-Specifically, where a defined policy blocks the use of this feature, the {{jsxref("Promise")}} returned by `navigator.credentials.get({publicKey})` will reject with a `SecurityError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks the use of this feature, the {{jsxref("Promise")}} returned by `navigator.credentials.get({publicKey})` will reject with a `NotAllowedError` {{domxref("DOMException")}}.
+The {{jsxref("Promise")}} will also reject with a `NotAllowedError` if access to the feature is granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes) and the frame does not also have {{glossary("Transient activation")}}.
 
 ## Syntax
 


### PR DESCRIPTION
FF123 supports Feature policy [`publickey-credentials-create`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) in https://bugzilla.mozilla.org/show_bug.cgi?id=1870863
As per usual for FF, this can't be set on the header, but only via `allow` on the frame. 

This attempts to update the docs with some corrections according to advice from engineers and my interpretation of the spec. Note that I think there are probably more relevant exceptions, but I don't propose to go through all the specs right now.

The specific issues fixed are:
1. Docs say creating/getting a credential is a `SecurityError`. Spec says `NotAllowedError` [in step 5 here](https://w3c.github.io/webappsec-credential-management/#algorithm-create)
2. If allow is declared in an iframe then transient activation is required on the iframe as well, or you get the same error.
3. This explicitly said you can't use `create()` in an iframe, but that was changed in WebAuthn spec in https://github.com/w3c/webauthn/pull/1801 and to the Credential Management spec in https://github.com/w3c/webappsec-credential-management/pull/209. I added some examples.

I'm seeing confirmation from engineers too in https://bugzilla.mozilla.org/show_bug.cgi?id=1870863#c7 but the spec seems fairly clear on the NotAllowedError and transient activation.

Other docs work can be tracked in #31890