### PR TITLE
chore(api): Fix trailing brackets left over from search/replace

### DIFF
--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -39,19 +39,19 @@ framebuffer:
   {{domxref("WebGLRenderingContext.framebufferRenderbuffer", "framebufferRenderbuffer()")}},
   {{domxref("WebGLRenderingContext.deleteFramebuffer","deleteFramebuffer()")}}, or
   {{domxref("WebGLRenderingContext.getFramebufferAttachmentParameter", "getFramebufferAttachmentParameter()")}}
-  on an opaque framebuffer results in the WebGL error `INVALID_OPERATION` (0x0502).
+  on an opaque framebuffer results in the WebGL error `INVALID_OPERATION` (`0x0502`).
 - Opaque framebuffers are considered incomplete and are not available for rendering
   other than while executing the {{domxref("XRSession.requestAnimationFrame","requestAnimationFrame()")}} callback.
-  Attempting to clear, draw to, or read from the framebuffer results in a WebGL `INVALID_FRAMEBUFFER_OPERATION` error (0x0506).
+  Attempting to clear, draw to, or read from the framebuffer results in a WebGL `INVALID_FRAMEBUFFER_OPERATION` error (`0x0506`).
   Calling {{domxref("WebGLRenderingContext.checkFramebufferStatus", "checkFramebufferStatus()")}} on the WebGL context from outside the animation frame
-  callback causes the WebGL `FRAMEBUFFER_UNSUPPORTED` error (0x8CDD) to be reported.
+  callback causes the WebGL `FRAMEBUFFER_UNSUPPORTED` error (`0x8CDD`) to be reported.
 - Opaque framebuffers initialized with the `depth` property set to `false` will not have a depth buffer and will
   rely on the coordinates alone to determine distance.
-- Opaque framebuffers initialized without specifying a `stencil`")}}` will not have a stencil buffer.
+- Opaque framebuffers initialized without specifying a `stencil` property will not have a stencil buffer.
 - Opaque framebuffers will not have an alpha channel available unless the `alpha` property is `true` when
   creating the layer.
 - The XR compositor assumes that opaque framebuffers use colors with premultiplied
-  alpha, regardless of whether or not the WebGL context's `premultipliedAlpha`")}}` context
+  alpha, regardless of whether or not the WebGL context's [`premultipliedAlpha`](/en-US/docs/Web/API/HTMLCanvasElement/getContext#premultipliedalpha) context
   attribute is set.
 
 > **Note:** The `depth` and `stencil` properties are


### PR DESCRIPTION
### Description

A couple of small typos after https://github.com/mdn/content/pull/24533, getting rid of the leftover brackets. Some formatting changes and linking to `premultipliedalpha` for context.

