### PR TITLE
Including matrix type

### DIFF
--- a/files/en-us/web/api/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/index.md
@@ -19,7 +19,7 @@ The **`CSSMatrixComponent`** interface of the {{domxref('CSS_Object_Model#css_ty
 ## Instance properties
 
 - {{domxref('CSSMatrixComponent.matrix','matrix')}}
-  - : A matrix of type [`DOMMatrix`](/en-US/docs/Web/API/DOMMatrix/DOMMatrix).
+  - : A {{domxref("DOMMatrix")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/index.md
@@ -19,7 +19,7 @@ The **`CSSMatrixComponent`** interface of the {{domxref('CSS_Object_Model#css_ty
 ## Instance properties
 
 - {{domxref('CSSMatrixComponent.matrix','matrix')}}
-  - : A matrix.
+  - : A matrix of type [`DOMMatrix`](/en-US/docs/Web/API/DOMMatrix/DOMMatrix).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Adding parameter type

### Motivation

The current description does not include the parameter type

### Additional details

I can't find it in the spec, but if you want to test, run:

CSSStyleValue.parse("transform", "matrix(1, 2, -1, 1, 80, 80)")[0].matrix.constructor.name