### PR TITLE
Fix incorrect comment in Wasm memory.copy example

### DIFF
--- a/files/en-us/webassembly/reference/memory/copy/index.md
+++ b/files/en-us/webassembly/reference/memory/copy/index.md
@@ -22,8 +22,6 @@ i32.const 25
 
 ;; Copy data from [100, 125] to [50, 75]
 memory.copy
-
-;; the top item on the stack will now either be the previous number of pages (success) or `-1` (failure)
 ```
 
 | Instruction   | Binary opcode |


### PR DESCRIPTION
### Description

Fixed an incorrect comment about the return value of `memory.copy` (probably accidentally kept after a paste from `memory.grow`).

### Motivation

Spotted it while reading MDN and did a quick fix :)