### PR TITLE
Fix the format of `title` tag

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -31,7 +31,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 >
 > - **title**
 >   - : Title heading displayed at the top of the page.
->     Format as `NameOfTheParentInterface: NameOfTheMethod() method`.
+>     Format as `"NameOfTheParentInterface: NameOfTheMethod() method"`.
 >     For example, the [count()](/en-US/docs/Web/API/IDBIndex/count) method of the [IDBIndex](/en-US/docs/Web/API/IDBIndex) interface has a _title_ of `IDBIndex: count() method`.
 > - **slug**
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -31,8 +31,8 @@ browser-compat: path.to.feature.NameOfTheMethod
 >
 > - **title**
 >   - : Title heading displayed at the top of the page.
->     Format as _NameOfTheParentInterface_**.**_NameOfTheMethod_**()**.
->     For example, the [count()](/en-US/docs/Web/API/IDBIndex/count) method of the [IDBIndex](/en-US/docs/Web/API/IDBIndex) interface has a _title_ of `IDBIndex.count()`.
+>     Format as `NameOfTheParentInterface: NameOfTheMethod() method`.
+>     For example, the [count()](/en-US/docs/Web/API/IDBIndex/count) method of the [IDBIndex](/en-US/docs/Web/API/IDBIndex) interface has a _title_ of `IDBIndex: count() method`.
 > - **slug**
 >
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`.
@@ -108,7 +108,7 @@ If the method doesn't return anything, just put "None ({{jsxref('undefined')}}).
 
 ### Exceptions
 
-Include a list of all the exceptions that the constructor can raise. Include one term and definition for each exception.
+Include a list of all the exceptions that the method can raise. Include one term and definition for each exception.
 
 - `Exception1`
   - : Include descriptions of how the exception is raised.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -18,7 +18,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 >
 > ```md
 > ---
-> title: NameOfTheParentInterface.NameOfTheProperty
+> title: NameOfTheParentInterface: NameOfTheProperty property
 > slug: Web/API/NameOfTheParentInterface/NameOfTheProperty
 > page-type: web-api-instance-property OR web-api-static-property
 > status:
@@ -31,8 +31,8 @@ browser-compat: path.to.feature.NameOfTheProperty
 >
 > - **title**
 >   - : Title heading displayed at the top of the page.
->     Format as _NameOfTheParentInterface_**.**_NameOfTheProperty_.
->     For example, the [`capabilities`](/en-US/docs/Web/API/VRDisplay/capabilities) property of the [`VRDisplay`](/en-US/docs/Web/API/VRDisplay) interface has a `title` of `VRDisplay.capabilities`.
+>     Format as `NameOfTheParentInterface: NameOfTheProperty property`.
+>     For example, the [`capabilities`](/en-US/docs/Web/API/VRDisplay/capabilities) property of the [`VRDisplay`](/en-US/docs/Web/API/VRDisplay) interface has a `title` of `VRDisplay: capabilities property`.
 > - **slug**
 >
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -31,7 +31,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 >
 > - **title**
 >   - : Title heading displayed at the top of the page.
->     Format as `NameOfTheParentInterface: NameOfTheProperty property`.
+>     Format as "NameOfTheParentInterface: NameOfTheProperty property".
 >     For example, the [`capabilities`](/en-US/docs/Web/API/VRDisplay/capabilities) property of the [`VRDisplay`](/en-US/docs/Web/API/VRDisplay) interface has a `title` of `VRDisplay: capabilities property`.
 > - **slug**
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -18,7 +18,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 >
 > ```md
 > ---
-> title: NameOfTheParentInterface: NameOfTheProperty property
+> title: "NameOfTheParentInterface: NameOfTheProperty property"
 > slug: Web/API/NameOfTheParentInterface/NameOfTheProperty
 > page-type: web-api-instance-property OR web-api-static-property
 > status:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix the format of `title` tag, with the recent style.

### Motivation

These templates shows `title` as the old format.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
