### PR TITLE
Fix broken links to SVG presentation attributes

### DIFF
--- a/files/en-us/web/svg/element/fedropshadow/index.md
+++ b/files/en-us/web/svg/element/fedropshadow/index.md
@@ -77,4 +77,4 @@ svg {
 ## See also
 
 - [SVG Filter primitive attributes](/en-US/docs/Web/SVG/Attribute#filters_attributes) including {{SVGAttr('height')}}, {{SVGAttr('in')}}, {{SVGAttr('result')}}, {{SVGAttr('x')}}, {{SVGAttr('y')}}, and {{SVGAttr('width')}}.
-- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute/Presentation), including {{SVGAttr('flood-color')}}, and {{SVGAttr('flood-opacity')}}.
+- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute#presentation_attributes), including {{SVGAttr('flood-color')}}, and {{SVGAttr('flood-opacity')}}.

--- a/files/en-us/web/svg/element/polygon/index.md
+++ b/files/en-us/web/svg/element/polygon/index.md
@@ -56,7 +56,7 @@ svg {
 
 ## See also
 
-- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute/Presentation) including {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}
+- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute#presentation_attributes) including {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}
 
 - **Other SVG basic shapes:**
 

--- a/files/en-us/web/svg/element/polyline/index.md
+++ b/files/en-us/web/svg/element/polyline/index.md
@@ -54,5 +54,5 @@ svg {
 
 ## See also
 
-- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute/Presentation), including {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}
+- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute#presentation_attributes), including {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}
 - Other SVG basic shapes: {{ SVGElement('circle') }}, {{ SVGElement('ellipse') }}, **{{ SVGElement('line') }}**, **{{ SVGElement('polygon') }}**, {{ SVGElement('rect') }}

--- a/files/en-us/web/svg/element/rect/index.md
+++ b/files/en-us/web/svg/element/rect/index.md
@@ -71,5 +71,5 @@ svg {
 
 ## See also
 
-- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute/Presentation) including {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}
+- [SVG presentation attributes](/en-US/docs/Web/SVG/Attribute#presentation_attributes) including {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}
 - Other basic SVG shapes: {{SVGElement('circle')}}, {{ SVGElement('ellipse') }}, {{ SVGElement('line') }}, **{{ SVGElement('polygon') }}**, {{ SVGElement('polyline') }}


### PR DESCRIPTION
Proper fix for https://github.com/mdn/content/pull/32494.