### PR TITLE
Added a 'Value' section in contenteditable attribute doc

### DIFF
--- a/files/en-us/web/html/global_attributes/contenteditable/index.md
+++ b/files/en-us/web/html/global_attributes/contenteditable/index.md
@@ -11,6 +11,8 @@ The **`contenteditable`** [global attribute](/en-US/docs/Web/HTML/Global_attribu
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-contenteditable.html","tabbed-shorter")}}
 
+## Value
+
 The attribute must take one of the following values:
 
 - `true` or an _empty string_, which indicates that the element is editable.


### PR DESCRIPTION
It is more consistant with other attributes which have a 'Value' section for their enumerated values

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added a 'Value' section in contenteditable attribute doc

### Motivation

The documentation of other attributes values is often done in a 'Value' section, but for contenteditable, it is done in the 'Try it' section 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
