### PR TITLE
Bluetooth.requestDevice() update the options

### DIFF
--- a/files/en-us/web/api/bluetooth/index.md
+++ b/files/en-us/web/api/bluetooth/index.md
@@ -26,13 +26,6 @@ _Inherits properties from its parent {{domxref("EventTarget")}}._
 - {{domxref("Bluetooth.requestDevice","Bluetooth.requestDevice()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object with the specified options.
 
-## Events
-
-Listen to these events using {{domxref("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
-
-- {{DOMxRef("Bluetooth/availabilitychanged_event", "availabilitychanged")}}
-  - : Fired on {{domxref("navigator.bluetooth")}} when the Bluetooth system as a whole becomes available or unavailable to the user agent.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/bluetooth/index.md
+++ b/files/en-us/web/api/bluetooth/index.md
@@ -26,6 +26,13 @@ _Inherits properties from its parent {{domxref("EventTarget")}}._
 - {{domxref("Bluetooth.requestDevice","Bluetooth.requestDevice()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object with the specified options.
 
+## Events
+
+Listen to these events using {{domxref("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
+- {{DOMxRef("Bluetooth/availabilitychanged_event", "availabilitychanged")}}
+  - : Fired on {{domxref("navigator.bluetooth")}} when the Bluetooth system as a whole becomes available or unavailable to the user agent.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -30,15 +30,15 @@ requestDevice(options)
     - `filters` {{optional_inline}}
 
       - : An array of filter objects indicating the properties of devices that will be matched.
-        To match a filter object, a device must match all the values of the filter: all its listed services, name, namePrefix, and so on.
+        To match a filter object, a device must match all the values of the filter: all its specified `services`, `name`, `namePrefix`, and so on.
 
         Each filter consists of an array of objects with the following properties:
 
         - `services` {{optional_inline}}
 
           - : An array of values indicating the Bluetooth GATT (Generic Attribute Profile) services that a Bluetooth device must support.
-            Each value can be a valid name from the [GATT assigned services keys](https://github.com/WebBluetoothCG/registries/blob/master/gatt_assigned_services.txt), such as `'battery_service'` or `'blood_pressure'`.
-            You can also pass a full UUID such as `'0000180F-0000-1000-8000-00805f9b34fb'` or the short 16-bit (`0x180F`) or 32-bit aliases.
+            Each value can be a valid name from the [GATT assigned services list](https://github.com/WebBluetoothCG/registries/blob/master/gatt_assigned_services.txt), such as `'battery_service'` or `'blood_pressure'`.
+            You can also pass a full service UUID such as `'0000180F-0000-1000-8000-00805f9b34fb'` or the short 16-bit (`0x180F`) or 32-bit alias.
             Note that these are the same values that can be passed to {{domxref("BluetoothUUID/getService_static","BluetoothUUID.getService()")}}.
 
         - `name` {{optional_inline}}
@@ -67,7 +67,7 @@ requestDevice(options)
             Each filter object has the following properties:
 
             - `service`
-              - : The GATT service name, the UUID, or the UUID 16-bit or 32-bit forms.
+              - : The GATT service name, the service UUID, or the UUID 16-bit or 32-bit form.
                 This takes the same values as the elements of the [`services`](#services) array.
             - `dataPrefix` {{optional_inline}}
               - : The data prefix.
@@ -82,7 +82,7 @@ requestDevice(options)
 
       - : An array of optional service identifiers.
 
-        The identifiers take the same values as the elements of the [`services`](#services) array (a GATT service name, UUID, or UUID short 16-bit or 32-bit forms).
+        The identifiers take the same values as the elements of the [`services`](#services) array (a GATT service name, service UUID, or UUID short 16-bit or 32-bit form).
 
     - `optionalManufacturerData` {{optional_inline}}
 
@@ -98,9 +98,9 @@ requestDevice(options)
         The default is `false`.
 
         This option is appropriate when devices have not advertised enough information for filtering to be useful.
-        When this is `true` you should omit all [`filters`](#filters) and [`exclusionFilters`](#exclusionfilters), and you must set [`optionalServices`](#optionalservices) in order to be able to _use_ the returned device.
+        When `acceptAllDevices` is set to `true` you should omit all [`filters`](#filters) and [`exclusionFilters`](#exclusionfilters), and you must set [`optionalServices`](#optionalservices) to be able to _use_ the returned device.
 
-After the user selects a device to pair in this origin, it is only allowed to access services whose UUID was listed in the services list in any element of [`filters.services`](#services) or in [`optionalServices`](#optionalservices).
+After the user selects a device to pair in the current origin, it is only allowed to access services whose UUID was listed in the services list in any element of [`filters.services`](#services) or in [`optionalServices`](#optionalservices).
 It is therefore important to list the required services.
 In particular, when filtering with just [`name`](#name) you must remember to also specify the desired services in [`optionalServices`](#optionalservices).
 

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -100,6 +100,8 @@ After the user selects a device to pair in this origin, it is only allowed to ac
 It is therefore important to list the required services.
 In particular, when filtering with just [`name`](#name) you must remember to also specify the desired services in [`optionalServices`](#optionalservices).
 
+> **Note:** Even though the `options` argument is technically optional, in order to return any results you must either set a value for `filters` or set `acceptAllDevices` to `true`.
+
 ### Return value
 
 A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -85,16 +85,20 @@ requestDevice(options)
         The identifiers take the same values as the elements of the [`services`](#services) array (a GATT service name, UUID, or UUID short 16-bit or 32-bit forms).
 
     - `optionalManufacturerData` {{optional_inline}}
-      - : An array of optional manufacture data.
-        This is not used for filtering.
-        The origin is allowed to access any manufacturer data from manufacturer codes.
+
+      - : An optional array of integer manufacturer codes.
+        This takes the same values as [`companyIdentifier`](#companyidentifier).
+
+        The data is not used for filtering the devices, but advertisements that match the specified set are still delivered in `advertisementreceived` events.
+        This is useful because it allows code to specify an interest in data received from Bluetooth devices without constraining the filter controlling which devices are presented to the user in the permission prompt.
+
     - `acceptAllDevices` {{optional_inline}}
 
       - : A boolean value indicating that the requesting script can accept all Bluetooth devices.
         The default is `false`.
 
-        > **Note:** This option is appropriate when devices have not advertised enough information for filtering to be useful.
-        > You should omit all [`filters`](#filters) and [`exclusionFilters`](#exclusionfilters), and you must set [`optionalServices`](#optionalservices) in order to be able to use the device.
+        This option is appropriate when devices have not advertised enough information for filtering to be useful.
+        When this is `true` you should omit all [`filters`](#filters) and [`exclusionFilters`](#exclusionfilters), and you must set [`optionalServices`](#optionalservices) in order to be able to _use_ the returned device.
 
 After the user selects a device to pair in this origin, it is only allowed to access services whose UUID was listed in the services list in any element of [`filters.services`](#services) or in [`optionalServices`](#optionalservices).
 It is therefore important to list the required services.

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -23,16 +23,82 @@ requestDevice(options)
 ### Parameters
 
 - `options` {{optional_inline}}
-  - : An object that sets options for the device request.
+
+  - : An object that sets options for selecting an appropriate device.
     The available options are:
-    - `filters`
-      - : An array of filter objects.
-        Each filter consists of an array of `BluetoothServiceUUID`s, a `name` parameter, and a `namePrefix` parameter.
-    - `optionalServices`
-      - : An array of `BluetoothServiceUUID`s.
-    - `acceptAllDevices`
+
+    - `filters` {{optional_inline}}
+
+      - : An array of filter objects indicating the properties of devices that will be matched.
+        To match a filter object, a device must match all the values of the filter: all its listed services, name, namePrefix, and so on.
+
+        Each filter consists of an array of objects with the following properties:
+
+        - `services` {{optional_inline}}
+
+          - : An array of values indicating the Bluetooth GATT (Generic Attribute Profile) services that a Bluetooth device must support.
+            Each value can be a valid name from the [GATT assigned services keys](https://github.com/WebBluetoothCG/registries/blob/master/gatt_assigned_services.txt), such as `'battery_service'` or `'blood_pressure'`.
+            You can also pass a full UUID such as `'0000180F-0000-1000-8000-00805f9b34fb'` or the short 16-bit (`0x180F`) or 32-bit aliases.
+            Note that these are the same values that can be passed to {{domxref("BluetoothUUID/getService_static","BluetoothUUID.getService()")}}.
+
+        - `name` {{optional_inline}}
+          - : A string containing the precise name of the device to match against.
+        - `namePrefix` {{optional_inline}}
+          - : A string containing the name prefix to match against.
+            All devices that have a name starting with this string will be matched.
+        - `manufacturerData` {{optional_inline}}
+
+          - : An array of objects matching against manufacturer data in the Bluetooth Low Energy (BLE) advertising packets. <!-- BluetoothManufacturerDataFilterInit -->
+            Each filter object has the following properties:
+
+            - `companyIdentifier`
+              - : A mandatory number identifying the manufacturer of the device.
+                Company identifiers are listed in the Bluetooth specification [Assigned numbers](https://www.bluetooth.com/specifications/assigned-numbers/), Section 7.
+                For example, to match against devices manufacturered by "Digianswer A/S", with assigned hex number `0x000C`, you would specify `12`.
+            - `dataPrefix` {{optional_inline}}
+              - : The data prefix.
+                A buffer containing values to match against the values at the start of the advertising manufacturer data.
+            - `mask` {{optional_inline}}
+              - : This allows you to match against bytes within the manufacturer data, by masking some bytes of the service data `dataPrefix`.
+
+        - `serviceData` {{optional_inline}} <!-- BluetoothServiceDataFilterInit -->
+
+          - : An array of objects matching against service data in the Bluetooth Low Energy (BLE) advertising packets.<!-- BluetoothServiceDataFilterInit -->
+            Each filter object has the following properties:
+
+            - `service`
+              - : The GATT service name, the UUID, or the UUID 16-bit or 32-bit forms.
+                This takes the same values as the elements of the [`services`](#services) array.
+            - `dataPrefix` {{optional_inline}}
+              - : The data prefix.
+                A buffer containing values to match against the values at the start of the advertising service data.
+            - `mask` {{optional_inline}}
+              - : This allows you to match against bytes within the service data, by masking some bytes of the service data `dataPrefix`.
+
+    - `exclusionFilters` {{optional_inline}}
+      - : An array of filter objects indicating the characteristics of devices that will be excluded from matching.
+        The properties of the array elements are the same as for [`filters`](#filters).
+    - `optionalServices` {{optional_inline}}
+
+      - : An array of optional service identifiers.
+
+        The identifiers take the same values as the elements of the [`services`](#services) array (a GATT service name, UUID, or UUID short 16-bit or 32-bit forms).
+
+    - `optionalManufacturerData` {{optional_inline}}
+      - : An array of optional manufacture data.
+        This is not used for filtering.
+        The origin is allowed to access any manufacturer data from manufacturer codes.
+    - `acceptAllDevices` {{optional_inline}}
+
       - : A boolean value indicating that the requesting script can accept all Bluetooth devices.
         The default is `false`.
+
+        > **Note:** This option is appropriate when devices have not advertised enough information for filtering to be useful.
+        > You should omit all [`filters`](#filters) and [`exclusionFilters`](#exclusionfilters), and you must set [`optionalServices`](#optionalservices) in order to be able to use the device.
+
+After the user selects a device to pair in this origin, it is only allowed to access services whose UUID was listed in the services list in any element of [`filters.services`](#services) or in [`optionalServices`](#optionalservices).
+It is therefore important to list the required services.
+In particular, when filtering with just [`name`](#name) you must remember to also specify the desired services in [`optionalServices`](#optionalservices).
 
 ### Return value
 
@@ -80,7 +146,7 @@ navigator.bluetooth
   .catch((error) => console.error(`Something went wrong. ${error}`));
 ```
 
-[Detailed examples](https://webbluetoothcg.github.io/web-bluetooth/#example-filter-by-services) are in the specification.
+[Detailed examples](https://webbluetoothcg.github.io/web-bluetooth/#example-filter-by-services) are in the specification and also in [Communicating with Bluetooth devices over JavaScript](https://developer.chrome.com/docs/capabilities/bluetooth) on _developer.chrome.com_.
 
 ## Specifications
 
@@ -89,3 +155,7 @@ navigator.bluetooth
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Communicating with Bluetooth devices over JavaScript](https://developer.chrome.com/docs/capabilities/bluetooth) on _developer.chrome.com_.

--- a/files/en-us/web/api/bluetoothdevice/index.md
+++ b/files/en-us/web/api/bluetoothdevice/index.md
@@ -31,6 +31,13 @@ environment.
 - {{DOMxRef("BluetoothDevice.forget()")}} {{Experimental_Inline}}
   - : Provides a way for the page to revoke access to a device the user has granted access to.
 
+## Events
+
+Listen to these events using {{domxref("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
+- {{DOMxRef("BluetoothDevice/gattserverdisconnected_event", "gattserverdisconnected")}}
+  - : Fired on a device when an active GATT connection is lost.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.md
@@ -24,11 +24,6 @@ The `BluetoothRemoteGattCharacteristic` interface of the [Web Bluetooth API](/en
 - {{DOMxRef("BluetoothRemoteGATTCharacteristic.value")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : The currently cached characteristic value. This value gets updated when the value of the characteristic is read or updated via a notification or indication.
 
-### Events
-
-- `oncharacteristicvaluechanged` {{Experimental_Inline}}
-  - : Event handler for the `characteristicvaluechanged` event.
-
 ## Instance methods
 
 - {{DOMxRef("BluetoothRemoteGATTCharacteristic.getDescriptor()")}} {{Experimental_Inline}}
@@ -47,6 +42,11 @@ The `BluetoothRemoteGattCharacteristic` interface of the [Web Bluetooth API](/en
   - : Returns a {{JSxRef("Promise")}} that resolves when `navigator.bluetooth` is added to the active notification context.
 - {{DOMxRef("BluetoothRemoteGATTCharacteristic.stopNotifications()")}} {{Experimental_Inline}}
   - : Returns a {{JSxRef("Promise")}} that resolves when `navigator.bluetooth` is removed from the active notification context.
+
+## Events
+
+- {{DOMxRef("BluetoothRemoteGATTCharacteristic/characteristicvaluechanged_event", "characteristicvaluechanged")}} {{Experimental_Inline}}
+  - : Fired on a {{domxref("BluetoothRemoteGATTCharacteristic")}} when its value changes.
 
 ## Specifications
 


### PR DESCRIPTION
This updates `Bluetooth.requestDevice()` which has many new options.

The information largely comes from https://github.com/WebBluetoothCG/web-bluetooth/issues/620 and https://developer.chrome.com/docs/capabilities/bluetooth

Note that I have not tried to update the examples to show new options. But the key ones were already covered, and the new ones are well covered in the linked document.

This follows on from #32533 