### PR TITLE
CSS: hwb() description

### DIFF
--- a/files/en-us/glossary/color_wheel/index.md
+++ b/files/en-us/glossary/color_wheel/index.md
@@ -12,14 +12,15 @@ Color wheels are convenient for comparing colors expressed in polar or cylindric
 
 In such cases, _complementary colors_ are often found opposite on the same diameter. Similarly, _monochromatic colors_ – colors of the same _tone_ but of different _shades_ – are located on the same radius, and _triadic colors_ – three colors evenly spaced around the color wheel that lead to colors that work well together – are also easy to find.
 
-Color wheels are used in real life when we want to choose between different hues. For example, when selecting wall paint or the color for a piece furniture.
+Color wheels are used in real life when we want to choose between different hues. For example, when selecting wall paint or the color for a piece of furniture.
 
 In the digital world, color wheels are used in _color pickers_, like the default one on macOS:
 [![The default color picker on macOS Monterey](color_wheel_macos.png)](/en-US/docs/Glossary/Color_wheel/color_wheel_macos.png)
 
 ## See also
 
+- {{glossary("color space")}}
+- [`<color>`](/en-US/docs/Web/CSS/color_value) CSS data type
 - [_Color theory and the color wheel_](https://www.canva.com/colors/color-wheel/)
 - [_How to Use the Color Wheel to Pick Your Perfect Color Palette_](https://www.bhg.com/decorating/color/basics/color-wheel-color-chart/) in _Better Homes & Gardens_
 - [_Color wheel_](https://en.wikipedia.org/wiki/Color_wheel) in _Wikipedia_
-- [`<color>`](/en-US/docs/Web/CSS/color_value) (the CSS color type)

--- a/files/en-us/web/css/color_value/hwb/index.md
+++ b/files/en-us/web/css/color_value/hwb/index.md
@@ -31,11 +31,11 @@ hwb(from lch(40% 70 240deg) h w calc(b - 30))
 
 This [`sRGB`](/en-US/docs/Glossary/Color_space#srgb_color_spaces) color function is defined by a {{CSSXref("&lt;hue&gt;")}} angle value, a whiteness value, a blackness value, and, optionally, an alpha value representing the color's transparency.
 
-The angles corresponding to particular hues differ across the sRGB (used by {{CSSXref("color_value/hsl", "hsl()")}} and `hwb()`, CIELAB (used by {{CSSXref("color_value/lch", "lch()")}}), and Oklab (used by {{CSSXref("color_value/oklch", "oklch()")}}) color spaces, with `hwb()` being in the same color space as `hsl()`, having the same hue color angles. See the {{CSSXref("&lt;hue&gt;")}} reference page for more detail and examples, or try changing the hues on the [color picker](/en-US/docs/Web/CSS/CSS_Colors#colors_in_action) to see it in action.
+The angles corresponding to particular hues differ across the sRGB (used by {{CSSXref("color_value/hsl", "hsl()")}} and `hwb()`), CIELAB (used by {{CSSXref("color_value/lch", "lch()")}}), and Oklab (used by {{CSSXref("color_value/oklch", "oklch()")}}) color spaces. `hwb()` is in the same color space as `hsl()`, and therefore has the same hue color angles. See the {{CSSXref("&lt;hue&gt;")}} reference page for more detail and examples, or try changing the hues on the [color picker](/en-US/docs/Web/CSS/CSS_Colors#colors_in_action) to see it in action.
 
 An `hwb()` color is fully saturated when it's whiteness (`W`) and blackness (`B`) values are both `0`. For any hue value `H`, `hwb(H 0% 0%)` is the same color as `hsl(H 100% 50%)`. Increasing the whiteness value lightens the color. Increasing the blackness darkens the color.
 
-When both the blackness and whiteness are greater than 0, the color gets muted, tending towards grey. When the amount of whiteness and blackness added in are equal to or greater than 100% — in other words, if `W + B >= 100%`, the color function defines a shade of gray. When the sum of both values is greater than 100%, if `W + B > 100%`, the whiteness and blackness values of the grey color are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
+When both the blackness and whiteness are greater than 0, the color gets muted, tending towards grey. When the amount of whiteness and blackness added in are equal to or greater than 100% — in other words, if `W + B >= 100%`, the color function defines a shade of gray. When the sum of both values is greater than 100% (`W + B > 100%`), the whiteness and blackness values of the grey color are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
 
 ## Values
 
@@ -55,11 +55,11 @@ The parameters are as follows:
 
 - `W`
 
-  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's whiteness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no whiteness, whereas `100%` represents full whiteness if `B` is `0`, otherwise both the `W` and `B` values are normalized.
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's whiteness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no whiteness. `100%` represents full whiteness if `B` is `0`, otherwise both the `W` and `B` values are normalized.
 
 - `B`
 
-  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's blackness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no blackness, whereas `100%` represents full blackness if `W` is `0`, otherwise both the `W` and `B` values are normalized.
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's blackness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no blackness. `100%` represents full blackness if `W` is `0`, otherwise both the `W` and `B` values are normalized.
 
 - `A` {{optional_inline}}
 
@@ -87,11 +87,11 @@ The parameters are as follows:
 
 - `W`
 
-  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's whiteness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no whiteness, whereas `100%` represents full whiteness if `B` is `0`, otherwise both the `W` and `B` values are normalized.
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's whiteness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no whiteness. `100%` represents full whiteness if `B` is `0`, otherwise both the `W` and `B` values are normalized.
 
 - `B`
 
-  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's blackness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no blackness, whereas `100%` represents full blackness if `W` is `0`, otherwise both the `W` and `B` values are normalized.
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's blackness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no blackness. `100%` represents full blackness if `W` is `0`, otherwise both the `W` and `B` values are normalized.
 
 - `A` {{optional_inline}}
   - : An {{CSSXref("&lt;alpha-value&gt;")}} representing the alpha channel value of the output color, where the number `0` corresponds to `0%` (fully transparent) and `1` corresponds to `100%` (fully opaque). Additionally, the keyword `none` can be used to explicitly specify no alpha channel. If the `A` channel value is not explicitly specified, it defaults to the alpha channel value of the origin color. If included, the value is preceded by a slash (`/`).

--- a/files/en-us/web/css/color_value/hwb/index.md
+++ b/files/en-us/web/css/color_value/hwb/index.md
@@ -27,11 +27,21 @@ hwb(from #0000FF h calc(w + 30) b)
 hwb(from lch(40% 70 240deg) h w calc(b - 30))
 ```
 
-### Values
+## Description
+
+This [`sRGB`](/en-US/docs/Glossary/Color_space#srgb_color_spaces) color function is defined by a {{CSSXref("&lt;hue&gt;")}} angle value, a whiteness value, a blackness value, and, optionally, an alpha value representing the color's transparency.
+
+The angles corresponding to particular hues differ across the sRGB (used by {{CSSXref("color_value/hsl", "hsl()")}} and `hwb()`, CIELAB (used by {{CSSXref("color_value/lch", "lch()")}}), and Oklab (used by {{CSSXref("color_value/oklch", "oklch()")}}) color spaces, with `hwb()` being in the same color space as `hsl()`, having the same hue color angles. See the {{CSSXref("&lt;hue&gt;")}} reference page for more detail and examples, or try changing the hues on the [color picker](/en-US/docs/Web/CSS/CSS_Colors#colors_in_action) to see it in action.
+
+An `hwb()` color is fully saturated when it's whiteness (`W`) and blackness (`B`) values are both `0`. For any hue value `H`, `hwb(H 0% 0%)` is the same color as `hsl(H 100% 50%)`. Increasing the whiteness value lightens the color. Increasing the blackness darkens the color.
+
+When both the blackness and whiteness are greater than 0, the color gets muted, tending towards grey. When the amount of whiteness and blackness added in are equal to or greater than 100% — in other words, if `W + B >= 100%`, the color function defines a shade of gray. When the sum of both values is greater than 100%, if `W + B > 100%`, the whiteness and blackness values of the grey color are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
+
+## Values
 
 Below are descriptions of the allowed values for both absolute and [relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors).
 
-#### Absolute value syntax
+### Absolute value syntax
 
 ```text
 hwb(H W B[ / A])
@@ -43,15 +53,13 @@ The parameters are as follows:
 
   - : A {{CSSXref("&lt;number&gt;")}}, an {{CSSXref("&lt;angle&gt;")}}, or the keyword `none` (equivalent to `0deg` in this case) representing the color's {{CSSXref("&lt;hue&gt;")}} angle.
 
-    > **Note:** The angles corresponding to particular hues differ across the sRGB (used by {{CSSXref("color_value/hsl", "hsl()")}} and `hwb()`, CIELAB (used by {{CSSXref("color_value/lch", "lch()")}}), and Oklab (used by {{CSSXref("color_value/oklch", "oklch()")}}) color spaces. See the {{CSSXref("&lt;hue&gt;")}} reference page for more detail and examples.
+- `W`
 
-- `W`, `B`
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's whiteness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no whiteness, whereas `100%` represents full whiteness if `B` is `0`, otherwise both the `W` and `B` values are normalized.
 
-  - : Each one is a {{CSSXref("&lt;percentage&gt;")}} or the keyword `none` (equivalent to `0%` in this case). These values represent the color's whiteness and blackness respectively, specifying the amount to mix in. `0%` represents no whiteness or blackness, whereas `100%` represents full whiteness or blackness.
+- `B`
 
-    If `W + B = 100%`, it defines a shade of gray.
-
-    If `W + B > 100%`, `W` and `B` are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's blackness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no blackness, whereas `100%` represents full blackness if `W` is `0`, otherwise both the `W` and `B` values are normalized.
 
 - `A` {{optional_inline}}
 
@@ -61,7 +69,7 @@ The parameters are as follows:
 
 > **Note:** Absolute `hwb()` colors are serialized to {{CSSXref("color_value/rgb", "rgb()")}} values. The values of the red, green, and blue components may be rounded in serialization.
 
-#### Relative value syntax
+### Relative value syntax
 
 ```text
 hwb(from <color> H W B[ / A])
@@ -70,23 +78,27 @@ hwb(from <color> H W B[ / A])
 The parameters are as follows:
 
 - `from <color>`
+
   - : The keyword `from` is always included when defining a relative color, followed by a {{cssxref("&lt;color&gt;")}} value representing the **origin color**. This is the original color that the relative color is based on. The origin color can be _any_ valid {{cssxref("&lt;color&gt;")}} syntax, including another relative color.
+
 - `H`
+
   - : A {{CSSXref("&lt;number&gt;")}}, an {{CSSXref("&lt;angle&gt;")}}, or the keyword `none` (equivalent to `0deg` in this case) representing the output color's {{CSSXref("&lt;hue&gt;")}} angle.
-- `W`, `B`
 
-  - : Each value can be written as a {{CSSXref("&lt;percentage&gt;")}} or the keyword `none` (equivalent to `0%` in this case). These values represent the whiteness and blackness channel values of the output color respectively, specifying the amount to mix in. `0%` represents no whiteness or blackness, whereas `100%` represents full whiteness or blackness.
+- `W`
 
-    If `W + B = 100%`, it defines a shade of gray.
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's whiteness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no whiteness, whereas `100%` represents full whiteness if `B` is `0`, otherwise both the `W` and `B` values are normalized.
 
-    If `W + B > 100%`, `W` and `B` are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
+- `B`
+
+  - : A {{CSSXref("&lt;percentage&gt;")}} representing the color's blackness or the keyword `none` (equivalent to `0%` in this case) to mix in. `0%` represents no blackness, whereas `100%` represents full blackness if `W` is `0`, otherwise both the `W` and `B` values are normalized.
 
 - `A` {{optional_inline}}
   - : An {{CSSXref("&lt;alpha-value&gt;")}} representing the alpha channel value of the output color, where the number `0` corresponds to `0%` (fully transparent) and `1` corresponds to `100%` (fully opaque). Additionally, the keyword `none` can be used to explicitly specify no alpha channel. If the `A` channel value is not explicitly specified, it defaults to the alpha channel value of the origin color. If included, the value is preceded by a slash (`/`).
 
 > **Note:** To fully enable the representation of the full spectrum of visible colors, the output of relative `hwb()` color functions is serialized to `color(srgb)`. That means that querying the output color value via the {{DOMxRef("HTMLElement.style")}} property or the {{DOMxRef("CSSStyleDeclaration.getPropertyValue()")}} method returns the output color as a [`color(srgb ...)`](/en-US/docs/Web/CSS/color_value/color) value.
 
-#### Defining relative color output channel components
+### Defining relative color output channel components
 
 When using relative color syntax inside an `hwb()` function, the browser converts the origin color into an equivalent HWB color (if it is not already specified as such). The color is defined as three distinct color channel values — `h` (hue), `w` (white), and `b` (black) — plus an alpha channel value (`alpha`). These channel values are made available inside the function to be used when defining the output color channel values:
 
@@ -150,7 +162,7 @@ hwb(from hsl(0 100% 50%) calc(h + 120) calc(w + 25) calc(b + 10) / calc(alpha - 
 
 > **Note:** Because the origin color channel values are resolved to `<number>` values, you have to add numbers to them when using them in calculations, even in cases where a channel would normally accept `<percentage>`, `<angle>`, or other value types. Adding a `<percentage>` to a `<number>`, for example, doesn't work.
 
-### Formal syntax
+## Formal syntax
 
 {{csssyntax}}
 


### PR DESCRIPTION
HWB

* add description to hwb() color function
* separate definitions for whiteness and blackness
* heading levels (so stuff shows up in the sidebar)

Color wheel glossary term

* Grammar nit
* added color space glossary term
* See also order and match MDN writing style

Part of https://github.com/openwebdocs/project/issues/194 (will be making numerous small-ish pull requests to enable smaller chunk PR reviews)
