### PR TITLE
Fix long titles in breadcrumbs

### DIFF
--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MDN Web Docs Glossary: Definitions of Web-related terms"
+title: MDN Web Docs Glossary
 short-title: MDN Web Docs Glossary
 slug: Glossary
 page-type: landing-page

--- a/files/en-us/glossary/index.md
+++ b/files/en-us/glossary/index.md
@@ -1,6 +1,6 @@
 ---
-title: MDN Web Docs Glossary
-short-title: MDN Web Docs Glossary
+title: "MDN Web Docs Glossary: Definitions of Web-related terms"
+short-title: Glossary
 slug: Glossary
 page-type: landing-page
 ---

--- a/files/en-us/web/html/attributes/index.md
+++ b/files/en-us/web/html/attributes/index.md
@@ -1,5 +1,6 @@
 ---
 title: HTML attribute reference
+short-title: Attributes
 slug: Web/HTML/Attributes
 page-type: landing-page
 ---

--- a/files/en-us/web/svg/attribute/index.md
+++ b/files/en-us/web/svg/attribute/index.md
@@ -1,5 +1,6 @@
 ---
 title: SVG Attribute reference
+short-title: Attributes
 slug: Web/SVG/Attribute
 page-type: landing-page
 ---

--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -1,5 +1,6 @@
 ---
 title: SVG element reference
+short-title: Elements
 slug: Web/SVG/Element
 page-type: landing-page
 ---

--- a/files/en-us/web/svg/index.md
+++ b/files/en-us/web/svg/index.md
@@ -1,5 +1,6 @@
 ---
 title: "SVG: Scalable Vector Graphics"
+short-title: SVG
 slug: Web/SVG
 page-type: landing-page
 ---


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The longer title of the Glossary appears in the breadcrumbs. The part after the colon is not particularly necessary or helpful and is explained in the intro para on the [Glossary landing page](https://developer.mozilla.org/en-US/docs/Glossary).

### Motivation

To reduce the glossary title in the breadcrumbs

### Additional details

Before:

<kbd><img src="https://github.com/mdn/content/assets/23019147/b061c570-fce9-4e9f-bf7f-9b094f2cb6e2" alt="screenshot with the longer title MDN Web Docs Glossary: Definitions of Web-related terms in the breadcrumbs" /></kbd>

After:
<kbd><img src="https://github.com/mdn/content/assets/23019147/94dd8be2-1c7d-49ec-b9ab-bebde8af0271" alt="screenshot with the shorter title MDN Web Docs Glossary in the breadcrumbs" /></kbd>
