### PR TITLE
Correct mimeype for mp4 video

### DIFF
--- a/files/en-us/web/api/mediarecorder/istypesupported_static/index.md
+++ b/files/en-us/web/api/mediarecorder/istypesupported_static/index.md
@@ -37,7 +37,7 @@ const types = [
   "video/webm;codecs=daala",
   "video/webm;codecs=h264",
   "audio/webm;codecs=opus",
-  "video/mpeg",
+  "video/mp4",
 ];
 
 for (const type of types) {


### PR DESCRIPTION
video/mpeg is not a valid mimetype - it's `video/mp4`. Specifically in the context of MediaRecorder, `video/mp4` is what Safari supports, and no browsers will react to `video/mpeg`

According to [RFC 4337](http://www.rfc-editor.org/rfc/rfc4337.txt) § 2, video/mp4 is indeed the correct Content-Type for MPEG-4 video.