### PR TITLE
getYear deprecation

### DIFF
--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -120,7 +120,7 @@ This code creates a `Date` object, then walks up the prototype chain, logging th
 
 ![Prototype chain for myDate](mydate-prototype-chain.svg)
 
-In fact, when you call familiar methods, like `myDate2.getMonth()`,
+In fact, when you call familiar methods, like `myDate2.getTime()`,
 you are calling a method that's defined on `Date.prototype`.
 
 ## Shadowing properties
@@ -130,20 +130,18 @@ What happens if you define a property in an object, when a property with the sam
 ```js
 const myDate = new Date(1995, 11, 17);
 
-console.log(myDate.getYear()); // 95
+console.log(myDate.getTime()); // 819129600000
 
-myDate.getYear = function () {
+myDate.getTime = function () {
   console.log("something else!");
 };
 
-myDate.getYear(); // 'something else!'
+myDate.getTime(); // 'something else!'
 ```
 
-This should be predictable, given the description of the prototype chain. When we call `getYear()` the browser first looks in `myDate` for a property with that name, and only checks the prototype if `myDate` does not define it. So when we add `getYear()` to `myDate`, then the version in `myDate` is called.
+This should be predictable, given the description of the prototype chain. When we call `getTime()` the browser first looks in `myDate` for a property with that name, and only checks the prototype if `myDate` does not define it. So when we add `getTime()` to `myDate`, then the version in `myDate` is called.
 
 This is called "shadowing" the property.
-
-(Note: `getYear()` is deprecated, a suitable alternative is `getFullYear()`.)
 
 ## Setting a prototype
 

--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -143,6 +143,8 @@ This should be predictable, given the description of the prototype chain. When w
 
 This is called "shadowing" the property.
 
+(Note: `getYear()` is deprecated, a suitable alternative is `getFullYear()`.)
+
 ## Setting a prototype
 
 There are various ways of setting an object's prototype in JavaScript, and here we'll describe two: `Object.create()` and constructors.


### PR DESCRIPTION
Added a note for getYear() and suggested its alternative method.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added a deprecation note for getYear() and suggested a suitable alternative method to use

### Motivation

To help readers who encounter a problem with getYear() not showing the correct output for years after 2000

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
