### PR TITLE
Add more relevant render buffer methods

### DIFF
--- a/files/en-us/web/api/webglrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderbuffer/index.md
@@ -19,6 +19,9 @@ The `WebGLRenderbuffer` object does not define any methods or properties of its 
 - {{domxref("WebGLRenderingContext.createRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
+- {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
+- {{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}
 
 ## Examples
 
@@ -44,4 +47,7 @@ const buffer = gl.createRenderbuffer();
 - {{domxref("WebGLRenderingContext.createRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
+- {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
+- {{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}
 - Other buffers: {{domxref("WebGLBuffer")}}, {{domxref("WebGLFramebuffer")}}

--- a/files/en-us/web/api/webglrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderbuffer/index.md
@@ -18,10 +18,10 @@ The `WebGLRenderbuffer` object does not define any methods or properties of its 
 - {{domxref("WebGLRenderingContext.bindRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.createRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteRenderbuffer()")}}
-- {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
-- {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
-- {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
 - {{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
+- {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
 
 ## Examples
 
@@ -46,8 +46,8 @@ const buffer = gl.createRenderbuffer();
 - {{domxref("WebGLRenderingContext.bindRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.createRenderbuffer()")}}
 - {{domxref("WebGLRenderingContext.deleteRenderbuffer()")}}
-- {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
-- {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
-- {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
 - {{domxref("WebGLRenderingContext.framebufferRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.getRenderbufferParameter()")}}
+- {{domxref("WebGLRenderingContext.isRenderbuffer()")}}
+- {{domxref("WebGLRenderingContext.renderbufferStorage()")}}
 - Other buffers: {{domxref("WebGLBuffer")}}, {{domxref("WebGLFramebuffer")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This change adds more links to WebGL methods that relate to render buffers. These operate on the bound RenderBuffer object.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
