### PR TITLE
fix(macro): remove inline status macros from CSS value sections, part 2

### DIFF
--- a/files/en-us/web/css/@document/index.md
+++ b/files/en-us/web/css/@document/index.md
@@ -33,7 +33,7 @@ An `@document` rule can specify one or more matching functions. If any of the fu
   - : Matches if the document URL is on the domain provided (or a subdomain of it).
 - `media-document()`
   - : Matches the media according to the string in parameter, one of `video`, `image`, `plugin` or `all`.
-- `regexp()` {{Deprecated_Inline}} {{Non-standard_Inline}}
+- `regexp()`
   - : Matches if the document URL is matched by the [regular expression](/en-US/docs/Web/JavaScript/Guide/Regular_expressions) provided. The expression must match the entire URL.
 
 The values provided to the `url()`, `url-prefix()`, `domain()`, and `media-document()` functions can be optionally enclosed by single or double quotes. The values provided to the `regexp()` function _must_ be enclosed in quotes.

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -55,7 +55,7 @@ src:
     If omitted, the browser will download the resource and then detect the format.
     If including a font source for backward-compatibility that is not in the list of [defined keywords](#formal_syntax), enclose the format string in quotes.
     Possible values are described in the [Font formats](#font_formats) section below.
-- `tech()` {{Experimental_inline}}
+- `tech()`
   - : An optional declaration that follows the `url()` value that provides a hint for the user agent on the font technology.
     The value for `tech()` may be one of the keywords described in [Font technologies](#font_technologies).
 - `local(<font-face-name>)`

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -32,7 +32,7 @@ where:
   - : Is a comma-separated list of [media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries), which specify the media-dependent conditions for applying the CSS rules defined in the linked URL. If the browser does not support any of these queries, it does not load the linked resource.
 - _layer-name_
   - : Is the name of a [cascade layer](/en-US/docs/Web/CSS/@layer) into which the contents of the linked resource are imported.
-- _supports-condition_ {{experimental_inline}}
+- _supports-condition_
   - : Indicates the feature(s) that the browser must support in order for the stylesheet to be imported.
     If the browser does not conform to the conditions specified in the _supports-condition_, it may not fetch the linked stylesheet, and even if downloaded through some other path, will not load it.
     The syntax of `supports()` is almost identical to that described in {{CSSxRef("@supports")}}, and that topic can be used as a more complete reference.

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -33,7 +33,7 @@ The **`@keyframes`** CSS [at-rule](/en-US/docs/Web/CSS/At-rule) controls the int
   - : An ending offset of `100%`.
 - {{cssxref("&lt;percentage&gt;")}}
   - : A percentage of the time through the animation sequence at which the specified keyframe should occur.
-- `<timeline-range-name>` {{cssxref("&lt;percentage&gt;")}} {{experimental_inline}}
+- `<timeline-range-name>` {{cssxref("&lt;percentage&gt;")}}
   - : A percentage of the time through the specified {{cssxref("animation-range")}} at which the specified keyframe should occur. See [CSS scroll-driven animations](/en-US/docs/Web/CSS/CSS_scroll-driven_animations) for more information on the kinds of animations that use named timeline ranges.
 
 ## Description

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -73,13 +73,13 @@ Media feature expressions test for their presence or value, and are entirely opt
     Added in Media Queries Level 4.
 - {{cssxref("@media/color-index", "color-index")}}
   - : Number of entries in the output device's color lookup table, or zero if the device does not use such a table
-- {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}} {{deprecated_inline}}
+- {{cssxref("@media/device-aspect-ratio", "device-aspect-ratio")}}
   - : Width-to-height aspect ratio of the output device.
     Deprecated in Media Queries Level 4.
-- {{cssxref("@media/device-height", "device-height")}} {{deprecated_inline}}
+- {{cssxref("@media/device-height", "device-height")}}
   - : Height of the rendering surface of the output device.
     Deprecated in Media Queries Level 4.
-- {{cssxref("@media/device-width", "device-width")}} {{deprecated_inline}}
+- {{cssxref("@media/device-width", "device-width")}}
   - : Width of the rendering surface of the output device. Deprecated in Media Queries Level 4.
 - {{cssxref("@media/display-mode", "display-mode")}}
   - : The mode in which an application is being displayed: for example [fullscreen](/en-US/docs/Web/API/Fullscreen_API) or [picture-in-picture](/en-US/docs/Web/API/Document_Picture-in-Picture_API) mode.

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -54,7 +54,7 @@ The following example returns true and applies the CSS style if the browser supp
 The function syntax checks if a browser supports values or expressions within the function.
 The functions supported in the function syntax are described in the following sections.
 
-#### `selector()` {{Experimental_Inline}}
+#### `selector()`
 
 This function evaluates if a browser supports the specified selector syntax.
 The following example returns true and applies the CSS style if the browser supports the [child combinator](/en-US/docs/Web/CSS/Child_combinator):

--- a/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
@@ -57,5 +57,5 @@ Briefly defined as `:blank` in [Selectors Level 4](https://drafts.csswg.org/sele
 
 ## See also
 
-- {{CSSxRef(":blank")}} {{Experimental_Inline}}
+- {{CSSxRef(":blank")}}
 - {{CSSxRef(":empty")}}

--- a/files/en-us/web/css/_colon_empty/index.md
+++ b/files/en-us/web/css/_colon_empty/index.md
@@ -84,5 +84,5 @@ The text that provides the interactive control's accessible name can be hidden u
 
 ## See also
 
-- {{CSSxRef(":-moz-only-whitespace")}} {{Non-standard_Inline}} – The {{glossary("Vendor_Prefix", "prefixed")}} implementation of the changes in [Selectors Level 4](https://drafts.csswg.org/selectors-4/#the-empty-pseudo)
-- {{CSSxRef(":blank")}} {{Experimental_Inline}}
+- {{CSSxRef(":-moz-only-whitespace")}} – The {{glossary("Vendor_Prefix", "prefixed")}} implementation of the changes in [Selectors Level 4](https://drafts.csswg.org/selectors-4/#the-empty-pseudo)
+- {{CSSxRef(":blank")}}

--- a/files/en-us/web/css/_colon_first-child/index.md
+++ b/files/en-us/web/css/_colon_first-child/index.md
@@ -97,7 +97,7 @@ ul li:first-child {
 
 ## See also
 
-- {{CSSxRef(":-moz-first-node")}} {{Non-standard_Inline}}
+- {{CSSxRef(":-moz-first-node")}}
 - {{CSSxRef(":first-of-type")}}
 - {{CSSxRef(":last-child")}}
 - {{CSSxRef(":nth-child", ":nth-child()")}}

--- a/files/en-us/web/css/_colon_last-child/index.md
+++ b/files/en-us/web/css/_colon_last-child/index.md
@@ -97,7 +97,7 @@ ul li:last-child {
 
 ## See also
 
-- {{CSSxRef(":-moz-last-node")}} {{Non-standard_Inline}}
+- {{CSSxRef(":-moz-last-node")}}
 - {{CSSxRef(":last-of-type")}}
 - {{CSSxRef(":first-child")}}
 - {{CSSxRef(":nth-child")}}

--- a/files/en-us/web/css/attr/index.md
+++ b/files/en-us/web/css/attr/index.md
@@ -36,7 +36,7 @@ attr(data-something, "default");
 
 - `attribute-name`
   - : The name of an attribute on the HTML element referenced in the CSS.
-- `<type-or-unit>` {{Experimental_Inline}}
+- `<type-or-unit>`
 
   - : A keyword representing either the type of the attribute's value, or its unit, as in HTML some attributes have implicit units. If the use of `<type-or-unit>` as a value for the given attribute is invalid, the `attr()` expression will be invalid too. If omitted, it defaults to `string`. The list of valid values are:
 
@@ -46,13 +46,13 @@ attr(data-something, "default");
 
         Default value: an empty string.
 
-    - `color` {{Experimental_Inline}}
+    - `color`
 
       - : The attribute value is parsed as a hash (3- or 6-value hash) or a keyword. It must be a valid CSS {{CSSxRef("&lt;string&gt;")}} value. Leading and trailing spaces are stripped.
 
         Default value: `currentcolor`.
 
-    - `url` {{Experimental_Inline}}
+    - `url`
 
       - : The attribute value is parsed as a string that is used inside a CSS `url()` function.
         Relative URL are resolved relatively to the original document, not relatively to the style sheet.
@@ -60,21 +60,21 @@ attr(data-something, "default");
 
         Default value: the URL `about:invalid` that points to a non-existent document with a generic error condition.
 
-    - `integer` {{Experimental_Inline}}
+    - `integer`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;integer&gt;")}}. If it is not valid, that is not an integer or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0`, or, if `0` is not a valid value for the property, the property's minimum value.
 
-    - `number` {{Experimental_Inline}}
+    - `number`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;number&gt;")}}. If it is not valid, that is not a number or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0`, or, if `0` is not a valid value for the property, the property's minimum value.
 
-    - `length` {{Experimental_Inline}}
+    - `length`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;length&gt;")}} dimension, that is including the unit (e.g. `12.5em`). If it is not valid, that is not a length or out of the range accepted by the CSS property, the default value is used.
         If the given unit is a relative length, `attr()` computes it to an absolute length.
@@ -82,7 +82,7 @@ attr(data-something, "default");
 
         Default value: `0`, or, if `0` is not a valid value for the property, the property's minimum value.
 
-    - `em`, `ex`, `px`, `rem`, `vw`, `vh`, `vmin`, `vmax`, `mm`, `cm`, `in`, `pt`, or `pc` {{Experimental_Inline}}
+    - `em`, `ex`, `px`, `rem`, `vw`, `vh`, `vmin`, `vmax`, `mm`, `cm`, `in`, `pt`, or `pc`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;number&gt;")}}, that is without the unit (e.g. `12.5`), and interpreted as a {{CSSxRef("&lt;length&gt;")}} with the specified unit. If it is not valid, that is not a number or out of the range accepted by the CSS property, the default value is used.
         If the given unit is a relative length, `attr()` computes it to an absolute length.
@@ -90,48 +90,48 @@ attr(data-something, "default");
 
         Default value: `0`, or, if `0` is not a valid value for the property, the property's minimum value.
 
-    - `angle` {{Experimental_Inline}}
+    - `angle`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;angle&gt;")}} dimension, that is including the unit (e.g. `30.5deg`). If it is not valid, that is not an angle or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0deg`, or, if `0deg` is not a valid value for the property, the property's minimum value.
 
-    - `deg`, `grad`, `rad` {{Experimental_Inline}}
+    - `deg`, `grad`, `rad`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;number&gt;")}}, that is without the unit (e.g. `12.5`), and interpreted as an {{CSSxRef("&lt;angle&gt;")}} with the specified unit. If it is not valid, that is not a number or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0deg`, or, if `0deg` is not a valid value for the property, the property's minimum value.
 
-    - `time` {{Experimental_Inline}}
+    - `time`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;time&gt;")}} dimension, that is including the unit (e.g. `30.5ms`). If it is not valid, that is not a time or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0s`, or, if `0s` is not a valid value for the property, the property's minimum value.
 
-    - `s`, `ms` {{Experimental_Inline}}
+    - `s`, `ms`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;number&gt;")}}, that is without the unit (e.g. `12.5`), and interpreted as an {{CSSxRef("&lt;time&gt;")}} with the specified unit. If it is not valid, that is not a number or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0s`, or, if `0s` is not a valid value for the property, the property's minimum value.
 
-    - `frequency` {{Experimental_Inline}}
+    - `frequency`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;frequency&gt;")}} dimension, that is including the unit (e.g. `30.5kHz`). If it is not valid, that is not a frequency or out of the range accepted by the CSS property, the default value is used.
 
         Default value: `0Hz`, or, if `0Hz` is not a valid value for the property, the property's minimum value.
 
-    - `Hz`, `kHz` {{Experimental_Inline}}
+    - `Hz`, `kHz`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;number&gt;")}}, that is without the unit (e.g. `12.5`), and interpreted as a {{CSSxRef("&lt;frequency&gt;")}} with the specified unit. If it is not valid, that is not a number or out of the range accepted by the CSS property, the default value is used.
         Leading and trailing spaces are stripped.
 
         Default value: `0Hz`, or, if `0Hz` is not a valid value for the property, the property's minimum value.
 
-    - `%` {{Experimental_Inline}}
+    - `%`
 
       - : The attribute value is parsed as a CSS {{CSSxRef("&lt;number&gt;")}}, that is without the unit (e.g. `12.5`), and interpreted as a {{CSSxRef("&lt;percentage&gt;")}}. If it is not valid, that is not a number or out of the range accepted by the CSS property, the default value is used.
         If the given value is used as a length, `attr()` computes it to an absolute length.
@@ -139,7 +139,7 @@ attr(data-something, "default");
 
         Default value: `0%`, or, if `0%` is not a valid value for the property, the property's minimum value.
 
-- `<fallback>` {{Experimental_Inline}}
+- `<fallback>`
   - : The value to be used if the associated attribute is missing or contains an invalid value. If not set, CSS will use the default value defined for each `<type-or-unit>`.
 
 ### Formal syntax

--- a/files/en-us/web/css/attribute_selectors/index.md
+++ b/files/en-us/web/css/attribute_selectors/index.md
@@ -59,7 +59,7 @@ a[class~="logo"] {
   - : Represents elements with an attribute name of _attr_ whose value contains at least one occurrence of _value_ within the string.
 - `[attr operator value i]`
   - : Adding an `i` (or `I`) before the closing bracket causes the value to be compared case-insensitively (for characters within the {{Glossary("ASCII")}} range).
-- `[attr operator value s]` {{Experimental_Inline}}
+- `[attr operator value s]`
   - : Adding an `s` (or `S`) before the closing bracket causes the value to be compared case-sensitively (for characters within the {{Glossary("ASCII")}} range).
 
 ## Examples

--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -38,10 +38,10 @@ To see the code for this sample, [view the source on GitHub](https://github.com/
 - {{cssxref("background-repeat")}}
 - {{cssxref("background-size")}}
 - {{cssxref("background")}} shorthand
-- {{cssxref("background-position-x")}} {{experimental_inline}}
-- {{cssxref("background-position-y")}} {{experimental_inline}}
-- {{cssxref("background-position-inline")}} {{experimental_inline}}
-- {{cssxref("background-position-block")}} {{experimental_inline}}
+- {{cssxref("background-position-x")}}
+- {{cssxref("background-position-y")}}
+- {{cssxref("background-position-inline")}}
+- {{cssxref("background-position-block")}}
 
 - {{cssxref("border-bottom-color")}}
 - {{cssxref("border-bottom-style")}}

--- a/files/en-us/web/css/css_basic_user_interface/index.md
+++ b/files/en-us/web/css/css_basic_user_interface/index.md
@@ -34,10 +34,10 @@ To see the code for this basic user interface sample, [view the source on GitHub
   - {{CSSxRef("caret-color")}}
   - {{CSSxRef("caret-shape")}}
 - {{CSSxRef("cursor")}}
-- {{CSSxRef("nav-down")}} {{Experimental_Inline}}
-- {{CSSxRef("nav-left")}} {{Experimental_Inline}}
-- {{CSSxRef("nav-right")}} {{Experimental_Inline}}
-- {{CSSxRef("nav-up")}} {{Experimental_Inline}}
+- {{CSSxRef("nav-down")}}
+- {{CSSxRef("nav-left")}}
+- {{CSSxRef("nav-right")}}
+- {{CSSxRef("nav-up")}}
 - {{CSSxRef("outline")}}, shorthand for:
   - {{CSSxRef("outline-color")}}
   - {{CSSxRef("outline-style")}}

--- a/files/en-us/web/css/css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/index.md
@@ -43,7 +43,7 @@ Margins surround the border edge of a box, and provide spacing between boxes.
 - {{CSSxRef("margin-left")}}
 - {{CSSxRef("margin-right")}}
 - {{CSSxRef("margin-top")}}
-- {{CSSxRef("margin-trim")}} {{Experimental_Inline}}
+- {{CSSxRef("margin-trim")}}
 
 ### Properties for controlling the padding for a box
 

--- a/files/en-us/web/css/css_cascade/index.md
+++ b/files/en-us/web/css/css_cascade/index.md
@@ -33,7 +33,7 @@ The opposite also occurs. Sometimes there are no declarations defining the value
 - {{cssxref("initial")}}
 - {{cssxref("inherit")}}
 - {{cssxref("revert")}}
-- {{cssxref("revert-layer")}} {{Experimental_Inline}}
+- {{cssxref("revert-layer")}}
 - {{cssxref("unset")}}
 - {{cssxref("important", "!important")}} flag
 

--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -48,10 +48,10 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
   - [`oklab()`](/en-US/docs/Web/CSS/color_value/oklab)
   - [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch)
   - [`color()`](/en-US/docs/Web/CSS/color_value/color)
-- [`color-contrast()`](/en-US/docs/Web/CSS/color_value/color-contrast) {{Experimental_Inline}}
+- [`color-contrast()`](/en-US/docs/Web/CSS/color_value/color-contrast)
 - [`color-mix()`](/en-US/docs/Web/CSS/color_value/color-mix)
-- [`device-cmyk()`](/en-US/docs/Web/CSS/color_value/device-cmyk) {{Experimental_Inline}}
-- {{CSSXref("color_value/light-dark", "light-dark()")}} {{Experimental_Inline}}
+- [`device-cmyk()`](/en-US/docs/Web/CSS/color_value/device-cmyk)
+- {{CSSXref("color_value/light-dark", "light-dark()")}}
 
 ### Data types
 
@@ -72,7 +72,7 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
 
 ### Interfaces
 
-- `CSSColorProfileRule` {{Experimental_Inline}}
+- `CSSColorProfileRule`
 
 ## Guides
 

--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -106,9 +106,9 @@ The example below shows a three-column track grid with new rows created at a min
 - {{CSSxRef("row-gap")}}
 - {{CSSxRef("column-gap")}}
 - {{CSSxRef("gap")}}
-- {{CSSxRef("masonry-auto-flow")}} {{Experimental_Inline}}
-- {{CSSxRef("align-tracks")}} {{Experimental_Inline}}
-- {{CSSxRef("justify-tracks")}} {{Experimental_Inline}}
+- {{CSSxRef("masonry-auto-flow")}}
+- {{CSSxRef("align-tracks")}}
+- {{CSSxRef("justify-tracks")}}
 
 ### Functions
 
@@ -133,7 +133,7 @@ The example below shows a three-column track grid with new rows created at a min
 - [Grid layout and accessibility](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility)
 - [Realizing common layouts using grids](/en-US/docs/Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids)
 - [Subgrid](/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
-- [Masonry layout](/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout) {{Experimental_Inline}}
+- [Masonry layout](/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout)
 
 ## Specifications
 

--- a/files/en-us/web/css/css_logical_properties_and_values/index.md
+++ b/files/en-us/web/css/css_logical_properties_and_values/index.md
@@ -41,7 +41,7 @@ The transition to logical axes is ongoing and not fully defined by the module; s
 
 ### Properties for margins
 
-- {{CSSxRef("margin")}} (`logical` {{Experimental_Inline}} keyword)
+- {{CSSxRef("margin")}} (`logical` keyword)
 - {{CSSxRef("margin-block")}}
 - {{CSSxRef("margin-block-end")}}
 - {{CSSxRef("margin-block-start")}}
@@ -51,7 +51,7 @@ The transition to logical axes is ongoing and not fully defined by the module; s
 
 ### Properties for paddings
 
-- {{CSSxRef("padding")}} (`logical` {{Experimental_Inline}} keyword)
+- {{CSSxRef("padding")}} (`logical` keyword)
 - {{CSSxRef("padding-block")}}
 - {{CSSxRef("padding-block-end")}}
 - {{CSSxRef("padding-block-start")}}
@@ -132,10 +132,10 @@ The transition to logical axes is ongoing and not fully defined by the module; s
 
 ### Deprecated properties
 
-- `offset-block-end` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-end")}})
-- `offset-block-start` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-block-start")}})
-- `offset-inline-end` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-end")}})
-- `offset-inline-start` {{Non-standard_Inline}} {{Deprecated_Inline}} (now {{CSSxRef("inset-inline-start")}})
+- `offset-block-end` (now {{CSSxRef("inset-block-end")}})
+- `offset-block-start` (now {{CSSxRef("inset-block-start")}})
+- `offset-inline-end` (now {{CSSxRef("inset-inline-end")}})
+- `offset-inline-start` (now {{CSSxRef("inset-inline-start")}})
 
 ### Unsupported properties
 

--- a/files/en-us/web/css/css_masking/index.md
+++ b/files/en-us/web/css/css_masking/index.md
@@ -13,7 +13,7 @@ The **CSS masking** module that defines masking and clipping for partially or fu
 
 ### Properties
 
-- {{cssxref("clip")}} {{deprecated_inline}}
+- {{cssxref("clip")}}
 - {{cssxref("clip-path")}}
 - {{cssxref("clip-rule")}}
 - {{cssxref("mask")}}

--- a/files/en-us/web/css/css_overflow/index.md
+++ b/files/en-us/web/css/css_overflow/index.md
@@ -37,10 +37,10 @@ A link is included in content box above to demonstrate the effects of keyboard f
 - {{CSSxRef("scrollbar-gutter")}}
 - {{CSSxRef("text-overflow")}}
 - {{CSSxRef("block-ellipsis")}}
-- {{CSSxRef("continue")}} {{experimental_inline}}
-- {{CSSxRef("line-clamp")}} {{experimental_inline}}
-- {{CSSxRef("max-lines")}} {{experimental_inline}}
-- {{CSSxRef("-webkit-line-clamp")}} {{non-standard_inline}}
+- {{CSSxRef("continue")}}
+- {{CSSxRef("line-clamp")}}
+- {{CSSxRef("max-lines")}}
+- {{CSSxRef("-webkit-line-clamp")}}
 
 ### Data types
 
@@ -50,7 +50,7 @@ A link is included in content box above to demonstrate the effects of keyboard f
 
 - [Overflowing content](/en-US/docs/Learn/CSS/Building_blocks/Overflowing_content)
   - : CSS building block: learn what overflow is and how to manage it.
-- {{Experimental_Inline}} [Creating a named scroll timeline](/en-US/docs/Web/CSS/scroll-timeline-name#creating_a_named_scroll_timeline)
+- [Creating a named scroll timeline](/en-US/docs/Web/CSS/scroll-timeline-name#creating_a_named_scroll_timeline)
   - : The CSS scroll timeline {{cssxref('scroll-timeline-name')}} and {{cssxref('scroll-timeline-axis')}} properties, along with the {{cssxref('scroll-timeline')}} shorthand, create animations tied to the scroll offset of a scroll container.
 
 ## Related concepts

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -19,7 +19,7 @@ Selectors, whether used in CSS or JavaScript, enable targeting HTML elements bas
 
 - `+` ([Next-sibling combinator](/en-US/docs/Web/CSS/Next-sibling_combinator))
 - `>` ([Child combinator](/en-US/docs/Web/CSS/Child_combinator))
-- `||` ([Column combinator](/en-US/docs/Web/CSS/Column_combinator)) {{Experimental_Inline}}
+- `||` ([Column combinator](/en-US/docs/Web/CSS/Column_combinator))
 - `~` ([Subsequent sibling combinator](/en-US/docs/Web/CSS/Subsequent-sibling_combinator))
 - " " ([Descendant combinator](/en-US/docs/Web/CSS/Descendant_combinator))
 - `|` ([Namespace separator](/en-US/docs/Web/CSS/Namespace_separator))

--- a/files/en-us/web/css/css_text/index.md
+++ b/files/en-us/web/css/css_text/index.md
@@ -29,9 +29,9 @@ The **CSS text** module defines how to perform text manipulation, like line brea
 - {{cssxref("text-justify")}}
 - {{cssxref("text-size-adjust")}}
 - {{cssxref("text-transform")}}
-- {{cssxref("text-wrap")}} {{experimental_inline}}
+- {{cssxref("text-wrap")}}
 - {{cssxref("white-space")}}
-- {{cssxref("white-space-collapse")}} {{experimental_inline}}
+- {{cssxref("white-space-collapse")}}
 - {{cssxref("word-break")}}
 - {{cssxref("word-spacing")}}
 

--- a/files/en-us/web/css/display-inside/index.md
+++ b/files/en-us/web/css/display-inside/index.md
@@ -20,7 +20,7 @@ These keywords specify the element's inner {{CSSxRef("display")}} type, which de
 
 Valid `<display-inside>` values:
 
-- `flow` {{Experimental_Inline}}
+- `flow`
 
   - : The element lays out its contents using flow layout (block-and-inline layout).
 
@@ -36,7 +36,7 @@ Valid `<display-inside>` values:
   - : The element behaves like a block element and lays out its content according to the [flexbox model](/en-US/docs/Web/CSS/CSS_flexible_box_layout).
 - `grid`
   - : The element behaves like a block element and lays out its content according to the [grid model](/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout).
-- `ruby` {{Experimental_Inline}}
+- `ruby`
   - : The element behaves like an inline element and lays out its content according to the ruby formatting model. It behaves like the corresponding HTML {{HTMLElement("ruby")}} elements.
 
 > **Note:** Browsers that support the two value syntax, on finding the inner value only, such as when `display: flex` or `display: grid` is specified, will set their outer value to `block`. This will result in expected behavior; for example if you specify an element to be `display: grid`, you would expect that the box created on the grid container would be a block level box.

--- a/files/en-us/web/css/display-internal/index.md
+++ b/files/en-us/web/css/display-internal/index.md
@@ -31,13 +31,13 @@ Valid `<display-internal>` values:
   - : These elements behave like {{HTMLElement("col")}} HTML elements.
 - `table-caption`
   - : These elements behave like {{HTMLElement("caption")}} HTML elements.
-- `ruby-base` {{Experimental_Inline}}
+- `ruby-base`
   - : These elements behave like {{HTMLElement("rb")}} HTML elements.
-- `ruby-text` {{Experimental_Inline}}
+- `ruby-text`
   - : These elements behave like {{HTMLElement("rt")}} HTML elements.
-- `ruby-base-container` {{Experimental_Inline}}
+- `ruby-base-container`
   - : These elements are generated as anonymous boxes.
-- `ruby-text-container` {{Experimental_Inline}}
+- `ruby-text-container`
   - : These elements behave like {{HTMLElement("rtc")}} HTML elements.
 
 ## Formal syntax

--- a/files/en-us/web/css/image/index.md
+++ b/files/en-us/web/css/image/index.md
@@ -103,7 +103,7 @@ image-set('cat.jpg' 1x, 'dog.jpg' 1x) /* every image in an image set must have a
 ## See also
 
 - {{CSSxRef("&lt;gradient&gt;")}}
-- {{CSSxRef("element","element()")}} {{Experimental_Inline}}
+- {{CSSxRef("element","element()")}}
 - {{CSSxRef("image/image", "image()")}}
 - {{CSSxRef("image/image-set","image-set()")}}
 - {{CSSxRef("cross-fade","cross-fade()")}}

--- a/files/en-us/web/css/system-color/index.md
+++ b/files/en-us/web/css/system-color/index.md
@@ -64,51 +64,51 @@ Note that these keywords are _case insensitive_, but are listed here with mixed 
 
 The following keywords were defined in earlier versions of the CSS Color Module. They are now deprecated for use on public web pages.
 
-- `ActiveBorder` {{deprecated_inline}}
+- `ActiveBorder`
   - : Active window border.
-- `ActiveCaption` {{deprecated_inline}}
+- `ActiveCaption`
   - : Active window caption. Should be used with `CaptionText` as foreground color.
-- `AppWorkspace` {{deprecated_inline}}
+- `AppWorkspace`
   - : Background color of multiple document interface.
-- `Background` {{deprecated_inline}}
+- `Background`
   - : Desktop background.
-- `ButtonHighlight` {{deprecated_inline}}
+- `ButtonHighlight`
   - : The color of the border facing the light source for 3-D elements that appear 3-D due to that layer of surrounding border.
-- `ButtonShadow` {{deprecated_inline}}
+- `ButtonShadow`
   - : The color of the border away from the light source for 3-D elements that appear 3-D due to that layer of surrounding border.
-- `CaptionText` {{deprecated_inline}}
+- `CaptionText`
   - : Text in caption, size box, and scrollbar arrow box. Should be used with the `ActiveCaption` background color.
-- `InactiveBorder` {{deprecated_inline}}
+- `InactiveBorder`
   - : Inactive window border.
-- `InactiveCaption` {{deprecated_inline}}
+- `InactiveCaption`
   - : Inactive window caption. Should be used with the `InactiveCaptionText` foreground color.
-- `InactiveCaptionText` {{deprecated_inline}}
+- `InactiveCaptionText`
   - : Color of text in an inactive caption. Should be used with the `InactiveCaption` background color.
-- `InfoBackground` {{deprecated_inline}}
+- `InfoBackground`
   - : Background color for tooltip controls. Should be used with the `InfoText` foreground color.
-- `InfoText` {{deprecated_inline}}
+- `InfoText`
   - : Text color for tooltip controls. Should be used with the `InfoBackground` background color.
-- `Menu` {{deprecated_inline}}
+- `Menu`
   - : Menu background. Should be used with the `MenuText` or `-moz-MenuBarText` foreground color.
-- `MenuText` {{deprecated_inline}}
+- `MenuText`
   - : Text in menus. Should be used with the `Menu` background color.
-- `Scrollbar` {{deprecated_inline}}
+- `Scrollbar`
   - : Background color of scroll bars.
-- `ThreeDDarkShadow` {{deprecated_inline}}
+- `ThreeDDarkShadow`
   - : The color of the darker (generally outer) of the two borders away from the light source for 3-D elements that appear 3-D due to two concentric layers of surrounding border.
-- `ThreeDFace` {{deprecated_inline}}
+- `ThreeDFace`
   - : The face background color for 3-D elements that appear 3-D due to two concentric layers of surrounding border. Should be used with the `ButtonText` foreground color.
-- `ThreeDHighlight` {{deprecated_inline}}
+- `ThreeDHighlight`
   - : The color of the lighter (generally outer) of the two borders facing the light source for 3-D elements that appear 3-D due to two concentric layers of surrounding border.
-- `ThreeDLightShadow` {{deprecated_inline}}
+- `ThreeDLightShadow`
   - : The color of the darker (generally inner) of the two borders facing the light source for 3-D elements that appear 3-D due to two concentric layers of surrounding border.
-- `ThreeDShadow` {{deprecated_inline}}
+- `ThreeDShadow`
   - : The color of the lighter (generally inner) of the two borders away from the light source for 3-D elements that appear 3-D due to two concentric layers of surrounding border.
-- `Window` {{deprecated_inline}}
+- `Window`
   - : Window background. Should be used with the `WindowText` foreground color.
-- `WindowFrame` {{deprecated_inline}}
+- `WindowFrame`
   - : Window frame.
-- `WindowText` {{deprecated_inline}}
+- `WindowText`
   - : Text in windows. Should be used with the `Window` background color.
 
 ## Examples

--- a/files/en-us/web/css/text-wrap/index.md
+++ b/files/en-us/web/css/text-wrap/index.md
@@ -53,7 +53,7 @@ The `text-wrap` property is specified as a single keyword chosen from the list o
   - : Text is wrapped in a way that best balances the number of characters on each line, enhancing layout quality and legibility. Because counting characters and balancing them across multiple lines is computationally expensive, this value is only supported for blocks of text spanning a limited number of lines (six or less for Chromium and ten or less for Firefox).
 - `pretty`
   - : Results in the same behavior as `wrap`, except that the user agent will use a slower algorithm that favors better layout over speed. This is intended for body copy where good typography is favored over performance (for example, when the number of [orphans](/en-US/docs/Web/CSS/orphans) should be kept to a minimum).
-- `stable` {{experimental_inline}}
+- `stable`
   - : Results in the same behavior as `wrap`, except that when the user is editing the content, the lines that come before the lines they are editing remain static rather than the whole block of text re-wrapping.
 
 ## Description

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -17,7 +17,7 @@ Transitions enable you to define the transition between two states of an element
 
 This property is a shorthand for the following CSS properties:
 
-- [`transition-behavior`](/en-US/docs/Web/CSS/transition-behavior) {{experimental_inline}}
+- [`transition-behavior`](/en-US/docs/Web/CSS/transition-behavior)
 - [`transition-delay`](/en-US/docs/Web/CSS/transition-delay)
 - [`transition-duration`](/en-US/docs/Web/CSS/transition-duration)
 - [`transition-property`](/en-US/docs/Web/CSS/transition-property)

--- a/files/en-us/web/css/url/index.md
+++ b/files/en-us/web/css/url/index.md
@@ -45,7 +45,7 @@ mask-image: image(url(mask.png), skyblue, linear-gradient(rgb(0 0 0 / 100%), tra
 content: url(star.svg) url(star.svg) url(star.svg) url(star.svg) url(star.svg);
 
 /* at-rules */
-@document url("https://www.example.com/") { /* … */ } {{Experimental_Inline}}
+@document url("https://www.example.com/") { /* … */ }
 @import url("https://www.example.com/style.css");
 @namespace url(http://www.w3.org/1999/xhtml);
 ```
@@ -79,7 +79,7 @@ The **`url()`** function can be included as a value for
     - path
       - : References the ID of an [SVG shape](/en-US/docs/Web/SVG/Tutorial/Basic_Shapes) — `circle`, `ellipse`, `line`, `path`, `polygon`, `polyline`, or `rect` — using the shape's geometry as the path.
 
-- `<url-modifier>` {{Experimental_Inline}}
+- `<url-modifier>`
   - : In the future, the `url()` function may support specifying a modifier, an identifier or a functional notation, which alters the meaning of the URL string. This is not supported and not fully defined in the specification.
 
 ### Formal syntax


### PR DESCRIPTION
- continuing https://github.com/mdn/content/pull/32756
Removing inline macros from rest of the pages.

ping @wbamberg 