### PR TITLE
Adding length type

### DIFF
--- a/files/en-us/web/api/cssperspective/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.md
@@ -22,13 +22,13 @@ new CSSPerspective(length)
 
 - {{domxref('CSSPerspective.length','length')}}
   - : A value for the distance from z=0 of the {{domxref('CSSPerspective')}} object to be
-    constructed. This must be a {{cssxref('length')}}.
+    constructed. This must be a {{cssxref('length')}} of type {{cssxref('CSSUnitValue')}}.
 
 ### Exceptions
 
 - [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
   - : Raised if the value of `CSSPerspective.length` exists but is not a
-    {{cssxref('length')}}.
+    {{cssxref('CSSUnitValue')}}.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Adding the construct-able type of the length param

### Motivation

You can't construct a <length>,  so the docs are not useful to someone who actually wants to call this API

### Additional details

Sorry, I can't find this in the spec, but the following code works in Chrome:

var unit = new CSSUnitValue(7, 'px');
var cssp = new CSSPerspective(unit);

Also, if you run the following code, a CSSUnitValue is created:

CSSStyleValue.parse("transform", "perspective(20px)")[0].constructor.name