### PR TITLE
Removes unnecessary semicolon in js private_properties docs

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_properties/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_properties/index.md
@@ -62,7 +62,7 @@ It is a syntax error to refer to `#` names from outside of the class. It is also
 class ClassWithPrivateField {
   #privateField;
 
-  constructor() {;
+  constructor() {
     delete this.#privateField; // Syntax error
     this.#undeclaredField = 42; // Syntax error
   }


### PR DESCRIPTION
Removes unnecessary semicolon

### Description

I just found a semicolon that is syntactically correct bust most likely considered unnecessary as it is placed directly behind the opening brace (`constructor() {;`).

### Additional details

Found in the first code block in the description of private properties in javascript:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties#description
