### PR TITLE
Error in specificity weight calculation table

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_and_inheritance/index.md
@@ -190,7 +190,7 @@ The following table shows a few isolated examples to get you in the mood. Try go
 | `h1 + p::first-letter`                    | 0           | 0       | 3        | 0-0-3             |
 | `li > a[href*="en-US"] > .inline-warning` | 0           | 2       | 2        | 0-2-2             |
 | `#identifier`                             | 1           | 0       | 0        | 1-0-0             |
-| `button:not(#mainBtn, .cta`)              | 1           | 0       | 1        | 1-0-1             |
+| `button:not(#mainBtn, .cta)`              | 1           | 1       | 1        | 1-1-1             |
 
 Before we move on, let's look at an example in action.
 


### PR DESCRIPTION
The table that demonstrates specificity weight calculation for some selectors contains an error. For the last selector, i.e. `button:not(#mainBtn, .cta)`, the total specificity is `1-1-1`. However, on the site, it's mentioned as `1-0-1`. This is incorrect. `button` accounts for the rightmost `1`, `#mainBtn` results in leftmost `1` and the middle `1` is due to `.cta`. 

Also, a minor correction, `button:not(#mainBtn, .cta`) has been replaced with `button:not(#mainBtn, .cta)`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
