### PR TITLE
Synchronize with BCD v5.5.16

### DIFF
--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -2,15 +2,13 @@
 title: Background Synchronization API
 slug: Web/API/Background_Synchronization_API
 page-type: web-api-overview
-status:
-  - experimental
 browser-compat:
   - api.SyncManager
   - api.ServiceWorkerGlobalScope.sync_event
 spec-urls: https://wicg.github.io/background-sync/spec/
 ---
 
-{{DefaultAPISidebar("Background Sync")}}{{Securecontext_Header}}{{SeeCompatTable}}
+{{DefaultAPISidebar("Background Sync")}}{{Securecontext_Header}}
 
 The **Background Synchronization API** enables a web app to defer tasks so that they can be run in a [service worker](/en-US/docs/Web/API/Service_Worker_API) once the user has a stable network connection.
 

--- a/files/en-us/web/api/bluetoothdevice/index.md
+++ b/files/en-us/web/api/bluetoothdevice/index.md
@@ -35,7 +35,7 @@ environment.
 
 Listen to these events using {{domxref("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
-- {{DOMxRef("BluetoothDevice/gattserverdisconnected_event", "gattserverdisconnected")}}
+- {{DOMxRef("BluetoothDevice/gattserverdisconnected_event", "gattserverdisconnected")}} {{experimental_inline}}
   - : Fired on a device when an active GATT connection is lost.
 
 ## Specifications

--- a/files/en-us/web/api/contentvisibilityautostatechangeevent/index.md
+++ b/files/en-us/web/api/contentvisibilityautostatechangeevent/index.md
@@ -2,12 +2,10 @@
 title: ContentVisibilityAutoStateChangeEvent
 slug: Web/API/ContentVisibilityAutoStateChangeEvent
 page-type: web-api-interface
-status:
-  - experimental
 browser-compat: api.ContentVisibilityAutoStateChangeEvent
 ---
 
-{{APIRef("CSS Containment")}}{{SeeCompatTable}}
+{{APIRef("CSS Containment")}}
 
 The **`ContentVisibilityAutoStateChangeEvent`** interface is the event object for the {{domxref("element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}} event, which fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_containment#skips_its_contents).
 

--- a/files/en-us/web/api/customstateset/add/index.md
+++ b/files/en-us/web/api/customstateset/add/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: add() method"
 short-title: add()
 slug: Web/API/CustomStateSet/add
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.add
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`add`** method of the {{domxref("CustomStateSet")}} interface adds value representing a custom state to the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/clear/index.md
+++ b/files/en-us/web/api/customstateset/clear/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: clear() method"
 short-title: clear()
 slug: Web/API/CustomStateSet/clear
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.clear
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`clear()`** method of the {{domxref("CustomStateSet")}} interface removes all elements from the `CustomStateSet` object.
 

--- a/files/en-us/web/api/customstateset/delete/index.md
+++ b/files/en-us/web/api/customstateset/delete/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: delete() method"
 short-title: delete()
 slug: Web/API/CustomStateSet/delete
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.delete
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`delete()`** method of the {{domxref("CustomStateSet")}} interface deletes a single value from the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/entries/index.md
+++ b/files/en-us/web/api/customstateset/entries/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: entries() method"
 short-title: entries()
 slug: Web/API/CustomStateSet/entries
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.entries
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`entries`** method of the {{domxref("CustomStateSet")}} interface returns a new [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) object, containing an array of `[value,value]` for each element in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/foreach/index.md
+++ b/files/en-us/web/api/customstateset/foreach/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: forEach() method"
 short-title: forEach()
 slug: Web/API/CustomStateSet/forEach
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.forEach
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`forEach()`** method of the {{domxref("CustomStateSet")}} interface executes a provided function for each value in the `CustomStateSet` object.
 

--- a/files/en-us/web/api/customstateset/has/index.md
+++ b/files/en-us/web/api/customstateset/has/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: has() method"
 short-title: has()
 slug: Web/API/CustomStateSet/has
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.has
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`has()`** method of the {{domxref("CustomStateSet")}} interface returns a {{jsxref("Boolean")}} asserting whether an element is present with the given value.
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -2,12 +2,10 @@
 title: CustomStateSet
 slug: Web/API/CustomStateSet
 page-type: web-api-interface
-status:
-  - experimental
 browser-compat: api.CustomStateSet
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of states for an [autonomous custom element](/en-US/docs/Web/API/Web_components/Using_custom_elements#types_of_custom_element), and allows states to be added and removed from the set.
 
@@ -15,26 +13,26 @@ The interface can be used to expose the internal states of a custom element, all
 
 ## Instance properties
 
-- {{domxref("CustomStateSet.size")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.size")}}
   - : Returns the number of values in the `CustomStateSet`.
 
 ## Instance methods
 
-- {{domxref("CustomStateSet.add()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.add()")}}
   - : Adds a value to the set.
-- {{domxref("CustomStateSet.clear()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.clear()")}}
   - : Removes all elements from the `CustomStateSet` object.
-- {{domxref("CustomStateSet.delete()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.delete()")}}
   - : Removes one value from the `CustomStateSet` object.
-- {{domxref("CustomStateSet.entries()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.entries()")}}
   - : Returns a new iterator with the values for each element in the `CustomStateSet` in insertion order.
-- {{domxref("CustomStateSet.forEach()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.forEach()")}}
   - : Executes a provided function for each value in the `CustomStateSet` object.
-- {{domxref("CustomStateSet.has()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.has()")}}
   - : Returns a {{jsxref("Boolean")}} asserting whether an element is present with the given value.
-- {{domxref("CustomStateSet.keys()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.keys()")}}
   - : An alias for {{domxref("CustomStateSet.values()")}}.
-- {{domxref("CustomStateSet.values()")}} {{Experimental_Inline}}
+- {{domxref("CustomStateSet.values()")}}
   - : Returns a new iterator object that yields the values for each element in the `CustomStateSet` object in insertion order.
 
 ## Description

--- a/files/en-us/web/api/customstateset/keys/index.md
+++ b/files/en-us/web/api/customstateset/keys/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: keys() method"
 short-title: keys()
 slug: Web/API/CustomStateSet/keys
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.keys
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`keys()`** method of the {{domxref("CustomStateSet")}} interface is an alias for {{domxref("CustomStateSet.values")}}.
 

--- a/files/en-us/web/api/customstateset/size/index.md
+++ b/files/en-us/web/api/customstateset/size/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: size property"
 short-title: size
 slug: Web/API/CustomStateSet/size
 page-type: web-api-instance-property
-status:
-  - experimental
 browser-compat: api.CustomStateSet.size
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`size`** property of the {{domxref("CustomStateSet")}} interface returns the number of values in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/values/index.md
+++ b/files/en-us/web/api/customstateset/values/index.md
@@ -3,12 +3,10 @@ title: "CustomStateSet: values() method"
 short-title: values()
 slug: Web/API/CustomStateSet/values
 page-type: web-api-instance-method
-status:
-  - experimental
 browser-compat: api.CustomStateSet.values
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`values()`** method of the {{domxref("CustomStateSet")}} interface returns a new iterator object that yields the values for each element in the `CustomStateSet` object in insertion order.
 

--- a/files/en-us/web/api/element/contentvisibilityautostatechange_event/index.md
+++ b/files/en-us/web/api/element/contentvisibilityautostatechange_event/index.md
@@ -3,12 +3,10 @@ title: "Element: contentvisibilityautostatechange event"
 short-title: contentvisibilityautostatechange
 slug: Web/API/Element/contentvisibilityautostatechange_event
 page-type: web-api-event
-status:
-  - experimental
 browser-compat: api.Element.contentvisibilityautostatechange_event
 ---
 
-{{APIRef("CSS Containment")}}{{SeeCompatTable}}
+{{APIRef("CSS Containment")}}
 
 The **`contentvisibilityautostatechange`** event fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_containment#skips_its_contents).
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -292,7 +292,7 @@ Listen to these events using `addEventListener()` or by assigning an event liste
   - : Fires on an element that is in the [_hidden until found_](/en-US/docs/Web/HTML/Global_attributes/hidden) state, when the browser is about to reveal its content because the user has found the content through the "find in page" feature or through fragment navigation.
 - {{domxref("Element/beforescriptexecute_event","beforescriptexecute")}} {{Non-standard_Inline}}
   - : Fired when a script is about to be executed.
-- {{domxref("Element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}} {{Experimental_Inline}}
+- {{domxref("Element/contentvisibilityautostatechange_event", "contentvisibilityautostatechange")}}
   - : Fires on any element with {{cssxref("content-visibility", "content-visibility: auto")}} set on it when it starts or stops being [relevant to the user](/en-US/docs/Web/CSS/CSS_containment#relevant_to_the_user) and [skipping its contents](/en-US/docs/Web/CSS/CSS_containment#skips_its_contents).
 - {{domxref("Element/scroll_event", "scroll")}}
   - : Fired when the document view or an element has been scrolled.

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -19,7 +19,7 @@ This interface has no constructor. An `ElementInternals` object is returned when
   - : Returns the {{domxref("ShadowRoot")}} object associated with this element.
 - {{domxref("ElementInternals.form")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("HTMLFormElement")}} associated with this element.
-- {{domxref("ElementInternals.states")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+- {{domxref("ElementInternals.states")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("CustomStateSet")}} associated with this element.
 - {{domxref("ElementInternals.willValidate")}} {{ReadOnlyInline}}
   - : A boolean value which returns true if the element is a submittable element that is a candidate for

--- a/files/en-us/web/api/elementinternals/states/index.md
+++ b/files/en-us/web/api/elementinternals/states/index.md
@@ -3,12 +3,10 @@ title: "ElementInternals: states property"
 short-title: states
 slug: Web/API/ElementInternals/states
 page-type: web-api-instance-property
-status:
-  - experimental
 browser-compat: api.ElementInternals.states
 ---
 
-{{APIRef("Web Components")}}{{SeeCompatTable}}
+{{APIRef("Web Components")}}
 
 The **`states`** read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("CustomStateSet")}} representing the possible states of the custom element.
 

--- a/files/en-us/web/api/fencedframeconfig/index.md
+++ b/files/en-us/web/api/fencedframeconfig/index.md
@@ -19,7 +19,7 @@ A `FencedFrameConfig` object instance has an exposed method, but it also maps to
 
 ## Instance methods
 
-- {{domxref("FencedFrameConfig.setSharedStorageContext", "setSharedStorageContext()")}}
+- {{domxref("FencedFrameConfig.setSharedStorageContext", "setSharedStorageContext()")}} {{experimental_inline}}
   - : Passes in data from the embedding document to the `<fencedframe>`'s shared storage.
 
 ## Examples

--- a/files/en-us/web/api/htmlfencedframeelement/index.md
+++ b/files/en-us/web/api/htmlfencedframeelement/index.md
@@ -17,13 +17,13 @@ The **`HTMLFencedFrameElement`** interface represents a {{htmlelement("fencedfra
 
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
-- {{domxref("HTMLFencedFrameElement.allow")}}
+- {{domxref("HTMLFencedFrameElement.allow")}} {{experimental_inline}}
   - : Gets and sets the value of the corresponding `<fencedframe>` `allow` attribute, which represents a [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) applied to the content when it is first embedded.
-- {{domxref("HTMLFencedFrameElement.config")}}
+- {{domxref("HTMLFencedFrameElement.config")}} {{experimental_inline}}
   - : a {{domxref("FencedFrameConfig")}} object, which represents the navigation of a {{htmlelement("fencedframe")}}, i.e. what content will be displayed in it. A `FencedFrameConfig` is returned from a source such as the [Protected Audience API](https://developer.chrome.com/docs/privacy-sandbox/fledge/).
-- {{domxref("HTMLFencedFrameElement.height")}}
+- {{domxref("HTMLFencedFrameElement.height")}} {{experimental_inline}}
   - : Gets and sets the value of the corresponding `<fencedframe>` `height` attribute, which specifies the height of the element.
-- {{domxref("HTMLFencedFrameElement.width")}}
+- {{domxref("HTMLFencedFrameElement.width")}} {{experimental_inline}}
   - : Gets and sets the value of the corresponding `<fencedframe>` `width` attribute, which specifies the width of the element.
 
 ## Examples

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
@@ -29,9 +29,9 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
   - : An integer specifying the number of times the remote receiver has notified this `RTCRtpSender` that some amount of encoded video data for one or more frames has been lost, using Picture Loss Indication (PLI) packets. _Only available for video streams._
 - {{domxref("RTCOutboundRtpStreamStats.qpSum", "qpSum")}}
   - : A 64-bit value containing the sum of the QP values for every frame encoded by this {{domxref("RTCRtpSender")}}. _Valid only for video streams._
-- {{domxref("RTCOutboundRtpStreamStats.qualityLimitationDurations", "qualityLimitationDurations")}}
+- {{domxref("RTCOutboundRtpStreamStats.qualityLimitationDurations", "qualityLimitationDurations")}} {{experimental_inline}}
   - : A record mapping each of the quality limitation reasons in the {{domxref("RTCRemoteInboundRtpStreamStats")}} enumeration to a floating-point value indicating the number of seconds the stream has spent with its quality limited for that reason.
-- {{domxref("RTCOutboundRtpStreamStats.qualityLimitationReason", "qualityLimitationReason")}}
+- {{domxref("RTCOutboundRtpStreamStats.qualityLimitationReason", "qualityLimitationReason")}} {{experimental_inline}}
   - : One of the string `none`, `cpu`, `bandwidth`, or `other`, explaining why the resolution and/or frame rate is being limited for this RTP stream. _Valid only for video streams_.
 - {{domxref("RTCOutboundRtpStreamStats.remoteId", "remoteId")}}
   - : A string which identifies the {{domxref("RTCRemoteInboundRtpStreamStats")}} object that provides statistics for the remote peer for this same SSRC. This ID is stable across multiple calls to `getStats()`.
@@ -45,7 +45,7 @@ The statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} re
   - : An integer indicating the number of times this sender received a Slice Loss Indication (SLI) frame from the remote peer, indicating that one or more consecutive video macroblocks have been lost or corrupted. Available only for video streams.
 - {{domxref("RTCOutboundRtpStreamStats.targetBitrate", "targetBitrate")}}
   - : A value indicating the bit rate the `RTCRtpSender`'s codec is configured to attempt to achieve in its output media.
-- {{domxref("RTCOutboundRtpStreamStats.totalEncodedBytesTarget", "totalEncodedBytesTarget")}}
+- {{domxref("RTCOutboundRtpStreamStats.totalEncodedBytesTarget", "totalEncodedBytesTarget")}} {{experimental_inline}}
   - : A cumulative sum of the _target_ frame sizes (the targeted maximum size of the frame in bytes when the codec is asked to compress it) for all of the frames encoded so far. This will likely differ from the total of the _actual_ frame sizes.
 - {{domxref("RTCOutboundRtpStreamStats.totalEncodeTime", "totalEncodeTime")}}
   - : A floating-point value indicating the total number of seconds that have been spent encoding the frames encoded so far by this {{domxref("RTCRtpSender")}}.

--- a/files/en-us/web/api/rtcpeerconnection/addstream/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addstream/index.md
@@ -9,7 +9,7 @@ status:
 browser-compat: api.RTCPeerConnection.addStream
 ---
 
-{{APIRef("WebRTC")}}{{Deprecated_Header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{non-standard_header}}
 
 The **`addStream()`** method of the {{domxref("RTCPeerConnection")}} interface adds a {{domxref("MediaStream")}} as a local source of audio or video.
 Instead of using this obsolete method, you should instead use {{domxref("RTCPeerConnection.addTrack", "addTrack()")}} once for each track you wish to send to the remote peer.

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -37,7 +37,7 @@ _Also inherits properties from its parent interface,_ {{domxref("EventTarget")}}
   - : Returns a reference to the {{domxref("PushManager")}} interface for managing push subscriptions including subscribing, getting an active subscription, and accessing push permission status.
 - {{domxref("ServiceWorkerRegistration.scope")}} {{ReadOnlyInline}}
   - : Returns a unique identifier for a service worker registration. This must be on the same origin as the document that registers the {{domxref("ServiceWorker")}}.
-- {{domxref("ServiceWorkerRegistration.sync")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+- {{domxref("ServiceWorkerRegistration.sync")}} {{ReadOnlyInline}}
   - : Returns a reference to the {{domxref("SyncManager")}} interface, which manages background synchronization processes.
 - {{domxref("ServiceWorkerRegistration.updateViaCache")}} {{ReadOnlyInline}}
   - : Returns a string indicating what is the cache strategy to use when updating the service worker scripts. It can be one of the following: `imports`, `all`, or `none`.

--- a/files/en-us/web/api/serviceworkerregistration/sync/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/sync/index.md
@@ -3,12 +3,10 @@ title: "ServiceWorkerRegistration: sync property"
 short-title: sync
 slug: Web/API/ServiceWorkerRegistration/sync
 page-type: web-api-instance-property
-status:
-  - experimental
 browser-compat: api.ServiceWorkerRegistration.sync
 ---
 
-{{APIRef("Background Sync")}}{{SeeCompatTable}}{{SecureContext_Header}} {{AvailableInWorkers}}
+{{APIRef("Background Sync")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
 The **`sync`** read-only property of the
 {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the

--- a/files/en-us/web/api/syncevent/index.md
+++ b/files/en-us/web/api/syncevent/index.md
@@ -2,12 +2,10 @@
 title: SyncEvent
 slug: Web/API/SyncEvent
 page-type: web-api-interface
-status:
-  - experimental
 browser-compat: api.SyncEvent
 ---
 
-{{APIRef("Background Sync")}}{{SeeCompatTable}}
+{{APIRef("Background Sync")}}
 
 The **`SyncEvent`** interface of the {{domxref("Background Synchronization API", "", "", "nocode")}} represents a sync action that is dispatched on the {{domxref("ServiceWorkerGlobalScope")}} of a ServiceWorker.
 
@@ -17,7 +15,7 @@ This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 
 ## Constructor
 
-- {{domxref("SyncEvent.SyncEvent", "SyncEvent()")}} {{Experimental_Inline}}
+- {{domxref("SyncEvent.SyncEvent", "SyncEvent()")}}
   - : Creates a new `SyncEvent` object.
 
 ## Instance properties

--- a/files/en-us/web/api/syncevent/syncevent/index.md
+++ b/files/en-us/web/api/syncevent/syncevent/index.md
@@ -3,12 +3,10 @@ title: "SyncEvent: SyncEvent() constructor"
 short-title: SyncEvent()
 slug: Web/API/SyncEvent/SyncEvent
 page-type: web-api-constructor
-status:
-  - experimental
 browser-compat: api.SyncEvent.SyncEvent
 ---
 
-{{APIRef("Background Sync")}}{{SeeCompatTable}}
+{{APIRef("Background Sync")}}
 
 The **`SyncEvent()`** constructor creates a new {{domxref("SyncEvent")}} object.
 

--- a/files/en-us/web/api/syncmanager/index.md
+++ b/files/en-us/web/api/syncmanager/index.md
@@ -2,12 +2,10 @@
 title: SyncManager
 slug: Web/API/SyncManager
 page-type: web-api-interface
-status:
-  - experimental
 browser-compat: api.SyncManager
 ---
 
-{{APIRef("Background Sync")}}{{SeeCompatTable}}
+{{APIRef("Background Sync")}}
 
 The **`SyncManager`** interface of the {{domxref("Background Synchronization API", "", "", "nocode")}} provides an interface for registering and listing sync registrations.
 

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.blur
 ---
 
-{{APIRef}}
+{{APIRef}}{{deprecated_header}}
 
 The **`Window.blur()`** method does nothing.
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -49,7 +49,7 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : Returns a reference to the document that the window contains.
 - {{domxref("Window.documentPictureInPicture")}} {{ReadOnlyInline}} {{experimental_inline}} {{SecureContext_Inline}}
   - : Returns a reference to the [document Picture-in-Picture](/en-US/docs/Web/API/Document_Picture-in-Picture_API) window for the current document context.
-- {{domxref("Window.fence")}} {{ReadOnlyInline}}
+- {{domxref("Window.fence")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns a {{domxref("Fence")}} object instance for the current document context. Available only to documents embedded inside a {{htmlelement("fencedframe")}}.
 - {{domxref("Window.frameElement")}} {{ReadOnlyInline}}
   - : Returns the element in which the window is embedded, or null if the window is not embedded.
@@ -169,7 +169,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Decodes a string of data which has been encoded using base-64 encoding.
 - {{domxref("Window.alert()")}}
   - : Displays an alert dialog.
-- {{domxref("Window.blur()")}}
+- {{domxref("Window.blur()")}} {{deprecated_inline}}
   - : Sets focus away from the window.
 - {{domxref("btoa", "Window.btoa()")}}
   - : Creates a base-64 encoded ASCII string from a string of binary data.
@@ -276,7 +276,7 @@ _This interface inherits methods from the {{domxref("EventTarget")}} interface._
   - : Lets a website or app gain access to a sandboxed file system for its own use.
 - {{domxref("Window.setImmediate()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Executes a function after the browser has finished other heavy tasks.
-- {{domxref("Window.setResizable()")}} {{Non-standard_Inline}}
+- {{domxref("Window.setResizable()")}} {{Non-standard_Inline}} {{deprecated_inline}}
   - : Does nothing (no-op). Kept for backward compatibility with Netscape 4.x.
 - {{domxref("Window.showModalDialog()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Displays a modal dialog.

--- a/files/en-us/web/http/headers/content-security-policy/fenced-frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/fenced-frame-src/index.md
@@ -2,10 +2,12 @@
 title: "CSP: fenced-frame-src"
 slug: Web/HTTP/Headers/Content-Security-Policy/fenced-frame-src
 page-type: http-csp-directive
+status:
+  - experimental
 browser-compat: http.headers.Content-Security-Policy.fenced-frame-src
 ---
 
-{{HTTPSidebar}}
+{{HTTPSidebar}}{{SeeCompatTable}}
 
 The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP)
 **`fenced-frame-src`** directive specifies valid sources for nested browsing contexts loaded into {{HTMLElement("fencedframe")}} elements.

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -56,7 +56,7 @@ where `<policy-directive>` consists of:
   - : Restricts the URLs which can be loaded using script interfaces.
 - {{CSP("default-src")}}
   - : Serves as a fallback for the other {{Glossary("Fetch directive", "fetch directives")}}.
-- {{CSP("fenced-frame-src")}}
+- {{CSP("fenced-frame-src")}} {{experimental_inline}}
   - : Specifies valid sources for nested browsing contexts loaded into {{HTMLElement("fencedframe")}} elements.
 - {{CSP("font-src")}}
   - : Specifies valid sources for fonts loaded using {{cssxref("@font-face")}}.

--- a/files/en-us/web/http/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/headers/sec-fetch-dest/index.md
@@ -74,7 +74,7 @@ Servers should ignore this header if it contains any other value.
   - : The destination is embedded content. This might originate from an HTML {{HTMLElement("embed")}} tag.
 - `empty`
   - : The destination is the empty string. This is used for destinations that do not have their own value. For example: {{domxref("fetch()")}}, {{domxref("navigator.sendBeacon()")}}, {{domxref("EventSource")}}, {{domxref("XMLHttpRequest")}}, {{domxref("WebSocket")}}, etc.
-- `fencedframe`
+- `fencedframe` {{experimental_inline}}
   - : The destination is a [fenced frame](/en-US/docs/Web/API/Fenced_frame_API).
 - `font`
   - : The destination is a font. This might originate from CSS {{cssxref("@font-face")}}.

--- a/files/en-us/web/http/headers/supports-loading-mode/index.md
+++ b/files/en-us/web/http/headers/supports-loading-mode/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: http.headers.Supports-Loading-Mode
 ---
 
-{{HTTPSidebar}}{{securecontext_header}}
+{{HTTPSidebar}}{{securecontext_header}}{{SeeCompatTable}}
 
 The **`Supports-Loading-Mode`** header allows a response to opt-in to being loaded in a novel, higher-risk context that it would otherwise fail to be loaded in.
 

--- a/files/en-us/web/manifest/shortcuts/index.md
+++ b/files/en-us/web/manifest/shortcuts/index.md
@@ -2,12 +2,10 @@
 title: shortcuts
 slug: Web/Manifest/shortcuts
 page-type: web-manifest-member
-status:
-  - experimental
 browser-compat: html.manifest.shortcuts
 ---
 
-{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
+{{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
Jumpstarting the bot after removing inline status badges from all CSS pages. Updated bot code has been manually run on the latest BCD code.



