### PR TITLE
Change module in example code to mod_mime

### DIFF
--- a/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
@@ -160,7 +160,7 @@ Associates media types with one or more extensions to make sure the resources wi
 Servers should use `text/javascript` for JavaScript resources as indicated in the [HTML specification](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages)
 
 ```apacheconf
-<IfModule mod_expires.c>
+<IfModule mod_mime.c>
   # Data interchange
     AddType application/atom+xml      atom
     AddType application/json          json map topojson


### PR DESCRIPTION
### Description

The example code didn’t work for me because it checked for the wrong module (`mod_expires`). It should be using `mod_mime` to set the MIME types.

### Motivation

The example code to set MIME types will work again.