### PR TITLE
Router definition in glossary

### DIFF
--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 There are three definitions for **routers** on the web:
 
-1. In computer networing, a router is a device that forwards {{Glossary("Packet", "data packets")}} between computer networks.
+1. In computer networking, a router is a device that forwards {{Glossary("Packet", "data packets")}} between computer networks.
 2. For a {{Glossary('SPA', 'Single-page application')}}, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}.
    This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
 3. In the implementation of an {{Glossary("API", "Application Programming Interface (API))}}, a router is a software component that parses a request and directs or routes the request to various handlers within a program.

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -8,9 +8,11 @@ page-type: glossary-definition
 
 There are three definitions for **routers** on the web:
 
-1. For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions. They are distributed by retailers allowing user interaction to the internet.
-2. For a {{Glossary('SPA', 'Single-page application')}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
-3. In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
+1. In computer networing, a router is a device that forwards {{Glossary("Packet", "data packets")}} between computer networks.
+5. For a {{Glossary('SPA', 'Single-page application')}}, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}.
+   This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
+7. In the implementation of an {{Glossary("API", "Application Programming Interface (API))}}, a router is a software component that parses a request and directs or routes the request to various handlers within a program.
+   The router code usually accepts a response from the handler and facilitates its return to the requester.
 
 ## See also
 

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -8,11 +8,9 @@ page-type: glossary-definition
 
 There are three definitions for **routers** on the web:
 
-1. In computer networking, a router is a device that forwards {{Glossary("Packet", "data packets")}} between computer networks.
-2. For a {{Glossary('SPA', 'Single-page application')}}, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}.
-   This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
-3. In the implementation of an {{Glossary("API", "Application Programming Interface (API))}}, a router is a software component that parses a request and directs or routes the request to various handlers within a program.
-   The router code usually accepts a response from the handler and facilitates its return to the requester.
+1. For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions.
+2. For a {{Glossary('SPA', 'Single-page application')}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
+3. In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
 
 ## See also
 

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -9,9 +9,9 @@ page-type: glossary-definition
 There are three definitions for **routers** on the web:
 
 1. In computer networing, a router is a device that forwards {{Glossary("Packet", "data packets")}} between computer networks.
-5. For a {{Glossary('SPA', 'Single-page application')}}, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}.
+2. For a {{Glossary('SPA', 'Single-page application')}}, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}.
    This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
-7. In the implementation of an {{Glossary("API", "Application Programming Interface (API))}}, a router is a software component that parses a request and directs or routes the request to various handlers within a program.
+3. In the implementation of an {{Glossary("API", "Application Programming Interface (API))}}, a router is a software component that parses a request and directs or routes the request to various handlers within a program.
    The router code usually accepts a response from the handler and facilitates its return to the requester.
 
 ## See also

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 There are three definitions for **routers** on the web:
 
-For the network layer, the router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
+1. For the network layer, the router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
 2. For a {{Glossary('SPA', 'Single-page application')}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
 3. In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
 

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 There are three definitions for **routers** on the web:
 
-1. For the network layer, the router is a networking device that decides data {{Glossary('Packet')}}s directions.
+For the network layer, the router is a networking device that decides where to direct {{Glossary('Packet', 'data packets')}}.
 2. For a {{Glossary('SPA', 'Single-page application')}} in the application layer, a router is a library that decides what web page is presented by a given {{Glossary('URL')}}. This middleware module is used for all URL functions, as these are given a path to a file that is rendered to open the next page.
 3. In the implementation of an {{Glossary('API')}} in a service layer, a router is a software component that parses a request and directs or routes the request to various handlers within a program. The router code usually accepts a response from the handler and facilitates its return to the requester.
 


### PR DESCRIPTION
Fixes #32230

Mentioning "retailer" is completely unnecessary.