### PR TITLE
added release note for text-wrap & content-visibility

### DIFF
--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -18,6 +18,9 @@ This article provides information about the changes in Firefox 124 that affect d
 
 ### CSS
 
+- The [`content-visibility`](/en-US/docs/Web/CSS/content-visibility) CSS property value `auto` is now enabled by default. This allows content to skip rendering if it is not [relevant to the user](/en-US/docs/Web/CSS/CSS_containment#relevant_to_the_user). ([Firefox bug 1874874](https://bugzil.la/1874874)).
+- The {{cssxref("text-wrap")}} property has now been converted to a shorthand property and covers the constituent properties {{cssxref("text-wrap-mode")}} and {{cssxref("text-wrap-style")}}. ([Firefox bug 1758391](https://bugzil.la/1758391)).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
### Description

- added release note for text-wrap
- added release note for content-visibility

### Motivation

Working on the [Convert text-wrap CSS property to a shorthand](https://github.com/mdn/content/issues/32341) Issue

### Related issues and pull requests
- [Content PR](https://github.com/mdn/content/pull/32728)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/22621)
- [data PR](https://github.com/mdn/data/pull/720)
- [Interactive examples PR](https://github.com/mdn/interactive-examples/pull/2746)