### PR TITLE
fix(ci): make husky post pull script 'sh' compatible

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$BRANCH" != "main" ]; then
   exit 0

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,5 +1,5 @@
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$BRANCH" != "main" ]]; then
+if [ "$BRANCH" != "main" ]; then
   exit 0
 fi
 
@@ -7,7 +7,7 @@ if [ -f ".husky/_/history" ]; then
   lastHash=$(cat ./.husky/_/history)
   isUpdated=$(git diff $lastHash HEAD -- ./package.json)
   if [ "$isUpdated" != "" ]; then
-    echo -e "\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
+    echo "\n⚠🔥 'package.json' has changed. Please run 'yarn install'! 🔥"
   fi
 else
   yarn install

--- a/.husky/update-history
+++ b/.husky/update-history
@@ -2,6 +2,6 @@
 # The stored commit hash is used by the post-merge script .husky/post-merge
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$BRANCH" == "main" ]]; then
+if [ "$BRANCH" = "main" ]; then
   echo $(git rev-parse HEAD) > ./.husky/_/history
 fi

--- a/.husky/update-history
+++ b/.husky/update-history
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 # This script stores the 'main' branch's HEAD commit hash in .husky/_/history
 # The stored commit hash is used by the post-merge script .husky/post-merge
 


### PR DESCRIPTION
This is an interesting case. On most systems `sh` is symlinked to `bash`. So the existing husky scripts run without any issues on those systems.
I implemented the script on Fedora where `sh -> bash`. So it worked there without any issues.

Now I've destro hopped to Ubuntu based Linux Mint. Here `sh` doesn't redirect to `bash`. :(

The PR updates the shell scripts to make them compatible with `sh`. For testing in local try commands:
```
# check where 'sh' is redirected to
ls -la /bin/sh

# if not bash then run following commands to test both the scripts
rm ./.husky/_/history
sh ./.husky/post-merge
```