### PR TITLE
Fix misleading information regarding default value of `lang` attribute

### DIFF
--- a/files/en-us/web/html/global_attributes/lang/index.md
+++ b/files/en-us/web/html/global_attributes/lang/index.md
@@ -9,7 +9,7 @@ browser-compat: html.global_attributes.lang
 
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single "language tag" in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
-> **Note:** The default value of `lang` is `unknown`, therefore it is recommended to always specify this attribute with the appropriate value.
+> **Note:** The default value of `lang` is the empty string. It is recommended to always specify this attribute with the appropriate value.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}
 

--- a/files/en-us/web/html/global_attributes/lang/index.md
+++ b/files/en-us/web/html/global_attributes/lang/index.md
@@ -9,7 +9,7 @@ browser-compat: html.global_attributes.lang
 
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single "language tag" in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
-> **Note:** The default value of `lang` is the empty string which means the language is unknown, therefore it is recommended to always specify this attribute with the appropriate value.
+> **Note:** The default value of `lang` is the empty string, which means that the language is unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}
 

--- a/files/en-us/web/html/global_attributes/lang/index.md
+++ b/files/en-us/web/html/global_attributes/lang/index.md
@@ -9,7 +9,7 @@ browser-compat: html.global_attributes.lang
 
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single "language tag" in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
-> **Note:** The default value of `lang` is the empty string which means the language is unknown. It is recommended to always specify this attribute with the appropriate value.
+> **Note:** The default value of `lang` is the empty string which means the language is unknown, therefore it is recommended to always specify this attribute with the appropriate value.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}
 

--- a/files/en-us/web/html/global_attributes/lang/index.md
+++ b/files/en-us/web/html/global_attributes/lang/index.md
@@ -9,7 +9,7 @@ browser-compat: html.global_attributes.lang
 
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single "language tag" in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
-> **Note:** The default value of `lang` is the empty string. It is recommended to always specify this attribute with the appropriate value.
+> **Note:** The default value of `lang` is the empty string which means the language is unknown. It is recommended to always specify this attribute with the appropriate value.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}
 


### PR DESCRIPTION
### Description

Previously the word "unknown" was highlighed as code tag, which was misleading. The word appears in [W3C specs](https://www.w3.org/TR/html401/struct/dirlang.html#language-info) as literal text only and I'd say it was never meant to be interpreted as a string:

> The default value of this attribute is unknown

The [WHATWG spec](https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes) gives a better description:

> Its value must be a valid BCP 47 language tag, or the empty string. Setting the attribute to the empty string indicates that the primary language is unknown.

### Motivation

I was mislead believing `"unknown"` was a valid value for the `lang` attribute, see https://github.com/github/relative-time-element/pull/275 for more discussion.