### PR TITLE
Unhide HTML code block in tutorial

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -589,7 +589,7 @@ If I set `box1` to `display: grid` I can give it a track definition and it too w
 }
 ```
 
-```html hidden
+```html
 <div class="wrapper">
   <div class="box box1">
     <div class="nested">a</div>


### PR DESCRIPTION
### Description

Unhide the HTML code block in [this](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#nesting_without_subgrid) Grid layout section. The lack of it made the code of the section more confusing to replicate for the reader.

### Motivation

Make the guide easier to follow. The lack of the code block mentioned doesn't seem to be deliberate.