### PR TITLE
Explain why the Express tutorial uses require rather than import

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -366,7 +366,7 @@ The _devstart_ and _serverstart_ scripts can be used to start the same **./bin/w
 ### www file
 
 The file **/bin/www** is the application entry point! The very first thing this does is `require()` the "real" application entry point (**app.js**, in the project root) that sets up and returns the [`express()`](https://expressjs.com/en/api.html) application object.
-`require()` is a global node function that is used to import JavaScript scripts into the current file.
+`require()` is the [CommonJS way](https://nodejs.org/api/modules.html to import JavaScript code, JSON, and other files into the current file.
 Here we specify **app.js** module using a relative path and omit the optional (.**js**) file extension.
 
 ```js
@@ -379,9 +379,9 @@ Here we specify **app.js** module using a relative path and omit the optional (.
 const app = require("../app");
 ```
 
-> **Note:** Nodejs 14 and later also have stable support for the ES6 `import` statement for importing JavaScript (ECMAScript) modules.
+> **Note:** Node.js 14 and later support ES6 `import` statements for importing JavaScript (ECMAScript) modules.
 > To use this feature you have to add `"type": "module",` to your Express **package.json** file, all the modules in your application have to use `import` rather than `require()`, and for _relative imports_ you must include the file extension (for more information see the [Node documentation](https://nodejs.org/api/esm.html#introduction)).
-> While there are benefits to using `import`, this tutorial uses `require()` in order to match the official Express documentation.
+> While there are benefits to using `import`, this tutorial uses `require()` in order to match [the Express documentation](https://expressjs.com/en/starter/hello-world.html).
 
 The remainder of the code in this file sets up a node HTTP server with `app` set to a specific port (defined in an environment variable or 3000 if the variable isn't defined), and starts listening and reporting server errors and connections. For now you don't really need to know anything else about the code (everything in this file is "boilerplate"), but feel free to review it if you're interested.
 

--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -366,6 +366,8 @@ The _devstart_ and _serverstart_ scripts can be used to start the same **./bin/w
 ### www file
 
 The file **/bin/www** is the application entry point! The very first thing this does is `require()` the "real" application entry point (**app.js**, in the project root) that sets up and returns the [`express()`](https://expressjs.com/en/api.html) application object.
+`require()` is a global node function that is used to import JavaScript scripts into the current file.
+Here we specify **app.js** module using a relative path and omit the optional (.**js**) file extension.
 
 ```js
 #!/usr/bin/env node
@@ -377,7 +379,9 @@ The file **/bin/www** is the application entry point! The very first thing this 
 const app = require("../app");
 ```
 
-> **Note:** `require()` is a global node function that is used to import modules into the current file. Here we specify **app.js** module using a relative path and omitting the optional (.**js**) file extension.
+> **Note:** Nodejs 14 and later also have stable support for the ES6 `import` statement for importing JavaScript (ECMAScript) modules.
+> To use this feature you have to add `"type": "module",` to your Express **package.json** file, all the modules in your application have to use `import` rather than `require()`, and for _relative imports_ you must include the file extension (for more information see the [Node documentation](https://nodejs.org/api/esm.html#introduction)).
+> While there are benefits to using `import`, this tutorial uses `require()` in order to match the official Express documentation.
 
 The remainder of the code in this file sets up a node HTTP server with `app` set to a specific port (defined in an environment variable or 3000 if the variable isn't defined), and starts listening and reporting server errors and connections. For now you don't really need to know anything else about the code (everything in this file is "boilerplate"), but feel free to review it if you're interested.
 

--- a/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/skeleton_website/index.md
@@ -366,7 +366,7 @@ The _devstart_ and _serverstart_ scripts can be used to start the same **./bin/w
 ### www file
 
 The file **/bin/www** is the application entry point! The very first thing this does is `require()` the "real" application entry point (**app.js**, in the project root) that sets up and returns the [`express()`](https://expressjs.com/en/api.html) application object.
-`require()` is the [CommonJS way](https://nodejs.org/api/modules.html to import JavaScript code, JSON, and other files into the current file.
+`require()` is the [CommonJS way](https://nodejs.org/api/modules.html) to import JavaScript code, JSON, and other files into the current file.
 Here we specify **app.js** module using a relative path and omit the optional (.**js**) file extension.
 
 ```js


### PR DESCRIPTION
Fixes #32705

Not strictly a fix, because IMO the existing text was not broken. But this explains that you can use `import` with Express/node, why we don't, and points to the docs for more info.