### PR TITLE
Mention `String#replaceAll` as well as `String#replace` under `Symbol.replace` article

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -52,4 +52,5 @@ console.log("football".replace(new CustomReplacer("foo"))); // "#!@?tball"
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
 - {{jsxref("String.prototype.replace()")}}
+- {{jsxref("String.prototype.replaceAll()")}}
 - [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -7,9 +7,9 @@ browser-compat: javascript.builtins.Symbol.replace
 
 {{JSRef}}
 
-The **`Symbol.replace`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@replace`. The {{jsxref("String.prototype.replace()")}} method looks up this symbol on its first argument for the method that replaces substrings matched by the current object.
+The **`Symbol.replace`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@replace`. The {{jsxref("String.prototype.replace()")}} and {{jsxref("String.prototype.replaceAll()")}} methods look up this symbol on their first argument for the method that replaces substrings matched by the current object.
 
-For more information, see [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace) and {{jsxref("String.prototype.replace()")}}.
+For more information, see [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace), and {{jsxref("String.prototype.replace()")}}, and {{jsxref("String.prototype.replaceAll()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-replace.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -9,7 +9,7 @@ browser-compat: javascript.builtins.Symbol.replace
 
 The **`Symbol.replace`** static data property represents the [well-known symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#well-known_symbols) `@@replace`. The {{jsxref("String.prototype.replace()")}} and {{jsxref("String.prototype.replaceAll()")}} methods look up this symbol on their first argument for the method that replaces substrings matched by the current object.
 
-For more information, see [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace), and {{jsxref("String.prototype.replace()")}}, and {{jsxref("String.prototype.replaceAll()")}}.
+For more information, see [`RegExp.prototype[@@replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace), {{jsxref("String.prototype.replace()")}}, and {{jsxref("String.prototype.replaceAll()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-replace.html")}}
 


### PR DESCRIPTION
### Description

Mention `String#replaceAll` as well as `String#replace` under `Symbol.replace` article.

### Motivation

`String#replaceAll` also looks up `Symbol.replace`:

```js
class Replacer {
    [Symbol.replace](str) {
        return `hello, ${str}`
    }
}

console.log('world'.replace(new Replacer()))
// hello, world
console.log('world'.replaceAll(new Replacer()))
// hello, world
```

### Additional details

[ES Spec](https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replaceall):

> c. Let replacer be ? [GetMethod](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getmethod)(searchValue, [@@replace](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-well-known-symbols)).

MDN's [`RegExp.prototype[@@replace]()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace) article already mentions this, but not the `Symbol.replace` one.

### Related issues and pull requests

N/A