### PR TITLE
added the FF release note for Date.parse() bug fixes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -24,6 +24,11 @@ This article provides information about the changes in Firefox 123 that affect d
 
 ### JavaScript
 
+- The {{jsxref("Date.parse()")}} global object has had a number of bug fixes to bring it into line with how other browsers parse the values being passed.
+  - Incorrect day of month (e.g. "31 April") now skips over to the following month (e.g. "1 May"). ([Firefox bug 1872333](https://bugzil.la/1872333)).
+  - Incomplete time zone (e.g. "1/1/70 gm") or AM/PM (e.g. "1/1/70 10:00 a") are no longer accepted. ([Firefox bug 1870570](https://bugzil.la/1870570)).
+  - Single number dates are now accepted (e.g. `Date.parse("0")` now returns `946684800000` - Sat Jan 01 2000 00:00:00). ([Firefox bug 1870434](https://bugzil.la/1870434)).
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
### Description

Added the Firefox 123 release note for `Date.parse()`

### Motivation

Working on the updates for [`Date.parse()` in Firefox 123](https://github.com/mdn/content/issues/319140)

### Additional details

- [https://bugzilla.mozilla.org/show_bug.cgi?id=1870434](https://bugzilla.mozilla.org/show_bug.cgi?id=1870434)
- [https://bugzilla.mozilla.org/show_bug.cgi?id=1870570](https://bugzilla.mozilla.org/show_bug.cgi?id=1870570)
- [https://bugzilla.mozilla.org/show_bug.cgi?id=1872333](https://bugzilla.mozilla.org/show_bug.cgi?id=1872333)

### Related issues and pull requests

- No BCD needed
- [Content PR](https://github.com/mdn/content/pull/32253)