### PR TITLE
docs(http): Update link to IANA HTTP fields registry

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/document_an_http_header/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/document_an_http_header/index.md
@@ -13,7 +13,7 @@ You will need to know or be able to dive into some [HTTP](/en-US/docs/Web/HTTP).
 ## Step 1 – Determine the HTTP header to document
 
 - There are many HTTP headers defined in various IETF standards.
-- IANA maintains a [registry of headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml) and Wikipedia lists the [known header fields](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), but not all are relevant to web developers or are part of an official standard.
+- IANA maintains a [registry of HTTP header fields](https://www.iana.org/assignments/http-fields/http-fields.xhtml) and Wikipedia lists the [known header fields](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields), but not all are relevant to web developers or are part of an official standard.
 - If there are any **red links** on the current [HTTP headers reference overview page](/en-US/docs/Web/HTTP/Headers), these headers are a good choice to document.
 - If in doubt, [ask the MDN Web Docs team](/en-US/docs/MDN/Community/Communication_channels) whether or not it makes sense to write about the header you have chosen.
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -8,7 +8,8 @@ page-type: landing-page
 
 **HTTP headers** let the client and the server pass additional information with an HTTP request or response. An HTTP header consists of its case-insensitive name followed by a colon (`:`), then by its value. {{Glossary("Whitespace")}} before the value is ignored.
 
-Custom proprietary headers have historically been used with an `X-` prefix, but this convention was deprecated in June 2012 because of the inconveniences it caused when nonstandard fields became standard in [RFC 6648](https://datatracker.ietf.org/doc/html/rfc6648); others are listed in an [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers), whose original content was defined in [RFC 4229](https://datatracker.ietf.org/doc/html/rfc4229). IANA also maintains a [registry of proposed new HTTP headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers).
+Custom proprietary headers have historically been used with an `X-` prefix, but this convention was deprecated in June 2012 because of the inconveniences it caused when nonstandard fields became standard in [RFC 6648](https://datatracker.ietf.org/doc/html/rfc6648); others are listed in the [IANA HTTP Field Name Registry](https://www.iana.org/assignments/http-fields/http-fields.xhtml), whose original content was defined in [RFC 4229](https://datatracker.ietf.org/doc/html/rfc4229).
+The IANA registry lists headers, including [information about their status](https://github.com/protocol-registries/http-fields?tab=readme-ov-file#choosing-the-right-status), which may be "permanent" (standards-defined), "provisional" (new), "deprecated" (use not recommended), or "obsolete" (no longer in use).
 
 Headers can be grouped according to their contexts:
 
@@ -390,5 +391,5 @@ You can help by [writing new entries](/en-US/docs/MDN/Writing_guidelines/Howto/D
 ## See also
 
 - [Wikipedia page on List of HTTP headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields)
-- [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers)
+- [IANA registry](https://www.iana.org/assignments/http-fields/http-fields.xhtml)
 - [HTTP Working Group](https://httpwg.org/specs/)

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -39,7 +39,7 @@ Learn how to use HTTP with guides and tutorials.
 Browse through detailed HTTP reference documentation.
 
 - [HTTP Headers](/en-US/docs/Web/HTTP/Headers)
-  - : HTTP message headers are used to describe a resource, or the behavior of the server or the client. Header fields are kept in an [IANA registry](https://www.iana.org/assignments/message-headers/message-headers.xhtml#perm-headers). IANA also maintains a [registry of proposed new HTTP message headers](https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers).
+  - : HTTP message headers are used to describe a resource, or the behavior of the server or the client. Header fields are maintained in an [IANA HTTP Field Name Registry](https://www.iana.org/assignments/http-fields/http-fields.xhtml), which includes [information about their status](https://github.com/protocol-registries/http-fields?tab=readme-ov-file#choosing-the-right-status), which may be "permanent" (standards-defined), "provisional" (new), "deprecated" (use not recommended), or "obsolete" (no longer in use).
 - [HTTP Request Methods](/en-US/docs/Web/HTTP/Methods)
   - : The different operations that can be done with HTTP: {{HTTPMethod("GET")}}, {{HTTPMethod("POST")}}, and also less common requests like {{HTTPMethod("OPTIONS")}}, {{HTTPMethod("DELETE")}}, or {{HTTPMethod("TRACE")}}.
 - [HTTP Status Response Codes](/en-US/docs/Web/HTTP/Status)


### PR DESCRIPTION
### Description

Updating the URL for IANA HTTP field registry.

### Motivation

New document address for https://www.iana.org/assignments/message-headers/message-headers.xhtml#prov-headers

>HTTP field name registrations have been moved to [https://www.iana.org/assignments/http-fields] 
per [[RFC-ietf-httpbis-semantics-19](https://www.iana.org/go/draft-ietf-httpbis-semantics-19)].


### Related issues and pull requests

Fixes #32453 