### PR TITLE
fix(oklch): prevent hue from changing when exemplifying chroma change

### DIFF
--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -182,10 +182,10 @@ div {
 }
 
 [data-color="red"] {
-  background-color: oklch(100% 0.4 30);
+  background-color: oklch(50% 0.4 30);
 }
 [data-color="red-chroma"] {
-  background-color: oklch(100% 0.3 30);
+  background-color: oklch(50% 0.3 30);
 }
 
 [data-color="green"] {

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -185,7 +185,7 @@ div {
   background-color: oklch(100% 0.4 30);
 }
 [data-color="red-chroma"] {
-  background-color: oklch(100% 0.3 40);
+  background-color: oklch(100% 0.3 30);
 }
 
 [data-color="green"] {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
the commit msg says it all

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I think that was an oversight, the old color is more pleasant, but it doesn't let readers grasp what the chroma does to the color, as it seems it's the objective of that section

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
