### PR TITLE
fix incorrect method parameter '...arguments' with actual parameters (target, prop, receiver)

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -77,7 +77,7 @@ const handler3 = {
     if (prop === "message2") {
       return "world";
     }
-    return Reflect.get(...arguments);
+    return Reflect.get(target, prop, receiver);
   },
 };
 


### PR DESCRIPTION
### Description

The [Proxy documentation page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) currently contains an example which is most likely outdated. The parameter `..arguments` no longer exists. At least, when I used TypeScript it complained that the arguments did not exist. On the other hand, this example seems to work: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get -> related PR: https://github.com/mdn/interactive-examples/pull/2752

```javascript
const handler3 = {
  get(target, prop, receiver) {
    if (prop === "message2") {
      return "world";
    }
    return Reflect.get(...arguments);
  },
};
```

should most likely be

```javascript
const handler3 = {
  get(target, prop, receiver) {
    if (prop === "message2") {
      return "world";
    }
    return Reflect.get(target, prop, receiver);
  },
};
```

### Motivation

This ensures that the example is correct and the code can be copied i.e. is directly functional. 

### Additional details

- Documentation Page: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
