### PR TITLE
Update dnt/index.md to mention GPC

### DIFF
--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -14,6 +14,8 @@ The **`DNT`** (**D**o **N**ot
 **T**rack) request header indicates the user's tracking preference. It lets
 users indicate whether they would prefer privacy rather than personalized content.
 
+Use **`GPC`** (**G**lobal **P**rivacy **C**ontrol) instead.
+
 <table class="properties">
   <tbody>
     <tr>
@@ -73,3 +75,5 @@ navigator.doNotTrack; // "0", "1" or null
 - DNT browser settings help:
   - [Firefox](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature)
   - [Chrome](https://support.google.com/chrome/answer/2790761)
+- [GPC - Global Privacy Control](https://globalprivacycontrol.org/)
+  - [Enabling GPC in Firefox](https://support.mozilla.org/en-US/kb/global-privacy-control?as=u&utm_source=inproduct)

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -14,7 +14,7 @@ The **`DNT`** (**D**o **N**ot
 **T**rack) request header indicates the user's tracking preference. It lets
 users indicate whether they would prefer privacy rather than personalized content.
 
-Use **`GPC`** (**G**lobal **P**rivacy **C**ontrol) instead.
+DNT is deprecated in favor of [Global Privacy Control](https://globalprivacycontrol.org/), which is communicated to servers using the {{HTTPHeader("Sec-GPC")}} header, and accessible to clients from {{domxref("navigator.globalPrivacyControl")}}.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
### Description

Do Not Track is obsolete. Mention the successor standard Global Privacy Control

### Motivation

This will make it easier for users to find a replacement for the obsolete feature which the page describes.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
This change includes links giving context.

### Related issues and pull requests

None.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
