### PR TITLE
fix: `Clipboard.prototype.write` event listener fix

### DIFF
--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -51,7 +51,7 @@ This example function replaces the current contents of the clipboard with a spec
 Note that for this particular case, you could just as readily use `Clipboard.writeText()`.
 
 ```js
-button.addEventListener("click", setClipboard("<empty clipboard>"));
+button.addEventListener("click", () => setClipboard("<empty clipboard>"));
 
 async function setClipboard(text) {
   const type = "text/plain";

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -78,7 +78,7 @@ This example writes the canvas to a blob, using the default MIME type of `image/
 ```js
 // Get canvas can add an event handler for the click event.
 const canvas = document.getElementById("canvas");
-canvas.addEventListener("click", copyCanvasContentsToClipboard());
+canvas.addEventListener("click", copyCanvasContentsToClipboard);
 
 async function copyCanvasContentsToClipboard() {
   // Copy canvas to blob


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fixes a small error on the `Clipboard.prototype.write` page where a handler is called immediately instead of being passed to `addEventListener`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

example code currently does not execute correctly

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

\-

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

\-
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
