### PR TITLE
Fixed docs for WebGL2RenderingContext.uniformMatrix

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
@@ -62,8 +62,7 @@ uniformMatrix4fv(location, transpose, data, srcOffset, srcLength)
   - : A {{domxref("WebGLUniformLocation")}} object containing the location of the uniform
     attribute to modify.
 - `transpose`
-  - : A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether to transpose the matrix. Must be
-    `false`.
+  - : A {{domxref("WebGL_API/Types", "GLboolean")}} specifying whether to transpose the matrix.
 - `data`
   - : A {{jsxref("Float32Array")}} of float values.
 


### PR DESCRIPTION
Resolves #31939

---

The docs for:
- [`WebGLRenderingContext.uniformMatrix`] (1.0)
- [`WebGL2RenderingContext.uniformMatrix`] (2.0)

Both mention that `transpose`:

> Must be `false`. 

---

However, when checking the spec for [WebGL 1.0] and [WebGL 2.0], or more specifically [OpenGL ES 2.0] and [OpenGL ES 3.0] which they are based on.

Then the [OpenGL ES 2.0] spec mentions:

> The matrix is specified in column-major order. `transpose` must be `FALSE`.

While the [OpenGL ES 3.0] spec mentions:

> If `transpose` is `FALSE`, the matrix is specified in column major order, otherwise in row major order.

[`WebGLRenderingContext.uniformMatrix`]: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/uniformMatrix
[`WebGL2RenderingContext.uniformMatrix`]: https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/uniformMatrix

[WebGL 1.0]: https://registry.khronos.org/webgl/specs/latest/1.0/
[WebGL 2.0]: https://registry.khronos.org/webgl/specs/latest/2.0/

[OpenGL ES 2.0]: https://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf
[OpenGL ES 3.0]: https://registry.khronos.org/OpenGL/specs/es/3.0/es_spec_3.0.pdf
