### PR TITLE
FF125 Relnote - SVGAElement.text removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -44,6 +44,8 @@ This article provides information about the changes in Firefox 125 that affect d
 
 #### Removals
 
+- The [`SVGAElement.text`](/en-US/docs/Web/API/SVGAElement#svgaelement.text) property has been removed. The {{domxref("Node.textContent", "textContent")}} property (inherited from `Node`) is broadly supported and should be used instead. ([Firefox bug 1880689](https://bugzil.la/1880689)).
+
 ### WebAssembly
 
 #### Removals

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -32,7 +32,7 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.target")}} {{ReadOnlyInline}}
   - : It corresponds to the {{SVGAttr("target")}} attribute of the given element.
 - {{domxref("SVGAElement.text")}}
-  - : A string being a synonym for the {{domxref("Node.textContent")}} property.
+  - : A string that is a synonym for the {{domxref("Node.textContent")}} property.
 - {{domxref("SVGAElement.type")}}
   - : A string that reflects the `type` attribute, indicating the MIME type of the linked resource.
 


### PR DESCRIPTION
FF125 removes [`SVGAElement.text`](https://developer.mozilla.org/en-US/docs/Web/API/SVGAElement) in https://bugzilla.mozilla.org/show_bug.cgi?id=1880689 because no other browser supports it, and because it is a synonym for the widely used `textContent`. This adds a release note.

Note that I didn't add inline deprecation markup because the MDN scripts should fix that up automatically when the BCD merges.

Related docs work can be tracked in #32779