### PR TITLE
chore: fix indentation in webassembly tutorials

### DIFF
--- a/files/en-us/webassembly/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/understanding_the_text_format/index.md
@@ -265,12 +265,12 @@ In WebAssembly text format, it looks something like this (see [global.wat](https
 
 ```wasm
 (module
-   (global $g (import "js" "global") (mut i32))
-   (func (export "getGlobal") (result i32)
-        (global.get $g))
-   (func (export "incGlobal")
-        (global.set $g
-            (i32.add (global.get $g) (i32.const 1))))
+  (global $g (import "js" "global") (mut i32))
+  (func (export "getGlobal") (result i32)
+    (global.get $g))
+  (func (export "incGlobal")
+    (global.set $g
+      (i32.add (global.get $g) (i32.const 1))))
 )
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

A minor fix in WebAssembly tutorials.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Consistently use 2-space indentations.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
