### PR TITLE
PHP Ob_end_flush - add if statement

### DIFF
--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -93,7 +93,9 @@ while (true) {
     $counter = rand(1, 10);
   }
 
-  if (ob_get_contents()) ob_end_flush();
+  if (ob_get_contents()) {
+      ob_end_flush();
+  }
   flush();
 
   // Break the loop if the client aborted the connection (closed the page)

--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -92,7 +92,7 @@ while (true) {
     $counter = rand(1, 10);
   }
 
-  ob_end_flush();
+  if (ob_get_contents()) ob_end_flush();
   flush();
 
   // Break the loop if the client aborted the connection (closed the page)

--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -71,8 +71,9 @@ The {{Glossary("PHP")}} code for the example we're using here follows:
 
 ```php
 date_default_timezone_set("America/New_York");
-header("Cache-Control: no-store");
+header("X-Accel-Buffering: no");
 header("Content-Type: text/event-stream");
+header("Cache-Control: no-cache");
 
 $counter = rand(1, 10);
 while (true) {


### PR DESCRIPTION
Added check before calling ob_end_flush() to prevent errors

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Continous error using example when calling *ob_end_flush()*, this will check if there is any content to be flushed before calling it.

### Motivation

Making sure the example works "out of the box"!

### Additional details

[PHP Ob_end_flush page](https://www.php.net/manual/en/function.ob-end-flush.php)

### Related issues and pull requests

Issue i found when trying the example
