### PR TITLE
Add note about using Array.prototype.includes()

### DIFF
--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.operators.in
 
 The **`in`** operator returns `true` if the specified property is in the specified object or its prototype chain.
 
-If you need to find if a certain value exists in an array, use {{jsxref("Array/includes", "includes()")}}.
+The `in` operator cannot be used to search for values in other collections. To test if a certain value exists in an array, use {{jsxref("Array.prototype.includes()")}}. For sets, use {{jsxref("Set.prototype.has()")}}.
 
 {{EmbedInteractiveExample("pages/js/expressions-inoperator.html")}}
 

--- a/files/en-us/web/javascript/reference/operators/in/index.md
+++ b/files/en-us/web/javascript/reference/operators/in/index.md
@@ -9,6 +9,8 @@ browser-compat: javascript.operators.in
 
 The **`in`** operator returns `true` if the specified property is in the specified object or its prototype chain.
 
+If you need to find if a certain value exists in an array, use {{jsxref("Array/includes", "includes()")}}.
+
 {{EmbedInteractiveExample("pages/js/expressions-inoperator.html")}}
 
 ## Syntax


### PR DESCRIPTION
Added a note relating to a possible misconception about the `in` operator in JavaScript. In Python `in` operator is used similarly to how `includes()` is used in JavaScript, hence the misunderstanding.