### PR TITLE
beforeunload event requires sticky activation

### DIFF
--- a/files/en-us/web/security/user_activation/index.md
+++ b/files/en-us/web/security/user_activation/index.md
@@ -28,7 +28,6 @@ If an activation has been triggered, the user agent differentiates between two t
 
 APIs that require transient activation (list is not exhaustive):
 
-- {{domxref("Window/beforeunload_event", "beforeunload")}} event
 - {{domxref("Clients.openWindow()")}}
 - {{domxref("Clipboard.read()")}}
 - {{domxref("Clipboard.readText()")}}
@@ -73,6 +72,7 @@ APIs that require transient activation (list is not exhaustive):
 
 APIs that require sticky activation (not exhaustive):
 
+- {{domxref("Window/beforeunload_event", "beforeunload")}} event
 - {{domxref("Navigator.vibrate()")}}
 - {{domxref("VirtualKeyboard.show()")}}
 - Autoplay of [Media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) (in particular for [`AudioContexts`](/en-US/docs/Web/API/AudioContext)).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The `beforeunload` event should be places in Sticky activation section, not Transient activation section, at the page "Features gated by user activation".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Documentation about the `beforeunload` event is inconsistent. The information on the "Features gated by user activation" page is incorrect, the information on the page "Window: beforeunload event" in the "Usage Notes" section is correct.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

- [Features gated by user activation - Transient activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation#transient_activation)
- [Features gated by user activation - Sticky activation](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation#sticky_activation)
- [Window: beforeunload event - Usage notes](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Relates to #26772

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
