### PR TITLE
Navigator.share() example - try add permission policy

### DIFF
--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -159,7 +159,7 @@ btn.addEventListener("click", async () => {
 
 Click the button to launch the share dialog on your platform. Text will appear below the button to indicate whether the share was successful or provide an error code.
 
-{{EmbedLiveSample('Sharing a URL')}}
+{{EmbedLiveSample('Sharing a URL','','','','','','web-share')}}
 
 ### Sharing files
 


### PR DESCRIPTION
This adds `web-share` Permission-Policy to the URL sharing example in `Navigator.share()`.

This works on FF (with feature enabled) and Chrome. That surprised me a bit, since it means that the server must be sending the directive too for this to work on chrome (not just setting allow on the iframe.

Fixes #32130