### PR TITLE
Service Worker API: add link to web.dev lifecycle article

### DIFF
--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -127,8 +127,9 @@ In the future, service workers will be able to do a number of other useful thing
 
 ## See also
 
-- [ServiceWorker Cookbook](https://github.com/mdn/serviceworker-cookbook)
 - [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
+- [ServiceWorker Cookbook](https://github.com/mdn/serviceworker-cookbook)
+- [Service Worker Lifecycle](https://web.dev/articles/service-worker-lifecycle)
 - [Service workers basic code example](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker)
 - Web APIs that are related to the Service Worker API:
   - {{domxref("Background Fetch API", "", "", "nocode")}}

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -128,7 +128,6 @@ In the future, service workers will be able to do a number of other useful thing
 ## See also
 
 - [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
-- [ServiceWorker Cookbook](https://github.com/mdn/serviceworker-cookbook)
 - [Service Worker Lifecycle](https://web.dev/articles/service-worker-lifecycle)
 - [Service workers basic code example](https://github.com/mdn/dom-examples/tree/main/service-worker/simple-service-worker)
 - Web APIs that are related to the Service Worker API:


### PR DESCRIPTION
Added the extremely informative and useful web.dev article https://web.dev/articles/service-worker-lifecycle as a link in the See Also section and, for good measure, moved the link to the MDN docs Using Service Workers page to the top of that section.