### PR TITLE
Add section on how to handle Glitch node limits

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -497,6 +497,31 @@ To start using Glitch you will first need to create an account:
 - Select GitHub in the popup to sign up using your GitHub credentials.
 - You'll then be logged in to the Glitch dashboard: <https://glitch.com/dashboard>.
 
+### Update Node Versions
+
+Hosting providers commonly support some major version of recent node releases.
+If the exact "minor" version you have specified in your `package.json` file is not supported they will usually fall back to the closest version they support (and often this will just work).
+
+Unfortunately, at time of writing, the highest supported version on Glitch is node 16.
+If you have been developing with node 17 or later, you should reduce the version used in your `package.json` file as shown.
+You will also need to retest:
+
+```json
+  "engines": {
+    "node": ">=v16"
+  },
+```
+
+Glitch [plans to update node and keep it better updated in future](https://blog.glitch.com/post/rebuilding-glitch) — and it may be that by the time you read this the node version limit no longer exists.
+Instead of updating node for your project first, you might upload it and see if it works.
+If the application doesn't load you could then modify the `package.json` in the Glitch editor to reduce the node version.
+
+> **Note:** You can also check the supported versions by entering the following command into the terminal of any Glitch project:
+>
+> ```sh
+> ls -l /opt/nvm/versions/node | grep '^d' | awk '{ print $9 }'
+> ```
+
 ### Deploy on Glitch from GitHub
 
 Next we'll import the Library project from GitHub.

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -307,17 +307,12 @@ You can find the version of node that was used for development by entering the c
 v16.17.1
 ```
 
-Open **package.json**, and add this information as an **engines > node** section as shown (using the version number for your system).
+Open **package.json**, and add this information as an **engines > node** as shown (using the version number for your system).
 
 ```json
-{
-  "name": "express-locallibrary-tutorial",
-  "version": "0.0.0",
   "engines": {
     "node": ">=16.17.1"
   },
-  "private": true,
-  // …
 ```
 
 The hosting service might not support the specific indicated version of node, but this change should ensure that it attempts to use a version with the same major version number, or a more recent version.

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -497,13 +497,13 @@ To start using Glitch you will first need to create an account:
 - Select GitHub in the popup to sign up using your GitHub credentials.
 - You'll then be logged in to the Glitch dashboard: <https://glitch.com/dashboard>.
 
-### Update Node Versions
+### Troubleshooting Node.js version
 
-Hosting providers commonly support some major version of recent node releases.
+Hosting providers commonly support some major version of recent Node.js releases.
 If the exact "minor" version you have specified in your `package.json` file is not supported they will usually fall back to the closest version they support (and often this will just work).
 
-Unfortunately, at time of writing, the highest supported version on Glitch is node 16.
-If you have been developing with node 17 or later, you should reduce the version used in your `package.json` file as shown.
+Unfortunately, at time of writing, the highest supported version on Glitch is Node.js 16.
+If you have been developing with Node.js 17 or later, you should reduce the version used in your `package.json` file as shown.
 You will also need to retest:
 
 ```json
@@ -512,9 +512,9 @@ You will also need to retest:
   },
 ```
 
-Glitch [plans to update node and keep it better updated in future](https://blog.glitch.com/post/rebuilding-glitch) — and it may be that by the time you read this the node version limit no longer exists.
-Instead of updating node for your project first, you might upload it and see if it works.
-If the application doesn't load you could then modify the `package.json` in the Glitch editor to reduce the node version.
+Glitch [plans to update node and keep it better updated in future](https://blog.glitch.com/post/rebuilding-glitch) — and it may be that by the time you read this the version limit no longer exists.
+Instead of downgrading the `node` version, you could upload your project to see if it builds.
+If there are errors and your application doesn't load, you should try setting the `node` version to `>=v16` in your `package.json` in the Glitch editor.
 
 > **Note:** You can also check the supported versions by entering the following command into the terminal of any Glitch project:
 >


### PR DESCRIPTION
Fixes #32678

Glitch currently supports up to node 16, and it is quite likely people will be testing on later versions. This explains that you need to modify your node version if higher than 16. 

Glitch are planning to fix this, so I have linked to their roadmap and also provided info on how you can work out the current set of node version. In a year or so once they have fixed this we can probably remove this section.