### PR TITLE
Define XMLHttpRequest failure

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -15,7 +15,7 @@ following a request being sent.
 ## Value
 
 A string which contains either the textual data received using the
-`XMLHttpRequest` or `null` if the request failed or
+`XMLHttpRequest` or `null` if the request failed (non 2XX status) or
 `""` if the request has not yet been sent by calling
 {{domxref("XMLHttpRequest.send", "send()")}}.
 

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -15,9 +15,7 @@ following a request being sent.
 ## Value
 
 A string which contains either the textual data received using the
-`XMLHttpRequest` or `null` if the request failed (non 2XX status) or
-`""` if the request has not yet been sent by calling
-{{domxref("XMLHttpRequest.send", "send()")}}.
+`XMLHttpRequest` or `""` if the request failed or the response has not yet been received.
 
 While handling an asynchronous request, the value of `responseText` always
 has the current content received from the server, even if it's incomplete because the

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -15,7 +15,7 @@ following a request being sent.
 ## Value
 
 A string which contains either the textual data received using the
-`XMLHttpRequest` or `""` if the request failed or the response has not yet been received.
+`XMLHttpRequest` or `""` if the request failed or if no content has been received yet.
 
 While handling an asynchronous request, the value of `responseText` always
 has the current content received from the server, even if it's incomplete because the


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Attempting to resolve #31129 by specifying a failed request is a non-2XX response code.

### Motivation

Just looking to clarify the confusion found by @maxpblum

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
MDN response code docs [https://developer.mozilla.org/en-US/docs/Web/HTTP/Status](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)

### Related issues and pull requests

Fixes #31129 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
