### PR TITLE
Add explicit parameter to EmbedLiveSample

### DIFF
--- a/files/en-us/web/api/htmlelement/hidepopover/index.md
+++ b/files/en-us/web/api/htmlelement/hidepopover/index.md
@@ -33,9 +33,11 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
+### Hiding a popover
+
 The following example provides functionality to hide a popover by pressing a particular key on the keyboard.
 
-### HTML
+#### HTML
 
 ```html
 <button popovertarget="mypopover">Toggle popover's display</button>
@@ -44,7 +46,7 @@ The following example provides functionality to hide a popover by pressing a par
 </div>
 ```
 
-### JavaScript
+#### JavaScript
 
 ```js
 const popover = document.getElementById("mypopover");
@@ -56,9 +58,9 @@ document.addEventListener("keydown", (event) => {
 });
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("","100%",100)}}
+{{EmbedLiveSample("Hiding a popover","100%",100)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/css_cascading_variables/index.md
+++ b/files/en-us/web/css/css_cascading_variables/index.md
@@ -91,7 +91,7 @@ input {
 }
 ```
 
-{{EmbedLiveSample("",600,160)}}
+{{EmbedLiveSample("Custom properties in action",600,160)}}
 
 In these color swatches, the {{cssxref("background-color")}} is set using the {{cssxref("color_value/hsl", "hsl()")}} {{cssxref("&lt;color&gt;")}} function as `hsl(var(--hue) 50% 50%)`.
 Each color swatch increments the {{cssxref("hue")}} value by 10 degrees like `calc(var(--hue) + 10)`, `calc(var(--hue) + 20)` etc.

--- a/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_grid_layout/grids_logical_values_and_writing_modes/index.md
@@ -65,7 +65,7 @@ p {
 }
 ```
 
-{{EmbedLiveSample("","",200)}}
+{{EmbedLiveSample("Issues with physical properties","",200)}}
 
 This is a very simple example of the problem with physical values and properties being used in CSS. They prevent the browser being able to do the work to switch writing mode, as they make the assumption that the text is flowing left to right and top to bottom.
 

--- a/files/en-us/web/css/css_properties_and_values_api/index.md
+++ b/files/en-us/web/css/css_properties_and_values_api/index.md
@@ -57,7 +57,7 @@ CSS.registerProperty({
 <div class="box"><p>Linear gradient with transition</p></div>
 ```
 
-{{EmbedLiveSample("",600,120)}}
+{{EmbedLiveSample("Properties and values API in action",600,120)}}
 
 The box has a [backround](/en-US/docs/Web/CSS/background) consisting of a [linear gradient](/en-US/docs/Web/CSS/gradient/linear-gradient) from `--stop-color` (the custom property) to [`lavenderblush`](/en-US/docs/Web/CSS/named-color).
 The value of `--stop-color` is set to `cornflowerblue` at first, but when you hover over the box, `--stop-color` [transitions](/en-US/docs/Web/CSS/transition) to `aquamarine` over two seconds (`linear-gradient(to right, aquamarine, lavenderblush)`).

--- a/files/en-us/web/css/inheritance/index.md
+++ b/files/en-us/web/css/inheritance/index.md
@@ -31,7 +31,7 @@ p {
 <p>This paragraph has <em>emphasized text</em> in it.</p>
 ```
 
-{{EmbedLiveSample("","",40)}}
+{{EmbedLiveSample("Inherited properties","",40)}}
 
 The words "emphasized text" will appear green, since the `em` element has inherited the value of the [`color`](/en-US/docs/Web/CSS/color) property from the `p` element. It does _not_ get the initial value of the property (which is the color that is used for the root element when the page specifies no color).
 
@@ -51,7 +51,7 @@ p {
 <p>This paragraph has <em>emphasized text</em> in it.</p>
 ```
 
-{{EmbedLiveSample("","",40)}}
+{{EmbedLiveSample("Non-inherited properties","",40)}}
 
 The words "emphasized text" will not have another border (since the initial value of [`border-style`](/en-US/docs/Web/CSS/border-style) is `none`).
 
@@ -89,7 +89,7 @@ em {
 <p>This paragraph has <em>emphasized text</em> in it.</p>
 ```
 
-{{EmbedLiveSample("","",40)}}
+{{EmbedLiveSample("Overriding inheritance, an example","",40)}}
 
 We can see here another border around the word "emphasized text".
 

--- a/files/en-us/web/css/margin-left/index.md
+++ b/files/en-us/web/css/margin-left/index.md
@@ -147,17 +147,11 @@ The `margin-left` property is specified as the keyword `auto`, or a `<length>`, 
 
 ## Examples
 
+### Setting margin-left as a percentage
+
 Percentage values for `margin-left` are relative to the container's inline size.
 
-### CSS
-
-```css
-.example {
-  margin-left: 50%;
-}
-```
-
-### HTML
+#### HTML
 
 ```html
 <p>
@@ -174,9 +168,17 @@ Percentage values for `margin-left` are relative to the container's inline size.
 </p>
 ```
 
-### Result
+#### CSS
 
-{{EmbedLiveSample("","","250")}}
+```css
+.example {
+  margin-left: 50%;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Setting margin-left as a percentage","","250")}}
 
 ## Specifications
 

--- a/files/en-us/web/html/element/object/index.md
+++ b/files/en-us/web/html/element/object/index.md
@@ -62,7 +62,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 #### Result
 
-{{EmbedLiveSample}}
+{{EmbedLiveSample("Embed a video")}}
 
 If the video in the example fails to load, the user will be provided with an image as fallback content. The {{HTMLElement("img")}} tag is used to display an image. We include the `src` attribute set to the path to the image we want to embed. We also include the `alt` attribute, which provides the image with an accessible name. If the image also fails to load, the content of the `alt` attribute will be displayed.
 


### PR DESCRIPTION
The first parameter to `EmbedLiveSample` tells the macro where to find the code blocks that the example needs to include. Authors used to be able to omit the first parameter, and it would then infer code blocks to include from the structure of the document.

This no longer works reliably, so this PR updates all live samples that weren't passing an explicit parameter so that they do.

See also https://github.com/mdn/content/pull/32203.