### PR TITLE
Fix base64 code example

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -52,7 +52,9 @@ function base64ToBytes(base64) {
 }
 
 function bytesToBase64(bytes) {
-  const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join("");
+  const binString = Array.from(bytes, (byte) =>
+    String.fromCodePoint(byte),
+  ).join("");
   return btoa(binString);
 }
 

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -67,7 +67,7 @@ new TextDecoder().decode(base64ToBytes("YSDEgCDwkICAIOaWhyDwn6aE")); // "a ƒÄ ê
 
 The `bytesToBase64` and `base64ToBytes` functions in the previous section can be used directly to convert between Base64 strings and [`Uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)s.
 
-For better performances, asynchronous conversion between base64 data URLs is possible natively within the web platform via the [`FileReader`](/en-US/docs/Web/API/FileReader) and [`fetch`](/en-US/docs/Web/API/Fetch_API) APIs:
+For better performance, asynchronous conversion between base64 data URLs is possible natively within the web platform via the [`FileReader`](/en-US/docs/Web/API/FileReader) and [`fetch`](/en-US/docs/Web/API/Fetch_API) APIs:
 
 ```js
 async function bytesToBase64DataUrl(bytes, type = "application/octet-stream") {

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -52,7 +52,7 @@ function base64ToBytes(base64) {
 }
 
 function bytesToBase64(bytes) {
-  const binString = String.fromCodePoint(...bytes);
+  const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join("");
   return btoa(binString);
 }
 

--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -65,7 +65,7 @@ new TextDecoder().decode(base64ToBytes("YSDEgCDwkICAIOaWhyDwn6aE")); // "a ƒÄ ê
 
 The `bytesToBase64` and `base64ToBytes` functions in the previous section can be used directly to convert between Base64 strings and [`Uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)s.
 
-Alternatively, asynchronous conversion between base64 data URLs is possible natively within the web platform via the [`FileReader`](/en-US/docs/Web/API/FileReader) and [`fetch`](/en-US/docs/Web/API/Fetch_API) APIs:
+For better performances, asynchronous conversion between base64 data URLs is possible natively within the web platform via the [`FileReader`](/en-US/docs/Web/API/FileReader) and [`fetch`](/en-US/docs/Web/API/Fetch_API) APIs:
 
 ```js
 async function bytesToBase64DataUrl(bytes, type = "application/octet-stream") {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

#### Fix error in `bytesToBase64` code example

Using `fromCodePoint(...bytes)` leads to the error `RangeError: Maximum call stack size exceeded` when `bytes` is long (it happens with 150k bytes for me with Chrome 122 on Linux).

Using `Array.from` fixes this issue.

#### Mention that `FileReader` and `fetch` offer better performances

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Prevent developers from using a piece of code that gives the impression it's working, but might fail later if used with long data.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Error in Chrome 122 on Linux when calling `bytesToBase64` with an argument of size 150k:

![image](https://github.com/mdn/content/assets/29386932/d398c65e-3bde-4245-aa0b-5496e061f7d9)


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
