### PR TITLE
Crossreference Element.localName and Element.tagName

### DIFF
--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -75,6 +75,7 @@ particular XML documents. For example, in the qualified name
 
 ## See also
 
+- {{domxref("Element.tagName")}}
 - {{domxref("Element.namespaceURI")}}
 - {{domxref("Element.prefix")}}
 - {{domxref("Attr.localName")}}

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -14,8 +14,8 @@ it's called.
 
 For example, if the element is an {{HTMLElement("img")}}, its
 `tagName` property is `IMG` (for HTML documents; it may be cased
-differently for XML/XHTML documents). Note: You can use {{domxref("Element.localName")}}
-to access the Element's local name — which for the case in the example is `img`(lowercase) .
+differently for XML/XHTML documents). Note: You can use {{domxref("Element.localName", "localName")}}
+to access the Element's local name — which for the case in the example is `img` (lowercase) .
 
 ## Value
 

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -15,7 +15,7 @@ it's called.
 For example, if the element is an {{HTMLElement("img")}}, its
 `tagName` property is `"IMG"` (for HTML documents; it may be cased
 differently for XML/XHTML documents). Note: You can use {{domxref("Element.localName")}}
-to access the local name which is `"img"` in the example.
+to access the Element's local name — which for the case in the example is `img`(lowercase) .
 
 ## Value
 

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -14,7 +14,8 @@ it's called.
 
 For example, if the element is an {{HTMLElement("img")}}, its
 `tagName` property is `"IMG"` (for HTML documents; it may be cased
-differently for XML/XHTML documents).
+differently for XML/XHTML documents). Note: You can use {{domxref("Element.localName")}}
+to access the local name which is `"img"` in the example.
 
 ## Value
 
@@ -60,3 +61,7 @@ creating the original document.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Element.localName")}}

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -13,7 +13,7 @@ of the {{domxref("Element")}} interface returns the tag name of the element on w
 it's called.
 
 For example, if the element is an {{HTMLElement("img")}}, its
-`tagName` property is `"IMG"` (for HTML documents; it may be cased
+`tagName` property is `IMG` (for HTML documents; it may be cased
 differently for XML/XHTML documents). Note: You can use {{domxref("Element.localName")}}
 to access the Element's local name — which for the case in the example is `img`(lowercase) .
 

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -14,7 +14,7 @@ it's called.
 
 For example, if the element is an {{HTMLElement("img")}}, its
 `tagName` property is `IMG` (for HTML documents; it may be cased
-differently for XML/XHTML documents). Note: You can use {{domxref("Element.localName", "localName")}}
+differently for XML/XHTML documents). Note: You can use the {{domxref("Element.localName", "localName")}} property
 to access the Element's local name — which for the case in the example is `img` (lowercase) .
 
 ## Value


### PR DESCRIPTION
### Description

Otherwise it takes a while to find the lowercase variant when you need the exact name like in this API:

https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/get

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- ✍️ Summarize your changes in one or two sentences -->
