### PR TITLE
"different from", not "different than"

### DIFF
--- a/files/en-us/web/css/transform/index.md
+++ b/files/en-us/web/css/transform/index.md
@@ -12,7 +12,7 @@ It modifies the coordinate space of the CSS [visual formatting model](/en-US/doc
 
 {{EmbedInteractiveExample("pages/css/transform.html")}}
 
-If the property has a value different than `none`, a [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) will be created.
+If the property has a value different from `none`, a [stacking context](/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) will be created.
 In that case, the element will act as a [containing block](/en-US/docs/Web/CSS/Containing_block) for any `position: fixed;` or `position: absolute;` elements that it contains.
 
 > **Warning:** Only transformable elements can be `transform`ed.


### PR DESCRIPTION
### Description

Correct the grammar,

### Motivation

Correct grammar is less distracting.
