### PR TITLE
Remove incorrect note for document.createEvent

### DIFF
--- a/files/en-us/web/api/document/createevent/index.md
+++ b/files/en-us/web/api/document/createevent/index.md
@@ -58,33 +58,6 @@ Event type strings suitable for passing to `createEvent()` are listed in the
 [DOM standard — see the table in step 2](https://dom.spec.whatwg.org/#dom-document-createevent). Bear in mind that most event objects now have constructors, which
 are the modern recommended way to create event object instances.
 
-Gecko supports some non-standard event object aliases, which are listed below.
-
-<table class="fullwidth-table">
-  <tbody>
-    <tr>
-      <th>Event Module</th>
-      <th>Standard event object</th>
-      <th>Gecko also supports</th>
-    </tr>
-    <tr>
-      <td>Text event module</td>
-      <td><code>TextEvent</code></td>
-      <td><code>TextEvents</code></td>
-    </tr>
-    <tr>
-      <td>Keyboard event module</td>
-      <td><code>KeyboardEvent</code></td>
-      <td><code>KeyEvents</code></td>
-    </tr>
-    <tr>
-      <td>Basic events module</td>
-      <td><code>Event</code></td>
-      <td><code>Events</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
`TextEvents` and `KeyEvents` are not supported in Gecko, and `Events` is in the DOM standard.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

See above.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

See above.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
