### PR TITLE
chore(macros): Remove 'Xref_cssinitial', 'Xref_cssinherited', 'Xref_csscomputed', 'NonStandardBadge'

### DIFF
--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -42,7 +42,7 @@ deleteDatabase(name, options)
     database that doesn't exist does not throw an exception, in contrast to
     {{DOMxRef("IDBDatabase.deleteObjectStore()")}}, which does throw an exception if the
     named object store does not exist.
-- `options` {{optional_inline}} {{NonStandardBadge}}
+- `options` {{optional_inline}} {{Non-standard_Inline}}
   - : In Gecko, since [version 26](/en-US/docs/Mozilla/Firefox/Releases/26), you can include
     a non-standard optional storage parameter that specifies whether you want to delete a
     `permanent` (the default value) IndexedDB, or an indexedDB in

--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -77,10 +77,10 @@ Border repeat styles, when included, are interpreted in the order of `<repeat-x>
 
 ## Formal definition
 
-- {{ Xref_cssinitial() }}: `none`
+- [Initial value](/en-US/docs/Web/CSS/initial_value): `none`
 - Applies to: all elements
-- {{ Xref_cssinherited() }}: no
-- {{ Xref_csscomputed() }}: as specified
+- [Inherited](/en-US/docs/Web/CSS/Inheritance): no
+- [Computed value](/en-US/docs/Web/CSS/computed_value): as specified
 
 ## Formal syntax
 


### PR DESCRIPTION
### Description

This PR removes the only occurrences of the following macros in content:

- `{{Xref_cssinitial}}`
- `{{Xref_cssinherited}}`
- `{{Xref_csscomputed}}`
- `{{NonStandardBadge}}`

There are no other uses of these macros and they can be replaced with regular Markdown links.

In the case of `{{NonStandardBadge}}`, replaced with `{{non-standard_inline}}` which appears to have the same effect.

### Motivation

Removing unnecessary macros
