### PR TITLE
Change inert example from the body element to a div

### DIFF
--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -16,9 +16,9 @@ Specifically, `inert` does the following:
 - Hides the element and its content from assistive technologies by excluding them from the accessibility tree.
 
 ```html
-<body inert>
+<div inert>
   <!-- content -->
-</body>
+</div>
 ```
 
 The `inert` attribute can be added to sections of content that should not be interactive. When an element is inert, it along with all of the element's descendants, including normally interactive elements such as links, buttons, and form controls are disabled because they cannot receive focus or be clicked.


### PR DESCRIPTION
Using inert on the body element removes it from being interacted with and read by assistive technologies. You never want to do that to the whole document, especially as you cannot un-inert content further down in the DOM.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed the body element to a div element in the example.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

You never want to inert the whole document.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
