### PR TITLE
Fixed type of stdDeviation in feDropShadow

### DIFF
--- a/files/en-us/web/svg/element/fedropshadow/index.md
+++ b/files/en-us/web/svg/element/fedropshadow/index.md
@@ -60,7 +60,7 @@ svg {
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
 - {{SVGAttr("stdDeviation")}}
   - : This attribute defines the standard deviation for the blur operation in the drop shadow.
-    _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number); _Default value_: `2`; _Animatable_: **yes**
+    _Value type_: [**\<number-optional-number>**](/en-US/docs/Web/SVG/Content_type#number-optional-number); _Default value_: `2`; _Animatable_: **yes**
 
 ### Global attributes
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

According to [Specifications](https://drafts.fxtf.org/filter-effects/#element-attrdef-fedropshadow-stddeviation) the type of stdDeviation is not `number` but `number-optional-number`.

<!-- ✍️ Summarize your changes in one or two sentences

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers?

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
