### PR TITLE
Fix typo on "HTTP Messages" page

### DIFF
--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -75,7 +75,7 @@ Bodies can be broadly divided into two categories:
 
 ### Status line
 
-_Note: The start-line is called the "status line" in requests._
+_Note: The start-line is called the "status line" in responses._
 
 The start line of an HTTP response, called the _status line_, contains the following information:
 

--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -29,7 +29,7 @@ The start-line and HTTP headers of the HTTP message are collectively known as th
 
 ### Request line
 
-_Note: The start-line is called the "request-line" in requests._
+> **Note:** The start-line is called the "request-line" in requests.
 
 HTTP requests are messages sent by the client to initiate an action on the server. Their _request-line_ contain three elements:
 
@@ -75,7 +75,7 @@ Bodies can be broadly divided into two categories:
 
 ### Status line
 
-_Note: The start-line is called the "status line" in responses._
+> **Note:** The start-line is called the "status line" in responses.
 
 The start line of an HTTP response, called the _status line_, contains the following information:
 


### PR DESCRIPTION
### Description

"HTTP Messages" page has nice 2 notes about alternative names for "start-line" (one in Requests section and one in Responses section). Second note was probably copied and pasted without changing the "requests" text to "responses".

### Motivation

Improve clarity and reduce confusion for the docs readers.

### Additional details

Requests section says: "The start-line is called the "request-line" in requests." (correct)
Responses section says: "The start-line is called the "status line" in requests." (incorrect, should be "responses")

### Related issues and pull requests

Relates to #28319 - here notes about start-line were introduced
