### PR TITLE
fix(macro): remove inline status macros from CSS value sections, part 1

### DIFF
--- a/files/en-us/web/css/-moz-orient/index.md
+++ b/files/en-us/web/css/-moz-orient/index.md
@@ -17,9 +17,9 @@ The `-moz-orient` property is specified as one of the keyword values chosen from
 
 ### Values
 
-- `inline` {{non-standard_inline}}
+- `inline`
   - : The element is rendered in the same direction as the axis of the text: horizontally for horizontal writing modes, vertically for vertical writing modes.
-- `block` {{non-standard_inline}}
+- `block`
   - : The element is rendered orthogonally to the axis of the text: vertically for horizontal writing modes, horizontal for vertical writing modes.
 - `horizontal`
   - : The element is rendered horizontally.

--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -32,11 +32,11 @@ For elements that normally take user input, such as a {{HTMLElement("textarea")}
 
 ### Values
 
-- `none` {{Deprecated_Inline}} {{Non-standard_Inline}}
+- `none`
   - : The element does not respond to user input, and it does not become {{CSSxRef(":active")}}.
-- `enabled` {{Deprecated_Inline}} {{Non-standard_Inline}}
+- `enabled`
   - : The element accepts user input. For textboxes, this is the default behavior. **Please note that this value is no longer supported in Firefox 60 onwards ([Firefox bug 1405087](https://bugzil.la/1405087)).**
-- `disabled` {{Deprecated_Inline}} {{Non-standard_Inline}}
+- `disabled`
   - : The element does not accept user input. However, this is not the same as setting `disabled` to true, in that the element is drawn normally. **Please note that this value is no longer supported in Firefox 60 onwards ([Firefox bug 1405087](https://bugzil.la/1405087)).**
 
 ## Formal definition

--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -37,7 +37,7 @@ When applied to anchor elements, the truncating can happen in the middle of the 
 
 ### Values
 
-- `none` {{experimental_inline}}
+- `none`
   - : This value specifies that the content won't be clamped.
 - {{cssxref("integer")}}
   - : This value specifies the number of lines after which the content will be clamped. It must be greater than 0.

--- a/files/en-us/web/css/animation-duration/index.md
+++ b/files/en-us/web/css/animation-duration/index.md
@@ -35,7 +35,7 @@ animation-duration: unset;
 
 ### Values
 
-- `auto` {{Experimental_Inline}}
+- `auto`
 
   - : For time-based animations, `auto` is equivalent to a value of `0s` (see below). For [CSS scroll-driven animations](/en-US/docs/Web/CSS/CSS_scroll-driven_animations), `auto` fills the entire timeline with the animation.
 

--- a/files/en-us/web/css/animation-timeline/index.md
+++ b/files/en-us/web/css/animation-timeline/index.md
@@ -63,13 +63,13 @@ animation-timeline: unset;
 
   - : The animation's timeline is the document's default [DocumentTimeline](/en-US/docs/Web/API/DocumentTimeline).
 
-- `scroll()` {{Experimental_Inline}}
+- `scroll()`
 
   - : An anonymous scroll progress timeline is provided by some ancestor scroller of the current element. The function parameters allow you to select the scroller, and the scrolling axis the timeline will be measured along.
 
     See {{cssxref("animation-timeline/scroll", "scroll()")}} for more information.
 
-- `view()` {{Experimental_Inline}}
+- `view()`
 
   - : An anonymous view progress timeline is provided by the subject that `animation-timeline: view();` is set on. The function parameters allow you to select the scrollbar axis along which timeline progress will be tracked and an inset that adjusts the position of the box in which the subject is deemed to be visible.
 

--- a/files/en-us/web/css/break-after/index.md
+++ b/files/en-us/web/css/break-after/index.md
@@ -61,9 +61,9 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
   - : Allows, but does not force, any break (page, column, or region) to be inserted right after the principal box.
 - `avoid`
   - : Avoids any break (page, column, or region) from being inserted right after the principal box.
-- `always` {{experimental_inline}}
+- `always`
   - : Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
-- `all` {{experimental_inline}}
+- `all`
   - : Forces a page break right after the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
 
 #### Page break values
@@ -90,9 +90,9 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
 
 #### Region break values
 
-- `avoid-region` {{experimental_inline}}
+- `avoid-region`
   - : Avoids any region break right after the principal box.
-- `region` {{experimental_inline}}
+- `region`
   - : Forces a region break right after the principal box.
 
 ## Page break aliases

--- a/files/en-us/web/css/break-before/index.md
+++ b/files/en-us/web/css/break-before/index.md
@@ -61,9 +61,9 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
   - : Allows, but does not force, any break (page, column, or region) to be inserted right before the principal box.
 - `avoid`
   - : Avoids any break (page, column, or region) from being inserted right before the principal box.
-- `always` {{experimental_inline}}
+- `always`
   - : Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
-- `all` {{experimental_inline}}
+- `all`
   - : Forces a page break right after the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
 
 #### Page break values
@@ -90,9 +90,9 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
 
 #### Region break values
 
-- `avoid-region` {{experimental_inline}}
+- `avoid-region`
   - : Avoids any region break right before the principal box.
-- `region` {{experimental_inline}}
+- `region`
   - : Forces a region break right before the principal box.
 
 ## Page break aliases

--- a/files/en-us/web/css/break-inside/index.md
+++ b/files/en-us/web/css/break-inside/index.md
@@ -48,7 +48,7 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
   - : Avoids any page break within the principal box.
 - `avoid-column`
   - : Avoids any column break within the principal box.
-- `avoid-region` {{experimental_inline}}
+- `avoid-region`
   - : Avoids any region break within the principal box.
 
 ## Page break aliases

--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -35,7 +35,7 @@ The `column-fill` property is specified as one of the keyword values listed belo
   - : Columns are filled sequentially. Content takes up only the room it needs, possibly resulting in some columns remaining empty.
 - `balance`
   - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.
-- `balance-all` {{Experimental_Inline}}
+- `balance-all`
   - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), all fragments are balanced.
 
 ## Formal definition

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -80,7 +80,7 @@ The keywords and data types mentioned above are described in more detail below:
 
   - : The default value. Computes to `none` for the {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements. For other pseudo-elements, the content will be the initial (or normal) content expected for that {{cssxref("::marker")}}, {{cssxref("::placeholder")}}, or {{cssxref("::file-selector-button")}}. For regular elements or page margin boxes, this computes to `contents`.
 
-- `contents` {{Experimental_Inline}}
+- `contents`
 
   - : Adds the contents of the element itself to the generated content value.
 
@@ -108,11 +108,11 @@ The keywords and data types mentioned above are described in more detail below:
     - `no-open-quote` and `no-close-quote`
       - : Introduces no content, but increments (decrements) the level of nesting for quotes.
 
-- `<target>` {{Experimental_Inline}}
+- `<target>`
 
   - : The `<target>` data type includes three target functions, `<target-counter()>`, `<target-counters()>`, and `<target-text()>` that create cross-references obtained from the target end of a link. See [Formal syntax](#formal_syntax).
 
-- `<leader()>` {{Experimental_Inline}}
+- `<leader()>`
 
   - : The `<leader()>` data type inclues a leader function: `leader( <leader-type> )`. This function accepts the keyword values `dotted`, `solid`, or `space` (equal to `leader(".")`, `leader("_")`, and `leader(" ")`, respectively), or a `<string>` as a parameter. When supported and used as a value for `content`, the leader-type provided will be inserted as a repeating pattern, visually connecting content across a horizontal line.
 

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -89,7 +89,7 @@ The keyword values can be grouped into six value categories.
 
   - : These keywords specify the element's inner display type, which defines the type of formatting context that its contents are laid out in (assuming it is a non-replaced element):
 
-    - `flow` {{Experimental_Inline}}
+    - `flow`
 
       - : The element lays out its contents using flow layout (block-and-inline layout).
 
@@ -105,7 +105,7 @@ The keyword values can be grouped into six value categories.
       - : The element behaves like a block-level element and lays out its content according to the [flexbox model](/en-US/docs/Web/CSS/CSS_flexible_box_layout).
     - `grid`
       - : The element behaves like a block-level element and lays out its content according to the [grid model](/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout).
-    - `ruby` {{Experimental_Inline}}
+    - `ruby`
       - : The element behaves like an inline-level element and lays out its content according to the ruby formatting model. It behaves like the corresponding HTML {{HTMLElement("ruby")}} elements.
 
 > **Note:** When browsers that support multi-keyword syntax encounter a display property that only has an **inner** value (e.g., `display: flex` or `display: grid`), the outer value is set to `block` (e.g., `display: block flex` and `display: block grid`).
@@ -146,13 +146,13 @@ This can be used together with {{CSSxRef("list-style-type")}} and {{CSSxRef("lis
       - : These elements behave like {{HTMLElement("col")}} HTML elements.
     - `table-caption`
       - : These elements behave like {{HTMLElement("caption")}} HTML elements.
-    - `ruby-base` {{Experimental_Inline}}
+    - `ruby-base`
       - : These elements behave like {{HTMLElement("rb")}} HTML elements.
-    - `ruby-text` {{Experimental_Inline}}
+    - `ruby-text`
       - : These elements behave like {{HTMLElement("rt")}} HTML elements.
-    - `ruby-base-container` {{Experimental_Inline}}
+    - `ruby-base-container`
       - : These elements are generated as anonymous boxes.
-    - `ruby-text-container` {{Experimental_Inline}}
+    - `ruby-text-container`
       - : These elements behave like {{HTMLElement("rtc")}} HTML elements.
 
 ### Box

--- a/files/en-us/web/css/grid-template-columns/index.md
+++ b/files/en-us/web/css/grid-template-columns/index.md
@@ -85,7 +85,7 @@ grid-template-columns: unset;
   - : Represents the formula `max(minimum, min(limit, max-content))`, where _minimum_ represents an `auto` minimum (which is often, but not always, equal to a {{cssxref("min-content")}} minimum), and _limit_ is the track sizing function passed as an argument to fit-content(). This is essentially calculated as the smaller of `minmax(auto, max-content)` and `minmax(auto, limit)`.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of columns that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout) {{Experimental_Inline}}
+- [`masonry`](/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout)
   - : The masonry value indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.

--- a/files/en-us/web/css/grid-template-rows/index.md
+++ b/files/en-us/web/css/grid-template-rows/index.md
@@ -86,7 +86,7 @@ This property may be specified as:
   - : Represents the formula `min(max-content, max(auto, argument))`, which is calculated similar to `auto` (i.e. `minmax(auto, max-content)`), except that the track size is clamped at _argument_ if it is greater than the `auto` minimum.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of rows that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout) {{Experimental_Inline}}
+- [`masonry`](/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout)
   - : The masonry value indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -53,7 +53,7 @@ height: unset;
   - : The intrinsic minimum height.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the fit-content formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, <length-percentage>))`.
 - {{cssxref("clamp", "clamp()")}}
   - : Enables selecting a middle value within a range of values between a defined minimum and maximum.

--- a/files/en-us/web/css/image-rendering/index.md
+++ b/files/en-us/web/css/image-rendering/index.md
@@ -33,9 +33,9 @@ image-rendering: unset;
 
 - `auto`
   - : The scaling algorithm is UA dependent. Since version 1.9 (Firefox 3.0), Gecko uses _bilinear_ resampling (high quality).
-- `smooth` {{Experimental_Inline}}
+- `smooth`
   - : The image should be scaled with an algorithm that maximizes the appearance of the image. In particular, scaling algorithms that "smooth" colors are acceptable, such as bilinear interpolation. This is intended for images such as photos.
-- `high-quality` {{Experimental_Inline}}
+- `high-quality`
   - : Identical to `smooth`, but with a preference for higher-quality scaling. If system resources are constrained, images with `high-quality` should be prioritized over those with any other value, when considering which images to degrade the quality of and to what degree.
 - `crisp-edges`
   - : The image is scaled with an algorithm such as "nearest neighbor" that preserves contrast and edges in the image. Generally intended for images such as pixel art or line drawings, no blurring or color smoothing occurs.

--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -59,13 +59,13 @@ One or more of the keyword values listed below, separated by commas.
   - : Uses the nearest SVG viewport as reference box. If a [`viewBox`](/en-US/docs/Web/SVG/Attribute/viewBox) attribute is specified for the element creating the SVG viewport, the reference box is positioned at the origin of the coordinate system established by the `viewBox` attribute and the dimension of the reference box is set to the width and height values of the `viewBox` attribute.
 - `no-clip`
   - : The painted content is not clipped.
-- `border` {{non-standard_inline}}
+- `border`
   - : This keyword behaves the same as `border-box`.
-- `padding` {{non-standard_inline}}
+- `padding`
   - : This keyword behaves the same as `padding-box`.
-- `content` {{non-standard_inline}}
+- `content`
   - : This keyword behaves the same as `content-box`.
-- `text` {{non-standard_inline}}
+- `text`
   - : This keyword clips the mask image to the text of the element.
 
 ## Formal definition

--- a/files/en-us/web/css/mask-origin/index.md
+++ b/files/en-us/web/css/mask-origin/index.md
@@ -55,11 +55,11 @@ One or more of the keyword values listed below, separated by commas.
   - : The position is relative to the stroke bounding box.
 - `view-box`
   - : Uses the nearest SVG viewport as reference box. If a {{svgattr("viewBox")}} attribute is specified for the element creating the SVG viewport, the reference box is positioned at the origin of the coordinate system established by the `viewBox` attribute and the dimension of the reference box is set to the width and height values of the `viewBox` attribute.
-- `content` {{non-standard_inline}}
+- `content`
   - : Same as `content-box`.
-- `padding` {{non-standard_inline}}
+- `padding`
   - : Same as `padding-box`.
-- `border` {{non-standard_inline}}
+- `border`
   - : Same as `border-box`.
 
 ## Formal definition

--- a/files/en-us/web/css/max-block-size/index.md
+++ b/files/en-us/web/css/max-block-size/index.md
@@ -58,17 +58,17 @@ The `max-block-size` property's value can be any value that's legal for the {{cs
   - : The intrinsic minimum `max-block-size`.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the `fit-content` formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, argument))`.
 
 ### How writing-mode affects directionality
 
 The values of `writing-mode` affect the mapping of `max-block-size` to `max-width` or `max-height` as follows:
 
-| Values of `writing-mode`                                                                                                                                              | `max-block-size` is equivalent to |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `horizontal-tb`, `lr` {{deprecated_inline}}, `lr-tb` {{deprecated_inline}}, `rl` {{deprecated_inline}}, `rb` {{deprecated_inline}}, `rb-rl` {{deprecated_inline}}     | {{cssxref("max-height")}}         |
-| `vertical-rl`, `vertical-lr`, `sideways-rl` {{experimental_inline}}, `sideways-lr` {{experimental_inline}}, `tb` {{deprecated_inline}}, `tb-rl` {{deprecated_inline}} | {{cssxref("max-width")}}          |
+| Values of `writing-mode`                                                  | `max-block-size` is equivalent to |
+| ------------------------------------------------------------------------- | --------------------------------- |
+| `horizontal-tb`, `lr`, `lr-tb`, `rl`, `rb`, `rb-rl`                       | {{cssxref("max-height")}}         |
+| `vertical-rl`, `vertical-lr`, `sideways-rl`, `sideways-lr`, `tb`, `tb-rl` | {{cssxref("max-width")}}          |
 
 > **Note:** The `writing-mode` values `sideways-lr` and `sideways-rl` were removed from the CSS Writing Modes Level 3 specification late in its design process. They may be restored in Level 4.
 

--- a/files/en-us/web/css/max-height/index.md
+++ b/files/en-us/web/css/max-height/index.md
@@ -51,7 +51,7 @@ max-height: unset;
   - : The intrinsic minimum `max-height`.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the `fit-content` formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, argument))`.
 
 ## Accessibility concerns

--- a/files/en-us/web/css/max-width/index.md
+++ b/files/en-us/web/css/max-width/index.md
@@ -51,7 +51,7 @@ max-width: unset;
   - : The intrinsic minimum `max-width`.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the `fit-content` formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, argument))`.
 
 ## Accessibility concerns

--- a/files/en-us/web/css/min-height/index.md
+++ b/files/en-us/web/css/min-height/index.md
@@ -50,7 +50,7 @@ min-height: unset;
   - : The intrinsic minimum `min-height`.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the `fit-content` formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, argument))`.
 
 ## Formal definition

--- a/files/en-us/web/css/min-width/index.md
+++ b/files/en-us/web/css/min-width/index.md
@@ -50,7 +50,7 @@ min-width: unset;
   - : The intrinsic minimum `min-width`.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the `fit-content` formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, argument))`.
 
 ## Formal definition

--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -36,7 +36,7 @@ The `outline-color` property is specified as any one of the values listed below.
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the outline, specified as a `<color>`.
-- `auto` {{Experimental_Inline}}
+- `auto`
   - : Computes to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) unless [`outline-style`](/en-US/docs/Web/CSS/outline-style) is set to `auto` then it computes to the [accent color](/en-US/docs/Web/CSS/accent-color).
 
 ## Description

--- a/files/en-us/web/css/page-break-after/index.md
+++ b/files/en-us/web/css/page-break-after/index.md
@@ -47,9 +47,9 @@ This property applies to block elements that generate a box. It won't apply on a
   - : Force page breaks after the element so that the next page is formatted as a left page. It's the page placed on the left side of the spine of the book or the back side of the page in duplex printing.
 - `right`
   - : Force page breaks after the element so that the next page is formatted as a right page. It's the page placed on the right side of the spine of the book or the front side of the page in duplex printing.
-- `recto` {{experimental_inline}}
+- `recto`
   - : If pages progress left-to-right, then this acts like `right`. If pages progress right-to-left, then this acts like `left`.
-- `verso` {{experimental_inline}}
+- `verso`
   - : If pages progress left-to-right, then this acts like `left`. If pages progress right-to-left, then this acts like `right`.
 
 ## Page break aliases

--- a/files/en-us/web/css/page-break-before/index.md
+++ b/files/en-us/web/css/page-break-before/index.md
@@ -47,9 +47,9 @@ page-break-before: unset;
   - : Force page breaks before the element so that the next page is formatted as a left page. It's the page placed on the left side of the spine of the book or the back side of the page in duplex printing.
 - `right`
   - : Force page breaks before the element so that the next page is formatted as a right page. It's the page placed on the right side of the spine of the book or the front side of the page in duplex printing.
-- `recto` {{experimental_inline}}
+- `recto`
   - : If pages progress left-to-right, then this acts like `right`. If pages progress right-to-left, then this acts like `left`.
-- `verso` {{experimental_inline}}
+- `verso`
   - : If pages progress left-to-right, then this acts like `left`. If pages progress right-to-left, then this acts like `right`.
 
 ## Page break aliases

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -34,9 +34,9 @@ ruby-position: unset;
   - : ![Over example](screen_shot_2015-03-04_at_13.02.20.png)Is a keyword indicating that the ruby has to be placed over the main text for horizontal scripts and right to it for vertical scripts.
 - `under`
   - : ![Under example](screen_shot_2015-03-04_at_13.02.07.png)Is a keyword indicating that the ruby has to be placed under the main text for horizontal scripts and left to it for vertical scripts.
-- `inter-character` {{Experimental_Inline}}
+- `inter-character`
   - : Is a keyword indicating that the ruby has to be placed between the different characters.
-- `alternate` {{Experimental_Inline}}
+- `alternate`
   - : Is a keyword indicating that the ruby alternates between over and under, when there are multiple levels of annotation.
 
 ## Formal definition

--- a/files/en-us/web/css/text-align/index.md
+++ b/files/en-us/web/css/text-align/index.md
@@ -48,15 +48,15 @@ The `text-align` property is specified in one of the following ways:
   - : The same as `left` if direction is left-to-right and `right` if direction is right-to-left.
 - `end`
   - : The same as `right` if direction is left-to-right and `left` if direction is right-to-left.
-- `left` {{deprecated_inline}} {{non-standard_inline}}
+- `left`
   - : The inline contents are aligned to the left edge of the line box.
-- `right` {{deprecated_inline}} {{non-standard_inline}}
+- `right`
   - : The inline contents are aligned to the right edge of the line box.
-- `center` {{deprecated_inline}} {{non-standard_inline}}
+- `center`
   - : The inline contents are centered within the line box.
 - `justify`
   - : The inline contents are justified. Text should be spaced to line up its left and right edges to the left and right edges of the line box, except for the last line.
-- `justify-all` {{experimental_inline}}
+- `justify-all`
   - : Same as `justify`, but also forces the last line to be justified.
 - `match-parent`
   - : Similar to `inherit`, but the values `start` and `end` are calculated according to the parent's {{cssxref("direction")}} and are replaced by the appropriate `left` or `right` value.

--- a/files/en-us/web/css/text-decoration-line/index.md
+++ b/files/en-us/web/css/text-decoration-line/index.md
@@ -47,7 +47,7 @@ The `text-decoration-line` property is specified as `none`, or **one or more** s
   - : Each line of text has a decorative line above it.
 - `line-through`
   - : Each line of text has a decorative line going through its middle.
-- `blink` {{deprecated_inline}}
+- `blink`
   - : The text blinks (alternates between visible and invisible). Conforming user agents may not blink the text. This value is **deprecated** in favor of [CSS animations](/en-US/docs/Web/CSS/animation).
 
 ## Formal definition

--- a/files/en-us/web/css/text-decoration-style/index.md
+++ b/files/en-us/web/css/text-decoration-style/index.md
@@ -45,7 +45,7 @@ text-decoration-style: unset;
   - : Draws a dashed line.
 - wavy
   - : Draws a wavy line.
-- \-moz-none {{ non-standard_inline }}
+- \-moz-none
   - : Draws no line. Use {{ cssxref("text-decoration-line") }}`: none` instead.
 
 ## Formal definition

--- a/files/en-us/web/css/text-justify/index.md
+++ b/files/en-us/web/css/text-justify/index.md
@@ -36,7 +36,7 @@ text-justify: unset;
   - : The text is justified by adding space between words (effectively varying {{cssxref("word-spacing")}}), which is most appropriate for languages that separate words using spaces, like English or Korean.
 - `inter-character`
   - : The text is justified by adding space between characters (effectively varying {{cssxref("letter-spacing")}}), which is most appropriate for languages like Japanese.
-- `distribute` {{deprecated_inline}}
+- `distribute`
   - : Exhibits the same behavior as `inter-character`; this value is kept for backwards compatibility.
 
 ## Formal definition

--- a/files/en-us/web/css/text-overflow/index.md
+++ b/files/en-us/web/css/text-overflow/index.md
@@ -43,7 +43,7 @@ The `text-overflow` property may be specified using one or two values. If one va
   - : The default for this property. This keyword value will truncate the text at the limit of the [content area](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), therefore the truncation can happen in the middle of a character. To clip at the transition between characters you can specify `text-overflow` as an empty string, if that is supported in your target browsers: `text-overflow: '';`.
 - `ellipsis`
   - : This keyword value will display an ellipsis (`'…'`, `U+2026 HORIZONTAL ELLIPSIS`) to represent clipped text. The ellipsis is displayed inside the [content area](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), decreasing the amount of text displayed. If there is not enough space to display the ellipsis, it is clipped.
-- `<string>` {{experimental_inline}}
+- `<string>`
   - : The {{cssxref("&lt;string&gt;")}} to be used to represent clipped text. The string is displayed inside the [content area](/en-US/docs/Web/CSS/CSS_box_model/Introduction_to_the_CSS_box_model), shortening the size of the displayed text. If there is not enough space to display the string itself, it is clipped.
 
 ## Formal definition

--- a/files/en-us/web/css/text-rendering/index.md
+++ b/files/en-us/web/css/text-rendering/index.md
@@ -34,13 +34,13 @@ text-rendering: unset;
 
 ### Values
 
-- `auto` {{Non-standard_Inline}}
+- `auto`
   - : The browser makes educated guesses about when to optimize for speed, legibility, and geometric precision while drawing text. For differences in how this value is interpreted by the browser, see the compatibility table.
 - `optimizeSpeed`
   - : The browser emphasizes rendering speed over legibility and geometric precision when drawing text. It disables kerning and ligatures.
 - `optimizeLegibility`
   - : The browser emphasizes legibility over rendering speed and geometric precision. This enables kerning and optional ligatures.
-- `geometricPrecision` {{Non-standard_Inline}}
+- `geometricPrecision`
 
   - : The browser emphasizes geometric precision over rendering speed and legibility. Certain aspects of fonts — such as kerning — don't scale linearly. So this value can make text using those fonts look good.
 

--- a/files/en-us/web/css/text-transform/index.md
+++ b/files/en-us/web/css/text-transform/index.md
@@ -45,7 +45,7 @@ text-transform: unset;
 
 - `capitalize`
 
-  - : Is a keyword that converts the first _letter_ of each word to uppercase. Other characters remain unchanged (they retain their original case as written in the element's text). A letter is defined as a character that is part of Unicode's Letter or Number general categories {{experimental_inline}}; thus, any punctuation marks or symbols at the beginning of a word are ignored.
+  - : Is a keyword that converts the first _letter_ of each word to uppercase. Other characters remain unchanged (they retain their original case as written in the element's text). A letter is defined as a character that is part of Unicode's Letter or Number general categories; thus, any punctuation marks or symbols at the beginning of a word are ignored.
 
     > **Note:** Authors should not expect `capitalize` to follow language-specific title casing conventions (such as skipping articles in English).
 

--- a/files/en-us/web/css/text-wrap-style/index.md
+++ b/files/en-us/web/css/text-wrap-style/index.md
@@ -38,7 +38,7 @@ When wrapping is allowed (see {{CSSXRef("text-wrap-mode")}}), the `text-wrap-sty
   - : Text is wrapped in a way that best balances the number of characters on each line, enhancing layout quality and legibility. Because counting characters and balancing them across multiple lines is computationally expensive, this value is only supported for blocks of text spanning a limited number of lines (six or less for Chromium and ten or less for Firefox).
 - `pretty`
   - : Results in the same behavior as `wrap`, except that the user agent will use a slower algorithm that favors better layout over speed. This is intended for body copy where good typography is favored over performance (for example, when the number of [orphans](/en-US/docs/Web/CSS/orphans) should be kept to a minimum).
-- `stable` {{experimental_inline}}
+- `stable`
   - : Results in the same behavior as `wrap`, except that when the user is editing the content, the lines that come before the lines they are editing remain static rather than the whole block of text re-wrapping.
 
 ## Description

--- a/files/en-us/web/css/user-modify/index.md
+++ b/files/en-us/web/css/user-modify/index.md
@@ -37,7 +37,7 @@ The `-moz-user-modify` property is specified as one of the keyword values from t
   - : Default value. Contents are read-only.
 - `read-write`
   - : The user is able to read and write contents.
-- `read-write-plaintext-only` {{Non-standard_Inline}} {{Deprecated_Inline}}
+- `read-write-plaintext-only`
   - : Same as `read-write`, but rich text formatting will be lost.
 - `write-only`
   - : The user is able to edit the content, but not to read it.

--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -55,7 +55,7 @@ width: unset;
   - : The intrinsic minimum width.
 - `fit-content`
   - : Use the available space, but not more than [max-content](/en-US/docs/Web/CSS/max-content), i.e `min(max-content, max(min-content, stretch))`.
-- `fit-content({{cssxref("&lt;length-percentage&gt;")}})` {{Experimental_Inline}}
+- `fit-content({{cssxref("&lt;length-percentage&gt;")}})`
   - : Uses the fit-content formula with the available space replaced by the specified argument, i.e. `min(max-content, max(min-content, <length-percentage>))`.
 
 ## Accessibility concerns

--- a/files/en-us/web/css/word-break/index.md
+++ b/files/en-us/web/css/word-break/index.md
@@ -39,9 +39,9 @@ The `word-break` property is specified as a single keyword chosen from the list 
   - : To prevent overflow, word breaks should be inserted between any two characters (excluding Chinese/Japanese/Korean text).
 - `keep-all`
   - : Word breaks should not be used for Chinese/Japanese/Korean (CJK) text. Non-CJK text behavior is the same as for `normal`.
-- `auto-phrase` {{Experimental_Inline}}
+- `auto-phrase`
   - : Has the same effect as `word-break: normal` except that language-specific analysis is performed to improve word breaks by not placing them in the middle of natural phrases.
-- `break-word` {{Deprecated_Inline}}
+- `break-word`
   - : Has the same effect as `overflow-wrap: anywhere` combined with `word-break: normal`, regardless of the actual value of the {{cssxref("overflow-wrap")}} property.
 
 > **Note:** In contrast to `word-break: break-word` and `overflow-wrap: break-word` (see {{cssxref("overflow-wrap")}}), `word-break: break-all` will create a break at the exact place where text would otherwise overflow its container (even if putting an entire word on its own line would negate the need for a break).

--- a/files/en-us/web/css/writing-mode/index.md
+++ b/files/en-us/web/css/writing-mode/index.md
@@ -43,17 +43,17 @@ The `writing-mode` property is specified as one of the values listed below. The 
   - : For `ltr` scripts, content flows vertically from top to bottom. For `rtl` scripts, content flows vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways toward the right.
 - `sideways-lr`
   - : For `ltr` scripts, content flows vertically from bottom to top. For `rtl` scripts, content flows vertically from top to bottom. All the glyphs, even those in vertical scripts, are set sideways toward the left.
-- `lr` {{deprecated_inline}}
+- `lr`
   - : Deprecated except for SVG1 documents. For CSS, use `horizontal-tb` instead.
-- `lr-tb` {{deprecated_inline}}
+- `lr-tb`
   - : Deprecated except for SVG1 documents. For CSS, use `horizontal-tb` instead.
-- `rl` {{deprecated_inline}}
+- `rl`
   - : Deprecated except for SVG1 documents. For CSS, use `horizontal-tb` instead.
-- `tb` {{deprecated_inline}}
+- `tb`
   - : Deprecated except for SVG1 documents. For CSS, use `vertical-lr` instead.
-- `tb-lr` {{deprecated_inline}}
+- `tb-lr`
   - : Deprecated except for SVG1 documents. For CSS, use `vertical-lr` instead.
-- `tb-rl` {{deprecated_inline}}
+- `tb-rl`
   - : Deprecated except for SVG1 documents. For CSS, use `vertical-rl` instead.
 
 ## Formal definition

--- a/files/en-us/web/css/zoom/index.md
+++ b/files/en-us/web/css/zoom/index.md
@@ -38,7 +38,7 @@ zoom: unset;
 
 - `normal`
   - : Render this element at its normal size.
-- `reset` {{non-standard_inline}}
+- `reset`
   - : Do not (de)magnify this element if the user applies non-pinch-based zooming (e.g. by pressing <kbd>Ctrl</kbd> \- <kbd>-</kbd> or <kbd>Ctrl</kbd> \+ <kbd>+</kbd> keyboard shortcuts) to the document. **Do not use** this value, _use the standard `unset` value instead_.
 - {{cssxref("&lt;percentage&gt;")}}
   - : Zoom factor. `100%` is equivalent to `normal`. Values larger than `100%` zoom in. Values smaller than `100%` zoom out.


### PR DESCRIPTION
There is a pending discussion about how to document CSS values and there are inconsistencies in BCD data about CSS values. Till all the issues get resolved it's been decided to stop using inline status macros in CSS pages.

The PR removes inline status macros from pages of type `css-property`.