### PR TITLE
Update {{AvailableInWorkers}} macros usage of XMLHttpRequest API

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.abort
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`XMLHttpRequest.abort()`** method aborts the request if
 it has already been sent. When a request is aborted, its

--- a/files/en-us/web/api/xmlhttprequest/abort_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.abort_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `abort` event is fired when a request has been aborted, for example because the program called {{domxref("XMLHttpRequest.abort()")}}.
 

--- a/files/en-us/web/api/xmlhttprequest/channel/index.md
+++ b/files/en-us/web/api/xmlhttprequest/channel/index.md
@@ -7,6 +7,6 @@ status:
   - non-standard
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 XMLHttpRequest.channel is an `nsIChannel` that used by the object when performing the request. This is `null` if the channel hasn't been created yet. In the case of a multi-part request, this is the initial channel, not the different parts in the multi-part request. **Requires elevated privileges to access.**

--- a/files/en-us/web/api/xmlhttprequest/error_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/error_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.error_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `error` event is fired when the request encountered an error.
 

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.getAllResponseHeaders
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} method
 **`getAllResponseHeaders()`** returns all the response

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.getResponseHeader
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{DOMxRef("XMLHttpRequest")}} method
 **`getResponseHeader()`** returns the string containing the

--- a/files/en-us/web/api/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("notservice")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 `XMLHttpRequest` (XHR) objects are used to interact with servers. You can retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just part of a page without disrupting what the user is doing.
 

--- a/files/en-us/web/api/xmlhttprequest/load_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/load_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.load_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `load` event is fired when an {{domxref("XMLHttpRequest")}} transaction completes successfully.
 

--- a/files/en-us/web/api/xmlhttprequest/loadend_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/loadend_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.loadend_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`loadend`** event is fired when a request has completed, whether successfully (after {{domxref("XMLHttpRequest/load_event", "load")}}) or unsuccessfully (after {{domxref("XMLHttpRequest/abort_event", "abort")}} or {{domxref("XMLHttpRequest/error_event", "error")}}).
 

--- a/files/en-us/web/api/xmlhttprequest/loadstart_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/loadstart_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.loadstart_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`loadstart`** event is fired when a request has started to load data.
 

--- a/files/en-us/web/api/xmlhttprequest/mozanon/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozanon/index.md
@@ -7,6 +7,6 @@ status:
   - non-standard
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 **`XMLHttpRequest.mozAnon`** is a boolean. If true, the request will be sent without cookies or authentication headers.

--- a/files/en-us/web/api/xmlhttprequest/mozbackgroundrequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozbackgroundrequest/index.md
@@ -7,7 +7,7 @@ status:
   - non-standard
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 > **Note:** This method is not available from Web content. It requires elevated privileges to access.
 

--- a/files/en-us/web/api/xmlhttprequest/mozsystem/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozsystem/index.md
@@ -7,6 +7,6 @@ status:
   - non-standard
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 **`mozSystem`** is a boolean. If true, the same origin policy is not enforced on the request.

--- a/files/en-us/web/api/xmlhttprequest/open/index.md
+++ b/files/en-us/web/api/xmlhttprequest/open/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.open
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} method **`open()`**
 initializes a newly-created request, or re-initializes an existing one.

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.overrideMimeType
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} method
 **`overrideMimeType()`** specifies a MIME type other than the

--- a/files/en-us/web/api/xmlhttprequest/progress_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/progress_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.progress_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`progress`** event is fired periodically when a request receives more data.
 

--- a/files/en-us/web/api/xmlhttprequest/readystate/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystate/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.readyState
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **XMLHttpRequest.readyState** property returns the state an XMLHttpRequest client is in. An XHR client exists in one of the following states:
 

--- a/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.readystatechange_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `readystatechange` event is fired whenever the {{domxref("XMLHttpRequest.readyState", "readyState")}} property of the {{domxref("XMLHttpRequest")}} changes.
 

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.response
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}}
 **`response`** property returns the response's body content as

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.responseText
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The read-only {{domxref("XMLHttpRequest")}} property
 **`responseText`** returns the text received from a server

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.responseType
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} property
 **`responseType`** is an enumerated string value specifying

--- a/files/en-us/web/api/xmlhttprequest/responseurl/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responseurl/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.responseURL
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The read-only **`XMLHttpRequest.responseURL`** property returns the serialized URL of the response or the empty string if the URL is `null`. If the URL is returned, any URL fragment present in the URL will be stripped away. The value of `responseURL` will be the final URL obtained after any redirects.
 

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.responseXML
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`XMLHttpRequest.responseXML`** read-only property returns
 a {{domxref("Document")}} containing the HTML or XML retrieved by the request; or

--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.send
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} method
 **`send()`** sends the request to the server.

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.XMLHttpRequest.setRequestHeader
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} method **`setRequestHeader()`** sets the value of an HTTP request header.
 When using `setRequestHeader()`, you must call it after calling {{domxref("XMLHttpRequest.open", "open()")}}, but before calling {{domxref("XMLHttpRequest.send", "send()")}}.

--- a/files/en-us/web/api/xmlhttprequest/status/index.md
+++ b/files/en-us/web/api/xmlhttprequest/status/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.status
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The read-only **`XMLHttpRequest.status`** property returns the numerical HTTP [status code](/en-US/docs/Web/HTTP/Status) of the `XMLHttpRequest`'s response.
 

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.statusText
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The read-only **`XMLHttpRequest.statusText`** property returns a string containing the response's status message as returned by the HTTP server. Unlike [`XMLHTTPRequest.status`](/en-US/docs/Web/API/XMLHttpRequest/status) which indicates a numerical status code, this property contains the _text_ of the response status, such as "OK" or "Not Found". If the request's [`readyState`](/en-US/docs/Web/API/XMLHttpRequest/readyState) is in `UNSENT` or `OPENED` state, the value of `statusText` will be an empty string.
 

--- a/files/en-us/web/api/xmlhttprequest/timeout/index.md
+++ b/files/en-us/web/api/xmlhttprequest/timeout/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.timeout
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`XMLHttpRequest.timeout`** property is an `unsigned long` representing the number of milliseconds a request can take before automatically being terminated. The default value is 0, which means there is no timeout. Timeout shouldn't be used for synchronous XMLHttpRequests requests used in a {{Glossary('document environment')}} or it will throw an `InvalidAccessError` exception. When a timeout happens, a [timeout](/en-US/docs/Web/API/XMLHttpRequest/timeout_event) event is fired.
 

--- a/files/en-us/web/api/xmlhttprequest/timeout_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/timeout_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.timeout_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`timeout`** event is fired when progression is terminated due to preset time expiring.
 

--- a/files/en-us/web/api/xmlhttprequest/upload/index.md
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.upload
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The {{domxref("XMLHttpRequest")}} `upload` property returns an {{domxref("XMLHttpRequestUpload")}} object that can be observed to monitor an upload's progress.
 

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.XMLHttpRequest.withCredentials
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`XMLHttpRequest.withCredentials`** property is a boolean value that indicates whether or not cross-site `Access-Control` requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting `withCredentials` has no effect on same-origin requests.
 

--- a/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.XMLHttpRequest.XMLHttpRequest
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`XMLHttpRequest()`** constructor
 creates a new {{domxref("XMLHttpRequest")}}.

--- a/files/en-us/web/api/xmlhttprequest_api/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/index.md
@@ -6,7 +6,7 @@ browser-compat: api.XMLHttpRequest
 spec-urls: https://xhr.spec.whatwg.org/
 ---
 
-{{DefaultAPISidebar("XMLHttpRequest API")}} {{AvailableInWorkers("notservice")}}
+{{DefaultAPISidebar("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **XMLHttpRequest API** enables web apps to make HTTP requests to web servers and receive the responses programmatically using JavaScript. This in turn enables a website to update just part of a page with data from the server, rather than having to navigate to a whole new page. This practice is also sometimes known as {{glossary("Ajax")}}.
 

--- a/files/en-us/web/api/xmlhttprequesteventtarget/index.md
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.XMLHttpRequestEventTarget
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 `XMLHttpRequestEventTarget` is the interface that describes the event handlers shared on {{domxref("XMLHttpRequest")}} and {{domxref("XMLHttpRequestUpload")}}.
 

--- a/files/en-us/web/api/xmlhttprequestupload/abort_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/abort_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequestUpload.abort_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `abort` event is fired at {{domxref("XMLHttpRequestUpload")}} when a request has been aborted, for example because the program called {{domxref("XMLHttpRequest.abort()")}}.
 

--- a/files/en-us/web/api/xmlhttprequestupload/error_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/error_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequestUpload.error_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `error` event is fired when the request encountered an error.
 

--- a/files/en-us/web/api/xmlhttprequestupload/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.XMLHttpRequestUpload
 ---
 
-{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("notservice")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`XMLHttpRequestUpload`** interface represents the upload process for a specific {{domxref("XMLHttpRequest")}}. It is an _opaque_ object that represents the underlying, browser-dependent, upload process. It is an {{domxref("XMLHttpRequestEventTarget")}} and can be obtained by calling {{domxref("XMLHttpRequest.upload")}}.
 

--- a/files/en-us/web/api/xmlhttprequestupload/load_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/load_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequest.load_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The `load` event is fired when an {{domxref("XMLHttpRequestUpload")}} transaction completes successfully.
 

--- a/files/en-us/web/api/xmlhttprequestupload/load_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/load_event/index.md
@@ -3,7 +3,7 @@ title: "XMLHttpRequestUpload: load event"
 short-title: load
 slug: Web/API/XMLHttpRequestUpload/load_event
 page-type: web-api-event
-browser-compat: api.XMLHttpRequest.load_event
+browser-compat: api.XMLHttpRequestUpload.load_event
 ---
 
 {{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}

--- a/files/en-us/web/api/xmlhttprequestupload/loadend_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/loadend_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequestUpload.loadend_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`loadend`** event is fired when a request has completed, whether successfully (after {{domxref("XMLHttpRequestUpload/load_event", "load")}}) or unsuccessfully (after {{domxref("XMLHttpRequestUpload/abort_event", "abort")}} or {{domxref("XMLHttpRequestUpload/error_event", "error")}}).
 

--- a/files/en-us/web/api/xmlhttprequestupload/loadstart_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/loadstart_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequestUpload.loadstart_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`loadstart`** event is fired when a request has started to load data.
 

--- a/files/en-us/web/api/xmlhttprequestupload/progress_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/progress_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequestUpload.progress_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`progress`** event is fired periodically when a request receives more data.
 

--- a/files/en-us/web/api/xmlhttprequestupload/timeout_event/index.md
+++ b/files/en-us/web/api/xmlhttprequestupload/timeout_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.XMLHttpRequestUpload.timeout_event
 ---
 
-{{APIRef("XMLHttpRequest API")}}
+{{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
 The **`timeout`** event is fired when progression is terminated due to preset time expiring.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

the `XMLHttpRequest`,`XMLHttpRequestUpload`,`XMLHttpRequestEventTarget` interfaces of XMLHttpRequest API is available to Window, DedicatedWorker, SharedWorker, expect for ServiceWorker

so the usage of {{AvailableInWorkers("window_and_worker_except_service")}} can be added to better reflect its available scope

it also fix a incorrect *browser-compat* key of `XMLHttpRequestUpload.load_event`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

see the spec https://xhr.spec.whatwg.org/

part of the #31675

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
