### PR TITLE
Rewrite `finally()`'s "Return value" section

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -26,7 +26,10 @@ promiseInstance.finally(onFinally)
 
 ### Return value
 
-Returns an equivalent {{jsxref("Promise")}}. If the handler throws an error or returns a rejected promise, the promise returned by `finally()` will be rejected with that value instead. Otherwise, the return value of the handler does not affect the state of the original promise.
+Given `promise.finally(onFinally)`:
+
+- If `onFinally` throws an error or returns a rejected promise, `finally()` will return a promise rejected with that value.
+- Otherwise, `finally()` will return a promise that settles with the same value as `promise`.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -26,10 +26,7 @@ promiseInstance.finally(onFinally)
 
 ### Return value
 
-Given `promise.finally(onFinally)`:
-
-- If `onFinally` throws an error or returns a rejected promise, `finally()` will return a promise rejected with that value.
-- Otherwise, `finally()` will return a promise that settles with the same value as `promise`.
+Returns a new {{jsxref("Promise")}} immediately. This new promise is always pending when returned, regardless of the current promise's status. If `onFinally` throws an error or returns a rejected promise, the returned promise will reject with that value. Otherwise, the returned promise will settle with the same state as the current promise.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -26,7 +26,7 @@ promiseInstance.finally(onFinally)
 
 ### Return value
 
-Returns a new {{jsxref("Promise")}} immediately. This new promise is always pending when returned, regardless of the current promise's status. If `onFinally` throws an error or returns a rejected promise, the returned promise will reject with that value. Otherwise, the returned promise will settle with the same state as the current promise.
+Returns a new {{jsxref("Promise")}} immediately. This new promise is always pending when returned, regardless of the current promise's status. If `onFinally` throws an error or returns a rejected promise, the new promise will reject with that value. Otherwise, the new promise will settle with the same state as the current promise.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Rewrite `finally()`'s "Return value" section

### Motivation

This was the original wording:

> Returns an equivalent Promise. If the handler throws an error or returns a rejected promise, the promise returned by finally() will be rejected with that value instead. Otherwise, the return value of the handler does not affect the state of the original promise.

I'm not convinced my change is necessary, but I was uncertain about the meaning of "Returns an equivalent Promise," so the motivation of my edit was to clarify that phrase.

In my change, I would've liked to have written this as pure prose, but I couldn't find a way to refer to the `promise` in `promise.finally(onFinally)` with words alone. I may lack the terminology needed to articulate it. Some ideas I experimented with were, "The promise that called `finally()`" and "The previous link of the promise chain." Both felt too abstract and/or convoluted to me, so I worried it would confuse the reader. 

### Additional details

Fixes #32736

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
