### PR TITLE
fix: wrong `&` explanation in nesting css selector.

### DIFF
--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -374,7 +374,7 @@ In the following CSS we are creating the styles for `.card`, `.card h2` and then
     /* equivalent to `.card h2` */
     color: slateblue;
     .featured & {
-      /* equivalent to `.featured.card h2` */
+      /* equivalent to `.featured :is(.card h2)` */
       color: tomato;
     }
   }

--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -363,7 +363,7 @@ In this example there are 3 cards, one of which is featured. The cards are all e
 }
 ```
 
-In the following CSS we are creating the styles for `.card`, `.card h2` and then in the `h2` styles we nest the `.featured` class with the `&` nesting selector appended which creates a style for `.card :is(.featured h2)`. And we can furthur transform `.card :is(.featured h2)` to `:is(.card h2):is(.featured h2)`) to better help us understand.
+In the following CSS, we are creating the styles for `.card` and `.card h2`. Then, in the `h2` style block, we nest the `.featured` class with the `&` nesting selector appended which creates a style for `.card :is(.featured h2)`, which is equivalent to `:is(.card h2):is(.featured h2)`.
 
 ```css
 .card {

--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -363,7 +363,7 @@ In this example there are 3 cards, one of which is featured. The cards are all e
 }
 ```
 
-In the following CSS we are creating the styles for `.card`, `.card h2` and then in the `h2` styles we nest the `.featured` class with the `&` nesting selector appended which creates a style for `.card.featured h2`.
+In the following CSS we are creating the styles for `.card`, `.card h2` and then in the `h2` styles we nest the `.featured` class with the `&` nesting selector appended which creates a style for `.card :is(.featured h2)`. And we can furthur transform `.card :is(.featured h2)` to `:is(.card h2):is(.featured h2)`) to better help us understand.
 
 ```css
 .card {
@@ -374,7 +374,7 @@ In the following CSS we are creating the styles for `.card`, `.card h2` and then
     /* equivalent to `.card h2` */
     color: slateblue;
     .featured & {
-      /* equivalent to `.featured :is(.card h2)` */
+      /* equivalent to `:is(.card h2):is(.featured h2)` */
       color: tomato;
     }
   }


### PR DESCRIPTION
### Description

In the example of section "Appended nesting selector", the explanation of the `&`  is wrong.

In the example, the comment says `.featured &` is equivalent to `.featured.card h2`:

```css
.card {
  padding: 0.5rem;
  border: 1px solid black;
  border-radius: 0.5rem;
  & h2 {
    /* equivalent to `.card h2` */
    color: slateblue;
    .featured & {
      /* equivalent to `.featured.card h2` */
      color: tomato;
    }
  }
}
```

But actually, `&` is equivalent to `:is()` ([w3](https://www.w3.org/TR/css-nesting-1/#nest-selector)). And `.featured.card h2` is not equivalent to `.featured :is(.card h2)`.

### Motivation

Inaccurate explanations may confuse readers so we need to clarify it.

### Additional details

This is a common mistake, as discussed in the [blog](https://www.bram.us/2023/01/17/using-is-in-complex-selectors-selects-more-than-you-might-initially-think/#nesting).

And there has been a [StackOverflow issue](https://stackoverflow.com/questions/77988661/what-does-trailing-mean-in-css-nesting-selectors/77988832) about this example.

### Related issues and pull requests

N/A
