### PR TITLE
Update CSSPerspective Type (1)

### DIFF
--- a/files/en-us/web/api/cssperspective/length/index.md
+++ b/files/en-us/web/api/cssperspective/length/index.md
@@ -16,7 +16,7 @@ value is 0 or a negative number, no perspective transform is applied.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}
+A {{domxref("CSSUnitValue")}}
 
 ## Examples
 


### PR DESCRIPTION
The type of CSSPerspective length is inaccurate

### Description

Correcting the type

### Motivation

It's wrong. Wrong I tell you!

### Additional details

Sorry, I can't find this in the spec, but:

CSSNumericValue doesn't even have a constructor. Meanwhile, the following code works in Chrome:

var unit = new CSSUnitValue(7, 'px');
var cssp = new CSSPerspective(unit);

Also, if you run the following code, a CSSUnitValue is created:

CSSStyleValue.parse("transform", "perspective(20px)")[0].constructor.name

A second PR, fixing this in the linking page follows