### PR TITLE
Fix typo under "Determining storage access by a third party"

### DIFF
--- a/files/en-us/web/api/web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/index.md
@@ -34,7 +34,7 @@ These mechanisms are available via the {{domxref("Window.sessionStorage")}} and 
 
 ## Determining storage access by a third party
 
-Each origin has its own storage — this is true for both web storage and [shared storage](/en-US/docs/Web/API/Shared_Storage_API)). However, access of third-party (i.e., embedded) code to shared storage depends on its [browsing context](/en-US/docs/Glossary/Browsing_context). The context in which a third-party code from another origin runs determines the storage access of the third-party code.
+Each origin has its own storage — this is true for both web storage and [shared storage](/en-US/docs/Web/API/Shared_Storage_API). However, access of third-party (i.e., embedded) code to shared storage depends on its [browsing context](/en-US/docs/Glossary/Browsing_context). The context in which a third-party code from another origin runs determines the storage access of the third-party code.
 
 ![A box diagram showing a top-level browsing context called publisher.com, with third-party content embedded in it](embedded-content.png)
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Removed an extra closed parenthesis in the first paragraph of the section under "Determining storage access by a third party".
