### PR TITLE
FF125 RelNote: Intl.Segmenter supported

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -964,48 +964,6 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ## JavaScript
 
-### Intl.Segmenter
-
-The {{jsxref("Intl.Segmenter")}} is supported in nightly builds, allowing developers to perform locale-sensitive text segmentation.
-This enables splitting a string into meaningful items (graphemes, words or sentences) in different locales.
-(See [Firefox bug 1423593](https://bugzil.la/1423593) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>122</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>NA</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>NA</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>NA</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">None</td>
-    </tr>
-  </tbody>
-</table>
-
 ### SharedArrayBuffer is growable
 
 The {{jsxref("SharedArrayBuffer")}} is now growable using the {{jsxref("SharedArrayBuffer.prototype.grow()")}} method.

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -22,8 +22,9 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ### JavaScript
 
-- {{jsxref("Intl.Segmenter")}} is now supported, allowing developers to perform locale-sensitive text segmentation.
-  This enables splitting a string into meaningful items (graphemes, words or sentences) in different locales.
+- {{jsxref("Intl.Segmenter")}} is now supported, allowing developers to perform locale-sensitive text segmentation of a string.
+  This enables, for example, splitting a string into words in languages that don't use spaces to separate them: `Intl.Segmenter("ja-JP", { granularity: "word" })`.
+  You can also split strings into into grapheme or sentences.
   ([Firefox bug 1423593](https://bugzil.la/1423593), [Firefox bug 1883914](https://bugzil.la/1883914).)
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -22,6 +22,10 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ### JavaScript
 
+- The {{jsxref("Intl.Segmenter")}} is now supported, allowing developers to perform locale-sensitive text segmentation.
+  This enables splitting a string into meaningful items (graphemes, words or sentences) in different locales.
+  ([Firefox bug 1423593](https://bugzil.la/1423593), [Firefox bug 1883914](https://bugzil.la/1883914).)
+
 #### Removals
 
 ### SVG

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -24,7 +24,7 @@ This article provides information about the changes in Firefox 125 that affect d
 
 - {{jsxref("Intl.Segmenter")}} is now supported, allowing developers to perform locale-sensitive text segmentation of a string.
   This enables, for example, splitting a string into words in languages that don't use spaces to separate them: `Intl.Segmenter("ja-JP", { granularity: "word" })`.
-  You can also split strings into into grapheme or sentences.
+  You can also split strings into graphemes or sentences.
   ([Firefox bug 1423593](https://bugzil.la/1423593), [Firefox bug 1883914](https://bugzil.la/1883914).)
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -22,7 +22,7 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ### JavaScript
 
-- The {{jsxref("Intl.Segmenter")}} is now supported, allowing developers to perform locale-sensitive text segmentation.
+- {{jsxref("Intl.Segmenter")}} is now supported, allowing developers to perform locale-sensitive text segmentation.
   This enables splitting a string into meaningful items (graphemes, words or sentences) in different locales.
   ([Firefox bug 1423593](https://bugzil.la/1423593), [Firefox bug 1883914](https://bugzil.la/1883914).)
 


### PR DESCRIPTION
FF125 supports [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) in https://bugzilla.mozilla.org/show_bug.cgi?id=1883914.

This removes the FF experimental feature and adds to release note.

Related docs can be tracked in #32661