### PR TITLE
Clearer example for `MouseEvent#buttons`

### DIFF
--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -60,7 +60,7 @@ function format(event) {
   return JSON.stringify(obj, null, 2);
 }
 
-const log = document.getElementById('log');
+const log = document.getElementById("log");
 function logButtons(event) {
   log.textContent = format(event);
 }

--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -39,23 +39,34 @@ This example logs the `buttons` property when you trigger a {{domxref("Element/m
 
 ```html
 <p>Click anywhere with one or more mouse buttons.</p>
-<pre id="log">buttons: </pre>
+<pre id="log">[No clicks yet]</pre>
 ```
 
 ### JavaScript
 
 ```js
-let log = document.createTextNode("?"); // let log = new Text('?');
+const buttonNames = ['left', 'right', 'wheel', 'back', 'forward'];
+function mouseButtonPressed(event, buttonName) {
+  // Use binary `&` with the relevant power of 2 to check if a given button is pressed
+  return Boolean(event.buttons & (2 ** buttonNames.indexOf(buttonName)));
+}
 
-function logButtons(e) {
-  log.data = `${e.buttons} (${e.type})`; // log.nodeValue= `${e.buttons} (${e.type})`;
+function format(event) {
+  const { type, buttons } = event;
+  const obj = { type, buttons };
+  for (const buttonName of buttonNames) {
+    obj[buttonName] = mouseButtonPressed(event, buttonName);
+  }
+  return JSON.stringify(obj, null, 2);
+}
+
+const log = document.getElementById('log');
+function logButtons(event) {
+  log.textContent = format(event);
 }
 
 document.addEventListener("mouseup", logButtons);
 document.addEventListener("mousedown", logButtons);
-// document.addEventListener('mousemove', logButtons);
-
-document.querySelector("#log").appendChild(log);
 ```
 
 ### Result

--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -45,7 +45,7 @@ This example logs the `buttons` property when you trigger a {{domxref("Element/m
 ### JavaScript
 
 ```js
-const buttonNames = ['left', 'right', 'wheel', 'back', 'forward'];
+const buttonNames = ["left", "right", "wheel", "back", "forward"];
 function mouseButtonPressed(event, buttonName) {
   // Use binary `&` with the relevant power of 2 to check if a given button is pressed
   return Boolean(event.buttons & (2 ** buttonNames.indexOf(buttonName)));

--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -48,7 +48,7 @@ This example logs the `buttons` property when you trigger a {{domxref("Element/m
 const buttonNames = ["left", "right", "wheel", "back", "forward"];
 function mouseButtonPressed(event, buttonName) {
   // Use binary `&` with the relevant power of 2 to check if a given button is pressed
-  return Boolean(event.buttons & (2 ** buttonNames.indexOf(buttonName)));
+  return Boolean(event.buttons & (1 << buttonNames.indexOf(buttonName)));
 }
 
 function format(event) {


### PR DESCRIPTION
### Description

Clearer example for `MouseEvent#buttons`.

### Motivation

Current example is both too simple (doesn't indicate how to check if individual mouse buttons are pressed) and too complicated (requires understanding of how HTML text nodes work, an unrelated low-level concept that most JS devs rarely use).

### Summary of changes

* Demonstrate how to check for individual mouse buttons using binary `&` and powers of two
* Include the individual mouse buttons in the log output
* Set HTML element `textContent` rather than text node `data` property
* Remove irrelevant comments

### CodePen

[Previewable CodePen version](https://codepen.io/lionel-rowe/pen/eYodZRz)