### PR TITLE
fix: convert 'suggest yarn install' script from Shell to JS

### DIFF
--- a/.husky/update-history
+++ b/.husky/update-history
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-
-# This script stores the 'main' branch's HEAD commit hash in .husky/_/history
-# The stored commit hash is used by the post-merge script .husky/post-merge
-
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "$BRANCH" = "main" -a -d "./.husky/_" ]; then
-  echo $(git rev-parse HEAD) > ./.husky/_/history
-fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "type": "module",
   "scripts": {
-    "postinstall": "sh ./.husky/update-history",
+    "postinstall": "node scripts/update-history.js",
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build yari-build",
     "content": "env-cmd --silent cross-env CONTENT_ROOT=files yari-tool",
     "filecheck": "env-cmd --silent cross-env CONTENT_ROOT=files yari-filecheck --cwd=.",

--- a/scripts/update-history.js
+++ b/scripts/update-history.js
@@ -1,0 +1,16 @@
+/**
+ * This script stores the 'main' branch's HEAD commit hash in .husky/_/history
+ * The stored commit hash is used by the post-merge script .husky/post-merge
+ */
+
+import fs from "node:fs";
+import { execGit } from "./utils.js";
+
+const HUSKY_ROOT = ".husky/_/";
+const HISTORY_FILE = HUSKY_ROOT + "history";
+
+const branch = execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd: "." });
+if (branch === "main" && fs.existsSync(HUSKY_ROOT)) {
+  const hash = execGit(["rev-parse", "HEAD"], { cwd: "." });
+  fs.writeFileSync(HISTORY_FILE, hash);
+}


### PR DESCRIPTION
Current script works well on Windows if
- Gitbash used
- `C:\Program Files\Git\biin` added to `PATH`

For some reason people don't wan't to use Gitbash. So to make it work without any change required from contributor's end we need to convert the script to NodeJs.