### PR TITLE
<dir> element - remove comment about browser removal

### DIFF
--- a/files/en-us/web/html/element/dir/index.md
+++ b/files/en-us/web/html/element/dir/index.md
@@ -11,7 +11,7 @@ browser-compat: html.elements.dir
 
 The **`<dir>`** [HTML](/en-US/docs/Web/HTML) element is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the {{Glossary("user agent")}}. Do not use this obsolete element; instead, you should use the {{HTMLElement("ul")}} element for lists, including lists of files.
 
-> **Warning:** Do not use this element. Though present in early HTML specifications, it has been deprecated in HTML 4, and has since been removed entirely. **No major browsers support this element.**
+> **Warning:** Do not use this element. Though present in early HTML specifications, it has been deprecated in HTML 4, and has since been removed entirely.
 
 ## DOM interface
 


### PR DESCRIPTION
Fixes #32333

The https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dir doc had the comment **No major browsers support this element.** but if you look at the BCD table and canIuse it is still marked as supported. Further, the associated API shows up as still existing in the BCD collector.

So this is very likely an incorrect statement.