### PR TITLE
fix errors in ::spelling-error and ::grammar-error examples

### DIFF
--- a/files/en-us/web/css/_doublecolon_grammar-error/index.md
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.md
@@ -39,7 +39,9 @@ In this example, eventual supporting browsers should highlight any flagged gramm
 #### HTML
 
 ```html
-<p contenteditable spellcheck="true">My friends is coming to the party tonight.</p>
+<p contenteditable spellcheck="true">
+  My friends is coming to the party tonight.
+</p>
 ```
 
 #### CSS

--- a/files/en-us/web/css/_doublecolon_grammar-error/index.md
+++ b/files/en-us/web/css/_doublecolon_grammar-error/index.md
@@ -39,7 +39,7 @@ In this example, eventual supporting browsers should highlight any flagged gramm
 #### HTML
 
 ```html
-<p>My friends is coming to the party tonight.</p>
+<p contenteditable spellcheck="true">My friends is coming to the party tonight.</p>
 ```
 
 #### CSS

--- a/files/en-us/web/css/_doublecolon_spelling-error/index.md
+++ b/files/en-us/web/css/_doublecolon_spelling-error/index.md
@@ -48,7 +48,7 @@ In this example, eventual supporting browsers should highlight any flagged spell
 
 ```css
 ::spelling-error {
-  text-decoration: wavy red;
+  text-decoration: wavy red underline;
 }
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

In the `::spelling-error` example, the `text-decoration` property was missing a value for `text-decoration-line` and the line does not appear (at least on Chromium), so I added `underline` to the property.

Additionally, added `contenteditable` and `spellcheck="true"` attributes to the `<p>` in the `::grammar-error` example for consistency with `::spelling-error` and so browsers know to grammar-check.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Currently, the `::spelling-error` example may not show any kind of text decoration on spelling errors, and the `::grammar-error` example is not editable so no grammar errors will be found.
 
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->

