### PR TITLE
http.server is not limited to serving static files

### DIFF
--- a/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -108,13 +108,19 @@ To do this:
 
 ## Running server-side languages locally
 
-Python's `http.server` (or `SimpleHTTPServer` for Python 2) module is useful, but it is merely a _static_ file server; it doesn't know how to run code written in languages such as Python, PHP or JavaScript. To handle them, you'll need something more — exactly what you'll need depends on the server-side language you are trying to run. Here are a few examples:
+The best approach for working with server side languages, such as Python, PHP, or JavaScript, depends on the server-side language you are using, and whether you're working with a web framework or "stand-alone" code.
 
-- To run Python server-side code, you'll need to use a Python web framework. There are many popular Python web frameworks, such as Django (a [guide](/en-US/docs/Learn/Server-side/Django) is available), [Flask](https://flask.palletsprojects.com/), and [Pyramid](https://trypyramid.com).
-- To run Node.js (JavaScript) server-side code, you'll need to use raw node or a framework built on top of it. Express is a good choice — see [Express Web Framework (Node.js/JavaScript)](/en-US/docs/Learn/Server-side/Express_Nodejs).
-- To run PHP server-side code, launch [PHP's built-in development server](https://www.php.net/manual/en/features.commandline.webserver.php):
+If you working with a web framework, usually the framework will provide its own simple and easy to use development server.
+For example, the following languages/frameworks come with a development server:
+
+- Python web frameworks, such as [Django](/en-US/docs/Learn/Server-side/Django), [Flask](https://flask.palletsprojects.com/), and [Pyramid](https://trypyramid.com).
+- Node/JavaScript frameworks such as [Express Web Framework (Node.js/JavaScript)](/en-US/docs/Learn/Server-side/Express_Nodejs)
+- PHP has its own [built-in development server](https://www.php.net/manual/en/features.commandline.webserver.php):
 
   ```bash
   cd path/to/your/php/code
   php -S localhost:8000
   ```
+
+If you're not working directly with with a server-side framework or a programming language that provides a development server, Python's `http.server` module can also be used to test server-side code written in languages such as Python, PHP, JavaScript, and so on, by invoking server-side GCI scripts.
+For examples of how to use this feature see [Execute a Script Remotely Through the Common Gateway Interface (CGI)](https://realpython.com/python-http-server/#execute-a-script-remotely-through-the-common-gateway-interface-cgi) in _How to Launch an HTTP Server in One Line of Python Code_ on realpython.com.

--- a/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -110,7 +110,7 @@ To do this:
 
 The best approach for working with server side languages, such as Python, PHP, or JavaScript, depends on the server-side language you are using, and whether you're working with a web framework or "stand-alone" code.
 
-If you're working with a web framework, usually the framework will provide its own simple and easy to use development server.
+If you're working with a web framework, usually the framework will provide its own development server.
 For example, the following languages/frameworks come with a development server:
 
 - Python web frameworks, such as [Django](/en-US/docs/Learn/Server-side/Django), [Flask](https://flask.palletsprojects.com/), and [Pyramid](https://trypyramid.com).
@@ -122,5 +122,5 @@ For example, the following languages/frameworks come with a development server:
   php -S localhost:8000
   ```
 
-If you're not working directly with with a server-side framework or a programming language that provides a development server, Python's `http.server` module can also be used to test server-side code written in languages such as Python, PHP, JavaScript, and so on, by invoking server-side GCI scripts.
+If you're not working directly with with a server-side framework or a programming language that provides a development server, Python's `http.server` module can also be used to test server-side code written in languages such as Python, PHP, JavaScript, and so on, by invoking server-side Common Gateway Interface (CGI) scripts.
 For examples of how to use this feature see [Execute a Script Remotely Through the Common Gateway Interface (CGI)](https://realpython.com/python-http-server/#execute-a-script-remotely-through-the-common-gateway-interface-cgi) in _How to Launch an HTTP Server in One Line of Python Code_ on realpython.com.

--- a/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
+++ b/files/en-us/learn/common_questions/tools_and_setup/set_up_a_local_testing_server/index.md
@@ -110,7 +110,7 @@ To do this:
 
 The best approach for working with server side languages, such as Python, PHP, or JavaScript, depends on the server-side language you are using, and whether you're working with a web framework or "stand-alone" code.
 
-If you working with a web framework, usually the framework will provide its own simple and easy to use development server.
+If you're working with a web framework, usually the framework will provide its own simple and easy to use development server.
 For example, the following languages/frameworks come with a development server:
 
 - Python web frameworks, such as [Django](/en-US/docs/Learn/Server-side/Django), [Flask](https://flask.palletsprojects.com/), and [Pyramid](https://trypyramid.com).


### PR DESCRIPTION
Fixes #32446

This modifies the [Running server-side languages locally](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server#running_server-side_languages_locally) section in _setting up a local testing server_ to make it clear that:
- The right way to serve local files depends on what you're doing
- If you're using a web framework that has a development server then using that server is probably the easiest approach for testing the code.
- Otherwise you can use some other server, and it points out that `http.server` is an option. I don't know much about this, but there seems to be a fairly good tutorial in realpython, so I linked to that. 
  - We could say more and separate out a section for this case if reviewers think that would be useful. The poster of the issue provided an example in the issue. I didn't want to make this document too heavyweight, because I think that most audiences for this doc will be using a web framework.
  
  