### PR TITLE
Bigint multiplication assignment fix

### DIFF
--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -38,46 +38,48 @@ You are advised to not use `"" + x` to perform [string coercion](/en-US/docs/Web
 
 ## Examples
 
-### Number addition
+### Addition using numbers
 
 ```js
-// Number + Number -> addition
 1 + 2; // 3
+```
 
-// Boolean + Number -> addition
+Other non-string, non-BigInt values are coerced to numbers:
+
+```js
 true + 1; // 2
-
-// Boolean + Boolean -> addition
 false + false; // 0
 ```
 
-### BigInt addition
+### Addion using BigInts
 
 ```js
-// BigInt + BigInt -> addition
 1n + 2n; // 3n
+```
 
-// BigInt + Number -> throws TypeError
+You cannot mix BigInt and number operands in addition.
+
+```js example-bad
 1n + 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+2 + 1n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+"1" + 2n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
 
-// To add a BigInt to a non-BigInt, convert either operand
+To do addition with a BigInt and a non-BigInt, convert either operand:
+
+```js
 1n + BigInt(2); // 3n
 Number(1n) + 2; // 3
 ```
 
-### String concatenation
+### Addition using strings
+
+If one of the operands is a string, the other is converted to a string and they are concatenated:
 
 ```js
-// String + String -> concatenation
 "foo" + "bar"; // "foobar"
-
-// Number + String -> concatenation
 5 + "foo"; // "5foo"
-
-// String + Boolean -> concatenation
 "foo" + false; // "foofalse"
-
-// String + Number -> concatenation
 "2" + 2; // "22"
 ```
 

--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
@@ -27,53 +27,35 @@ x += y
 
 ```js
 let bar = 5;
-// Number + Number -> addition
 bar += 2; // 7
 ```
 
-### Addition assignment using numbers and booleans
+Other non-string, non-BigInt values are coerced to numbers:
 
 ```js
 let baz = true;
-
-// Boolean + Number -> addition
 baz += 1; // 2
-
-// Number + Boolean -> addition
 baz += false; // 2
-```
-
-### Addition assignment using booleans and strings
-
-```js
-let foo = "foo";
-
-// String + Boolean -> concatenation
-foo += false; // "foofalse"
-
-// String + String -> concatenation
-foo += "bar"; // "foofalsebar"
-```
-
-### Addition assignment using numbers and strings
-
-```js
-let bar = 5;
-
-// Number + String -> concatenation
-bar += "foo"; // "7foo"
 ```
 
 ### Addition assignment using BigInts
 
 ```js
 let x = 1n;
-
-// BigInt + BigInt -> addition
 x += 2n; // 3n
 
-// BigInt + Number -> throws TypeError
 x += 1; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
+
+### Addition assignment using strings
+
+```js
+let foo = "foo";
+foo += false; // "foofalse"
+foo += "bar"; // "foofalsebar"
+
+let bar = 5;
+bar += "foo"; // "5foo"
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition_assignment/index.md
@@ -23,7 +23,15 @@ x += y
 
 ## Examples
 
-### Using addition assignment
+### Addition assignment using numbers
+
+```js
+let bar = 5;
+// Number + Number -> addition
+bar += 2; // 7
+```
+
+### Addition assignment using numbers and booleans
 
 ```js
 let baz = true;
@@ -35,6 +43,8 @@ baz += 1; // 2
 baz += false; // 2
 ```
 
+### Addition assignment using booleans and strings
+
 ```js
 let foo = "foo";
 
@@ -45,15 +55,16 @@ foo += false; // "foofalse"
 foo += "bar"; // "foofalsebar"
 ```
 
+### Addition assignment using numbers and strings
+
 ```js
 let bar = 5;
-
-// Number + Number -> addition
-bar += 2; // 7
 
 // Number + String -> concatenation
 bar += "foo"; // "7foo"
 ```
+
+### Addition assignment using BigInts
 
 ```js
 let x = 1n;

--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -25,14 +25,23 @@ For BigInt division, the result is the quotient of the two operands truncated to
 
 ## Examples
 
-### Basic division
+### Division using numbers
 
 ```js
 1 / 2; // 0.5
-
 Math.floor(3 / 2); // 1
-
 1.0 / 2.0; // 0.5
+
+2 / 0; // Infinity
+2.0 / 0.0; // Infinity, because 0.0 === 0
+2.0 / -0.0; // -Infinity
+```
+
+Other non-BigInt values are coerced to numbers:
+
+```js
+5 / "2"; // 2.5
+5 / "foo"; // NaN
 ```
 
 ### Division using BigInts
@@ -43,20 +52,21 @@ Math.floor(3 / 2); // 1
 -1n / 3n; // 0n
 1n / -3n; // 0n
 
-2n / 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
-
-// To do division with a BigInt and a non-BigInt, convert either operand
-2n / BigInt(2); // 1n
-Number(2n) / 2; // 1
+2n / 0n; // RangeError: BigInt division by zero
 ```
 
-### Division by zero
+You cannot mix BigInt and number operands in division.
+
+```js example-bad
+2n / 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+2 / 2n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
+
+To do division with a BigInt and a non-BigInt, convert either operand:
 
 ```js
-2.0 / 0; // Infinity
-2.0 / 0.0; // Infinity, because 0.0 === 0
-2.0 / -0.0; // -Infinity
-2n / 0n; // RangeError: BigInt division by zero
+2n / BigInt(2); // 1n
+Number(2n) / 2; // 1
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -33,9 +33,11 @@ For BigInt division, the result is the quotient of the two operands truncated to
 Math.floor(3 / 2); // 1
 
 1.0 / 2.0; // 0.5
+```
 
 ### Division using BigInts
 
+```js
 1n / 2n; // 0n
 5n / 3n; // 1n
 -1n / 3n; // 0n

--- a/files/en-us/web/javascript/reference/operators/division/index.md
+++ b/files/en-us/web/javascript/reference/operators/division/index.md
@@ -34,6 +34,8 @@ Math.floor(3 / 2); // 1
 
 1.0 / 2.0; // 0.5
 
+### Division using BigInts
+
 1n / 2n; // 0n
 5n / 3n; // 1n
 -1n / 3n; // 0n
@@ -50,12 +52,9 @@ Number(2n) / 2; // 1
 
 ```js
 2.0 / 0; // Infinity
-
 2.0 / 0.0; // Infinity, because 0.0 === 0
-
 2.0 / -0.0; // -Infinity
-
-2n / 0n; // RangeError: Division by zero
+2n / 0n; // RangeError: BigInt division by zero
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.md
@@ -23,7 +23,7 @@ x /= y
 
 ## Examples
 
-### Using division assignment
+### Division assignment using numbers
 
 ```js
 let bar = 5;
@@ -31,8 +31,17 @@ let bar = 5;
 bar /= 2; // 2.5
 bar /= 2; // 1.25
 bar /= 0; // Infinity
-bar /= "foo"; // NaN
+```
 
+### Division assignment using non-numbers
+
+```js
+bar /= "foo"; // NaN
+```
+
+### Division assignment using BigInts
+
+```js
 let foo = 3n;
 foo /= 2n; // 1n
 foo /= 2n; // 0n

--- a/files/en-us/web/javascript/reference/operators/division_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/division_assignment/index.md
@@ -33,9 +33,11 @@ bar /= 2; // 1.25
 bar /= 0; // Infinity
 ```
 
-### Division assignment using non-numbers
+Other non-BigInt values are coerced to numbers:
 
 ```js
+let bar = 5;
+bar /= "2"; // 2.5
 bar /= "foo"; // NaN
 ```
 
@@ -45,6 +47,9 @@ bar /= "foo"; // NaN
 let foo = 3n;
 foo /= 2n; // 1n
 foo /= 2n; // 0n
+
+foo /= 0n; // RangeError: BigInt division by zero
+foo /= 1; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/exponentiation/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation/index.md
@@ -39,7 +39,7 @@ Note that some programming languages use the caret symbol `^` for exponentiation
 
 ## Examples
 
-### Basic exponentiation
+### Exponentiation using numbers
 
 ```js
 2 ** 3; // 8
@@ -50,13 +50,32 @@ Note that some programming languages use the caret symbol `^` for exponentiation
 NaN ** 2; // NaN
 NaN ** 0; // 1
 1 ** Infinity; // NaN
+```
 
+Other non-BigInt values are coerced to numbers:
+
+```js
+2 ** "3"; // 8
+2 ** "hello"; // NaN
+```
+
+### Exponentiation using BigInts
+
+```js
 2n ** 3n; // 8n
 2n ** 1024n; // A very large number, but not Infinity
+```
 
+You cannot mix BigInt and number operands in exponentiation.
+
+```js example-bad
 2n ** 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+2 ** 2n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
 
-// To do exponentiation with a BigInt and a non-BigInt, convert either operand
+To do exponentiation with a BigInt and a non-BigInt, convert either operand:
+
+```js
 2n ** BigInt(2); // 4n
 Number(2n) ** 2; // 4
 ```

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -23,21 +23,21 @@ x **= y
 
 ## Examples
 
-### Exponentiation assignment with numbers
+### Exponentiation assignment using numbers
 
 ```js
 let bar = 5;
 bar **= 2; // 25
 ```
 
-### Exponentiation assignment with non-numbers
+### Exponentiation assignment using non-numbers
 
 ```js
 let baz = 5;
 baz **= "foo"; // NaN
 ```
 
-### Exponentiation assignment with BigInts
+### Exponentiation assignment using BigInts
 
 ```js
 let foo = 3n;

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -30,7 +30,7 @@ let bar = 5;
 bar **= 2; // 25
 ```
 
-### Exponentiation assignment using non-numbers
+Other non-BigInt values are coerced to numbers:
 
 ```js
 let baz = 5;
@@ -42,6 +42,7 @@ baz **= "foo"; // NaN
 ```js
 let foo = 3n;
 foo **= 2n; // 9n
+foo **= 1; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/exponentiation_assignment/index.md
@@ -23,14 +23,23 @@ x **= y
 
 ## Examples
 
-### Using exponentiation assignment
+### Exponentiation assignment with numbers
 
 ```js
 let bar = 5;
-
 bar **= 2; // 25
-bar **= "foo"; // NaN
+```
 
+### Exponentiation assignment with non-numbers
+
+```js
+let baz = 5;
+baz **= "foo"; // NaN
+```
+
+### Exponentiation assignment with BigInts
+
+```js
 let foo = 3n;
 foo **= 2n; // 9n
 ```

--- a/files/en-us/web/javascript/reference/operators/multiplication/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication/index.md
@@ -28,16 +28,12 @@ The `*` operator is overloaded for two types of operands: number and [BigInt](/e
 ```js
 2 * 2; // 4
 -2 * 2; // -4
-```
 
-### Multiplication with Infinity
-
-```js
 Infinity * 0; // NaN
 Infinity * Infinity; // Infinity
 ```
 
-### Multiplication with non-numbers
+Other non-BigInt values are coerced to numbers:
 
 ```js
 "foo" * 2; // NaN
@@ -49,10 +45,18 @@ Infinity * Infinity; // Infinity
 ```js
 2n * 2n; // 4n
 -2n * 2n; // -4n
+```
 
+You cannot mix BigInt and number operands in multiplication.
+
+```js example-bad
 2n * 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+2 * 2n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
 
-// To multiply a BigInt with a non-BigInt, convert either operand
+To do multiplication with a BigInt and a non-BigInt, convert either operand:
+
+```js
 2n * BigInt(2); // 4n
 Number(2n) * 2; // 4
 ```

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -23,14 +23,23 @@ x *= y
 
 ## Examples
 
-### Using multiplication assignment
+### Multiplication assignment using numbers
 
 ```js
 let bar = 5;
-
 bar *= 2; // 10
-bar *= "foo"; // NaN
+```
 
+### Multiplication assignment using non-numbers
+
+```js
+let bar = 5;
+bar *= "foo"; // NaN
+```
+
+### Multiplication assignment using BigInts
+
+```js
 let foo = 3n;
 foo *= 2n; // 6n
 ```

--- a/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/multiplication_assignment/index.md
@@ -30,7 +30,7 @@ let bar = 5;
 bar *= 2; // 10
 ```
 
-### Multiplication assignment using non-numbers
+Other non-BigInt values are coerced to numbers:
 
 ```js
 let bar = 5;
@@ -42,6 +42,7 @@ bar *= "foo"; // NaN
 ```js
 let foo = 3n;
 foo *= 2n; // 6n
+foo *= 1; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/subtraction/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction/index.md
@@ -23,30 +23,23 @@ The `-` operator is overloaded for two types of operands: number and [BigInt](/e
 
 ## Examples
 
-### Subtraction with numbers
+### Subtraction using numbers
 
 ```js
-// Number - Number -> subtraction
 5 - 3; // 2
-
-// Number - Number -> subtraction
 3 - 5; // -2
 ```
 
-### Subtraction with non-numbers
+Other non-BigInt values are coerced to numbers:
 
 ```js
-// String - Number -> subtraction
 "foo" - 3; // NaN; "foo" is converted to the number NaN
-
-// Number - String -> subtraction
 5 - "3"; // 2; "3" is converted to the number 3
 ```
 
-### Subtraction with BigInts
+### Subtraction using BigInts
 
 ```js
-// BigInt - BigInt -> subtraction
 2n - 1n; // 1n
 ```
 
@@ -55,6 +48,13 @@ You cannot mix BigInt and number operands in subtraction.
 ```js example-bad
 2n - 1; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 2 - 1n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
+
+To do subtraction with a BigInt and a non-BigInt, convert either operand:
+
+```js
+2n - BigInt(1); // 1n
+Number(2n) - 1; // 1
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/subtraction_assignment/index.md
@@ -23,16 +23,26 @@ x -= y
 
 ## Examples
 
-### Using subtraction assignment
+### Subtraction assignment using numbers
 
 ```js
 let bar = 5;
 
 bar -= 2; // 3
-bar -= "foo"; // NaN
+```
 
+Other non-BigInt values are coerced to numbers:
+
+```js
+bar -= "foo"; // NaN
+```
+
+### Subtraction assignment using BigInts
+
+```js
 let foo = 3n;
 foo -= 2n; // 1n
+foo -= 1; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 ```
 
 ## Specifications


### PR DESCRIPTION
Fixes #32492

This matches the pattern of the docs in Multiplication assignment to  [Multiplication](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication) - i.e. using a heading to make it clear we're working with BigInt assignment.

I have similarly changed the other main cases - addition assignment, division, exponentiation. 

> Would have to change for every assignment operator though.

@Josh-Cena I've changed the ones that it makes sense for consistency, or where I think the same problem that caused confusion for multiplication could happen again. But I have not changed cases like https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment that don't already talk about BigInts. You might find a case or two that could still benefit from this but I'm not too concerned as this is not a change, but a consistency improvement to match existing docs.
