### PR TITLE
rgba() is not necessarily legacy.

### DIFF
--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -42,7 +42,7 @@ Currently, the RGB color space predominates as the space web developers work in.
 
 ## The sRGB color space
 
-Color has many ways of being defined, as is apparent in the [`<color>` data type](/en-US/docs/Web/CSS/color_value), including RGB, RGB decimal, RGB percent, HSL, HWB, LCH, and CMYK, among others.
+Color has many ways of being defined, as is apparent in the [`<color>` data type](/en-US/docs/Web/CSS/color_value), including RGB, RGB decimal, RGB percent, HSL, HWB, LCH, LAB, and CMYK, among others.
 
 For digital concerns, much of the technology has historically resided in the RGB color space. The RGB color model is extended to include "alpha" — RGBA — to allow specification of the opacity of a color. Other methods for measuring color involve measurements using other color spaces and are supported in modern displays and browsers. Still, color measurements in the RGB color space predominate, including in video production.
 
@@ -50,7 +50,7 @@ Technologies, such as [OpenGL](https://en.wikipedia.org/wiki/OpenGL) and [Direct
 
 ### CSS color values
 
-It's important to know that there are variations even within one color space, such as the RGB color space. For example, variations of the RGB color space include **RGB**, **sRGB**, **Adobe RGB**, **Adobe Wide Gamut RGB**, and **RGBA**, among others.
+It's important to know that there are variations even within one {{glossary("color space")}}, such as the {{glossary("RGB")}} color space. For example, variations of the RGB color space include **RGB**, **sRGB**, **Adobe RGB**, **Adobe Wide Gamut RGB**, and **RGBA**, among others.
 
 These are examples of the CSS notations used to define a color. Here the example color for each is a fully opaque magenta:
 
@@ -66,8 +66,8 @@ color: rgb(100% 0% 100% / 100%);
 color: rgb(255 0 255);
 color: rgb(255 0 255 / 1);
 
-/* legacy rgba notation */
-color: rgba(100%, 0%, 100%, 100%);
+/* legacy rgb and rgba notation */
+color: rgb(100%, 0%, 100%);
 color: rgba(255, 0, 255, 1);
 
 /* by sRGB value in hex */
@@ -83,6 +83,18 @@ color: hsl(300deg 100% 50% / 100%);
 /* by HWB representation of the sRGB value */
 color: hwb(300deg 0% 0%);
 color: hwb(300 0% 0% / 1);
+
+/* by LAB representation of the sRGB value*/
+color: lab(60 93.56 -60.5);
+color: lab(60 93.56 -60.5 / 1);
+
+/* representation in the CIELAB color spaces */
+oklch(0.7 0.32 328.37);
+oklch(0.7 0.32 328.37 / 1);
+
+/* color() function in the XYZ color space */
+color(xyz-d65 0.59 0.28 0.96);
+color(xyz-d65 0.59 0.28 0.96 / 1);
 ```
 
 The first example uses one of the defined [named colors](/en-US/docs/Web/CSS/named-color).
@@ -93,11 +105,13 @@ Shown after that are hex color values. Hexadecimal is a numbering system with ba
 
 If all values are pairs of identical digits, the value can be represented by single digits that the browser will duplicate. Thus `f00` is the same as `ff0000`. If a fourth set of numbers is present, that value is the A in RGBA, the alpha channel defining transparency in terms of the opacity value of the color. A higher value means the color is more opaque and therefore, less transparent. In the examples above, the alpha value is `f`, `ff`, `1`, and `100%` for fully opaque.
 
-The examples also show the legacy [`rgba()`](/en-US/docs/Web/CSS/color_value/rgb#legacy_syntax_rgba) syntax. The older syntax for color functions was comma-separated, with separate functions for when the alpha channel was included. New color functions only have one syntax with space-separated (rather than comma-separated) values, with the alpha channel, if present, being preceded by a slash.
+The example also shows the legacy syntax for both [`rgb()` and `rgba()`](/en-US/docs/Web/CSS/color_value/rgb#examples). The legacy syntax for color functions was comma-separated, with a separate function for when the alpha channel was included. New color functions only have one syntax with space-separated (rather than comma-separated) values, with the alpha channel, if present, being preceded by a slash.
 
 The following examples show "HSL", which stands for _Hue, Saturation, and Lightness_. HSL color values are considered by many to be more intuitive than RGB values. The color produced from the settings are still in the sRGB colorspace, but [`hsl()`](/en-US/docs/Web/CSS/color_value/hsl) is an intuitive syntax for many. The hue is adjusted as an angle, and it is easy to create a user interface using a knob or circular control to adjust the hue. Do note that HSL colors incorporate _lightness_, not _luminance_, which is a significant consideration.
 
-The last examples shows "HWB" which stands for _Hue, Whiteness, and Blackness_. Unlike `rgba()` and `hsla()`, [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb) does not have a legacy `a` syntax and does not support comma-separated values. With both `hsl()` and `hwb()` the first value can be a [`<number>`](/en-US/docs/Web/CSS/number) or an [`<angle>`](/en-US/docs/Web/CSS/angle) value. When unitless, the value is interpreted as `deg` degrees.
+The next examples shows "HWB" which stands for _Hue, Whiteness, and Blackness_. With both `hsl()` and [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb) the first value can be a [`<number>`](/en-US/docs/Web/CSS/number) or an [`<angle>`](/en-US/docs/Web/CSS/angle) value. When unitless, the value is interpreted as `deg` degrees.
+
+There are several other color functions and color spaces. The last three examples demonstrate representing magenta using the [`lab()`](/en-US/docs/Web/CSS/color_value/lab), [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch), and [`color()`](/en-US/docs/Web/CSS/color_value/color) color functions.
 
 ### Conversions
 
@@ -109,17 +123,15 @@ In addition to developer tools, many tools can convert RGB to HSL for you and pr
 
 ![Color picker with HSL and RGB, with color contrast values.](microcolorsc.jpg)
 
-As noted earlier, the [CSS color module](/en-US/docs/Web/CSS/CSS_colors) includes adding additional colorspaces, including [`lch()`](/en-US/docs/Web/CSS/color_value/lch) functional color notation and the [`lab()`](/en-US/docs/Web/CSS/color_value/lab) color coordinate system which can specify any visible color, but because of its ubiquity, sRGB is the default and preferred colorspace for accessibility.
+As noted earlier, the [CSS color module](/en-US/docs/Web/CSS/CSS_colors) includes adding additional colorspaces, including [`lch()`](/en-US/docs/Web/CSS/color_value/lch) and [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch) functional color notation and the [`lab()`](/en-US/docs/Web/CSS/color_value/lab) and `oklab()`](/en-US/docs/Web/CSS/color_value/oklab) color coordinate system which can specify any visible color, but because of its ubiquity, sRGB is the default and preferred colorspace for accessibility.
 
 Where accessibility is concerned, however, standards and guidelines are currently written predominantly using the sRGB color space, especially as it applies to color contrast ratios.
 
 > **Note:** Almost all systems used today to view Web content assume sRGB encoding. Unless it is known that another color space will be used to process and display the content, authors should evaluate using sRGB colorspace. If using other color spaces, apply the principles of [minimum contrast ratios](https://webaim.org/articles/contrast/#sc143).
 
-[CSS Color Module Level 5](https://drafts.csswg.org/css-color-5/) introduced [`lch()`](/en-US/docs/Web/CSS/color_value/lch) functional color notation and the [`lab()`](/en-US/docs/Web/CSS/color_value/lab) color coordinate system which can specify any visible color. These will change the domination of the sRGB color space in the future, but we are not there yet.
-
 ### Querying color values
 
-The {{domxref('Window.getComputedStyle()')}} method returns values using the RGB Decimal Reference scale. For example, calling `Window.getComputedStyle()` on a div with a `background-color: #990000;` set returns the computed background color as `rgb(153 0 0)` — the RGB Decimal reference. Being tied to computer hardware,`Window.getComputedStyle()` measures color in terms of RGB, not how the human eye perceives color.
+The {{domxref('Window.getComputedStyle()')}} method returns values using the RGB Decimal Reference scale or via `color(srgb...)`. For example, calling `Window.getComputedStyle()` on a div with a `background-color: #2550000;` set returns the computed background color as `rgb(255 0 0)` — the RGB Decimal reference. However, when [using relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors), such as `background-color: rgb(from blue 255 0 0)`, calling `Window.getComputedStyle()` returns the computed background color as `color(srgb 1 0 0)`. Being tied to computer hardware,`Window.getComputedStyle()` measures color in terms of RGB, not how the human eye perceives color.
 
 ### Red / green color blindness
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -74,9 +74,9 @@ div.comma-separated {
 
 {{EmbedLiveSample('Legacy syntax: comma-separated values', '100%', '150px')}}
 
-### Legacy syntax: rgba()
+### rgba() syntax
 
-The legacy `rgba()` syntax is an alias for `rgb()`.
+The `rgba()` syntax is an alias for `rgb()`.
 
 #### HTML
 
@@ -105,7 +105,7 @@ div.rgba {
 
 #### Result
 
-{{EmbedLiveSample('Legacy syntax: rgba()', '100%', '150px')}}
+{{EmbedLiveSample('rgba() syntax', '100%', '150px')}}
 
 ## Specifications
 


### PR DESCRIPTION
rgba() is an alias for rgb().

the example isn't using the legacy syntax of using commas, so i updated the text, title, and live sample function call to remove the "legacy" lingo.