### PR TITLE
Add note about `compareDocumentPosition()` returning 0

### DIFF
--- a/files/en-us/web/api/node/comparedocumentposition/index.md
+++ b/files/en-us/web/api/node/comparedocumentposition/index.md
@@ -47,6 +47,8 @@ contains the node on which `compareDocumentPosition()` was
 called, then both the `DOCUMENT_POSITION_CONTAINS` and
 `DOCUMENT_POSITION_PRECEDING` bits would be set, producing a value of `10` (`0x0A`).
 
+When comparing a node with itself, `compareDocumentPosition()` returns `0`.
+
 ## Example
 
 ```js

--- a/files/en-us/web/api/node/comparedocumentposition/index.md
+++ b/files/en-us/web/api/node/comparedocumentposition/index.md
@@ -41,13 +41,11 @@ following constant properties of {{domxref("Node")}}:
 - `Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC` (`32`)
   - : The result relies upon arbitrary and/or implementation-specific behavior and is not guaranteed to be portable.
 
-More than one bit is set if multiple scenarios apply. For example, if
+Zero or more bits can be set, depending on which scenarios apply. For example, if
 `otherNode` is located earlier in the document **_and_**
 contains the node on which `compareDocumentPosition()` was
 called, then both the `DOCUMENT_POSITION_CONTAINS` and
 `DOCUMENT_POSITION_PRECEDING` bits would be set, producing a value of `10` (`0x0A`).
-
-When comparing a node with itself, `compareDocumentPosition()` returns `0`.
 
 ## Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

`compareDocumentPosition()` returns 0 when comparing a node with itself.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

After reading the documentation I was surprised to see a `0`, as I was expecting it to returns _something_ in every case. Hopefully this can avoid some confusion to who encounters the same case in the future :)

### Additional details

Step 1 of https://dom.spec.whatwg.org/#dom-node-comparedocumentposition

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
