### PR TITLE
Add note about multiplication operands

### DIFF
--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -44,6 +44,7 @@ In addition, the following notes apply:
 - It is permitted to nest `calc()` functions, in which case the inner ones are treated as simple parentheses.
 - For lengths, you can't use `0` to mean `0px` (or another length unit); instead, you must use the version with the unit: `margin-top: calc(0px + 20px);` is valid, while `margin-top: calc(0 + 20px);` is invalid.
 - The `calc()` function cannot directly substitute the numeric value for percentage types; for instance `calc(100 / 4)%` is invalid, while `calc(100% / 4)` is valid.
+- The `*` operator requires one of the operands to be unitless. For example `font-size: calc(1.25rem * 1.25)` is valid but `font-size: calc(1.25rem * 125%)` is invalid.
 
 ### Formal syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add an additional note to the `calc` page to clarify that for multiplication (`*`) one of the operands needs to be unitless
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This was a bit of a puzzler, until a colleague pointed me at this from https://css-tricks.com/a-complete-guide-to-calc-in-css/#aa-multiplication-requires-one-of-the-numbers-to-be-unitless

> Multiplication (*) requires one of the numbers to be unitless

So figured it was worth putting here

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://css-tricks.com/a-complete-guide-to-calc-in-css/#aa-multiplication-requires-one-of-the-numbers-to-be-unitless

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
