### PR TITLE
Point to the correct parent of SVGDescElement (SVGElement, not SVGGeometryElement)

### DIFF
--- a/files/en-us/web/api/svgcircleelement/index.md
+++ b/files/en-us/web/api/svgcircleelement/index.md
@@ -24,7 +24,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 
 ## Instance methods
 
-_This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
+_Inherits methods from its parent interface,  {{domxref("SVGGeometryElement")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/svgcircleelement/index.md
+++ b/files/en-us/web/api/svgcircleelement/index.md
@@ -24,7 +24,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 
 ## Instance methods
 
-_This interface has no methods but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
+_This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/svgcircleelement/index.md
+++ b/files/en-us/web/api/svgcircleelement/index.md
@@ -24,7 +24,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 
 ## Instance methods
 
-_Inherits methods from its parent interface,  {{domxref("SVGGeometryElement")}}._
+_Inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/svgdescelement/index.md
+++ b/files/en-us/web/api/svgdescelement/index.md
@@ -13,11 +13,11 @@ The **`SVGDescElement`** interface corresponds to the {{SVGElement("desc")}} ele
 
 ## Instance properties
 
-_This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
+_Inherits methods from its parent interface, {{domxref("SVGElement")}}._
 
 ## Instance methods
 
-_This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
+_Inherits methods from its parent interface, {{domxref("SVGElement")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/svgdescelement/index.md
+++ b/files/en-us/web/api/svgdescelement/index.md
@@ -13,11 +13,11 @@ The **`SVGDescElement`** interface corresponds to the {{SVGElement("desc")}} ele
 
 ## Instance properties
 
-_This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
+_This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 ## Instance methods
 
-_This interface has no methods but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
+_This interface has no methods but inherits methods from its parent, {{domxref("SVGElement")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/svgdescelement/index.md
+++ b/files/en-us/web/api/svgdescelement/index.md
@@ -13,7 +13,7 @@ The **`SVGDescElement`** interface corresponds to the {{SVGElement("desc")}} ele
 
 ## Instance properties
 
-_This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
+_This interface has no properties but inherits properties from its parent, {{domxref("SVGElement")}}._
 
 ## Instance methods
 

--- a/files/en-us/web/api/svgellipseelement/index.md
+++ b/files/en-us/web/api/svgellipseelement/index.md
@@ -13,7 +13,7 @@ The **`SVGEllipseElement`** interface provides access to the properties of {{SVG
 
 ## Instance properties
 
-_This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
+_Inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
 
 - {{domxref("SVGEllipseElement.cx")}} {{ReadOnlyInline}}
   - : This property returns a {{domxref("SVGAnimatedLength")}} reflecting the {{SVGAttr("cx")}} attribute of the given {{SVGElement("ellipse")}} element.
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 
 ## Instance methods
 
-_This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
+_Inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
 
 ## Example
 

--- a/files/en-us/web/api/svgellipseelement/index.md
+++ b/files/en-us/web/api/svgellipseelement/index.md
@@ -13,7 +13,7 @@ The **`SVGEllipseElement`** interface provides access to the properties of {{SVG
 
 ## Instance properties
 
-_This interface also inherits properties from its parent interface, {{domxref("SVGGeometryElement")}}._
+_This interface also inherits properties from its parent, {{domxref("SVGGeometryElement")}}._
 
 - {{domxref("SVGEllipseElement.cx")}} {{ReadOnlyInline}}
   - : This property returns a {{domxref("SVGAnimatedLength")}} reflecting the {{SVGAttr("cx")}} attribute of the given {{SVGElement("ellipse")}} element.
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 ## Instance methods
 
-_This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
+_This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 
 ## Example
 

--- a/files/en-us/web/api/svglineelement/index.md
+++ b/files/en-us/web/api/svglineelement/index.md
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 
 ## Instance methods
 
-_This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
+_This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/svglineelement/index.md
+++ b/files/en-us/web/api/svglineelement/index.md
@@ -26,7 +26,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGeometry
 
 ## Instance methods
 
-_This interface doesn't implement any specific methods, but inherits methods from its parent, {{domxref("SVGGeometryElement")}}._
+_Inherits methods from its parent interface, {{domxref("SVGGeometryElement")}}._
 
 ## Specifications
 


### PR DESCRIPTION
### Description

The correct parent interface for `SVGDescElement` is `SVGElement`
Source: https://svgwg.org/svg2-draft/struct.html#InterfaceSVGDescElement
(the Inheritance Diagram is correct, I just fixed the text/link).

### Motivation

Accuracy 🤓

### Additional details

Since I was looking at the 7 _actual_ children of `SVGGeometryElement`, I also aligned some of their phrasing
(I adhere to LIBTYFI ⚜️ so I hope it's okay I did it in the same PR).