### PR TITLE
proxy.ProxyInfo.proxyAuthorizationHeader HTTP support

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -37,7 +37,7 @@ Values of this type are objects. They contain the following properties:
   - : `number`. Failover timeout in seconds. If the connection fails to connect the proxy server after this number of seconds, the next proxy server in the array returned from the `proxy.onRequest` listener will be used.
 - `proxyAuthorizationHeader`
 
-  - : `string`. When set, passed to the {{httpheader("Proxy-Authorization")}} request header sent to HTTP or HTTPS proxies as part of a [CONNECT](/en-US/docs/Web/HTTP/Methods/CONNECT) request. Used to authenticate to HTTP and HTTPS proxies that allow non-challenging authentication.
+  - : `string`. When set, this is passed to the {{httpheader("Proxy-Authorization")}} request header sent to HTTP or HTTPS proxies as part of a [CONNECT](/en-US/docs/Web/HTTP/Methods/CONNECT) request. Used to authenticate to HTTP and HTTPS proxies that allow non-challenging authentication.
 
     For instance, if you want to send "username" and "password" for "basic" authentication, you can set the `proxyAuthorizationHeader` property to `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -37,7 +37,7 @@ Values of this type are objects. They contain the following properties:
   - : `number`. Failover timeout in seconds. If the connection fails to connect the proxy server after this number of seconds, the next proxy server in the array returned from the `proxy.onRequest` listener will be used.
 - `proxyAuthorizationHeader`
 
-  - : `string`. This string, if set to non-empty, is passed directly as a value to the {{httpheader("Proxy-Authorization")}} request header sent to HTTPS proxies as part of HTTPS and CONNECT requests. In other words, this can be used to directly authenticate to HTTPS proxies that allow (non-challenging) authentication.
+  - : `string`. When set, passed to the {{httpheader("Proxy-Authorization")}} request header sent to HTTP or HTTPS proxies as part of a [CONNECT](/en-US/docs/Web/HTTP/Methods/CONNECT) request. Used to authenticate to HTTP and HTTPS proxies that allow non-challenging authentication.
 
     For instance, if you want to send "username" and "password" for "basic" authentication, you can set the `proxyAuthorizationHeader` property to `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`
 

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ## Changes for add-on developers
 
+- The content of the {{WebExtAPIRef("proxy.ProxyInfo")}} property `proxyAuthorization` is now passed to the {{httpheader("Proxy-Authorization")}} request header sent to HTTP proxies (in addition to the existing support for HTTPS proxies) as part of a [CONNECT](/en-US/docs/Web/HTTP/Methods/CONNECT) request ([Firefox bug 1794464](https://bugzil.la/1794464)).
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
### Description

Amended the description of 'proxy.ProxyInfo.proxyAuthorizationHeader' to note that it also supports setting for HTTP proxies. This change was made in [Bug 1794464](https://bugzilla.mozilla.org/show_bug.cgi?id=1794464) 
Allow HTTP authentication in proxy.onRequest.

### Related issues and pull requests

Fixes #32475