### PR TITLE
feat(CSS): Add interactive example for `text-wrap`

### DIFF
--- a/files/en-us/web/css/text-wrap/index.md
+++ b/files/en-us/web/css/text-wrap/index.md
@@ -14,6 +14,8 @@ The **`text-wrap`** CSS property controls how text inside an element is wrapped.
 
 > **Note:** The {{CSSxRef("white-space-collapse")}} and `text-wrap` properties can be declared together using the {{CSSxRef("white-space")}} shorthand property.
 
+{{EmbedInteractiveExample("pages/css/text-wrap.html")}}
+
 ## Syntax
 
 ```css


### PR DESCRIPTION
### Description

This PR adds an interactive example for the CSS property `text-wrap`.

### Motivation

There is no interactive example.

### Additional details

[Add example of `text-wrap`](https://github.com/mdn/interactive-examples/pull/2745)