### PR TITLE
Add page for Permission Policy `bluetooth` directive

### DIFF
--- a/files/en-us/web/http/headers/permissions-policy/bluetooth/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/bluetooth/index.md
@@ -1,0 +1,40 @@
+---
+title: "Permissions-Policy: bluetooth"
+slug: Web/HTTP/Headers/Permissions-Policy/bluetooth
+page-type: http-permissions-policy-directive
+status:
+  - experimental
+browser-compat: http.headers.Permissions-Policy.bluetooth
+---
+
+{{HTTPSidebar}} {{SeeCompatTable}}
+
+The HTTP {{HTTPHeader('Permissions-Policy')}} header `bluetooth` directive controls whether the methods exposed by the [bluetooth attribute on the Navigator object](/en-US/docs/Web/API/Navigator/bluetooth) may be used.
+
+Specifically, where a defined policy blocks use of this feature, [`Navigator.bluetooth`](/en-US/docs/Web/API/Navigator/bluetooth) method calls will return a {{jsxref("Promise")}} that rejects with a {{domxref("DOMException")}}.
+
+## Syntax
+
+```http
+Permissions-Policy: bluetooth=<allowlist>;
+```
+
+- `<allowlist>`
+  - : A list of origins for which permission is granted to use the feature. See [`Permissions-Policy` > Syntax](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#syntax) for more details.
+
+## Default policy
+
+The default allowlist for `bluetooth` is `self`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{HTTPHeader('Permissions-Policy')}} header
+- [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy)


### PR DESCRIPTION
### Description

Document Permission Policy `bluetooth` directive behavior

https://chromestatus.com/feature/6439287120723968
https://webbluetoothcg.github.io/web-bluetooth/#permissions-policy

### Related issues and pull requests

Related PR: https://github.com/mdn/browser-compat-data/pull/22525
