### PR TITLE
Fix typo in "Introduction to client-side frameworks"

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/introduction/index.md
@@ -121,7 +121,7 @@ The previous snippet references another build function: `buildDeleteButtonEl()`.
 function buildDeleteButtonEl(id) {
   const button = document.createElement("button");
   button.setAttribute("type", "button");
-  button.textContent "Delete";
+  button.textContent = "Delete";
 
   return button;
 }


### PR DESCRIPTION
A missing '=' in a JS code snippet in [Introduction to client-side frameworks](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Introduction) has been added. Specifically, it is in the 4th line of the buildDeleteButtonEl() function.