### PR TITLE
Add more relevant frame buffer methods

### DIFF
--- a/files/en-us/web/api/webglframebuffer/index.md
+++ b/files/en-us/web/api/webglframebuffer/index.md
@@ -19,6 +19,8 @@ The `WebGLFramebuffer` object does not define any methods or properties of its o
 - {{domxref("WebGLRenderingContext.createFramebuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteFramebuffer()")}}
 - {{domxref("WebGLRenderingContext.isFramebuffer()")}}
+- {{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.framebufferTexture2D()")}}
 
 ## Examples
 
@@ -44,4 +46,6 @@ const buffer = gl.createFramebuffer();
 - {{domxref("WebGLRenderingContext.createFramebuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteFramebuffer()")}}
 - {{domxref("WebGLRenderingContext.isFramebuffer()")}}
+- {{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.framebufferTexture2D()")}}
 - Other buffers: {{domxref("WebGLBuffer")}}, {{domxref("WebGLRenderbuffer")}}


### PR DESCRIPTION
### Description

Link to methods relating to frame buffers in WebGL.

### Motivation

Makes it easier to see the surface of frame buffer APIs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
