### PR TITLE
Update Firefox 123 release notes for WebDriver conforming changes.

### DIFF
--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -63,11 +63,17 @@ This article provides information about the changes in Firefox 123 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-#### General
-
 #### WebDriver BiDi
 
+* Added the [network.fetchError](https://w3c.github.io/webdriver-bidi/#event-network-fetchError) event that is emitted when a network request ends in an error ([Firefox bug 1790375](https://bugzil.la/1790375)).
+* Support for the [browsingContext.locateNodes](https://w3c.github.io/webdriver-bidi/#commands-browsingcontextlocatenodes) command has been introduced that can be used to find elements on the given page. Supported locators for now are `CssLocator` ([Firefox bug 1790375](https://bugzil.la/1855023)) and `XPathLocator` ([Firefox bug 1790375](https://bugzil.la/1869536)).
+* Improved the [browsingContext.create](https://w3c.github.io/webdriver-bidi/#command-browsingContext-create) command on Android to seamlessly switch to opening a new tab if the `type` argument is specified as `window` ([Firefox bug 1790375](https://bugzil.la/1875086)).
+* Fixed an issue with the deserialization process of a `DateRemoteValue`, where the presence of a non-standard (ISO 8601) date string such as 200009 did not trigger an error ([Firefox bug 1790375](https://bugzil.la/1872116)).
+* Fixed an issue with the [script.evaluate](https://w3c.github.io/webdriver-bidi/#command-script-evaluate), [script.callFunction](https://w3c.github.io/webdriver-bidi/#command-script-callFunction), and [script.disown](https://w3c.github.io/webdriver-bidi/#command-script-disown) commands where specifying both the `context` and `realm` arguments would result in an `invalid argument` error, rather than simply ignoring the `realm` argument as intended ([Firefox bug 1790375](https://bugzil.la/1873688)).
+
 #### Marionette
+
+* Fixed a bug with [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys) where sending text containing surrogate pairs would fail ([Firefox bug 1790375](https://bugzil.la/1866431)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -65,15 +65,15 @@ This article provides information about the changes in Firefox 123 that affect d
 
 #### WebDriver BiDi
 
-* Added the [network.fetchError](https://w3c.github.io/webdriver-bidi/#event-network-fetchError) event that is emitted when a network request ends in an error ([Firefox bug 1790375](https://bugzil.la/1790375)).
-* Support for the [browsingContext.locateNodes](https://w3c.github.io/webdriver-bidi/#commands-browsingcontextlocatenodes) command has been introduced that can be used to find elements on the given page. Supported locators for now are `CssLocator` ([Firefox bug 1790375](https://bugzil.la/1855023)) and `XPathLocator` ([Firefox bug 1790375](https://bugzil.la/1869536)).
-* Improved the [browsingContext.create](https://w3c.github.io/webdriver-bidi/#command-browsingContext-create) command on Android to seamlessly switch to opening a new tab if the `type` argument is specified as `window` ([Firefox bug 1790375](https://bugzil.la/1875086)).
-* Fixed an issue with the deserialization process of a `DateRemoteValue`, where the presence of a non-standard (ISO 8601) date string such as 200009 did not trigger an error ([Firefox bug 1790375](https://bugzil.la/1872116)).
-* Fixed an issue with the [script.evaluate](https://w3c.github.io/webdriver-bidi/#command-script-evaluate), [script.callFunction](https://w3c.github.io/webdriver-bidi/#command-script-callFunction), and [script.disown](https://w3c.github.io/webdriver-bidi/#command-script-disown) commands where specifying both the `context` and `realm` arguments would result in an `invalid argument` error, rather than simply ignoring the `realm` argument as intended ([Firefox bug 1790375](https://bugzil.la/1873688)).
+- Added the [network.fetchError](https://w3c.github.io/webdriver-bidi/#event-network-fetchError) event that is emitted when a network request ends in an error ([Firefox bug 1790375](https://bugzil.la/1790375)).
+- Support for the [browsingContext.locateNodes](https://w3c.github.io/webdriver-bidi/#commands-browsingcontextlocatenodes) command has been introduced to find elements on the given page. Supported locators for now are `CssLocator` ([Firefox bug 1855023](https://bugzil.la/1855023)) and `XPathLocator` ([Firefox bug 1869536](https://bugzil.la/1869536)).
+- Improved the [browsingContext.create](https://w3c.github.io/webdriver-bidi/#command-browsingContext-create) command on Android to seamlessly switch to opening a new tab if the `type` argument is specified as `window` ([Firefox bug 1875086](https://bugzil.la/1875086)).
+- Fixed an issue with the deserialization process of a `DateRemoteValue`, where the presence of a non-standard (ISO 8601) date string such as `200009` did not trigger an error ([Firefox bug 1872116](https://bugzil.la/1872116)).
+- Fixed an issue with the [script.evaluate](https://w3c.github.io/webdriver-bidi/#command-script-evaluate), [script.callFunction](https://w3c.github.io/webdriver-bidi/#command-script-callFunction), and [script.disown](https://w3c.github.io/webdriver-bidi/#command-script-disown) commands where specifying both the `context` and `realm` arguments would result in an `invalid argument` error, rather than simply ignoring the `realm` argument as intended ([Firefox bug 1873688](https://bugzil.la/1873688)).
 
 #### Marionette
 
-- Fixed a bug with [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys) where sending text containing surrogate pairs would fail ([Firefox bug 1790375](https://bugzil.la/1866431)).
+- Fixed a bug with [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys) where sending text containing surrogate pairs would fail ([Firefox bug 1866431](https://bugzil.la/1866431)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -73,7 +73,7 @@ This article provides information about the changes in Firefox 123 that affect d
 
 #### Marionette
 
-* Fixed a bug with [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys) where sending text containing surrogate pairs would fail ([Firefox bug 1790375](https://bugzil.la/1866431)).
+- Fixed a bug with [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys) where sending text containing surrogate pairs would fail ([Firefox bug 1790375](https://bugzil.la/1866431)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
This updates the WebDriver section of the Firefox 123 release notes for all the [note-worthy WebDriver changes in this release](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox122&query_format=advanced&o1=equals&f1=cf_status_firefox123&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=16905819).

@juliandescottes can you please take a look?