### PR TITLE
correct alt info of svelte typescript

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -904,7 +904,7 @@ Svelte stores support generics out of the box. And, because of generic type infe
 
 If you open the file `Todos.svelte` and assign a `number` type to our `$alert` store, you'll get the following error:
 
-![Todo Type object property complete should be completed](13-vscode-generic-alert-error.png)
+![Argument of type 9999 is not assignable to parameter of type string](13-vscode-generic-alert-error.png)
 
 That's because when we defined our alert store in the `stores.ts` file with:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
According to the content of the picture, the alt content is not right

![13-vscode-generic-alert-error](https://github.com/mdn/content/assets/84226578/f0ecce5c-e2d6-4ee6-aed4-a818e3adb54e)

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
