### PR TITLE
getRandomValues: clarify security

### DIFF
--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -43,9 +43,7 @@ Note that `typedArray` is modified in-place, and no copy is made.
 
 ## Usage notes
 
-Don't use `getRandomValues()` to generate encryption keys.
-Instead, use the {{domxref("SubtleCrypto.generateKey", "generateKey()")}} method.
-There are a few reasons for this; for example, `getRandomValues()` is not guaranteed to be running in a secure context.
+Prefer the {{domxref("SubtleCrypto.generateKey", "generateKey()")}} method for key generation, which is guaranteed to be running in a secure context.
 
 There is no minimum degree of entropy mandated by the Web Cryptography specification.
 User agents are instead urged to provide the best entropy they can when generating random numbers,


### PR DESCRIPTION
The wording is really bad.

It says: “do not getRandomValues” to generate keys…”there are some reasons for this”…”for example, it’s not guaranteed to run in secure context”.

1. Using cryptographically secure PRNG, such as getRandomValues, is industry standard. One should not tell to “not use it”. In fact, generateKey uses the same thing inside. [Proof from WebKit](https://github.com/WebKit/WebKit/blob/594c0f11b1e8b3e512d68eedd581a189cdf834f0/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp#L69)
2. If there are “some reasons”, they should be listed.
3. generateKey is very limited. It doesn’t support most popular curves: secp256k1 (cryptocurrency), ed25519, x25519 (TLS), etc. So a user is forced to use getRandomValues instead. If mdn writes “do not use”, then it should specify alternatives. There are no alternatives for these cases

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Additional details

I write cryptography in javascript: https://paulmillr.com/noble