### PR TITLE
Normalize “no notable changes” usage in Firefox release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -38,14 +38,6 @@ This article provides information about the changes in Firefox 103 that will aff
   For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized.
   See [Firefox bug 1556604](https://bugzil.la/1556604) for more details.
 
-### HTTP
-
-No notable changes.
-
-### Security
-
-No notable changes.
-
 ### APIs
 
 - [`ReadableStream`](/en-US/docs/Web/API/ReadableStream), [`WritableStream`](/en-US/docs/Web/API/WritableStream), [`TransformStream`](/en-US/docs/Web/API/TransformStream) are now [Transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects), which means that ownership can be transferred when sharing the objects between a window and workers using `postMessage`, or when using [`structuredClone()`](/en-US/docs/Web/API/structuredClone) to copy an object.
@@ -55,10 +47,6 @@ No notable changes.
 - [`caches`](/en-US/docs/Web/API/caches), [`CacheStorage`](/en-US/docs/Web/API/CacheStorage), and [`Cache`](/en-US/docs/Web/API/Cache) now require a [secure context](/en-US/docs/Web/Security/Secure_Contexts); the properties/interfaces are not defined if used in an insecure context.
   Previously `cache` would return a `CacheStorage` that would throw an exception if used outside of a secure context.
   See [Firefox bug 1112134](https://bugzil.la/1112134) for more details.
-
-### WebAssembly
-
-No notable changes.
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -28,14 +28,6 @@ No notable changes.
   The `stack` is not yet serialized when errors are sent using other APIs, such as [`Worker.postMessage()`](/en-US/docs/Web/API/Worker/postMessage)
   (See [Firefox bug 1774866](https://bugzil.la/1774866) for more details.)
 
-### HTTP
-
-No notable changes.
-
-### Security
-
-No notable changes.
-
 ### APIs
 
 #### DOM
@@ -61,10 +53,6 @@ No notable changes.
   The option was previously deprecated, and users that need this functionality should already have migrated to {{domxref("StorageManager.persist()")}}.
   (See [Firefox bug 1354500](https://bugzil.la/1354500) for more details.)
 
-### WebAssembly
-
-No notable changes.
-
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### WebDriver BiDi
@@ -76,10 +64,6 @@ No notable changes.
 
 - Improved stability and performance when minimizing or restoring windows on Linux ([Firefox bug 1780212](https://bugzil.la/1780212)).
 - Added support for `touch` actions ([Firefox bug 1543337](https://bugzil.la/1543337)).
-
-## Changes for add-on developers
-
-No notable changes.
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -28,24 +28,12 @@ This article provides information about the changes in Firefox 106 that will aff
 
 No notable changes.
 
-### HTTP
-
-No notable changes.
-
-### Security
-
-No notable changes.
-
 ### APIs
 
 #### DOM
 
 - The [`HTMLMetaElement.media`](/en-US/docs/Web/API/HTMLMetaElement/media) property is now supported. This property enables you to set different theme colors based on `media` values (e.g. `max-width: 600px`).
   Meta elements with `media` properties allow the browser to use the `content` value in conjunction with `theme-color` to set the page or UI colors for a given media query ([Firefox bug 1706179](https://bugzil.la/1706179)).
-
-### WebAssembly
-
-No notable changes.
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 

--- a/files/en-us/mozilla/firefox/releases/114/index.md
+++ b/files/en-us/mozilla/firefox/releases/114/index.md
@@ -45,14 +45,6 @@ No notable changes.
 
 - [`CSSImportRule.supportsText`](/en-US/docs/Web/API/CSSImportRule/supportsText) can now be used for getting any `supports()` conditions that were specified when using the {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/At-rule) ([Firefox bug 1829590](https://bugzil.la/1829590)).
 
-#### DOM
-
-No notable changes.
-
-#### Media, WebRTC, and Web Audio
-
-No notable changes.
-
 #### Removals
 
 - The deprecated and non-standard `mozImageSmoothingEnabled` property is permanently removed.

--- a/files/en-us/mozilla/firefox/releases/115/index.md
+++ b/files/en-us/mozilla/firefox/releases/115/index.md
@@ -28,10 +28,6 @@ This article provides information about the changes in Firefox 115 that affect d
   These methods return a new array with elements that have been shallow copied (similarly named methods without the `to` prefix modify the array elements in place).
   ([Firefox bug 1811057](https://bugzil.la/1811057)).
 
-### SVG
-
-No notable changes.
-
 ### HTTP
 
 - The [`Sec-Purpose`](/en-US/docs/Web/HTTP/Headers/Sec-Purpose) HTTP {{Glossary("Fetch metadata request header", "fetch metadata request header")}} is now included in requests to {{Glossary("Prefetch")}} resources.

--- a/files/en-us/mozilla/firefox/releases/117/index.md
+++ b/files/en-us/mozilla/firefox/releases/117/index.md
@@ -71,10 +71,6 @@ No notable changes.
 
 - Properties that are not supported in highlight pseudo-elements ([`::highlight()`](/en-US/docs/Web/CSS/::highlight), [`::target-text`](/en-US/docs/Web/CSS/::target-text), [`::spelling-error`](/en-US/docs/Web/CSS/::spelling-error), [`::grammar-error`](/en-US/docs/Web/CSS/::grammar-error), and [`::selection`](/en-US/docs/Web/CSS/::selection)) are now reported in the [Page Inspector](https://firefox-source-docs.mozilla.org/devtools-user/#page-inspector) CSS rules panel ([Firefox bug 1842157](https://bugzil.la/1842157)).
 
-## Changes for add-on developers
-
-No notable changes.
-
 ## Older versions
 
 {{Firefox_for_developers}}

--- a/files/en-us/mozilla/firefox/releases/118/index.md
+++ b/files/en-us/mozilla/firefox/releases/118/index.md
@@ -35,14 +35,6 @@ No notable changes.
 - The [`<semantics>`](/en-US/docs/Web/MathML/Element/semantics) and [`<maction>`](/en-US/docs/Web/MathML/Element/maction) elements only render the first child element by default now. The `mathml.legacy_maction_and_semantics_implementations.disabled` preference has been removed (Firefox bug [1788223](https://bugzil.la/1788223)).
 - All values of the [`mathvariant`](/en-US/docs/Web/MathML/Element/mi#mathvariant) attribute other than `normal` are now deprecated. Additionally, the attribute's use is now limited to the `<mi>` element (Firefox bug [1845461](https://bugzil.la/1845461)).
 
-### SVG
-
-No notable changes.
-
-### Security
-
-No notable changes.
-
 ### APIs
 
 - The <kbd>⊞ Windows Logo</kbd> key on Windows and the <kbd>Command</kbd> key on macOS now return a value of `"Meta"` for [`KeyboardEvent.key`](/en-US/docs/Web/API/KeyboardEvent/key), instead of `"OS"`, and [`KeyboardEvent.code`](/en-US/docs/Web/API/KeyboardEvent/code) returns `MetaLeft`/`MetaRight` instead of `OSLeft`/`OSRight` (Firefox bug [1232918](https://bugzil.la/1232918)).

--- a/files/en-us/mozilla/firefox/releases/120/index.md
+++ b/files/en-us/mozilla/firefox/releases/120/index.md
@@ -47,10 +47,6 @@ This article provides information about the changes in Firefox 120 that affect d
 
   - Timezone `'Z'` is now accepted for non-ISO formats (e.g. `Jan 1 1970 10:00Z`) ([Firefox bug 1852422](https://bugzil.la/1852422))
 
-### SVG
-
-No notable changes
-
 ### HTTP
 
 - The [`103 Early Hints`](/en-US/docs/Web/HTTP/Status/103) HTTP [information response](/en-US/docs/Web/HTTP/Status#information_responses) status code is enabled for [preconnecting](/en-US/docs/Web/HTML/Attributes/rel/preconnect) to a particular origin (that the page is likely to need resources from).
@@ -58,10 +54,6 @@ No notable changes
 - Firefox supports the [Global Privacy Control](https://globalprivacycontrol.org/) {{HTTPHeader("Sec-GPC")}} request header, which may be sent to indicate that the user does not consent to a website or service selling or sharing their personal information with third parties.
   Users can enable the header, in both normal and private browsing modes, by setting the preference `privacy.globalprivacycontrol.enabled` to `true` (in `about:config`).
   The {{domxref("Navigator.globalPrivacyControl")}} and {{domxref("WorkerNavigator.globalPrivacyControl")}} properties allow JavaScript to check the user consent preference ([Firefox bug 1856029](https://bugzil.la/1856029)).
-
-### Security
-
-No notable changes
 
 ### APIs
 
@@ -77,10 +69,6 @@ No notable changes
 
 - Added serialization support for `Proxy` and `Generator` objects ([Firefox bug 1841786](https://bugzil.la/1841786)).
 - Added `authChallenges` property (the list of authentication challenges present in the headers), to `responseStarted` and `responseCompleted` network events, which will be useful in order to handle the upcoming `network.authRequired` event ([Firefox bug 1855149](https://bugzil.la/1855149)).
-
-## Changes for add-on developers
-
-No notable changes
 
 ## Older versions
 

--- a/files/en-us/mozilla/firefox/releases/123/index.md
+++ b/files/en-us/mozilla/firefox/releases/123/index.md
@@ -16,6 +16,10 @@ This article provides information about the changes in Firefox 123 that affect d
 
 - The {{htmlelement("template")}} element now supports a `shadowrootmode` attribute that allows declarative creation of a shadow DOM subtree. The attribute can be set to either `open` or `closed`, which expose or hide JavaScript in the shadow DOM from external code, respectively. These are the same values as the `mode` option of the {{domxref("Element.attachShadow()", "attachShadow()")}} method. ([Firefox bug 1870052](https://bugzil.la/1870052))
 
+### CSS
+
+No notable changes.
+
 ### JavaScript
 
 - The {{jsxref("Date.parse()")}} global object has had a number of bug fixes to bring it into line with how other browsers parse the values being passed.

--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -10,10 +10,18 @@ This article provides information about the changes in Firefox 124 that affect d
 
 ## Changes for web developers
 
+### HTML
+
+No notable changes.
+
 ### CSS
 
 - The [`content-visibility`](/en-US/docs/Web/CSS/content-visibility) CSS property value `auto` is now enabled by default. This allows content to skip rendering if it is not [relevant to the user](/en-US/docs/Web/CSS/CSS_containment#relevant_to_the_user). ([Firefox bug 1874874](https://bugzil.la/1874874)).
 - The {{cssxref("text-wrap")}} property has now been converted to a shorthand property and covers the constituent properties {{cssxref("text-wrap-mode")}} and {{cssxref("text-wrap-style")}}. ([Firefox bug 1758391](https://bugzil.la/1758391)).
+
+### JavaScript
+
+No notable changes.
 
 ### SVG
 


### PR DESCRIPTION
### Description

- Keep only the big three (HTML, CSS, JS)
- Remove the rest of the empty sections

### Motivation

To normalize usage. I haven’t gone too far away in the past, only for the 100s versions.