### PR TITLE
Badging API: Clarify displaying a notification is required

### DIFF
--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -120,6 +120,7 @@ PWAs can use the following mechanisms to update in the background and display, u
 
 - [Push API](/en-US/docs/Web/API/Push_API)
   - : PWAs can use this API to receive messages from a server even when the app is not running. Most browsers require a notification to be displayed whenever a push message is received. This is fine for some use cases (for example, showing a notification when updating the badge), but makes it impossible to subtly update the badge without displaying a notification. In addition, users must grant your site notification permission in order to receive push messages.
+    For more information, see the [ServiceWorkerRegistration: showNotification() method](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification).
 - [Background Synchronization API](/en-US/docs/Web/API/Background_Synchronization_API)
   - : PWAs can use this API to run code in the background when a stable network connection is detected.
 - [Web Periodic Background Synchronization API](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API)

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -119,7 +119,7 @@ Badges can be useful to re-engage users with your app when they're not already u
 PWAs can use the following mechanisms to update in the background and display, update, or hide their badges:
 
 - [Push API](/en-US/docs/Web/API/Push_API)
-  - : PWAs can use this API to receive messages from a server even when the app is not running.
+  - : PWAs can use this API to receive messages from a server even when the app is not running. Most browsers require a notification to be displayed whenever a push message is received. This is fine for some use cases (for example, showing a notification when updating the badge), but makes it impossible to subtly update the badge without displaying a notification. In addition, users must grant your site notification permission in order to receive push messages.
 - [Background Synchronization API](/en-US/docs/Web/API/Background_Synchronization_API)
   - : PWAs can use this API to run code in the background when a stable network connection is detected.
 - [Web Periodic Background Synchronization API](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API)
@@ -142,11 +142,14 @@ self.addEventListener("push", (event) => {
       navigator.clearAppBadge();
     }
   }
+  // ⚠️ Obligatory, but skipped for brevity:
+  // show the notification to the user.
 });
 ```
 
 ## See also
 
 - [How to create an app badge](https://web.dev/patterns/web-apps/badges/)
+- [Badging for app icons](https://developer.chrome.com/docs/capabilities/web-apis/badging-api)
 - [Re-engage users with badges, notifications, and push messages](https://learn.microsoft.com/microsoft-edge/progressive-web-apps-chromium/how-to/notifications-badges)
 - [Codelab: Build a push notification server](https://web.dev/articles/push-notifications-server-codelab)

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -130,7 +130,7 @@ Here is a service worker code example showing how to listen to a server's Push m
 
 ```js
 // Listen to "push" events in the service worker.
-self.addEventListener("push", async (event) => {
+self.addEventListener("push", (event) => {
   // Extract the unread count from the push message data.
   const message = event.data.json();
   const unreadCount = message.unreadCount;
@@ -143,10 +143,8 @@ self.addEventListener("push", async (event) => {
       navigator.clearAppBadge();
     }
   }
-  // It's obligatory to show the notification to the user.
-  navigator.serviceWorker.ready.then((registration) => {
-    registration.showNotification(`${unreadCount} unread messages`);
-  });
+  // It's obligatory to show the notification to the user.  
+  self.registration.showNotification(`${unreadCount} unread messages`);
 });
 ```
 

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -143,7 +143,7 @@ self.addEventListener("push", (event) => {
       navigator.clearAppBadge();
     }
   }
-  // It's obligatory to show the notification to the user.  
+  // It's obligatory to show the notification to the user.
   self.registration.showNotification(`${unreadCount} unread messages`);
 });
 ```

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -129,7 +129,7 @@ Here is a service worker code example showing how to listen to a server's Push m
 
 ```js
 // Listen to "push" events in the service worker.
-self.addEventListener("push", (event) => {
+self.addEventListener("push", async (event) => {
   // Extract the unread count from the push message data.
   const message = event.data.json();
   const unreadCount = message.unreadCount;
@@ -142,8 +142,10 @@ self.addEventListener("push", (event) => {
       navigator.clearAppBadge();
     }
   }
-  // ⚠️ Obligatory, but skipped for brevity:
-  // show the notification to the user.
+  // It's obligatory to show the notification to the user.
+  navigator.serviceWorker.ready.then((registration) => {
+    registration.showNotification(`${unreadCount} unread messages`);
+  });
 });
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarify that displaying a notification is required, even if just updating the badge. 

### Motivation

This confused people who thought it was fine to not display the notification.

### Additional details

https://developer.chrome.com/docs/capabilities/web-apis/badging-api#web_push_api
