### PR TITLE
fix(api): Chrome respects document.fonts.check() per spec since v 120

### DIFF
--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -77,8 +77,6 @@ console.log(document.fonts.check("12px i-dont-exist"));
 // true: the matching font is a nonexistent font
 ```
 
-> **Note:** In this situation Chrome incorrectly returns `false`. This can make [fingerprinting](/en-US/docs/Glossary/Fingerprinting) easier, because an attacker can easily test which system fonts the browser has.
-
 ### System and unloaded fonts
 
 If we specify both a system font and a font in the set that is not yet loaded, then `check()` returns `false`:


### PR DESCRIPTION
#### Summary

Chrome `document.fonts.check` should return `true` for non-existent fonts.

Fixes #32484

#### Test results and supporting details

* Bug https://issues.chromium.org/issues/40893726
* Revision https://chromium.googlesource.com/chromium/src/+/c23f99b74b4f738fe1f5a3e04cca8c9d2f17aaed

Tested on browserstack with the following:

```js
const invalid = document.fonts.check("italic bold 16px Invalid");
const menlo = document.fonts.check("medium Menlo");

console.log(invalid);
console.log(menlo);

console.log(document.fonts.check("12px i-dont-exist"));
// true: the matching font is a nonexistent font
```

#### Related issues and PRs

- [x] https://github.com/mdn/content/issues/32484
- [ ] https://github.com/mdn/browser-compat-data/pull/22340