### PR TITLE
fix(svg elements): Update section name to match the template

### DIFF
--- a/files/en-us/web/svg/element/a/index.md
+++ b/files/en-us/web/svg/element/a/index.md
@@ -95,7 +95,7 @@ svg|a:active {
   - : The URL or URL fragment that the hyperlink points to. May be required for backwards compatibility for older browsers.
     _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Content_type#url)** ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/circle/index.md
+++ b/files/en-us/web/svg/element/circle/index.md
@@ -44,7 +44,7 @@ svg {
 
 > **Note:** Starting with SVG2, `cx`, `cy`, and `r` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/clippath/index.md
+++ b/files/en-us/web/svg/element/clippath/index.md
@@ -74,7 +74,7 @@ By default, {{cssxref("pointer-events")}} are not dispatched on clipped regions.
   - : Defines the coordinate system for the contents of the `<clipPath>` element.
     _Value type_: `userSpaceOnUse`|`objectBoundingBox` ; _Default value_: `userSpaceOnUse`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/defs/index.md
+++ b/files/en-us/web/svg/element/defs/index.md
@@ -40,7 +40,7 @@ svg {
 
 {{EmbedLiveSample('Example', 150, '100%')}}
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/desc/index.md
+++ b/files/en-us/web/svg/element/desc/index.md
@@ -40,7 +40,7 @@ svg {
 
 This element only includes global attributes
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/ellipse/index.md
+++ b/files/en-us/web/svg/element/ellipse/index.md
@@ -49,7 +49,7 @@ svg {
 
 > **Note:** Starting with SVG2 `cx`, `cy`, `rx` and `ry` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/fedropshadow/index.md
+++ b/files/en-us/web/svg/element/fedropshadow/index.md
@@ -62,7 +62,7 @@ svg {
   - : This attribute defines the standard deviation for the blur operation in the drop shadow.
     _Value type_: [**\<number-optional-number>**](/en-US/docs/Web/SVG/Content_type#number-optional-number); _Default value_: `2`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/foreignobject/index.md
+++ b/files/en-us/web/svg/element/foreignobject/index.md
@@ -67,7 +67,7 @@ svg {
 
 > **Note:** Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/g/index.md
+++ b/files/en-us/web/svg/element/g/index.md
@@ -33,7 +33,7 @@ svg {
 
 {{EmbedLiveSample('Example', 100, '100%')}}
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/line/index.md
+++ b/files/en-us/web/svg/element/line/index.md
@@ -48,7 +48,7 @@ svg {
   - : Defines the total path length in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/lineargradient/index.md
+++ b/files/en-us/web/svg/element/lineargradient/index.md
@@ -68,7 +68,7 @@ svg {
   - : This attribute defines the y coordinate of the ending point of the vector gradient along which the linear gradient is drawn.
     _Value type_: {{cssxref("length-percentage")}} | {{cssxref("number")}}; _Default value_: `0%`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/marker/index.md
+++ b/files/en-us/web/svg/element/marker/index.md
@@ -191,7 +191,7 @@ svg {
   - : This attribute defines the bound of the SVG viewport for the current SVG fragment.
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Content_type#list-of-ts)** ; _Default value_: none; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/mask/index.md
+++ b/files/en-us/web/svg/element/mask/index.md
@@ -62,7 +62,7 @@ svg {
   - : This attribute defines the width of the masking area.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length) ; _Default value_: `120%`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/path/index.md
+++ b/files/en-us/web/svg/element/path/index.md
@@ -41,7 +41,7 @@ svg {
   - : This attribute lets authors specify the total length for the path, in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/pattern/index.md
+++ b/files/en-us/web/svg/element/pattern/index.md
@@ -86,7 +86,7 @@ svg {
   - : This attribute determines the y coordinate shift of the pattern tile.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/polygon/index.md
+++ b/files/en-us/web/svg/element/polygon/index.md
@@ -42,7 +42,7 @@ svg {
   - : This attribute lets specify the total length for the path, in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/polyline/index.md
+++ b/files/en-us/web/svg/element/polyline/index.md
@@ -40,7 +40,7 @@ svg {
   - : This attribute lets specify the total length for the path, in user units.
     _Value type_: [**\<number>**](/en-US/docs/Web/SVG/Content_type#number) ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/radialgradient/index.md
+++ b/files/en-us/web/svg/element/radialgradient/index.md
@@ -76,7 +76,7 @@ svg {
   - : An [\<IRI>](/en-US/docs/Web/SVG/Content_type#iri) reference to another `<radialGradient>` element that will be used as a template.
     _Value type_: [**\<IRI>**](/en-US/docs/Web/SVG/Content_type#iri) ; _Default value_: none; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/rect/index.md
+++ b/files/en-us/web/svg/element/rect/index.md
@@ -57,7 +57,7 @@ svg {
 
 > **Note:** Starting with SVG2, `x`, `y`, `width`, `height`, `rx` and `ry` are _Geometry Properties_, meaning those attributes can also be used as CSS properties for that element.
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/script/index.md
+++ b/files/en-us/web/svg/element/script/index.md
@@ -65,7 +65,7 @@ Click the circle to change colors.
   - : The {{Glossary("URL")}} to the script to load.
     _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Content_type#url)** ; _Default value_: _none_; _Animatable_: **no**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/set/index.md
+++ b/files/en-us/web/svg/element/set/index.md
@@ -49,7 +49,7 @@ svg {
   - : This attribute defines the value to be applied to the target attribute for the duration of the animation. The value must match the requirements of the target attribute.
     _Value type_: [**\<anything>**](/en-US/docs/Web/SVG/Content_type#anything); _Default value_: none; _Animatable_: **no**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/stop/index.md
+++ b/files/en-us/web/svg/element/stop/index.md
@@ -50,7 +50,7 @@ svg {
   - : This attribute defines the opacity of the gradient stop. It can be used as a CSS property.
     _Value type_: [**\<opacity>**](/en-US/docs/Web/SVG/Content_type#opacity_value); _Default value_: `1`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/style/index.md
+++ b/files/en-us/web/svg/element/style/index.md
@@ -49,7 +49,7 @@ svg {
   - : This attribute the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
     _Value type_: [**`<string>`**](/en-US/docs/Web/SVG/Content_type#string); _Default value_: _none_; _Animatable_: **no**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/svg/index.md
+++ b/files/en-us/web/svg/element/svg/index.md
@@ -118,7 +118,7 @@ To change the iframe's dimensions try resizing the dotted red border from bottom
 
 > **Note:** Starting with SVG2, `x`, `y`, `width`, and `height` are _Geometry Properties_, meaning these attributes can also be used as CSS properties.
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/symbol/index.md
+++ b/files/en-us/web/svg/element/symbol/index.md
@@ -72,7 +72,7 @@ svg {
   - : This attribute determines the y coordinate of the symbol.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Content_type#percentage) ; _Default value_: `0`; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/text/index.md
+++ b/files/en-us/web/svg/element/text/index.md
@@ -74,7 +74,7 @@ svg {
   - : A width that the text should be scaled to fit.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/textpath/index.md
+++ b/files/en-us/web/svg/element/textpath/index.md
@@ -65,7 +65,7 @@ svg {
   - : The width of the space into which the text will render.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Content_type#percentage)|[**\<number>**](/en-US/docs/Web/SVG/Content_type#number) ; _Default value_: _auto_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/title/index.md
+++ b/files/en-us/web/svg/element/title/index.md
@@ -41,7 +41,7 @@ svg {
 
 This element only includes global attributes
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/tspan/index.md
+++ b/files/en-us/web/svg/element/tspan/index.md
@@ -67,7 +67,7 @@ svg {
   - : A width that the text should be scaled to fit.
     _Value type_: [**\<length>**](/en-US/docs/Web/SVG/Content_type#length)|[**\<percentage>**](/en-US/docs/Web/SVG/Content_type#percentage) ; _Default value_: _none_; _Animatable_: **yes**
 
-## Usage notes
+## Usage context
 
 {{svginfo}}
 

--- a/files/en-us/web/svg/element/use/index.md
+++ b/files/en-us/web/svg/element/use/index.md
@@ -67,6 +67,8 @@ For security reasons, browsers may apply the [same-origin policy](/en-US/docs/We
 
 > **Warning:** Since SVG 2, the {{SVGAttr("xlink:href")}} attribute is deprecated in favor of {{SVGAttr("href")}}. See {{SVGAttr("xlink:href")}} page for more information.
 
+## Usage context
+
 {{SVGInfo}}
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As per the [SVG element template](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/SVG_element_page_template), the name of the section containing the call to the `{{svginfo}}` macro is "Usage context". This is different from the "Usage notes" section we have on other reference pages to include description and working of the property/element/method.
This PR updates "Usage note" to "Usage context" for sections containing `{{svginfo}}`.

### Motivation

Consistency with the template


