### PR TITLE
Fix short circuit text

### DIFF
--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing/index.md
@@ -96,7 +96,7 @@ console.log(preservingFalsy); // '' (as myText is neither undefined nor null)
 
 ### Short-circuiting
 
-Like the OR and AND logical operators, the right-hand side expression is not evaluated if the left-hand side proves to be neither `null` nor `undefined`.
+Like the OR and AND logical operators, the right-hand side expression is not evaluated if the left-hand side proves to be either `null` or `undefined`.
 
 ```js
 function a() {


### PR DESCRIPTION
The description of the short circuiting behavior when assigning a default value to a variable was incorrect

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The current text describes a behavior that is exactly the opposite of what the operator does.

### Motivation

The documentation should contain correct statements so users aren't confused.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
