### PR TITLE
HTTP Warning Header - deprecation warning

### DIFF
--- a/files/en-us/web/http/headers/warning/index.md
+++ b/files/en-us/web/http/headers/warning/index.md
@@ -9,6 +9,9 @@ browser-compat: http.headers.Warning
 
 {{HTTPSidebar}} {{deprecated_header}}
 
+> **Note:** The header was deprecated because it is not widely generated or surfaced to users (see [RFC9111](https://www.rfc-editor.org/rfc/rfc9111#field.warning)).
+> Some of the information can be inferred from other headers such as {{httpheader("Age")}}.
+
 The **`Warning`** HTTP header contains information about possible problems with the status of the message.
 More than one `Warning` header may appear in a response.
 


### PR DESCRIPTION
Fixes #32564

Generally I think if we can state the alternatives approach for a deprecated entity, that is a "good thing" - in this way we can because the spec states it. 

This would be much easier if we had https://github.com/mdn/yari/issues/8969