### PR TITLE
Remove claim that the Link header is semantically equivalent to the HTML link element

### DIFF
--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -7,7 +7,7 @@ browser-compat: http.headers.Link
 
 {{HTTPSidebar}}
 
-The HTTP **`Link`** entity-header field provides a means for serializing one or more links in HTTP headers. It is semantically equivalent to the HTML {{HTMLElement("link")}} element.
+The HTTP **`Link`** entity-header field provides a means for serializing one or more links in HTTP headers. In many cases, it has the same effect as the HTML {{HTMLElement("link")}} element.
 
 > **Note:** Some browsers do not support the "icon" relation via HTTP ([FF#1185705](https://bugzilla.mozilla.org/show_bug.cgi?id=1185705)). Use HTML `<link rel="icon">` instead.
 


### PR DESCRIPTION
…TML \<link> element

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `Link` header is not equivalent to the `<link>` element. This PR would change "semantically equivalent" to "In many cases, it has the same effect as".

### Motivation

While this statement was part of RFC 5988, it [has been removed in the superseding RFC 8022](https://httpwg.org/specs/rfc8288.html#changes-from-rfc-5988).

This was [discussed](https://github.com/mnot/I-D/issues/141) at the time:

> > [the link header field] is semantically equivalent to the <LINK> element in HTML, as well as the atom:link feed-level element in Atom.
>
> No, it's not; an application has to opt into using the link header field.

In particular, the `rel` values for the `Link` header are defined by the [IANA Link Relations registry](https://www.iana.org/assignments/link-relations/link-relations.xhtml), and the `rel` values for the `<link>` element are defined by the [HTML5 spec](https://html.spec.whatwg.org/multipage/links.html#linkTypes) with extensions defined in the [microformats wiki](https://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions). 

### Additional details

For example, this works:

```html
<link rel="stylesheet" href="index.css">
```

but this doesn't:

```
Link: <index.css>; rel="stylesheet"
```

(it works in Firefox, but it [isn't standardized](https://github.com/whatwg/html/issues/8741) and [webkit declined to implement it](https://bugs.webkit.org/show_bug.cgi?id=20018#c17))

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/24870