### PR TITLE
fix(meta): Update MDN team email

### DIFF
--- a/files/en-us/mdn/community/communication_channels/index.md
+++ b/files/en-us/mdn/community/communication_channels/index.md
@@ -58,6 +58,6 @@ You can use the forums listed below for discussing code problems.
 
 Each localization team has its own [method of communication](/en-US/docs/MDN/Community/Contributing/Translated_content).
 
-## Mailing list
+## Email
 
-For any nonpublic communication, send an email to [mdn-admins](mailto:mdn-admins@mozilla.org).
+For any nonpublic communication, send an email to [mdn-web-docs@mozilla.com](mailto:mdn-web-docs@mozilla.com).


### PR DESCRIPTION
### Description

Updates the MDN team email to current active account.

### Motivation

Provides a non-public way to get in touch with the team

Fixes https://github.com/mdn/content/issues/32302