### PR TITLE
Add other ways to immediately invoke a function 

### DIFF
--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -60,6 +60,8 @@ The function `a` will be called before the function `b`, which will be called be
 
 ### Using the grouping operator to eliminate parsing ambiguity
 
+#### IIFE functions
+
 An [expression statement](/en-US/docs/Web/JavaScript/Reference/Statements/Expression_statement) cannot start with the keyword `function`, because the parser would see it as the start of a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function). This means the following [IIFE](/en-US/docs/Glossary/IIFE) syntax is invalid:
 
 ```js-nolint example-bad
@@ -86,11 +88,15 @@ Another way to do this is by wrapping the function declaration and its call with
 
 You may also use [unary operator](/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#unary_operators), before the function, especially the [`void`](/en-US/docs/Web/JavaScript/Reference/Operators/void#immediately_invoked_function_expressions) operator to eliminate ambiguity.
 
+#### Arrow functions' return value
+
 In an [arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) concise body (one that directly returns an expression without the keyword `return`), the grouping operator can be used to return an object literal expression, because otherwise the left curly brace would be interpreted as the start of the function body.
 
 ```js
 const f = () => ({ a: 1 });
 ```
+
+#### Property accessor with primitive types
 
 If a property is accessed on a number literal, the [property accessor](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) dot `.` may be ambiguous with a decimal point, unless the number already has a decimal point. You can wrap integer literals in parentheses to eliminate this ambiguity.
 

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -76,7 +76,15 @@ The grouping operator can be used to eliminate this ambiguity, since when the pa
 })();
 ```
 
-You may also use the [`void`](/en-US/docs/Web/JavaScript/Reference/Operators/void#immediately_invoked_function_expressions) operator to eliminate ambiguity.
+Another way to do this is by wrapping the function declaration and its call with the grouping operator.
+
+```js
+(function () {
+  // code
+})();
+```
+
+You may also use [unary operator](/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#unary_operators), before the function, especially the [`void`](/en-US/docs/Web/JavaScript/Reference/Operators/void#immediately_invoked_function_expressions) operator to eliminate ambiguity.
 
 In an [arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) concise body (one that directly returns an expression without the keyword `return`), the grouping operator can be used to return an object literal expression, because otherwise the left curly brace would be interpreted as the start of the function body.
 

--- a/files/en-us/web/javascript/reference/operators/grouping/index.md
+++ b/files/en-us/web/javascript/reference/operators/grouping/index.md
@@ -78,12 +78,12 @@ The grouping operator can be used to eliminate this ambiguity, since when the pa
 })();
 ```
 
-Another way to do this is by wrapping the function declaration and its call with the grouping operator.
+Another way to do this is by wrapping the function and its call with the grouping operator.
 
 ```js
 (function () {
   // code
-})();
+}());
 ```
 
 You may also use [unary operator](/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#unary_operators), before the function, especially the [`void`](/en-US/docs/Web/JavaScript/Reference/Operators/void#immediately_invoked_function_expressions) operator to eliminate ambiguity.


### PR DESCRIPTION
Add other ways to immediately invoke a function and enhance the grouping operator usage section's structure.