### PR TITLE
chore(macros): Replace no_tag_omission macro with line of text

### DIFF
--- a/files/en-us/web/html/element/fencedframe/index.md
+++ b/files/en-us/web/html/element/fencedframe/index.md
@@ -124,7 +124,7 @@ Without this title, they have to navigate into the `<iframe>` to determine what 
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>{{no_tag_omission}}</td>
+      <td>None, both the starting and ending tag are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>


### PR DESCRIPTION
### Description

This one slipped in to the main branch while https://github.com/mdn/content/pull/32394 was in progress.

A Yari deprecation should follow as this is the last occurrence in EN content.