### PR TITLE
Fixed typo in "Handling common JavaScript problems"

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -51,7 +51,7 @@ Things have improved significantly since then; modern browsers do a good job of 
 These days, most cross-browser JavaScript problems are seen:
 
 - When poor-quality browser-sniffing code, feature-detection code, and vendor prefix usage block browsers from running code they could otherwise use just fine.
-- When developers make use of new/nascent JavaScript features, modern Web APIs, etc.) in their code, and find that such features don't work in older browsers.
+- When developers make use of new/nascent JavaScript features, modern Web APIs, etc. in their code, and find that such features don't work in older browsers.
 
 We'll explore all these problems and more below.
 


### PR DESCRIPTION
### Description

Fixed a small typo on "Handling common JavaScript problems".
Specifically, removed misplaced closing parenthesis on line 54.

### Motivation

Been reading the page and noticed that there was a misplaced closing parenthesis, so I though it would be appropriate to fix it.

### Additional details

I hope it's not inappropriate to just commit a single character edit?

### Related issues and pull requests

Probably none.
