### PR TITLE
docs(learn): Revise Angular tutorial for v17

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_building/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_building/index.md
@@ -57,7 +57,7 @@ You can use any backend such as [Firebase](https://firebase.google.com/docs/host
 
 ### Host locally
 
-For fun you can easily host the built app on your machine using [`http-server`](https://www.npmjs.com/package/http-server) package by running following command:
+For fun, you can host the built app on your machine using [`http-server`](https://www.npmjs.com/package/http-server) package by running following command after running a build:
 
 ```bash
 npx http-server ./dist/todo/browser/ -o

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_building/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_building/index.md
@@ -63,7 +63,8 @@ For fun you can easily host the built app on your machine using [`http-server`](
 npx http-server ./dist/todo/browser/ -o
 ```
 
-The command hosts `dist/todo/browser` direcotry on `8080` port. Open URL `http://127.0.0.1:8080` in a web browser to check the app. You can access the app from any machine in your LAN using `http://<server-ip-address>:8080` URL.
+This command serves the `dist/todo/browser` directory on port `8080` so you can open `http://127.0.0.1:8080` in your browser to see the app running.
+The HTTP server also lets you access the app at your computer's IP address from any other device on your local network, and this address is listed under the `127.0.0.1` address in the console.
 
 ## What's next
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_building/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_building/index.md
@@ -55,6 +55,16 @@ Because these files are static, you can host them on any web server capable of s
 
 You can use any backend such as [Firebase](https://firebase.google.com/docs/hosting), [Google Cloud](https://cloud.google.com/solutions/web-hosting), or [App Engine](https://cloud.google.com/appengine/docs/standard/python/getting-started/hosting-a-static-website).
 
+### Host locally
+
+For fun you can easily host the built app on your machine using [`http-server`](https://www.npmjs.com/package/http-server) package by running following command:
+
+```bash
+npx http-server ./dist/todo/browser/ -o
+```
+
+The command hosts `dist/todo/browser` direcotry on `8080` port. Open URL `http://127.0.0.1:8080` in a web browser to check the app. You can access the app from any machine in your LAN using `http://<server-ip-address>:8080` URL.
+
 ## What's next
 
 At this point, you've built a basic application, but your Angular journey is just beginning.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -38,7 +38,7 @@ It is now time to look at Google's Angular framework, another popular option tha
 
 ## What is Angular?
 
-Angular is a development platform, built on [TypeScript](https://www.typescriptlang.org/). As a platform, Angular includes:
+Angular is a framework and development platform, built on [TypeScript](https://www.typescriptlang.org/). It is used for creating single-page web applications. As a platform, Angular includes:
 
 - A component-based framework for building scalable web applications
 - A collection of well-integrated libraries that cover a wide variety of features, including routing, forms management, client-server communication, and more
@@ -46,7 +46,7 @@ Angular is a development platform, built on [TypeScript](https://www.typescriptl
 
 When you build applications with Angular, you're taking advantage of a platform that can scale from single-developer projects to enterprise-level applications. Angular is designed to make updating as easy as possible, so you can take advantage of the latest developments with a minimum of effort. Best of all, the Angular ecosystem consists of a diverse group of over 1.7 million developers, library authors, and content creators.
 
-Before you start exploring the Angular platform, you should know about the Angular CLI. The Angular CLI is the fastest, easiest, and recommended way to develop Angular applications. The Angular CLI makes a number of tasks easy. Here are some example commands using the CLI:
+Before you start exploring the Angular platform, you should know about the Angular CLI. The Angular CLI is the fastest, easiest, and recommended way to develop Angular applications. The Angular CLI makes a number of tasks easy. Here are some example commands that you'll use frequently:
 
 | Command                                          | Description                                                           |
 | ------------------------------------------------ | --------------------------------------------------------------------- |
@@ -68,9 +68,9 @@ To install Angular on your local system, you need the following:
 
 - **Node.js**
 
-  Angular requires a [current, active LTS, or maintenance LTS](https://nodejs.org/en/about/previous-releases) version of Node.js. For information about specific version requirements, see the `engines` key in the [package.json](https://unpkg.com/@angular/cli/package.json) file.
+  Angular requires a [active LTS or maintenance LTS](https://nodejs.org/en/about/previous-releases) version of Node.js. For information about specific version requirements, see the [Version compatibility](https://angular.io/guide/versions) page.
 
-  For more information on installing Node.js, see [nodejs.org](https://nodejs.org).
+  For more information on installing Node.js, see [nodejs.org](https://nodejs.org/en/download).
   If you are unsure what version of Node.js runs on your system, run `node -v` in a terminal window.
 
 - **npm package manager**
@@ -90,7 +90,7 @@ npm install -g @angular/cli
 ```
 
 Angular CLI commands all start with `ng`, followed by what you'd like the CLI to do.
-In the directory you would like to build your app, use the following [`ng new`](https://angular.io/cli/new) command to create a new application called `todo`:
+Create a new directory where you want to build your app, and switch to the directory in the terminal. Then use the following [`ng new`](https://angular.io/cli/new) command to create a new application called `todo`:
 
 ```bash
 ng new todo --routing=false --style=css --ssr=false
@@ -100,7 +100,7 @@ The `ng new` command creates a minimal starter Angular application.
 The additional flags, `--routing` and `--style`, and `--ssr` define how to handle navigation and styles in the application, and configures server-side rendering.
 This tutorial describes these features later in more detail.
 
-The first time you run `ng`, you'll be asked if you want to enable terminal autocompletion and analytics.
+The first time you run `ng`, you may be asked if you want to enable terminal [autocompletion](https://angular.io/cli/completion) and analytics.
 Autocompletion is convenient because pressing <kbd>TAB</kbd> while typing `ng` commands will show possible options and will autocomplete arguments.
 
 You can also decide if you want to allow analytics about the CLI usage to be sent to Angular maintainers at Google.
@@ -116,7 +116,7 @@ ng serve
 In the browser, navigate to `http://localhost:4200/` to see your new starter application.
 If you change any of the source files, the application automatically reloads.
 
-While `ng serve` is running, you can open a second terminal tab or terminal window to run commands without stopping the server.
+While `ng serve` is running, open a second terminal tab or terminal window to run commands without stopping the server.
 If at any point you would like to stop serving your application, press `Ctrl+c` in the terminal that's running the `ng serve` command.
 
 ## Get familiar with your Angular application
@@ -146,6 +146,7 @@ In this way, you are using the best practices from the very beginning.
 
 The Angular CLI also generates a file for component testing called `app.component.spec.ts`, but this tutorial doesn't go into testing, so you can ignore that file.
 Whenever you generate a component, the CLI creates these files in a directory with the name you specify and we'll see an example of that later.
+
 To learn more about testing, see the [Angular testing guide](https://angular.io/guide/testing).
 
 ## The structure of an Angular application
@@ -175,17 +176,18 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-item",
+  standalone: true,
   // the following metadata specifies the location of the other parts of the component
   templateUrl: "./item.component.html",
   styleUrls: ["./item.component.css"],
 })
 export class ItemComponent {
-  // your code goes here
+  // code goes here
 }
 ```
 
 This component is called `ItemComponent`, and its selector is `app-item`.
-You use a selector just like regular HTML tags by placing it within other templates.
+You use a selector just like regular HTML tags by placing it within other templates, i.e `<app-item></app-item>`.
 When a selector is in a template, the browser renders the template of that component whenever an instance of the selector is encountered.
 This tutorial guides you through creating two components and using one within the other.
 
@@ -217,7 +219,7 @@ To write inline HTML, use the `template` property and write your HTML within bac
 ```js
 @Component({
   selector: "app-root",
-  template: `<h1>Hi!</h1>`,
+  template: `<h1>To do application</h1>`,
 })
 export class AppComponent {
   // code goes here
@@ -240,7 +242,8 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-root",
-  templateUrl: "./app.component.html",
+  standalone: true,
+  template: "<h1>{{ title }}</h1>",
   styleUrls: ["./app.component.css"],
 })
 export class AppComponent {
@@ -285,6 +288,7 @@ With component-specific styles, you can organize your CSS so that it is easily m
 
 It's recommended to [make components standalone](https://angular.io/guide/component-overview#creating-a-component-manually-1) unless a project already makes use of [NgModules](https://angular.io/guide/ngmodules) (Angular modules) to organize code.
 This tutorial uses [standalone components](https://angular.io/guide/standalone-components) which are easier to start with.
+
 It's common to import [`CommonModule`](https://angular.io/api/common/CommonModule) so that your component can make use of common [directives](https://angular.io/api/common#directives) and [pipes](https://angular.io/api/common#pipes).
 This tutorial makes use of `ngFor` and `ngIf`, so we can make sure they're available like so:
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -187,7 +187,7 @@ export class ItemComponent {
 ```
 
 This component is called `ItemComponent`, and its selector is `app-item`.
-You use a selector just like regular HTML tags by placing it within other templates, i.e `<app-item></app-item>`.
+You use a selector just like regular HTML tags by placing it within other templates, i.e. `<app-item></app-item>`.
 When a selector is in a template, the browser renders the template of that component whenever an instance of the selector is encountered.
 This tutorial guides you through creating two components and using one within the other.
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -8,6 +8,9 @@ page-type: learn-module-chapter
 
 It is now time to look at Google's Angular framework, another popular option that you'll come across often. In this article we look at what Angular has to offer, install the prerequisites and set up a sample app, and look at Angular's basic architecture.
 
+> **Note:**
+> This tutorial targets [Angular version 17](https://angular.io/guide/update-to-version-17) and was last revised in March 2024 (`Angular CLI: 17.3.0`).
+
 <table>
   <tbody>
     <tr>
@@ -43,44 +46,15 @@ Angular is a development platform, built on [TypeScript](https://www.typescriptl
 
 When you build applications with Angular, you're taking advantage of a platform that can scale from single-developer projects to enterprise-level applications. Angular is designed to make updating as easy as possible, so you can take advantage of the latest developments with a minimum of effort. Best of all, the Angular ecosystem consists of a diverse group of over 1.7 million developers, library authors, and content creators.
 
-Before you start exploring the Angular platform, you should know about the Angular CLI. The Angular CLI is the fastest, easiest, and recommended way to develop Angular applications. The Angular CLI makes a number of tasks easy. Here are some examples:
+Before you start exploring the Angular platform, you should know about the Angular CLI. The Angular CLI is the fastest, easiest, and recommended way to develop Angular applications. The Angular CLI makes a number of tasks easy. Here are some example commands using the CLI:
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>
-        <code><a href="https://angular.io/cli/build">ng build</a></code>
-      </td>
-      <td>Compiles an Angular app into an output directory.</td>
-    </tr>
-    <tr>
-      <td>
-        <code><a href="https://angular.io/cli/serve">ng serve</a></code>
-      </td>
-      <td>Builds and serves your application, rebuilding on file changes.</td>
-    </tr>
-    <tr>
-      <td>
-        <code><a href="https://angular.io/cli/generate">ng generate</a></code>
-      </td>
-      <td>Generates or modifies files based on a schematic.</td>
-    </tr>
-    <tr>
-      <td>
-        <code><a href="https://angular.io/cli/test">ng test</a></code>
-      </td>
-      <td>Runs unit tests on a given project.</td>
-    </tr>
-    <tr>
-      <td>
-        <code><a href="https://angular.io/cli/e2e">ng e2e</a></code>
-      </td>
-      <td>
-        Builds and serves an Angular application, then runs end-to-end tests.
-      </td>
-    </tr>
-  </tbody>
-</table>
+| Command                                          | Description                                                           |
+| ------------------------------------------------ | --------------------------------------------------------------------- |
+| [`ng build`](https://angular.io/cli/build)       | Compiles an Angular app into an output directory.                     |
+| [`ng serve`](https://angular.io/cli/serve)       | Builds and serves your application, rebuilding on file changes.       |
+| [`ng generate`](https://angular.io/cli/generate) | Generates or modifies files based on a schematic.                     |
+| [`ng test`](https://angular.io/cli/test)         | Runs unit tests on a given project.                                   |
+| [`ng e2e`](https://angular.io/cli/e2e)           | Builds and serves an Angular application, then runs end-to-end tests. |
 
 You'll find the Angular CLI to be a valuable tool for building out your applications.
 
@@ -106,69 +80,73 @@ To install Angular on your local system, you need the following:
   This guide uses the [npm client](https://docs.npmjs.com/cli/install/) command line interface, which is installed with `Node.js` by default.
   To check that you have the npm client installed, run `npm -v` in a terminal window.
 
-## Set up your application
+## Creating an Angular application
 
 You can use the Angular CLI to run commands in your terminal for generating, building, testing, and deploying Angular applications.
-To install the Angular CLI, run the following command in your terminal:
+To install the Angular CLI globally, run the following command in your terminal:
 
 ```bash
 npm install -g @angular/cli
 ```
 
 Angular CLI commands all start with `ng`, followed by what you'd like the CLI to do.
-In the Desktop directory, use the following `ng new` command to create a new application called `todo`:
+In the directory you would like to build your app, use the following `ng new` command to create a new application called `todo`:
 
 ```bash
-ng new todo --routing=false --style=css
+ng new todo --routing=false --style=css --ssr=false
 ```
 
-The `ng new` command creates a minimal starter Angular application on your Desktop.
-The additional flags, `--routing` and `--style`, define how to handle navigation and styles in the application.
+The `ng new` command creates a minimal starter Angular application.
+The additional flags, `--routing` and `--style`, and `--ssr` define how to handle navigation and styles in the application, and configures server-side rendering.
 This tutorial describes these features later in more detail.
 
-If you are prompted to enforce stricter type checking, you can respond with yes.
+The first time you run `ng`, you'll be asked if you want to enable terminal autocompletion and analytics.
+Autocompletion is convenient because pressing <kbd>TAB</kbd> while typing `ng` commands will show possible options and will autocomplete arguments.
 
-Navigate into your new project with the following `cd` command:
+You can also decide if you want to allow analytics about the CLI usage to be sent to Angular maintainers at Google.
+To find out more about analytics, see the [Angular `ng analytics` CLI documentation](https://angular.io/cli/analytics).
+
+To run your `todo` application, navigate into your new project with the `cd` command and run `ng serve`:
 
 ```bash
 cd todo
-```
-
-To run your `todo` application, use `ng serve`:
-
-```bash
 ng serve
 ```
-
-When the CLI prompts you about analytics, answer `no`.
 
 In the browser, navigate to `http://localhost:4200/` to see your new starter application.
 If you change any of the source files, the application automatically reloads.
 
-While `ng serve` is running, you might want to open a second terminal tab or window in order to run commands.
-If at any point you would like to stop serving your application, press `Ctrl+c` while in the terminal.
+While `ng serve` is running, you can open a second terminal tab or terminal window to run commands without stopping the server.
+If at any point you would like to stop serving your application, press `Ctrl+c` in the terminal that's running the `ng serve` command.
 
 ## Get familiar with your Angular application
 
-The application source files that this tutorial focuses on are in `src/app`.
-Key files that the CLI generates automatically include the following:
+The application source files that this tutorial focuses on are in `src/app`:
 
-1. `app.module.ts`: Specifies the files that the application uses.
-   This file acts as a central hub for the other files in your application.
-2. `app.component.ts`: Also known as the class, contains the logic for the application's main page.
-3. `app.component.html`: Contains the HTML for `AppComponent`. The contents of this file are also known as the template.
+```plain
+src/app
+├── app.component.css
+├── app.component.html
+├── app.component.spec.ts
+├── app.component.ts
+└── app.config.ts
+```
+
+Key files that the CLI generates automatically are the following:
+
+1. `app.component.ts`: Also known as the class, contains the logic for the application's main page.
+2. `app.component.html`: Contains the HTML for `AppComponent`. The contents of this file are also known as the template.
    The template determines the view or what you see in the browser.
-4. `app.component.css`: Contains the styles for `AppComponent`. You use this file when you want to define styles that only apply to a specific component, as opposed to your application overall.
+3. `app.component.css`: Contains the styles for `AppComponent`. You use this file when you want to define styles that only apply to a specific component, as opposed to your application overall.
 
 A component in Angular is made up of three main parts—the template, styles, and the class.
 For example, `app.component.ts`, `app.component.html`, and `app.component.css` together constitute the `AppComponent`.
 This structure separates the logic, view, and styles so that the application is more maintainable and scalable.
-
 In this way, you are using the best practices from the very beginning.
 
 The Angular CLI also generates a file for component testing called `app.component.spec.ts`, but this tutorial doesn't go into testing, so you can ignore that file.
-
-Whenever you generate a component, the CLI creates these four files in a directory with the name you specify.
+Whenever you generate a component, the CLI creates these files in a directory with the name you specify and we'll see an example of that later.
+To learn more about testing, see the [Angular testing guide](https://angular.io/guide/testing).
 
 ## The structure of an Angular application
 
@@ -211,8 +189,8 @@ You use a selector just like regular HTML tags by placing it within other templa
 When a selector is in a template, the browser renders the template of that component whenever an instance of the selector is encountered.
 This tutorial guides you through creating two components and using one within the other.
 
-**NOTE:** The name of the component above is `ItemComponent` which is also the name of the class. Why?
-The names are the same simply because a component is nothing but a class supplemented by a TypeScript decorator.
+> **Note:** The name of the component above is `ItemComponent` which is also the name of the class.
+> The names are the same simply because a component is nothing but a class supplemented by a TypeScript decorator.
 
 Angular's component model offers strong encapsulation and an intuitive application structure.
 Components also make your application easier to unit test and can improve the overall readability of your code.
@@ -302,6 +280,26 @@ Typically, a component uses styles in a separate file using the `styleUrls` prop
 ```
 
 With component-specific styles, you can organize your CSS so that it is easily maintainable and portable.
+
+### Standalone components
+
+It's recommended to [make components standalone](https://angular.io/guide/component-overview#creating-a-component-manually-1) unless a project already makes use of [NgModules](https://angular.io/guide/ngmodules) (Angular modules) to organize code.
+This tutorial uses standalone components which are easier to start with.
+It's common to import [`CommonModule`](https://angular.io/api/common/CommonModule) so that your component can make use of common [directives](https://angular.io/api/common#directives) and [pipes](https://angular.io/api/common#pipes).
+This tutorial makes use of `ngFor` and `ngIf`, so we can make sure they're available like so:
+
+```js
+import { Component } from "@angular/core";
+import { CommonModule } from '@angular/common';
+
+@Component({
+  standalone: true,
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
+  imports: [CommonModule],
+})
+```
 
 ## Summary
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -90,7 +90,7 @@ npm install -g @angular/cli
 ```
 
 Angular CLI commands all start with `ng`, followed by what you'd like the CLI to do.
-In the directory you would like to build your app, use the following `ng new` command to create a new application called `todo`:
+In the directory you would like to build your app, use the following [`ng new`](https://angular.io/cli/new) command to create a new application called `todo`:
 
 ```bash
 ng new todo --routing=false --style=css --ssr=false
@@ -284,7 +284,7 @@ With component-specific styles, you can organize your CSS so that it is easily m
 ### Standalone components
 
 It's recommended to [make components standalone](https://angular.io/guide/component-overview#creating-a-component-manually-1) unless a project already makes use of [NgModules](https://angular.io/guide/ngmodules) (Angular modules) to organize code.
-This tutorial uses standalone components which are easier to start with.
+This tutorial uses [standalone components](https://angular.io/guide/standalone-components) which are easier to start with.
 It's common to import [`CommonModule`](https://angular.io/api/common/CommonModule) so that your component can make use of common [directives](https://angular.io/api/common#directives) and [pipes](https://angular.io/api/common#pipes).
 This tutorial makes use of `ngFor` and `ngIf`, so we can make sure they're available like so:
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
@@ -43,21 +43,32 @@ ng generate component item
 
 The `ng generate component` command creates a component and folder with the name you specify.
 Here, the folder and component name is `item`.
-You can find the `item` directory within the `app` folder.
+You can find the `item` directory within the `app` folder:
+
+```plain
+src/app/item
+├── item.component.css
+├── item.component.html
+├── item.component.spec.ts
+└── item.component.ts
+```
 
 Just as with the `AppComponent`, the `ItemComponent` is made up of the following files:
 
 - `item.component.html` for HTML
 - `item.component.ts` for logic
 - `item.component.css` for styles
+- `item.component.spec.ts` for testing the component
 
 You can see a reference to the HTML and CSS files in the `@Component()` decorator metadata in `item.component.ts`.
 
 ```js
 @Component({
   selector: 'app-item',
+  standalone: true,
+  imports: [],
   templateUrl: './item.component.html',
-  styleUrls: ['./item.component.css'],
+  styleUrl: './item.component.css'
 })
 ```
 
@@ -107,7 +118,6 @@ The next section explains how components share data in detail.
 
 The next two buttons for editing and deleting the current item are within a `<div>`.
 On this `<div>` is an `*ngIf`, a built-in Angular directive that you can use to dynamically change the structure of the DOM.
-
 This `*ngIf` means that if `editable` is `false`, this `<div>` is in the DOM. If `editable` is `true`, Angular removes this `<div>` from the DOM.
 
 ```html
@@ -159,11 +169,11 @@ The `saveItem()` method takes the value from the `#editedItem` element and chang
 ## Prepare the AppComponent
 
 In the next section, you will add code that relies on communication between the `AppComponent` and the `ItemComponent`.
-
 Add the following line near the top of the `app.component.ts` file to import the `Item`:
 
 ```ts
 import { Item } from "./item";
+import { ItemComponent } from "./item/item.component";
 ```
 
 Then, configure the AppComponent by adding the following to the same file's class:
@@ -176,21 +186,32 @@ remove(item: Item) {
 
 The `remove()` method uses the JavaScript `Array.splice()` method to remove one item at the `indexOf` the relevant item.
 In plain English, this means that the `splice()` method removes the item from the array.
-For more information on the `splice()` method, see the MDN Web Docs article on [`Array.prototype.splice()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice).
+For more information on the `splice()` method, see the [`Array.prototype.splice()` documentation](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice).
 
 ## Add logic to ItemComponent
 
 To use the `ItemComponent` UI, you must add logic to the component such as functions, and ways for data to go in and out.
-
 In `item.component.ts`, edit the JavaScript imports as follows:
 
 ```js
 import { Component, Input, Output, EventEmitter } from "@angular/core";
+import { CommonModule } from "@angular/common";
 import { Item } from "../item";
 ```
 
 The addition of `Input`, `Output`, and `EventEmitter` allows `ItemComponent` to share data with `AppComponent`.
 By importing `Item`, `ItemComponent` can understand what an `item` is.
+You can update the `@Component` to use [`CommonModule`](https://angular.io/api/common/CommonModule) in `app/item/item.component.ts` so that we can use the `ngIf` directives:
+
+```js
+@Component({
+  selector: 'app-item',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './item.component.html',
+  styleUrl: './item.component.css',
+})
+```
 
 Further down `item.component.ts`, replace the generated `ItemComponent` class with the following:
 
@@ -242,14 +263,12 @@ The `AppComponent` serves as a shell for the application where you can include o
 
 To use the `ItemComponent` in `AppComponent`, put the `ItemComponent` selector in the `AppComponent` template.
 Angular specifies the selector of a component in the metadata of the `@Component()` decorator.
-In this example, the selector is `app-item`:
+In this example, we've defined the selector as `app-item`:
 
 ```js
 @Component({
   selector: 'app-item',
-  templateUrl: './item.component.html',
-  styleUrls: ['./item.component.css']
-})
+  // ...
 ```
 
 To use the `ItemComponent` selector within the `AppComponent`, you add the element, `<app-item>`, which corresponds to the selector you defined for the component class to `app.component.html`.
@@ -267,6 +286,18 @@ Replace the current unordered list in `app.component.html` with the following up
     <app-item (remove)="remove(i)" [item]="i"></app-item>
   </li>
 </ul>
+```
+
+Change the `imports` in `app.component.ts` to include `ItemComponent` as well as `CommonModule`:
+
+```js
+@Component({
+  standalone: true,
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
+  imports: [CommonModule, ItemComponent],
+})
 ```
 
 The double curly brace syntax, `\{{}}`, in the `<h2>` interpolates the length of the `items` array and displays the number.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
@@ -200,7 +200,7 @@ import { Item } from "../item";
 ```
 
 The addition of `Input`, `Output`, and `EventEmitter` allows `ItemComponent` to share data with `AppComponent`.
-By importing `Item`, `ItemComponent` can understand what an `item` is.
+By importing `Item`, the `ItemComponent` can understand what an `item` is.
 You can update the `@Component` to use [`CommonModule`](https://angular.io/api/common/CommonModule) in `app/item/item.component.ts` so that we can use the `ngIf` directives:
 
 ```js
@@ -225,6 +225,7 @@ export class ItemComponent {
 
   saveItem(description: string) {
     if (!description) return;
+
     this.editable = false;
     this.item.description = description;
   }
@@ -272,7 +273,7 @@ In this example, we've defined the selector as `app-item`:
 ```
 
 To use the `ItemComponent` selector within the `AppComponent`, you add the element, `<app-item>`, which corresponds to the selector you defined for the component class to `app.component.html`.
-Replace the current unordered list in `app.component.html` with the following updated version:
+Replace the current unordered list `<ul>` in `app.component.html` with the following updated version:
 
 ```html
 <h2>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_styling/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_styling/index.md
@@ -39,7 +39,7 @@ The Angular CLI generates two types of style files:
 - `styles.css`: In the `src` directory, the styles in this file apply to your entire application unless you specify styles at the component level.
 
 Depending on whether you are using a CSS preprocessor, the extension on your CSS files can vary.
-Angular supports plain CSS, SCSS, Sass, Less, and Stylus.
+Angular supports plain CSS, SCSS, Sass, and Less.
 
 In `src/styles.css`, paste the following styles:
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -87,7 +87,7 @@ You won't use this file until [later](/en-US/docs/Learn/Tools_and_testing/Client
 
 ## Add logic to AppComponent
 
-Now that you know what an `item` is, you can give your application some items by adding them to the TypeScript file, `app.component.ts`.
+Now that you know what an `item` is, you can give your application some items by adding them to the app.
 In `app.component.ts`, replace the contents with the following:
 
 ```js
@@ -96,10 +96,10 @@ import { CommonModule } from "@angular/common";
 
 @Component({
   standalone: true,
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
   imports: [CommonModule],
-  selector: "app-root",
-  templateUrl: "./app.component.html",
-  styleUrls: ["./app.component.css"],
 })
 export class AppComponent {
   title = "todo";
@@ -126,14 +126,17 @@ export class AppComponent {
 
 The first line is a JavaScript import that imports Angular.
 The `@Component()` decorator specifies metadata about the `AppComponent`.
-The default metadata properties are as follows:
+Here's some more information about the metadata we're using:
 
-- `selector`: Tells you the name of the CSS selector that you use in a template to instantiate this component. Here it is `'app-root'`.
+- [`standalone`](https://angular.io/api/core/Component#standalone): Describe whether the component requires a [NgModule](https://angular.io/guide/ngmodules#the-basic-ngmodule) or not.
+  Your app will directly manage template dependencies (components, directives, etc.) using imports when it's a standalone.
+- [`selector`](https://angular.io/api/core/Directive#selector): Tells you the name of the CSS selector that you use in a template to instantiate this component. Here it is `'app-root'`.
   In the `index.html`, within the `body` tag, the Angular CLI added `<app-root></app-root>` when generating your application.
   You use all component selectors in the same way by adding them to other component HTML templates.
-- `templateUrl`: Specifies the HTML file to associate with this component.
+- [`templateUrl`](https://angular.io/api/core/Component#templateurl): Specifies the HTML file to associate with this component.
   Here it is, './app.component.html',
-- `styleUrls`: Provides the location and name of the file for your styles that apply specifically to this component. Here it is `'./app.component.css'`.
+- [`styleUrls`](https://angular.io/api/core/Component#styleurls): Provides the location and name of the file for your styles that apply specifically to this component. Here it is `'./app.component.css'`.
+- [`imports`](https://angular.io/api/core/Component#imports): Allows you to specify the component's dependencies that can be used within its template.
 
 The `filter` property is of type `union`, which means `filter` could have the value of `all`, `active`, or `done`.
 With the `union` type, if you make a typo in the value you assign to the `filter` property, TypeScript lets you know so that you can catch the bug early.
@@ -179,9 +182,8 @@ What would you like to do today?
 
 ## Add items to the list
 
-A to-do list needs a way to add items.
-
-In `app.component.ts`, add the following method to the class:
+A to-do list needs a way to add items, so let's get started.
+In `app.component.ts`, add the following method to the class after the `allItems` array:
 
 ```ts
 addItem(description: string) {
@@ -197,7 +199,6 @@ The `addItem()` method uses the array method `unshift()` to add a new item to th
 You could alternatively use `push()`, which would add the new item to the end of the array and the bottom of the list.
 
 To use the `addItem()` method, edit the HTML in the `AppComponent` template.
-
 In `app.component.html`, replace the `<h2>` with the following:
 
 ```html

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -37,7 +37,7 @@ At this point, we are ready to start creating our to-do list application using A
 
 ## The to-do application structure
 
-Like any web application, an Angular application has an `index.html` as the entry point. The `indiex.html` acually is the app's top level HTML template:
+Like any web application, an Angular application has an `index.html` as the entry point. The `index.html` acually is the app's top level HTML template:
 
 ```html
 <!doctype html>

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -37,9 +37,22 @@ At this point, we are ready to start creating our to-do list application using A
 
 ## The to-do application structure
 
-Just like a basic application that doesn't use a framework, an Angular application has an `index.html`.
-Within the `<body>` tag of the `index.html`, Angular uses a special element — `<app-root>` — to insert your main component, which in turn includes other components you create.
-Generally, you don't need to touch the `index.html`, instead focusing your work within specialized areas of your application called components.
+Like any web application, an Angular application has an `index.html` as the entry point. The `indiex.html` acually is the app's top level HTML template:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- ... -->
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>
+```
+
+Within the `<body>` tag, Angular uses a special element — `<app-root>` — to insert your main component, which in turn includes other components you create.
+Generally, you don't need to touch the `index.html`, and you mostly focus your work within specialized areas of your application called components.
 
 ### Organize your application with components
 
@@ -83,7 +96,7 @@ export interface Item {
 }
 ```
 
-You won't use this file until [later](/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component#add_logic_to_itemcomponent), but it is a good time to know and record your knowledge of what an `item` is. The `Item` interface creates an `item` object model so that your application will understand what an `item` is. For this to-do list, an `item` is an object that has a description and can be done.
+You won't use this file until [later](/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component#add_logic_to_itemcomponent), but it is a good time to know and record your knowledge of what an `item` is. The `Item` interface creates an `item` object model so that your application will understand what an `item` is. For this to-do list, an `item` is an object that has a description and can be marked done.
 
 ## Add logic to AppComponent
 
@@ -102,7 +115,7 @@ import { CommonModule } from "@angular/common";
   imports: [CommonModule],
 })
 export class AppComponent {
-  title = "todo";
+  componentTitle = "My To Do List";
 
   filter: "all" | "active" | "done" = "all";
 
@@ -124,17 +137,17 @@ export class AppComponent {
 }
 ```
 
-The first line is a JavaScript import that imports Angular.
+The first two lines are JavaScript imports. In this case they are importing Angular libraries.
 The `@Component()` decorator specifies metadata about the `AppComponent`.
 Here's some more information about the metadata we're using:
 
 - [`standalone`](https://angular.io/api/core/Component#standalone): Describe whether the component requires a [NgModule](https://angular.io/guide/ngmodules#the-basic-ngmodule) or not.
   Your app will directly manage template dependencies (components, directives, etc.) using imports when it's a standalone.
-- [`selector`](https://angular.io/api/core/Directive#selector): Tells you the name of the CSS selector that you use in a template to instantiate this component. Here it is `'app-root'`.
+- [`selector`](https://angular.io/api/core/Directive#selector): Tells you the the CSS selector that you use in a template to place this component. Here it is `'app-root'`.
   In the `index.html`, within the `body` tag, the Angular CLI added `<app-root></app-root>` when generating your application.
   You use all component selectors in the same way by adding them to other component HTML templates.
 - [`templateUrl`](https://angular.io/api/core/Component#templateurl): Specifies the HTML file to associate with this component.
-  Here it is, './app.component.html',
+  Here it is, `'./app.component.html'`,
 - [`styleUrls`](https://angular.io/api/core/Component#styleurls): Provides the location and name of the file for your styles that apply specifically to this component. Here it is `'./app.component.css'`.
 - [`imports`](https://angular.io/api/core/Component#imports): Allows you to specify the component's dependencies that can be used within its template.
 
@@ -142,11 +155,10 @@ The `filter` property is of type `union`, which means `filter` could have the va
 With the `union` type, if you make a typo in the value you assign to the `filter` property, TypeScript lets you know so that you can catch the bug early.
 This guide shows you how to add filtering in a later step, but you can also use a filter to show the default list of all the items.
 
-The `allItems` array contains the to-do items and whether they are `done`.
+The `allItems` array contains the to-do items and whether they are done.
 The first item, `eat`, has a `done` value of true.
 
-The getter, `get items()`, retrieves the items from the `allItems` array if the `filter` is equal to `all`.
-Otherwise, `get items()` returns the `done` items or the outstanding items depending on how the user filters the view.
+The getter, `get items()`, retrieves the items from the `allItems` array if the `filter` is equal to `all`. Otherwise, `get items()` returns the done or pending items depending on how the user filters the view.
 The getter also establishes the name of the array as `items`, which you'll use in the next section.
 
 ## Add HTML to the AppComponent template
@@ -155,7 +167,7 @@ To see the list of items in the browser, replace the contents of `app.component.
 
 ```html
 <div class="main">
-  <h1>My To Do List</h1>
+  <h1>\{{ componentTitle }}</h1>
   <h2>What would you like to do today?</h2>
 
   <ul>
@@ -187,6 +199,8 @@ In `app.component.ts`, add the following method to the class after the `allItems
 
 ```ts
 addItem(description: string) {
+  if (!description) return;
+
   this.allItems.unshift({
     description,
     done: false


### PR DESCRIPTION
### Description

There were some errors in the Angular tutorial and some fixes have landed, but there was a need to follow through the steps again from the beginning to make sure everything works as expected.

This PR uses 17.3.0 (current when using `npm install -g @angular/cli` at time of writing).

### Motivation

Keeping the tutorials using frameworks error-free at the very least.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/32132
