### PR TITLE
Remove browser compat tables for microdata

### DIFF
--- a/files/en-us/web/html/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/global_attributes/itemid/index.md
@@ -2,6 +2,7 @@
 title: itemid
 slug: Web/HTML/Global_attributes/itemid
 page-type: html-attribute
+spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemid
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/en-us/web/html/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/global_attributes/itemid/index.md
@@ -2,7 +2,6 @@
 title: itemid
 slug: Web/HTML/Global_attributes/itemid
 page-type: html-attribute
-browser-compat: html.global_attributes.itemid
 ---
 
 {{HTMLSidebar("Global_attributes")}}
@@ -71,10 +70,6 @@ This example uses microdata attributes to represent the following structured dat
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/global_attributes/itemprop/index.md
@@ -2,6 +2,7 @@
 title: itemprop
 slug: Web/HTML/Global_attributes/itemprop
 page-type: html-attribute
+spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#names:-the-itemprop-attribute
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/en-us/web/html/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/global_attributes/itemprop/index.md
@@ -2,7 +2,6 @@
 title: itemprop
 slug: Web/HTML/Global_attributes/itemprop
 page-type: html-attribute
-browser-compat: html.global_attributes.itemprop
 ---
 
 {{HTMLSidebar("Global_attributes")}}
@@ -424,10 +423,6 @@ This example uses microdata attributes to represent the following structured dat
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/global_attributes/itemref/index.md
@@ -2,6 +2,7 @@
 title: itemref
 slug: Web/HTML/Global_attributes/itemref
 page-type: html-attribute
+spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemref
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/en-us/web/html/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/global_attributes/itemref/index.md
@@ -2,7 +2,6 @@
 title: itemref
 slug: Web/HTML/Global_attributes/itemref
 page-type: html-attribute
-browser-compat: html.global_attributes.itemref
 ---
 
 {{HTMLSidebar("Global_attributes")}}
@@ -52,10 +51,6 @@ This example uses microdata attributes to represent the following structured dat
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -2,6 +2,7 @@
 title: itemscope
 slug: Web/HTML/Global_attributes/itemscope
 page-type: html-attribute
+spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemscope
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -2,7 +2,6 @@
 title: itemscope
 slug: Web/HTML/Global_attributes/itemscope
 page-type: html-attribute
-browser-compat: html.global_attributes.itemscope
 ---
 
 {{HTMLSidebar("Global_attributes")}}
@@ -265,10 +264,6 @@ There are four `itemscope` attributes in the following example. Each `itemscope`
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/global_attributes/itemtype/index.md
@@ -2,7 +2,6 @@
 title: itemtype
 slug: Web/HTML/Global_attributes/itemtype
 page-type: html-attribute
-browser-compat: html.global_attributes.itemtype
 ---
 
 {{HTMLSidebar("Global_attributes")}}
@@ -192,10 +191,6 @@ This example uses microdata attributes to represent structured data for a produc
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/global_attributes/itemtype/index.md
@@ -2,6 +2,7 @@
 title: itemtype
 slug: Web/HTML/Global_attributes/itemtype
 page-type: html-attribute
+spec-urls: https://html.spec.whatwg.org/multipage/microdata.html#attr-itemtype
 ---
 
 {{HTMLSidebar("Global_attributes")}}

--- a/files/en-us/web/html/microdata/index.md
+++ b/files/en-us/web/html/microdata/index.md
@@ -147,10 +147,6 @@ In some cases, search engines covering specific regions may provide locally-spec
 
 > **Note:** A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data). Try it on the HTML shown above.
 
-## Browser compatibility
-
-Supported in Firefox 16. Removed in Firefox 49.
-
 ## See also
 
 - [Global Attributes](/en-US/docs/Web/HTML/Global_attributes)


### PR DESCRIPTION
Goes with https://github.com/mdn/browser-compat-data/pull/21978.