### PR TITLE
Modified the description in the Constructor section.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -77,7 +77,7 @@ The method {{jsxref("Object.getOwnPropertySymbols()")}} returns an array of Symb
 ## Constructor
 
 - {{jsxref("Symbol/Symbol", "Symbol()")}}
-  - : Creates a new `Symbol` object. It is not a constructor in the traditional sense, because it can only be called as a function, instead of being constructed with `new Symbol()`.
+  - : Creates a value of type `Symbol` when called as a function. Throws `TypeError` when called with the `new` operator.
 
 ## Static properties
 


### PR DESCRIPTION
### Description

`Symbol()` does not create an object. It creates a value of type `Symbol`. Note also that "Creates a new ..." is redundant so I omitted the "new". 

### Related issues and pull requests

Fixes #32207.
