### PR TITLE
Cleaner attributeFilter/attributeOldValue example (MutationObserver)

### DIFF
--- a/files/en-us/web/api/mutationobserver/observe/index.md
+++ b/files/en-us/web/api/mutationobserver/observe/index.md
@@ -130,18 +130,9 @@ for example, reflect changes to users' nicknames, or to mark them as away from k
 ```js
 function callback(mutationList) {
   mutationList.forEach((mutation) => {
-    switch (mutation.type) {
-      case "attributes":
-        switch (mutation.attributeName) {
-          case "status":
-            userStatusChanged(mutation.target.username, mutation.target.status);
-            break;
-          case "username":
-            usernameChanged(mutation.oldValue, mutation.target.username);
-            break;
-        }
-        break;
-    }
+    const { attributeName, oldValue, target } = mutation;
+    const newValue = target.getAttribute(attributeName);
+    console.log(`${attributeName}: ${oldValue} -> ${newValue}`);
   });
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Simplify callback, in the `MutationObserver` example illustrating the usage of `attributeFilter` & `attributeOldValue`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I thought the old version had a typo, in `userStatusChanged(mutation.target.username, mutation.target.status);`, `mutation.target.username` seems like it should've been `mutation.oldValue`, though after taking a closer look, this was probably intentional.

While fixing this "typo", I decided the old callback was unnecessary complex -- e.g. the outer `switch` wasn't doing anything (aside from serving as a future placeholder perhaps) -- so I made it a bit more "to the point". Also seems a tiny bit unusual to have an example that calls functions not provided (`userStatusChanged` & `usernameChanged`), this new one is a little easier to modify and begin playing with.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Old version added in #9737:
https://github.com/mdn/content/pull/9737/files#diff-fc20b9f4adbc6723e9fe01425cea6512399d9a9bd69451d25f8fd6f0b8f92788R144-R170

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
