### PR TITLE
Rename section "Never use eval()!" to "Never use direct eval()!"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.eval
 
 {{jsSidebar("Objects")}}
 
-> **Warning:** Executing JavaScript from a string is an enormous security risk. It is far too easy for a bad actor to run arbitrary code when you use `eval()`. See [Never use eval()!](#never_use_eval!), below.
+> **Warning:** Executing JavaScript from a string is an enormous security risk. It is far too easy for a bad actor to run arbitrary code when you use `eval()`. See [Never use direct eval()!](#never_use_direct_eval!), below.
 
 The **`eval()`** function evaluates JavaScript code represented as a string and returns its completion value. The source is parsed as a script.
 

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -162,7 +162,7 @@ Indirect eval can be seen as if the code is evaluated within a separate `<script
   new Ctor(); // [Function: Ctor]
   ```
 
-### Never use eval()!
+### Never use direct eval()!
 
 Using direct `eval()` suffers from multiple problems:
 


### PR DESCRIPTION
### Motivation

Despite the section title, the contents of the body are referring specifically to _direct_ `eval()`.

### Additional details

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#description

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
