### PR TITLE
Canvas API: Remove "false" from addEventListener

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -69,12 +69,9 @@ If you try to call `drawImage()` before the image has finished loading, it won't
 
 ```js
 const img = new Image(); // Create new img element
-img.addEventListener(
-  "load",
-  () => {
-    // execute drawImage statements here
-  }
-);
+img.addEventListener("load", () => {
+  // execute drawImage statements here
+});
 img.src = "myImage.png"; // Set source path
 ```
 

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -73,8 +73,7 @@ img.addEventListener(
   "load",
   () => {
     // execute drawImage statements here
-  },
-  false,
+  }
 );
 img.src = "myImage.png"; // Set source path
 ```


### PR DESCRIPTION
Removed the capture third argument to the addEventLIstener  because it is false by default.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Removed the capture third argument of addEventListener 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
because the third argument is false by default so it is redundant

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
