### PR TITLE
Describe `import('moduleName')` behavior when module does not exist

### DIFF
--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -28,7 +28,7 @@ The `import()` call is a syntax that closely resembles a function call, but `imp
 
 Returns a promise which fulfills to a [module namespace object](#module_namespace_object): an object containing all exports from `moduleName`.
 
-The evaluation of `import()` never synchronously throws an error. `moduleName` is [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), and if coercion throws, the promise is rejected with the thrown error.
+`import()` never synchronously throws an error. For example, `moduleName` is [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), and if coercion throws, the promise is rejected with the thrown error. Similarly, if `moduleName` refers to a module that doesn't exist, the promise is rejected with the thrown error.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/operators/import/index.md
+++ b/files/en-us/web/javascript/reference/operators/import/index.md
@@ -26,9 +26,14 @@ The `import()` call is a syntax that closely resembles a function call, but `imp
 
 ### Return value
 
-Returns a promise which fulfills to a [module namespace object](#module_namespace_object): an object containing all exports from `moduleName`.
+Returns a promise which:
 
-`import()` never synchronously throws an error. For example, `moduleName` is [coerced to a string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion), and if coercion throws, the promise is rejected with the thrown error. Similarly, if `moduleName` refers to a module that doesn't exist, the promise is rejected with the thrown error.
+- If the referenced module is loaded and evaluated successfully, fulfills to a [module namespace object](#module_namespace_object): an object containing all exports from `moduleName`.
+- If the [coercion to string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion) of `moduleName` throws, rejects with the thrown error.
+- If `moduleName` refers to a module that doesn't exist, rejects with an implementation-defined error (Node uses a generic `Error`, while all browsers use `TypeError`).
+- If evaluation of the referenced module throws, rejects with the thrown error.
+
+> **Note:** `import()` never synchronously throws an error.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Describe `import('moduleName')` behavior when module does not exist

### Motivation

- I wasn't sure if `import()` would fail asynchronously if the `moduleName` had a typo or didn't exist. In hindsight, I could've deduced that from the way the text was written, but I thought it might help to be explicit? 
- I tested in node.js and confirmed it will fail asynchronously in this scenario.
- I'm not sure if this is an overall improvement, but hopefully, worst case scenario, it will give someone an idea of how to iterate on what I wrote.
