### PR TITLE
Remove references to IE

### DIFF
--- a/files/en-us/web/api/document/plugins/index.md
+++ b/files/en-us/web/api/document/plugins/index.md
@@ -27,7 +27,3 @@ An {{domxref("HTMLCollection")}}.
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [MSDN documentation](<https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms537477(v=vs.85)>)

--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -108,61 +108,6 @@ This starts by looking at the value of the `fullscreenElement` attribute on the 
 
 If fullscreen mode is already active (`fullscreenElement` is non-`null`), we call {{DOMxRef("document.exitFullscreen()")}}.
 
-## Prefixing
-
-For the moment not all browsers are implementing the unprefixed version of the API (for vendor agnostic access to the Fullscreen API you can use [Fscreen](https://github.com/rafgraph/fscreen)). Here is the table summarizing the prefixes and name differences between them:
-
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th scope="row">Standard</th>
-      <th scope="col">WebKit (Safari) / Blink (Chrome &#x26; Opera) / Edge</th>
-      <th scope="col">Gecko (Firefox)</th>
-      <th scope="col">Internet Explorer</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">
-        {{DOMxRef("Document.fullscreen")}} {{Deprecated_Inline}}
-      </th>
-      <td><code>webkitIsFullScreen</code></td>
-      <td><code>mozFullScreen</code></td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        {{DOMxRef("Document.fullscreenEnabled")}}
-      </th>
-      <td><code>webkitFullscreenEnabled</code></td>
-      <td><code>mozFullScreenEnabled</code></td>
-      <td><code>msFullscreenEnabled</code></td>
-    </tr>
-    <tr>
-      <th scope="row">
-        {{DOMxRef("Document.fullscreenElement")}}
-      </th>
-      <td><code>webkitFullscreenElement</code></td>
-      <td><code>mozFullScreenElement</code></td>
-      <td><code>msFullscreenElement</code></td>
-    </tr>
-    <tr>
-      <th scope="row">{{DOMxRef("Document.exitFullscreen()")}}</th>
-      <td><code>webkitExitFullscreen()</code></td>
-      <td><code>mozCancelFullScreen()</code></td>
-      <td><code>msExitFullscreen()</code></td>
-    </tr>
-    <tr>
-      <th scope="row">
-        {{DOMxRef("Element.requestFullscreen()")}}
-      </th>
-      <td><code>webkitRequestFullscreen()</code></td>
-      <td><code>mozRequestFullScreen()</code></td>
-      <td><code>msRequestFullscreen()</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/zoom/index.md
+++ b/files/en-us/web/css/zoom/index.md
@@ -149,4 +149,3 @@ Not part of any standard. Apple has [a description in the Safari CSS Reference](
 ## See also
 
 - [`zoom` entry in CSS-Tricks' CSS Almanac](https://css-tricks.com/almanac/properties/z/zoom/)
-- [Bug 390936: Implement Internet Explorer `zoom` property for CSS](https://bugzil.la/390936) on the Firefox issue tracker Bugzilla

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -27,9 +27,9 @@ For [HTML](/en-US/docs/Web/HTML) documents, browsers use a DOCTYPE in the beginn
 </html>
 ```
 
-The DOCTYPE shown in the example, `<!DOCTYPE html>`, is the simplest possible, and the one recommended by current HTML standards. Earlier versions of the HTML standard recommended other variants, but all existing browsers today will use full standards mode for this DOCTYPE, even the dated Internet Explorer 6. There are no valid reasons to use a more complicated DOCTYPE. If you do use another DOCTYPE, you may risk choosing one which triggers almost standards mode or quirks mode.
+The DOCTYPE shown in the example, `<!DOCTYPE html>`, is the simplest possible, and the one recommended by current HTML standards. Earlier versions of the HTML standard recommended other variants, but all existing browsers today will use full standards mode for this DOCTYPE. There are no valid reasons to use a more complicated DOCTYPE. If you do use another DOCTYPE, you may risk choosing one which triggers almost standards mode or quirks mode.
 
-Make sure you put the DOCTYPE right at the beginning of your HTML document. Anything before the DOCTYPE, like a comment or an XML declaration will trigger quirks mode in Internet Explorer 9 and older.
+Put the DOCTYPE right at the beginning of your HTML document, before any other content.
 
 The only purpose of `<!DOCTYPE html>` is to activate no-quirks mode. Older versions of HTML standard DOCTYPEs provided additional meaning, but no browser ever used the DOCTYPE for anything other than switching between render modes.
 
@@ -37,7 +37,7 @@ See also a detailed description of [when different browsers choose various modes
 
 ### XHTML
 
-If you serve your page as [XHTML](/en-US/docs/Glossary/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a DOCTYPE to enable standards mode, as such documents always use 'full standards mode'. Note however that serving your pages as `application/xhtml+xml` will cause Internet Explorer 8 to show a download dialog box for an unknown format instead of displaying your page, as the first version of Internet Explorer with support for XHTML is Internet Explorer 9.
+If you serve your page as [XHTML](/en-US/docs/Glossary/XHTML) using the `application/xhtml+xml` MIME type in the `Content-Type` HTTP header, you do not need a DOCTYPE to enable standards mode, as such documents always use 'full standards mode'.
 
 If you serve XHTML-like content using the `text/html` MIME type, browsers will read it as HTML, and you will need the DOCTYPE to use standards mode.
 

--- a/files/en-us/web/http/headers/x-xss-protection/index.md
+++ b/files/en-us/web/http/headers/x-xss-protection/index.md
@@ -9,7 +9,7 @@ browser-compat: http.headers.X-XSS-Protection
 
 {{HTTPSidebar}}{{Non-standard_header}}
 
-The HTTP **`X-XSS-Protection`** response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting ({{Glossary("Cross-site_scripting", "XSS")}}) attacks. These protections are largely unnecessary in modern browsers when sites implement a strong {{HTTPHeader("Content-Security-Policy")}} that disables the use of inline JavaScript (`'unsafe-inline'`).
+The HTTP **`X-XSS-Protection`** response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when they detected reflected cross-site scripting ({{Glossary("Cross-site_scripting", "XSS")}}) attacks. These protections are largely unnecessary in modern browsers when sites implement a strong {{HTTPHeader("Content-Security-Policy")}} that disables the use of inline JavaScript (`'unsafe-inline'`).
 
 > **Warning:** Even though this feature can protect users of older web browsers that don't yet support {{Glossary("CSP")}}, in some cases, **XSS protection can create XSS vulnerabilities** in otherwise safe websites. See the section below for more information.
 

--- a/files/en-us/web/media/audio_and_video_delivery/cross-browser_audio_basics/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/cross-browser_audio_basics/index.md
@@ -558,50 +558,6 @@ There are also a couple of events related to buffering:
 
 > **Note:** You can read more on [Buffering, Seeking and Time Ranges](/en-US/docs/Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges) elsewhere.
 
-## Browser support
-
-The following tables list basic audio support across desktop and mobile browsers, and what audio codecs are supported.
-
-### Desktop
-
-| Desktop Browser   | Version |
-| ----------------- | ------- |
-| Chrome            | 4+      |
-| Firefox           | 3.5+    |
-| Internet Explorer | 9+      |
-| Opera             | 10.5+   |
-| Safari            | 4+      |
-
-### Mobile
-
-| Mobile Browser    | Version |
-| ----------------- | ------- |
-| Chrome (Android)  | 32+     |
-| Firefox (Android) | 26+     |
-| IE Mobile         | 10+     |
-| Opera Mobile      | 11+     |
-| Safari (iOS)      | 4+      |
-| Android Browser   | 2.3+    |
-| Blackberry        | 7+      |
-
-## Audio Codec Support
-
-| Browser                  | Ogg | MP3     | AAC | PCM      | Opus    |
-| ------------------------ | --- | ------- | --- | -------- | ------- |
-| Firefox 3.5+             | ✓   | ✓ \*26+ |     | ✓        | ✓ \*14+ |
-| Safari 5+                |     | ✓       | ✓   |          |         |
-| Chrome 6+                | ✓   | ✓       | ✓   | ✓ \*9+   |         |
-| Opera 10.5+              | ✓   |         |     |          |         |
-| Internet Explorer 9+     |     | ✓       | ✓   |          |         |
-| Firefox Mobile           | ✓   | ✓       | ✓   | ✓        | ✓       |
-| Safari iOS3+             |     | ✓       | ✓   | ✓ \*4.2+ |         |
-| Chrome Mobile            | ✓   | ✓       | ✓   | ✓        |         |
-| Opera Mobile             | ✓   | ✓       | ✓   | ✓        |         |
-| Internet Explorer Mobile | ✓   | ✓       | ✓   | ✓        |         |
-| Android 2.3+             | ✓   | ✓       | ✓   | ✓        |         |
-
-> **Note:** Nearly all browsers support MP3 — for more details see this page on [media format browser compatibility](/en-US/docs/Web/Media/Formats#browser_compatibility).
-
 ## See also
 
 - [Buffering, Seeking and Time Ranges](/en-US/docs/Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges)

--- a/files/en-us/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -94,28 +94,9 @@ HLS can also be decoded using JavaScript, which means we can support the latest 
 
 At the start of the streaming session, an [extended M3U (m3u8) playlist](https://en.wikipedia.org/wiki/M3U8#Extended_M3U_directives) is downloaded. This contains the metadata for the various sub-streams that are provided.
 
-### Streaming File Format Support
-
-| Browser               | DASH  | HLS   | Opus (Audio) |
-| --------------------- | ----- | ----- | ------------ |
-| Firefox 32            | ✓ [1] | ✓ [2] | ✓ 14+        |
-| Safari 6+             |       | ✓     |              |
-| Chrome 24+            | ✓ [1] | ✓     |              |
-| Opera 20+             | ✓ [1] |       |              |
-| Internet Explorer 10+ | ✓ 11  | ✓ [2] |              |
-| Firefox Mobile        | ✓     | ✓     | ✓            |
-| Safari iOS6+          |       | ✓     |              |
-| Chrome Mobile         | ✓     | ✓ [2] |              |
-| Opera Mobile          | ✓ [1] | ✓     |              |
-| Android               | ✓     |       |              |
-
-\[1] Via JavaScript and MSE
-
-\[2] Via JavaScript and a CORS Proxy
-
 ## Audio Streaming File Formats
 
-There are also some audio formats beginning to see support across browsers.
+There are also several audio formats:
 
 ### Opus
 

--- a/files/en-us/web/media/formats/audio_codecs/index.md
+++ b/files/en-us/web/media/formats/audio_codecs/index.md
@@ -401,28 +401,6 @@ As a patent-encumbered format, AAC support is somewhat less predictable. For exa
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <tbody>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-            <tr>
-              <th scope="row">AAC support</th>
-              <td>Yes</td>
-              <td>Yes</td>
-              <td>Yes</td>
-              <td>9</td>
-              <td>Yes</td>
-              <td>3.1</td>
-            </tr>
-          </tbody>
-        </table>
         <p>
           Due to patent issues, Firefox does not directly support AAC. Instead,
           Firefox relies upon a platform's native support for AAC. This
@@ -453,39 +431,6 @@ As a patent-encumbered format, AAC support is somewhat less predictable. For exa
         developers of codecs are required to obtain a patent license through
         <a href="https://www.via-corp.com/licensing/aac/">VIA Licensing</a>
       </td>
-    </tr>
-  </tbody>
-</table>
-
-<table class="standard-table" style="margin-left: 4em; max-width: 30em">
-  <caption>
-    AAC support in Firefox using external library, by platform
-  </caption>
-  <thead>
-    <tr>
-      <th scope="row">Platform</th>
-      <th scope="col">First Firefox version<br />with AAC support</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">Windows (Vista and later)</th>
-      <td>22</td>
-    </tr>
-    <tr>
-      <th scope="row">Android</th>
-      <td>20</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Linux (depends on
-        <a href="https://gstreamer.freedesktop.org/">GStreamer</a>)
-      </th>
-      <td>26</td>
-    </tr>
-    <tr>
-      <th scope="row">macOS</th>
-      <td>35</td>
     </tr>
   </tbody>
 </table>
@@ -549,13 +494,11 @@ Keep in mind, however, that lossless codecs require substantially more bandwidth
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
             <tr>
               <th scope="row">ALAC support</th>
-              <td>No</td>
               <td>No</td>
               <td>No</td>
               <td>No</td>
@@ -651,7 +594,6 @@ As a speech-specific codec, AMR is essentially useless for any other content, in
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -660,7 +602,6 @@ As a speech-specific codec, AMR is essentially useless for any other content, in
               <td>No</td>
               <td>?</td>
               <td>No</td>
-              <td>?</td>
               <td>No</td>
               <td>?</td>
             </tr>
@@ -753,7 +694,6 @@ FLAC is a great choice for smaller audio effects files where pristine quality an
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -762,8 +702,7 @@ FLAC is a great choice for smaller audio effects files where pristine quality an
               <td>Yes</td>
               <td>Yes</td>
               <td>51 (desktop)<br />58 (mobile)</td>
-              <td>No</td>
-              <td>No</td>
+              <td>Yes</td>
               <td>11</td>
             </tr>
           </tbody>
@@ -846,7 +785,6 @@ This codec is required to be supported by all [WebRTC](/en-US/docs/Web/API/WebRT
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -855,7 +793,6 @@ This codec is required to be supported by all [WebRTC](/en-US/docs/Web/API/WebRT
               <td>23</td>
               <td>15</td>
               <td>22</td>
-              <td>No</td>
               <td>43</td>
               <td>11</td>
             </tr>
@@ -949,7 +886,6 @@ G.722 is primarily used with WebRTC connections, as it's one of the audio codecs
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -958,7 +894,6 @@ G.722 is primarily used with WebRTC connections, as it's one of the audio codecs
               <td>Yes</td>
               <td>Yes</td>
               <td>Yes</td>
-              <td>No</td>
               <td>Yes</td>
               <td>Yes</td>
             </tr>
@@ -1069,7 +1004,6 @@ The patents behind MP3 have expired, removing many or most licensing concerns ar
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -1078,7 +1012,6 @@ The patents behind MP3 have expired, removing many or most licensing concerns ar
               <td>Yes</td>
               <td>Yes</td>
               <td>Yes</td>
-              <td>9</td>
               <td>Yes</td>
               <td>3.1</td>
             </tr>
@@ -1274,7 +1207,6 @@ Opus is a good all-around audio codec for use in your web applications, and can 
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -1283,7 +1215,6 @@ Opus is a good all-around audio codec for use in your web applications, and can 
               <td>33</td>
               <td>14</td>
               <td>15</td>
-              <td>No</td>
               <td>20</td>
               <td>11</td>
             </tr>
@@ -1376,7 +1307,6 @@ Generally, Vorbis is more efficient in terms of size and bit rate than MP3 at si
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -1385,7 +1315,6 @@ Generally, Vorbis is more efficient in terms of size and bit rate than MP3 at si
               <td>4</td>
               <td>17</td>
               <td>3.5</td>
-              <td>No</td>
               <td>11.5</td>
               <td>No</td>
             </tr>

--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -57,7 +57,7 @@ To learn more about a specific container format, find it in this list and click 
     <tr>
       <th scope="row"><a href="#flac">FLAC</a></th>
       <td>Free Lossless Audio Codec</td>
-      <td>All browsers</td>
+      <td>All browsers.</td>
     </tr>
     <tr>
       <th scope="row"><a href="#mpegmpeg-2">MPEG / MPEG-2</a></th>
@@ -67,14 +67,12 @@ To learn more about a specific container format, find it in this list and click 
     <tr>
       <th scope="row"><a href="#mpeg-4_mp4">MPEG-4 (MP4)</a></th>
       <td>Moving Picture Experts Group 4</td>
-      <td>All browsers</td>
+      <td>All browsers.</td>
     </tr>
     <tr>
       <th scope="row"><a href="#ogg">Ogg</a></th>
       <td>Ogg</td>
-      <td>
-        All browsers
-      </td>
+      <td>All browsers.</td>
     </tr>
     <tr>
       <th scope="row"><a href="#quicktime">QuickTime (MOV)</a></th>
@@ -84,9 +82,7 @@ To learn more about a specific container format, find it in this list and click 
     <tr>
       <th scope="row"><a href="#webm">WebM</a></th>
       <td>Web Media</td>
-      <td>
-        <p>All browsers
-      </td>
+      <td>All browsers.</td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -57,7 +57,7 @@ To learn more about a specific container format, find it in this list and click 
     <tr>
       <th scope="row"><a href="#flac">FLAC</a></th>
       <td>Free Lossless Audio Codec</td>
-      <td>Chrome 56, Edge 16, Firefox 51, Safari 11</td>
+      <td>All browsers</td>
     </tr>
     <tr>
       <th scope="row"><a href="#mpegmpeg-2">MPEG / MPEG-2</a></th>
@@ -67,14 +67,13 @@ To learn more about a specific container format, find it in this list and click 
     <tr>
       <th scope="row"><a href="#mpeg-4_mp4">MPEG-4 (MP4)</a></th>
       <td>Moving Picture Experts Group 4</td>
-      <td>Chrome 3, Edge 12, Firefox, Internet Explorer 9, Opera 24, Safari 3.1</td>
+      <td>All browsers</td>
     </tr>
     <tr>
       <th scope="row"><a href="#ogg">Ogg</a></th>
       <td>Ogg</td>
       <td>
-        <p>Chrome 3, Firefox 3.5, Edge 17 (desktop only), Internet Explorer 9, Opera 10.50</p>
-        <p>Edge requires <a href="https://www.microsoft.com/store/productId/9N5TDP8VCMHS">Web Media Extensions</a> to be installed.</p>
+        All browsers
       </td>
     </tr>
     <tr>
@@ -86,8 +85,7 @@ To learn more about a specific container format, find it in this list and click 
       <th scope="row"><a href="#webm">WebM</a></th>
       <td>Web Media</td>
       <td>
-        <p>Chrome 6, Edge 17 (desktop only), Firefox 4, Opera 10.6, Safari 14.1 (macOS), Safari 15 (iOS).</p>
-        <p>Edge requires <a href="https://www.microsoft.com/store/productId/9N5TDP8VCMHS">Web Media Extensions</a> to be installed.</p>
+        <p>All browsers
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -866,7 +866,7 @@ PNG is widely supported, with all major browsers offering full support for its f
       </td>
     </tr>
     <tr>
-      <th scope="row">Maximum dimensions</t h>
+      <th scope="row">Maximum dimensions</th>
       <td>2,147,483,647×2,147,483,647 pixels</td>
     </tr>
     <tr>

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -334,10 +334,6 @@ As support is not yet comprehensive (and has little historical depth) you should
             can be used to adjust the compliance strictness with the specification.
             Animated images are not supported.
           </li>
-          <li>
-            Firefox 77 to 92 require the preference
-            <code>image.avif.enable</code> set <code>true</code>. Earlier versions provide only basic support.
-          </li>
         </ul>
       </td>
     </tr>
@@ -415,7 +411,7 @@ Theoretically, several compression algorithms are supported, and the image data 
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        All versions of Chrome, Edge, Firefox, Internet Explorer, Opera, and Safari
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
       </td>
     </tr>
     <tr>
@@ -533,7 +529,7 @@ Typically, modern content should use [PNG](#png_portable_network_graphics) for l
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        All versions of Chrome, Edge, Firefox, Internet Explorer, Opera, and Safari
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
       </td>
     </tr>
     <tr>
@@ -630,7 +626,7 @@ If you use ICO files, you should use the BMP format, as support for PNG inside I
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        All versions of Chrome, Edge, Firefox, Internet Explorer, Opera, and Safari
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
       </td>
     </tr>
     <tr>
@@ -780,7 +776,7 @@ The JFIF (**J**PEG **F**ile **I**nterchange **F**ormat) specification describes 
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        All versions of Chrome, Edge, Firefox, Internet Explorer, Opera, and Safari
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
       </td>
     </tr>
     <tr>
@@ -848,8 +844,6 @@ The JFIF (**J**PEG **F**ile **I**nterchange **F**ormat) specification describes 
 The {{Glossary("PNG")}} (pronounced "**ping**") image format uses lossless compression, while supporting higher color depths than [GIF](#gif_graphics_interchange_format) and being more efficient, as well as featuring full alpha transparency support.
 
 PNG is widely supported, with all major browsers offering full support for its features.
-Internet Explorer, which introduced PNG support in versions 4–5, did not fully support it until IE 9, and had many infamous bugs for many of the intervening years, including in the once-omnipresent Internet Explorer 6.
-This slowed PNG adoption, but it is now commonly used, especially when precise reproduction of the source image is needed.
 
 <table class="standard-table">
   <tbody>
@@ -868,70 +862,11 @@ This slowed PNG adoption, but it is now commonly used, especially when precise r
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <thead>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Basic support</th>
-              <td>1</td>
-              <td>12</td>
-              <td>1</td>
-              <td>5</td>
-              <td>3.5.1 (Presto)<br />15 (Blink)</td>
-              <td>1</td>
-            </tr>
-            <tr>
-              <th scope="row">Alpha channel</th>
-              <td>1</td>
-              <td>12</td>
-              <td>1</td>
-              <td>5</td>
-              <td>6 (Presto)<br />All (Blink)</td>
-              <td>1</td>
-            </tr>
-            <tr>
-              <th scope="row">Gamma correction</th>
-              <td>no</td>
-              <td>yes</td>
-              <td>1</td>
-              <td>8</td>
-              <td>1</td>
-              <td>broken</td>
-            </tr>
-            <tr>
-              <th scope="row">Color correction</th>
-              <td>no</td>
-              <td>yes</td>
-              <td>3</td>
-              <td>9</td>
-              <td>no</td>
-              <td>no</td>
-            </tr>
-            <tr>
-              <th scope="row">Interlacing</th>
-              <td>no</td>
-              <td>?</td>
-              <td>1</td>
-              <td>broken</td>
-              <td>3.5.1</td>
-              <td>no</td>
-            </tr>
-          </tbody>
-        </table>
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
       </td>
     </tr>
     <tr>
-      <th scope="row">Maximum dimensions</th>
+      <th scope="row">Maximum dimensions</t h>
       <td>2,147,483,647×2,147,483,647 pixels</td>
     </tr>
     <tr>
@@ -1047,41 +982,7 @@ It's not generally useful for strictly bitmap or photographic images, although i
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <thead>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">SVG support</th>
-              <td>4</td>
-              <td>12</td>
-              <td>3</td>
-              <td>9</td>
-              <td>10 (Presto)<br />15 (Blink)</td>
-              <td>3.2</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                SVG as image ({{HTMLElement("img")}}, etc.)
-              </th>
-              <td>28</td>
-              <td>12</td>
-              <td>4</td>
-              <td>9</td>
-              <td>10 (Presto)<br />15 (Blink)</td>
-              <td>9</td>
-            </tr>
-          </tbody>
-        </table>
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
       </td>
     </tr>
     <tr>
@@ -1298,47 +1199,8 @@ Provide a fallback in either [JPEG](#jpeg_joint_photographic_experts_group_image
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <tbody>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-            <tr>
-              <th scope="row">Lossy WebP support</th>
-              <td>17</td>
-              <td>18</td>
-              <td>65</td>
-              <td>no</td>
-              <td>11.10 (Presto)<br />15 (Blink)</td>
-              <td>14</td>
-            </tr>
-            <tr>
-              <th scope="row">Lossless WebP</th>
-              <td>23<br />25 on Android</td>
-              <td>18</td>
-              <td>65</td>
-              <td>no</td>
-              <td>12.10 (Presto)<br />15 (Blink)</td>
-              <td>14</td>
-            </tr>
-            <tr>
-              <th scope="row">Animation</th>
-              <td>32</td>
-              <td>18</td>
-              <td>65</td>
-              <td>no</td>
-              <td>19 (Blink)</td>
-              <td>14</td>
-            </tr>
-          </tbody>
-        </table>
-        <p>WebP can also be used for <em>exporting</em> images from a Canvas from Firefox 96 and Chrome 50 (see <a href="/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility"><code>HTMLCanvasElement.toBlob()</code></a> for more detailed support version information).</p>
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
+        <p>WebP can also be used for <em>exporting</em> images from a Canvas. See <a href="/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility"><code>HTMLCanvasElement.toBlob()</code></a> for more detailed support version information.</p>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -580,7 +580,6 @@ For the time being, because of these factors, AV1 is not yet ready to be your fi
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
               <th scope="col">Firefox Android</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -590,9 +589,8 @@ For the time being, because of these factors, AV1 is not yet ready to be your fi
               <td>75</td>
               <td>67</td>
               <td>113</td>
-              <td>No</td>
               <td>57</td>
-              <td>No</td>
+              <td>17</td>
             </tr>
           </tbody>
         </table>
@@ -745,28 +743,7 @@ In HTML content for web browsers, AVC is broadly compatible and many platforms s
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <tbody>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-            <tr>
-              <th scope="row">AVC/H.264 support</th>
-              <td>4</td>
-              <td>12</td>
-              <td>35</td>
-              <td>9</td>
-              <td>25</td>
-              <td>3.2</td>
-            </tr>
-          </tbody>
-        </table>
+        All versions of Chrome, Edge, Firefox, Opera, and Safari
         <p>
           Firefox support for AVC is dependent upon the operating system's
           built-in or preinstalled codecs for AVC and its container in order to
@@ -885,13 +862,11 @@ H.263 is a proprietary format, with [patents](https://www.itu.int/ITU-T/recommen
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
             <tr>
               <th scope="row">H.263 support</th>
-              <td>No</td>
               <td>No</td>
               <td>No</td>
               <td>No</td>
@@ -1057,7 +1032,6 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -1066,7 +1040,6 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
               <td>107</td>
               <td>18</td>
               <td>No</td>
-              <td>11</td>
               <td>94</td>
               <td>11</td>
             </tr>
@@ -1185,7 +1158,6 @@ You almost certainly don't want to use this format, since it isn't supported in 
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -1194,7 +1166,6 @@ You almost certainly don't want to use this format, since it isn't supported in 
               <td>No</td>
               <td>No</td>
               <td>Yes</td>
-              <td>No</td>
               <td>No</td>
               <td>No</td>
             </tr>
@@ -1303,13 +1274,11 @@ Because any MPEG-2 decoder can also play MPEG-1 video, it's compatible with a wi
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
             <tr>
               <th scope="row">MPEG-1 support</th>
-              <td>No</td>
               <td>No</td>
               <td>No</td>
               <td>No</td>
@@ -1473,13 +1442,11 @@ However, few web browsers support MPEG-2 without the support of a plugin, and wi
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
             <tr>
               <th scope="row">MPEG-2 support</th>
-              <td>No</td>
               <td>No</td>
               <td>No</td>
               <td>No</td>
@@ -1610,7 +1577,6 @@ The [Theora Cookbook](https://en.flossmanuals.net/ogg-theora/_full/) offers addi
               <th scope="col">Chrome</th>
               <th scope="col">Edge</th>
               <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
               <th scope="col">Opera</th>
               <th scope="col">Safari</th>
             </tr>
@@ -1619,7 +1585,6 @@ The [Theora Cookbook](https://en.flossmanuals.net/ogg-theora/_full/) offers addi
               <td>3</td>
               <td>Yes</td>
               <td>3.5</td>
-              <td>No</td>
               <td>10.5</td>
               <td>No</td>
             </tr>
@@ -1711,40 +1676,8 @@ Web browsers are _required_ to support VP8 for WebRTC, but not all browsers that
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <tbody>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-            <tr>
-              <th scope="row">VP8 support</th>
-              <td>25</td>
-              <td>14</td>
-              <td>4</td>
-              <td>9</td>
-              <td>16</td>
-              <td>12.1</td>
-            </tr>
-            <tr>
-              <th scope="row">MSE compatibility</th>
-              <td></td>
-              <td></td>
-              <td>Yes</td>
-              <td></td>
-              <td></td>
-              <td></td>
-            </tr>
-          </tbody>
-        </table>
-        <p>Edge support for VP8 requires the use of <a href="/en-US/docs/Web/API/Media_Source_Extensions_API">Media Source Extensions</a>.</p>
-        <p>macOS: Safari 14.1 supports VP8 in WebRTC, MSE and video elements. Safari 12.2 only supports VP8 in WebRTC connections.</p>
-        <p>iOS: Safari 12.1 and later support VP8 in WebRTC connections only.</p>
+        <p>All versions of Chrome, Edge, Firefox, Opera, and Safari<p>
+        <p><a href="https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/">iOS: Safari 12.1</a> and later support VP8 in WebRTC connections only.</p>
         <p>Firefox only supports VP8 in MSE when no H.264 hardware decoder is available. Use {{domxref("MediaSource.isTypeSupported_static", "MediaSource.isTypeSupported()")}} to check for availability.</p>
       </td>
     </tr>
@@ -1877,46 +1810,11 @@ This is especially true if you wish to use an open codec rather than a proprieta
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        <table class="standard-table">
-          <tbody>
-            <tr>
-              <th scope="row">Feature</th>
-              <th scope="col">Chrome</th>
-              <th scope="col">Edge</th>
-              <th scope="col">Firefox</th>
-              <th scope="col">Internet Explorer</th>
-              <th scope="col">Opera</th>
-              <th scope="col">Safari</th>
-            </tr>
-            <tr>
-              <th scope="row">VP9 support</th>
-              <td>29</td>
-              <td>14</td>
-              <td>28</td>
-              <td>No</td>
-              <td>10.6</td>
-              <td>14 (macOS), 15 (iOS)</td>
-            </tr>
-            <tr>
-              <th scope="row">MSE compatibility</th>
-              <td></td>
-              <td></td>
-              <td>Yes</td>
-              <td></td>
-              <td></td>
-              <td>14 (macOS 11.3+), 15 (iOS)</td>
-            </tr>
-          </tbody>
-        </table>
+        <p>All versions of Chrome, Edge, Firefox, Opera, and Safari<p>
         <p>
           Firefox only supports VP8 in MSE when no H.264 hardware decoder is available. Use
           {{domxref("MediaSource.isTypeSupported_static", "MediaSource.isTypeSupported()")}} to check for availability.
         </p>
-        <ul>
-          <li>Safari 14: (macOS, iOS) supports VP9 in WebM for WebRTC.</li>
-          <li>Safari 14: (macOS) Supports VP9 in <a href="/en-US/docs/Web/API/Media_Source_Extensions_API">MSE</a> from MacOS 11.3.</li>
-          <li>Safari 14.1: (macOS) supports WebM files containing VP9 video tracks "everywhere".</li>
-          <li>Safari 15: (macOS) supports VP9 in WebM in <a href="/en-US/docs/Web/API/Media_Source_Extensions_API">MSE</a>.</li>
         </ul>
       </td>
     </tr>

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -1051,7 +1051,6 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
           is installed, and has the same support status as Chrome on other platforms. Edge (Legacy) only supports HEVC for devices with a hardware decoder.
         </p>
         <p>Mozilla will not support HEVC while it is encumbered by patents.</p>
-        <p>Internet Explorer only supports HEVC for devices with a hardware decoder.</p>
         <p>Opera and other Chromium based browsers have the same support status as Chrome.</p>
         <p>Safari supports HEVC for all devices on macOS High Sierra or later.</p>
       </td>
@@ -1965,5 +1964,4 @@ The documentation for your codec choices will probably offer information you'll 
 - {{RFC(4381)}}: MIME Type Registrations for 3GPP2 Multimedia Files
 - {{RFC(4337)}}: MIME Type Registrations for MPEG-4
 - [Video codecs in Opera](https://dev.opera.com/articles/introduction-html5-video/#codecs--the-fly-in-the-ointment)
-- [Video](/en-US/docs/Web/API/HTMLVideoElement) and [audio](/en-US/docs/Web/HTML/Element/audio) codecs in Internet Explorer
 - [Video and audio codecs in Chrome](https://www.chromium.org/audio-video/)


### PR DESCRIPTION
Remove references to internet explorer.

I updated some Codecs. If all modern browsers support a feature for over a year, changed to "all browsers."

This is NOT an in-depth edit to existing pages. Please create an issue for page edits or removals (I will be doing that for two pages that needed further editing)