### PR TITLE
[Intl.DurationFormat] fix comment/code mismatch

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/durationformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/durationformat/index.md
@@ -60,7 +60,7 @@ new Intl.DurationFormat("fr-FR", { style: "long" }).format(duration);
 new Intl.DurationFormat("en", { style: "short" }).format(duration);
 // "1 hr, 46 min and 40 sec"
 
-// With style set to "short" and locale "pt"
+// With style set to "narrow" and locale "pt"
 new Intl.DurationFormat("pt", { style: "narrow" }).format(duration);
 // "1h 46min 40s"
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The code comment doesn't match the example code, and also doesn't match the example output. 

### Motivation

It's incorrect and confusing

### Additional details

This can only be tested using macOS due to limited cross-browser support for this feature

### Related issues and pull requests

None
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
