### PR TITLE
Express - genre form add collation earlier

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -71,7 +71,9 @@ exports.genre_create_post = [
     } else {
       // Data from form is valid.
       // Check if Genre with same name already exists.
-      const genreExists = await Genre.findOne({ name: req.body.name }).exec();
+      const genreExists = await Genre.findOne({ name: req.body.name })
+        .collation({ locale: "en", strength: 2 })
+        .exec();
       if (genreExists) {
         // Genre exists, redirect to its detail page.
         res.redirect(genreExists.url);


### PR DESCRIPTION
The genre form includes `collation()` code to find duplicates in the detailed discussion, but this is not in the code that users are instructed to copy earlier in the topic. This adds `collation()` to the genre post route.

Fixes #32865