### PR TITLE
added the release note for first-letter first-line on svg text elements

### DIFF
--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -26,6 +26,8 @@ This article provides information about the changes in Firefox 124 that affect d
 
 ### SVG
 
+- The {{cssxref("::first-letter")}} and {{cssxref("::first-line")}} CSS pseudo-elements can now be applied to the {{SVGElement("text")}} SVG element. This allows you to change the fill, stroke or font of the first letter/line of a `<text>` element using CSS, for example. ([Firefox bug 1302722](https://bugzil.la/1302722)).
+
 #### Removals
 
 ### HTTP


### PR DESCRIPTION
### Description

Added firefox release note for `::first-letter` and `::first-line` on SVG `<text>` element

### Motivation

Working on [issue 32339](https://github.com/mdn/content/issues/32339) 

### Related issues and pull requests

- [Firefox Bug 1302722](https://bugzilla.mozilla.org/show_bug.cgi?id=1302722)
- [Content PR](https://github.com/mdn/content/pull/32467)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/22320)