### PR TITLE
Clarify "n lines *or less*" lines for text-wrap: balance

### DIFF
--- a/files/en-us/web/css/text-wrap/index.md
+++ b/files/en-us/web/css/text-wrap/index.md
@@ -41,7 +41,7 @@ The `text-wrap` property is specified as a single keyword chosen from the list o
 - `nowrap` {{experimental_inline}}
   - : Text does not wrap across lines. It will overflow its containing element rather than breaking onto a new line.
 - `balance`
-  - : Text is wrapped in a way that best balances the number of characters on each line, enhancing layout quality and legibility. Because counting characters and balancing them across multiple lines is computationally expensive, this value is only supported for blocks of text spanning a limited number of lines (six for Chromium and ten for Firefox).
+  - : Text is wrapped in a way that best balances the number of characters on each line, enhancing layout quality and legibility. Because counting characters and balancing them across multiple lines is computationally expensive, this value is only supported for blocks of text spanning a limited number of lines (six or less for Chromium and ten or less for Firefox).
 - `pretty`
   - : Results in the same behavior as `wrap`, except that the user agent will use a slower algorithm that favors better layout over speed. This is intended for body copy where good typography is favored over performance (for example, when the number of [orphans](/en-US/docs/Web/CSS/orphans) should be kept to a minimum).
 - `stable` {{experimental_inline}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- The original parenthetical mentioned "n lines for Chromium..." This modification changes it to "n lines *or less* for Chromium..."
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

- When I read the original parenthetical, I spent a brain cycle wondering if it's exactly `n` or `<= n`. Since I believe it's conveying the latter, I made the text more explicit.

<!-- ❓ Why are you making these changes and how do they help readers? -->
