### PR TITLE
fix: normalize capitalization for GitHub and TypeScript

### DIFF
--- a/files/en-us/learn/server-side/django/deployment/index.md
+++ b/files/en-us/learn/server-side/django/deployment/index.md
@@ -437,7 +437,7 @@ To start using PythonAnywhere you will first need to create an account:
 
 ### Install library from GitHub
 
-Next we're going open a Bash prompt, set up a virtual environment, and fetch the local library source code from Github.
+Next we're going open a Bash prompt, set up a virtual environment, and fetch the local library source code from GitHub.
 We'll also configure the default database and collect static files so that they can be served by PythonAnywhere.
 
 1. First open the Console management screen by selecting **Consoles** in the top application bar.

--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -391,7 +391,7 @@ py -3 -m django --version
 Source Code Management (SCM) and versioning tools allow you to reliably store and recover versions of your source code, try out changes, and share code between your experiments and "known good code" when you need to.
 
 There are many different SCM tools, including git, Mercurial, Perforce, SVN (Subversion), CVS (Concurrent Versions System), etc., and cloud SCM hosting sources such as Bitbucket, GitHub, and GitLab.
-For this tutorial we'll hosting our code on [GitHub](https://github.com/), one of the most popular cloud based source code hosting services, and using the **git** tool to manage our source code locally and send it to Github when needed.
+For this tutorial we'll hosting our code on [GitHub](https://github.com/), one of the most popular cloud based source code hosting services, and using the **git** tool to manage our source code locally and send it to GitHub when needed.
 
 > **Note:** Using SCM tools is good software development practice!
 > Ths instructions provide a basic introduction to git and GitHub.
@@ -399,7 +399,7 @@ For this tutorial we'll hosting our code on [GitHub](https://github.com/), one o
 
 ### Key concepts
 
-Git (and Github) use repositories ("repos") as the top level "bucket" for storing code, where each repo normally contains the source code for just one application or module.
+Git (and GitHub) use repositories ("repos") as the top level "bucket" for storing code, where each repo normally contains the source code for just one application or module.
 Repositories can be public, in which case the code is visible to everyone on the internet, or private, in which case they are restricted to the owning organization or user account.
 
 All work is done on a particular "branch" of code in your repo.
@@ -529,7 +529,7 @@ This is a useful change to make, but mostly we're doing it to show you how to pu
    ```
 
 7. At this point, the remote repo has not been changed.
-   We can push the `update_gitignore` branch to the "origin" repo (Github) using the following command:
+   We can push the `update_gitignore` branch to the "origin" repo (GitHub) using the following command:
 
    ```bash
    git push origin update_gitignore
@@ -542,7 +542,7 @@ This is a useful change to make, but mostly we're doing it to show you how to pu
 
    ![Banner asking if user wants to compare and merge recent branch updates](github_compare_and_pull_banner.png)
 
-   After merging, the "main" branch on the repo on Github will contain your changes to `.gitignore`.
+   After merging, the "main" branch on the repo on GitHub will contain your changes to `.gitignore`.
 
 9. You can continue to update your local repo as files change using this add/commit/push cycle.
 

--- a/files/en-us/learn/server-side/django/skeleton_website/index.md
+++ b/files/en-us/learn/server-side/django/skeleton_website/index.md
@@ -58,7 +58,7 @@ At the end of this article, we discuss other site-wide configuration you might a
 To create the project:
 
 1. Open a command shell (or a terminal window), and make sure you are in your [virtual environment](/en-US/docs/Learn/Server-side/Django/development_environment#using_a_virtual_environment).
-2. Navigate to the folder where you want to create your local library application (later on we'll move it to the "django_local_library" that you [created as a local Github repository](/en-US/docs/Learn/Server-side/Django/development_environment#clone_the_repo_to_your_local_computer) when setting up the development environment).
+2. Navigate to the folder where you want to create your local library application (later on we'll move it to the "django_local_library" that you [created as a local GitHub repository](/en-US/docs/Learn/Server-side/Django/development_environment#clone_the_repo_to_your_local_computer) when setting up the development environment).
 3. Create the new project using the `django-admin startproject` command as shown, and then navigate into the project folder:
 
    ```bash
@@ -336,11 +336,11 @@ At this point, we know that Django is working!
 
 > **Note:** The example page demonstrates a great Django feature — automated debug logging. Whenever a page cannot be found, Django displays an error screen with useful information or any error raised by the code. In this case, we can see that the URL we've supplied doesn't match any of our URL patterns (as listed). Logging is turned off in production (which is when we put the site live on the Web), in which case a less informative but more user-friendly page will be served.
 
-## Don't forget to backup to Github
+## Don't forget to backup to GitHub
 
 We've just done some significant work, so now is a good time to backup the project using GitHub.
 
-First move the _content_ of the top level **locallibrary** folder into the **django_local_library** folder that you [created as a local Github repository](/en-US/docs/Learn/Server-side/Django/development_environment#clone_the_repo_to_your_local_computer) when setting up the development environment.
+First move the _content_ of the top level **locallibrary** folder into the **django_local_library** folder that you [created as a local GitHub repository](/en-US/docs/Learn/Server-side/Django/development_environment#clone_the_repo_to_your_local_computer) when setting up the development environment.
 This will include **manage.py**, the **locallibrary** subfolder, the **catalog** subfolder, and anything else inside the top level folder.
 
 Then add and commit the changes in the **django_local_library** folder and push them to GitHub.

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -487,7 +487,7 @@ Note that the variables are _secret_: the `.env` should not be included in your 
 The Glitch editing view also provides _terminal_ access to the web app environment, which you can use to work with the web app as though it was running on your local machine.
 
 That's all the overview you need to get started.
-Next, we will set up a Glitch account, upload the Library project from Github, and connect it to a database.
+Next, we will set up a Glitch account, upload the Library project from GitHub, and connect it to a database.
 
 ### Get a Glitch account
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_item_component/index.md
@@ -240,7 +240,7 @@ When you use a property in the template, you must also declare it in the class.
 An `@Input()` serves as a doorway for data to come into the component, and an `@Output()` acts as a doorway for data to go out of the component.
 An `@Output()` has to be of type `EventEmitter`, so that a component can raise an event when there's data ready to share with another component.
 
-> **Note:** The `!` in the class's property declaration is called a [definite assignment assertion](https://www.typescriptlang.org/docs/handbook/2/classes.html#--strictpropertyinitialization). This operator tells Typescript that the `item` field is always initialized and not `undefined`, even when TypeScript cannot tell from the constructor's definition. If this operator is not included in your code and you have strict TypeScript compilation settings, the app will fail to compile.
+> **Note:** The `!` in the class's property declaration is called a [definite assignment assertion](https://www.typescriptlang.org/docs/handbook/2/classes.html#--strictpropertyinitialization). This operator tells TypeScript that the `item` field is always initialized and not `undefined`, even when TypeScript cannot tell from the constructor's definition. If this operator is not included in your code and you have strict TypeScript compilation settings, the app will fail to compile.
 
 Use `@Input()` to specify that the value of a property can come from outside of the component.
 Use `@Output()` in conjunction with `EventEmitter` to specify that the value of a property can leave the component so that another component can receive that data.

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_todo_list_beginning/index.md
@@ -60,7 +60,7 @@ Components are a central building block of Angular applications.
 This to-do application has two components — a component as a foundation for your application, and a component for handling to-do items.
 
 Each component is made up of a TypeScript class, HTML, and CSS.
-TypeScript transpiles, or converts, into JavaScript, which means that your application ultimately ends up in plain JavaScript but you have the convenience of using Typescript's extended features and streamlined syntax.
+TypeScript transpiles, or converts, into JavaScript, which means that your application ultimately ends up in plain JavaScript but you have the convenience of using TypeScript's extended features and streamlined syntax.
 
 ### Dynamically change the UI with \*ngIf and \*ngFor
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -163,7 +163,7 @@ As we said before, TypeScript is a superset of JavaScript, so your application w
 
 Once you have TypeScript configured, you can start using it from a Svelte component by just adding a `<script lang='ts'>` at the beginning of the script section. To use it from regular JavaScript files, just change the file extension from `.js` to `.ts`. You'll also have to update any corresponding import statements to remove the `.ts` file extension from all `import` statements.
 
-> **Note:** Typescript will throw an error if you use the `.ts` file extension in an `import` statement, so you if you have a file `./foo.ts`, you must import it as "./foo".
+> **Note:** TypeScript will throw an error if you use the `.ts` file extension in an `import` statement, so you if you have a file `./foo.ts`, you must import it as "./foo".
 > See the [Module resolution for bundlers, TypeScript runtimes, and Node.js loaders](https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution-for-bundlers-typescript-runtimes-and-nodejs-loaders) section of the TypeScript manual for more information.
 
 > **Note:** Using TypeScript in component markup sections is [not supported yet](https://github.com/sveltejs/svelte/issues/4701). You'll have to use JavaScript from the markup, and TypeScript in the `<script lang='ts'>` section.

--- a/files/en-us/mdn/community/discussions/managing_and_resolving_discussions/index.md
+++ b/files/en-us/mdn/community/discussions/managing_and_resolving_discussions/index.md
@@ -12,7 +12,7 @@ The MDN community is encouraged to [initiate and engage in discussions](/en-US/d
 
 Most discussions do not need a formal resolution process. These MDN discussion guidelines are here for the discussions that need a timely resolution, are stalled, are at risk of becoming stalled, or are otherwise not moving toward a conclusion and would benefit from a formal process:
 
-1. Each discussion is held / rooted in a [discussion on Github](https://github.com/orgs/mdn/discussions). This Github discussion serves as the "source of truth" for the topic.
+1. Each discussion is held / rooted in a [discussion on GitHub](https://github.com/orgs/mdn/discussions). This GitHub discussion serves as the "source of truth" for the topic.
 
    - To maintain continuity, remember to capture summaries and notes from any meetings and async discussions in this GitHub discussion thread.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
@@ -71,6 +71,6 @@ To learn which parameters each macro supports and the order of parameters for ea
 ## See also
 
 - [Using macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros)
-- [Macros](https://github.com/mdn/yari/tree/main/kumascript/macros) on Github
+- [Macros](https://github.com/mdn/yari/tree/main/kumascript/macros) on GitHub
 - [Commonly used macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros), including BCD macros ( `\{{Compat}}`, `\{{Compat(&lt;feature>)}}`, and `\{{Compat(&lt;feature>, &lt;depth>)}}`) and specification macros (`\{{Specifications}}` / `\{{Specifications(&lt;feature>)}}`)
 - [Banners and notices guide](/en-US/docs/MDN/Writing_guidelines/Page_structures/Banners_and_notices) including the `\{{SeeCompatTable}}`, `\{{Deprecated_Header}}`, and `\{{SecureContext_Header}}` macros.

--- a/files/en-us/mdn/writing_guidelines/page_structures/sidebars/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/sidebars/index.md
@@ -107,7 +107,7 @@ Once you have determined the links to include in your sidebar, submit a pull req
 
 > **Note:** This `<section>` must be appended to the end of the document, instead of between the frontmatter and the page content. Only one sidebar is created per page, so any macro listed after the frontmatter must be removed.
 
-The [macro source code](https://github.com/mdn/yari/tree/main/kumascript/macros) is on Github. Each macro includes the documentation for itself, including parameters, if any.
+The [macro source code](https://github.com/mdn/yari/tree/main/kumascript/macros) is on GitHub. Each macro includes the documentation for itself, including parameters, if any.
 
 ## See also
 
@@ -115,4 +115,4 @@ The [macro source code](https://github.com/mdn/yari/tree/main/kumascript/macros)
 - [Content link macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Links)
 - [Page section macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros)
 - [Banners and notices macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Banners_and_notices)
-- [All macros](https://github.com/mdn/yari/tree/main/kumascript/macros) on Github
+- [All macros](https://github.com/mdn/yari/tree/main/kumascript/macros) on GitHub


### PR DESCRIPTION
### Description

Fix a couple of common typos:

* `Github` -> `GitHub`
* `Typescript` -> `TypeScript`

### Related issues and pull requests

Similar types of fixes:

- [x] https://github.com/mdn/content/pull/28190
- [x] https://github.com/mdn/content/pull/28079

