### PR TITLE
Remove incorrect distinction between delegation and inheritance

### DIFF
--- a/files/en-us/learn/javascript/objects/object-oriented_programming/index.md
+++ b/files/en-us/learn/javascript/objects/object-oriented_programming/index.md
@@ -227,13 +227,7 @@ In the two previous articles, we looked at a couple of core JavaScript features:
 
 - **the prototype chain** seems like a natural way to implement inheritance. For example, if we can have a `Student` object whose prototype is `Person`, then it can inherit `name` and override `introduceSelf()`.
 
-But it's worth understanding the differences between these features and the "classical" OOP concepts described above. We'll highlight a couple of them here.
-
-First, in class-based OOP, classes and objects are two separate constructs, and objects are always created as instances of classes. Also, there is a distinction between the feature used to define a class (the class syntax itself) and the feature used to instantiate an object (a constructor). In JavaScript, we can and often do create objects without any separate class definition, either using a function or an object literal. This can make working with objects much more lightweight than it is in classical OOP.
-
-Second, although a prototype chain looks like an inheritance hierarchy and behaves like it in some ways, it's different in others. When a subclass is instantiated, a single object is created which combines properties defined in the subclass with properties defined further up the hierarchy. With prototyping, each level of the hierarchy is represented by a separate object, and they are linked together via the `__proto__` property. The prototype chain's behavior is less like inheritance and more like **delegation**. Delegation is a programming pattern where an object, when asked to perform a task, can perform the task itself or ask another object (its **delegate**) to perform the task on its behalf. In many ways, delegation is a more flexible way of combining objects than inheritance (for one thing, it's possible to change or completely replace the delegate at run time).
-
-That said, constructors and prototypes can be used to implement class-based OOP patterns in JavaScript. But using them directly to implement features like inheritance is tricky, so JavaScript provides extra features, layered on top of the prototype model, that map more directly to the concepts of class-based OOP. These extra features are the subject of the next article.
+Constructors and prototypes can be used to implement class-based OOP patterns in JavaScript. But using them directly to implement features like inheritance is tricky, so JavaScript provides extra features, layered on top of the prototype model, that map more directly to the concepts of class-based OOP. These extra features are the subject of the next article.
 
 ## Summary
 


### PR DESCRIPTION
Lines such as "less like inheritance and more like delegation", which is the premise behind these few paragraphs, are misleading and inaccurate.

Delegation and inheritance are not either/or concepts. Delegation is one possible way to implement inheritance, and delegation is even an ordinary and commonly chosen way to implement inheritance.

Below is an example in Python that demonstrates Python's class inheritance is delegation. Ruby's and Perl's class inheritance is also delegation. Others have told me Objective-C's and Lua's inheritance is delegation. And finally ECMAScript spec editor Allen Wirfs-Brock -- the same spec editor who's name is on the cover page of the ES6 spec -- will describe the similarities between's JavaScript's and Smalltalk's inheritance.

Python's class inheritance, for a specific example, is implemented with delegation. Python's instances delegate at runtime to class objects, which delegate at runtime to superclass objects, which can delegate further, forming a chain of objects that are traversed at runtime. To demonstrate, below is Python code that defines a class and creates an instance, then monkey patches that class which is immediately reflected in the already-existing instance.

    # Python
    class SomeClass:
        def someMethod(self):
            return "someMethod"

    instance = SomeClass()

    # Python checks if `instance` contains a field named "someMethod", which it
    # doesn't, so Python delegates to the class object, where it finds the
    # original version of the method.
    print(instance.someMethod()) # "someMethod"

    SomeClass.someMethod = lambda self: "MONKEY PATCHED!"

    # Python checks if `instance` contains a field named "someMethod", which it
    # doesn't, so Python delegates to the class object, where it finds the
    # monkey-patched version of the method.
    print(instance.someMethod()) # "MONKEY PATCHED!"

Python's class inheritance can also replace the delegate at runtime, something that these paragraphs explicitly and inaccurately claim inheritance can't do.

    print(instance.someMethod()) # "MONKEY PATCHED!"

    class SomeOtherClass:
        def someMethod(self):
            return "Not even the same class."

    # Python's `__class__` does the same job as JavaScript's `__proto__`.
    instance.__class__ = SomeOtherClass

    print(instance.someMethod()) # "Not even the same class."

And finally here is ECMAScript spec editor Allen Wirfs-Brock [giving a video talk comparing JavaScript classes to Smalltalk classes](https://www.youtube.com/watch?v=EPHmm8JiGbg&t=37m28s). "The punchline," he says in the talk, "is they actually aren’t as different as you might think."

These few paragraphs were written with a faulty premise. Seems the best remedy is to remove these few paragraphs.