### PR TITLE
chore: remove the version arguments of Firefox_for_developers macros

### DIFF
--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -54,4 +54,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(99)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -85,4 +85,4 @@ For more information, see the [full bug list](https://bugzilla.mozilla.org/bugli
 
 ## Older versions
 
-{{Firefox_for_developers(100)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -65,4 +65,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(101)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -82,4 +82,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(102)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -83,4 +83,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(103)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -53,4 +53,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(104)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -74,4 +74,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(105)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -66,4 +66,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(106)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/108/index.md
+++ b/files/en-us/mozilla/firefox/releases/108/index.md
@@ -71,4 +71,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(107)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/109/index.md
+++ b/files/en-us/mozilla/firefox/releases/109/index.md
@@ -76,4 +76,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(108)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/11/index.md
+++ b/files/en-us/mozilla/firefox/releases/11/index.md
@@ -133,4 +133,4 @@ The following interfaces were implementation details that are no longer needed:
 
 ## See also
 
-{{Firefox_for_developers('10')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/110/index.md
+++ b/files/en-us/mozilla/firefox/releases/110/index.md
@@ -77,4 +77,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(109)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -72,4 +72,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(110)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/112/index.md
+++ b/files/en-us/mozilla/firefox/releases/112/index.md
@@ -59,4 +59,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(111)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -74,4 +74,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(112)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -81,4 +81,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(113)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -74,4 +74,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(114)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/116/index.md
+++ b/files/en-us/mozilla/firefox/releases/116/index.md
@@ -85,4 +85,4 @@ This article provides information about the changes in Firefox 116 that affect d
 
 ## Older versions
 
-{{Firefox_for_developers(115)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -77,4 +77,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(116)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -76,4 +76,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(117)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -75,4 +75,4 @@ This article provides information about the changes in Firefox 119 that affect d
 
 ## Older versions
 
-{{Firefox_for_developers(118)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -122,4 +122,4 @@ Mozilla has been working on integrating its own Web developer tools that complem
 
 ## See also
 
-{{Firefox_for_developers('11')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -84,4 +84,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(119)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/121/index.md
+++ b/files/en-us/mozilla/firefox/releases/121/index.md
@@ -91,4 +91,4 @@ These features are newly shipped in Firefox 121 but are disabled by default. To 
 
 ## Older versions
 
-{{Firefox_for_developers(120)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/122/index.md
+++ b/files/en-us/mozilla/firefox/releases/122/index.md
@@ -98,4 +98,4 @@ These features are newly shipped in Firefox 122 but are disabled by default. To 
 
 ## Older versions
 
-{{Firefox_for_developers(121)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -81,4 +81,4 @@ These features are newly shipped in Firefox 123 but are disabled by default. To 
 
 ## Older versions
 
-{{Firefox_for_developers(122)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -82,4 +82,4 @@ These features are newly shipped in Firefox 124 but are disabled by default. To 
 
 ## Older versions
 
-{{Firefox_for_developers(123)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -68,4 +68,4 @@ These features are newly shipped in Firefox 125 but are disabled by default. To 
 
 ## Older versions
 
-{{Firefox_for_developers(124)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/13/index.md
+++ b/files/en-us/mozilla/firefox/releases/13/index.md
@@ -113,4 +113,4 @@ Starting in Firefox 13, Firefox for Windows requires at least Windows XP Service
 
 ## See also
 
-{{Firefox_for_developers('12')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/14/index.md
+++ b/files/en-us/mozilla/firefox/releases/14/index.md
@@ -76,4 +76,4 @@ _No change._
 
 ## See also
 
-{{Firefox_for_developers('13')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/15/index.md
+++ b/files/en-us/mozilla/firefox/releases/15/index.md
@@ -96,4 +96,4 @@ The following interfaces have been removed.
 
 ## See also
 
-{{Firefox_for_developers('14')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/17/index.md
+++ b/files/en-us/mozilla/firefox/releases/17/index.md
@@ -104,4 +104,4 @@ None removed.
 
 ### Older versions
 
-{{Firefox_for_developers('16')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/18/index.md
+++ b/files/en-us/mozilla/firefox/releases/18/index.md
@@ -89,4 +89,4 @@ The following interfaces have been removed.
 
 ### Older versions
 
-{{Firefox_for_developers('17')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/19/index.md
+++ b/files/en-us/mozilla/firefox/releases/19/index.md
@@ -63,4 +63,4 @@ Support for XForms has been [**removed**](https://www.philipp-wagner.com/blog/20
 
 ### Older versions
 
-{{Firefox_for_developers('18')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/2/index.md
+++ b/files/en-us/mozilla/firefox/releases/2/index.md
@@ -80,4 +80,4 @@ Firefox 2 provides an enhanced version of the same clean user interface offered 
 
 ## See also
 
-{{Firefox_for_developers('2')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -74,4 +74,4 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 
 ### Older versions
 
-{{Firefox_for_developers('19')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/21/index.md
+++ b/files/en-us/mozilla/firefox/releases/21/index.md
@@ -114,4 +114,4 @@ Firefox 21 was released on May 14, 2013. This article lists key changes that are
 
 ### Older versions
 
-{{Firefox_for_developers('20')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/22/index.md
+++ b/files/en-us/mozilla/firefox/releases/22/index.md
@@ -71,4 +71,4 @@ page-type: firefox-release-notes
 
 ### Versions
 
-{{Firefox_for_developers('21')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/23/index.md
+++ b/files/en-us/mozilla/firefox/releases/23/index.md
@@ -70,4 +70,4 @@ Addons that overlay chrome://browser/content/debugger.xul must now overlay chrom
 
 ### Older versions
 
-{{Firefox_for_developers('22')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/24/index.md
+++ b/files/en-us/mozilla/firefox/releases/24/index.md
@@ -60,4 +60,4 @@ page-type: firefox-release-notes
 
 ## Older versions
 
-{{Firefox_for_developers('23')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/25/index.md
+++ b/files/en-us/mozilla/firefox/releases/25/index.md
@@ -68,4 +68,4 @@ _No change._
 
 ### Older versions
 
-{{Firefox_for_developers('24')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/26/index.md
+++ b/files/en-us/mozilla/firefox/releases/26/index.md
@@ -70,4 +70,4 @@ ECMAScript 2015 implementation continues!
 
 ### Older versions
 
-{{Firefox_for_developers('25')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/27/index.md
+++ b/files/en-us/mozilla/firefox/releases/27/index.md
@@ -91,4 +91,4 @@ _No change._
 
 ### Older versions
 
-{{Firefox_for_developers('26')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/28/index.md
+++ b/files/en-us/mozilla/firefox/releases/28/index.md
@@ -86,4 +86,4 @@ _No change._
 
 ### Older versions
 
-{{Firefox_for_developers('27')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/29/index.md
+++ b/files/en-us/mozilla/firefox/releases/29/index.md
@@ -105,4 +105,4 @@ _No change._
 
 ### Older versions
 
-{{Firefox_for_developers('28')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/3.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/index.md
@@ -217,4 +217,4 @@ If you're an extension developer, you should start by reading [Updating extensio
 
 ## See also
 
-{{Firefox_for_developers('3')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/3.6/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/index.md
@@ -203,4 +203,4 @@ The following assorted changes have been made:
 
 ## See also
 
-{{Firefox_for_developers('3.5')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/3/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/index.md
@@ -150,4 +150,4 @@ If you're a developer trying to get a handle on all the new features in Firefox 
 
 ## See also
 
-{{Firefox_for_developers('2')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/30/index.md
+++ b/files/en-us/mozilla/firefox/releases/30/index.md
@@ -71,4 +71,4 @@ _No change._
 
 ### Older versions
 
-{{Firefox_for_developers('29')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/31/index.md
+++ b/files/en-us/mozilla/firefox/releases/31/index.md
@@ -107,4 +107,4 @@ Highlights:
 
 ### Older versions
 
-{{Firefox_for_developers('30')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/32/index.md
+++ b/files/en-us/mozilla/firefox/releases/32/index.md
@@ -124,4 +124,4 @@ A `getDataDirectory()` method has been added to [`Addon`](/en-US/docs/Mozilla/Ad
 
 ### Older versions
 
-{{Firefox_for_developers('31')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/33/index.md
+++ b/files/en-us/mozilla/firefox/releases/33/index.md
@@ -118,4 +118,4 @@ _No change._
 
 ### Older versions
 
-{{Firefox_for_developers('32')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/34/index.md
+++ b/files/en-us/mozilla/firefox/releases/34/index.md
@@ -124,4 +124,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('33')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/35/index.md
+++ b/files/en-us/mozilla/firefox/releases/35/index.md
@@ -117,4 +117,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('34')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/36/index.md
+++ b/files/en-us/mozilla/firefox/releases/36/index.md
@@ -161,4 +161,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('35')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/37/index.md
+++ b/files/en-us/mozilla/firefox/releases/37/index.md
@@ -101,4 +101,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('36')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -151,4 +151,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('37')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/39/index.md
+++ b/files/en-us/mozilla/firefox/releases/39/index.md
@@ -96,4 +96,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('38')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -498,4 +498,4 @@ In addition to the specific changes referenced below, it's important to note tha
 
 ## See also
 
-{{Firefox_for_developers('3.6')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/40/index.md
+++ b/files/en-us/mozilla/firefox/releases/40/index.md
@@ -166,4 +166,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('39')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/41/index.md
+++ b/files/en-us/mozilla/firefox/releases/41/index.md
@@ -163,4 +163,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('40')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/42/index.md
+++ b/files/en-us/mozilla/firefox/releases/42/index.md
@@ -152,4 +152,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('41')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/43/index.md
+++ b/files/en-us/mozilla/firefox/releases/43/index.md
@@ -140,4 +140,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers('42')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/44/index.md
+++ b/files/en-us/mozilla/firefox/releases/44/index.md
@@ -218,4 +218,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers(43)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/45/index.md
+++ b/files/en-us/mozilla/firefox/releases/45/index.md
@@ -148,4 +148,4 @@ Starting in Firefox 45, search plugins located in the user's profile's `searchpl
 
 ## Older versions
 
-{{Firefox_for_developers(44)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/46/index.md
+++ b/files/en-us/mozilla/firefox/releases/46/index.md
@@ -153,4 +153,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers(45)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/47/index.md
+++ b/files/en-us/mozilla/firefox/releases/47/index.md
@@ -139,4 +139,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers(46)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/48/index.md
+++ b/files/en-us/mozilla/firefox/releases/48/index.md
@@ -133,4 +133,4 @@ page-type: firefox-release-notes
 
 ## Older versions
 
-{{Firefox_for_developers(47)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/49/index.md
+++ b/files/en-us/mozilla/firefox/releases/49/index.md
@@ -289,4 +289,4 @@ _No change._
 
 ## Older versions
 
-{{Firefox_for_developers(48)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/5/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/index.md
@@ -129,4 +129,4 @@ The following interfaces were implementation details that are no longer needed:
 
 ## See also
 
-{{Firefox_for_developers('4')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/50/index.md
+++ b/files/en-us/mozilla/firefox/releases/50/index.md
@@ -148,4 +148,4 @@ page-type: firefox-release-notes
 
 ## Older versions
 
-{{Firefox_for_developers(49)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/51/index.md
+++ b/files/en-us/mozilla/firefox/releases/51/index.md
@@ -175,4 +175,4 @@ page-type: firefox-release-notes
 
 ## Older versions
 
-{{Firefox_for_developers(50)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/52/index.md
+++ b/files/en-us/mozilla/firefox/releases/52/index.md
@@ -198,4 +198,4 @@ New APIs:
 
 ## Older versions
 
-{{Firefox_for_developers(51)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/53/index.md
+++ b/files/en-us/mozilla/firefox/releases/53/index.md
@@ -168,4 +168,4 @@ Enhanced APIs:
 
 ## Older versions
 
-{{Firefox_for_developers(52)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/54/index.md
+++ b/files/en-us/mozilla/firefox/releases/54/index.md
@@ -91,4 +91,4 @@ Firefox 54 was released on June 13, 2017. This article lists key changes that ar
 
 ## Older versions
 
-{{Firefox_for_developers(53)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/55/index.md
+++ b/files/en-us/mozilla/firefox/releases/55/index.md
@@ -175,4 +175,4 @@ Firefox 55 was released on August 8, 2017. This article lists key changes that a
 
 ## Older versions
 
-{{Firefox_for_developers(54)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/56/index.md
+++ b/files/en-us/mozilla/firefox/releases/56/index.md
@@ -126,4 +126,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(55)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/57/index.md
+++ b/files/en-us/mozilla/firefox/releases/57/index.md
@@ -239,4 +239,4 @@ The following APIs have been added or extended:
 
 ## Older versions
 
-{{Firefox_for_developers(56)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/58/index.md
+++ b/files/en-us/mozilla/firefox/releases/58/index.md
@@ -192,4 +192,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(57)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/59/index.md
+++ b/files/en-us/mozilla/firefox/releases/59/index.md
@@ -175,4 +175,4 @@ Support for the non-standard `pcast:` and `feed:` protocols has been removed fro
 
 ## Older versions
 
-{{Firefox_for_developers(58)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -194,4 +194,4 @@ The following interfaces were implementation details that are no longer needed:
 
 ## See also
 
-{{Firefox_for_developers('5')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/60/index.md
+++ b/files/en-us/mozilla/firefox/releases/60/index.md
@@ -154,4 +154,4 @@ Theme API:
 
 ## Older versions
 
-{{Firefox_for_developers(59)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/61/index.md
+++ b/files/en-us/mozilla/firefox/releases/61/index.md
@@ -178,4 +178,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(60)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/62/index.md
+++ b/files/en-us/mozilla/firefox/releases/62/index.md
@@ -167,4 +167,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(61)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/63/index.md
+++ b/files/en-us/mozilla/firefox/releases/63/index.md
@@ -214,4 +214,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(62)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/64/index.md
+++ b/files/en-us/mozilla/firefox/releases/64/index.md
@@ -163,4 +163,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(63)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/65/index.md
+++ b/files/en-us/mozilla/firefox/releases/65/index.md
@@ -192,4 +192,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(64)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/66/index.md
+++ b/files/en-us/mozilla/firefox/releases/66/index.md
@@ -144,4 +144,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(65)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/67/index.md
+++ b/files/en-us/mozilla/firefox/releases/67/index.md
@@ -147,4 +147,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(66)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/68/index.md
+++ b/files/en-us/mozilla/firefox/releases/68/index.md
@@ -182,4 +182,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(67)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/69/index.md
+++ b/files/en-us/mozilla/firefox/releases/69/index.md
@@ -134,4 +134,4 @@ This article provides information about the changes in Firefox 69 that will affe
 
 ## Older versions
 
-{{Firefox_for_developers(68)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/7/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/index.md
@@ -190,4 +190,4 @@ The following interfaces were removed as part of the removal of the ActiveX embe
 
 ## See also
 
-{{Firefox_for_developers('6')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/70/index.md
+++ b/files/en-us/mozilla/firefox/releases/70/index.md
@@ -146,4 +146,4 @@ The following [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/th
 
 ## Older versions
 
-{{Firefox_for_developers(69)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/71/index.md
+++ b/files/en-us/mozilla/firefox/releases/71/index.md
@@ -121,4 +121,4 @@ The following non-standard {{domxref("DataTransfer")}} members have been removed
 
 ## Older versions
 
-{{Firefox_for_developers(70)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/72/index.md
+++ b/files/en-us/mozilla/firefox/releases/72/index.md
@@ -134,4 +134,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(71)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/73/index.md
+++ b/files/en-us/mozilla/firefox/releases/73/index.md
@@ -81,4 +81,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(72)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/74/index.md
+++ b/files/en-us/mozilla/firefox/releases/74/index.md
@@ -102,4 +102,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(73)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/75/index.md
+++ b/files/en-us/mozilla/firefox/releases/75/index.md
@@ -110,4 +110,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(74)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/76/index.md
+++ b/files/en-us/mozilla/firefox/releases/76/index.md
@@ -85,4 +85,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(75)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/77/index.md
+++ b/files/en-us/mozilla/firefox/releases/77/index.md
@@ -77,4 +77,4 @@ This article provides information about the changes in Firefox 77 that will affe
 
 ## Older versions
 
-{{Firefox_for_developers(76)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/78/index.md
+++ b/files/en-us/mozilla/firefox/releases/78/index.md
@@ -84,4 +84,4 @@ See also [New in Firefox 78: DevTools improvements, new regex engine, and abunda
 
 ## Older versions
 
-{{Firefox_for_developers(77)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/79/index.md
+++ b/files/en-us/mozilla/firefox/releases/79/index.md
@@ -97,4 +97,4 @@ See also [Firefox 79: The safe return of shared memory, new tooling, and platfor
 
 ## Older versions
 
-{{Firefox_for_developers(78)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/80/index.md
+++ b/files/en-us/mozilla/firefox/releases/80/index.md
@@ -60,4 +60,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(79)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/81/index.md
+++ b/files/en-us/mozilla/firefox/releases/81/index.md
@@ -71,4 +71,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(80)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/82/index.md
+++ b/files/en-us/mozilla/firefox/releases/82/index.md
@@ -61,4 +61,4 @@ This article provides information about the changes in Firefox 82 that will affe
 
 ## Older versions
 
-{{Firefox_for_developers(81)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/83/index.md
+++ b/files/en-us/mozilla/firefox/releases/83/index.md
@@ -50,4 +50,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(82)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/84/index.md
+++ b/files/en-us/mozilla/firefox/releases/84/index.md
@@ -75,4 +75,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(83)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/85/index.md
+++ b/files/en-us/mozilla/firefox/releases/85/index.md
@@ -65,4 +65,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(84)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/86/index.md
+++ b/files/en-us/mozilla/firefox/releases/86/index.md
@@ -77,4 +77,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(85)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/87/index.md
+++ b/files/en-us/mozilla/firefox/releases/87/index.md
@@ -85,4 +85,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(86)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/88/index.md
+++ b/files/en-us/mozilla/firefox/releases/88/index.md
@@ -65,4 +65,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(87)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/89/index.md
+++ b/files/en-us/mozilla/firefox/releases/89/index.md
@@ -67,4 +67,4 @@ _No changes._
 
 ## Older versions
 
-{{Firefox_for_developers(88)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/9/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/index.md
@@ -140,4 +140,4 @@ The IDL parser no longer includes support for the never fully-implemented notion
 
 ## See also
 
-{{Firefox_for_developers('8')}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/90/index.md
+++ b/files/en-us/mozilla/firefox/releases/90/index.md
@@ -74,4 +74,4 @@ This article provides information about the changes in Firefox 90 that will affe
 
 ## Older versions
 
-{{Firefox_for_developers(89)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/91/index.md
+++ b/files/en-us/mozilla/firefox/releases/91/index.md
@@ -57,4 +57,4 @@ No changes
 
 ## Older versions
 
-{{Firefox_for_developers(90)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/92/index.md
+++ b/files/en-us/mozilla/firefox/releases/92/index.md
@@ -59,4 +59,4 @@ No changes
 
 ## Older versions
 
-{{Firefox_for_developers(91)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/93/index.md
+++ b/files/en-us/mozilla/firefox/releases/93/index.md
@@ -67,4 +67,4 @@ This article provides information about the changes in Firefox 93 that will affe
 
 ## Older versions
 
-{{Firefox_for_developers(92)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/94/index.md
+++ b/files/en-us/mozilla/firefox/releases/94/index.md
@@ -48,4 +48,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(93)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/95/index.md
+++ b/files/en-us/mozilla/firefox/releases/95/index.md
@@ -48,4 +48,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(94)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/96/index.md
+++ b/files/en-us/mozilla/firefox/releases/96/index.md
@@ -68,4 +68,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(95)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/97/index.md
+++ b/files/en-us/mozilla/firefox/releases/97/index.md
@@ -71,4 +71,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(96)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/98/index.md
+++ b/files/en-us/mozilla/firefox/releases/98/index.md
@@ -47,4 +47,4 @@ No notable changes
 
 ## Older versions
 
-{{Firefox_for_developers(97)}}
+{{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/99/index.md
+++ b/files/en-us/mozilla/firefox/releases/99/index.md
@@ -46,4 +46,4 @@ No notable changes.
 
 ## Older versions
 
-{{Firefox_for_developers(98)}}
+{{Firefox_for_developers}}


### PR DESCRIPTION
### Description

remove the version arguments of Firefox_for_developers macros

### Related issues and pull requests

The {{Firefox_for_developers}} macro has been rewritten and it does not need the version argument anymore, see also: mdn/yari#10034.
