### PR TITLE
var(): invalid v. undefined

### DIFF
--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -39,7 +39,7 @@ The syntax of the fallback, like that of custom properties, allows commas. For e
 
 - `<declaration-value>`
 
-  - : The custom property's fallback value, which is used in case the custom property is not defined. This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks. The fallback value can itself be a custom property using the `var()` syntax.
+  - : The custom property's fallback value, which is used in case the custom property is not defined or equals a [CSS-wide keyword](/en-US/docs/Web/CSS/CSS_Values_and_Units#css-wide_values). This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks. The fallback value can itself be a custom property using the `var()` syntax.
 
     > **Note:** `var(--a,)` is valid, specifying that if the `--a` custom property is not defined or equals a [CSS-wide keyword](/en-US/docs/Web/CSS/CSS_Values_and_Units#css-wide_values), the `var()` should be replaced with nothing.
 

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -41,7 +41,7 @@ The syntax of the fallback, like that of custom properties, allows commas. For e
 
   - : The custom property's fallback value, which is used in case the custom property is not defined. This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks. The fallback value can itself be a custom property using the `var()` syntax.
 
-    > **Note:** `var(--a,)` is valid, specifying that if the `--a` custom property is not defined, the `var()` should be replaced with nothing.
+    > **Note:** `var(--a,)` is valid, specifying that if the `--a` custom property is not defined or equals a [CSS-wide keyword](/en-US/docs/Web/CSS/CSS_Values_and_Units#css-wide_values), the `var()` should be replaced with nothing.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -27,7 +27,7 @@ var(--custom-prop, var(--default-value));
 var(--custom-prop, var(--default-value, red));
 ```
 
-The first argument to the function is the name of the custom property to be substituted. An optional second argument to the function serves as a fallback value. If the custom property referenced by the first argument is not defined, the function uses the second value.
+The first argument to the function is the name of the custom property to be substituted. An optional second argument to the function serves as a fallback value. If the custom property referenced by the first argument is not defined or equals a [CSS-wide keyword](/en-US/docs/Web/CSS/CSS_Values_and_Units#css-wide_values), the function uses the second value.
 
 The syntax of the fallback, like that of custom properties, allows commas. For example, `var(--foo, red, blue)` defines a fallback of `red, blue`; that is, anything between the first comma and the end of the function is considered a fallback value.
 

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -27,7 +27,7 @@ var(--custom-prop, var(--default-value));
 var(--custom-prop, var(--default-value, red));
 ```
 
-The first argument to the function is the name of the custom property to be substituted. An optional second argument to the function serves as a fallback value. If the custom property referenced by the first argument is invalid, the function uses the second value.
+The first argument to the function is the name of the custom property to be substituted. An optional second argument to the function serves as a fallback value. If the custom property referenced by the first argument is not defined, the function uses the second value.
 
 The syntax of the fallback, like that of custom properties, allows commas. For example, `var(--foo, red, blue)` defines a fallback of `red, blue`; that is, anything between the first comma and the end of the function is considered a fallback value.
 
@@ -39,9 +39,9 @@ The syntax of the fallback, like that of custom properties, allows commas. For e
 
 - `<declaration-value>`
 
-  - : The custom property's fallback value, which is used in case the custom property is invalid in the used context. This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks. The fallback value can itself be a custom property using the `var()` syntax.
+  - : The custom property's fallback value, which is used in case the custom property is not defined. This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks. The fallback value can itself be a custom property using the `var()` syntax.
 
-    > **Note:** `var(--a,)` is valid, specifying that if the `--a` custom property is invalid or missing, the `var()` should be replaced with nothing.
+    > **Note:** `var(--a,)` is valid, specifying that if the `--a` custom property is not defined, the `var()` should be replaced with nothing.
 
 ### Formal syntax
 


### PR DESCRIPTION
The current description seems a bit misleading. As in reality if one sets a custom property to an invalid value, fallback won't be applied.

Example: 

The following won't be resolved to `50px` _(even though `5yy` is invalid and in theory, according to the current description should be used instead)_

```css
BUTTON {
   --vv: 5yy;
   font-size: var(--vv, 50px);
}
```

[Using Cascading Variables: the var() notation](https://drafts.csswg.org/css-variables/#using-variables:~:text=The%20first%20argument%20to%20the%20function%20is%20the%20name%20of%20the%20custom%20property%20to%20be%20substituted.%20The%20second%20argument%20to%20the%20function%2C%20if%20provided%2C%20is%20a%20fallback%20value%2C%20which%20is%20used%20as%20the%20substitution%20value%20when%20the%20value%20of%20the%20referenced%20custom%20property%20is%20the%20guaranteed%2Dinvalid%20value.)

[Guaranteed-Invalid Values](https://drafts.csswg.org/css-variables/#guaranteed-invalid:~:text=The%20initial%20value%20of%20a%20custom%20property%20is%20a%20guaranteed%2Dinvalid%20value.)

### Description

Change in description to make it less misleading for developers.

I'm open to suggestions, 
as the main point of the change is to make it more easily understandable than it is now, in my opinion.




