### PR TITLE
WebGPU examples: remove TS from JS

### DIFF
--- a/files/en-us/web/api/gpudevice/createtexture/index.md
+++ b/files/en-us/web/api/gpudevice/createtexture/index.md
@@ -127,13 +127,13 @@ In the WebGPU samples [Textured Cube sample](https://webgpu.github.io/webgpu-sam
 ```js
 //...
 
-let cubeTexture: GPUTexture; // Sample is written in TypeScript
+let cubeTexture;
 
 {
   const img = document.createElement("img");
   img.src = new URL(
     "../../../assets/img/Di-3d.png",
-    import.meta.url
+    import.meta.url,
   ).toString();
   await img.decode();
   const imageBitmap = await createImageBitmap(img);
@@ -149,7 +149,7 @@ let cubeTexture: GPUTexture; // Sample is written in TypeScript
   device.queue.copyExternalImageToTexture(
     { source: imageBitmap },
     { texture: cubeTexture },
-    [imageBitmap.width, imageBitmap.height]
+    [imageBitmap.width, imageBitmap.height],
   );
 }
 

--- a/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
+++ b/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
@@ -179,16 +179,17 @@ The following criteria must be met when calling **`writeTexture()`**, otherwise 
 In the WebGPU Samples [Textured Cube example](https://webgpu.github.io/webgpu-samples/samples/texturedCube), the following snippet is used to fetch an image and upload it into a {{domxref("GPUTexture")}}:
 
 ```js
+let cubeTexture;
 {
   const img = document.createElement("img");
   img.src = new URL(
     "../../../assets/img/Di-3d.png",
-    import.meta.url
+    import.meta.url,
   ).toString();
   await img.decode();
   const imageBitmap = await createImageBitmap(img);
 
-  const cubeTexture = device.createTexture({
+  cubeTexture = device.createTexture({
     size: [imageBitmap.width, imageBitmap.height, 1],
     format: "rgba8unorm",
     usage:
@@ -200,7 +201,7 @@ In the WebGPU Samples [Textured Cube example](https://webgpu.github.io/webgpu-sa
   device.queue.copyExternalImageToTexture(
     { source: imageBitmap },
     { texture: cubeTexture },
-    [imageBitmap.width, imageBitmap.height]
+    [imageBitmap.width, imageBitmap.height],
   );
 }
 ```

--- a/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
+++ b/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
@@ -179,7 +179,6 @@ The following criteria must be met when calling **`writeTexture()`**, otherwise 
 In the WebGPU Samples [Textured Cube example](https://webgpu.github.io/webgpu-samples/samples/texturedCube), the following snippet is used to fetch an image and upload it into a {{domxref("GPUTexture")}}:
 
 ```js
-let cubeTexture: GPUTexture; // TypeScript
 {
   const img = document.createElement("img");
   img.src = new URL(
@@ -189,7 +188,7 @@ let cubeTexture: GPUTexture; // TypeScript
   await img.decode();
   const imageBitmap = await createImageBitmap(img);
 
-  cubeTexture = device.createTexture({
+  const cubeTexture = device.createTexture({
     size: [imageBitmap.width, imageBitmap.height, 1],
     format: "rgba8unorm",
     usage:

--- a/files/en-us/web/api/gpurenderbundleencoder/draw/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/draw/index.md
@@ -42,9 +42,7 @@ None ({{jsxref("Undefined")}}).
 ## Examples
 
 ```js
-function recordRenderPass(
-  passEncoder: GPURenderBundleEncoder | GPURenderPassEncoder // TypeScript
-) {
+function recordRenderPass(passEncoder) {
   if (settings.dynamicOffsets) {
     passEncoder.setPipeline(dynamicPipeline);
   } else {

--- a/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
@@ -66,9 +66,7 @@ The following criteria must be met when calling **`setBindGroup()`**, otherwise 
 ## Examples
 
 ```js
-function recordRenderPass(
-  passEncoder: GPURenderBundleEncoder | GPURenderPassEncoder // TypeScript
-) {
+function recordRenderPass(passEncoder) {
   if (settings.dynamicOffsets) {
     passEncoder.setPipeline(dynamicPipeline);
   } else {

--- a/files/en-us/web/api/gpurenderbundleencoder/setpipeline/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setpipeline/index.md
@@ -40,9 +40,7 @@ The following criteria must be met when calling **`setPipeline()`**, otherwise a
 ## Examples
 
 ```js
-function recordRenderPass(
-  passEncoder: GPURenderBundleEncoder | GPURenderPassEncoder // TypeScript
-) {
+function recordRenderPass(passEncoder) {
   if (settings.dynamicOffsets) {
     passEncoder.setPipeline(dynamicPipeline);
   } else {

--- a/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
@@ -50,9 +50,7 @@ The following criteria must be met when calling **`setVertexBuffer()`**, otherwi
 ### Set vertex buffer
 
 ```js
-function recordRenderPass(
-  passEncoder: GPURenderBundleEncoder | GPURenderPassEncoder // TypeScript
-) {
+function recordRenderPass(passEncoder) {
   if (settings.dynamicOffsets) {
     passEncoder.setPipeline(dynamicPipeline);
   } else {

--- a/files/en-us/web/api/gputexture/index.md
+++ b/files/en-us/web/api/gputexture/index.md
@@ -53,13 +53,13 @@ In the WebGPU samples [Textured Cube sample](https://webgpu.github.io/webgpu-sam
 
 ```js
 //...
-let cubeTexture: GPUTexture; // Sample is written in TypeScript
+let cubeTexture;
 {
   const img = document.createElement("img");
 
   img.src = new URL(
     "../../../assets/img/Di-3d.png",
-    import.meta.url
+    import.meta.url,
   ).toString();
 
   await img.decode();
@@ -78,7 +78,7 @@ let cubeTexture: GPUTexture; // Sample is written in TypeScript
   device.queue.copyExternalImageToTexture(
     { source: imageBitmap },
     { texture: cubeTexture },
-    [imageBitmap.width, imageBitmap.height]
+    [imageBitmap.width, imageBitmap.height],
   );
 }
 //...


### PR DESCRIPTION
This PR removes TypeScript syntax from our JavaScript examples.  **We should never be using TypeScript syntax in examples, unless it is explicitly a TypeScript example.**