### PR TITLE
Fix a template of a constructor page

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -32,7 +32,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 > - **title**
 >   - : Title heading displayed at the top of the page.
 >     Format as `NameOfTheParentInterface: NameOfTheConstructor() constuctor`.
->     For example, the [Request()](/en-US/docs/Web/API/Request/Request) constructor has a _title_ of `Request()`.
+>     For example, the [Request()](/en-US/docs/Web/API/Request/Request) constructor has a _title_ of `Request: Request() constructor`.
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`.
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheConstructor`.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -18,8 +18,8 @@ browser-compat: path.to.feature.NameOfTheConstructor
 >
 > ```md
 > ---
-> title: NameOfTheConstructor()
-> slug: Web/API/NameOfTheParentInterface/NameOfTheParentInterface
+> title: NameOfTheParentInterface: NameOfTheConstructor() constuctor
+> slug: Web/API/NameOfTheParentInterface/NameOfTheConstructor
 > page-type: web-api-constructor
 > status:
 >   - experimental
@@ -31,12 +31,12 @@ browser-compat: path.to.feature.NameOfTheConstructor
 >
 > - **title**
 >   - : Title heading displayed at the top of the page.
->     Format as _NameOfTheParentInterface_**()**.
+>     Format as `NameOfTheParentInterface: NameOfTheConstructor() constuctor`.
 >     For example, the [Request()](/en-US/docs/Web/API/Request/Request) constructor has a _title_ of `Request()`.
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`.
->     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheParentInterface`.
->     Note that the name of the constructor function in the slug omits the parenthesis (it ends in `NameOfTheParentInterface` not `NameOfTheParentInterface()`).
+>     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheConstructor`.
+>     Note that the name of the constructor function in the slug omits the parenthesis (it ends in `NameOfTheConstructor` not `NameOfTheConstructor()`).
 > - **page-type**
 >   - : The `page-type` key for Web/API constructors is always `web-api-constructor`.
 > - **status**


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Fix the format of the title in the front matter.
- Fix `NameOfTheConstructor` from `NameOfTheParentInterface` because some constructors have a different name from the interface's name, such as [HTMLImageElement: Image() constructor](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image)

### Motivation

- To adjust to recent writing style.
- To support constructors which has different name from interface which belongs to.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
