### PR TITLE
Exper features - fix browser version in table for clipboard read/write

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1665,8 +1665,8 @@ The [Clipboard.read()](/en-US/docs/Web/API/Clipboard/read), [Clipboard.readText(
     </tr>
     <tr>
       <th>Beta</th>
+      <td>122</td>
       <td>Yes</td>
-      <td>No</td>
     </tr>
     <tr>
       <th>Release</th>


### PR DESCRIPTION
Table was showing version of browser as "Yes" when it is actually 122. This fixes it to 122. Comes from https://github.com/mdn/content/pull/31140#discussion_r1489660773