### PR TITLE
Feat add example to MathML mtd page using example given in w3c mathml…

### DIFF
--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -27,6 +27,43 @@ Some browsers may also support the following attributes:
   - : Specifies the vertical alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
 
+## Examples
+
+### Matrix using mtable, mrow, mtr and mtd
+
+```html
+<math display="block">
+  <mfrac>
+    <mi>A</mi>
+    <mn>2</mn>
+  </mfrac>
+  <mo>=</mo>
+  <mrow>
+    <mo>(</mo>
+    <mtable>
+      <mtr>
+        <mtd><mn>1</mn></mtd>
+        <mtd><mn>2</mn></mtd>
+        <mtd><mn>3</mn></mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>4</mn></mtd>
+        <mtd><mn>5</mn></mtd>
+        <mtd><mn>6</mn></mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn></mtd>
+        <mtd><mn>8</mn></mtd>
+        <mtd><mn>9</mn></mtd>
+      </mtr>
+    </mtable>
+    <mo>)</mo>
+  </mrow>
+</math>
+```
+
+{{EmbedLiveSample('Alignment with row number')}}
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
… core

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added an example to the mtd page in MathML based on the example in the [W3C documentation]( https://w3c.github.io/mathml-core/#tabular-math)

### Motivation

To learn more how to contribute in open source projects and to help users of MathML to understand better what it does

### Additional details

[W3C documentation](https://w3c.github.io/mathml-core/#tabular-math) from where i get the example.

### Related issues and pull requests

[Related to this issue #2463](https://github.com/mdn/interactive-examples/issues/2463)


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
