### PR TITLE
Simplify console examples

### DIFF
--- a/files/en-us/web/api/console/count_static/index.md
+++ b/files/en-us/web/api/console/count_static/index.md
@@ -31,17 +31,13 @@ None ({{jsxref("undefined")}}).
 For example, given code like this:
 
 ```js
-let user = "";
-
-function greet() {
+function greet(user) {
   console.count();
   return `hi ${user}`;
 }
 
-user = "bob";
-greet();
-user = "alice";
-greet();
+greet("bob");
+greet("alice");
 greet();
 console.count();
 ```
@@ -60,18 +56,14 @@ The label is displayed as `default` because no explicit label was supplied.
 If we pass the `user` variable as the `label` argument to the first invocation of `console.count()`, and the string "alice" to the second:
 
 ```js
-let user = "";
-
-function greet() {
+function greet(user) {
   console.count(user);
   return `hi ${user}`;
 }
 
-user = "bob";
-greet();
-user = "alice";
-greet();
-greet();
+greet("bob");
+greet("alice");
+greet("alice");
 console.count("alice");
 ```
 

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -31,18 +31,14 @@ None ({{jsxref("undefined")}}).
 For example, given code like this:
 
 ```js
-let user = "";
-
-function greet() {
+function greet(user) {
   console.count();
   return `hi ${user}`;
 }
 
-user = "bob";
-greet();
-user = "alice";
-greet();
-greet();
+greet("bob");
+greet("alice");
+greet("alice");
 console.count();
 console.countReset();
 ```
@@ -62,18 +58,15 @@ Note that the call to `console.counterReset()` resets the value of the default c
 If we pass the `user` variable as the `label` argument with the string "bob" to the first invocation of `console.count()`, and the string "alice" to the second:
 
 ```js
-let user = "";
-
-function greet() {
+function greet(user) {
   console.count(user);
   return `hi ${user}`;
 }
 
-user = "bob";
-greet();
-user = "alice";
-greet();
-greet();
+user = ;
+greet("bob");
+greet("bob");
+greet("bob");
 console.countReset("bob");
 console.count("alice");
 ```

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -63,7 +63,6 @@ function greet(user) {
   return `hi ${user}`;
 }
 
-user = ;
 greet("bob");
 greet("bob");
 greet("bob");

--- a/files/en-us/web/api/console/countreset_static/index.md
+++ b/files/en-us/web/api/console/countreset_static/index.md
@@ -64,8 +64,8 @@ function greet(user) {
 }
 
 greet("bob");
-greet("bob");
-greet("bob");
+greet("alice");
+greet("alice");
 console.countReset("bob");
 console.count("alice");
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Simplify the examples for the `console.count` and `console.countReset` methods.

### Motivation

Reading these docs, it was distracting to see the mutation of a higher scoped variable that was then referenced in the function rather than simply passing the string to the function. This revision results in a shorter example and is easier to follow in my opinion.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
