### PR TITLE
Add note about `ProgressEvent.loaded` reporting different values depending on the browser

### DIFF
--- a/files/en-us/web/api/progressevent/index.md
+++ b/files/en-us/web/api/progressevent/index.md
@@ -21,14 +21,11 @@ The **`ProgressEvent`** interface represents events measuring progress of an und
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("ProgressEvent.lengthComputable")}} {{ReadOnlyInline}}
-  - : A boolean flag indicating if the ratio between the value of the data already transmitted or processed (`loaded`), and the total size of the data being transmitted or processed (`total`), is calculable. In other words, it tells if the progress is measurable or not.
+  - : A boolean flag indicating if the ratio between the size of the data already transmitted or processed (`loaded`), and the total size of the data (`total`), is calculable. In other words, it tells if the progress is measurable or not.
 - {{domxref("ProgressEvent.loaded")}} {{ReadOnlyInline}}
-  - : A 64-bit unsigned integer
-indicating the size, in bytes, of the data already transmitted or processed. The ratio can be calculated by dividing `ProgressEvent.total` by the value of this property.
-When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead. Note that for compressed requests of unknown total size, `loaded` might contain the size of the compressed, or decompressed, data, depending on the browser. As of 2024, it contains the size of the compressed data in Firefox, and the size of the uncompressed data in Chrome.
+  - : A 64-bit unsigned integer indicating the size, in bytes, of the data already transmitted or processed. The ratio can be calculated by dividing `ProgressEvent.total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead. Note that for compressed requests of unknown total size, `loaded` might contain the size of the compressed, or decompressed, data, depending on the browser. As of 2024, it contains the size of the compressed data in Firefox, and the size of the uncompressed data in Chrome.
 - {{domxref("ProgressEvent.total")}} {{ReadOnlyInline}}
-  - : A 64-bit unsigned integer
-value indicating the total size, in bytes, of the data being transmitted or processed. When downloading a resource using HTTP, this value is taken from the `Content-Length` response header. It only counts the body of the HTTP message, and doesn't include headers and other overhead.
+  - : A 64-bit unsigned integer indicating the total size, in bytes, of the data being transmitted or processed. When downloading a resource using HTTP, this value is taken from the `Content-Length` response header. It only counts the body of the HTTP message, and doesn't include headers and other overhead.
 
 ## Instance methods
 

--- a/files/en-us/web/api/progressevent/index.md
+++ b/files/en-us/web/api/progressevent/index.md
@@ -21,11 +21,14 @@ The **`ProgressEvent`** interface represents events measuring progress of an und
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("ProgressEvent.lengthComputable")}} {{ReadOnlyInline}}
-  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+  - : A boolean flag indicating if the ratio between the value of the data already transmitted or processed (`loaded`), and the total size of the data being transmitted or processed (`total`), is calculable. In other words, it tells if the progress is measurable or not.
 - {{domxref("ProgressEvent.loaded")}} {{ReadOnlyInline}}
-  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+  - : A 64-bit unsigned integer
+indicating the size, in bytes, of the data already transmitted or processed. The ratio can be calculated by dividing `ProgressEvent.total` by the value of this property.
+When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead. Note that for compressed requests of unknown total size, `loaded` might contain the size of the compressed, or decompressed, data, depending on the browser. As of 2024, it contains the size of the compressed data in Firefox, and the size of the uncompressed data in Chrome.
 - {{domxref("ProgressEvent.total")}} {{ReadOnlyInline}}
-  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
+  - : A 64-bit unsigned integer
+value indicating the total size, in bytes, of the data being transmitted or processed. When downloading a resource using HTTP, this value is taken from the `Content-Length` response header. It only counts the body of the HTTP message, and doesn't include headers and other overhead.
 
 ## Instance methods
 

--- a/files/en-us/web/api/progressevent/loaded/index.md
+++ b/files/en-us/web/api/progressevent/loaded/index.md
@@ -8,11 +8,11 @@ browser-compat: api.ProgressEvent.loaded
 
 {{APIRef("XMLHttpRequest API")}}
 
-The **`ProgressEvent.loaded`** read-only property is an integer
-representing the amount of work already performed by the underlying process. The ratio
-of work done can be calculated with the property and `ProgressEvent.total`.
-When downloading a resource using HTTP, this value is specified in bytes (not bits), and only represents the part of the content
-itself, not headers and other overhead.
+The **`ProgressEvent.loaded`** read-only property is a 64-bit unsigned integer
+indicating the size, in bytes, of the data already transmitted or processed. The ratio can be calculated by dividing `ProgressEvent.total` by the value of this property.
+When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+
+Note that for compressed requests of unknown total size, `loaded` might contain the size of the compressed, or decompressed, data, depending on the browser. As of 2024, it contains the size of the compressed data in Firefox, and the size of the uncompressed data in Chrome.
 
 ## Value
 

--- a/files/en-us/web/api/progressevent/total/index.md
+++ b/files/en-us/web/api/progressevent/total/index.md
@@ -9,7 +9,7 @@ browser-compat: api.ProgressEvent.total
 {{APIRef("XMLHttpRequest API")}}
 
 The **`ProgressEvent.total`** read-only property is a 64-bit unsigned integer
-value indicating the total size, in bytes, of the data being transmitted or processed.
+indicating the total size, in bytes, of the data being transmitted or processed.
 
 When downloading a resource using HTTP, this value is taken from the `Content-Length` response header. It only counts the body of the HTTP message, and doesn't include headers and other overhead.
 

--- a/files/en-us/web/api/progressevent/total/index.md
+++ b/files/en-us/web/api/progressevent/total/index.md
@@ -8,11 +8,10 @@ browser-compat: api.ProgressEvent.total
 
 {{APIRef("XMLHttpRequest API")}}
 
-The **`ProgressEvent.total`** read-only property is an unsigned
-64-bit integer value indicating the total size of the data being processed or
-transmitted. In the case of an HTTP transmission, this is the size of the body of the
-message (the `Content-Length`), and does not include headers and other
-overhead.
+The **`ProgressEvent.total`** read-only property is a 64-bit unsigned integer
+value indicating the total size, in bytes, of the data being transmitted or processed.
+
+When downloading a resource using HTTP, this value is taken from the `Content-Length` response header. It only counts the body of the HTTP message, and doesn't include headers and other overhead.
 
 If the event's {{domxref("ProgressEvent.lengthComputable", "lengthComputable")}}
 property is `false`, this value is meaningless and should be ignored.


### PR DESCRIPTION
### Description

#### Add note about `ProgressEvent.loaded` reporting different values depending on the browser

In Firefox, `loaded` is the size of the compressed data; in Chrome, it's the size of the decompress data. I would have loved to find sources for this, but the only thing I could find is that the RFC doesn't specify which value it should be! Browsers implement it differently.

I also did some rephrasing to make all sentences similar.

### Motivation

Make developers aware that the values of `loaded` might be different for their users.

### Additional details

- In Chrome, downloading a content of 1.3MB (1,345,276 bytes), while logging the value of `loaded`, shows a total of `1345276` at the end.
- In Firefox, downloading the same content of 1,345,276 bytes, while logging the value of `loaded`, shows a total of `1017454` at the end.
