### PR TITLE
replaced `img` by `form` in examples for rel="noreferrer"

### DIFF
--- a/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
@@ -30,7 +30,7 @@ You can also mitigate such risks using:
 
 - The {{httpheader("Referrer-Policy")}} header on your server to control what information is sent through the {{httpheader("Referer")}} header. For example, a directive of `no-referrer` would omit the Referer header entirely.
 - The `referrerpolicy` attribute on HTML elements that are in danger of leaking such information (such as {{HTMLElement("img")}} and {{HTMLElement("a")}}). This can for example be set to `no-referrer` to stop the `Referer` header being sent altogether.
-- The [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute set to [`noreferrer`](/en-US/docs/Web/HTML/Attributes/rel/noreferrer) on HTML elements that are in danger of leaking such information (such as {{HTMLElement("img")}} and {{HTMLElement("a")}}).
+- The [`rel`](/en-US/docs/Web/HTML/Attributes/rel) attribute set to [`noreferrer`](/en-US/docs/Web/HTML/Attributes/rel/noreferrer) on HTML elements that are in danger of leaking such information (such as {{HTMLElement("form")}} and {{HTMLElement("a")}}).
 - A {{HTMLElement("meta")}} element with a [name](/en-US/docs/Web/HTML/Element/meta#name) of `referrer` and the content set to `no-referrer` to disable the Referer header for the whole document. See [Referrer-Policy Integration with HTML](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#integration_with_html).
 - The [Exit page](https://geekthis.net/post/hide-http-referer-headers/#exit-page-redirect) technique.
 


### PR DESCRIPTION
### Description

Examples for `HTML` attribute `rel=noreferrer` include `img`, but this attribute is not valid for `img` elements.

### Motivation

Fixing incorrect information.

### Additional details

According to the MDN page for the [HTML rel attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) the attribute can is not valid to be used with HTML `img` elements. Therefore `img` elements shouldn't be mentioned as examples in this case.

Since only `a`, `area` and `form` elements can have `rel=noreferrer`, I've replaced the incorrect example with `form` instead.
