### PR TITLE
fix(css): updated :disabled example

### DIFF
--- a/files/en-us/web/css/_colon_disabled/index.md
+++ b/files/en-us/web/css/_colon_disabled/index.md
@@ -57,9 +57,9 @@ input[type="text"]:disabled {
 ### JavaScript
 
 ```js
-// Wait for the page to finish loading
+// Toggle the disabled Input fields when the checkbox is clicked
 document.addEventListener(
-  "DOMContentLoaded",
+  "click",
   () => {
     // Attach `change` event listener to checkbox
     document.getElementById("billing-checkbox").onchange = toggleBilling;

--- a/files/en-us/web/css/_colon_disabled/index.md
+++ b/files/en-us/web/css/_colon_disabled/index.md
@@ -56,29 +56,22 @@ input[type="text"]:disabled {
 
 ### JavaScript
 
+Toggle the disabled input fields when the checkbox is clicked
+
 ```js
-// Toggle the disabled Input fields when the checkbox is clicked
-document.addEventListener(
-  "click",
-  () => {
-    // Attach `change` event listener to checkbox
-    document.getElementById("billing-checkbox").onchange = toggleBilling;
-  },
-  false,
-);
+const checkbox = document.querySelector("#billing-checkbox");
+const billingItems = document.querySelectorAll('#billing input[type="text"]');
 
-function toggleBilling() {
-  // Select the billing text fields
-  const billingItems = document.querySelectorAll('#billing input[type="text"]');
-
-  // Toggle the billing text fields
+checkbox.addEventListener("change", () => {
   billingItems.forEach((item) => {
     item.disabled = !item.disabled;
   });
-}
+});
 ```
 
 ### Result
+
+Check/un-check the checkbox to change the styling on the billing fields.
 
 {{EmbedLiveSample('Examples', 300, 250)}}
 


### PR DESCRIPTION
Fixes #32481 

Changed `DOMContentLoaded` to `click` event in JavaScript.


https://github.com/mdn/content/assets/87417638/9b01a26d-a6d9-4383-a79b-d55c461a443a

