### PR TITLE
Remove paragraph explaining deleted example

### DIFF
--- a/files/en-us/web/css/hyphenate-limit-chars/index.md
+++ b/files/en-us/web/css/hyphenate-limit-chars/index.md
@@ -11,8 +11,6 @@ The **`hyphenate-limit-chars`** [CSS](/en-US/docs/Web/CSS) property specifies th
 
 This property provides you with fine-grained control over hyphenation in text. This control enables you to avoid awkward hyphenations and set appropriate hyphenation for different languages, which, in turn, allows for better typography.
 
-In the interactive example above, the default minimum word length setting of `hyphenate-limit-chars` is too large for either of the long words to be hyphenated, and so the output looks untidy. However, by choosing the other value option, the minimum word length limit is reduced. This allows both the long words to be hyphenated, making for a neater layout.
-
 ## Syntax
 
 ```css


### PR DESCRIPTION
The example content was removed in
2344afbffd22b7932b755d6c74b8242ededdfbd2

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove a paragraph that opens, "In the interactive example above...", where the example itself has already been removed.

### Motivation

Without the example, the explanation makes no sense.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #32160


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
