### PR TITLE
Update 'Browser detection using the user agent' docs

### DIFF
--- a/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
@@ -214,7 +214,7 @@ Most browsers set the name and version in the format _BrowserName/VersionNumber_
 
 Also, pay attention not to use a simple regular expression on the BrowserName, user agents also contain strings outside the Keyword/Value syntax. Safari & Chrome contain the string 'like Gecko', for instance.
 
-| Engine                          | Must contain    | Must not contain               |
+| Browser name                    | Must contain    | Must not contain               |
 | ------------------------------- | --------------- | ------------------------------ |
 | Firefox                         | `Firefox/xyz`   | `Seamonkey/xyz`                |
 | Seamonkey                       | `Seamonkey/xyz` |                                |


### PR DESCRIPTION
### Description
Firefox, Seamonkey, Chrome... are names of browsers, not engines. So I changed the header of the table from `Engine` to `Browser name` in [Browser Name and version](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name_and_version) section.
### Motivation
Fix table
### Additional details
[Rendering engine](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#rendering_engine) section is separate.
### Related issues and pull requests