### PR TITLE
chore(macros): Replace no_tag_omission macro with single sentence of text

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -148,7 +148,7 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -459,7 +459,7 @@ Spacing may be created using CSS properties like {{CSSxRef("margin")}}.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/abbr/index.md
+++ b/files/en-us/web/html/element/abbr/index.md
@@ -167,7 +167,7 @@ This is especially helpful for people who are unfamiliar with the terminology or
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/address/index.md
+++ b/files/en-us/web/html/element/address/index.md
@@ -83,7 +83,7 @@ Although it renders text with the same default styling as the {{HTMLElement("i")
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/article/index.md
+++ b/files/en-us/web/html/element/article/index.md
@@ -105,7 +105,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/aside/index.md
+++ b/files/en-us/web/html/element/aside/index.md
@@ -75,7 +75,7 @@ This example uses `<aside>` to mark up a paragraph in an article. The paragraph 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -422,7 +422,7 @@ Also it's a good practice to provide some content (such as the direct download l
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/b/index.md
+++ b/files/en-us/web/html/element/b/index.md
@@ -68,7 +68,7 @@ Keywords are displayed with the default style of the
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/bdi/index.md
+++ b/files/en-us/web/html/element/bdi/index.md
@@ -142,7 +142,7 @@ body {
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/bdo/index.md
+++ b/files/en-us/web/html/element/bdo/index.md
@@ -69,7 +69,7 @@ The HTML 4 specification did not specify events for this element; they were adde
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/blockquote/index.md
+++ b/files/en-us/web/html/element/blockquote/index.md
@@ -72,7 +72,7 @@ This example demonstrates the use of the `<blockquote>` element to quote a passa
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -237,7 +237,7 @@ Whether clicking on a {{HTMLElement("button")}} or {{HTMLElement("input")}} butt
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/canvas/index.md
+++ b/files/en-us/web/html/element/canvas/index.md
@@ -127,7 +127,7 @@ The `<canvas>` element on its own is just a bitmap and does not provide informat
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/cite/index.md
+++ b/files/en-us/web/html/element/cite/index.md
@@ -90,7 +90,7 @@ Typically, browsers style the contents of a `<cite>` element in italics by defau
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/code/index.md
+++ b/files/en-us/web/html/element/code/index.md
@@ -65,7 +65,7 @@ A CSS rule can be defined for the `code` selector to override the browser's defa
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/data/index.md
+++ b/files/en-us/web/html/element/data/index.md
@@ -64,7 +64,7 @@ The following example displays product names but also associates each name with 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/datalist/index.md
+++ b/files/en-us/web/html/element/datalist/index.md
@@ -146,7 +146,7 @@ When deciding to use the `<datalist>` element, here are some accessibility issue
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/del/index.md
+++ b/files/en-us/web/html/element/del/index.md
@@ -93,7 +93,7 @@ Some people who use screen readers deliberately disable announcing content that 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/details/index.md
+++ b/files/en-us/web/html/element/details/index.md
@@ -229,7 +229,7 @@ This CSS creates a look similar to a tabbed interface, where activating the tab 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -142,7 +142,7 @@ Note the `<abbr>` element nested inside the `<dfn>`. The former establishes that
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -534,7 +534,7 @@ The `<dialog>` element is exposed by browsers in a manner similar to custom dial
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/div/index.md
+++ b/files/en-us/web/html/element/div/index.md
@@ -102,7 +102,7 @@ The `<div>` element has [an implicit role of `generic`](https://www.w3.org/TR/wa
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/dl/index.md
+++ b/files/en-us/web/html/element/dl/index.md
@@ -188,7 +188,7 @@ As of iOS 14, VoiceOver will announce that `<dl>` content is a list when navigat
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -77,7 +77,7 @@ In this example, the `<em>` element is used to highlight an implicit or explicit
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/fieldset/index.md
+++ b/files/en-us/web/html/element/fieldset/index.md
@@ -119,7 +119,7 @@ This example shows a disabled `<fieldset>` with two controls inside it. Note how
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/figcaption/index.md
+++ b/files/en-us/web/html/element/figcaption/index.md
@@ -41,7 +41,7 @@ Please see the {{HTMLElement("figure")}} page for examples on `<figcaption>`.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/figure/index.md
+++ b/files/en-us/web/html/element/figure/index.md
@@ -131,7 +131,7 @@ function NavigatorExample() {
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/footer/index.md
+++ b/files/en-us/web/html/element/footer/index.md
@@ -78,7 +78,7 @@ Prior to the release of Safari 13, the `contentinfo` [landmark role](/en-US/docs
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -142,7 +142,7 @@ The following attributes control behavior during form submission.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/header/index.md
+++ b/files/en-us/web/html/element/header/index.md
@@ -98,7 +98,7 @@ The `<header>` element defines a [`banner`](/en-US/docs/Web/Accessibility/ARIA/R
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/heading_elements/index.md
+++ b/files/en-us/web/html/element/heading_elements/index.md
@@ -189,7 +189,7 @@ In this example, screen reading technology would announce that there are two {{H
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/hgroup/index.md
+++ b/files/en-us/web/html/element/hgroup/index.md
@@ -77,7 +77,7 @@ The `<hgroup>` presently has no strong accessibility semantics. The content of t
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/i/index.md
+++ b/files/en-us/web/html/element/i/index.md
@@ -80,7 +80,7 @@ This example demonstrates using the `<i>` element to mark text that is in anothe
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -237,7 +237,7 @@ Without this title, they have to navigate into the `<iframe>` to determine what 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/ins/index.md
+++ b/files/en-us/web/html/element/ins/index.md
@@ -90,7 +90,7 @@ Some people who use screen readers deliberately disable announcing content that 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/kbd/index.md
+++ b/files/en-us/web/html/element/kbd/index.md
@@ -167,7 +167,7 @@ This does some interesting nesting. For the menu option description, the entire 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/label/index.md
+++ b/files/en-us/web/html/element/label/index.md
@@ -172,7 +172,7 @@ An {{HTMLElement("input")}} element with a `type="button"` declaration and a val
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/legend/index.md
+++ b/files/en-us/web/html/element/legend/index.md
@@ -44,7 +44,7 @@ See {{HTMLElement("form")}} for examples on `<legend>`.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/map/index.md
+++ b/files/en-us/web/html/element/map/index.md
@@ -84,7 +84,7 @@ Click the left-hand parrot for JavaScript, or the right-hand parrot for CSS.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/mark/index.md
+++ b/files/en-us/web/html/element/mark/index.md
@@ -128,7 +128,7 @@ Some people who use screen readers deliberately disable announcing content that 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/menu/index.md
+++ b/files/en-us/web/html/element/menu/index.md
@@ -106,7 +106,7 @@ button {
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{No_Tag_Omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/meter/index.md
+++ b/files/en-us/web/html/element/meter/index.md
@@ -104,7 +104,7 @@ On Google Chrome, the resulting meter looks like this:
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/nav/index.md
+++ b/files/en-us/web/html/element/nav/index.md
@@ -94,7 +94,7 @@ The semantics of the `nav` element is that of providing links. However a `nav` e
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/noscript/index.md
+++ b/files/en-us/web/html/element/noscript/index.md
@@ -74,7 +74,7 @@ Rocks!
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/object/index.md
+++ b/files/en-us/web/html/element/object/index.md
@@ -93,7 +93,7 @@ If the video in the example fails to load, the user will be provided with an ima
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/ol/index.md
+++ b/files/en-us/web/html/element/ol/index.md
@@ -170,7 +170,7 @@ To determine which list to use, try changing the order of the list items; if the
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/output/index.md
+++ b/files/en-us/web/html/element/output/index.md
@@ -88,7 +88,7 @@ Many browsers implement this element as an [`aria-live`](/en-US/docs/Web/Accessi
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/picture/index.md
+++ b/files/en-us/web/html/element/picture/index.md
@@ -139,7 +139,7 @@ The `type` attribute specifies a [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -120,7 +120,7 @@ if (i &lt; 10 &amp;&amp; i &gt; 0)
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -103,7 +103,7 @@ If the `<progress>` element is describing the loading progress of a section of a
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/q/index.md
+++ b/files/en-us/web/html/element/q/index.md
@@ -62,7 +62,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/ruby/index.md
+++ b/files/en-us/web/html/element/ruby/index.md
@@ -70,7 +70,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/s/index.md
+++ b/files/en-us/web/html/element/s/index.md
@@ -91,7 +91,7 @@ Some people who use screen readers deliberately disable announcing content that 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/samp/index.md
+++ b/files/en-us/web/html/element/samp/index.md
@@ -118,7 +118,7 @@ The resulting output is this:
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -231,7 +231,7 @@ so that the script doesn't block parsing but is guaranteed to be evaluated befor
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/search/index.md
+++ b/files/en-us/web/html/element/search/index.md
@@ -130,7 +130,7 @@ This example demonstrates a page with two search features. The first is a global
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>

--- a/files/en-us/web/html/element/section/index.md
+++ b/files/en-us/web/html/element/section/index.md
@@ -118,7 +118,7 @@ Depending on the content, including a heading could also be good for SEO, so it 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -632,7 +632,7 @@ The `<hr>` within a `<select>` should be considered purely decorative, as they a
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/slot/index.md
+++ b/files/en-us/web/html/element/slot/index.md
@@ -101,7 +101,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/span/index.md
+++ b/files/en-us/web/html/element/span/index.md
@@ -82,7 +82,7 @@ li span {
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/sub/index.md
+++ b/files/en-us/web/html/element/sub/index.md
@@ -122,7 +122,7 @@ Another example:
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/sup/index.md
+++ b/files/en-us/web/html/element/sup/index.md
@@ -103,7 +103,7 @@ Ordinal numbers, such as "fourth" in English or "quinto" in Spanish may be abbre
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/table/index.md
+++ b/files/en-us/web/html/element/table/index.md
@@ -970,7 +970,7 @@ If the table cannot be broken apart, use a combination of the [`id`](/en-US/docs
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -226,7 +226,7 @@ Since `firstClone` is a `DocumentFragment`, only its children are added to `cont
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -241,7 +241,7 @@ I am a read-only textarea.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/time/index.md
+++ b/files/en-us/web/html/element/time/index.md
@@ -132,7 +132,7 @@ The _datetime value_ (the machine-readable value of the datetime) is the value o
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/tt/index.md
+++ b/files/en-us/web/html/element/tt/index.md
@@ -104,7 +104,7 @@ Although this element wasn't officially deprecated in HTML 4.01, its use was dis
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/u/index.md
+++ b/files/en-us/web/html/element/u/index.md
@@ -162,7 +162,7 @@ cite {
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/ul/index.md
+++ b/files/en-us/web/html/element/ul/index.md
@@ -143,7 +143,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/var/index.md
+++ b/files/en-us/web/html/element/var/index.md
@@ -114,7 +114,7 @@ This HTML uses `<var>` to enclose the names of two variables.
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -500,7 +500,7 @@ Captions should not obstruct the main subject of the video. They can be position
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>


### PR DESCRIPTION

### Description

This PR removes a macro which repeats a single line of text. The ratio of replaced text per macro invocation doesn't appear to be worth it considering the overhead.

### Motivation

Removing less-useful macros from content.

See https://github.com/mdn/yari/blob/main/kumascript/macros/no_tag_omission.ejs

