### PR TITLE
fix(ci): make the post yarn install script more robust

### DIFF
--- a/.husky/update-history
+++ b/.husky/update-history
@@ -4,6 +4,6 @@
 # The stored commit hash is used by the post-merge script .husky/post-merge
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$BRANCH" = "main" ]; then
+if [ "$BRANCH" = "main" -a -d "./.husky/_" ]; then
   echo $(git rev-parse HEAD) > ./.husky/_/history
 fi


### PR DESCRIPTION
- addresses https://github.com/mdn/content/pull/32269#issuecomment-1945303125

The `mdn/content` may get checkout out in CIs of other repos. Better check if directory exist before creating the file.