### PR TITLE
Fix return type for getAttributeNames

### DIFF
--- a/files/en-us/web/api/element/getattributenames/index.md
+++ b/files/en-us/web/api/element/getattributenames/index.md
@@ -31,7 +31,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+Array ({{jsxref("Array")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/element/getattributenames/index.md
+++ b/files/en-us/web/api/element/getattributenames/index.md
@@ -31,7 +31,7 @@ None.
 
 ### Return value
 
-Array ({{jsxref("Array")}}).
+An ({{jsxref("Array")}}) of strings.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The method **getAttributeNames** on **Element** returns Array as specified in the first paragraph of the document. But the **Return Value** section mistakenly uses **None/undefined**. This change fixes the Return value section of the document.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
I was reading through the document and noticed it in the guide. I hope that correcting the api docs will help others.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
N/A
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
