### PR TITLE
Add link to HTTP response statuses list on HTTP Messages page

### DIFF
--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -80,7 +80,7 @@ _Note: The start-line is called the "status line" in requests._
 The start line of an HTTP response, called the _status line_, contains the following information:
 
 1. The _protocol version_, usually `HTTP/1.1`, but can also be `HTTP/1.0`.
-2. A _status code_, indicating success or failure of the request. Common status codes are {{HTTPStatus("200")}}, {{HTTPStatus("404")}}, or {{HTTPStatus("302")}}.
+2. A [_status code_](/en-US/docs/Web/HTTP/Status), indicating success or failure of the request. Common status codes are {{HTTPStatus("200")}}, {{HTTPStatus("404")}}, or {{HTTPStatus("302")}}.
 3. A _status text_. A brief, purely informational, textual description of the status code to help a human understand the HTTP message.
 
 A typical status line looks like: `HTTP/1.1 404 Not Found`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds a link to the HTTP response status list on the first mention of status codes within the HTTP Messages page.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I am currently writing an introductory document on using a web API for users who have no knowledge of HTTP and believe that an easy link to the categorical list of all possible HTTP status codes and detail about them would be beneficial for those learning about HTTP.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

n/a

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

n/a

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
---
:)