### PR TITLE
fix(http): copy-paste err in Origin-Agent-Cluster directives

### DIFF
--- a/files/en-us/web/http/headers/origin-agent-cluster/index.md
+++ b/files/en-us/web/http/headers/origin-agent-cluster/index.md
@@ -9,7 +9,7 @@ browser-compat: http.headers.Origin-Agent-Cluster
 
 {{HTTPSidebar}}{{SeeCompatTable}}
 
-The **`Origin-Agent-Cluster`** HTTP response header is used to request that the associated {{domxref("Document")}} should be placed in an _origin-keyed agent cluster_. This means that operating system resources (for example, the operating system process) used to evaluate the document should be shared only with other documents from the same {{glossary("origin")}}.
+The **`Origin-Agent-Cluster`** HTTP response header is used to request that the associated {{domxref("Document")}} should be placed in an _origin-keyed [agent cluster](https://tc39.es/ecma262/#sec-agent-clusters)_. This means that operating system resources (for example, the operating system process) used to evaluate the document should be shared only with other documents from the same {{glossary("origin")}}.
 
 The effect of this is that a resource-intensive document will be less likely to degrade the performance of documents from other origins.
 
@@ -64,9 +64,8 @@ Origin-Agent-Cluster: <boolean>
 
 - `<boolean>`
 
-  - : `?1` indicates that the user-agent prefers a mobile experience (true).
-
-    `?0` indicates that user-agent does not prefer a mobile experience (false).
+  - : `?1` indicates that the associated {{domxref("Document")}} should be placed in an origin-keyed agent cluster.
+    Values other than `?1` are ignored (e.g., the `?0` structured field for false).
 
 ## Examples
 


### PR DESCRIPTION
### Description

There is some copy/paste prose left in the Directives section for Origin-Agent-Cluster. This is a response header, not requests with client hints.

Also `?1` is the only value that's valid, everything else is ignored / treated as omission of the response header.

### Related issues and pull requests

Fixes #32751