### PR TITLE
Fix typo: codeOuterGain to coneOuterGain

### DIFF
--- a/files/en-us/web/api/pannernode/orientationy/index.md
+++ b/files/en-us/web/api/pannernode/orientationy/index.md
@@ -22,7 +22,7 @@ of the audio source (that is, the direction in which it's facing), given as
 Depending on the directionality of the sound (as specified using the attributes
 {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}},
 {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}, and
-{{domxref("PannerNode.coneOuterGain", "codeOuterGain")}}), the orientation of the
+{{domxref("PannerNode.coneOuterGain", "coneOuterGain")}}), the orientation of the
 sound may alter the perceived volume of the sound as it's being played. If the sound
 is pointing toward the listener, it will be louder than if the sound is pointed away
 from the listener.

--- a/files/en-us/web/api/pannernode/orientationz/index.md
+++ b/files/en-us/web/api/pannernode/orientationz/index.md
@@ -22,7 +22,7 @@ of the audio source (that is, the direction in which it's facing), given as
 Depending on the directionality of the sound (as specified using the attributes
 {{domxref("PannerNode.coneInnerAngle", "coneInnerAngle")}},
 {{domxref("PannerNode.coneOuterAngle", "coneOuterAngle")}}, and
-{{domxref("PannerNode.coneOuterGain", "codeOuterGain")}}), the orientation of the
+{{domxref("PannerNode.coneOuterGain", "coneOuterGain")}}), the orientation of the
 sound may alter the perceived volume of the sound as it's being played. If the sound
 is pointing toward the listener, it will be louder than if the sound is pointed away
 from the listener.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The linked property name is `coneOuterGain`, not `codeOuterGain`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
