### PR TITLE
<color-function> data type

### DIFF
--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -60,7 +60,7 @@ A `<color>` value can be specified using one of the methods listed below:
 
 - By keywords: {{CSSXref("&lt;named-color&gt;")}} (such as `blue` or `pink`), {{CSSXref("&lt;system-color&gt;")}}, and [`currentcolor`](#currentcolor_keyword).
 - By hexadecimal notations: {{CSSXref("&lt;hex-color&gt;")}} (such as `#ff0000`).
-- By parameters in a color space using functional notations:
+- By `<color-function>`, with parameters in a color space using functional notations:
   - [sRGB](https://en.wikipedia.org/wiki/SRGB) color space: {{CSSXref("color_value/hsl", "hsl()")}}, {{CSSXref("color_value/hwb", "hwb()")}}, {{CSSXref("color_value/rgb", "rgb()")}};
   - [CIELAB](https://en.wikipedia.org/wiki/CIELAB_color_space) color space: {{CSSXref("color_value/lab", "lab()")}}, {{CSSXref("color_value/lch", "lch()")}};
   - [Oklab](https://bottosson.github.io/posts/oklab/) color space: {{CSSXref("color_value/oklab", "oklab()")}}, {{CSSXref("color_value/oklch", "oklch()")}};

--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -56,7 +56,7 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
 ### Data types
 
 - {{cssxref("&lt;color&gt;")}}
-- [`<absolute-color-function>`](#functions)
+- [`<color-function>`](#functions)
 - {{cssxref("hex-color")}}
 - {{cssxref("named-color")}}
 - {{cssxref("alpha-value")}}


### PR DESCRIPTION
added the term `<color-function>`, as that is a data type in the formal syntax within `<color>`.

Note the term "absolute" will be removed from the #functions section (line 42, not edited her to not conflict) in PR https://github.com/mdn/content/pull/32004/