### PR TITLE
FF123 Relnote: WebAuthn credential createion in cross origin frames

### DIFF
--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -38,6 +38,10 @@ This article provides information about the changes in Firefox 123 that affect d
 
 ### APIs
 
+- The [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) now supports cross-origin credential creation.
+  Specifically [`navigator.credentials.create({publicKey})`](/en-US/docs/Web/API/CredentialsContainer/create) can now be called in nested browsing contexts loaded from a different origin to the top-most document, if allowed by a [`Feature-Policy: publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) on the top level nesting [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe#allow).
+  ([Firefox bug 1870863](https://bugzil.la/1870863)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF123 supports Feature policy [`publickey-credentials-create`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) to allow cross origin credential creation in https://bugzilla.mozilla.org/show_bug.cgi?id=1870863

This adds a release note 

Other docs work can be tracked in #31890