### PR TITLE
fix(js): add concurrent modification case to "invalid array length" error page

### DIFF
--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -36,6 +36,7 @@ An invalid array length might appear in these situations:
 - Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>31</sup>-1 (2GiB-1) on a 32-bit system, or 2<sup>33</sup> (8GiB) on a 64-bit system.
 - Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property to a floating-point number.
 - Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>31</sup>-1 (2GiB-1).
+- Modifying the array size in {{jsxref("statements/for","for")}} loop.
 
 If you are creating an `Array`, using the constructor, you probably want to
 use the literal notation instead, as the first argument is interpreted as the length of
@@ -62,6 +63,12 @@ b.length = b.length + 1; // set the length property to 2^32
 b.length = 2.5; // set the length property to a floating-point number
 
 const c = new Array(2.5); // pass a floating-point number
+
+// concurrent modification
+const arr = [1, 2, 3];
+for (let e of arr) {
+  arr.push(e * 10);
+}
 ```
 
 ### Valid cases
@@ -84,6 +91,9 @@ b.length = Math.min(0xffffffff, b.length + 1);
 b.length = 3;
 
 const c = new Array(3);
+
+const arr = [1, 2, 3];
+arr.forEach((e) => arr.push(e * 10));
 ```
 
 ## See also

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -29,21 +29,13 @@ RangeError: Array size is not a small enough positive integer. (Safari)
 
 ## What went wrong?
 
-An invalid array length might appear in these situations:
+The error might appear when attempting to produce an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}} with an invalid length, which includes:
 
-- Creating an {{jsxref("Array")}} or {{jsxref("ArrayBuffer")}} with a negative length, or setting a negative value for the {{jsxref("Array/length", "length")}} property.
-- Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property greater than 2<sup>32</sup>-1.
-- Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>31</sup>-1 (2GiB-1) on a 32-bit system, or 2<sup>33</sup> (8GiB) on a 64-bit system.
-- Creating an {{jsxref("Array")}} or setting the {{jsxref("Array/length", "length")}} property to a floating-point number.
-- Before Firefox 89: Creating an {{jsxref("ArrayBuffer")}} that is bigger than 2<sup>31</sup>-1 (2GiB-1).
-- Modifying the array size in {{jsxref("statements/for","for")}} loop.
+- Negative length, via the constructor or setting the {{jsxref("Array/length", "length")}} property.
+- Non-integer length, via the constructor or setting the {{jsxref("Array/length", "length")}} property. (The `ArrayBuffer` constructor coerces the length to an integer, but the `Array` constructor does not.)
+- Exceeding the maximum length supported by the platform. For arrays, the maximum length is 2<sup>32</sup>-1. For `ArrayBuffer`, the maximum length is 2<sup>31</sup>-1 (2GiB-1) on 32-bit systems, or 2<sup>33</sup> (8GiB) on 64-bit systems. This can happen via the constructor, setting the `length` property, or array methods that implicitly set the length property (such as {{jsxref("Array/push", "push")}} and {{jsxref("Array/concat", "concat")}}).
 
-If you are creating an `Array`, using the constructor, you probably want to
-use the literal notation instead, as the first argument is interpreted as the length of
-the `Array`.
-
-Otherwise, you might want to clamp the length before setting the length property, or
-using it as argument of the constructor.
+If you are creating an `Array` using the constructor, you probably want to use the literal notation instead, as the first argument is interpreted as the length of the `Array`. Otherwise, you might want to clamp the length before setting the length property, or using it as argument of the constructor.
 
 ## Examples
 
@@ -64,9 +56,9 @@ b.length = 2.5; // set the length property to a floating-point number
 
 const c = new Array(2.5); // pass a floating-point number
 
-// concurrent modification
+// Concurrent modification that accidentally grows the array infinitely
 const arr = [1, 2, 3];
-for (let e of arr) {
+for (const e of arr) {
   arr.push(e * 10);
 }
 ```
@@ -92,6 +84,8 @@ b.length = 3;
 
 const c = new Array(3);
 
+// Because array methods save the length before iterating, it is safe to grow
+// the array during iteration
 const arr = [1, 2, 3];
 arr.forEach((e) => arr.push(e * 10));
 ```

--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.md
@@ -119,6 +119,16 @@ arr[1] = "n";
 console.log(iterator.next().value); // "n"
 ```
 
+Unlike [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods), the array iterator object does not save the array's length at the time of its creation, but reads it once on each iteration. Therefore, if the array grows during iteration, the iterator will visit the new elements too. This may lead to infinite loops.
+
+```js
+const arr = [1, 2, 3];
+for (const e of arr) {
+  arr.push(e * 10);
+}
+// RangeError: invalid array length
+```
+
 ### Iterating sparse arrays
 
 `values()` will visit empty slots as if they are `undefined`.


### PR DESCRIPTION
The exception is also thrown when array length is changed in a same `for` loop.

Tested on Google Chrome and Brave.