### PR TITLE
chore(api): Make macros with line breaks span a single line only, 4 of 4

### DIFF
--- a/files/en-us/web/api/videotracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/videotracklist/gettrackbyid/index.md
@@ -10,8 +10,7 @@ browser-compat: api.VideoTrackList.getTrackById
 
 The **{{domxref("VideoTrackList")}}** method
 **`getTrackById()`** returns the first
-{{domxref("VideoTrack")}} object from the track list whose {{domxref("VideoTrack.id",
-    "id")}} matches the specified string.
+{{domxref("VideoTrack")}} object from the track list whose {{domxref("VideoTrack.id", "id")}} matches the specified string.
 
 This lets you find a specified track if
 you know its ID string.

--- a/files/en-us/web/api/videotracklist/length/index.md
+++ b/files/en-us/web/api/videotracklist/length/index.md
@@ -25,8 +25,7 @@ A number indicating how many video tracks are included in the
 ## Examples
 
 This snippet gets the number of video tracks in the first {{HTMLElement("video")}}
-element found in the {{Glossary("DOM")}} by {{domxref("Document.querySelector",
-  "querySelector()")}}.
+element found in the {{Glossary("DOM")}} by {{domxref("Document.querySelector", "querySelector()")}}.
 
 ```js
 const videoElem = document.querySelector("video");

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -60,5 +60,4 @@ gl.drawBuffers([gl.NONE, gl.COLOR_ATTACHMENT1]);
 
 ## See also
 
-- {{domxref("WebGL2RenderingContext.clearBuffer",
-    "WebGL2RenderingContext.clearBuffer[fiuv]()")}}
+- {{domxref("WebGL2RenderingContext.clearBuffer", "WebGL2RenderingContext.clearBuffer[fiuv]()")}}

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
@@ -10,8 +10,7 @@ browser-compat: api.WebGL2RenderingContext.drawElementsInstanced
 
 The **`WebGL2RenderingContext.drawElementsInstanced()`** method
 of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) renders primitives from
-array data like the {{domxref("WebGLRenderingContext.drawElements()",
-  "gl.drawElements()")}} method. In addition, it can execute multiple instances of a set
+array data like the {{domxref("WebGLRenderingContext.drawElements()", "gl.drawElements()")}} method. In addition, it can execute multiple instances of a set
 of elements.
 
 > **Note:** When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
@@ -86,10 +85,8 @@ gl.drawElementsInstanced(gl.POINTS, 2, gl.UNSIGNED_SHORT, 0, 4);
 
 ## See also
 
-- {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()",
-    "ext.drawArraysInstancedANGLE()")}}
-- {{domxref("ANGLE_instanced_arrays.vertexAttribDivisorANGLE()",
-    "ext.vertexAttribDivisorANGLE()")}}
+- {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()", "ext.drawArraysInstancedANGLE()")}}
+- {{domxref("ANGLE_instanced_arrays.vertexAttribDivisorANGLE()", "ext.vertexAttribDivisorANGLE()")}}
 - {{domxref("WebGLRenderingContext.drawArrays()")}}
 - {{domxref("WebGLRenderingContext.drawElements()")}}
 - {{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
@@ -11,8 +11,7 @@ browser-compat: api.WebGL2RenderingContext.vertexAttribDivisor
 The **`WebGL2RenderingContext.vertexAttribDivisor()`** method
 of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) modifies the rate at
 which generic vertex attributes advance when rendering multiple instances of primitives
-with {{domxref("WebGL2RenderingContext.drawArraysInstanced()", "gl.drawArraysInstanced()")}} and
-{{domxref("WebGL2RenderingContext.drawElementsInstanced()", "gl.drawElementsInstanced()")}}.
+with {{domxref("WebGL2RenderingContext.drawArraysInstanced()", "gl.drawArraysInstanced()")}} and {{domxref("WebGL2RenderingContext.drawElementsInstanced()", "gl.drawElementsInstanced()")}}.
 
 > **Note:** When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
 > too.

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
@@ -11,10 +11,8 @@ browser-compat: api.WebGL2RenderingContext.vertexAttribDivisor
 The **`WebGL2RenderingContext.vertexAttribDivisor()`** method
 of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) modifies the rate at
 which generic vertex attributes advance when rendering multiple instances of primitives
-with {{domxref("WebGL2RenderingContext.drawArraysInstanced()",
-  "gl.drawArraysInstanced()")}} and
-{{domxref("WebGL2RenderingContext.drawElementsInstanced()",
-  "gl.drawElementsInstanced()")}}.
+with {{domxref("WebGL2RenderingContext.drawArraysInstanced()", "gl.drawArraysInstanced()")}} and
+{{domxref("WebGL2RenderingContext.drawElementsInstanced()", "gl.drawElementsInstanced()")}}.
 
 > **Note:** When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
 > too.

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.md
@@ -10,9 +10,7 @@ browser-compat: api.WebGLRenderingContext.clear
 
 The **`WebGLRenderingContext.clear()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) clears buffers to preset values.
 
-The preset values can be set by {{domxref("WebGLRenderingContext.clearColor", "clearColor()")}},
-{{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}} or
-{{domxref("WebGLRenderingContext.clearStencil", "clearStencil()")}}.
+The preset values can be set by {{domxref("WebGLRenderingContext.clearColor", "clearColor()")}}, {{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}} or {{domxref("WebGLRenderingContext.clearStencil", "clearStencil()")}}.
 
 The scissor box, dithering, and buffer writemasks can affect the `clear()`
 method.

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.md
@@ -10,8 +10,8 @@ browser-compat: api.WebGLRenderingContext.clear
 
 The **`WebGLRenderingContext.clear()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) clears buffers to preset values.
 
-The preset values can be set by {{domxref("WebGLRenderingContext.clearColor",
-  "clearColor()")}}, {{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}} or
+The preset values can be set by {{domxref("WebGLRenderingContext.clearColor", "clearColor()")}},
+{{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}} or
 {{domxref("WebGLRenderingContext.clearStencil", "clearStencil()")}}.
 
 The scissor box, dithering, and buffer writemasks can affect the `clear()`

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -67,12 +67,9 @@ gl.drawArrays(gl.POINTS, 0, 8);
 ## See also
 
 - {{domxref("WebGLRenderingContext.drawElements()")}}
-- {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()",
-    "ext.drawArraysInstancedANGLE()")}}
-- {{domxref("ANGLE_instanced_arrays.drawElementsInstancedANGLE()",
-    "ext.drawElementsInstancedANGLE()")}}
-- {{domxref("ANGLE_instanced_arrays.vertexAttribDivisorANGLE()",
-    "ext.vertexAttribDivisorANGLE()")}}
+- {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()", "ext.drawArraysInstancedANGLE()")}}
+- {{domxref("ANGLE_instanced_arrays.drawElementsInstancedANGLE()", "ext.drawElementsInstancedANGLE()")}}
+- {{domxref("ANGLE_instanced_arrays.vertexAttribDivisorANGLE()", "ext.vertexAttribDivisorANGLE()")}}
 - {{domxref("WebGL2RenderingContext.drawArraysInstanced()")}}
 - {{domxref("WebGL2RenderingContext.drawElementsInstanced()")}}
 - {{domxref("WebGL2RenderingContext.vertexAttribDivisor()")}}

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
@@ -24,10 +24,7 @@ are assigned by the WebGL layer when you create the attributes.
 Either way, since attributes cannot be used unless enabled, and are disabled by
 default, you need to call `enableVertexAttribArray()` to enable individual
 attributes so that they can be used. Once that's been done, other methods can be used to
-access the attribute, including
-{{domxref("WebGLRenderingContext.vertexAttribPointer", "vertexAttribPointer()")}},
-{{domxref("WebGLRenderingContext.vertexAttrib", "vertexAttrib*()")}},
-and {{domxref("WebGLRenderingContext.getVertexAttrib", "getVertexAttrib()")}}.
+access the attribute, including {{domxref("WebGLRenderingContext.vertexAttribPointer", "vertexAttribPointer()")}}, {{domxref("WebGLRenderingContext.vertexAttrib", "vertexAttrib*()")}}, and {{domxref("WebGLRenderingContext.getVertexAttrib", "getVertexAttrib()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
@@ -24,10 +24,10 @@ are assigned by the WebGL layer when you create the attributes.
 Either way, since attributes cannot be used unless enabled, and are disabled by
 default, you need to call `enableVertexAttribArray()` to enable individual
 attributes so that they can be used. Once that's been done, other methods can be used to
-access the attribute, including {{domxref("WebGLRenderingContext.vertexAttribPointer",
-  "vertexAttribPointer()")}}, {{domxref("WebGLRenderingContext.vertexAttrib",
-  "vertexAttrib*()")}}, and {{domxref("WebGLRenderingContext.getVertexAttrib",
-  "getVertexAttrib()")}}.
+access the attribute, including
+{{domxref("WebGLRenderingContext.vertexAttribPointer", "vertexAttribPointer()")}},
+{{domxref("WebGLRenderingContext.vertexAttrib", "vertexAttrib*()")}},
+and {{domxref("WebGLRenderingContext.getVertexAttrib", "getVertexAttrib()")}}.
 
 ## Syntax
 
@@ -40,8 +40,7 @@ enableVertexAttribArray(index)
 - `index`
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index number that uniquely identifies the
     vertex attribute to enable. If you know the name of the attribute but not its index,
-    you can get the index by calling {{domxref("WebGLRenderingContext.getAttribLocation",
-    "getAttribLocation()")}}.
+    you can get the index by calling {{domxref("WebGLRenderingContext.getAttribLocation", "getAttribLocation()")}}.
 
 ### Return value
 
@@ -95,8 +94,7 @@ the position attribute so it can be used by the shader program (in particular, b
 vertex shader).
 
 Then the vertex buffer is bound to the `aVertexPosition` attribute by
-calling {{domxref("WebGLRenderingContext.vertexAttribPointer",
-  "vertexAttribPointer()")}}. This step is not obvious, since this binding is almost a
+calling {{domxref("WebGLRenderingContext.vertexAttribPointer", "vertexAttribPointer()")}}. This step is not obvious, since this binding is almost a
 side effect. But as a result, accessing `aVertexPosition` now obtains data
 from the vertex buffer.
 
@@ -118,5 +116,4 @@ vertex shader, we're ready to draw the shape by calling
 - [Data in WebGL](/en-US/docs/Web/API/WebGL_API/Data)
 - [Adding 2D content to a WebGL context](/en-US/docs/Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context)
 - [A basic 2D WebGL animation sample](/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example)
-- {{domxref("WebGLRenderingContext.disableVertexAttribArray",
-    "disableVertexAttribArray()")}}
+- {{domxref("WebGLRenderingContext.disableVertexAttribArray", "disableVertexAttribArray()")}}

--- a/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.md
@@ -62,7 +62,5 @@ gl.generateMipmap(gl.TEXTURE_2D);
 - {{domxref("WebGLRenderingContext.createTexture()")}}
 - {{domxref("WebGLRenderingContext.bindTexture()")}}
 - {{domxref("WebGLRenderingContext.getTexParameter()")}}
-- {{domxref("WebGLRenderingContext.texParameter",
-    "WebGLRenderingContext.texParameterf()")}}
-- {{domxref("WebGLRenderingContext.texParameter",
-    "WebGLRenderingContext.texParameteri()")}}
+- {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}
+- {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}

--- a/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.md
@@ -27,8 +27,7 @@ getActiveAttrib(program, index)
 - `index`
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the vertex attribute to get. This
     value is an index 0 to N - 1 as returned
-    by {{domxref("WebGLRenderingContext.getProgramParameter",
-    "gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES)")}}.
+    by {{domxref("WebGLRenderingContext.getProgramParameter", "gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES)")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.md
@@ -28,8 +28,7 @@ getActiveUniform(program, index)
 - `index`
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the index of the uniform attribute to get. This
     value is an index 0 to N - 1 as returned
-    by {{domxref("WebGLRenderingContext.getProgramParameter",
-    "gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS)")}}.
+    by {{domxref("WebGLRenderingContext.getProgramParameter", "gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS)")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
@@ -893,8 +893,7 @@ You can query the following `pname` parameters when using a
       </td>
       <td>
         See
-        {{domxref("WebGL2RenderingContext/bindTransformFeedback",
-        "bindTransformFeedback")}}.
+        {{domxref("WebGL2RenderingContext/bindTransformFeedback", "bindTransformFeedback")}}.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
@@ -189,8 +189,6 @@ gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER);
 
 ## See also
 
-- {{domxref("WebGLRenderingContext.texParameter",
-    "WebGLRenderingContext.texParameterf()")}}
-- {{domxref("WebGLRenderingContext.texParameter",
-    "WebGLRenderingContext.texParameteri()")}}
+- {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameterf()")}}
+- {{domxref("WebGLRenderingContext.texParameter", "WebGLRenderingContext.texParameteri()")}}
 - {{domxref("EXT_texture_filter_anisotropic")}}

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
@@ -67,8 +67,7 @@ gl.stencilFunc(gl.LESS, 0, 0b1110011);
 ```
 
 To get the current stencil function, reference value, or other stencil information,
-query the following constants with {{domxref("WebGLRenderingContext.getParameter",
-  "getParameter()")}}.
+query the following constants with {{domxref("WebGLRenderingContext.getParameter", "getParameter()")}}.
 
 ```js
 gl.getParameter(gl.STENCIL_FUNC);

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
@@ -71,8 +71,7 @@ gl.stencilFuncSeparate(gl.FRONT, gl.LESS, 0.2, 1110011);
 ```
 
 To get the current stencil function, reference value, or other stencil information,
-query the following constants with {{domxref("WebGLRenderingContext.getParameter",
-  "getParameter()")}}.
+query the following constants with {{domxref("WebGLRenderingContext.getParameter", "getParameter()")}}.
 
 ```js
 gl.getParameter(gl.STENCIL_FUNC);

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
@@ -72,8 +72,7 @@ gl.stencilOp(gl.INCR, gl.DECR, gl.INVERT);
 ```
 
 To get the current information about stencil and depth pass or fail, query the
-following constants with {{domxref("WebGLRenderingContext.getParameter",
-  "getParameter()")}}.
+following constants with {{domxref("WebGLRenderingContext.getParameter", "getParameter()")}}.
 
 ```js
 gl.getParameter(gl.STENCIL_FAIL);

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
@@ -83,8 +83,7 @@ gl.stencilOpSeparate(gl.FRONT, gl.INCR, gl.DECR, gl.INVERT);
 ```
 
 To get the current information about stencil and depth pass or fail, query the
-following constants with {{domxref("WebGLRenderingContext.getParameter",
-  "getParameter()")}}.
+following constants with {{domxref("WebGLRenderingContext.getParameter", "getParameter()")}}.
 
 ```js
 gl.getParameter(gl.STENCIL_FAIL);

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -43,11 +43,8 @@ None ({{jsxref("undefined")}}).
 ## Description
 
 While vertex attributes are usually used to specify values which are different for each
-vertex (using {{domxref("WebGLRenderingContext.vertexAttribPointer()", "vertexAttribPointer")}}), it can be useful to specify a constant value. For example, if
-you have a shader which has a `color` vertex attribute, but you want to draw
-everything in a single color, you can use `vertexAttrib` to achieve that
-without creating a buffer filled with only one value or having to create a separate
-shader which uses a uniform for the color.
+vertex (using {{domxref("WebGLRenderingContext.vertexAttribPointer()", "vertexAttribPointer")}}), it can be useful to specify a constant value.
+For example, if you have a shader which has a `color` vertex attribute, but you want to draw everything in a single color, you can use `vertexAttrib` to achieve that without creating a buffer filled with only one value or having to create a separate shader which uses a uniform for the color.
 
 This value will be used if a bound array buffer has not been enabled with
 {{domxref("WebGLRenderingContext.enableVertexAttribArray()", "enableVertexAttribArray")}}.

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -43,16 +43,14 @@ None ({{jsxref("undefined")}}).
 ## Description
 
 While vertex attributes are usually used to specify values which are different for each
-vertex (using {{domxref("WebGLRenderingContext.vertexAttribPointer()",
-  "vertexAttribPointer")}}), it can be useful to specify a constant value. For example, if
+vertex (using {{domxref("WebGLRenderingContext.vertexAttribPointer()", "vertexAttribPointer")}}), it can be useful to specify a constant value. For example, if
 you have a shader which has a `color` vertex attribute, but you want to draw
 everything in a single color, you can use `vertexAttrib` to achieve that
 without creating a buffer filled with only one value or having to create a separate
 shader which uses a uniform for the color.
 
 This value will be used if a bound array buffer has not been enabled with
-{{domxref("WebGLRenderingContext.enableVertexAttribArray()",
-  "enableVertexAttribArray")}}.
+{{domxref("WebGLRenderingContext.enableVertexAttribArray()", "enableVertexAttribArray")}}.
 
 Attributes may be matrices, in which case columns of the matrix must be loaded into
 successive vertex attribute slots.

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -97,8 +97,7 @@ and will be supplied to the Vertex Buffer Object (VBO). First, we need to bind t
 this method, `gl.vertexAttribPointer()`, we specify in what order the
 attributes are stored, and what data type they are in. In addition, we need to include
 the stride, which is the total byte length of all attributes for one vertex. Also, we
-have to call {{domxref("WebGLRenderingContext/enableVertexAttribArray",
-  "gl.enableVertexAttribArray()")}} to tell WebGL that this attribute should be filled
+have to call {{domxref("WebGLRenderingContext/enableVertexAttribArray", "gl.enableVertexAttribArray()")}} to tell WebGL that this attribute should be filled
 with data from our array buffer.
 
 Usually, your 3D geometry is already in a certain binary format, so you need to read
@@ -121,13 +120,11 @@ they are stored in the array buffer. You have two options:
 - Either you specify the index yourself. In this case, you call
   {{domxref("WebGLRenderingContext.bindAttribLocation()", "gl.bindAttribLocation()")}}
   to connect a named attribute from the vertex shader to the index you want to use. This
-  must be done before calling {{domxref("WebGLRenderingContext.linkProgram()",
-    "gl.linkProgram()")}}. You can then provide this same index to
+  must be done before calling {{domxref("WebGLRenderingContext.linkProgram()", "gl.linkProgram()")}}. You can then provide this same index to
   `gl.vertexAttribPointer()`.
 - Alternatively, you use the index that is assigned by the graphics card when
   compiling the vertex shader. Depending on the graphics card, the index will vary, so
-  you must call {{domxref("WebGLRenderingContext.getAttribLocation()",
-    "gl.getAttribLocation()")}} to find out the index, and then provide this index to
+  you must call {{domxref("WebGLRenderingContext.getAttribLocation()", "gl.getAttribLocation()")}} to find out the index, and then provide this index to
   `gl.vertexAttribPointer()`.
   If you are using WebGL 2, you can specify the index yourself in the vertex shader code
   and override the default used by the graphics card, e.g.
@@ -140,8 +137,7 @@ While the `ArrayBuffer` can be filled with both integers and floats, the
 attributes will always be converted to a float when they are sent to the vertex shader.
 If you need to use integers in your vertex shader code, you can either cast the float
 back to an integer in the vertex shader (e.g. `(int) floatNumber`), or use
-{{domxref("WebGL2RenderingContext.vertexAttribIPointer()",
-  "gl.vertexAttribIPointer()")}} from WebGL2.
+{{domxref("WebGL2RenderingContext.vertexAttribIPointer()", "gl.vertexAttribIPointer()")}} from WebGL2.
 
 ### Default attribute values
 
@@ -150,9 +146,8 @@ the values for each attribute. Instead, we can supply a default value that will 
 identical for all vertices. We can call
 {{domxref("WebGLRenderingContext.disableVertexAttribArray()", "gl.disableVertexAttribArray()")}}
 to tell WebGL to use the default value, while calling
-{{domxref("WebGLRenderingContext.enableVertexAttribArray()",
-  "gl.enableVertexAttribArray()")}} will read the values from the array buffer as
-specified with `gl.vertexAttribPointer()`.
+{{domxref("WebGLRenderingContext.enableVertexAttribArray()", "gl.enableVertexAttribArray()")}}
+will read the values from the array buffer as specified with `gl.vertexAttribPointer()`.
 
 Similarly, if our vertex shader expects e.g. a 4-component attribute with
 `vec4` but in our `gl.vertexAttribPointer()` call we set the
@@ -172,9 +167,9 @@ color.
 
 ### Querying current settings
 
-You can call {{domxref("WebGLRenderingContext.getVertexAttrib()",
-  "gl.getVertexAttrib()")}} and {{domxref("WebGLRenderingContext.getVertexAttribOffset()",
-  "gl.getVertexAttribOffset()")}} to get the current parameters for an attribute, e.g. the
+You can call {{domxref("WebGLRenderingContext.getVertexAttrib()", "gl.getVertexAttrib()")}} and
+{{domxref("WebGLRenderingContext.getVertexAttribOffset()", "gl.getVertexAttribOffset()")}} to
+get the current parameters for an attribute, e.g. the
 data type or whether the attribute should be normalized. Keep in mind that these WebGL
 functions have a slow performance and it is better to store the state inside your
 JavaScript application. However, these functions are great for debugging a WebGL context

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -115,9 +115,8 @@ function sendText() {
 
 WebSockets is an event-driven API; when messages are received, a `message`
 event is sent to the `WebSocket` object. To handle it, add an event listener
-for the `message` event, or use the {{domxref("WebSocket/message_event",
-  "onmessage")}} event handler. To begin listening for incoming data, you can do something
-like this:
+for the `message` event, or use the {{domxref("WebSocket/message_event", "onmessage")}} event handler.
+To begin listening for incoming data, you can do something like this:
 
 ```js
 exampleSocket.onmessage = (event) => {

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -149,8 +149,8 @@ Java.
 - CSS property values may be accessed using the
   {{DOMxRef("CSSStyleDeclaration.getPropertyValue", "getPropertyValue(propName)")}} method or by indexing directly into the object
   using array or [dot notation](/en-US/docs/Learn/JavaScript/Objects/Basics#dot_notation) such as `obj['z-index']` or `obj.zIndex`.
-- The values returned by `getComputedStyle` are {{CSSxRef("resolved_value",
-    "resolved values", "", 1)}}. These are usually the same as CSS 2.1's
+- The values returned by `getComputedStyle` are {{CSSxRef("resolved_value", "resolved values", "", 1)}}.
+  These are usually the same as CSS 2.1's
   {{CSSxRef("computed_value","computed values", "", 1)}}, but for some older properties
   like `width`, `height`, or `padding`, they are
   instead the same as {{CSSxRef("used_value","used values", "", 1)}}. Originally, CSS

--- a/files/en-us/web/api/window/getselection/index.md
+++ b/files/en-us/web/api/window/getselection/index.md
@@ -49,11 +49,8 @@ function foo() {
 
 ### String representation of the Selection object
 
-In JavaScript, when an object is passed to a function expecting a string (like {{Domxref("window.alert()")}} or
-{{Domxref("document.write()")}}), the object's
-{{jsxref("Object.toString", "toString()")}} method is called and the returned value is
-passed to the function. This can make the object appear to be a string when used with
-other functions when it is really an object with properties and methods.
+In JavaScript, when an object is passed to a function expecting a string (like {{Domxref("window.alert()")}} or {{Domxref("document.write()")}}), the object's {{jsxref("Object.toString", "toString()")}} method is called and the returned value is passed to the function.
+This can make the object appear to be a string when used with other functions when it is really an object with properties and methods.
 
 In the above example, `selObj.toString()` is automatically called when it is
 passed to {{domxref("window.alert()")}}. However, attempting to use a JavaScript [String](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) property

--- a/files/en-us/web/api/window/getselection/index.md
+++ b/files/en-us/web/api/window/getselection/index.md
@@ -49,8 +49,8 @@ function foo() {
 
 ### String representation of the Selection object
 
-In JavaScript, when an object is passed to a function expecting a string (like {{
-  Domxref("window.alert()") }} or {{ Domxref("document.write()") }}), the object's
+In JavaScript, when an object is passed to a function expecting a string (like {{Domxref("window.alert()")}} or
+{{Domxref("document.write()")}}), the object's
 {{jsxref("Object.toString", "toString()")}} method is called and the returned value is
 passed to the function. This can make the object appear to be a string when used with
 other functions when it is really an object with properties and methods.

--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -22,14 +22,12 @@ An integer value indicating the window's layout viewport height in pixels. The p
 is read only and has no default value.
 
 To change the width of the window, call one of its resize methods, such as
-{{domxref("Window.resizeTo", "resizeTo()")}} or {{domxref("Window.resizeBy",
-  "resizeBy()")}}.
+{{domxref("Window.resizeTo", "resizeTo()")}} or {{domxref("Window.resizeBy", "resizeBy()")}}.
 
 ## Usage notes
 
 To obtain the height of the window minus its horizontal scroll bar and any borders, use
-the root {{HTMLElement("html")}} element's {{domxref("Element.clientHeight",
-  "clientHeight")}} property instead.
+the root {{HTMLElement("html")}} element's {{domxref("Element.clientHeight", "clientHeight")}} property instead.
 
 Both `innerHeight` and `innerWidth` are available on any window
 or any object that behaves like a window, such as a tab or frame.

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -42,8 +42,8 @@ property, which will be `true` if the document meets the media query's
 requirements.
 
 If you need to be kept aware of whether or not the document matches the media query at
-all times, you can instead watch for the {{domxref("MediaQueryList.change_event",
-  "change")}} event to be delivered to the object. There's [a good example of this](/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes)
+all times, you can instead watch for the {{domxref("MediaQueryList.change_event", "change")}} event to be delivered to the object.
+There's [a good example of this](/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes)
 in the article on {{domxref("Window.devicePixelRatio")}}.
 
 ## Examples
@@ -61,8 +61,7 @@ let mql = window.matchMedia("(max-width: 600px)");
 document.querySelector(".mq-value").innerText = mql.matches;
 ```
 
-The JavaScript code passes the media query to match into {{domxref("Window.matchMedia",
-  "matchMedia()")}} to compile it, then sets the `<span>`'s
+The JavaScript code passes the media query to match into {{domxref("Window.matchMedia", "matchMedia()")}} to compile it, then sets the `<span>`'s
 {{domxref("HTMLElement.innerText", "innerText")}} to the value of the results'
 {{domxref("MediaQueryList.matches", "matches")}} property, so that it indicates whether or
 not the document matches the media query at the moment the page was loaded.

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -61,10 +61,7 @@ let mql = window.matchMedia("(max-width: 600px)");
 document.querySelector(".mq-value").innerText = mql.matches;
 ```
 
-The JavaScript code passes the media query to match into {{domxref("Window.matchMedia", "matchMedia()")}} to compile it, then sets the `<span>`'s
-{{domxref("HTMLElement.innerText", "innerText")}} to the value of the results'
-{{domxref("MediaQueryList.matches", "matches")}} property, so that it indicates whether or
-not the document matches the media query at the moment the page was loaded.
+The JavaScript code passes the media query to match into {{domxref("Window.matchMedia", "matchMedia()")}} to compile it, then sets the `<span>`'s {{domxref("HTMLElement.innerText", "innerText")}} to the value of the results' {{domxref("MediaQueryList.matches", "matches")}} property, so that it indicates whether or not the document matches the media query at the moment the page was loaded.
 
 ### HTML
 

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -35,9 +35,9 @@ postMessage(message, targetOrigin, transfer)
 ### Parameters
 
 - `message`
-  - : Data to be sent to the other window. The data is serialized using
-    {{domxref("Web_Workers_API/Structured_clone_algorithm", "the structured clone
-    algorithm", "", 1)}}. This means you can pass a broad variety of data objects safely to the
+  - : Data to be sent to the other window. The data is serialized using the
+    {{domxref("Web_Workers_API/Structured_clone_algorithm", "structured clone algorithm", "", 1)}}.
+    This means you can pass a broad variety of data objects safely to the
     destination window without having to serialize them yourself.
 - `options` {{optional_Inline}}
   - : An optional object containing a `transfer` field with a sequence of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of, and a optional `targetOrigin` field with a string which restricts the message to the limited targets only.

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -35,10 +35,9 @@ postMessage(message, targetOrigin, transfer)
 ### Parameters
 
 - `message`
-  - : Data to be sent to the other window. The data is serialized using the
-    {{domxref("Web_Workers_API/Structured_clone_algorithm", "structured clone algorithm", "", 1)}}.
-    This means you can pass a broad variety of data objects safely to the
-    destination window without having to serialize them yourself.
+  - : Data to be sent to the other window.
+    The data is serialized using the {{domxref("Web_Workers_API/Structured_clone_algorithm", "structured clone algorithm", "", 1)}}.
+    This means you can pass a broad variety of data objects safely to the destination window without having to serialize them yourself.
 - `options` {{optional_Inline}}
   - : An optional object containing a `transfer` field with a sequence of [transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) to transfer ownership of, and a optional `targetOrigin` field with a string which restricts the message to the limited targets only.
 - `targetOrigin` {{optional_Inline}}

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -14,8 +14,7 @@ is currently scrolled vertically.
 
 This value is subpixel precise in modern
 browsers, meaning that it isn't necessarily a whole number. You can get the number of
-pixels the document is scrolled horizontally from the {{domxref("Window.scrollX",
-  "scrollX")}} property.
+pixels the document is scrolled horizontally from the {{domxref("Window.scrollX", "scrollX")}} property.
 
 ## Value
 

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -110,5 +110,4 @@ This obtains the value of the {{httpheader("Content-Type")}} header into the var
 ## See also
 
 - [Using XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest_API/Using_XMLHttpRequest)
-- Setting request headers: {{domxref("XMLHttpRequest.setRequestHeader",
-    "setRequestHeader()")}}
+- Setting request headers: {{domxref("XMLHttpRequest.setRequestHeader", "setRequestHeader()")}}

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
@@ -44,8 +44,8 @@ response.
 ## Examples
 
 In this example, a request is created and sent, and a {{domxref("XMLHttpRequest/readystatechange_event", "readystatechange")}}
-handler is established to look for the {{DOMxRef("XMLHttpRequest.readyState",
-  "readyState")}} to indicate that the headers have been received; when that is the case,
+handler is established to look for the {{DOMxRef("XMLHttpRequest.readyState", "readyState")}}
+to indicate that the headers have been received; when that is the case,
 the value of the {{httpheader("Content-Type")}} header is fetched. If the
 `Content-Type` isn't the desired value, the {{DOMxRef("XMLHttpRequest")}} is
 canceled by calling {{DOMxRef("XMLHttpRequest.abort", "abort()")}}.
@@ -79,5 +79,4 @@ client.onreadystatechange = () => {
 - [HTTP headers](/en-US/docs/Web/HTTP/Headers)
 - {{DOMxRef("XMLHttpRequest.getAllResponseHeaders", "getAllResponseHeaders()")}}
 - {{DOMxRef("XMLHttpRequest.response", "response")}}
-- Setting request headers: {{DOMxRef("XMLHttpRequest.setRequestHeader",
-    "setRequestHeader()")}}
+- Setting request headers: {{DOMxRef("XMLHttpRequest.setRequestHeader", "setRequestHeader()")}}

--- a/files/en-us/web/api/xmlhttprequest/open/index.md
+++ b/files/en-us/web/api/xmlhttprequest/open/index.md
@@ -69,6 +69,6 @@ None ({{jsxref("undefined")}}).
 
 - [Using XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest_API/Using_XMLHttpRequest)
 - Related {{domxref("XMLHttpRequest")}} methods:
-  {{domxref("XMLHttpRequest.setRequestHeader",
-    "setRequestHeader()")}}, {{domxref("XMLHttpRequest.send", "send()")}}, and
+  {{domxref("XMLHttpRequest.setRequestHeader","setRequestHeader()")}},
+  {{domxref("XMLHttpRequest.send", "send()")}}, and
   {{domxref("XMLHttpRequest.abort", "abort()")}}

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
@@ -15,8 +15,7 @@ transferred in a request.
 
 This may be used, for example, to force a stream to
 be treated and parsed as `"text/xml"`, even if the server does not report it
-as such. This method must be called before calling {{domxref("XMLHttpRequest.send",
-  "send()")}}.
+as such. This method must be called before calling {{domxref("XMLHttpRequest.send", "send()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -17,8 +17,8 @@ property.
 
 ## Value
 
-An appropriate object based on the value of {{domxref("XMLHttpRequest.responseType",
-  "responseType")}}. You may attempt to request the data be provided in a specific format
+An appropriate object based on the value of {{domxref("XMLHttpRequest.responseType", "responseType")}}.
+You may attempt to request the data be provided in a specific format
 by setting the value of `responseType` after calling
 {{domxref("XMLHttpRequest.open", "open()")}} to initialize the request but before
 calling {{domxref("XMLHttpRequest.send", "send()")}} to send the request to the server.

--- a/files/en-us/web/api/xpathevaluator/creatensresolver/index.md
+++ b/files/en-us/web/api/xpathevaluator/creatensresolver/index.md
@@ -12,8 +12,8 @@ This method adapts any DOM node to resolve namespaces so that an XPath expressio
 be easily evaluated relative to the context of the node where it appeared within the
 document.
 
-This adapter works like the DOM Level 3 method {{domxref("Node.lookupNamespaceURI",
-  "Node.lookupNamespaceURI()")}} in resolving the namespace URI from a given prefix using
+This adapter works like the DOM Level 3 method {{domxref("Node.lookupNamespaceURI", "Node.lookupNamespaceURI()")}}
+in resolving the namespace URI from a given prefix using
 the current information available in the node's hierarchy at the time the method is
 called, also correctly resolving the implicit `xml` prefix.
 

--- a/files/en-us/web/api/xrframe/getviewerpose/index.md
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.md
@@ -40,9 +40,7 @@ to the specified reference space.
 
 ## Examples
 
-In this callback function for {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}, the {{domxref("XRViewerPose")}} describing the viewer's
-viewpoint on the world is obtained by calling `getViewerPose()` on the
-{{domxref("XRFrame")}} passed into the callback.
+In this callback function for {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}, the {{domxref("XRViewerPose")}} describing the viewer's viewpoint on the world is obtained by calling `getViewerPose()` on the {{domxref("XRFrame")}} passed into the callback.
 
 ```js
 viewerPose = xrFrame.getViewerPose(xrReferenceSpace);

--- a/files/en-us/web/api/xrframe/getviewerpose/index.md
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.md
@@ -36,13 +36,11 @@ to the specified reference space.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if `getViewerPose()` was not
     called within the context of a callback to a
-    session's {{domxref("XRSession.requestAnimationFrame",
-    "XRSession.requestAnimationFrame()")}}.
+    session's {{domxref("XRSession.requestAnimationFrame", "XRSession.requestAnimationFrame()")}}.
 
 ## Examples
 
-In this callback function for {{domxref("XRSession.requestAnimationFrame",
-  "requestAnimationFrame()")}}, the {{domxref("XRViewerPose")}} describing the viewer's
+In this callback function for {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}, the {{domxref("XRViewerPose")}} describing the viewer's
 viewpoint on the world is obtained by calling `getViewerPose()` on the
 {{domxref("XRFrame")}} passed into the callback.
 

--- a/files/en-us/web/api/xrinputsource/gripspace/index.md
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.md
@@ -14,9 +14,8 @@ The read-only {{domxref("XRInputSource")}} property **`gripSpace`** returns an {
 
 An {{domxref("XRSpace")}} object representing the position and orientation of the input
 device in virtual space, suitable for rendering an image of the device into the scene.
-`gripSpace` is `null` if the input source is inherently
-untrackable. For example, only inputs whose {{domxref("XRInputSource.targetRayMode",
-  "targetRayMode")}} is `tracked-pointer` provide a `gripSpace`.
+`gripSpace` is `null` if the input source is not inherently
+trackable. For example, only inputs whose {{domxref("XRInputSource.targetRayMode", "targetRayMode")}} is `tracked-pointer` provide a `gripSpace`.
 
 Imagine that the controller is shaped like a straight rod, held in the user's fist. The
 native origin of the grip space is located at the centroid—the center of mass—of the

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.md
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.md
@@ -18,8 +18,7 @@ the input source's {{domxref("XRInputSource.targetRayMode", "targetRayMode")}}, 
 used both to fully interpret the device as an input source.
 
 To obtain an `XRSpace` representing the input controller's position and
-orientation in virtual space, use the {{domxref("XRInputSource.gripSpace",
-  "gripSpace")}} property.
+orientation in virtual space, use the {{domxref("XRInputSource.gripSpace", "gripSpace")}} property.
 
 ## Value
 
@@ -33,9 +32,8 @@ direction in which the target ray is pointing.
 
 ## Usage notes
 
-All input sources—regardless of their {{domxref("XRInputSource.targetRayMode",
-  "targetRayMode")}}—have a valid `targetRaySpace`. The exact meaning of this
-space varies, however, depending on the mode:
+All input sources—regardless of their {{domxref("XRInputSource.targetRayMode", "targetRayMode")}}—have a valid `targetRaySpace`.
+The exact meaning of this space varies, however, depending on the mode:
 
 - Every gaze input (`targetRayMode` value of `gaze`), shares the
   same {{domxref("XRSpace")}} object as their target ray space, since the gaze input
@@ -48,8 +46,8 @@ space varies, however, depending on the mode:
   orientation of the input device.
 
 To determine the position and orientation of the target ray while rendering a frame,
-pass it into the {{domxref("XRFrame")}} method {{domxref("XRFrame.getPose",
-  "getPose()")}} method, then use the returned {{domxref("XRPose")}} object's
+pass it into the {{domxref("XRFrame")}} method {{domxref("XRFrame.getPose", "getPose()")}} method,
+then use the returned {{domxref("XRPose")}} object's
 {{domxref("XRPose.transform", "transform")}} to gather the spatial information you need.
 
 ## Examples

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.md
@@ -62,8 +62,6 @@ index with array notation: `xrSession.inputSources[inputIdx]`.
 ## See also
 
 - [Inputs and input sources](/en-US/docs/Web/API/WebXR_Device_API/Inputs)
-- The {{domxref("XRInputSourceArray")}} method {{domxref("XRInputSourceArray.values",
-    "values()")}}
-- The
-  [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) method `keys()`
+- The {{domxref("XRInputSourceArray")}} method {{domxref("XRInputSourceArray.values", "values()")}}
+- The [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) method `keys()`
 - {{domxref("XRInputSource")}}

--- a/files/en-us/web/api/xrinputsourcearray/values/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.md
@@ -62,8 +62,7 @@ once every input has been delivered to `checkInput()`.
 ## See also
 
 - [Inputs and input sources](/en-US/docs/Web/API/WebXR_Device_API/Inputs)
-- The {{domxref("XRInputSourceArray")}} method {{domxref("XRInputSourceArray.keys",
-    "keys()")}}
+- The {{domxref("XRInputSourceArray")}} method {{domxref("XRInputSourceArray.keys", "keys()")}}
 - The
   [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) method `values()`
 - {{domxref("XRInputSource")}}

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.md
@@ -35,8 +35,8 @@ list.
 
 ## Examples
 
-This code shows a handler for the {{domxref("XRSession.selectstart_event",
-  "selectstart")}} event which gets the target ray's pose from the frame, mapping the pose
+This code shows a handler for the {{domxref("XRSession.selectstart_event", "selectstart")}}
+event which gets the target ray's pose from the frame, mapping the pose
 representing the ray (`event.inputSource.targetRaySpace`) to the overall
 reference space `myRefSpace`.
 

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.md
@@ -35,8 +35,7 @@ list.
 
 ## Examples
 
-This code shows a handler for the {{domxref("XRSession.selectstart_event", "selectstart")}}
-event which gets the target ray's pose from the frame, mapping the pose
+This code shows a handler for the {{domxref("XRSession.selectstart_event", "selectstart")}} event which gets the target ray's pose from the frame, mapping the pose
 representing the ray (`event.inputSource.targetRaySpace`) to the overall
 reference space `myRefSpace`.
 

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
@@ -22,8 +22,7 @@ as a hand controller, motion sensing device, or other input apparatus.
 
 ## Examples
 
-The snippet below shows a handler for the {{domxref("XRSession.select_event",
-  "select")}} event which looks specifically for events which happen on `gaze`
+The snippet below shows a handler for the {{domxref("XRSession.select_event", "select")}} event which looks specifically for events which happen on `gaze`
 input devices. The device type is identified by looking at the
 {{domxref("XRInputSource")}} in `inputSource` and its
 {{domxref("XRInputSource.targetRayMode", "targetRayMode")}} property.

--- a/files/en-us/web/api/xrpose/transform/index.md
+++ b/files/en-us/web/api/xrpose/transform/index.md
@@ -23,8 +23,8 @@ An {{domxref("XRRigidTransform")}} which provides the position and orientation o
 
 ## Examples
 
-This handler for the {{domxref("XRSession")}} event {{domxref("XRSession.select_event",
-  "select")}} handles events for tracked pointers. It determines the targeted object by
+This handler for the {{domxref("XRSession")}} event {{domxref("XRSession.select_event", "select")}}
+handles events for tracked pointers. It determines the targeted object by
 passing the event frame's pose into a function called `findTargetUsingRay()`,
 then dispatches the event differently depending on the user's handedness; this is done
 by comparing the value of the {{domxref("XRInputSource")}} property

--- a/files/en-us/web/api/xrpose/transform/index.md
+++ b/files/en-us/web/api/xrpose/transform/index.md
@@ -23,8 +23,7 @@ An {{domxref("XRRigidTransform")}} which provides the position and orientation o
 
 ## Examples
 
-This handler for the {{domxref("XRSession")}} event {{domxref("XRSession.select_event", "select")}}
-handles events for tracked pointers. It determines the targeted object by
+This handler for the {{domxref("XRSession")}} event {{domxref("XRSession.select_event", "select")}} handles events for tracked pointers. It determines the targeted object by
 passing the event frame's pose into a function called `findTargetUsingRay()`,
 then dispatches the event differently depending on the user's handedness; this is done
 by comparing the value of the {{domxref("XRInputSource")}} property

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
@@ -77,8 +77,7 @@ In this code, we obtain a local reference space, then
 use `getOffsetReferenceSpace()` to create a new space whose origin is
 adjusted to a position given by `startPosition` and whose orientation is
 looking directly along the Z axis. Then the first animation frame is requested using
-{{domxref("XRSession")}}'s {{domxref("XRSession.requestAnimationFrame",
-  "requestAnimationFrame()")}}.
+{{domxref("XRSession")}}'s {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}.
 
 ### Implementing rotation based on non-XR inputs
 

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.md
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.md
@@ -23,8 +23,7 @@ value using {{domxref("XRSession.updateRenderState")}}.
 A {{domxref("XRWebGLLayer")}} object which is used as the source of the world's
 contents when rendering each frame of the scene.
 
-See the examples below to see how to use {{domxref("XRSession.updateRenderState",
-  "updateRenderState()")}} to set the current `XRWebGLLayer` used for rendering
+See the examples below to see how to use {{domxref("XRSession.updateRenderState", "updateRenderState()")}} to set the current `XRWebGLLayer` used for rendering
 the scene.
 
 ## Examples
@@ -50,8 +49,7 @@ function setNewWebGLLayer(gl) {
 ```
 
 Here, the canvas obtained in the first line is the canvas into which WebGL is going to
-draw. That context is passed into {{domxref("XRWebGLLayer.XRWebGLLayer", "new
-  XRWebGLLayer()")}} to create an `XRWebGLLayer` which uses the contents of the
+draw. That context is passed into {{domxref("XRWebGLLayer.XRWebGLLayer", "new XRWebGLLayer()")}} to create an `XRWebGLLayer` which uses the contents of the
 WebGL context `gl` as the source of the world's image during presentation.
 
 ## Specifications

--- a/files/en-us/web/api/xrrigidtransform/matrix/index.md
+++ b/files/en-us/web/api/xrrigidtransform/matrix/index.md
@@ -12,8 +12,8 @@ The read-only {{domxref("XRRigidTransform")}} property
 **`matrix`** returns the transform
 matrix represented by the object. The returned matrix can then be premultiplied with a
 column vector to rotate the
-vector by the 3D rotation specified by the {{domxref("XRRigidTransform.orientation",
-  "orientation")}}, then translate
+vector by the 3D rotation specified by the
+{{domxref("XRRigidTransform.orientation", "orientation")}}, then translate
 it by the {{domxref("XRRigidTransform.position", "position")}}.
 
 ## Value
@@ -21,8 +21,7 @@ it by the {{domxref("XRRigidTransform.position", "position")}}.
 A {{jsxref("Float32Array")}} containing 16 entries which represents the 4x4 transform
 matrix which is described by
 the {{domxref("XRRigidTransform.position", "position")}} and
-{{domxref("XRRigidTransform.orientation",
-  "orientation")}} properties.
+{{domxref("XRRigidTransform.orientation", "orientation")}} properties.
 
 ## Usage notes
 

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.md
@@ -12,8 +12,7 @@ browser-compat: api.XRSession.cancelAnimationFrame
 
 The **`cancelAnimationFrame()`** method of
 the {{domxref("XRSession")}} interface cancels an animation frame which was previously
-requested by calling {{DOMxRef("XRSession.requestAnimationFrame",
-    "requestAnimationFrame")}}.
+requested by calling {{DOMxRef("XRSession.requestAnimationFrame", "requestAnimationFrame")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/xrsession/visibilitystate/index.md
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.md
@@ -48,8 +48,8 @@ It's important to keep in mind that because an immersive WebXR session is potent
 being shown using a different display than the HTML document in which it's running (such
 as when being shown on a headset), the value of a
 session's `visibilityState` may not necessarily be the same as the owning
-_{{domxref("document")}}'s_ {{domxref("Document.visibilityState",
-  "visibilityState")}}. For instance, if the viewer is using a headset tethered to a
+_{{domxref("document")}}'s_ {{domxref("Document.visibilityState", "visibilityState")}}.
+For instance, if the viewer is using a headset tethered to a
 computer and the immersive scene is obscured by a configuration UI, the user could peek
 out from behind the headset and still be able to see the document itself on their
 computer's monitor.

--- a/files/en-us/web/api/xrviewport/x/index.md
+++ b/files/en-us/web/api/xrviewport/x/index.md
@@ -10,11 +10,11 @@ browser-compat: api.XRViewport.x
 
 The read-only {{domxref("XRViewport")}} interface's
 **`x`** property indicates the offset from the left edge of
-the destination surface (typically a {{domxref("XRWebGLLayer")}} to the left edge of
+the destination surface (typically a {{domxref("XRWebGLLayer")}}) to the left edge of
 the viewport within the surface into which WebXR content is to be rendered. The
 viewport's {{domxref("XRViewport.y", "y")}} property identifies the `y`
-component of the origin, and its is given by the {{domxref("XRViewPort.width",
-  "width")}} and {{domxref("XRViewport.height", "height")}} properties.
+component of the origin, and its is given by the {{domxref("XRViewPort.width", "width")}}
+and {{domxref("XRViewport.height", "height")}} properties.
 
 ## Value
 

--- a/files/en-us/web/api/xrviewport/y/index.md
+++ b/files/en-us/web/api/xrviewport/y/index.md
@@ -10,11 +10,11 @@ browser-compat: api.XRViewport.y
 
 The read-only {{domxref("XRViewport")}} interface's
 **`y`** property indicates the offset from the bottom edge of
-the destination surface (typically a {{domxref("XRWebGLLayer")}} to the bottom edge of
+the destination surface (typically a {{domxref("XRWebGLLayer")}}) to the bottom edge of
 the viewport within the surface into which WebXR content is to be rendered. The
 viewport's {{domxref("XRViewport.x", "x")}} property identifies the `x`
-component of the origin, and its is given by the {{domxref("XRViewPort.width",
-  "width")}} and {{domxref("XRViewport.height", "height")}} properties.
+component of the origin, and its is given by the {{domxref("XRViewPort.width", "width")}}
+and {{domxref("XRViewport.height", "height")}} properties.
 
 ## Value
 

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -36,28 +36,22 @@ framebuffer:
 - Opaque framebuffers' attachments (buffers and the like) can't be inspected or
   changed. Calling functions such as
   {{domxref("WebGLRenderingContext.framebufferTexture2D", "framebufferTexture2D()")}},
-  {{domxref("WebGLRenderingContext.framebufferRenderbuffer",
-    "framebufferRenderbuffer()")}}, {{domxref("WebGLRenderingContext.deleteFramebuffer",
-    "deleteFramebuffer()")}}, or
-  {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter",
-    "getFramebufferAttachmentParameter()")}} on an opaque framebuffer results in the WebGL
-  error `INVALID_OPERATION` (0x0502).
+  {{domxref("WebGLRenderingContext.framebufferRenderbuffer", "framebufferRenderbuffer()")}},
+  {{domxref("WebGLRenderingContext.deleteFramebuffer","deleteFramebuffer()")}}, or
+  {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter", "getFramebufferAttachmentParameter()")}}
+  on an opaque framebuffer results in the WebGL error `INVALID_OPERATION` (0x0502).
 - Opaque framebuffers are considered incomplete and are not available for rendering
-  other than while executing the {{domxref("XRSession.requestAnimationFrame",
-    "requestAnimationFrame()")}} callback. Attempting to clear, draw to, or read from the
-  framebuffer results in a WebGL `INVALID_FRAMEBUFFER_OPERATION` error
-  (0x0506). Calling {{domxref("WebGLRenderingContext.checkFramebufferStatus",
-    "checkFramebufferStatus()")}} on the WebGL context from outside the animation frame
-  callback causes the WebGL `FRAMEBUFFER_UNSUPPORTED` error (0x8CDD) to be
-  reported.
+  other than while executing the {{domxref("XRSession.requestAnimationFrame","requestAnimationFrame()")}} callback.
+  Attempting to clear, draw to, or read from the framebuffer results in a WebGL `INVALID_FRAMEBUFFER_OPERATION` error (0x0506).
+  Calling {{domxref("WebGLRenderingContext.checkFramebufferStatus", "checkFramebufferStatus()")}} on the WebGL context from outside the animation frame
+  callback causes the WebGL `FRAMEBUFFER_UNSUPPORTED` error (0x8CDD) to be reported.
 - Opaque framebuffers initialized with the `depth` property set to `false` will not have a depth buffer and will
   rely on the coordinates alone to determine distance.
 - Opaque framebuffers initialized without specifying a `stencil`")}}` will not have a stencil buffer.
 - Opaque framebuffers will not have an alpha channel available unless the `alpha` property is `true` when
   creating the layer.
 - The XR compositor assumes that opaque framebuffers use colors with premultiplied
-  alpha, regardless of whether or not the WebGL context's
-  `premultipliedAlpha`")}}` context
+  alpha, regardless of whether or not the WebGL context's `premultipliedAlpha`")}}` context
   attribute is set.
 
 > **Note:** The `depth` and `stencil` properties are
@@ -77,8 +71,7 @@ just like the default framebuffer for any WebGL interface:
 ## Examples
 
 This example gets the `XRWebGLLayer` for a session and then passes its
-framebuffer into the WebGL context's {{domxref("WebGLRenderingContext.bindFramebuffer",
-  "bindFramebuffer()")}} function.
+framebuffer into the WebGL context's {{domxref("WebGLRenderingContext.bindFramebuffer", "bindFramebuffer()")}} function.
 
 ```js
 let glLayer = xrSession.renderState.baselayer;

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor_static/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor_static/index.md
@@ -110,8 +110,8 @@ function requestNativeScaleWebGLLayer(gl, xrSession) {
 }
 ```
 
-This starts by calling the [WebGL rendering context](/en-US/docs/Web/API/WebGLRenderingContext) function {{domxref("WebGLRenderingContext.makeXRCompatible",
-  "makeXRCompatible()")}}. When the returned {{jsxref("promise")}} resolves, we proceed by
+This starts by calling the [WebGL rendering context](/en-US/docs/Web/API/WebGLRenderingContext) function
+{{domxref("WebGLRenderingContext.makeXRCompatible", "makeXRCompatible()")}}. When the returned {{jsxref("promise")}} resolves, we proceed by
 calling `XRWebGLLayer`'s `getNativeFramebufferScaleFactor()`
 static function to get the scale factor needed to reach the native resolution, and we
 then pass that into the {{domxref("XRWebGLLayer.XRWebGLLayer", "WebGLLayer()")}}
@@ -120,8 +120,8 @@ property in its `layerInit` configuration object.
 
 That gets us a new {{domxref("XRWebGLLayer")}} object representing a rendering surface
 we can use for the {{domxref("XRSession")}}; we set it as the rendering surface for
-`xrSession` by calling its {{domxref("XRSession.updateRenderState",
-  "updateRenderState()")}} method, passing the new `glLayer` in using the
+`xrSession` by calling its
+{{domxref("XRSession.updateRenderState", "updateRenderState()")}} method, passing the new `glLayer` in using the
 {{domxref("XRRenderState")}} dictionary's {{domxref("XRRenderState.baseLayer")}}
 property. The result is a rendering context that looks like the diagram below:
 

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
@@ -74,5 +74,4 @@ let glLayer = new XRWebGLLayer(xrSession, gl, glLayerOptions);
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- WebGL depth buffer related methods: {{domxref("WebGLRenderingContext.depthFunc",
-    "depthFunc()")}}, {{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}}
+- WebGL depth buffer related methods: {{domxref("WebGLRenderingContext.depthFunc", "depthFunc()")}}, {{domxref("WebGLRenderingContext.clearDepth", "clearDepth()")}}

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -25,8 +25,7 @@ a full body message a partial message belongs.
     </tr>
     <tr>
       <th scope="row">
-        {{Glossary("Simple response header", "CORS-safelisted
-        response-header")}}
+        {{Glossary("Simple response header", "CORS-safelisted response-header")}}
       </th>
       <td>no</td>
     </tr>

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -55,8 +55,7 @@ where `<policy-directive>` consists of:
 - {{CSP("connect-src")}}
   - : Restricts the URLs which can be loaded using script interfaces.
 - {{CSP("default-src")}}
-  - : Serves as a fallback for the other {{Glossary("Fetch directive", "fetch
-    directives")}}.
+  - : Serves as a fallback for the other {{Glossary("Fetch directive", "fetch directives")}}.
 - {{CSP("fenced-frame-src")}}
   - : Specifies valid sources for nested browsing contexts loaded into {{HTMLElement("fencedframe")}} elements.
 - {{CSP("font-src")}}

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
@@ -80,7 +80,7 @@ loaded over {{glossary("HTTPS")}}. On Firefox, this can be changed by setting th
 
 You can either send the `X-DNS-Prefetch-Control` header server-side, or from
 individual documents, using the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#http-equiv) attribute on
-the {{ HTMLElement("meta") }} element, like this:
+the {{HTMLElement("meta")}} element, like this:
 
 ```html
 <meta http-equiv="x-dns-prefetch-control" content="off" />
@@ -91,8 +91,8 @@ You can reverse this setting by setting `content` to "`on`".
 ### Forcing lookup of specific hostnames
 
 You can force the lookup of specific hostnames without providing specific anchors using
-that hostname by using the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute on the {{
-  HTMLElement("link") }} element with a [link type](/en-US/docs/Web/HTML/Attributes/rel) of `dns-prefetch`:
+that hostname by using the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute on the
+{{HTMLElement("link")}} element with a [link type](/en-US/docs/Web/HTML/Attributes/rel) of `dns-prefetch`:
 
 ```html
 <link rel="dns-prefetch" href="https://www.mozilla.org" />

--- a/files/en-us/web/http/methods/connect/index.md
+++ b/files/en-us/web/http/methods/connect/index.md
@@ -11,8 +11,8 @@ The **HTTP `CONNECT` method** starts two-way communications
 with the requested resource. It can be used to open a tunnel.
 
 For example, the `CONNECT` method can be used to access websites that use
-{{Glossary("TLS")}} ({{Glossary("HTTPS")}}). The client asks an HTTP {{Glossary("Proxy
-  server")}} to tunnel the [TCP](/en-US/docs/Glossary/TCP) connection to
+{{Glossary("TLS")}} ({{Glossary("HTTPS")}}). The client asks an HTTP {{Glossary("Proxy server")}}
+to tunnel the [TCP](/en-US/docs/Glossary/TCP) connection to
 the desired destination. The proxy server then proceeds to make the connection on behalf of
 the client. Once the connection is established, the
 proxy server continues to relay the TCP stream to and

--- a/files/en-us/web/http/status/302/index.md
+++ b/files/en-us/web/http/status/302/index.md
@@ -17,8 +17,8 @@ Even if the specification requires the method (and the body) not to be altered w
 redirection is performed, not all user-agents conform here - you can still find this
 type of bugged software out there. It is therefore recommended to set the
 `302` code only as a response for {{HTTPMethod("GET")}} or
-{{HTTPMethod("HEAD")}} methods and to use {{HTTPStatus("307", "307 Temporary
-  Redirect")}} instead, as the method change is explicitly prohibited in that case.
+{{HTTPMethod("HEAD")}} methods and to use {{HTTPStatus("307", "307 Temporary Redirect")}}
+instead, as the method change is explicitly prohibited in that case.
 
 In the cases where you want the method used to be changed to {{HTTPMethod("GET")}}, use
 {{HTTPStatus("303", "303 See Other")}} instead. This is useful when you want to give a

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -110,8 +110,7 @@ cases:
           iterates
           <strong>all</strong> of an object's properties; the various mechanisms
           each include different subsets of properties.
-          ({{jsxref("Statements/for...in",
-          "for-in")}}
+          ({{jsxref("Statements/for...in", "for-in")}}
           includes only enumerable string-keyed properties;
           {{jsxref("Object.keys")}} includes only own, enumerable,
           string-keyed properties;


### PR DESCRIPTION
### Description

This PR makes macros that span multiple lines span a single lines only.

### Motivation

Removing poor authoring patterns, helping to make the documentation more ergonomic and readable for authors and easier to maintain in future when we want to remove or update these macros.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/32510
- [x] https://github.com/mdn/content/pull/32581
- [x] https://github.com/mdn/content/pull/32582
- [x] https://github.com/mdn/content/pull/32583

