### PR TITLE
fix: correct documentation for the iterator example

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arguments/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/@@iterator/index.md
@@ -47,11 +47,11 @@ You may still manually call the `next()` method of the returned iterator object 
 ```js
 function f() {
   const argsIter = arguments[Symbol.iterator]();
-  console.log(argsIter.next().value); // a
-  console.log(argsIter.next().value); // b
-  console.log(argsIter.next().value); // c
-  console.log(argsIter.next().value); // d
-  console.log(argsIter.next().value); // e
+  console.log(argsIter.next().value); // w
+  console.log(argsIter.next().value); // y
+  console.log(argsIter.next().value); // k
+  console.log(argsIter.next().value); // o
+  console.log(argsIter.next().value); // p
 }
 f("w", "y", "k", "o", "p");
 ```


### PR DESCRIPTION
Corrected the iterator example's comments showing the output so that it matched the example's input.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct the iterator example for the documentation since the comments did not match the input given in the code.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Reading through the documentation, I noticed a discrepancy in the example and wanted to reduce confusion for future readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
