### PR TITLE
fix: replace the broken link to SVG interface reference

### DIFF
--- a/files/en-us/web/svg/attribute/index.md
+++ b/files/en-us/web/svg/attribute/index.md
@@ -529,4 +529,4 @@ Below is a list of all of the attributes available in SVG along with links to re
 
 - [SVG element reference](/en-US/docs/Web/SVG/Element)
 - [SVG Tutorial](/en-US/docs/Web/SVG/Tutorial)
-- [SVG interface reference](/en-US/docs/Web/API/Document_Object_Model#svg_interfaces)
+- [SVG interface reference](/en-US/docs/Web/API/SVG_API#interfaces)


### PR DESCRIPTION
### Description

replace the broken link to SVG interface reference
