### PR TITLE
Fix #32630

### DIFF
--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -7,7 +7,7 @@ page-type: javascript-error
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "can't access lexical declaration \`_variable_' before initialization" occurs when a lexical variable was accessed before it was initialized.
-This happens within any block statement, when [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) variables are accessed before the place where they are declared is executed.
+This happens within any scope (global, module, function, or block) when [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) variables are accessed before the place where they are declared is executed.
 
 ## Message
 
@@ -24,7 +24,7 @@ ReferenceError: Cannot access uninitialized variable. (Safari)
 ## What went wrong?
 
 A lexical variable was accessed before it was initialized.
-This happens within any block statement, when variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) are accessed before the place where they are declared has been executed.
+This happens within any scope (global, module, function, or block) when variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) are accessed before the place where they are declared has been executed.
 
 Note that it is the execution order of access and variable declaration that matters, not the order in which the statements appear in the code.
 For more information, see the description of [Temporal Dead Zone](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).


### PR DESCRIPTION
Fixes #32630 by talking about scopes, not block statements

### Description

Talk about scopes rather than block statements, while still mentioning blocks

### Motivation

The previous text was open to misinterpretation (details in the issue).