### PR TITLE
Fix associated interfaces section of aria-controls

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
@@ -82,8 +82,8 @@ In this tabs example, each tab controls one tabpanel:
 
 ## Associated interfaces
 
-- {{domxref("Element.ariaBusy")}}
-  - : The [`ariaControls`](/en-US/docs/Web/API/Element/ariaBusy) property, part of each element's interface, reflects the value of the `aria-controls` attribute, which indicates whether an element is being modified.
+- {{domxref("Element.ariaControlsElements")}}
+  - : The `ariaControlsElements` property is part of each element's interface. Its value is a list of {{domxref("Element")}}s corresponding to the ID values specified in the `aria-controls` attribute.
 
 ## Associated roles
 


### PR DESCRIPTION
The MDN page for the `aria-controls` attribute has a section [Associated interfaces](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls#associated_interfaces) which seems to have been copied from the `aria-busy` page and not correctly adapted. It still points to `Element.ariaBusy` with the same description (just `aria-busy` replaced with `aria-controls`).

This PR fixes that section by pointing to the related interface `Element.ariaControlsElements`. A page for this property does not yet exist. It is still experimental and only supported by Safari at the moment. If you want I can also
- just remove the section (for now)
- create a very basic page for `Element.ariaControlsElements` (note that non of the other `Element.aria*Elements` properties have pages yet)
- remove the reference to `Element.ariaControlsElements` (via the domxref) macro