### PR TITLE
HTMLElement.click() - can be called on any element unless disabled

### DIFF
--- a/files/en-us/web/api/htmlelement/click/index.md
+++ b/files/en-us/web/api/htmlelement/click/index.md
@@ -8,13 +8,7 @@ browser-compat: api.HTMLElement.click
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLElement.click()`** method simulates a mouse click on
-an element.
-
-When `click()` is used with supported elements (such as an
-{{HTMLElement("input")}}), it fires the element's click event. This event then bubbles
-up to elements higher in the document tree (or event chain) and fires their click
-events.
+The **`HTMLElement.click()`** method simulates a mouse click on an element. When called on an element, the element's {{domxref("Element/click_event", "click")}} event is fired (unless its [`disabled`](/en-US/docs/Web/HTML/Attributes/disabled) attribute is set).
 
 ## Syntax
 


### PR DESCRIPTION
Fixes #32567

It is likely that all elements support the `click()` method (based on testing of some cases that you wouldn't think would, such as `style`). 
This makes that more clear by stating that the event will fire if this is called on an element. 