### PR TITLE
Fix mischanged words

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/copywithin/index.md
@@ -36,7 +36,7 @@ copyWithin(target, start, end)
     - Negative index counts back from the end of the array — if `-array.length <= end < 0`, `end + array.length` is used.
     - If `end < -array.length`, `0` is used.
     - If `end >= array.length` or `end` is omitted, `array.length` is used, causing all elements until the end to be copied.
-    - If `end` implies a position before or at the position that `start` implies, nothing is extracted.
+    - If `end` implies a position before or at the position that `start` implies, nothing is copied.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
@@ -33,7 +33,7 @@ fill(value, start, end)
     - Negative index counts back from the end of the array — if `-array.length <= end < 0`, `end + array.length` is used.
     - If `end < -array.length`, `0` is used.
     - If `end >= array.length` or `end` is omitted, `array.length` is used, causing all indices until the end to be filled.
-    - If `end` implies a position before or at the position that `start` implies, nothing is extracted.
+    - If `end` implies a position before or at the position that `start` implies, nothing is filled.
 
 ### Return value
 


### PR DESCRIPTION
Two of the function do not extract. Correct them back to the word used originally.
