### PR TITLE
AnalyserNode.getByteFrequencyData() values can't be infinite

### DIFF
--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -25,7 +25,7 @@ getByteFrequencyData(array)
 ### Parameters
 
 - `array`
-  - : The {{jsxref("Uint8Array")}} that the frequency domain data will be copied to. For any sample which is silent, the value is `-Infinity`.
+  - : The {{jsxref("Uint8Array")}} that the frequency domain data will be copied to.
     If the array has fewer elements than the {{domxref("AnalyserNode.frequencyBinCount")}}, excess elements are dropped. If it has more elements than needed, excess elements are ignored.
 
 ### Return value


### PR DESCRIPTION
Fixes #32803

As stated in the issue, values copied into an 8 bit unsigned integer array can't be -Infinite. This removes the text that states this is the case. There is nothing else significant in the spec around this that isn't already captured.