### PR TITLE
Add link to Object.seal() in introduction to Object.isSealed()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
@@ -7,8 +7,7 @@ browser-compat: javascript.builtins.Object.isSealed
 
 {{JSRef}}
 
-The **`Object.isSealed()`** static method determines if an object is
-[sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal) (meaning [extensions are prevented](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and its properties are non-configurable).
+The **`Object.isSealed()`** static method determines if an object is [sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal).
 
 {{EmbedInteractiveExample("pages/js/object-issealed.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
@@ -8,7 +8,7 @@ browser-compat: javascript.builtins.Object.isSealed
 {{JSRef}}
 
 The **`Object.isSealed()`** static method determines if an object is
-[sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal).
+[sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal) (meaning [extensions are prevented](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and its properties are non-configurable).
 
 {{EmbedInteractiveExample("pages/js/object-issealed.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/issealed/index.md
@@ -8,7 +8,7 @@ browser-compat: javascript.builtins.Object.isSealed
 {{JSRef}}
 
 The **`Object.isSealed()`** static method determines if an object is
-sealed.
+[sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal).
 
 {{EmbedInteractiveExample("pages/js/object-issealed.html")}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add link for `Object.seal()` to the introduction paragraph. 


### Motivation

Because otherwise the user has to scroll all the way to the bottom to #See_Also, or more realistically hit alt-back to Google and scroll to the next search result. 

> User: "What does `Object.isSealed()` do?"
> Bad answer: "why, it tells you if it's sealed, duh!" 
> Good answer: "Oh, you want the article on `Object.seal()`, here you go." //(My thought)
> Better answer: "It checks if the object is sealed against extensions or configuration. Details on seals over there, details on that check function down here." //(Thanks, @estelle)


### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Original: 
- The **`Object.isSealed()`** static method determines if an object is sealed.

Initial suggestion: just add the link.
- The **`Object.isSealed()`** static method determines if an object is [sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal).

Latest as of 3 commits: Define the term in-place, along with offering links. (suggested by @estelle )
- The **`Object.isSealed()`** static method determines if an object is [sealed](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal) (meaning [extensions are prevented](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) and its properties are non-configurable).



<!--### Related issues and pull requests-->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
