### PR TITLE
fix typo

### DIFF
--- a/files/en-us/web/api/idbobjectstore/put/index.md
+++ b/files/en-us/web/api/idbobjectstore/put/index.md
@@ -79,7 +79,7 @@ const objectStore = db
   .transaction(["toDoList"], "readwrite")
   .objectStore("toDoList");
 
-// Get the to-do list object that has this title as it's title
+// Get the to-do list object that has this title as its title
 const objectStoreTitleRequest = objectStore.get(title);
 
 objectStoreTitleRequest.onsuccess = () => {


### PR DESCRIPTION
### Description

Fix typo from "Get the to-do list object that has this title as **it's** title" to "Get the to-do list object that has this title as **its** title" (Emphasis added).

### Motivation
"It's" is a shortening of "it is". Expanding the current sentence, it reads like this: "Get the to-do list object that has this title as **it is** title". The author of the sentence likely had *its*, the possessive, in mind and an extra apostrophe snuck in.

### Additional details

* [It’s or its ? - Grammar - Cambridge Dictionary](https://dictionary.cambridge.org/grammar/british-grammar/it-s-or-its)
