### PR TITLE
Fix of stylesheet load events example

### DIFF
--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -358,8 +358,10 @@ this resource will then only be loaded if the media condition is true. For examp
 You can determine when a style sheet has been loaded by watching for a `load` event to fire on it; similarly, you can detect if an error has occurred while processing a style sheet by watching for an `error` event:
 
 ```html
+<link rel="stylesheet" href="mystylesheet.css" id="my-stylesheet" />
+
 <script>
-  const stylesheet = document.querySelector("#my-stylesheet");
+  const stylesheet = document.getElementById("my-stylesheet");
 
   stylesheet.onload = () => {
     // Do something interesting; the sheet has been loaded
@@ -369,8 +371,6 @@ You can determine when a style sheet has been loaded by watching for a `load` ev
     console.log("An error occurred loading the stylesheet!");
   };
 </script>
-
-<link rel="stylesheet" href="mystylesheet.css" id="my-stylesheet" />
 ```
 
 > **Note:** The `load` event fires once the stylesheet and all of its imported content has been loaded and parsed, and immediately before the styles start being applied to the content.


### PR DESCRIPTION
### Description

This PR fixes stylesheet load events example.

### Motivation

The tag ``link`` should go before the ``script``, otherwise the script runs before ``HTMLLinkElement`` is created and thus fails.