### PR TITLE
chore: remove link to unmaintained CORS tool

### DIFF
--- a/files/en-us/web/http/cors/errors/index.md
+++ b/files/en-us/web/http/cors/errors/index.md
@@ -56,4 +56,3 @@ Firefox's console displays messages in its console when requests fail due to COR
 - [Server-side CORS settings](/en-US/docs/Web/HTTP/CORS)
 - [CORS enabled image](/en-US/docs/Web/HTML/CORS_enabled_image)
 - [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin)
-- <https://www.test-cors.org> – page to test CORS requests


### PR DESCRIPTION
### Description

The linked tool looks buggy, has plenty of filed issues and has not been updated in approx 7 years, so we may remove it for now.

### Related issues and pull requests

Fixes #32079