### PR TITLE
chore(api): Make macros with line breaks span a single line only, 2 of 4

### DIFF
--- a/files/en-us/web/api/dompoint/frompoint_static/index.md
+++ b/files/en-us/web/api/dompoint/frompoint_static/index.md
@@ -60,9 +60,8 @@ const mutablePoint = DOMPoint.fromPoint(readOnlyPoint);
 ### Creating a 2D point
 
 This sample creates a 2D point, specifying an inline object that includes the values to
-use for {{domxref("DOMPointReadOnly.x", "x")}} and {{domxref("DOMPointReadOnly.y",
-  "y")}}. The _z_ and _w_ properties are allowed to keep their default
-values (0 and 1 respectively).
+use for {{domxref("DOMPointReadOnly.x", "x")}} and {{domxref("DOMPointReadOnly.y", "y")}}.
+The _z_ and _w_ properties are allowed to keep their default values (0 and 1 respectively).
 
 ```js
 const center = DOMPoint.fromPoint({ x: 75, y: -50, z: -55, w: 0.25 });

--- a/files/en-us/web/api/dompoint/w/index.md
+++ b/files/en-us/web/api/dompoint/w/index.md
@@ -16,8 +16,8 @@ point in space.
 
 A double-precision floating-point value indicating the _w_ perspective value for
 the point. This value is **unrestricted**, meaning that it is allowed to be
-infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity",
-  "±Infinity")}}). The default is 1.0.
+infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
+The default is 1.0.
 
 ## Specifications
 

--- a/files/en-us/web/api/dompoint/x/index.md
+++ b/files/en-us/web/api/dompoint/x/index.md
@@ -20,8 +20,7 @@ have altered the orientation of the axes.
 
 A double-precision floating-point value indicating the x coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be
-infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity",
-  "±Infinity")}}).
+infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
 
 ## Specifications
 
@@ -34,5 +33,4 @@ infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("In
 ## See also
 
 - The other coordinate properties: {{domxref("DOMPoint.y", "y")}},
-  {{domxref("DOMPoint.z", "z")}}, and the perspective value, {{domxref("DOMPoint.w",
-    "w")}}.
+  {{domxref("DOMPoint.z", "z")}}, and the perspective value, {{domxref("DOMPoint.w", "w")}}.

--- a/files/en-us/web/api/dompoint/y/index.md
+++ b/files/en-us/web/api/dompoint/y/index.md
@@ -33,5 +33,4 @@ to be infinite or invalid (that is, its value may be {{jsxref("NaN")}} or
 ## See also
 
 - The other coordinate properties: {{domxref("DOMPoint.x", "x")}},
-  {{domxref("DOMPoint.z", "z")}}, and the perspective value, {{domxref("DOMPoint.w",
-    "w")}}.
+  {{domxref("DOMPoint.z", "z")}}, and the perspective value, {{domxref("DOMPoint.w", "w")}}.

--- a/files/en-us/web/api/dompoint/z/index.md
+++ b/files/en-us/web/api/dompoint/z/index.md
@@ -34,5 +34,4 @@ to be infinite or invalid (that is, its value may be {{jsxref("NaN")}} or
 ## See also
 
 - The other coordinate properties: {{domxref("DOMPoint.x", "x")}},
-  {{domxref("DOMPoint.y", "y")}}, and the perspective value, {{domxref("DOMPoint.w",
-    "w")}}.
+  {{domxref("DOMPoint.y", "y")}}, and the perspective value, {{domxref("DOMPoint.w", "w")}}.

--- a/files/en-us/web/api/dompointreadonly/frompoint_static/index.md
+++ b/files/en-us/web/api/dompointreadonly/frompoint_static/index.md
@@ -46,8 +46,8 @@ A new {{domxref("DOMPointReadOnly")}} object (which is identical to the source p
 ### Creating a 2D point
 
 This sample creates a 2D point, specifying an inline object that includes the values to
-use for {{domxref("DOMPointReadOnly.x", "x")}} and {{domxref("DOMPointReadOnly.y",
-  "y")}}. The `z` and `w` properties are allowed to keep their
+use for {{domxref("DOMPointReadOnly.x", "x")}} and {{domxref("DOMPointReadOnly.y", "y")}}.
+The `z` and `w` properties are allowed to keep their
 default values (`0` and `1` respectively).
 
 ```js

--- a/files/en-us/web/api/dompointreadonly/x/index.md
+++ b/files/en-us/web/api/dompointreadonly/x/index.md
@@ -20,8 +20,7 @@ In general, positive values `x` mean to the right, and negative values of
 
 A double-precision floating-point value indicating the x coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be
-infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity",
-  "±Infinity")}}).
+infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/dompointreadonly/y/index.md
+++ b/files/en-us/web/api/dompointreadonly/y/index.md
@@ -22,8 +22,7 @@ In general, positive values of `y` mean downward, and negative values of
 
 A double-precision floating-point value indicating the y coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be
-infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity",
-  "±Infinity")}}).
+infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/dompointreadonly/z/index.md
+++ b/files/en-us/web/api/dompointreadonly/z/index.md
@@ -23,8 +23,7 @@ screen), assuming no transforms have resulted in a reversal.
 
 A double-precision floating-point value indicating the z coordinate's value for the
 point. This value is **unrestricted**, meaning that it is allowed to be
-infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity",
-  "±Infinity")}}).
+infinite or invalid (that is, its value may be {{jsxref("NaN")}} or {{jsxref("Infinity", "±Infinity")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -15,8 +15,8 @@ global attribute.
 
 If the `id` value is not the empty string, it must be unique in a document.
 
-The `id` is often used with {{domxref("Document.getElementById()",
-  "getElementById()")}} to retrieve a particular element. Another common case is to use an
+The `id` is often used with {{domxref("Document.getElementById()", "getElementById()")}}
+to retrieve a particular element. Another common case is to use an
 element's [ID as a selector](/en-US/docs/Web/CSS/ID_selectors) when styling
 the document with [CSS](/en-US/docs/Web/CSS).
 

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -15,7 +15,7 @@ global attribute.
 
 If the `id` value is not the empty string, it must be unique in a document.
 
-The `id` is often used with {{domxref("Document.getElementById()", "getElementById()")}} to retrieve a particular element. 
+The `id` is often used with {{domxref("Document.getElementById()", "getElementById()")}} to retrieve a particular element.
 Another common case is to use an element's [ID as a selector](/en-US/docs/Web/CSS/ID_selectors) when styling the document with [CSS](/en-US/docs/Web/CSS).
 
 > **Note:** Identifiers are case-sensitive, but you should avoid creating

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -15,10 +15,8 @@ global attribute.
 
 If the `id` value is not the empty string, it must be unique in a document.
 
-The `id` is often used with {{domxref("Document.getElementById()", "getElementById()")}}
-to retrieve a particular element. Another common case is to use an
-element's [ID as a selector](/en-US/docs/Web/CSS/ID_selectors) when styling
-the document with [CSS](/en-US/docs/Web/CSS).
+The `id` is often used with {{domxref("Document.getElementById()", "getElementById()")}} to retrieve a particular element. 
+Another common case is to use an element's [ID as a selector](/en-US/docs/Web/CSS/ID_selectors) when styling the document with [CSS](/en-US/docs/Web/CSS).
 
 > **Note:** Identifiers are case-sensitive, but you should avoid creating
 > IDs that differ only in the capitalization.

--- a/files/en-us/web/api/element/scrollheight/index.md
+++ b/files/en-us/web/api/element/scrollheight/index.md
@@ -16,8 +16,8 @@ screen due to overflow.
 
 The `scrollHeight` value is equal to the minimum height the element would
 require in order to fit all the content in the viewport without using a vertical
-scrollbar. The height is measured in the same way as {{domxref("Element.clientHeight",
-  "clientHeight")}}: it includes the element's padding, but not its border, margin or
+scrollbar. The height is measured in the same way as {{domxref("Element.clientHeight", "clientHeight")}}:
+it includes the element's padding, but not its border, margin or
 horizontal scrollbar (if present). It can also include the height of pseudo-elements
 such as {{cssxref("::before")}} or {{cssxref("::after")}}. If the element's content can
 fit without a need for vertical scrollbar, its `scrollHeight` is equal to

--- a/files/en-us/web/api/element/scrollwidth/index.md
+++ b/files/en-us/web/api/element/scrollwidth/index.md
@@ -14,8 +14,8 @@ screen due to overflow.
 
 The `scrollWidth` value is equal to the minimum width the element would
 require in order to fit all the content in the viewport without using a horizontal
-scrollbar. The width is measured in the same way as {{domxref("Element.clientWidth",
-  "clientWidth")}}: it includes the element's padding, but not its border, margin or
+scrollbar. The width is measured in the same way as {{domxref("Element.clientWidth", "clientWidth")}}:
+it includes the element's padding, but not its border, margin or
 vertical scrollbar (if present). It can also include the width of pseudo-elements such
 as {{cssxref("::before")}} or {{cssxref("::after")}}. If the element's content can fit
 without a need for horizontal scrollbar, its `scrollWidth` is equal to

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -12,8 +12,7 @@ browser-compat: api.Element.setCapture
 {{Deprecated_Header}}{{non-standard_header}}{{ APIRef("DOM") }}
 
 Call this method during the handling of a mousedown event to retarget all mouse events
-to this element until the mouse button is released or {{
-  domxref("document.releaseCapture()") }} is called.
+to this element until the mouse button is released or {{domxref("document.releaseCapture()")}} is called.
 
 > **Warning:** This interface never had much cross-browser
 > support and you probably looking for {{domxref("element.setPointerCapture")}} instead,

--- a/files/en-us/web/api/event/cancelable/index.md
+++ b/files/en-us/web/api/event/cancelable/index.md
@@ -29,8 +29,7 @@ method on the event. This keeps the implementation from executing the default ac
 that is associated with the event.
 
 Event listeners that handle multiple kinds of events may want to check
-`cancelable` before invoking their {{domxref("event.preventDefault",
-  "preventDefault()")}} methods.
+`cancelable` before invoking their {{domxref("event.preventDefault", "preventDefault()")}} methods.
 
 ## Value
 
@@ -39,8 +38,8 @@ canceled.
 
 ## Example
 
-For example, browser vendors are proposing that the {{domxref("Element/wheel_event",
-  "wheel")}} event can only be canceled [the first time the listener is called](https://github.com/WICG/interventions/issues/33) — any following `wheel` events cannot be
+For example, browser vendors are proposing that the {{domxref("Element/wheel_event", "wheel")}}
+event can only be canceled [the first time the listener is called](https://github.com/WICG/interventions/issues/33) — any following `wheel` events cannot be
 canceled.
 
 ```js

--- a/files/en-us/web/api/event/cancelable/index.md
+++ b/files/en-us/web/api/event/cancelable/index.md
@@ -38,9 +38,7 @@ canceled.
 
 ## Example
 
-For example, browser vendors are proposing that the {{domxref("Element/wheel_event", "wheel")}}
-event can only be canceled [the first time the listener is called](https://github.com/WICG/interventions/issues/33) — any following `wheel` events cannot be
-canceled.
+For example, browser vendors are proposing that the {{domxref("Element/wheel_event", "wheel")}} event can only be canceled [the first time the listener is called](https://github.com/WICG/interventions/issues/33) — any following `wheel` events cannot be canceled.
 
 ```js
 function preventScrollWheel(event) {

--- a/files/en-us/web/api/event/eventphase/index.md
+++ b/files/en-us/web/api/event/eventphase/index.md
@@ -29,8 +29,7 @@ flow. Possible values are:
     called are triggered during this phase.
 - `Event.AT_TARGET (2)`
   - : The event has arrived at
-    {{domxref("EventTarget", "the event's target", "",
-        1)}}.
+    {{domxref("EventTarget", "the event's target", "", 1)}}.
     Event listeners registered for this phase are called at this time. If
     {{domxref("Event.bubbles")}} is `false`, processing
     the event is finished after this phase is complete.

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -230,8 +230,7 @@ my_element.addEventListener("click", (e) => {
 });
 ```
 
-If an event handler (for example, {{domxref("Element.click_event",
-  "onclick")}}) is specified on an element in the HTML source, the JavaScript code in the
+If an event handler (for example, {{domxref("Element.click_event", "onclick")}}) is specified on an element in the HTML source, the JavaScript code in the
 attribute value is effectively wrapped in a handler function that binds the value of
 `this` in a manner consistent with the `addEventListener()`; an
 occurrence of `this` within the code represents a reference to the element.

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -230,10 +230,7 @@ my_element.addEventListener("click", (e) => {
 });
 ```
 
-If an event handler (for example, {{domxref("Element.click_event", "onclick")}}) is specified on an element in the HTML source, the JavaScript code in the
-attribute value is effectively wrapped in a handler function that binds the value of
-`this` in a manner consistent with the `addEventListener()`; an
-occurrence of `this` within the code represents a reference to the element.
+If an event handler (for example, {{domxref("Element.click_event", "onclick")}}) is specified on an element in the HTML source, the JavaScript code in the attribute value is effectively wrapped in a handler function that binds the value of `this` in a manner consistent with the `addEventListener()`; an occurrence of `this` within the code represents a reference to the element.
 
 ```html
 <table id="my_table" onclick="console.log(this.id);">

--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.md
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.md
@@ -14,8 +14,7 @@ The **`allowedFeatures()`** method of
 the {{DOMxRef("FeaturePolicy")}} interface returns a list of directive names of all
 features allowed by the [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy). This enables introspection of individual directives
 of the Permissions Policy it is run on. As such, `allowedFeatures()` method
-returns a subset of directives returned by {{DOMxRef("FeaturePolicy.features",
-    "features()")}}.
+returns a subset of directives returned by {{DOMxRef("FeaturePolicy.features", "features()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/fetchevent/respondwith/index.md
+++ b/files/en-us/web/api/fetchevent/respondwith/index.md
@@ -16,15 +16,15 @@ In most cases you can provide any response that the receiver understands. For ex
 if an {{HTMLElement('img')}} initiates the request, the response body needs to be
 image data. For security reasons, there are a few global rules:
 
-- You can only return {{domxref("Response")}} objects of {{domxref("Response.type",
-  "type")}} "`opaque`" if the {{domxref("fetchEvent.request")}} object's
+- You can only return {{domxref("Response")}} objects of {{domxref("Response.type", "type")}}
+  "`opaque`" if the {{domxref("fetchEvent.request")}} object's
   {{domxref("request.mode", "mode")}} is "`no-cors`". This prevents the
   leaking of private data.
-- You can only return {{domxref("Response")}} objects of {{domxref("Response.type",
-  "type")}} "`opaqueredirect`" if the {{domxref("fetchEvent.request")}}
+- You can only return {{domxref("Response")}} objects of {{domxref("Response.type", "type")}}
+  "`opaqueredirect`" if the {{domxref("fetchEvent.request")}}
   object's {{domxref("request.mode", "mode")}} is "`manual`".
-- You cannot return {{domxref("Response")}} objects of {{domxref("Response.type",
-  "type")}} "`cors`" if the {{domxref("fetchEvent.request")}} object's
+- You cannot return {{domxref("Response")}} objects of {{domxref("Response.type", "type")}}
+  "`cors`" if the {{domxref("fetchEvent.request")}} object's
   {{domxref("request.mode", "mode")}} is "`same-origin`".
 
 ### Specifying the final URL of a resource

--- a/files/en-us/web/api/filereader/result/index.md
+++ b/files/en-us/web/api/filereader/result/index.md
@@ -35,8 +35,7 @@ The result types are described below.
       </td>
       <td>
         The <code>result</code> is a JavaScript
-        {{jsxref("Global_Objects/ArrayBuffer",
-        "ArrayBuffer")}}
+        {{jsxref("Global_Objects/ArrayBuffer", "ArrayBuffer")}}
         containing binary data.
       </td>
     </tr>

--- a/files/en-us/web/api/filesystemdirectoryentry/createreader/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/createreader/index.md
@@ -60,8 +60,8 @@ function readDirectory(directory) {
 
 This works by creating an internal function, `getEntries()`, which calls
 itself recursively to get all the entries in the directory, concatenating each batch to
-the array. Each iteration, {{domxref("FileSystemDirectoryReader.readEntries",
-  "readEntries()")}} is called to get more entries. When it returns an empty array, the
+the array. Each iteration, {{domxref("FileSystemDirectoryReader.readEntries", "readEntries()")}}
+is called to get more entries. When it returns an empty array, the
 end of the directory has been reached, and the recursion ends. Once control is returned
 to `readDirectory()`, the array is returned to the caller.
 

--- a/files/en-us/web/api/filesystementry/name/index.md
+++ b/files/en-us/web/api/filesystementry/name/index.md
@@ -11,8 +11,7 @@ browser-compat: api.FileSystemEntry.name
 The read-only **`name`** property of
 the {{domxref("FileSystemEntry")}} interface returns a string
 specifying the entry's name; this is the entry within its parent directory (the last
-component of the path as indicated by the {{domxref("FileSystemEntry.fullPath",
-    "fullPath")}} property).
+component of the path as indicated by the {{domxref("FileSystemEntry.fullPath", "fullPath")}} property).
 
 ## Value
 

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -9,8 +9,7 @@ browser-compat: api.FileSystemHandle.isSameEntry
 {{securecontext_header}}{{APIRef("File System API")}}
 
 The **`isSameEntry()`** method of the
-{{domxref("FileSystemHandle")}} interface compares two {{domxref("FileSystemHandle",
-  "handles")}} to see if the associated entries (either a file or directory) match.
+{{domxref("FileSystemHandle")}} interface compares two {{domxref("FileSystemHandle", "handles")}} to see if the associated entries (either a file or directory) match.
 
 ## Syntax
 

--- a/files/en-us/web/api/focusevent/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/focusevent/index.md
@@ -23,8 +23,7 @@ new FocusEvent(type, options)
 ### Parameters
 
 _The `FocusEvent()` constructor also inherits arguments from
-{{domxref("UIEvent.UIEvent", "UIEvent()")}} and from {{domxref("Event.Event",
-    "Event()")}}._
+{{domxref("UIEvent.UIEvent", "UIEvent()")}} and from {{domxref("Event.Event", "Event()")}}._
 
 - `type`
   - : A string with the name of the event.

--- a/files/en-us/web/api/gamepad/buttons/index.md
+++ b/files/en-us/web/api/gamepad/buttons/index.md
@@ -8,8 +8,7 @@ browser-compat: api.Gamepad.buttons
 
 {{APIRef("Gamepad API")}}{{SecureContext_Header}}
 
-The **`Gamepad.buttons`** property of the {{domxref("Gamepad")
-  }} interface returns an array of {{domxref("gamepadButton")}} objects representing the
+The **`Gamepad.buttons`** property of the {{domxref("Gamepad")}} interface returns an array of {{domxref("gamepadButton")}} objects representing the
 buttons present on the device.
 
 Each entry in the array is 0 if the button is not pressed, and non-zero (typically 1.0)

--- a/files/en-us/web/api/history/go/index.md
+++ b/files/en-us/web/api/history/go/index.md
@@ -42,8 +42,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-To move back one page (the equivalent of calling {{domxref("History.back",
-  "back()")}}):
+To move back one page (the equivalent of calling {{domxref("History.back", "back()")}}):
 
 ```js
 history.go(-1);

--- a/files/en-us/web/api/htmlaudioelement/audio/index.md
+++ b/files/en-us/web/api/htmlaudioelement/audio/index.md
@@ -55,8 +55,8 @@ playback to begin:
 - Listen for the {{domxref("HTMLMediaElement.canplay_event", "canplay")}} event. It
   is sent to the `<audio>` element when there's enough audio
   available to begin playback, although interruptions may occur.
-- Listen for the {{domxref("HTMLMediaElement.canplaythrough_event",
-  "canplaythrough")}} event. It is sent when it's estimated that the audio should be
+- Listen for the {{domxref("HTMLMediaElement.canplaythrough_event", "canplaythrough")}} event.
+  It is sent when it's estimated that the audio should be
   able to play to the end without interruption.
 
 The event-based approach is best:

--- a/files/en-us/web/api/htmlelement/dataset/index.md
+++ b/files/en-us/web/api/htmlelement/dataset/index.md
@@ -38,8 +38,8 @@ attributes in our article [_Using data attributes_](/en-US/docs/Learn/HTML/Howto
 
 - `dash-style` to `camelCase` conversion
 
-  - : A custom data attribute name is transformed to a key for the {{
-      domxref("DOMStringMap") }} entry by the following:
+  - : A custom data attribute name is transformed to a key for the
+    {{domxref("DOMStringMap") }} entry by the following:
 
     1. Lowercase all ASCII capital letters (`A` to
        `Z`);

--- a/files/en-us/web/api/htmlimageelement/crossorigin/index.md
+++ b/files/en-us/web/api/htmlimageelement/crossorigin/index.md
@@ -22,9 +22,9 @@ without CORS (the fetch `no-cors` mode).
 Permitted values are:
 
 - `anonymous`
-  - : Requests by the {{HTMLElement("img")}} element have their {{domxref("Request.mode",
-    "mode")}} set to `cors` and their {{domxref("Request.credentials",
-    "credentials")}} mode set to `same-origin`. This means that CORS is enabled
+  - : Requests by the {{HTMLElement("img")}} element have their
+    {{domxref("Request.mode", "mode")}} set to `cors` and their {{domxref("Request.credentials", "credentials")}}
+    mode set to `same-origin`. This means that CORS is enabled
     and credentials are sent _if_ the image is fetched from the same origin from
     which the document was loaded.
 - `use-credentials`

--- a/files/en-us/web/api/htmlimageelement/image/index.md
+++ b/files/en-us/web/api/htmlimageelement/image/index.md
@@ -10,8 +10,7 @@ browser-compat: api.HTMLImageElement.Image
 
 The **`Image()`**
 constructor creates a new {{DOMxRef("HTMLImageElement")}} instance. It is functionally
-equivalent to {{DOMxRef("Document.createElement()",
-    "document.createElement('img')")}}.
+equivalent to {{DOMxRef("Document.createElement()", "document.createElement('img')")}}.
 
 > **Note:** This function should not be confused with the CSS [`image()`](/en-US/docs/Web/CSS/image/image) function.
 

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -28,8 +28,7 @@ image height, it will be rendered this tall.
 An integer value indicating the intrinsic height, in CSS pixels, of the image. This is
 the height at which the image is naturally drawn when no constraint or specific value is
 established for the image. This natural height is corrected for the pixel density of the
-device on which it's being presented, unlike {{domxref("HTMLImageElement.height",
-  "height")}}.
+device on which it's being presented, unlike {{domxref("HTMLImageElement.height", "height")}}.
 
 If the intrinsic height is not available—either because the image does not specify an
 intrinsic height or because the image data is not available in order to obtain this

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.md
@@ -10,8 +10,7 @@ browser-compat: api.HTMLImageElement.naturalWidth
 
 The {{domxref("HTMLImageElement")}} interface's read-only
 **`naturalWidth`** property returns the intrinsic (natural),
-density-corrected width of the image in {{Glossary("CSS pixel", "CSS
-    pixels")}}.
+density-corrected width of the image in {{Glossary("CSS pixel", "CSS pixels")}}.
 
 This is the width the image is if drawn with nothing constraining
 its width; if you neither specify a width for the image nor place the image inside a

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -126,9 +126,8 @@ article img {
 #### JavaScript
 
 The JavaScript code handles the two buttons that let you toggle the third width option
-between 40em and 50em; this is done by handling the {{domxref("Element.click_event",
-  "click")}} event, using the JavaScript string object {{jsxref("String.replace",
-  "replace()")}} method to replace the relevant portion of the `sizes` string.
+between 40em and 50em; this is done by handling the {{domxref("Element.click_event", "click")}}
+event, using the JavaScript string object {{jsxref("String.replace", "replace()")}} method to replace the relevant portion of the `sizes` string.
 
 ```js
 const image = document.querySelector("article img");

--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -18,8 +18,8 @@ candidate string contains an image URL and an optional width or pixel density de
 that indicates the conditions under which that candidate should be used instead of the
 image specified by the {{domxref("HTMLImageElement.src", "src")}} property.
 
-The `srcset` property, along with the {{domxref("HTMLImageElement.sizes",
-  "sizes")}} property, are a crucial component in designing responsive websites, as they
+The `srcset` property, along with the {{domxref("HTMLImageElement.sizes", "sizes")}}
+property, are a crucial component in designing responsive websites, as they
 can be used together to make pages that use appropriate images for the rendering
 situation.
 
@@ -76,8 +76,8 @@ candidate, and assign it a default descriptor of `1x`.
 "header640.png 640w, header960.png 960w, header1024.png 1024w"
 ```
 
-This string provides versions of a header image to use when the {{Glossary("user
-  agent", "user agent's")}} renderer needs an image of width 640px, 960px, or 1024px.
+This string provides versions of a header image to use when the {{Glossary("user agent", "user agent's")}}
+renderer needs an image of width 640px, 960px, or 1024px.
 
 Note that if any resource in a `srcset` is described with a "w" descriptor, all
 resources within that `srcset` must also be described with "w" descriptors, and

--- a/files/en-us/web/api/htmlimageelement/width/index.md
+++ b/files/en-us/web/api/htmlimageelement/width/index.md
@@ -53,8 +53,7 @@ drawn at 400px.
 ### JavaScript
 
 JavaScript looks at the `width` property to determine the width of the image
-at the moment. This is performed in the window's {{domxref("Window.load_event",
-  "load")}} and {{domxref("Window.resize_event", "resize")}} event handlers so the most
+at the moment. This is performed in the window's {{domxref("Window.load_event", "load")}} and {{domxref("Window.resize_event", "resize")}} event handlers so the most
 current width information is always available.
 
 ```js

--- a/files/en-us/web/api/htmlimageelement/x/index.md
+++ b/files/en-us/web/api/htmlimageelement/x/index.md
@@ -95,8 +95,8 @@ log(`Image's global Y: ${image.y}`);
 This uses the {{HTMLElement("table")}}'s {{domxref("HTMLTableElement.rows", "rows")}}
 property to get a list of the rows in the table, from which it looks up row 1 (which,
 being a zero-based index, means the second row from the top). Then it looks at that
-{{HTMLElement("tr")}} (table row) element's {{domxref("HTMLTableRowElement.cells",
-  "cells")}} property to get a list of the cells in that row. The third cell is taken from
+{{HTMLElement("tr")}} (table row) element's {{domxref("HTMLTableRowElement.cells", "cells")}}
+property to get a list of the cells in that row. The third cell is taken from
 that row (once again, specifying 2 as the zero-based offset).
 
 From there, we can get the `<img>` element itself from the cell by

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -24,8 +24,8 @@ default value for `step` if not specified.
 Valid on all numeric, date, and time input types that support the step attribute,
 including {{HTMLElement("input/date", "date")}}, {{HTMLElement("input/month", "month")}},
 {{HTMLElement("input/week", "week")}}, {{HTMLElement("input/time", "time")}},
-{{HTMLElement("input/datetime-local", "datetime-local")}}, {{HTMLElement("input/number",
-  "number")}}, and {{HTMLElement("input/range", "range")}}.
+{{HTMLElement("input/datetime-local", "datetime-local")}},
+{{HTMLElement("input/number", "number")}}, and {{HTMLElement("input/range", "range")}}.
 
 Given `<input id="myTime" type="time" max="17:00" step="900" value="17:00">`,
 invoking `myTime.stepDown(3)` will change the value to 16:15, decrementing the
@@ -124,8 +124,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-Click the button in this example to decrement the {{HTMLElement("input/number",
-  "number")}} input type:
+Click the button in this example to decrement the {{HTMLElement("input/number", "number")}} input type:
 
 ### HTML
 

--- a/files/en-us/web/api/htmlinputelement/stepup/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepup/index.md
@@ -123,8 +123,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-Click the button in this example to increment the {{HTMLElement("input/number",
-  "number")}} input type:
+Click the button in this example to increment the {{HTMLElement("input/number", "number")}} input type:
 
 ### HTML
 

--- a/files/en-us/web/api/htmlmediaelement/ended/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended/index.md
@@ -17,8 +17,7 @@ A boolean value which is `true` if the media contained in the
 element has finished playing.
 
 If the source of the media is a {{domxref("MediaStream")}}, this value is
-`true` if the value of the stream's {{domxref("MediaStream.active",
-  "active")}} property is `false`.
+`true` if the value of the stream's {{domxref("MediaStream.active", "active")}} property is `false`.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -14,8 +14,7 @@ to display the video in picture-in-picture mode.
 
 It's not guaranteed that the video will be put into picture-in-picture. If permission
 to enter that mode is granted, the returned {{jsxref("Promise")}} will resolve and the
-video will receive a {{domxref("HTMLVideoElement.enterpictureinpicture_event",
-  "enterpictureinpicture")}} event to let it know that it's now in picture-in-picture.
+video will receive a {{domxref("HTMLVideoElement.enterpictureinpicture_event", "enterpictureinpicture")}} event to let it know that it's now in picture-in-picture.
 
 ## Syntax
 

--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -36,8 +36,8 @@ A {{domxref("DOMHighResTimeStamp")}} value (which is a floating-point number)
 representing the number of milliseconds the user agent estimates are left in the current
 idle period. The value is ideally accurate to within about 5 microseconds.
 
-If the {{domxref("IdleDeadline")}} object's {{domxref("IdleDeadline.didTimeout",
-  "didTimeout")}} property is true, this method returns zero.
+If the {{domxref("IdleDeadline")}} object's {{domxref("IdleDeadline.didTimeout", "didTimeout")}}
+property is true, this method returns zero.
 
 ## Examples
 

--- a/files/en-us/web/api/idledetector/index.md
+++ b/files/en-us/web/api/idledetector/index.md
@@ -9,8 +9,7 @@ browser-compat: api.IdleDetector
 
 {{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
-The **`IdleDetector`** interface of the {{domxref('idle_detection_api','Idle
-Detection API','','true')}} provides methods and events for detecting user activity on a device or screen.
+The **`IdleDetector`** interface of the {{domxref('idle_detection_api','Idle Detection API','','true')}} provides methods and events for detecting user activity on a device or screen.
 
 This interface requires a secure context.
 

--- a/files/en-us/web/api/keyboardevent/charcode/index.md
+++ b/files/en-us/web/api/keyboardevent/charcode/index.md
@@ -69,8 +69,7 @@ input.addEventListener("keypress", (e) => {
 - `charCode` is never set in the {{domxref("Element/keydown_event", "keydown")}} and
   {{domxref("Element/keyup_event", "keyup")}} events. In these cases, `keyCode` is set instead.
 - To get the code of the key regardless of whether it was stored in
-  `keyCode` or `charCode`, query the {{
-    domxref("UIEvent/which", "which") }} property.
+  `keyCode` or `charCode`, query the {{domxref("UIEvent/which", "which")}} property.
 - Characters entered through an {{glossary("IME")}} do not register through `keyCode` or
   `charCode`.
 - For a list of the `charCode` values associated with particular keys, run

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.md
@@ -57,8 +57,7 @@ initKeyEvent (type, bubbles, cancelable, view,
     generated is a combination of keys containing the <kbd>Meta</kbd> key.
 - `keyCode`
   - : An `unsigned long` representing the virtual key code value of the key
-    which was pressed, otherwise `0`. See {{ domxref("KeyboardEvent.keyCode")
-    }} for the list of key codes.
+    which was pressed, otherwise `0`. See {{domxref("KeyboardEvent.keyCode")}} for the list of key codes.
 - `charCode`
   - : An `unsigned long` representing the Unicode character associated with
     the pressed key otherwise `0`.

--- a/files/en-us/web/api/mediadeviceinfo/groupid/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/groupid/index.md
@@ -53,11 +53,9 @@ The `getDeviceGroup()` function takes as input the
 be built. The function starts by initializing the result array, `devList`, to
 be an empty array.
 
-Then {{domxref("MediaDevices.enumerateDevices",
-  "navigator.mediaDevices.enumerateDevices()")}} is called to get the list of all media
-devices. Once the promise resolves, we walk the list using {{jsxref("Array.forEach",
-  "forEach()")}}. For each device, if its {{domxref("MediaDeviceInfo.groupId",
-  "groupId")}} matches the main device's `groupId`, we push the
+Then {{domxref("MediaDevices.enumerateDevices", "navigator.mediaDevices.enumerateDevices()")}} is called to get the list of all media
+devices. Once the promise resolves, we walk the list using {{jsxref("Array.forEach", "forEach()")}}.
+For each device, if its {{domxref("MediaDeviceInfo.groupId", "groupId")}} matches the main device's `groupId`, we push the
 {{domxref("MediaDeviceInfo")}} object onto the list.
 
 Finally, the list, which now contains a `MediaDeviceInfo` object for each

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.md
@@ -14,9 +14,8 @@ read-only **`mediaElement`** property indicates the
 receiving audio.
 
 This stream was specified when the node was first created,
-either using the {{domxref("MediaElementAudioSourceNode.MediaElementAudioSourceNode",
-  "MediaElementAudioSourceNode()")}} constructor or the
-{{domxref("AudioContext.createMediaElementSource()")}} method.
+either using the {{domxref("MediaElementAudioSourceNode.MediaElementAudioSourceNode", "MediaElementAudioSourceNode()")}}
+constructor or the {{domxref("AudioContext.createMediaElementSource()")}} method.
 
 ## Value
 

--- a/files/en-us/web/api/mediaquerylist/media/index.md
+++ b/files/en-us/web/api/mediaquerylist/media/index.md
@@ -30,8 +30,7 @@ let mql = window.matchMedia("(max-width: 600px)");
 document.querySelector(".mq-value").innerText = mql.media;
 ```
 
-The JavaScript code passes the media query to match into {{DOMxRef("Window.matchMedia",
-  "matchMedia()")}} to compile it, then sets the `<span>`'s
+The JavaScript code passes the media query to match into {{DOMxRef("Window.matchMedia", "matchMedia()")}} to compile it, then sets the `<span>`'s
 {{DOMxRef("HTMLElement.innerText", "innerText")}} to the value of the result's
 {{DOMxRef("MediaQueryList.media", "media")}} property.
 

--- a/files/en-us/web/api/mediarecorder/error_event/index.md
+++ b/files/en-us/web/api/mediarecorder/error_event/index.md
@@ -46,15 +46,14 @@ the value of {{domxref("DOMException.name", "MediaRecorderErrorEvent.error.name"
 
 - `SecurityError`
   - : The {{domxref("MediaStream")}} is configured to disallow recording. This may be the
-    case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia",
-    "getUserMedia()")}} when the user denies permission to use an input device.
+    case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} when the user denies permission to use an input device.
 - `InvalidModificationError`
   - : The number of tracks on the stream being recorded has changed. You can't add or
     remove tracks while recording media.
 - `UnknownError`
   - : An non-security related error occurred that cannot otherwise be categorized.
-    Recording stops, the `MediaRecorder`'s {{domxref("MediaRecorder.state",
-    "state")}} becomes `inactive`, one last {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event is
+    Recording stops, the `MediaRecorder`'s {{domxref("MediaRecorder.state", "state")}}
+    becomes `inactive`, one last {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event is
     sent to the `MediaRecorder` with the remaining received data, and finally a
     {{domxref("MediaRecorder/stop_event", "stop")}} event is sent.
 

--- a/files/en-us/web/api/mediarecorder/error_event/index.md
+++ b/files/en-us/web/api/mediarecorder/error_event/index.md
@@ -52,10 +52,7 @@ the value of {{domxref("DOMException.name", "MediaRecorderErrorEvent.error.name"
     remove tracks while recording media.
 - `UnknownError`
   - : An non-security related error occurred that cannot otherwise be categorized.
-    Recording stops, the `MediaRecorder`'s {{domxref("MediaRecorder.state", "state")}}
-    becomes `inactive`, one last {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event is
-    sent to the `MediaRecorder` with the remaining received data, and finally a
-    {{domxref("MediaRecorder/stop_event", "stop")}} event is sent.
+    Recording stops, the `MediaRecorder`'s {{domxref("MediaRecorder.state", "state")}} becomes `inactive`, one last {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event is sent to the `MediaRecorder` with the remaining received data, and finally a {{domxref("MediaRecorder/stop_event", "stop")}} event is sent.
 
 ## Examples
 

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.md
@@ -27,8 +27,7 @@ new MediaRecorder(stream, options)
 
 - `stream`
   - : The {{domxref("MediaStream")}} that will be recorded. This source media can come
-    from a stream created using {{domxref("MediaDevices.getUserMedia",
-    "navigator.mediaDevices.getUserMedia()")}} or from an {{HTMLElement("audio")}},
+    from a stream created using {{domxref("MediaDevices.getUserMedia", "navigator.mediaDevices.getUserMedia()")}} or from an {{HTMLElement("audio")}},
     {{HTMLElement("video")}} or {{HTMLElement("canvas")}} element.
 - `options` {{optional_inline}}
 

--- a/files/en-us/web/api/mediarecorder/start/index.md
+++ b/files/en-us/web/api/mediarecorder/start/index.md
@@ -74,8 +74,7 @@ handler to respond to these errors.
     - The `videoKeyFrameIntervalDuration` and `videoKeyFrameIntervalCount` parameter are both specificed when creating the `MediaRecorder`.
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("MediaStream")}} is configured to disallow recording. This may be the
-    case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia",
-    "getUserMedia()")}} when the user denies permission to use an input device. This
+    case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} when the user denies permission to use an input device. This
     exception may also be delivered as an {{domxref("MediaRecorder.error_event", "error")}} event if
     the security options for the source media change after recording begins.
 

--- a/files/en-us/web/api/mediarecordererrorevent/error/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/error/index.md
@@ -39,15 +39,14 @@ method references.
     information, if it exists.
 - `SecurityError`
   - : The {{domxref("MediaStream")}} is configured to disallow recording. This may be the
-    case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia",
-    "getUserMedia()")}} when the user denies permission to use an input device.
+    case, for example, with sources obtained using {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} when the user denies permission to use an input device.
 - `InvalidModificationError`
   - : The number of tracks on the stream being recorded has changed. You can't add or
     remove tracks while recording media.
 - `UnknownError`
   - : A non-security related error occurred that cannot otherwise be categorized.
-    Recording stops, the `MediaRecorder`'s {{domxref("MediaRecorder.state",
-    "state")}} becomes `inactive`, one last {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event is
+    Recording stops, the `MediaRecorder`'s {{domxref("MediaRecorder.state", "state")}} becomes `inactive`,
+    one last {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event is
     sent to the `MediaRecorder` with the remaining received data, and finally a
     {{domxref("MediaRecorder/stop_event", "stop")}} event is sent.
 

--- a/files/en-us/web/api/mediasession/setpositionstate/index.md
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.md
@@ -70,8 +70,7 @@ function updatePositionState() {
 }
 ```
 
-We can use this function when updating {{domxref('MediaMetadata', 'media session
-  metadata')}} and within callbacks for actions, such as below.
+We can use this function when updating {{domxref('MediaMetadata', 'media session metadata')}} and within callbacks for actions, such as below.
 
 ```js
 navigator.mediaSession.setActionHandler("seekbackward", (details) => {

--- a/files/en-us/web/api/mediasource/addsourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/addsourcebuffer/index.md
@@ -40,10 +40,7 @@ created and added to the media source.
   - : Thrown if the {{domxref("MediaSource")}} is not in the `"open"`
     {{domxref("MediaSource.readyState", "readyState")}}.
 - `NotSupportedError` {{domxref("DOMException")}}
-  - : Thrown if the specified `mimeType` isn't supported by the {{Glossary("user agent")}},
-    or is not compatible with the MIME types of other
-    {{domxref("SourceBuffer")}} objects that are already included in the media source's
-    {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}} list.
+  - : Thrown if the specified `mimeType` isn't supported by the {{Glossary("user agent")}}, or is not compatible with the MIME types of other {{domxref("SourceBuffer")}} objects that are already included in the media source's {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}} list.
 - `QuotaExceededError` {{domxref("DOMException")}}
   - : Thrown if the user agent can't handle any more `SourceBuffer` objects, or creating
     a new `SourceBuffer` using the given `mimeType` would result in

--- a/files/en-us/web/api/mediasource/addsourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/addsourcebuffer/index.md
@@ -40,8 +40,8 @@ created and added to the media source.
   - : Thrown if the {{domxref("MediaSource")}} is not in the `"open"`
     {{domxref("MediaSource.readyState", "readyState")}}.
 - `NotSupportedError` {{domxref("DOMException")}}
-  - : Thrown if the specified `mimeType` isn't supported by the {{Glossary("user
-    agent")}}, or is not compatible with the MIME types of other
+  - : Thrown if the specified `mimeType` isn't supported by the {{Glossary("user agent")}},
+    or is not compatible with the MIME types of other
     {{domxref("SourceBuffer")}} objects that are already included in the media source's
     {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}} list.
 - `QuotaExceededError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.md
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.md
@@ -27,8 +27,8 @@ None.
 ### Return value
 
 An array of {{domxref("MediaStreamTrack")}} objects, one for each audio track contained
-in the stream. Audio tracks are those tracks whose {{domxref("MediaStreamTrack.kind",
-  "kind")}} property is `audio`. The array is empty if the stream contains no
+in the stream. Audio tracks are those tracks whose {{domxref("MediaStreamTrack.kind", "kind")}}
+property is `audio`. The array is empty if the stream contains no
 audio tracks.
 
 > **Note:** The order of the returned tracks is not defined by the

--- a/files/en-us/web/api/mediastream/getvideotracks/index.md
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.md
@@ -36,8 +36,7 @@ is empty if the stream contains no video tracks.
 
 The following example, extracted from [Chrome's
 Image Capture / Photo Resolution Sample](https://googlechrome.github.io/samples/image-capture/photo-resolution.html), uses `getVideoTracks()` to
-retrieve a track for passing to the {{domxref("ImageCapture.ImageCapture",
-  "ImageCapture()")}} constructor.
+retrieve a track for passing to the {{domxref("ImageCapture.ImageCapture", "ImageCapture()")}} constructor.
 
 ```js
 let imageCapture;


### PR DESCRIPTION
### Description

This PR makes macros that span multiple lines span a single lines only.

### Motivation

Removing poor authoring patterns, helping to make the documentation more ergonomic and readable for authors and easier to maintain in future when we want to remove or update these macros.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/32510
- [x] https://github.com/mdn/content/pull/32581
- [x] https://github.com/mdn/content/pull/32583
- [x] https://github.com/mdn/content/pull/32584
