### PR TITLE
Add `animation` to list of CSS properties that create a new stacking context

### DIFF
--- a/files/en-us/web/css/css_positioned_layout/understanding_z-index/stacking_context/index.md
+++ b/files/en-us/web/css/css_positioned_layout/understanding_z-index/stacking_context/index.md
@@ -25,6 +25,7 @@ A stacking context is formed, anywhere in the document, by any element in the fo
 - Element with any of the following properties with value other than `none`:
 
   - {{cssxref("transform")}}
+  - {{cssxref("animation")}}
   - {{cssxref("filter")}}
   - {{cssxref("backdrop-filter")}}
   - {{cssxref("perspective")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

My team was recently debugging an issue with stacking contexts and found that adding an `animation` property to an element seemed to create a new stacking context. We didn't see that property in the list of elements that can create a new stacking context on [this page](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context#description) and were wondering if it should be added.

### Motivation

The only places online we could find that mentioned the possibility of `animation` messing with the stacking context was on [this page](https://webdesign.tutsplus.com/css3-animations-the-hiccups-and-bugs-youll-want-to-avoid--webdesign-4867t) under the header `Pseudo Elements and Z-index` and in [this random Codepen](https://codepen.io/colin/pen/NPXBKV). If `animation` is indeed a property that can create a new stacking context, it would be helpful to update the MDN web docs to have this information in a more authoritative source.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
