### PR TITLE
Fix documentation on the effect of returning false

### DIFF
--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -97,7 +97,7 @@ value is {{jsxref("undefined")}}. The `void` operator can be used to return
 Arrow functions introduce a short-hand braceless syntax that returns an expression.
 This can cause unintended side effects if the expression is a function call where the returned value changes from `undefined` to some other value.
 
-For example, if `doSomething()` returns `false` in the code below, the checkbox will no longer be marked as checked or unchecked when the checkbox is clicked (setting the handler to `false` disables the default action).
+For example, if `doSomething()` returns `false` in the code below, the checkbox will no longer be marked as checked or unchecked when the checkbox is clicked (returning `false` from the handler disables the default action).
 
 ```js example-bad
 checkbox.onclick = () => doSomething();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The docs for `void` incorrectly state that _setting_ an `onclick` handler to `false` will remove its default behavior, when the example shows a possible case where the handler would `return` false. This PR fixes the language to be clearer.
<!-- ✍️ Summarize your changes in one or two sentences -->
