### PR TITLE
Add missing CORS header in preflight response example

### DIFF
--- a/files/en-us/glossary/preflight_request/index.md
+++ b/files/en-us/glossary/preflight_request/index.md
@@ -17,7 +17,7 @@ For example, a client might be asking a server if it would allow a {{HTTPMethod(
 ```http
 OPTIONS /resource/foo
 Access-Control-Request-Method: DELETE
-Access-Control-Request-Headers: origin, x-requested-with
+Access-Control-Request-Headers: Origin, X-Requested-With
 Origin: https://foo.bar.org
 ```
 
@@ -28,7 +28,7 @@ HTTP/1.1 204 No Content
 Connection: keep-alive
 Access-Control-Allow-Origin: https://foo.bar.org
 Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
-Access-Control-Allow-Headers: origin, x-requested-with
+Access-Control-Allow-Headers: Origin, X-Requested-With
 Access-Control-Max-Age: 86400
 ```
 

--- a/files/en-us/glossary/preflight_request/index.md
+++ b/files/en-us/glossary/preflight_request/index.md
@@ -28,6 +28,7 @@ HTTP/1.1 204 No Content
 Connection: keep-alive
 Access-Control-Allow-Origin: https://foo.bar.org
 Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
+Access-Control-Allow-Headers: origin, x-requested-with
 Access-Control-Max-Age: 86400
 ```
 


### PR DESCRIPTION
### Description

The [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) page's example sends an `Access-Control-Request-Headers` header, but the example response does not contain an `Access-Control-Allow-Headers` which is [required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers). This PR simply adds one.

### Motivation

Readers may believe that a server (wanting a preflight request to succeed) doesn't need to respond with an `Access-Control-Allow-Headers` header if the client sends an `Access-Control-Request-Headers` header.

### Additional details

N/A

### Related issues and pull requests

N/A
