### PR TITLE
provided hyperlink to a qualifying topic

### DIFF
--- a/files/en-us/web/css/position/index.md
+++ b/files/en-us/web/css/position/index.md
@@ -31,7 +31,7 @@ position: unset;
 ### Values
 
 - `static`
-  - : The element is positioned according to the normal flow of the document. The {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("z-index")}} properties have _no effect_. This is the default value.
+  - : The element is positioned according to the [Normal Flow](/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow) of the document. The {{cssxref("top")}}, {{cssxref("right")}}, {{cssxref("bottom")}}, {{cssxref("left")}}, and {{cssxref("z-index")}} properties have _no effect_. This is the default value.
 - `relative`
 
   - : The element is positioned according to the normal flow of the document, and then offset _relative to itself_ based on the values of `top`, `right`, `bottom`, and `left`. The offset does not affect the position of any other elements; thus, the space given for the element in the page layout is the same as if position were `static`.


### PR DESCRIPTION
### Description

In the documentation for the CSS 'position' property, particularly in the [functional specification of 'static'](https://developer.mozilla.org/en-US/docs/Web/CSS/position#static), I propose a slight modification to the term "normal flow", capitalizing it and providing a direct link to the qualifying documentation page located at [Normal Flow](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow). 


### Motivation

By capitalizing "Normal Flow" and linking it to the relevant CSS layout tools documentation, greater context is afforded to the technical usage of a fundamental concept DOM layout tools . This enhancement not only clarifies the default behavior of elements positioned statically but also empowers users to delve deeper into the intricacies of CSS layout.
