### PR TITLE
Ff125 transport vs peer connection - cross link state/gathering state

### DIFF
--- a/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
+++ b/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
@@ -8,7 +8,11 @@ browser-compat: api.RTCIceTransport.gatheringState
 
 {{APIRef("WebRTC")}}
 
-The **`gatheringState`** read-only property of the {{domxref("RTCIceTransport")}} interface returns a string that indicates the current gathering state of the ICE agent: `"new"`, `"gathering"`, or `"complete"`.
+The **`gatheringState`** read-only property of the {{domxref("RTCIceTransport")}} interface returns a string that indicates the current gathering state of the ICE agent for this transport: `"new"`, `"gathering"`, or `"complete"`.
+
+You can detect when the value of this property changes by watching for an event of type {{domxref("RTCIceTransport/gatheringstatechange_event", "gatheringstatechange")}}.
+
+Note that **`gatheringState`** represents the gathering state of just this transport, while {{domxref("RTCPeerConnection.iceGatheringState")}} represents the overall gathering state of the whole connection, including every {{domxref("RTCIceTransport")}} used by every {{domxref("RTCRtpSender")}} and every {{domxref("RTCRtpReceiver")}} on the entire connection.
 
 ## Value
 

--- a/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.md
+++ b/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.md
@@ -10,9 +10,7 @@ browser-compat: api.RTCIceTransport.gatheringstatechange_event
 
 A **`gatheringstatechange`** event is sent to an {{domxref("RTCIceTransport")}} when its {{Glossary("ICE")}} candidate gathering state changes.
 
-The gathering state, whose actual status can be found in the transport object's {{domxref("RTCIceTransport.gatheringState", "gatheringState")}} property, indicates whether or not the ICE agent has begun gathering candidates, and if so, if it has finished doing so.
-
-The key difference between `gatheringstatechange` and {{domxref("RTCPeerConnection.icegatheringstatechange_event", "icegatheringstatechange")}} is that the latter represents the overall state of the connection including every {{domxref("RTCIceTransport")}} used by every {{domxref("RTCRtpSender")}} and every {{domxref("RTCRtpReceiver")}} on the entire connection. In contrast, `gatheringstatechange` represents changes to the candidate gathering state for a single transport.
+The gathering state, whose actual status can be found in the transport object's {{domxref("RTCIceTransport.gatheringState", "gatheringState")}} property, indicates whether or not the ICE agent has begun gathering candidates on this transport, and if so, if it has finished doing so.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/rtcicetransport/state/index.md
+++ b/files/en-us/web/api/rtcicetransport/state/index.md
@@ -11,6 +11,7 @@ browser-compat: api.RTCIceTransport.state
 The **`state`** read-only property of the {{domxref("RTCIceTransport")}} interface returns the current state of the ICE transport, so you can determine the state of ICE gathering in which the ICE agent currently is operating.
 
 This differs from the {{domxref("RTCIceTransport.gatheringState", "gatheringState")}}, which only indicates whether or not ICE gathering is currently underway.
+It also differs from {{domxref("RTCPeerConnection.connectionState")}}, which aggregates the states across every {{domxref("RTCIceTransport")}} used by every {{domxref("RTCRtpSender")}} and every {{domxref("RTCRtpReceiver")}} on the entire connection.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnection/connectionstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstate/index.md
@@ -57,4 +57,5 @@ const connectionState = peerConnection.connectionState;
 - [Lifetime of a WebRTC session](/en-US/docs/Web/API/WebRTC_API/Session_lifetime)
 - {{domxref("RTCPeerConnection")}}
 - {{domxref("RTCPeerConnection.connectionstatechange_event", "connectionstatechange")}}
+- {{domxref("RTCIceTransport.state")}}
 - [WebRTC](/en-US/docs/Web/API/WebRTC_API)

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.md
@@ -8,10 +8,13 @@ browser-compat: api.RTCPeerConnection.iceGatheringState
 
 {{APIRef("WebRTC")}}
 
-The **`iceGatheringState`** read-only property of the {{domxref("RTCPeerConnection")}} interface returns a string that describes the connection's ICE gathering state.
+The **`iceGatheringState`** read-only property of the {{domxref("RTCPeerConnection")}} interface returns a string that describes the overall ICE gathering state for this connection.
 This lets you detect, for example, when collection of ICE candidates has finished.
 
 You can detect when the value of this property changes by watching for an event of type {{domxref("RTCPeerConnection/icegatheringstatechange_event", "icegatheringstatechange")}}.
+
+Note that **`iceGatheringState`** represents the overall gathering state of the connection, including every {{domxref("RTCIceTransport")}} used by every {{domxref("RTCRtpSender")}} and every {{domxref("RTCRtpReceiver")}} on the entire connection.
+This contrasts with {{domxref("RTCIceTransport.gatheringState")}}, which represents the gathering state for a single transport.
 
 ## Value
 
@@ -23,8 +26,7 @@ The possible values are:
   - : The ICE agent is in the process of gathering candidates for the connection.
 - `complete`
   - : The ICE agent has finished gathering candidates.
-    If something happens that requires collecting new candidates,
-    such as a new interface being added or the addition of a new ICE server, the state will revert to `gathering` to gather those candidates.
+    If something happens that requires collecting new candidates, such as a new interface being added or the addition of a new ICE server, the state will revert to `gathering` to gather those candidates.
 
 ## Example
 


### PR DESCRIPTION
Follows on from #32816 - cross linking the  [`RTCPeerConnection.iceGatheringState`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState) and `connectionState`, and the transport  object state/gathering state and explain difference/sameness.

Missed these in the last PR.

Related docs work can be tracked in #32775