### PR TITLE
CSS color: tweaks

### DIFF
--- a/files/en-us/web/css/@media/color-gamut/index.md
+++ b/files/en-us/web/css/@media/color-gamut/index.md
@@ -11,10 +11,10 @@ The **`color-gamut`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web
 
 ## Syntax
 
-The `color-gamut` feature is specified as one of the following keyword values:
+The `color-gamut` feature is specified as one of the following {{glossary("color space", "color spaces")}} as keyword values:
 
 - `srgb`
-  - : The user agent and the output device can support approximately the [sRGB](https://en.wikipedia.org/wiki/SRGB) gamut or more. This includes the vast majority of color displays.
+  - : The user agent and the output device can support approximately the [sRGB](/en-US/docs/Glossary/Color_space#srgb_color_spaces) gamut or more. This includes the vast majority of color displays.
 - `p3`
   - : The user agent and the output device can support approximately the gamut specified by the [Display P3](https://www.color.org/chardata/rgb/DisplayP3.xalter) color space or more. The P3 gamut is larger than and includes the sRGB gamut.
 - `rec2020`
@@ -57,6 +57,9 @@ p {
 
 ## See also
 
-- [color()](/en-US/docs/Web/CSS/color_value/color) function to specify colors in a defined colorspace.
-- [@media](/en-US/docs/Web/CSS/@media) at-rule that is used to specify the color-gamut expression.
+- [`color()`](/en-US/docs/Web/CSS/color_value/color) function to specify colors in a defined colorspace.
+- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
+- [`@media`](/en-US/docs/Web/CSS/@media) at-rule that is used to specify the color-gamut expression.
 - [Using media queries](/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) to understand when and how to use a media query.
+- [CSS media queries](/en-US/docs/Web/CSS/CSS_media_queries) module
+- [sRGB](https://en.wikipedia.org/wiki/SRGB) on Wikipedia

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -14,7 +14,7 @@ The **`hsl()`** functional notation expresses a color in the {{glossary("RGB", "
 
 {{EmbedInteractiveExample("pages/css/function-hsl.html")}}
 
-Defining _complementary colors_ with `hsl()` can be done with a single formula, as they are positioned on the same diameter of the {{glossary("color wheel")}}. If `θ` is the hue angle of a color, its complementary one will have `180deg - θ` as its hue angle.
+Defining _complementary colors_ with `hsl()` can be done by adding or subtracting 180 degrees from the hue value, as they are positioned on the same diameter of the {{glossary("color wheel")}}. For example, if the hue angle of a color is `1θdeg`, its complementary has `190deg` as its hue angle.
 
 ## Syntax
 
@@ -33,7 +33,7 @@ hsl(from rgb(200 0 0) calc(h + 30) s calc(l + 30))
 
 The `hsla()` function can also be used to express sRGB colors. This is an alias for `hsl()` that accepts the same parameters.
 
-> **Note:** `hsl()`/`hsla()` can also be written in a legacy form in which all values are separated with commas, for example `hsl(120deg, 75%, 25%)`. The `none` value is not permitted in the comma-separated legacy syntax, and the `%` units are required.
+> **Note:** `hsl()`/`hsla()` can also be written in a legacy form in which all values are separated with commas, for example `hsl(120, 75%, 25%)` or `hsla(120deg, 75%, 25%, 0.8)`. The `none` value is not permitted in the comma-separated legacy syntax, the `deg` on the hue value is optional, and the `%` units are required for the saturation and lightness values.
 
 ### Values
 
@@ -294,15 +294,18 @@ div.comma-separated {
 
 {{EmbedLiveSample("legacy_syntax_comma-separated_values", "100%", 150)}}
 
-### Legacy syntax: hsla()
+### Legacy versus modern syntax
 
-The `hsla()` syntax is an alias for `hsl()`.
+The example demonstrates how `hsla()` syntax is an alias for `hsl()`; both are supported using both modern and legacy syntaxes.
 
 #### HTML
 
 ```html
-<div class="hsl"></div>
-<div class="hsla"></div>
+<div class="modern">HSL</div>
+<div class="legacy">HSL</div>
+<div class="modernWithAlpha">HSL</div>
+<div class="modernHSLA">HSLA</div>
+<div class="legacyHSLA">HSLA</div>
 ```
 
 #### CSS
@@ -310,22 +313,43 @@ The `hsla()` syntax is an alias for `hsl()`.
 ```css
 div {
   width: 100px;
-  height: 50px;
-  margin: 1rem;
+  min-height: 50px;
+  font-family: sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+body {
+  display: flex;
+  gap: 20px;
+}
+```
+
+```css
+div.modern {
+  background-color: hsl(90 80% 50%);
 }
 
-div.hsl {
-  background-color: hsl(0 100% 50% / 50%);
+div.legacy {
+  background-color: hsl(90, 80%, 50%);
 }
 
-div.hsla {
-  background-color: hsla(0, 100%, 50%, 0.5);
+div.modernWithAlpha {
+  background-color: hsl(90 80% 50% / 50%);
+}
+
+div.modernHSLA {
+  background-color: hsla(90 80% 50% / 50%);
+}
+
+div.legacyHSLA {
+  background-color: hsla(90, 80%, 50%, 0.5);
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("legacy_syntax_hsla", "100%", 150)}}
+{{EmbedLiveSample("legacy_versus_modern_syntax", "100%", 70)}}
 
 ## Specifications
 
@@ -337,9 +361,10 @@ div.hsla {
 
 ## See also
 
-- [List of all color notations](/en-US/docs/Web/CSS/color)
 - {{CSSXref("&lt;hue&gt;")}} data type
+- [`lch()`](/en-US/docs/Web/CSS/color_value/lch) and [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb) color functions
+- [Hue interpolation in `color-mix()`](/en-US/docs/Web/CSS/color_value/color-mix#using_hue_interpolation_in_color-mix)
+- [List of all color notations](/en-US/docs/Web/CSS/color_value)
 - [Using relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors)
 - [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
-- [Color picker tool](/en-US/docs/Web/CSS/CSS_colors/Color_picker_tool) on MDN
-- [Color picker](https://colorjs.io/apps/picker/) by Lea Verou
+- [Color picker tool](https://colorjs.io/apps/picker/) by Lea Verou

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -296,7 +296,7 @@ div.comma-separated {
 
 ### Legacy versus modern syntax
 
-The example demonstrates how `hsla()` syntax is an alias for `hsl()`; both are supported using both modern and legacy syntaxes.
+The example demonstrates how the `hsla()` syntax is an alias for `hsl()`; both are supported using both modern and legacy (comma-separated) syntaxes.
 
 #### HTML
 

--- a/files/en-us/web/css/hex-color/index.md
+++ b/files/en-us/web/css/hex-color/index.md
@@ -35,40 +35,51 @@ A `<hex-color>` value can be used everywhere where a [`<color>`](/en-US/docs/Web
 
 ## Examples
 
-### Hexadecimal syntax for a fully opaque hot pink
+### Hexadecimal hot pink
+
+This example includes four hot pink squares, with fully opaque or semi-transparent backgrounds created using four different-length case-insensitive hex-color syntaxes.
 
 #### HTML
 
 ```html
-<span>
-  #f09
-  <div class="c1"></div>
-</span>
-<span>
+<div>
   #F09
+  <div class="c1"></div>
+</div>
+<div>
+  #f09a
   <div class="c2"></div>
-</span>
-<span>
+</div>
+<div>
   #ff0099
   <div class="c3"></div>
-</span>
-<span>
-  #FF0099
+</div>
+<div>
+  #FF0099AA
   <div class="c4"></div>
-</span>
+</div>
 ```
 
 #### CSS
+
+The hot pink background colors are created using the three-, four-, size-, and eight-value hex notations, using both uppercase and lowercase letters.
 
 ```css hidden
 body {
   display: flex;
   justify-content: space-evenly;
+  font-family: monospace;
+}
+div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 ```
 
 ```css
-div {
+[class] {
   width: 40px;
   height: 40px;
 }
@@ -76,19 +87,19 @@ div {
   background: #f09;
 }
 .c2 {
-  background: #f09;
+  background: #f09a;
 }
 .c3 {
   background: #ff0099;
 }
 .c4 {
-  background: #ff0099;
+  background: #ff0099aa;
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("Hexadecimal_syntax_for_a_fully_opaque_hot_pink", "100%", 100)}}
+{{EmbedLiveSample("Hexadecimal_hot_pink", "100%", 100)}}
 
 ## Specifications
 
@@ -100,6 +111,7 @@ div {
 
 ## See also
 
-- [`<color>`](/en-US/docs/Web/CSS/color_value): the color data type
-- [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb): the function allowing to set the three components of the color, as well as its transparency, using decimal values
+- [`<color>`](/en-US/docs/Web/CSS/color_value) data type
+- {{cssxref("named-color")}} data-type
+- [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb) color function
 - [CSS color](/en-US/docs/Web/CSS/CSS_colors) module


### PR DESCRIPTION
* Update `color-gamut` media descriptor with links and glossary terms
* updated `HSL()` color function, changing the `hsla()` legacy example to be a modern versus legacy example and making the complementary colors paragraph note clearer (and fixed a typo). Also, updated the see also.
* updated the `<hex-color>` page to add alpha to the example and make see also conform to how they are written on other pages.

Part of https://github.com/openwebdocs/project/issues/194 (will be making numerous small-ish pull requests to enable smaller chunk PR reviews) 