### PR TITLE
Deleted removed values

### DIFF
--- a/files/en-us/web/css/-moz-float-edge/index.md
+++ b/files/en-us/web/css/-moz-float-edge/index.md
@@ -16,10 +16,8 @@ The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property speci
 
 ```css
 /* Keyword values */
--moz-float-edge: border-box;
 -moz-float-edge: content-box;
 -moz-float-edge: margin-box;
--moz-float-edge: padding-box;
 
 /* Global values */
 -moz-float-edge: inherit;
@@ -29,14 +27,10 @@ The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property speci
 
 ### Values
 
-- `border-box`
-  - : The height and width properties include the content, padding and border but not the margin.
 - `content-box`
   - : The height and width properties include the content, but not the padding, border or margin.
 - `margin-box`
   - : The height and width properties include the content, padding, border and margin.
-- `padding-box`
-  - : The height and width properties include the content and padding but not the border or margin.
 
 ## Formal definition
 

--- a/files/en-us/web/css/-moz-float-edge/index.md
+++ b/files/en-us/web/css/-moz-float-edge/index.md
@@ -40,7 +40,7 @@ The non-standard **`-moz-float-edge`** [CSS](/en-US/docs/Web/CSS) property speci
 
 ```plain
 -moz-float-edge =
-  border-box | content-box | margin-box | padding-box
+  content-box | margin-box
 ```
 
 ## Examples


### PR DESCRIPTION
As values were removed 16 years ago there is no need to mention their existence on MDN

### Description

Delete removed values

### Motivation

They were removed 16 years ago, so there is no need to mention them on MDN 

### Additional details

[Firefox bug 432891](https://bugzil.la/432891)

### Related issues and pull requests

