### PR TITLE
chore(a11y): Change 'See Also' to 'See also'

### DIFF
--- a/files/en-us/web/accessibility/accessibility_and_spacial_patterns/index.md
+++ b/files/en-us/web/accessibility/accessibility_and_spacial_patterns/index.md
@@ -54,7 +54,7 @@ Space has to surround the braille character. A user of braille does not lay a fi
 
 The nature of space can change depending upon what MIME type is being used, and its version. For example, borders on SVG can extend both inward and outward from its dimensions, or for newer versions of SVG, entirely outward from it, thus reducing the space around the SVG to enable perception.
 
-## See Also
+## See also
 
 ### MDN
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-activedescendant/index.md
@@ -48,7 +48,7 @@ Relevant only as an attribute on elements with the following roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 <section id="Quick_links">
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-atomic/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-atomic/index.md
@@ -30,7 +30,7 @@ Used in **ALL** [roles](/en-US/docs/Web/Accessibility/ARIA/Roles).
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [Event.ariaAtomic](/en-US/docs/Web/API/Element/ariaAtomic)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-autocomplete/index.md
@@ -53,7 +53,7 @@ Used in roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) role
 - [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role) role

--- a/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
@@ -47,7 +47,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
 - [`aria-brailleroledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-brailleroledescription)

--- a/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
@@ -65,7 +65,7 @@ Used in **ALL** roles (except [`generic`](/en-US/docs/Web/Accessibility/ARIA/Rol
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription).
 - [`Element.ariaRoleDescription`](/en-US/docs/Web/API/Element/ariaRoleDescription)

--- a/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-busy/index.md
@@ -67,7 +67,7 @@ Used in **ALL** roles
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
 - [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live)

--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -77,7 +77,7 @@ myHTMLElement.ariaChecked = true;
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox)
 - [`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)

--- a/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
@@ -83,7 +83,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindex/index.md
@@ -104,7 +104,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute
 - [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -90,7 +90,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`Element.ariaColIndexText`](/en-US/docs/Web/API/Element/ariaColIndexText)
 - [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex)

--- a/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
@@ -159,7 +159,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - The {{HTMLElement('th')}} and {{HTMLElement('td')}} [`colspan`](/en-US/docs/Web/HTML/Element/td#attributes) attribute
 - [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) property

--- a/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
@@ -93,7 +93,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
@@ -81,7 +81,7 @@ Usable in all roles; except in for elements with the role of [`gridcell`](/en-US
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)
 - {{cssxref(':local-link')}}

--- a/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
@@ -48,7 +48,7 @@ Used in **all** roles. Usable in all HTML elements as well.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - {{HTMLElement('label')}}
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)

--- a/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
@@ -49,7 +49,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [HTML `title` attribute](/en-US/docs/Web/HTML/Global_attributes/title)
 - [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)

--- a/files/en-us/web/accessibility/aria/attributes/aria-details/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-details/index.md
@@ -64,7 +64,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML [id](/en-US/docs/Web/HTML/Global_attributes/id) attribute
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -146,7 +146,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [Making disabled buttons more inclusive](https://css-tricks.com/making-disabled-buttons-more-inclusive/) by Sandrina Pereira
 - [Styling for Windows high contrast with new standards for forced colors](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/)

--- a/files/en-us/web/accessibility/aria/attributes/aria-dropeffect/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-dropeffect/index.md
@@ -52,7 +52,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-grabbed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-grabbed)
 - [HTML global `draggable` attribute](/en-US/docs/Web/HTML/Global_attributes/draggable)

--- a/files/en-us/web/accessibility/aria/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-errormessage/index.md
@@ -92,7 +92,7 @@ Inherits from roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML [`invalid`](/en-US/docs/Web/HTML/Global_attributes#invalid) attribute
 - CSS {{CSSxref(':invalid')}} pseudoclass

--- a/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
@@ -113,7 +113,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
 - [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns)

--- a/files/en-us/web/accessibility/aria/attributes/aria-flowto/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-flowto/index.md
@@ -32,7 +32,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML [id](/en-US/docs/Web/HTML/Global_attributes/id) attribute
 - HTML [tabindex](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute

--- a/files/en-us/web/accessibility/aria/attributes/aria-grabbed/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-grabbed/index.md
@@ -40,7 +40,7 @@ Used in **ALL** [roles](/en-US/docs/Web/Accessibility/ARIA/Roles)
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-dropeffect`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-dropeffect)
 - [HTML global `draggable` attribute](/en-US/docs/Web/HTML/Global_attributes/draggable)

--- a/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
@@ -76,7 +76,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
 - [`menu`](/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
@@ -81,7 +81,7 @@ Used in **ALL** roles
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)
 - [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal)

--- a/files/en-us/web/accessibility/aria/attributes/aria-invalid/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-invalid/index.md
@@ -141,7 +141,7 @@ Inherited into role:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-errormessage)
 - CSS {{CSSXRef(':valid')}} pseudoclass

--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -128,7 +128,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-keyshortcuts` best practices](https://www.w3.org/TR/wai-aria-practices-1.2/#kbd_shortcuts)
 - HTML [`accesskey`](/en-US/docs/Web/HTML/Global_attributes#accesskey) attribute

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -92,7 +92,7 @@ The `aria-label` attribute is **NOT** supported in:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - {{HTMLElement('label')}} element
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)

--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -112,7 +112,7 @@ The `aria-labelledby` attribute is **NOT** supported in:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement('label')}} element
 - HTML {{HTMLElement('legend')}} element

--- a/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-level/index.md
@@ -58,7 +58,7 @@ Used in roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`<h1>` through `<h6>`: The HTML Section Heading elements](/en-US/docs/Web/HTML/Element/Heading_Elements) ({{htmlelement("Heading_Elements", "h1")}}, {{htmlelement("Heading_Elements", "h2")}}, {{htmlelement("Heading_Elements", "h3")}}, {{htmlelement("Heading_Elements", "h4")}}, {{htmlelement("Heading_Elements", "h5")}}, and {{htmlelement("Heading_Elements", "h6")}})
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
@@ -79,7 +79,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic)
 - [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant)

--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -91,7 +91,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement("dialog")}} element
 - [`alertdialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role)

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
@@ -49,7 +49,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - ARIA [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role) role
 - ARIA [`searchbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role) role

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -154,7 +154,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement('select')}} element
 - HTML {{HTMLElement('option')}} element

--- a/files/en-us/web/accessibility/aria/attributes/aria-orientation/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-orientation/index.md
@@ -75,7 +75,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [Understanding WCAG: Keyboard](/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-owns/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-owns/index.md
@@ -57,7 +57,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-controls`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
 - [`aria-owns` browser support](https://a11ysupport.io/tech/aria/aria-owns_attribute)

--- a/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
@@ -60,7 +60,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [HTML `placeholder` attribute](/en-US/docs/Web/HTML/Element/input#placeholder)
 - [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)

--- a/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
@@ -71,7 +71,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-pressed/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-pressed/index.md
@@ -55,7 +55,7 @@ Used in roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`<input type="button">`](/en-US/docs/Web/HTML/Element/input/button)
 - [`<input type="submit">`](/en-US/docs/Web/HTML/Element/input/submit)

--- a/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
@@ -65,7 +65,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [HTML `readonly` attribute](/en-US/docs/Web/HTML/Attributes/readonly)
 - [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)

--- a/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
@@ -49,7 +49,7 @@ Used in **ALL** roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic)
 - [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live)

--- a/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
@@ -87,7 +87,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML [`required`](/en-US/docs/Web/HTML/Element/input#required) attribute
 - [`:optional` pseudoclass](/en-US/docs/Web/CSS/:optional)

--- a/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
@@ -68,7 +68,7 @@ Supported by all roles and by all base markup elements except for `role="generic
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA roles](/en-US/docs/Web/Accessibility/ARIA/Roles)
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowcount/index.md
@@ -75,7 +75,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
 - [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount)

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
@@ -91,7 +91,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext)
 - [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount)

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindextext/index.md
@@ -44,7 +44,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)
 - [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount)

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
@@ -44,7 +44,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - The [`rowspan`](/en-US/docs/Web/HTML/Element/td#rowspan) attribute on {{HTMLElement('td')}}
 - [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex)

--- a/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
@@ -122,7 +122,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed)
 - [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked)

--- a/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-setsize/index.md
@@ -81,7 +81,7 @@ Inherits into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset)
 - [Treegrid Email Inbox](https://www.w3.org/TR/2019/WD-wai-aria-practices-1.2-20191218/examples/treegrid/treegrid-1.html) example

--- a/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
@@ -77,7 +77,7 @@ Used in roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [Sortable table example](https://www.w3.org/TR/wai-aria-practices-1.2/examples/table/sortable-table.html) -W3C
 - [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
@@ -66,7 +66,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`range` role](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role)
 - [`<input type="range>` element `max` attribute](/en-US/docs/Web/HTML/Element/input/range#max)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
@@ -53,7 +53,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`range` role](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role)
 - [`<input type="range>` element `min` attribute](/en-US/docs/Web/HTML/Element/input/range#min)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -115,7 +115,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`range` role](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role)
 - [`<input type="range>` element `value` attribute](/en-US/docs/Web/HTML/Element/input/range#value)

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuetext/index.md
@@ -51,7 +51,7 @@ Inherited into roles:
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow)
 

--- a/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -95,7 +95,7 @@ The code snippet above shows how to mark up an alert dialog that only provides a
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement("dialog")}} element
 - [The `dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)

--- a/files/en-us/web/accessibility/aria/roles/columnheader_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/columnheader_role/index.md
@@ -70,7 +70,7 @@ Columnheader has the same semantics `<th scope="col">`.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`table` role](/en-US/docs/Web/Accessibility/ARIA/Roles/table_role)
 - [`grid` role](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role)

--- a/files/en-us/web/accessibility/aria/roles/command_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/command_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `widget` role](/en-US/docs/Web/Accessibility/ARIA/Roles/widget_role)
 - [ARIA: `button` role](/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)

--- a/files/en-us/web/accessibility/aria/roles/composite_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/composite_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `widget` role](/en-US/docs/Web/Accessibility/ARIA/Roles/widget_role)
 - [ARIA: `grid` role](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role)

--- a/files/en-us/web/accessibility/aria/roles/definition_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/definition_role/index.md
@@ -36,7 +36,7 @@ The `definition` ARIA role can be included on an element that is a definition of
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [The `term` role](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role)
 - The {{HTMLElement('dfn')}} element

--- a/files/en-us/web/accessibility/aria/roles/directory_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/directory_role/index.md
@@ -22,7 +22,7 @@ Use the [`list`](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role) role instea
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [The `list` role](/en-US/docs/Web/Accessibility/ARIA/Roles/list_role)
 - The {{HTMLElement('ul')}} element

--- a/files/en-us/web/accessibility/aria/roles/generic_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/generic_role/index.md
@@ -33,7 +33,7 @@ This role is for use by user agents and not by developers. As such, no appropria
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement('div')}} and {{HTMLElement('span')}} elements
 - [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) roles such as

--- a/files/en-us/web/accessibility/aria/roles/group_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/group_role/index.md
@@ -89,7 +89,7 @@ This menu could be constructed using {{HTMLElement('select')}} and {{HTMLElement
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - The {{HTMLElement('fieldset')}} Element
 - [ARIA: `section` role](/en-US/docs/Web/Accessibility/ARIA/Roles/section_role)

--- a/files/en-us/web/accessibility/aria/roles/input_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/input_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `widget` role](/en-US/docs/Web/Accessibility/ARIA/Roles/widget_role)
 - [ARIA: `checkbox` role](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)

--- a/files/en-us/web/accessibility/aria/roles/landmark_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/landmark_role/index.md
@@ -29,7 +29,7 @@ Landmarks ensure content is in navigable regions. Use {{HTMLElement('main')}} fo
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `section` role](/en-US/docs/Web/Accessibility/ARIA/Roles/section_role)
 - [ARIA: `banner` role](/en-US/docs/Web/Accessibility/ARIA/Roles/banner_role)

--- a/files/en-us/web/accessibility/aria/roles/log_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/log_role/index.md
@@ -37,7 +37,7 @@ With an area that has scrolling text, such as a stock ticker, the [`marquee`](/e
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
 - [ARIA: `marquee` role](/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role)

--- a/files/en-us/web/accessibility/aria/roles/marquee_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/marquee_role/index.md
@@ -29,7 +29,7 @@ The marquee is required to have an accessible name. Use [`aria-labelledby`](/en-
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
 - [ARIA: `log` role](/en-US/docs/Web/Accessibility/ARIA/Roles/log_role)

--- a/files/en-us/web/accessibility/aria/roles/math_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/math_role/index.md
@@ -42,7 +42,7 @@ Had an image been used, the `alt` attribute would be used along with the `math` 
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [MathML on MDN](/en-US/docs/Web/MathML) and the [`<math>`](/en-US/docs/Web/MathML/Element/math) element (not HTML)
 - [The MathML specification](https://www.w3.org/TR/MathML3/)

--- a/files/en-us/web/accessibility/aria/roles/menu_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menu_role/index.md
@@ -185,7 +185,7 @@ The navigation example has a static button. The submenu example has a button tha
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`menubar`](/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role)
 - [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role)

--- a/files/en-us/web/accessibility/aria/roles/menubar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menubar_role/index.md
@@ -87,7 +87,7 @@ Note: The above interactions assumed the `menubar` is horizontal. If the `menuba
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`toolbar` role](/en-US/docs/Web/Accessibility/ARIA/Roles/toolbar_role)
 

--- a/files/en-us/web/accessibility/aria/roles/menuitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menuitem_role/index.md
@@ -107,7 +107,7 @@ When items in a `menubar` are arranged vertically and items in menu containers a
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`menuitemcheckbox` role](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role)
 - [`menuitemradio` role](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role)

--- a/files/en-us/web/accessibility/aria/roles/menuitemcheckbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menuitemcheckbox_role/index.md
@@ -131,7 +131,7 @@ The first rule of ARIA is: if a native HTML element or attribute has the semanti
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`menuitemradio` role](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role)
 - [`checkbox` role](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)

--- a/files/en-us/web/accessibility/aria/roles/menuitemradio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menuitemradio_role/index.md
@@ -142,7 +142,7 @@ The first rule of ARIA is: if a native HTML element or attribute has the semanti
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`radio` role](/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role)
 - [`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)

--- a/files/en-us/web/accessibility/aria/roles/note_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/note_role/index.md
@@ -42,7 +42,7 @@ In the above Wikipedia style entry for Madam C.J. Walker, the `hilitebox` with r
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [Document structure roles](/en-US/docs/Web/Accessibility/ARIA/Roles#1._document_structure_roles)
 

--- a/files/en-us/web/accessibility/aria/roles/presentation_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/presentation_role/index.md
@@ -53,7 +53,7 @@ None. If a global ARIA state and property is set, `presentation` or `none` will 
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) versus [`role="presentation/none"`](https://www.scottohara.me/blog/2018/05/05/hidden-vs-none.html) - by Scott O'Hara
 

--- a/files/en-us/web/accessibility/aria/roles/progressbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/progressbar_role/index.md
@@ -94,7 +94,7 @@ It is recommended to use a native {{HTMLElement("progress")}} or [`<input type="
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement('progress')}} element
 - Other range widgets include:

--- a/files/en-us/web/accessibility/aria/roles/radiogroup_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radiogroup_role/index.md
@@ -141,7 +141,7 @@ In this {{HTMLElement('fieldset')}} example, while `role="radiogroup"` is not ne
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - HTML {{HTMLElement('fieldset')}} element
 - HTML {{HTMLElement('input/radio', '&lt;input type="radio">')}} radio button element

--- a/files/en-us/web/accessibility/aria/roles/range_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/range_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `structure` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structure_role)
 - [ARIA: `meter` role](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role)

--- a/files/en-us/web/accessibility/aria/roles/roletype_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/roletype_role/index.md
@@ -22,7 +22,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `structure` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structure_role)
 - [ARIA: `widget` role](/en-US/docs/Web/Accessibility/ARIA/Roles/widget_role)

--- a/files/en-us/web/accessibility/aria/roles/scrollbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/scrollbar_role/index.md
@@ -154,7 +154,7 @@ The above CSS means a native scroll bar will appear when the user interacts with
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`<input type="range">`](/en-US/docs/Web/HTML/Element/input/range),
 - HTML {{HTMLElement('progress')}} element

--- a/files/en-us/web/accessibility/aria/roles/searchbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/searchbox_role/index.md
@@ -61,7 +61,7 @@ Including `role="searchbox"` when the form is a `search` and the label indicates
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`<input type="search">`](/en-US/docs/Web/HTML/Element/input/search)
 - [ARIA: `search` role](/en-US/docs/Web/Accessibility/ARIA/Roles/search_role)

--- a/files/en-us/web/accessibility/aria/roles/section_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/section_role/index.md
@@ -22,7 +22,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `structure` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structure_role)
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)

--- a/files/en-us/web/accessibility/aria/roles/sectionhead_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/sectionhead_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `structure` role](/en-US/docs/Web/Accessibility/ARIA/Roles/structure_role)
 - [ARIA: `columnheader` role](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role)

--- a/files/en-us/web/accessibility/aria/roles/select_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/select_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `composite` role](/en-US/docs/Web/Accessibility/ARIA/Roles/composite_role)
 - [ARIA: `group` role](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role)

--- a/files/en-us/web/accessibility/aria/roles/separator_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/separator_role/index.md
@@ -120,7 +120,7 @@ From the assistive technology user's perspective, the heading does not exist sin
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - Thematic break HTML {{HTMLElement('hr')}} element
 - [Example separator in a menubar](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/)

--- a/files/en-us/web/accessibility/aria/roles/status_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/status_role/index.md
@@ -33,7 +33,7 @@ Elements with the role status have an implicit [`aria-live`](/en-US/docs/Web/Acc
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
 - [ARIA: `log` role](/en-US/docs/Web/Accessibility/ARIA/Roles/log_role)

--- a/files/en-us/web/accessibility/aria/roles/structural_roles/index.md
+++ b/files/en-us/web/accessibility/aria/roles/structural_roles/index.md
@@ -55,7 +55,7 @@ Do not use structural roles. Opt for HTML semantic elements instead.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 <section id="Quick_links">
 

--- a/files/en-us/web/accessibility/aria/roles/structure_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/structure_role/index.md
@@ -25,7 +25,7 @@ Do not use `role="structure"`. Do use HTML and subclass structure roles.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `roletype` role](/en-US/docs/Web/Accessibility/ARIA/Roles/roletype_role)
 - [ARIA: `generic` role](/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role)

--- a/files/en-us/web/accessibility/aria/roles/tablist_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tablist_role/index.md
@@ -94,7 +94,7 @@ See the [`tabpanel`, `tab`, and `tablist` example](/en-US/docs/Web/Accessibility
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [`tab` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role)
 - [`tabpanel` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role)

--- a/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.md
@@ -62,7 +62,7 @@ See the [`tabpanel`, `tab`, and `tablist` example](/en-US/docs/Web/Accessibility
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA `tab` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role)
 - [ARIA `tablist` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role)

--- a/files/en-us/web/accessibility/aria/roles/term_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/term_role/index.md
@@ -82,7 +82,7 @@ Allow the term itself to define the accessible name. Do not use `aria-label` or 
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `definition` role](/en-US/docs/Web/Accessibility/ARIA/Roles/definition_role).
 - The HTML {{HTMLElement('dfn')}} element

--- a/files/en-us/web/accessibility/aria/roles/toolbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/toolbar_role/index.md
@@ -96,7 +96,7 @@ If any of the otherwise interactive elements within the toolbar are disabled, co
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [The CSS `:focus` pseudoclass](/en-US/docs/Web/CSS/:focus)
 - [The CSS `:focus-within` pseudoclass](/en-US/docs/Web/CSS/:focus-within)

--- a/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tooltip_role/index.md
@@ -109,7 +109,7 @@ Instead of using tooltips and hiding important information, consider writing cle
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [The `dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
 - [CSS: `:focus` pseudoclass](/en-US/docs/Web/CSS/:focus)

--- a/files/en-us/web/accessibility/aria/roles/tree_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tree_role/index.md
@@ -235,7 +235,7 @@ The alternative multi-selection model is a modifier key model in which moving fo
 
 {{Specifications}}
 
-## See Also
+## See also
 
 <section id="Quick_links">
 

--- a/files/en-us/web/accessibility/aria/roles/treegrid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/treegrid_role/index.md
@@ -151,7 +151,7 @@ It is important for all cells to be able to receive or contain keyboard focus be
 
 {{Specifications}}
 
-## See Also
+## See also
 
 <section id="Quick_links">
 

--- a/files/en-us/web/accessibility/aria/roles/treeitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/treeitem_role/index.md
@@ -232,7 +232,7 @@ If the tree has more than 7 tree items, including type ahead functionality is re
 
 {{Specifications}}
 
-## See Also
+## See also
 
 <section id="Quick_links">
 

--- a/files/en-us/web/accessibility/aria/roles/widget_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/widget_role/index.md
@@ -25,7 +25,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `roletype` role](/en-US/docs/Web/Accessibility/ARIA/Roles/roletype_role)
 

--- a/files/en-us/web/accessibility/aria/roles/window_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/window_role/index.md
@@ -21,7 +21,7 @@ Do not use.
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - [ARIA: `roletype` role](/en-US/docs/Web/Accessibility/ARIA/Roles/roletype_role)
 - [ARIA: `dialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)

--- a/files/en-us/web/css/css_nesting/nesting_and_specificity/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_and_specificity/index.md
@@ -46,7 +46,7 @@ In this example, the id selector (`#a`) has a specificity of [`1-0-0`](/en-US/do
 
 The `.foo` class selector has a specificity of `0-1-0`. This makes the total specificity `1-0-1` for `& c` and `0-1-1` for `.foo c`, meaning that `color: blue;` wins out.
 
-## See Also
+## See also
 
 - [CSS nesting](/en-US/docs/Web/CSS/CSS_nesting) module
 - [`&` nesting selector](/en-US/docs/Web/CSS/Nesting_selector)

--- a/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
+++ b/files/en-us/web/css/css_nesting/nesting_at-rules/index.md
@@ -142,7 +142,7 @@ Here the `.foo` selector assigns its rules to the **base** `@layer`. The nested 
 }
 ```
 
-## See Also
+## See also
 
 - [CSS Nesting](/en-US/docs/Web/CSS/CSS_nesting) module
 - [`&` nesting selector](/en-US/docs/Web/CSS/Nesting_selector)

--- a/files/en-us/web/css/css_ruby_layout/index.md
+++ b/files/en-us/web/css/css_ruby_layout/index.md
@@ -20,6 +20,6 @@ The **CSS ruby layout** module provides the rendering model and formatting contr
 
 {{Specifications}}
 
-## See Also
+## See also
 
 - {{HTMLElement('ruby')}}


### PR DESCRIPTION

### Description

There's a discrepancy between usage of "See Also" v "See also" section heading.

### Motivation

The writing guidelines require sentence casing for section titles.

See https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#titles
