### PR TITLE
Refactor docs to separate WebGL v1 and v2 content.

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
@@ -8,13 +8,11 @@ browser-compat: api.WebGL2RenderingContext.bufferData
 
 {{APIRef("WebGL")}}
 
-The **`WebGL2RenderingContext.bufferData()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) initializes and creates the
-buffer object's data store.
+The **`WebGL2RenderingContext.bufferData()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) creates and initializes the buffer object's data store.
 
 ## Syntax
 
 ```js-nolint
-// WebGL2
 bufferData(target, usage, srcOffset)
 bufferData(target, srcData, usage, srcOffset)
 bufferData(target, srcData, usage, srcOffset, length)
@@ -44,13 +42,15 @@ bufferData(target, srcData, usage, srcOffset, length)
     - `gl.PIXEL_UNPACK_BUFFER`
       - : Buffer used for pixel transfer operations.
 
-- `size`
+- `size`  {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLsizeiptr")}} setting the size in bytes of the buffer object's data
     store.
+    One of `size` and `srcData` must be provided.
 - `srcData` {{optional_inline}}
   - : An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}}, a {{jsxref("TypedArray")}} or a {{jsxref("DataView")}}
     that will be copied into the data store.
     If `null`, a data store is still created, but the content is uninitialized and undefined.
+    One of `size` and `srcData` must be provided.
 - `usage`
 
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the intended usage pattern of the data store
@@ -95,11 +95,13 @@ bufferData(target, srcData, usage, srcOffset, length)
         times as the source for WebGL drawing and image specification
         commands.
 
-- `srcOffset`
+- `srcOffset` {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading
     the buffer.
+    Only allowed if `srcData` is provided.
 - `length` {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0.
+  Only allowed if `srcOffset` is given.
 
 ### Return value
 

--- a/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
@@ -1,23 +1,23 @@
 ---
-title: "WebGLRenderingContext: bufferData() method"
+title: "WebGL2RenderingContext: bufferData() method"
 short-title: bufferData()
-slug: Web/API/WebGLRenderingContext/bufferData
+slug: Web/API/WebGL2RenderingContext/bufferData
 page-type: web-api-instance-method
-browser-compat: api.WebGLRenderingContext.bufferData
+browser-compat: api.WebGL2RenderingContext.bufferData
 ---
 
 {{APIRef("WebGL")}}
 
-The **`WebGLRenderingContext.bufferData()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) initializes and creates the
+The **`WebGL2RenderingContext.bufferData()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) initializes and creates the
 buffer object's data store.
 
 ## Syntax
 
 ```js-nolint
-// WebGL1
-bufferData(target, usage)
-bufferData(target, size, usage)
-bufferData(target, srcData, usage)
+// WebGL2
+bufferData(target, usage, srcOffset)
+bufferData(target, srcData, usage, srcOffset)
+bufferData(target, srcData, usage, srcOffset, length)
 ```
 
 ### Parameters
@@ -31,9 +31,6 @@ bufferData(target, srcData, usage)
         vertex coordinates, texture coordinate data, or vertex color data.
     - `gl.ELEMENT_ARRAY_BUFFER`
       - : Buffer used for element indices.
-
-    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the following values are available additionally:
-
     - `gl.COPY_READ_BUFFER`
       - : Buffer for copying from one buffer object to another.
     - `gl.COPY_WRITE_BUFFER`
@@ -71,9 +68,6 @@ bufferData(target, srcData, usage)
       - : The contents are intended to be specified
         once by the application, and used at most a few times as the source for
         WebGL drawing and image specification commands.
-
-    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}}, the following values are available additionally:
-
     - `gl.STATIC_READ`
       - : The contents are intended to be
         specified once by reading data from WebGL, and queried many times
@@ -101,6 +95,12 @@ bufferData(target, srcData, usage)
         times as the source for WebGL drawing and image specification
         commands.
 
+- `srcOffset`
+  - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading
+    the buffer.
+- `length` {{optional_inline}}
+  - : A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0.
+
 ### Return value
 
 None ({{jsxref("undefined")}}).
@@ -113,37 +113,6 @@ None ({{jsxref("undefined")}}).
 - A `gl.INVALID_ENUM` error is thrown if `target` or
   `usage` are not one of the allowed enums.
 
-## Examples
-
-### Using bufferData
-
-```js
-const canvas = document.getElementById("canvas");
-const gl = canvas.getContext("webgl");
-const buffer = gl.createBuffer();
-gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-gl.bufferData(gl.ARRAY_BUFFER, 1024, gl.STATIC_DRAW);
-```
-
-### Getting buffer information
-
-To check the current buffer usage and buffer size, use the
-{{domxref("WebGLRenderingContext.getBufferParameter()")}} method.
-
-```js
-gl.getBufferParameter(gl.ARRAY_BUFFER, gl.BUFFER_SIZE);
-gl.getBufferParameter(gl.ARRAY_BUFFER, gl.BUFFER_USAGE);
-```
-
-### Getting size of a typed array
-
-To calculate size parameter for a typed array.
-
-```js
-const dataArray = new Float32Array([1, 2, 3, 4]);
-const sizeInBytes = dataArray.length * dataArray.BYTES_PER_ELEMENT;
-```
-
 ## Specifications
 
 {{Specifications}}
@@ -154,7 +123,7 @@ const sizeInBytes = dataArray.length * dataArray.BYTES_PER_ELEMENT;
 
 ## See also
 
-- {{domxref("WebGL2RenderingContext.bufferData()")}}
+- {{domxref("WebGLRenderingContext.bufferData()")}}
 - {{domxref("WebGLRenderingContext.createBuffer()")}}
 - {{domxref("WebGLRenderingContext.bufferSubData()")}}
 - Other buffers: {{domxref("WebGLFramebuffer")}}, {{domxref("WebGLRenderbuffer")}}

--- a/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
@@ -13,7 +13,8 @@ The **`WebGL2RenderingContext.bufferData()`** method of the [WebGL API](/en-US/d
 ## Syntax
 
 ```js-nolint
-bufferData(target, usage, srcOffset)
+bufferData(target, size, usage)
+bufferData(target, srcData, usage)
 bufferData(target, srcData, usage, srcOffset)
 bufferData(target, srcData, usage, srcOffset, length)
 ```
@@ -52,7 +53,6 @@ bufferData(target, srcData, usage, srcOffset, length)
     If `null`, a data store is still created, but the content is uninitialized and undefined.
     One of `size` and `srcData` must be provided.
 - `usage`
-
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the intended usage pattern of the data store
     for optimization purposes. Possible values:
 

--- a/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
@@ -42,7 +42,7 @@ bufferData(target, srcData, usage, srcOffset, length)
     - `gl.PIXEL_UNPACK_BUFFER`
       - : Buffer used for pixel transfer operations.
 
-- `size`  {{optional_inline}}
+- `size` {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLsizeiptr")}} setting the size in bytes of the buffer object's data
     store.
     One of `size` and `srcData` must be provided.
@@ -101,7 +101,7 @@ bufferData(target, srcData, usage, srcOffset, length)
     Only allowed if `srcData` is provided.
 - `length` {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0.
-  Only allowed if `srcOffset` is given.
+    Only allowed if `srcOffset` is given.
 
 ### Return value
 

--- a/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bufferdata/index.md
@@ -53,6 +53,7 @@ bufferData(target, srcData, usage, srcOffset, length)
     If `null`, a data store is still created, but the content is uninitialized and undefined.
     One of `size` and `srcData` must be provided.
 - `usage`
+
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the intended usage pattern of the data store
     for optimization purposes. Possible values:
 

--- a/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
@@ -31,7 +31,6 @@ bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
       - : Buffer containing vertex attributes, such as
         vertex coordinates, texture coordinate data, or vertex color data.
     - `gl.ELEMENT_ARRAY_BUFFER`
-
       - : Buffer used for element indices.
     - `gl.COPY_READ_BUFFER`
       - : Buffer for copying from one buffer object to another.

--- a/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
@@ -15,7 +15,6 @@ object's data store.
 ## Syntax
 
 ```js-nolint
-// WebGL2
 bufferSubData(target, dstByteOffset, srcOffset)
 bufferSubData(target, dstByteOffset, srcData, srcOffset)
 bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
@@ -51,7 +50,7 @@ bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
 - `srcData` {{optional_inline}}
   - : An {{jsxref("ArrayBuffer")}}, {{jsxref("SharedArrayBuffer")}}, a {{jsxref("DataView")}}, or a {{jsxref("TypedArray")}}
     that will be copied into the data store.
-- `srcOffset`
+- `srcOffset` {{optional_inline}}
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading
     the buffer.
 - `length` {{optional_inline}}

--- a/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
@@ -15,7 +15,7 @@ object's data store.
 ## Syntax
 
 ```js-nolint
-bufferSubData(target, dstByteOffset, srcOffset)
+bufferSubData(target, dstByteOffset, srcData)
 bufferSubData(target, dstByteOffset, srcData, srcOffset)
 bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
 ```
@@ -54,7 +54,7 @@ bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
   - : A {{domxref("WebGL_API/Types", "GLuint")}} specifying the element index offset where to start reading
     the buffer.
 - `length` {{optional_inline}}
-  - : A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0.
+  - : A {{domxref("WebGL_API/Types", "GLuint")}} defaulting to 0, where 0 means `bufferSubData` should calculate the length.
 
 ### Return value
 

--- a/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/buffersubdata/index.md
@@ -1,23 +1,24 @@
 ---
-title: "WebGLRenderingContext: bufferSubData() method"
+title: "WebGL2RenderingContext: bufferSubData() method"
 short-title: bufferSubData()
-slug: Web/API/WebGLRenderingContext/bufferSubData
+slug: Web/API/WebGL2RenderingContext/bufferSubData
 page-type: web-api-instance-method
-browser-compat: api.WebGLRenderingContext.bufferSubData
+browser-compat: api.WebGL2RenderingContext.bufferSubData
 ---
 
 {{APIRef("WebGL")}}
 
-The **`WebGLRenderingContext.bufferSubData()`** method of the
+The **`WebGL2RenderingContext.bufferSubData()`** method of the
 [WebGL API](/en-US/docs/Web/API/WebGL_API) updates a subset of a buffer
 object's data store.
 
 ## Syntax
 
 ```js-nolint
-// WebGL1
-bufferSubData(target, offset)
-bufferSubData(target, offset, srcData)
+// WebGL2
+bufferSubData(target, dstByteOffset, srcOffset)
+bufferSubData(target, dstByteOffset, srcData, srcOffset)
+bufferSubData(target, dstByteOffset, srcData, srcOffset, length)
 ```
 
 ### Parameters
@@ -32,10 +33,6 @@ bufferSubData(target, offset, srcData)
     - `gl.ELEMENT_ARRAY_BUFFER`
 
       - : Buffer used for element indices.
-
-    When using a {{domxref("WebGL2RenderingContext", "WebGL 2 context", "", 1)}},
-    the following values are available additionally:
-
     - `gl.COPY_READ_BUFFER`
       - : Buffer for copying from one buffer object to another.
     - `gl.COPY_WRITE_BUFFER`
@@ -72,19 +69,6 @@ None ({{jsxref("undefined")}}).
 - A `gl.INVALID_ENUM` error is thrown if `target` is not one of
   the allowed enums.
 
-## Examples
-
-### Using `bufferSubData`
-
-```js
-const canvas = document.getElementById("canvas");
-const gl = canvas.getContext("webgl");
-const buffer = gl.createBuffer();
-gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-gl.bufferData(gl.ARRAY_BUFFER, 1024, gl.STATIC_DRAW);
-gl.bufferSubData(gl.ARRAY_BUFFER, 512, data);
-```
-
 ## Specifications
 
 {{Specifications}}
@@ -95,7 +79,7 @@ gl.bufferSubData(gl.ARRAY_BUFFER, 512, data);
 
 ## See also
 
-- {{domxref("WebGL2RenderingContext.bufferSubData()")}}
+- {{domxref("WebGLRenderingContext.bufferSubData()")}}
 - {{domxref("WebGLRenderingContext.createBuffer()")}}
 - {{domxref("WebGLRenderingContext.bufferData()")}}
 - Other buffers: {{domxref("WebGLFramebuffer")}}, {{domxref("WebGLRenderbuffer")}}

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
@@ -14,8 +14,6 @@ buffer object's data store.
 ## Syntax
 
 ```js-nolint
-// WebGL1
-bufferData(target, usage)
 bufferData(target, size, usage)
 bufferData(target, srcData, usage)
 ```

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
@@ -15,7 +15,6 @@ object's data store.
 ## Syntax
 
 ```js-nolint
-// WebGL1
 bufferSubData(target, offset)
 bufferSubData(target, offset, srcData)
 ```


### PR DESCRIPTION
### Description

WebGLRenderingContext and WebGL2RenderingContext have overloaded versions of the bufferData and bufferSubData functions. Before, all were documented under files/en-us/web/api/webglrenderingcontext. After a discussion on [a previous PR](https://github.com/mdn/content/pull/32598) it was decided to split them up.

### Motivation

As things stand today, webgl2renderingcontext/index.md contains broken links. This PR creates the files required to resolve those links.

### Related issues and pull requests

Relates to https://github.com/mdn/content/pull/32598
