### PR TITLE
chore(api): Remove unimplemented_inline macro from window.find() 'awholeword' param

### DIFF
--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -31,8 +31,8 @@ find(aString, aCaseSensitive, aBackwards, aWrapAround, aWholeWord, aSearchInFram
   - : A boolean value. If `true`, specifies a backward search.
 - `aWrapAround`
   - : A boolean value. If `true`, specifies a wrap around search.
-- `aWholeWord` {{Unimplemented_Inline}}
-  - : A boolean value. If `true`, specifies a whole word search. This is not implemented; see [Firefox bug 481513](https://bugzil.la/481513).
+- `aWholeWord`
+  - : A boolean value. If `true`, specifies a whole word search.
 - `aSearchInFrames`
   - : A boolean value. If `true`, specifies a search in frames.
 


### PR DESCRIPTION
### Description

This PR removes the only occurrence of `{{unimplemented_inline}}` in content.
Aside from the fact that it can be replaced with a note or prose, the actual issue itself appears to be no longer valid:

* codepen: https://codepen.io/bsmth/pen/JjzBLvV?editors=1111

So I am removing the "unimplemented" note entirely.

### Motivation

Removing unnecessary macros

### Additional details

* https://bugzil.la/481513
* https://github.com/orgs/mdn/discussions/637
