### PR TITLE
Fix PWA page iOS version

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -114,8 +114,8 @@ On desktop:
 On mobile:
 
 - On Android, Firefox, Chrome, Edge, Opera, and Samsung Internet Browser all support installing PWAs.
-- On iOS 16.3 and earlier, PWAs can only be installed with Safari.
-- On iOS 16.4 and later, PWAs can be installed from the Share menu in Safari, Chrome, Edge, Firefox, and Orion.
+- On iOS 17.3 and earlier, PWAs can only be installed with Safari.
+- On iOS 17.4 and later, PWAs can be installed from the Share menu in Safari, Chrome, Edge, Firefox, and Orion.
 
 ### Installing sites as apps
 


### PR DESCRIPTION
The current EU issues related to PWAs requiring a different way to install happens with the latest/newest iOS 17.4, not with the iOS 16.4 from previous year.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
