### PR TITLE
Consistency of expression

### DIFF
--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -33,7 +33,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td>
         Good choice for lossless animation sequences (GIF is less performant).
         AVIF and WebP have better performance but less broad browser support.<br />
-        <strong>Supported</strong>: Chrome, Edge, Firefox, Opera, Safari.
+        <strong>Support</strong>: Chrome, Edge, Firefox, Opera, Safari.
       </td>
     </tr>
     <tr>
@@ -47,7 +47,7 @@ The image file formats that are most commonly used on the web are listed below.
           It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency, etc.
           Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the
           <code><a href="/en-US/docs/Web/HTML/Element/picture">&#x3C;picture></a></code> element).<br />
-          <strong>Supported:</strong> Chrome, Edge, Firefox (still images only: animated images not implemented), Opera, Safari.
+          <strong>Support</strong>: Chrome, Edge, Firefox (still images only: animated images not implemented), Opera, Safari.
         </p>
       </td>
     </tr>
@@ -59,7 +59,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td>
         Good choice for simple images and animations. Prefer PNG for
         lossless <em>and</em> indexed still images, and consider WebP, AVIF or APNG for animation sequences.<br />
-        <strong>Supported:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
+        <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
       </td>
     </tr>
     <tr>
@@ -77,7 +77,7 @@ The image file formats that are most commonly used on the web are listed below.
           Good choice for lossy compression of still images (currently the most
           popular). Prefer PNG when more precise reproduction of the image is
           required, or WebP/AVIF if both better reproduction and higher compression are required.<br />
-          <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
+          <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
         </p>
       </td>
     </tr>
@@ -90,7 +90,7 @@ The image file formats that are most commonly used on the web are listed below.
         <p>
           PNG is preferred over JPEG for more precise reproduction of source
           images, or when transparency is needed. WebP/AVIF provide even better compression and reproduction, but browser support is more limited.<br />
-          <strong >Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
+          <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
         </p>
       </td>
     </tr>
@@ -101,7 +101,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td><code>.svg</code></td>
       <td>
         Vector image format; ideal for user interface elements, icons, diagrams, etc., that must be drawn accurately at different sizes.<br />
-        <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
+        <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
       </td>
     </tr>
     <tr>
@@ -113,7 +113,7 @@ The image file formats that are most commonly used on the web are listed below.
         Excellent choice for both images and animated images.
         WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc.
         AVIF offers slightly better compression, but is not quite as well-supported in browsers and does not support progressive rendering.<br />
-        <strong>Support:</strong> Chrome, Edge, Firefox, Opera, Safari
+        <strong>Support</strong>: Chrome, Edge, Firefox, Opera, Safari
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -33,7 +33,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td>
         Good choice for lossless animation sequences (GIF is less performant).
         AVIF and WebP have better performance but less broad browser support.<br />
-        <strong>Support</strong>: Chrome, Edge, Firefox, Opera, Safari.
+        <strong>Support:</strong> Chrome, Edge, Firefox, Opera, Safari.
       </td>
     </tr>
     <tr>
@@ -47,7 +47,7 @@ The image file formats that are most commonly used on the web are listed below.
           It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency, etc.
           Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the
           <code><a href="/en-US/docs/Web/HTML/Element/picture">&#x3C;picture></a></code> element).<br />
-          <strong>Support</strong>: Chrome, Edge, Firefox (still images only: animated images not implemented), Opera, Safari.
+          <strong>Support:</strong> Chrome, Edge, Firefox (still images only: animated images not implemented), Opera, Safari.
         </p>
       </td>
     </tr>
@@ -59,7 +59,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td>
         Good choice for simple images and animations. Prefer PNG for
         lossless <em>and</em> indexed still images, and consider WebP, AVIF or APNG for animation sequences.<br />
-        <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
+        <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
       </td>
     </tr>
     <tr>
@@ -77,7 +77,7 @@ The image file formats that are most commonly used on the web are listed below.
           Good choice for lossy compression of still images (currently the most
           popular). Prefer PNG when more precise reproduction of the image is
           required, or WebP/AVIF if both better reproduction and higher compression are required.<br />
-          <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
+          <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
         </p>
       </td>
     </tr>
@@ -90,7 +90,7 @@ The image file formats that are most commonly used on the web are listed below.
         <p>
           PNG is preferred over JPEG for more precise reproduction of source
           images, or when transparency is needed. WebP/AVIF provide even better compression and reproduction, but browser support is more limited.<br />
-          <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
+          <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
         </p>
       </td>
     </tr>
@@ -101,7 +101,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td><code>.svg</code></td>
       <td>
         Vector image format; ideal for user interface elements, icons, diagrams, etc., that must be drawn accurately at different sizes.<br />
-        <strong>Support</strong>: Chrome, Edge, Firefox, IE, Opera, Safari.
+        <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
       </td>
     </tr>
     <tr>
@@ -113,7 +113,7 @@ The image file formats that are most commonly used on the web are listed below.
         Excellent choice for both images and animated images.
         WebP offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency etc.
         AVIF offers slightly better compression, but is not quite as well-supported in browsers and does not support progressive rendering.<br />
-        <strong>Support</strong>: Chrome, Edge, Firefox, Opera, Safari
+        <strong>Support:</strong> Chrome, Edge, Firefox, Opera, Safari
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
### Description
The terms are not unified.

![스크린샷 2024-03-21 오후 3 29 47](https://github.com/mdn/content/assets/78193416/85136b56-a5a5-42ae-be41-48c475be7d61)

![스크린샷 2024-03-21 오후 3 29 52](https://github.com/mdn/content/assets/78193416/04bbe02a-10a6-434c-919b-ea97370797cc)

### Motivation

It's a mixture of `Supported` and `Support`unification as one

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to  #32772