### PR TITLE
FF125Relnote: Element.ariaBrailleLabel and .ariaBrailleRoleDescription

### DIFF
--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -38,6 +38,8 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ### APIs
 
+- {{domxref("Element.ariaBrailleLabel")}} and {{domxref("Element.ariaBrailleRoleDescription")}} are now supported, respectively reflecting the global ARIA HTML attributes [`aria-braillelabel`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-braillelabel) and [`aria-brailleroledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-brailleroledescription). ([Firefox bug 1861201](https://bugzil.la/1861201)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF125 adds support for `Element.ariaBrailleLabel` and `Element.ariaBrailleRoleDescription` properties in https://bugzilla.mozilla.org/show_bug.cgi?id=1861201. This adds there release note. The docs for these were done in #32833.

Related docs work is tracked in #32776