### PR TITLE
Fixed small typo from "fdx" to "fox"

### DIFF
--- a/files/en-us/web/xpath/functions/translate/index.md
+++ b/files/en-us/web/xpath/functions/translate/index.md
@@ -56,7 +56,7 @@ Example
 Output
 
 ```plain
-The quick red fdx.
+The quick red fox.
 ```
 
 - If `XYZ` contains more characters than `abc`, the extra characters are ignored.


### PR DESCRIPTION
Output "The quick red fdx" has a minor typo.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Small typo for output example. "fdx" should be "fox".

### Motivation

I like cleaning.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
