### PR TITLE
Unlink MediaTrack dictionaries' BCD keys

### DIFF
--- a/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: aspectRatio property"
 short-title: aspectRatio
 slug: Web/API/MediaTrackConstraints/aspectRatio
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.aspectRatio
+browser-compat: api.MediaStreamTrack.applyConstraints.aspectRatio_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: autoGainControl property"
 short-title: autoGainControl
 slug: Web/API/MediaTrackConstraints/autoGainControl
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.autoGainControl
+browser-compat: api.MediaStreamTrack.applyConstraints.autoGainControl_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: channelCount property"
 short-title: channelCount
 slug: Web/API/MediaTrackConstraints/channelCount
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.channelCount
+browser-compat: api.MediaStreamTrack.applyConstraints.channelCount_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: deviceId property"
 short-title: deviceId
 slug: Web/API/MediaTrackConstraints/deviceId
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.deviceId
+browser-compat: api.MediaStreamTrack.applyConstraints.deviceId_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: displaySurface property"
 short-title: displaySurface
 slug: Web/API/MediaTrackConstraints/displaySurface
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.displaySurface
+browser-compat: api.MediaStreamTrack.applyConstraints.displaySurface_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: echoCancellation property"
 short-title: echoCancellation
 slug: Web/API/MediaTrackConstraints/echoCancellation
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.echoCancellation
+browser-compat: api.MediaStreamTrack.applyConstraints.echoCancellation_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: facingMode property"
 short-title: facingMode
 slug: Web/API/MediaTrackConstraints/facingMode
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.facingMode
+browser-compat: api.MediaStreamTrack.applyConstraints.facingMode_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/framerate/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: frameRate property"
 short-title: frameRate
 slug: Web/API/MediaTrackConstraints/frameRate
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.frameRate
+browser-compat: api.MediaStreamTrack.applyConstraints.frameRate_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/groupid/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: groupId property"
 short-title: groupId
 slug: Web/API/MediaTrackConstraints/groupId
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.groupId
+browser-compat: api.MediaStreamTrack.applyConstraints.groupId_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/height/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/height/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: height property"
 short-title: height
 slug: Web/API/MediaTrackConstraints/height
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.height
+browser-compat: api.MediaStreamTrack.applyConstraints.height_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -2,7 +2,7 @@
 title: MediaTrackConstraints
 slug: Web/API/MediaTrackConstraints
 page-type: web-api-interface
-browser-compat: api.MediaTrackConstraints
+browser-compat: api.MediaStreamTrack.applyConstraints
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -2,7 +2,7 @@
 title: MediaTrackConstraints
 slug: Web/API/MediaTrackConstraints
 page-type: web-api-interface
-browser-compat: api.MediaStreamTrack.applyConstraints
+spec-urls: https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
 ---
 
 {{APIRef("Media Capture and Streams")}}
@@ -162,10 +162,6 @@ These constraints apply to the `video` property of the object passed into {{domx
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/mediatrackconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/latency/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: latency property"
 short-title: latency
 slug: Web/API/MediaTrackConstraints/latency
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.latency
+browser-compat: api.MediaStreamTrack.applyConstraints.latency_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: logicalSurface property"
 short-title: logicalSurface
 slug: Web/API/MediaTrackConstraints/logicalSurface
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.logicalSurface
+browser-compat: api.MediaStreamTrack.applyConstraints.logicalSurface_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: noiseSuppression property"
 short-title: noiseSuppression
 slug: Web/API/MediaTrackConstraints/noiseSuppression
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.noiseSuppression
+browser-compat: api.MediaStreamTrack.applyConstraints.noiseSuppression_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: sampleRate property"
 short-title: sampleRate
 slug: Web/API/MediaTrackConstraints/sampleRate
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.sampleRate
+browser-compat: api.MediaStreamTrack.applyConstraints.sampleRate_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: sampleSize property"
 short-title: sampleSize
 slug: Web/API/MediaTrackConstraints/sampleSize
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.sampleSize
+browser-compat: api.MediaStreamTrack.applyConstraints.sampleSize_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatrackconstraints/suppresslocalaudioplayback/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/suppresslocalaudioplayback/index.md
@@ -5,7 +5,7 @@ slug: Web/API/MediaTrackConstraints/suppressLocalAudioPlayback
 page-type: web-api-instance-property
 status:
   - experimental
-browser-compat: api.MediaTrackConstraints.suppressLocalAudioPlayback
+browser-compat: api.MediaStreamTrack.applyConstraints.suppressLocalAudioPlayback_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediatrackconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/volume/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 status:
   - deprecated
   - non-standard
-browser-compat: api.MediaTrackConstraints.volume
+browser-compat: api.MediaStreamTrack.applyConstraints.volume_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/en-us/web/api/mediatrackconstraints/width/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/width/index.md
@@ -3,7 +3,7 @@ title: "MediaTrackConstraints: width property"
 short-title: width
 slug: Web/API/MediaTrackConstraints/width
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackConstraints.width
+browser-compat: api.MediaStreamTrack.applyConstraints.width_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: aspectRatio property"
 short-title: aspectRatio
 slug: Web/API/MediaTrackSettings/aspectRatio
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.aspectRatio_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: aspectRatio property"
 short-title: aspectRatio
 slug: Web/API/MediaTrackSettings/aspectRatio
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.aspectRatio
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: autoGainControl property"
 short-title: autoGainControl
 slug: Web/API/MediaTrackSettings/autoGainControl
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.autoGainControl_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: autoGainControl property"
 short-title: autoGainControl
 slug: Web/API/MediaTrackSettings/autoGainControl
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.autoGainControl
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: channelCount property"
 short-title: channelCount
 slug: Web/API/MediaTrackSettings/channelCount
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.channelCount
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: channelCount property"
 short-title: channelCount
 slug: Web/API/MediaTrackSettings/channelCount
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.channelCount_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/cursor/index.md
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: cursor property"
 short-title: cursor
 slug: Web/API/MediaTrackSettings/cursor
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.cursor_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/cursor/index.md
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: cursor property"
 short-title: cursor
 slug: Web/API/MediaTrackSettings/cursor
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.cursor
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: deviceId property"
 short-title: deviceId
 slug: Web/API/MediaTrackSettings/deviceId
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.deviceId
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: deviceId property"
 short-title: deviceId
 slug: Web/API/MediaTrackSettings/deviceId
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.deviceId_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: displaySurface property"
 short-title: displaySurface
 slug: Web/API/MediaTrackSettings/displaySurface
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.displaySurface
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: displaySurface property"
 short-title: displaySurface
 slug: Web/API/MediaTrackSettings/displaySurface
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.displaySurface_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: echoCancellation property"
 short-title: echoCancellation
 slug: Web/API/MediaTrackSettings/echoCancellation
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.echoCancellation
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: echoCancellation property"
 short-title: echoCancellation
 slug: Web/API/MediaTrackSettings/echoCancellation
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.echoCancellation_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: facingMode property"
 short-title: facingMode
 slug: Web/API/MediaTrackSettings/facingMode
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.facingMode
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: facingMode property"
 short-title: facingMode
 slug: Web/API/MediaTrackSettings/facingMode
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.facingMode_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/framerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: frameRate property"
 short-title: frameRate
 slug: Web/API/MediaTrackSettings/frameRate
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.frameRate_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/framerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: frameRate property"
 short-title: frameRate
 slug: Web/API/MediaTrackSettings/frameRate
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.frameRate
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/groupid/index.md
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: groupId property"
 short-title: groupId
 slug: Web/API/MediaTrackSettings/groupId
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.groupId_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/groupid/index.md
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: groupId property"
 short-title: groupId
 slug: Web/API/MediaTrackSettings/groupId
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.groupId
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/height/index.md
+++ b/files/en-us/web/api/mediatracksettings/height/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: height property"
 short-title: height
 slug: Web/API/MediaTrackSettings/height
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.height
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/height/index.md
+++ b/files/en-us/web/api/mediatracksettings/height/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: height property"
 short-title: height
 slug: Web/API/MediaTrackSettings/height
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.height_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -2,7 +2,6 @@
 title: MediaTrackSettings
 slug: Web/API/MediaTrackSettings
 page-type: web-api-interface
-browser-compat: api.MediaTrackSettings
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -2,6 +2,9 @@
 title: MediaTrackSettings
 slug: Web/API/MediaTrackSettings
 page-type: web-api-interface
+spec-urls:
+  - https://w3c.github.io/mediacapture-main/#media-track-settings
+  - https://w3c.github.io/mediacapture-screen-share/#extensions-to-mediatracksettings
 ---
 
 {{APIRef("Media Capture and Streams")}}
@@ -106,10 +109,6 @@ Tracks containing video shared from a user's screen (regardless of whether the s
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/mediatracksettings/latency/index.md
+++ b/files/en-us/web/api/mediatracksettings/latency/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: latency property"
 short-title: latency
 slug: Web/API/MediaTrackSettings/latency
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.latency
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/latency/index.md
+++ b/files/en-us/web/api/mediatracksettings/latency/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: latency property"
 short-title: latency
 slug: Web/API/MediaTrackSettings/latency
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.latency_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: logicalSurface property"
 short-title: logicalSurface
 slug: Web/API/MediaTrackSettings/logicalSurface
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.logicalSurface
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: logicalSurface property"
 short-title: logicalSurface
 slug: Web/API/MediaTrackSettings/logicalSurface
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.logicalSurface_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: noiseSuppression property"
 short-title: noiseSuppression
 slug: Web/API/MediaTrackSettings/noiseSuppression
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.noiseSuppression
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: noiseSuppression property"
 short-title: noiseSuppression
 slug: Web/API/MediaTrackSettings/noiseSuppression
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.noiseSuppression_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: sampleRate property"
 short-title: sampleRate
 slug: Web/API/MediaTrackSettings/sampleRate
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.sampleRate
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: sampleRate property"
 short-title: sampleRate
 slug: Web/API/MediaTrackSettings/sampleRate
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.sampleRate_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: sampleSize property"
 short-title: sampleSize
 slug: Web/API/MediaTrackSettings/sampleSize
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.sampleSize_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: sampleSize property"
 short-title: sampleSize
 slug: Web/API/MediaTrackSettings/sampleSize
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.sampleSize
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/suppresslocalaudioplayback/index.md
+++ b/files/en-us/web/api/mediatracksettings/suppresslocalaudioplayback/index.md
@@ -5,6 +5,7 @@ slug: Web/API/MediaTrackSettings/suppressLocalAudioPlayback
 page-type: web-api-instance-property
 status:
   - experimental
+browser-compat: api.MediaStreamTrack.applyConstraints.suppressLocalAudioPlayback_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediatracksettings/suppresslocalaudioplayback/index.md
+++ b/files/en-us/web/api/mediatracksettings/suppresslocalaudioplayback/index.md
@@ -5,7 +5,6 @@ slug: Web/API/MediaTrackSettings/suppressLocalAudioPlayback
 page-type: web-api-instance-property
 status:
   - experimental
-browser-compat: api.MediaTrackSettings.suppressLocalAudioPlayback
 ---
 
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediatracksettings/volume/index.md
+++ b/files/en-us/web/api/mediatracksettings/volume/index.md
@@ -6,6 +6,7 @@ page-type: web-api-instance-property
 status:
   - deprecated
   - non-standard
+browser-compat: api.MediaStreamTrack.applyConstraints.volume_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/en-us/web/api/mediatracksettings/volume/index.md
+++ b/files/en-us/web/api/mediatracksettings/volume/index.md
@@ -6,7 +6,6 @@ page-type: web-api-instance-property
 status:
   - deprecated
   - non-standard
-browser-compat: api.MediaTrackSettings.volume
 ---
 
 {{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/en-us/web/api/mediatracksettings/width/index.md
+++ b/files/en-us/web/api/mediatracksettings/width/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSettings: width property"
 short-title: width
 slug: Web/API/MediaTrackSettings/width
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSettings.width
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksettings/width/index.md
+++ b/files/en-us/web/api/mediatracksettings/width/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSettings: width property"
 short-title: width
 slug: Web/API/MediaTrackSettings/width
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.width_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: aspectRatio property"
 short-title: aspectRatio
 slug: Web/API/MediaTrackSupportedConstraints/aspectRatio
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.aspectRatio
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: aspectRatio property"
 short-title: aspectRatio
 slug: Web/API/MediaTrackSupportedConstraints/aspectRatio
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.aspectRatio_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: autoGainControl property"
 short-title: autoGainControl
 slug: Web/API/MediaTrackSupportedConstraints/autoGainControl
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.autoGainControl
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: autoGainControl property"
 short-title: autoGainControl
 slug: Web/API/MediaTrackSupportedConstraints/autoGainControl
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.autoGainControl_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: channelCount property"
 short-title: channelCount
 slug: Web/API/MediaTrackSupportedConstraints/channelCount
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.channelCount_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: channelCount property"
 short-title: channelCount
 slug: Web/API/MediaTrackSupportedConstraints/channelCount
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.channelCount
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: deviceId property"
 short-title: deviceId
 slug: Web/API/MediaTrackSupportedConstraints/deviceId
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.deviceId
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: deviceId property"
 short-title: deviceId
 slug: Web/API/MediaTrackSupportedConstraints/deviceId
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.deviceId_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: displaySurface property"
 short-title: displaySurface
 slug: Web/API/MediaTrackSupportedConstraints/displaySurface
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.displaySurface
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: displaySurface property"
 short-title: displaySurface
 slug: Web/API/MediaTrackSupportedConstraints/displaySurface
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.displaySurface_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: echoCancellation property"
 short-title: echoCancellation
 slug: Web/API/MediaTrackSupportedConstraints/echoCancellation
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.echoCancellation_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: echoCancellation property"
 short-title: echoCancellation
 slug: Web/API/MediaTrackSupportedConstraints/echoCancellation
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.echoCancellation
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: facingMode property"
 short-title: facingMode
 slug: Web/API/MediaTrackSupportedConstraints/facingMode
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.facingMode
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: facingMode property"
 short-title: facingMode
 slug: Web/API/MediaTrackSupportedConstraints/facingMode
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.facingMode_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: frameRate property"
 short-title: frameRate
 slug: Web/API/MediaTrackSupportedConstraints/frameRate
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.frameRate_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: frameRate property"
 short-title: frameRate
 slug: Web/API/MediaTrackSupportedConstraints/frameRate
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.frameRate
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: groupId property"
 short-title: groupId
 slug: Web/API/MediaTrackSupportedConstraints/groupId
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.groupId_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: groupId property"
 short-title: groupId
 slug: Web/API/MediaTrackSupportedConstraints/groupId
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.groupId
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: height property"
 short-title: height
 slug: Web/API/MediaTrackSupportedConstraints/height
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.height
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: height property"
 short-title: height
 slug: Web/API/MediaTrackSupportedConstraints/height
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.height_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -2,7 +2,6 @@
 title: MediaTrackSupportedConstraints
 slug: Web/API/MediaTrackSupportedConstraints
 page-type: web-api-interface
-browser-compat: api.MediaTrackSupportedConstraints
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -2,6 +2,7 @@
 title: MediaTrackSupportedConstraints
 slug: Web/API/MediaTrackSupportedConstraints
 page-type: web-api-interface
+spec-urls: https://w3c.github.io/mediacapture-main/#media-track-supported-constraints
 ---
 
 {{APIRef("Media Capture and Streams")}}
@@ -59,10 +60,6 @@ For tracks containing video sources from the user's screen contents, the followi
   - : A Boolean value which is `true` if the {{domxref("MediaTrackConstraints.displaySurface", "displaySurface")}} constraint is supported in the current environment.
 - {{domxref("MediaTrackSupportedConstraints.logicalSurface", "logicalSurface")}}
   - : A Boolean value which is `true` if the {{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}} constraint is supported in the current environment.
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: latency property"
 short-title: latency
 slug: Web/API/MediaTrackSupportedConstraints/latency
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.latency
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: latency property"
 short-title: latency
 slug: Web/API/MediaTrackSupportedConstraints/latency
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.latency_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: logicalSurface property"
 short-title: logicalSurface
 slug: Web/API/MediaTrackSupportedConstraints/logicalSurface
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.logicalSurface_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: logicalSurface property"
 short-title: logicalSurface
 slug: Web/API/MediaTrackSupportedConstraints/logicalSurface
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.logicalSurface
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: noiseSuppression property"
 short-title: noiseSuppression
 slug: Web/API/MediaTrackSupportedConstraints/noiseSuppression
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.noiseSuppression
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: noiseSuppression property"
 short-title: noiseSuppression
 slug: Web/API/MediaTrackSupportedConstraints/noiseSuppression
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.noiseSuppression_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: sampleRate property"
 short-title: sampleRate
 slug: Web/API/MediaTrackSupportedConstraints/sampleRate
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.sampleRate_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: sampleRate property"
 short-title: sampleRate
 slug: Web/API/MediaTrackSupportedConstraints/sampleRate
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.sampleRate
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: sampleSize property"
 short-title: sampleSize
 slug: Web/API/MediaTrackSupportedConstraints/sampleSize
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.sampleSize_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: sampleSize property"
 short-title: sampleSize
 slug: Web/API/MediaTrackSupportedConstraints/sampleSize
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.sampleSize
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/suppresslocalaudioplayback/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/suppresslocalaudioplayback/index.md
@@ -5,7 +5,6 @@ slug: Web/API/MediaTrackSupportedConstraints/suppressLocalAudioPlayback
 page-type: web-api-instance-property
 status:
   - experimental
-browser-compat: api.MediaTrackSupportedConstraints.suppressLocalAudioPlayback
 ---
 
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/suppresslocalaudioplayback/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/suppresslocalaudioplayback/index.md
@@ -5,6 +5,7 @@ slug: Web/API/MediaTrackSupportedConstraints/suppressLocalAudioPlayback
 page-type: web-api-instance-property
 status:
   - experimental
+browser-compat: api.MediaStreamTrack.applyConstraints.suppressLocalAudioPlayback_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
@@ -6,7 +6,6 @@ page-type: web-api-instance-property
 status:
   - deprecated
   - non-standard
-browser-compat: api.MediaTrackSupportedConstraints.volume
 ---
 
 {{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
@@ -6,6 +6,7 @@ page-type: web-api-instance-property
 status:
   - deprecated
   - non-standard
+browser-compat: api.MediaStreamTrack.applyConstraints.volume_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
@@ -3,7 +3,6 @@ title: "MediaTrackSupportedConstraints: width property"
 short-title: width
 slug: Web/API/MediaTrackSupportedConstraints/width
 page-type: web-api-instance-property
-browser-compat: api.MediaTrackSupportedConstraints.width
 ---
 
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
@@ -3,6 +3,7 @@ title: "MediaTrackSupportedConstraints: width property"
 short-title: width
 slug: Web/API/MediaTrackSupportedConstraints/width
 page-type: web-api-instance-property
+browser-compat: api.MediaStreamTrack.applyConstraints.width_constraint
 ---
 
 {{APIRef("Media Capture and Streams")}}


### PR DESCRIPTION
This PR unlinks the BCD keys from the MediaTrack dictionaries, redirecting them to the new keys where applicable.

BCD PR: https://github.com/mdn/browser-compat-data/pull/21761
