### PR TITLE
Fix issue 32145: pass section name to live sample macro

### DIFF
--- a/files/en-us/web/api/range/getclientrects/index.md
+++ b/files/en-us/web/api/range/getclientrects/index.md
@@ -62,7 +62,7 @@ for (const rect of rectList) {
 
 #### Result
 
-{{EmbedLiveSample}}
+{{EmbedLiveSample("Logging selected client rect sizes")}}
 
 ## Specifications
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/32145.

The live sample system used to work without being passed an identifier for the section containing the example code, but this seems to have stopped working(?).