### PR TITLE
Remove `Handler` from the event name

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -19,7 +19,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > ```md
 > ---
 > title: "NameOfTheParentInterface: NameOfTheEvent event"
-> slug: Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event
+> slug: Web/API/NameOfTheParentInterface/NameOfTheEvent_event
 > page-type: web-api-event
 > status:
 >   - experimental
@@ -34,8 +34,8 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 >     Format as "_NameOfTheParentInterface_**:** _NameOfTheEvent_ **event**".
 >     For example, the [animationcancel](/en-US/docs/Web/API/Element/animationcancel_event) event of the [Window](/en-US/docs/Web/API/Window) interface has a _title_ of `Window: animationcancel event`.
 > - **slug**
->   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
->     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event`.
+>   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`.
+>     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheEvent_event`.
 > - **page-type**
 >   - : The `page-type` key for Web/API events is always `web-api-event`.
 > - **status**


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove `Handler` from the event name.

### Motivation

A slug should be based on the event's name rather than the event handler's name.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
