### PR TITLE
new document for HTMLInputElement.{selectionStart, selectionEnd, selectionDirection} properties 

### DIFF
--- a/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
@@ -12,9 +12,7 @@ The **`selectionDirection`** property of the {{domxref("HTMLInputElement")}} int
 
 ## Value
 
-A string.
-
-It can have one of the following values:
+A string. It can have one of the following values:
 
 - `forward`
   - : The user is extending the selection towards the end of the input text.
@@ -27,7 +25,7 @@ It can have one of the following values:
 
 > **Note:** On Mac, the direction indicates which end of the selection is affected when the user adjusts the size of the selection using the arrow keys with the Shift modifier: the "forward" direction means the end of the selection is modified, and the "backward" direction means the start of the selection is modified. The "none" direction is the default on Mac, it indicates that no particular direction has yet been selected. The user sets the direction implicitly when first adjusting the selection, based on which directional arrow key was used.
 
-## Example
+## Examples
 
 ### HTML
 
@@ -48,7 +46,7 @@ pConsole.textContent =
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
@@ -1,0 +1,60 @@
+---
+title: "HTMLInputElement: selectionDirection property"
+short-title: selectionDirection
+slug: Web/API/HTMLInputElement/selectionDirection
+page-type: web-api-instance-property
+browser-compat: api.HTMLInputElement.selectionDirection
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`selectionDirection`** property of the {{domxref("HTMLInputElement")}} interface is a string that indicates the direction in which the user is selecting the text.
+
+## Value
+
+A string.
+
+It can have one of the following values:
+
+- 'forward': The user is extending the selection towards the end of the input’s text.
+- 'backward': The user is extending the selection towards the start of the input’s text.
+- 'none': The user is not extending the selection.
+
+>**Note:** On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
+
+> **Note:** On Mac, the direction indicates which end of the selection is affected when the user adjusts the size of the selection using the arrow keys with the Shift modifier: the "forward" direction means the end of the selection is modified, and the "backward" direction means the start of the selection is modified. The "none" direction is the default on Mac, it indicates that no particular direction has yet been selected. The user sets the direction implicitly when first adjusting the selection, based on which directional arrow key was used.
+
+## Example
+
+### HTML
+```html
+<label for="selectionDirection">selectionDirection property</label>
+<input type="text" id="selectionDirection" value="MDN" />
+<p id="direction"></p>
+```
+
+### JavaScript
+```js
+const textSelectionDirection = document.querySelector("#selectionDirection");
+const pConsole = document.querySelector("#direction");
+pConsole.textContent = "Selection direction : " + textSelectionDirection.selectionDirection;
+``` 
+
+### Result
+
+{{EmbedLiveSample("Example")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.selectionDirection")}} property
+- {{domxref("HTMLInputElement.selectionStart")}} property
+- {{domxref("HTMLInputElement.selectionEnd")}} property
+- {{domxref("HTMLInputElement.setSelectionRange")}} method

--- a/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
@@ -16,17 +16,18 @@ A string.
 
 It can have one of the following values:
 
-- 'forward': The user is extending the selection towards the end of the input’s text.
-- 'backward': The user is extending the selection towards the start of the input’s text.
+- 'forward': The user is extending the selection towards the end of the input text.
+- 'backward': The user is extending the selection towards the start of the input text.
 - 'none': The user is not extending the selection.
 
->**Note:** On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
+> **Note:** On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
 
 > **Note:** On Mac, the direction indicates which end of the selection is affected when the user adjusts the size of the selection using the arrow keys with the Shift modifier: the "forward" direction means the end of the selection is modified, and the "backward" direction means the start of the selection is modified. The "none" direction is the default on Mac, it indicates that no particular direction has yet been selected. The user sets the direction implicitly when first adjusting the selection, based on which directional arrow key was used.
 
 ## Example
 
 ### HTML
+
 ```html
 <label for="selectionDirection">selectionDirection property</label>
 <input type="text" id="selectionDirection" value="MDN" />
@@ -34,10 +35,12 @@ It can have one of the following values:
 ```
 
 ### JavaScript
+
 ```js
 const textSelectionDirection = document.querySelector("#selectionDirection");
 const pConsole = document.querySelector("#direction");
-pConsole.textContent = "Selection direction : " + textSelectionDirection.selectionDirection;
+pConsole.textContent = 
+    "Selection direction : " + textSelectionDirection.selectionDirection;
 ``` 
 
 ### Result

--- a/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
@@ -39,9 +39,9 @@ It can have one of the following values:
 ```js
 const textSelectionDirection = document.querySelector("#selectionDirection");
 const pConsole = document.querySelector("#direction");
-pConsole.textContent = 
-    "Selection direction : " + textSelectionDirection.selectionDirection;
-``` 
+pConsole.textContent =
+  "Selection direction : " + textSelectionDirection.selectionDirection;
+```
 
 ### Result
 

--- a/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
@@ -16,9 +16,12 @@ A string.
 
 It can have one of the following values:
 
-- 'forward': The user is extending the selection towards the end of the input text.
-- 'backward': The user is extending the selection towards the start of the input text.
-- 'none': The user is not extending the selection.
+- `forward`
+  - : The user is extending the selection towards the end of the input text.
+- `backward`
+  - : The user is extending the selection towards the start of the input text.
+- `none`
+  - : The user is not extending the selection.
 
 > **Note:** On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
 

--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLInputElement.selectionEnd
 
 The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. When there is no selection, this returns the offset of the character immediately following the current text input cursor position.
 
-> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
+> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
 
 If `selectionEnd` is less than `selectionStart`, then both are
 treated as the value of `selectionEnd`.
@@ -19,41 +19,46 @@ treated as the value of `selectionEnd`.
 
 A non-negative number.
 
-## Example
+## Examples
 
 ### HTML
 
 ```html
-<!-- use selectionEnd on non text input element -->
+<!-- using selectionEnd on non text input element -->
 <label for="color">selectionStart property on type=color</label>
 <input id="color" type="color" />
 
-<!-- use selectionEnd on text input element -->
-<label for="pin">Input PIN</label>
-<input type="text" id="pin" value="impossible PIN: 102-12-145" />
-<button id="pin-btn" type="button">PIN correction</button>
+<!-- using selectionEnd on text input element -->
+<fieldset>
+  <legend>selectionEnd property on type=text</legend>
+  <label for="pin">Input PIN</label>
+  <input type="text" id="pin" value="impossible PIN: 102-12-145" />
+  <button id="pin-btn" type="button">PIN correction</button>
+</fieldset>
 ```
 
 ### JavaScript
 
 ```js
+const colorEnd = document.getElementById("color");
 const text = document.querySelector("#pin");
 const pinBtn = document.querySelector("#pin-btn");
 const validPinChecker = /[^\d{3}-\d{2}-\d{3}]/g;
 const selectionEnd = text.value.length;
+const selectedText = text.value.substring(text.selectionStart, selectionEnd);
 
 pinBtn.addEventListener("click", () => {
-  const selectedText = text.value.substring(text.selectionStart, selectionEnd);
   const correctedText = selectedText.replace(validPinChecker, "");
   text.value = correctedText;
 });
 
-console.log(colorStart.selectionEnd); // Output : null
+// open browser console to verify output
+console.log(colorEnd.selectionEnd); // Output : null
 ```
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -1,0 +1,70 @@
+---
+title: "HTMLInputElement: selectionEnd property"
+short-title: selectionEnd
+slug: Web/API/HTMLInputElement/selectionEnd
+page-type: web-api-instance-property
+browser-compat: api.HTMLInputElement.selectionEnd
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. When there’s no selection, this returns the offset of the character immediately following the current text input cursor position.
+
+>**Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
+
+If `selectionEnd` is less than `selectionStart`, then both are
+treated as the value of `selectionEnd`.
+
+## Value
+
+A non-negative number.
+
+## Example
+
+### HTML
+
+```html
+<!-- use selectionEnd on non text input element -->
+<label for="color">selectionStart property on type=color</label>
+<input id="color" type="color" />
+
+<!-- use selectionEnd on text input element -->
+<label for="pin">Input PIN</label>
+<input type="text" id="pin" value="impossible PIN: 102-12-145" />
+<button id="pin-btn" type="button">PIN correction</button>
+```
+
+### JavaScript
+
+```js
+const text = document.querySelector("#pin");
+const pinBtn = document.querySelector("#pin-btn");
+const validPinChecker = /[^\d{3}-\d{2}-\d{3}]/g; 
+const selectionEnd = text.value.length;
+
+pinBtn.addEventListener("click", () => {
+  const selectedText = text.value.substring(text.selectionStart, selectionEnd);
+  const correctedText = selectedText.replace(validPinChecker, "");
+  text.value = correctedText;
+});
+
+console.log(colorStart.selectionEnd); // Output : null
+```
+
+### Result
+
+{{EmbedLiveSample("Example")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.selectionEnd")}} property
+- {{domxref("HTMLInputElement.selectionStart")}} property
+- {{domxref("HTMLInputElement.setSelectionRange")}} method

--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -8,9 +8,9 @@ browser-compat: api.HTMLInputElement.selectionEnd
 
 {{ApiRef("HTML DOM")}}
 
-The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. When there’s no selection, this returns the offset of the character immediately following the current text input cursor position.
+The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. When there is no selection, this returns the offset of the character immediately following the current text input cursor position.
 
->**Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
+> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
 
 If `selectionEnd` is less than `selectionStart`, then both are
 treated as the value of `selectionEnd`.
@@ -39,7 +39,7 @@ A non-negative number.
 ```js
 const text = document.querySelector("#pin");
 const pinBtn = document.querySelector("#pin-btn");
-const validPinChecker = /[^\d{3}-\d{2}-\d{3}]/g; 
+const validPinChecker = /[^\d{3}-\d{2}-\d{3}]/g;
 const selectionEnd = text.value.length;
 
 pinBtn.addEventListener("click", () => {

--- a/files/en-us/web/api/htmlinputelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionstart/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLInputElement.selectionStart
 
 The **`selectionStart`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the beginning index of the selected text. When nothing is selected, then returns the position of the text input cursor (caret) inside of the `<input>` element.
 
-> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
+> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
 
 If `selectionStart` is greater than `selectionEnd`, then both are
 treated as the value of `selectionEnd`.
@@ -19,7 +19,7 @@ treated as the value of `selectionEnd`.
 
 A non-negative number.
 
-## Example
+## Examples
 
 ### HTML
 
@@ -31,11 +31,11 @@ A non-negative number.
 <!-- use selectionStart on text input element -->
 <fieldset>
   <legend>selectionStart property on type=text</legend>
-  <label for="statement">Select 'mdn' word from the text</label>
+  <label for="statement">Select 'mdn' word from the text : </label>
   <input
     type="text"
     id="statement"
-    value="The mdn is the best resource for developers" />
+    value="The mdn is a documentation repository." />
   <button id="statement-btn">Select mdn text</button>
 </fieldset>
 ```
@@ -53,12 +53,13 @@ statementBtn.addEventListener("click", () => {
   inputElement.focus();
 });
 
+// open browser console to verify output
 console.log(colorStart.selectionStart); // Output : null
 ```
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionstart/index.md
@@ -30,13 +30,13 @@ A non-negative number.
 
 <!-- use selectionStart on text input element -->
 <fieldset>
-    <legend>selectionStart property on type=text</legend>
-    <label for="statement">Select 'mdn' word from the text</label>
-    <input 
-        type="text" 
-        id="statement" 
-        value="The mdn is the best resource for developers" />
-    <button id="statement-btn">Select mdn text</button>
+  <legend>selectionStart property on type=text</legend>
+  <label for="statement">Select 'mdn' word from the text</label>
+  <input
+    type="text"
+    id="statement"
+    value="The mdn is the best resource for developers" />
+  <button id="statement-btn">Select mdn text</button>
 </fieldset>
 ```
 

--- a/files/en-us/web/api/htmlinputelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionstart/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLInputElement.selectionStart
 
 The **`selectionStart`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the beginning index of the selected text. When nothing is selected, then returns the position of the text input cursor (caret) inside of the `<input>` element.
 
->**Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
+> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
 
 If `selectionStart` is greater than `selectionEnd`, then both are
 treated as the value of `selectionEnd`.
@@ -32,7 +32,10 @@ A non-negative number.
 <fieldset>
     <legend>selectionStart property on type=text</legend>
     <label for="statement">Select 'mdn' word from the text</label>
-    <input type="text" id="statement" value="The mdn is the best resource for developers" />
+    <input 
+        type="text" 
+        id="statement" 
+        value="The mdn is the best resource for developers" />
     <button id="statement-btn">Select mdn text</button>
 </fieldset>
 ```

--- a/files/en-us/web/api/htmlinputelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionstart/index.md
@@ -1,0 +1,72 @@
+---
+title: "HTMLInputElement: selectionStart property"
+short-title: selectionStart
+slug: Web/API/HTMLInputElement/selectionStart
+page-type: web-api-instance-property
+browser-compat: api.HTMLInputElement.selectionStart
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`selectionStart`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the beginning index of the selected text. When nothing is selected, then returns the position of the text input cursor (caret) inside of the `<input>` element.
+
+>**Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types.Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
+
+If `selectionStart` is greater than `selectionEnd`, then both are
+treated as the value of `selectionEnd`.
+
+## Value
+
+A non-negative number.
+
+## Example
+
+### HTML
+
+```html
+<!-- use selectionStart on non text input element -->
+<label for="color">selectionStart property on type=color</label>
+<input id="color" type="color" />
+
+<!-- use selectionStart on text input element -->
+<fieldset>
+    <legend>selectionStart property on type=text</legend>
+    <label for="statement">Select 'mdn' word from the text</label>
+    <input type="text" id="statement" value="The mdn is the best resource for developers" />
+    <button id="statement-btn">Select mdn text</button>
+</fieldset>
+```
+
+### JavaScript
+
+```js
+const inputElement = document.getElementById("statement");
+const statementBtn = document.getElementById("statement-btn");
+const colorStart = document.getElementById("color");
+
+statementBtn.addEventListener("click", () => {
+  inputElement.selectionStart = 4;
+  inputElement.selectionEnd = 7;
+  inputElement.focus();
+});
+
+console.log(colorStart.selectionStart); // Output : null
+```
+
+### Result
+
+{{EmbedLiveSample("Example")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.selectionStart")}} property
+- {{domxref("HTMLInputElement.selectionEnd")}} property
+- {{domxref("HTMLInputElement.setSelectionRange")}} method


### PR DESCRIPTION
This PR add documentation for HTMLInputElement.{selectionStart, selectionEnd, selectionDirection} properties.

It is part of https://github.com/mdn/mdn/issues/520

Resource
[text field selection API](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection) 