### PR TITLE
fix: add misssing param `aShowDialog`

### DIFF
--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -35,6 +35,8 @@ find(aString, aCaseSensitive, aBackwards, aWrapAround, aWholeWord, aSearchInFram
   - : A boolean value. If `true`, specifies a whole word search.
 - `aSearchInFrames`
   - : A boolean value. If `true`, specifies a search in frames.
+- `aShowDialog`
+  - : A boolean value. If `true`, a search dialog is shown.
 
 ### Return value
 


### PR DESCRIPTION
### Description

add the description of the misssing param `aShowDialog`. Note, I think it's still necessary to keep the description of this param, though it is not implemented by any major browser cores:

- [Gecko](https://searchfox.org/mozilla-central/rev/a7809ff8b0a6d98e6df3183d3ca99c77ef2f983e/dom/base/nsGlobalWindowOuter.cpp#6366)
- [WebKit](https://github.com/WebKit/WebKit/blob/4aa7c4c9b5a35bf5e68871fd6ff955ced5011869/Source/WebCore/page/LocalDOMWindow.cpp#L1237-L1245)
- [Chromium](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/local_dom_window.cc;l=1444-1462;drc=1a2144ba75ade44590b6734615d4ca51cae766eb)
