### PR TITLE
fix(html): Replace external Wikipedia link with link to internal glossary page

### DIFF
--- a/files/en-us/web/api/htmlformelement/enctype/index.md
+++ b/files/en-us/web/api/htmlformelement/enctype/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLFormElement.enctype
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLFormElement.enctype`** property is the [MIME type](https://en.wikipedia.org/wiki/Mime_type) of content that is used
+The **`HTMLFormElement.enctype`** property is the {{Glossary("MIME_type", "MIME type")}} of content that is used
 to submit the form to the server. Possible values are:
 
 - `application/x-www-form-urlencoded`: The initial default type.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR replaces the external link with a link to our internal glossary page. 

We have a glossary page for [MIME type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type), which does include a link to the Wikipedia page in "See also". 

### Motivation

To prioritize internal pages that can provide context-specific explanations


