### PR TITLE
Remove outdated hgroup disclaimer

### DIFF
--- a/files/en-us/web/html/content_categories/index.md
+++ b/files/en-us/web/html/content_categories/index.md
@@ -134,8 +134,6 @@ Elements belonging to this category are {{HTMLElement("Heading_Elements", "<code
 
 > **Note:** Though likely to contain heading content, the {{HTMLElement("header")}} is not heading content itself.
 
-> **Note:** The {{HTMLElement("hgroup")}} element is not recommended as it does not work properly with assistive technologies. It was removed from the W3C HTML specification prior to HTML 5 being finalized, but is still part of the WHATWG specification and is at least partially supported by most browsers.
-
 ### Phrasing content
 
 Phrasing content, a subset of flow content, refers to the text and the markup within a document. Sequences of phrasing content make up paragraphs.

--- a/files/en-us/web/html/element/hgroup/index.md
+++ b/files/en-us/web/html/element/hgroup/index.md
@@ -11,8 +11,6 @@ The **`<hgroup>`** [HTML](/en-US/docs/Web/HTML) element represents a heading and
 
 {{EmbedInteractiveExample("pages/tabbed/hgroup.html", "tabbed-standard")}}
 
-> **Note:** The `<hgroup>` element is not recommended as it does not work properly with assistive technologies. It was removed from the W3C HTML specification but is still part of the WHATWG specification and is at least partially supported by most browsers.
-
 ## Attributes
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).


### PR DESCRIPTION
### Description

This reverts commit fbb5b30, and removes the problematic disclaimer about `<hgroup>` from the [Content categories](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories) page.

### Motivation

In #18530 in July 2022, the disclaimers were removed, but only from the hgroup page. I suspect the Content categories page was missed. Then in December 2023, #30856 copies the outdated note from Content categories back to the hgroup page. I don’t think that disclaimer should have been there on any page, per the description of #32213:

> The [`<hgroup>` element](https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element) was recently significantly revised in the HTML specification. The warnings about its impact on the outline algorithm are no longer relevant, as the concept of the outline algorithm was removed from the HTML specification as well.
> 
> This PR simply removes outdated content, and replaces the remaining bits with content that is more inline with the current definition for the element.

### Additional details

See [WHATWG Sections – the hgroup element](https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element)

### Related issues and pull requests

See #11153 for the initial rationale on removing those disclaimers.

