### PR TITLE
Add runtime.on performance warning

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -33,6 +33,8 @@ It also provides messaging APIs enabling you to:
   - : The reason that the {{WebExtAPIRef("runtime.onInstalled")}} event is being dispatched.
 - {{WebExtAPIRef("runtime.OnPerformanceWarningCategory")}}
   - : The category of warning that dispatched the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event.
+- {{WebExtAPIRef("runtime.OnPerformanceWarningSeverity")}}
+  - : The severity of warning that dispatched the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event.
 - {{WebExtAPIRef("runtime.OnRestartRequiredReason")}}
   - : The reason that the {{WebExtAPIRef("runtime.onRestartRequired")}} event is being dispatched.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -96,6 +96,8 @@ It also provides messaging APIs enabling you to:
   - : Fired when a message is sent from either an extension process or a content script.
 - {{WebExtAPIRef("runtime.onMessageExternal")}}
   - : Fired when a message is sent from another extension. Cannot be used in a content script.
+- {{WebExtAPIRef("runtime.onPerformanceWarning")}}
+  - : Fired when a runtime performance issue is detected for the extension.
 - {{WebExtAPIRef("runtime.onRestartRequired")}}
   - : Fired when the device needs to be restarted.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -31,6 +31,8 @@ It also provides messaging APIs enabling you to:
   - : Result of a call to {{WebExtAPIRef("runtime.requestUpdateCheck()")}}.
 - {{WebExtAPIRef("runtime.OnInstalledReason")}}
   - : The reason that the {{WebExtAPIRef("runtime.onInstalled")}} event is being dispatched.
+- {{WebExtAPIRef("runtime.OnPerformanceWarningCategory")}}
+  - : The category of warning that dispatched the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event.
 - {{WebExtAPIRef("runtime.OnRestartRequiredReason")}}
   - : The reason that the {{WebExtAPIRef("runtime.onRestartRequired")}} event is being dispatched.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
@@ -39,9 +39,9 @@ Events have three functions:
       - : `object`. An object with the following properties:
 
         - `category`
-          - : A {{WebExtAPIRef("runtime.OnPerformanceWarningCategory")}} object indicating the category of the warning.
+          - : {{WebExtAPIRef("runtime.OnPerformanceWarningCategory")}}. The category of the warning.
         - `severity`
-          - : `string`. The performance warning event severity. One of "low", "medium", or "high".
+          - : {{WebExtAPIRef("runtime.OnPerformanceWarningSeverity")}}. The severity of the warning.
         - `tabId` {{optional_inline}}
           - : `integer`. The ID of the tab that the performance warning relates to, if any.
         - `description`

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
@@ -45,8 +45,8 @@ Events have three functions:
 ## Examples
 
 ```js
-function handlePerformanceWarning(performanceWarningInfo) {
-  console.log(`Performance warning: ${performanceWarningInfo.description}`);
+function handlePerformanceWarning(details) {
+  console.log(`Performance warning: ${details.description}`);
 }
 
 browser.runtime.onPerformanceWarning.addListener(handlePerformanceWarning);

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
@@ -32,15 +32,20 @@ Events have three functions:
 
 - `listener`
 
-  - : The function called when this event occurs. The function is passed these arguments:
-    - `category`
-      - : `string`. "content_script", the performance warning event category.
-    - `severity`
-      - : `string`. The performance warning event severity. One of "low", "medium", or "high".
-    - `tabId`
-      - : `integer`. The ID of the tab that the performance warning relates to, if any.
-    - `description`
-      - : `string`. An explanation of what the warning means, possibly with information on how to address it.
+  - : The function called when this event occurs. The function is passed this argument:
+
+    - `details`
+
+      - : `object`. An object with the following properties:
+
+        - `category`
+          - : A {{WebExtAPIRef("runtime.OnPerformanceWarningCategory")}} object indicating the category of the warning.
+        - `severity`
+          - : `string`. The performance warning event severity. One of "low", "medium", or "high".
+        - `tabId` {{optional_inline}}
+          - : `integer`. The ID of the tab that the performance warning relates to, if any.
+        - `description`
+          - : `string`. An explanation of what the warning means, possibly with information on how to address it.
 
 ## Examples
 
@@ -57,35 +62,3 @@ browser.runtime.onPerformanceWarning.addListener(handlePerformanceWarning);
 ## Browser compatibility
 
 {{Compat}}
-
-> **Note:** This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onPerformanceWarning) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
-
-<!--
-// Copyright 2015 The Chromium Authors. All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//    * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//    * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//    * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--->

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarning/index.md
@@ -1,0 +1,91 @@
+---
+title: runtime.onPerformanceWarning
+slug: Mozilla/Add-ons/WebExtensions/API/runtime/onPerformanceWarning
+page-type: webextension-api-event
+browser-compat: webextensions.api.runtime.onPerformanceWarning
+---
+
+{{AddonSidebar}}
+
+This event fires when a runtime performance issue is detected for the extension. Observe this event to be notified of runtime performance problems with your extension.
+
+## Syntax
+
+```js-nolint
+browser.runtime.onPerformanceWarning.addListener(listener)
+browser.runtime.onPerformanceWarning.removeListener(listener)
+browser.runtime.onPerformanceWarning.hasListener(listener)
+```
+
+Events have three functions:
+
+- `addListener(listener)`
+  - : Adds a listener to this event.
+- `removeListener(listener)`
+  - : Stop listening to this event. The `listener` argument is the listener to remove.
+- `hasListener(listener)`
+  - : Checks whether at least one listener is registered for this event. Returns `true` if it is listening, `false` otherwise.
+
+## addListener syntax
+
+### Parameters
+
+- `listener`
+
+  - : The function called when this event occurs. The function is passed these arguments:
+    - `category`
+      - : `string`. "content_script", the performance warning event category.
+    - `severity`
+      - : `string`. The performance warning event severity. One of "low", "medium", or "high".
+    - `tabId`
+      - : `integer`. The ID of the tab that the performance warning relates to, if any.
+    - `description`
+      - : `string`. An explanation of what the warning means, possibly with information on how to address it.
+
+## Examples
+
+```js
+function handlePerformanceWarning(performanceWarningInfo) {
+  console.log(`Performance warning: ${performanceWarningInfo.description}`);
+}
+
+browser.runtime.onPerformanceWarning.addListener(handlePerformanceWarning);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onPerformanceWarning) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+
+<!--
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarningcategory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarningcategory/index.md
@@ -13,7 +13,7 @@ The category of warning that dispatched the {{WebExtAPIRef("runtime.onPerformanc
 
 Values of this type are strings. Possible values are:
 
-- `"content_script"`: The performance warning originated from a content script.
+- `"content_script"`: The performance warning is for a slow content script in the listening extension.
 
 {{WebExtExamples("h2")}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarningcategory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarningcategory/index.md
@@ -1,0 +1,22 @@
+---
+title: runtime.OnPerformanceWarningCategory
+slug: Mozilla/Add-ons/WebExtensions/API/runtime/OnPerformanceWarningCategory
+page-type: webextension-api-type
+browser-compat: webextensions.api.runtime.OnPerformanceWarningCategory
+---
+
+{{AddonSidebar}}
+
+The category of warning that dispatched the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event.
+
+## Type
+
+Values of this type are strings. Possible values are:
+
+- `"content_script"`: The performance warning originated from a content script.
+
+{{WebExtExamples("h2")}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarningseverity/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onperformancewarningseverity/index.md
@@ -1,0 +1,24 @@
+---
+title: runtime.OnPerformanceWarningSeverity
+slug: Mozilla/Add-ons/WebExtensions/API/runtime/OnPerformanceWarningSeverity
+page-type: webextension-api-type
+browser-compat: webextensions.api.runtime.OnPerformanceWarningSeverity
+---
+
+{{AddonSidebar}}
+
+The severity of warning that dispatched the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event.
+
+## Type
+
+Values of this type are strings. Possible values are:
+
+- `"low"`
+- `"medium"`
+- `"high"`
+
+{{WebExtExamples("h2")}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 124 that affect d
 
 ## Changes for add-on developers
 
+- Adds the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event that enables extensions to obtain information when the browser detects that the extension has a runtime performance issue ([Firefox bug 1861445](https://bugzil.la/1861445)).
+
 ### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -58,7 +58,7 @@ This article provides information about the changes in Firefox 124 that affect d
 
 ## Changes for add-on developers
 
-- Adds the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event that enables extensions to obtain information when the browser detects that the extension has a runtime performance issue ([Firefox bug 1861445](https://bugzil.la/1861445)).
+- Adds the {{WebExtAPIRef("runtime.onPerformanceWarning")}} event that enables extensions to obtain information when the browser detects that the extension has a runtime performance issue such as a slow-running content script ([Firefox bug 1861445](https://bugzil.la/1861445)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Adds API documentation and release note for the `runtime.on performance` event introduced by [Bug 1861445](https://bugzilla.mozilla.org/show_bug.cgi?id=1861445) Add new hang warning event API for WebExtensionswarning.

See https://github.com/mdn/browser-compat-data/pull/22196 and https://github.com/mdn/browser-compat-data/pull/22617 for browser compatibility data.

DO NOT MERGE until related BCD content is ready to merge.
