### PR TITLE
fix(learn): Update page titles

### DIFF
--- a/files/en-us/learn/css/first_steps/index.md
+++ b/files/en-us/learn/css/first_steps/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS first steps overview
+title: CSS first steps
 slug: Learn/CSS/First_steps
 page-type: learn-module
 ---

--- a/files/en-us/learn/forms/index.md
+++ b/files/en-us/learn/forms/index.md
@@ -1,5 +1,5 @@
 ---
-title: Core forms learning pathway
+title: Web form building blocks
 slug: Learn/Forms
 page-type: learn-module
 ---

--- a/files/en-us/learn/forms/index.md
+++ b/files/en-us/learn/forms/index.md
@@ -1,5 +1,5 @@
 ---
-title: Web forms — Working with user data
+title: Core forms learning pathway
 slug: Learn/Forms
 page-type: learn-module
 ---

--- a/files/en-us/learn/javascript/first_steps/index.md
+++ b/files/en-us/learn/javascript/first_steps/index.md
@@ -1,5 +1,5 @@
 ---
-title: JavaScript First Steps
+title: JavaScript first steps
 slug: Learn/JavaScript/First_steps
 page-type: learn-module
 ---

--- a/files/en-us/learn/mathml/first_steps/index.md
+++ b/files/en-us/learn/mathml/first_steps/index.md
@@ -1,5 +1,5 @@
 ---
-title: MathML first steps overview
+title: MathML first steps
 slug: Learn/MathML/First_steps
 page-type: learn-module
 ---


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the sidebar in the [Learn](https://developer.mozilla.org/en-US/docs/Learn) area, each drop-down's "first item" matches the drop-down header. This PR fixes a few discrepancies where the first item's page title is slightly different.

### Motivation

To follow the same style for page titles

### Additional details

A few instances where the above described style is followed

<kbd>![learnsidebar-1](https://github.com/mdn/content/assets/23019147/a84e4159-2371-4093-b3ae-96e7c54c658c)</kbd>

<kbd>![learnsidebar-2](https://github.com/mdn/content/assets/23019147/5eea3c24-543c-4116-a131-c0329e3d21ba)</kbd>

<kbd>![learnsidebar-4](https://github.com/mdn/content/assets/23019147/876b6d5b-64d7-4a17-b26f-49c7109d9668)
</kbd>

<kbd>![learnsidebar-3](https://github.com/mdn/content/assets/23019147/9f64bea2-6a9c-423e-8c4a-9f48fc5612c6)</kbd>
