### PR TITLE
Synchronize with webref/idl v3.44.2

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/activate_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.activate_event
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`activate`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active")}} worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchabort_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchabort_event
 ---
 
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`backgroundfetchabort`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when the user or the app itself cancels a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchclick_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchclick_event
 ---
 
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`backgroundfetchclick`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when the user clicks on the UI that the browser provides to show the user the progress of the [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchfail_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchfail_event
 ---
 
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`backgroundfetchfail`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation has failed: that is, when at least one network request in the fetch has failed to complete successfully.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/backgroundfetchsuccess_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.backgroundfetchsuccess_event
 ---
 
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`backgroundfetchsuccess`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation has completed successfully: that is, when all network requests in the fetch have completed successfully.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/canmakepayment_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/canmakepayment_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.canmakepayment_event
 ---
 
-{{APIRef("Payment Handler API")}}{{SeeCompatTable}}
+{{APIRef("Payment Handler API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`canmakepayment`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/clients/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/clients/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorkerGlobalScope.clients
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`clients`** read-only property of the
 {{domxref("ServiceWorkerGlobalScope")}} interface returns the [`Clients`](/en-US/docs/Web/API/Clients)

--- a/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.contentdelete_event
 ---
 
-{{APIRef("Content Index API")}}{{SeeCompatTable}}
+{{APIRef("Content Index API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`contentdelete`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when an item is removed from the indexed content via the user agent.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/cookiechange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/cookiechange_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.cookiechange_event
 ---
 
-{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
+{{APIRef("Cookie Store API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`cookiechange`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a cookie change occurs that matches the service worker's cookie change subscription list.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/cookiestore/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/cookiestore/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.cookieStore
 ---
 
-{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
+{{APIRef("Cookie Store API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`cookieStore`** read-only property of the {{domxref("ServiceWorkerGlobalScope")}} interface returns a reference to the {{domxref("CookieStore")}} object associated with this service worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/fetch_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.fetch_event
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`fetch`** event is fired in the service worker's global scope when the main app thread makes a network request. It enables the service worker to intercept network requests and send customized responses (for example, from a local cache).
 

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.ServiceWorkerGlobalScope
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`ServiceWorkerGlobalScope`** interface of the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) represents the global execution context of a service worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/install_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/install_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.install_event
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`install`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when a {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.installing")}} worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/message_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/message_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.message_event
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`message`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface occurs when incoming messages are received. Controlled pages can use the {{domxref("ServiceWorker.postMessage()")}} method to send messages to service workers.
 The service worker can optionally send a response back via the {{domxref("Client.postMessage()")}}, corresponding to the controlled page.

--- a/files/en-us/web/api/serviceworkerglobalscope/messageerror_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/messageerror_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.messageerror_event
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`messageerror`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface occurs when incoming messages can't be deserialized.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.notificationclick_event
 ---
 
-{{APIRef("Web Notifications")}}
+{{APIRef("Web Notifications")}}{{SecureContext_Header}}
 
 The **`notificationclick`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired to indicate that a system notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}} has been clicked.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclose_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.notificationclose_event
 ---
 
-{{APIRef("Web Notifications")}}
+{{APIRef("Web Notifications")}}{{SecureContext_Header}}
 
 The **`notificationclose`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface fires when a user closes a displayed notification spawned by {{domxref("ServiceWorkerRegistration.showNotification()")}}.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/paymentrequest_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/paymentrequest_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.paymentrequest_event
 ---
 
-{{APIRef("Payment Handler API")}}{{SeeCompatTable}}
+{{APIRef("Payment Handler API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`paymentrequest`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired on a payment app when a payment flow has been initiated on the merchant website via the {{domxref("PaymentRequest.show()")}} method.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.ServiceWorkerGlobalScope.periodicsync_event
 ---
 
-{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`periodicsync`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired at timed intervals, specified when registering a {{domxref('PeriodicSyncManager')}}.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/registration/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/registration/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorkerGlobalScope.registration
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`registration`** read-only property of the {{domxref("ServiceWorkerGlobalScope")}} interface returns a reference to the {{domxref("ServiceWorkerRegistration")}} object, which represents the service worker's registration.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/serviceworker/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorkerGlobalScope.serviceWorker
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`serviceWorker`** read-only property of the {{domxref("ServiceWorkerGlobalScope")}} interface returns a reference to the {{domxref("ServiceWorker")}} object, which represents the service worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerGlobalScope.skipWaiting
 ---
 
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}
 
 The **`ServiceWorkerGlobalScope.skipWaiting()`** method of the {{domxref("ServiceWorkerGlobalScope")}} forces the waiting service worker to become the active service worker.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerGlobalScope.sync_event
 ---
 
-{{APIRef("Background Sync")}}
+{{APIRef("Background Sync")}}{{SecureContext_Header}}
 
 The **`sync`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired when the page (or worker) that registered the event with the {{domxref('SyncManager')}} is running and as soon as network connectivity is available.
 


### PR DESCRIPTION
The changes have been auto generated using a script that referred [Webref/idl release v3.44.2](https://github.com/w3c/webref/releases/tag/%40webref%2Fidl%403.44.2)

All the changes are resulted from [tagging ServiceWorkerGlobalScope](https://github.com/w3c/ServiceWorker/commit/07824168ecb99757a589710fc0f5fb59886acfbf) with `[SecureContext]`.

Ping @wbamberg 