### PR TITLE
Add correct form action

### DIFF
--- a/files/en-us/web/http/headers/content-type/index.md
+++ b/files/en-us/web/http/headers/content-type/index.md
@@ -68,7 +68,7 @@ Content-Type: multipart/form-data; boundary=something
 In a {{HTTPMethod("POST")}} request, resulting from an HTML form submission, the `Content-Type` of the request is specified by the `enctype` attribute on the {{HTMLElement("form")}} element.
 
 ```html
-<form action="/" method="post" enctype="multipart/form-data">
+<form action="/foo" method="post" enctype="multipart/form-data">
   <input type="text" name="description" value="some text" />
   <input type="file" name="myFile" />
   <button type="submit">Submit</button>

--- a/files/en-us/web/http/headers/content-type/index.md
+++ b/files/en-us/web/http/headers/content-type/index.md
@@ -9,7 +9,8 @@ browser-compat: http.headers.Content-Type
 
 The **`Content-Type`** representation header is used to indicate the original {{Glossary("MIME type","media type")}} of the resource (prior to any content encoding applied for sending).
 
-In responses, a `Content-Type` header provides the client with the actual content type of the returned content. This header's value may be ignored, for example when browsers perform MIME sniffing; set the {{HTTPHeader("X-Content-Type-Options")}} header value to `nosniff` to prevent this behavior.
+In responses, a `Content-Type` header provides the client with the actual content type of the returned content.
+This header's value may be ignored, for example when browsers perform MIME sniffing; set the {{HTTPHeader("X-Content-Type-Options")}} header value to `nosniff` to prevent this behavior.
 
 In requests, (such as {{HTTPMethod("POST")}} or {{HTTPMethod("PUT")}}), the client tells the server what type of data is actually sent.
 
@@ -34,12 +35,8 @@ In requests, (such as {{HTTPMethod("POST")}} or {{HTTPMethod("PUT")}}), the clie
         {{Glossary("CORS-safelisted request header")}}
       </th>
       <td>
-        yes, with the additional restriction that values can't contain a
-        <em>CORS-unsafe request header byte</em>: 0x00-0x1F (except 0x09 (HT)),
-        <code>"():&#x3C;>?@[\]{}</code>, and 0x7F (DEL).<br />It also needs to
-        have a MIME type of its parsed value (ignoring parameters) of either
-        <code>application/x-www-form-urlencoded</code>,
-        <code>multipart/form-data</code>, or <code>text/plain</code>.
+        yes, with the additional restriction that values can't contain a <em>CORS-unsafe request header byte</em>: 0x00-0x1F (except 0x09 (HT)), <code>"():&#x3C;>?@[\]{}</code>, and 0x7F (DEL).
+        <br />It also needs to have a MIME type of its parsed value (ignoring parameters) of either <code>application/x-www-form-urlencoded</code>, <code>multipart/form-data</code>, or <code>text/plain</code>.
       </td>
     </tr>
   </tbody>
@@ -59,7 +56,10 @@ Content-Type: multipart/form-data; boundary=something
 - charset
   - : The character encoding standard. Case insensitive, lowercase is preferred.
 - boundary
-  - : For multipart entities the `boundary` directive is required. The directive consists of 1 to 70 characters from a set of characters (and not ending with white space) known to be very robust through email gateways. It is used to encapsulate the boundaries of the multiple parts of the message. Often, the header boundary is prepended with two dashes and the final boundary has two dashes appended at the end.
+  - : For multipart entities the `boundary` directive is required.
+    The directive consists of 1 to 70 characters from a set of characters (and not ending with white space) known to be very robust through email gateways.
+    It is used to encapsulate the boundaries of the multiple parts of the message.
+    Often, the header boundary is prepended with two dashes and the final boundary has two dashes appended at the end.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The HTML form example is lacking the correct action (`/foo` in this instance), as evident from the header outputs displayed below the HTML form (`POST /foo HTTP/1.1`)

### Motivation

The readers may be confused about why the header output path points to `POST /foo`, due that HTML form action is set to `<form action="/" method="post" enctype="multipart/form-data">`

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

MDN Page: [Content-Type in HTML forms](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#content-type_in_html_forms)
