### PR TITLE
Update window.blur() to reflect that it does nothing

### DIFF
--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -3,12 +3,18 @@ title: "Window: blur() method"
 short-title: blur()
 slug: Web/API/Window/blur
 page-type: web-api-instance-method
+status:
+  - deprecated
 browser-compat: api.Window.blur
 ---
 
 {{APIRef}}
 
-Shifts focus away from the window.
+The **`Window.blur()`** method does nothing.
+
+> **Note:** Historically, this method was the programmatic equivalent of the user shifting focus away
+> from the current window. This behavior was removed due to hostile sites abusing this functionality.
+> In Firefox, you can enable the old behavior with the `dom.disable_window_flip` preference.
 
 ## Syntax
 
@@ -29,11 +35,6 @@ None ({{jsxref("undefined")}}).
 ```js
 window.blur();
 ```
-
-## Notes
-
-The window\.blur() method is the programmatic equivalent of the user shifting focus away
-from the current window.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updates the page for `window.blur()` to reflect that it does nothing - [according to the spec](https://html.spec.whatwg.org/#dom-window-blur):

> The `blur()` method steps are to do nothing.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This helps readers who may be confused as to why `blur()` doesn't work.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- [Chromium's no-op `blur()` implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/dom_window.cc;l=588;drc=f4a00cc248dd2dc8ec8759fb51620d47b5114090)
- [Mozilla's check for if `blur()` should be allowed](https://github.com/mozilla/gecko-dev/blob/c26f7461fc2a51196b7f517c7f98a1e271dc9ec0/docshell/base/BrowsingContext.cpp#L2337) (only for browser chrome and when `dom.disable_window_flip` is off)


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
