### PR TITLE
fix(games): Fix broken links to three.js, related 404s

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
@@ -268,6 +268,5 @@ That was easier than you thought, right? A-Frame targets web developers by offer
 
 - [A-Frame website](https://aframe.io/)
 - [Introducing A-Frame 0.1.0 article](https://aframe.io/blog/2015/12/16/introducing-aframe/)
-- [Made with A-Frame Tumblr](https://aframevr.tumblr.com/)
 - [A-Frame physics plugin](https://github.com/ngokevin/aframe-physics-components)
 - [A-Frame gamepad controls plugin](https://github.com/donmccurdy/aframe-gamepad-controls)

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -137,7 +137,7 @@ The code above assign a dark grey ambient light for the whole scene. The box loo
 
 ## Material
 
-The basic PlayCanvas material is called [PhongMaterial](https://developer.playcanvas.com/user-manual/assets/types/material/) — add the following lines below the previous code.
+The basic PlayCanvas material is called [Material](https://developer.playcanvas.com/user-manual/assets/types/material/) — add the following lines below the previous code.
 
 ```js
 const boxMaterial = new pc.PhongMaterial();

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -137,7 +137,7 @@ The code above assign a dark grey ambient light for the whole scene. The box loo
 
 ## Material
 
-The basic PlayCanvas material is called [PhongMaterial](https://developer.playcanvas.com/en/user-manual/assets/materials/phong-material/) — add the following lines below the previous code.
+The basic PlayCanvas material is called [PhongMaterial](https://developer.playcanvas.com/user-manual/assets/types/material/) — add the following lines below the previous code.
 
 ```js
 const boxMaterial = new pc.PhongMaterial();

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -137,7 +137,8 @@ The code above assign a dark grey ambient light for the whole scene. The box loo
 
 ## Material
 
-The basic PlayCanvas material is called [Material](https://developer.playcanvas.com/user-manual/assets/types/material/) — add the following lines below the previous code.
+This example uses an older [material](https://developer.playcanvas.com/user-manual/assets/types/material/) called "Phong Material" (supported as of PlayCanvas Engine v1.65.0).
+To use `PhongMaterial`, add the following lines below the previous code:
 
 ```js
 const boxMaterial = new pc.PhongMaterial();

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -12,12 +12,21 @@ A typical 3D scene in a game — even the simplest one — contains standard ite
 
 ## Environment setup
 
-To start developing with Three.js, you don't need much. You should:
+To start developing with Three.js, you should make sure you are using a modern browser with good [WebGL](/en-US/docs/Web/API/WebGL_API) support, such as the latest Firefox or Chrome.
 
-- Make sure you are using a modern browser with good [WebGL](/en-US/docs/Web/API/WebGL_API) support, such as the latest Firefox or Chrome.
-- Create a directory to store your experiments in.
-- Save a copy of the [latest minimized Three.js library](https://threejs.org/build/three.min.js) inside your directory.
-- Open the [Three.js documentation](https://threejs.org/docs/) in a separate tab — it is useful to refer to.
+You can download the [latest Three.js library](https://github.com/mrdoob/three.js/archive/master.zip) and copy the minified version of Three.js from the uncompressed archive at `build/three.module.min.js` into your project.
+Bear in mind that the archives include source files, which makes the download size approximately 350MB.
+
+Alternatively, you can import Three.js [using a CDN or use Node.js](https://threejs.org/docs/#manual/en/introduction/Installation).
+A Node.js setup with Three.js installed as a dependency is convenient if you want to track versions and it can speed up collaboration and deployment:
+
+```bash
+npm install --save three
+npm install --save-dev vite # For development
+npx vite
+```
+
+Whichever way you choose to get started, make sure you have the [Three.js documentation](https://threejs.org/docs/) open somewhere while you're working for reference.
 
 ## HTML structure
 

--- a/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/glsl_shaders/index.md
@@ -36,11 +36,7 @@ Let's build a simple demo to explain those shaders in action. Be sure to read [T
 
 ### Environment setup
 
-To start with the WebGL shaders you don't need much. You should:
-
-- Make sure you are using a modern browser with good [WebGL](/en-US/docs/Web/API/WebGL_API) support, such as the latest Firefox or Chrome.
-- Create a directory to store your experiments in.
-- Save a copy of the [latest minimized Three.js library](https://threejs.org/build/three.min.js) inside your directory.
+To get started with the WebGL shaders, follow the environment setup steps described in the [Building up a basic demo with Three.js](/en-US/docs/Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js) so that you have Three.js working as expected.
 
 ### HTML structure
 

--- a/files/en-us/games/techniques/control_mechanisms/mobile_touch/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/mobile_touch/index.md
@@ -155,18 +155,32 @@ We can pull the ship around and do something in the meantime, and react when the
 
 ### Dedicated plugins
 
-You could go even further and use dedicated plugins like this [TouchControl plugin](https://github.com/Gamegur-us/phaser-touch-control-plugin).
-The initialization of TouchControl looks like this:
+You can use dedicated plugins that handle touch events in different ways, render UI controls, and more.
+Here are some plugin examples that use a virtual gamepad and joystick:
 
-```js
-this.game.touchControl = this.game.plugins.add(Phaser.TouchControl);
-this.game.touchControl.inputEnable();
+- [phaser-plugin-virtual-gamepad](https://github.com/ShawnHymel/phaser-plugin-virtual-gamepad) (Phaser 2)
+- [Virtual joystick](https://rexrainbow.github.io/phaser3-rex-notes/docs/site/virtualjoystick/) (Phaser 3)
+
+For basic plugins like the virtual gamepad, you can download the script and make it available in your page:
+
+```html
+<script src="js/phaser.min.js"></script>
+<!-- https://github.com/ShawnHymel/phaser-plugin-virtual-gamepad -->
+<script src="js/phaser-plugin-virtual-gamepad.js"></script>
 ```
 
-This allows you to create single or multi-directional touch controls for your games.
-We can adjust the player's velocity based on the current angle of the stick and move him appropriately.
+Then include them in your script and use them similar to the following snippet:
 
-If you want to see full example code that uses TouchControl, have a look at the [phaser-touch-control-plugin GitHub repository](https://github.com/Gamegur-us/phaser-touch-control-plugin/blob/master/demo/js/Game.js).
+```js
+// Add the VirtualGamepad plugin to a Phaser 2 game
+this.gamepad = this.game.plugins.add(Phaser.Plugin.VirtualGamepad);
+// Add a joystick to the game
+this.joystick = this.gamepad.addJoystick(100, 420, 1.2, "gamepad");
+// Add a button to the game
+this.button = this.gamepad.addButton(400, 420, 1.0, "gamepad");
+```
+
+For more information, have a look through then [unofficial catalog of Phaser plugins](https://phaserplugins.com/) to see if something fits your needs.
 
 ## Summary
 

--- a/files/en-us/games/techniques/control_mechanisms/mobile_touch/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/mobile_touch/index.md
@@ -155,24 +155,18 @@ We can pull the ship around and do something in the meantime, and react when the
 
 ### Dedicated plugins
 
-You could go even further and use dedicated plugins like [Virtual Joystick](https://phaser.io/shop/plugins/virtualjoystick) — this is a paid, official Phaser plugin, but you can find free and [open source alternatives](https://github.com/Gamegur-us/phaser-touch-control-plugin). The initialization of Virtual Joystick looks like this:
+You could go even further and use dedicated plugins like this [TouchControl plugin](https://github.com/Gamegur-us/phaser-touch-control-plugin).
+The initialization of TouchControl looks like this:
 
 ```js
-this.pad = this.game.plugins.add(Phaser.VirtualJoystick);
-this.stick = this.pad.addStick(30, 30, 80, "generic");
+this.game.touchControl = this.game.plugins.add(Phaser.TouchControl);
+this.game.touchControl.inputEnable();
 ```
 
-In the `create()` function of the `Game` state we're creating a virtual pad and a generic stick that has four directional virtual buttons by default. This is placed 30 pixels from the top and left edges of the screen and is 80 pixels wide.
-
-The stick being pressed can be handled during the gameplay in the `update` function like so:
-
-```js
-if (this.stick.isDown) {
-  // Move the player
-}
-```
-
+This allows you to create single or multi-directional touch controls for your games.
 We can adjust the player's velocity based on the current angle of the stick and move him appropriately.
+
+If you want to see full example code that uses TouchControl, have a look at the [phaser-touch-control-plugin GitHub repository](https://github.com/Gamegur-us/phaser-touch-control-plugin/blob/master/demo/js/Game.js).
 
 ## Summary
 

--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -707,7 +707,7 @@ Let's look at a simple example of how to create something with a WebGL library. 
 
 1. To start with, make a local copy of [threejs-cube/index.html](https://github.com/mdn/learning-area/blob/main/javascript/apis/drawing-graphics/threejs-cube/index.html) in a new folder, then save a copy of [metal003.png](https://github.com/mdn/learning-area/blob/main/javascript/apis/drawing-graphics/threejs-cube/metal003.png) in the same folder. This is the image we'll use as a surface texture for the cube later on.
 2. Next, create a new file called `script.js`, again in the same folder as before.
-3. Next, you need to [download the three.min.js library](https://raw.githubusercontent.com/mrdoob/three.js/dev/build/three.min.js) and save it in the same directory as before.
+3. Next, you need to have the Three.js library installed. You can follow the environment setup steps described in the [Building up a basic demo with Three.js](/en-US/docs/Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_Three.js) so that you have Three.js working as expected.
 4. Now we've got `three.js` attached to our page, we can start to write JavaScript that makes use of it into `script.js`. Let's start by creating a new scene — add the following into your `script.js` file:
 
    ```js


### PR DESCRIPTION
### Description

You cannot use https://threejs.org/build/three.min.js to download three.js anymore. Instead linking to their install docs and some hints for setting up with Node.js. There are three main options at the moment:

* Node.js (saying this is the preferred method)
* download the GitHub release artifact (350MB zip)
* use a CDN for the JS

__Additions:__

* Add up-to-date install instructions for three.js

__Changes:__

* Link to Three.js tutorial for setup steps in other resources instead of copy pasting.
* Updating link to Phong Material to https://developer.playcanvas.com/user-manual/assets/types/material/
* The [paid Phaser plugin](https://phaser.io/shop/plugins/virtualjoystick) appears to be gone, linking to [the open source version](https://github.com/Gamegur-us/phaser-touch-control-plugin) with links to example code.

__Removals:__

* Removing https://aframevr.tumblr.com/

### Motivation

Keep external links working & install docs up-to-date
