### PR TITLE
fix(svg attributes): Remove the element list and reorder sections (for attributes u-z )

### DIFF
--- a/files/en-us/web/svg/attribute/u1/index.md
+++ b/files/en-us/web/svg/attribute/u1/index.md
@@ -13,6 +13,8 @@ The **`u1`** attribute specifies list of {{Glossary("Unicode")}} characters (ref
 
 If a given Unicode character within the set has multiple corresponding `<glyph>` elements (i.e., there are multiple `<glyph>` elements with the same `unicode` attribute value but different {{SVGAttr("glyph-name")}} values), then all such glyphs are included in the set. Comma is the separator character; thus, to kern a comma, specify the comma as part of a range of Unicode characters or as a glyph name using the {{SVGAttr("g1")}} attribute. The total set of possible first glyphs in the kerning pair is the union of glyphs specified by the `u1` and `g1` attributes.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("hkern")}}

--- a/files/en-us/web/svg/attribute/u1/index.md
+++ b/files/en-us/web/svg/attribute/u1/index.md
@@ -18,7 +18,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("hkern")}}
 - {{SVGElement("vkern")}}
 
-## Context notes
+## Usage notes
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/u1/index.md
+++ b/files/en-us/web/svg/attribute/u1/index.md
@@ -9,7 +9,7 @@ browser-compat: svg.elements.hkern.u1
 
 {{SVGRef}}{{Deprecated_Header}}
 
-The **`u1`** attribute specifies list of {{Glossary("Unicode")}} characters (refer to the description of the {{SVGAttr("unicode")}} attribute of the {{SVGElement("glyph")}} element for a description of how to express individual Unicode characters) and/or ranges of Unicode characters, which identify a set of possible first {{Glossary("glyphs")}} in a kerning pair.
+The **`u1`** attribute specifies list of {{Glossary("Unicode")}} characters (refer to the description of the {{SVGAttr("unicode")}} attribute of the {{SVGElement("glyph")}} element for a description of how to express individual Unicode characters) and/or ranges of Unicode characters, which identify a set of possible first {{Glossary("glyph")}} in a kerning pair.
 
 If a given Unicode character within the set has multiple corresponding `<glyph>` elements (i.e., there are multiple `<glyph>` elements with the same `unicode` attribute value but different {{SVGAttr("glyph-name")}} values), then all such glyphs are included in the set. Comma is the separator character; thus, to kern a comma, specify the comma as part of a range of Unicode characters or as a glyph name using the {{SVGAttr("g1")}} attribute. The total set of possible first glyphs in the kerning pair is the union of glyphs specified by the `u1` and `g1` attributes.
 

--- a/files/en-us/web/svg/attribute/u2/index.md
+++ b/files/en-us/web/svg/attribute/u2/index.md
@@ -18,7 +18,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("hkern")}}
 - {{SVGElement("vkern")}}
 
-## Context notes
+## Usage notes
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/u2/index.md
+++ b/files/en-us/web/svg/attribute/u2/index.md
@@ -9,7 +9,7 @@ browser-compat: svg.elements.hkern.u2
 
 {{SVGRef}}{{Deprecated_Header}}
 
-The **`u2`** attribute specifies list of {{Glossary("Unicode")}} characters (refer to the description of the {{SVGAttr("unicode")}} attribute of the {{SVGElement("glyph")}} element for a description of how to express individual Unicode characters) and/or ranges of Unicode characters, which identify a set of possible second {{Glossary("glyphs")}} in a kerning pair.
+The **`u2`** attribute specifies list of {{Glossary("Unicode")}} characters (refer to the description of the {{SVGAttr("unicode")}} attribute of the {{SVGElement("glyph")}} element for a description of how to express individual Unicode characters) and/or ranges of Unicode characters, which identify a set of possible second {{Glossary("glyph")}} in a kerning pair.
 
 If a given Unicode character within the set has multiple corresponding `<glyph>` elements (i.e., there are multiple `<glyph>` elements with the same `unicode` attribute value but different {{SVGAttr("glyph-name")}} values), then all such glyphs are included in the set. Comma is the separator character; thus, to kern a comma, specify the comma as part of a range of Unicode characters or as a glyph name using the {{SVGAttr("g2")}} attribute. The total set of possible second glyphs in the kerning pair is the union of glyphs specified by the `u2` and `g2` attributes.
 

--- a/files/en-us/web/svg/attribute/u2/index.md
+++ b/files/en-us/web/svg/attribute/u2/index.md
@@ -13,6 +13,8 @@ The **`u2`** attribute specifies list of {{Glossary("Unicode")}} characters (ref
 
 If a given Unicode character within the set has multiple corresponding `<glyph>` elements (i.e., there are multiple `<glyph>` elements with the same `unicode` attribute value but different {{SVGAttr("glyph-name")}} values), then all such glyphs are included in the set. Comma is the separator character; thus, to kern a comma, specify the comma as part of a range of Unicode characters or as a glyph name using the {{SVGAttr("g2")}} attribute. The total set of possible second glyphs in the kerning pair is the union of glyphs specified by the `u2` and `g2` attributes.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("hkern")}}

--- a/files/en-us/web/svg/attribute/unicode-bidi/index.md
+++ b/files/en-us/web/svg/attribute/unicode-bidi/index.md
@@ -11,6 +11,8 @@ The **`unicode-bidi`** attribute specifies how the accumulation of the backgroun
 
 > **Note:** As a presentation attribute, `unicode-bidi` can be used as a CSS property. See the [CSS `unicode-bidi`](/en-US/docs/Web/CSS/unicode-bidi) property for more information.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("textPath")}}

--- a/files/en-us/web/svg/attribute/unicode-bidi/index.md
+++ b/files/en-us/web/svg/attribute/unicode-bidi/index.md
@@ -18,7 +18,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("tref")}}
 - {{SVGElement("tspan")}}
 
-## Context notes
+## Usage notes
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/unicode/index.md
+++ b/files/en-us/web/svg/attribute/unicode/index.md
@@ -17,9 +17,9 @@ It is often useful to refer to characters using XML character references express
 
 The `unicode` attribute contributes to the process for deciding which glyph(s) are used to represent which character(s).
 
-You can use this attribute with the following SVG elements:
+## Elements
 
-- {{SVGElement("glyph")}}
+You can use this attribute with the {{SVGElement("glyph")}} SVG element.
 
 ## Usage notes
 

--- a/files/en-us/web/svg/attribute/unicode/index.md
+++ b/files/en-us/web/svg/attribute/unicode/index.md
@@ -21,7 +21,7 @@ You can use this attribute with the following SVG elements:
 
 - {{SVGElement("glyph")}}
 
-## Context notes
+## Usage notes
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/vector-effect/index.md
+++ b/files/en-us/web/svg/attribute/vector-effect/index.md
@@ -61,9 +61,9 @@ You can use this attribute with the following SVG elements:
 - `fixed-position`
   - : This value specifies a special user coordinate system used by the element and its descendants. The position of user coordinate system is fixed in spite of any transformation changes from a host coordinate space. However, it does not specify the suppression of rotation, skew and scaling. When this vector effect and the {{SVGAttr("transform")}} property are defined at the same time, that property is consumed for this effect.
 
-## Example
+## Examples
 
-### Example: vector-effect="non-scaling-stroke"
+### Setting `vector-effect` as `non-scaling-stroke`
 
 ```html
 <svg viewBox="0 0 500 240">
@@ -95,7 +95,7 @@ You can use this attribute with the following SVG elements:
 
 #### Result
 
-{{EmbedLiveSample("Example_vector-effectnon-scaling-stroke", 550, 300)}}
+{{EmbedLiveSample("Setting vector-effect as non-scaling-stroke", 550, 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/vector-effect/index.md
+++ b/files/en-us/web/svg/attribute/vector-effect/index.md
@@ -11,6 +11,8 @@ The **`vector-effect`** property specifies the vector effect to use when drawing
 
 > **Note:** As a presentation attribute, `vector-effect` can be used as a CSS property.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("circle")}}

--- a/files/en-us/web/svg/attribute/vector-effect/index.md
+++ b/files/en-us/web/svg/attribute/vector-effect/index.md
@@ -97,7 +97,7 @@ You can use this attribute with the following SVG elements:
 
 #### Result
 
-{{EmbedLiveSample("Setting vector-effect as non-scaling-stroke", 550, 300)}}
+{{EmbedLiveSample("Setting vector-effect as non-scaling-stroke", 550, 330)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -237,6 +237,7 @@ svg:not(:root) {
 }
 ```
 
+The code snippet below includes three  {{SVGElement("svg")}}s  with different `viewbox` attribute values and identical {{SVGElement("rect")}} and {{SVGElement("circle")}} descendants creating very different results. The size of `<rect>` is defined using relative units, so the visual size of the square produced looks unchanged regardless of the `viewBox` value. The radius length {{SVGAttr("r")}} attribute of the `<circle>` is the same in each case, but this user unit value is resolved against the size defined in the `viewBox`, producing different results in each case.
 ```html
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <!--
@@ -287,7 +288,7 @@ svg:not(:root) {
 
 {{EmbedLiveSample("Examples", '100%', 200)}}
 
-The exact effect of this attribute is influenced by the {{ SVGAttr("preserveAspectRatio") }} attribute.
+The user units of `r="4"` are resolved against the `viewBox` sizes, creating dramatically different circle sizes. The exact effect of the `viewbox` attribute is influenced by the {{ SVGAttr("preserveAspectRatio") }} attribute.
 
 > **Note:** Values for `width` or `height` lower or equal to `0` disable rendering of the element.
 

--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -11,81 +11,7 @@ The **`viewBox`** attribute defines the position and dimension, in user space, o
 
 The value of the `viewBox` attribute is a list of four numbers: `min-x`, `min-y`, `width` and `height`. The numbers `min-x` and `min-y` represent the top left coordinates of the viewport. The numbers `width` and `height` represent its dimensions. These numbers, which are separated by whitespace and/or a comma, specify a rectangle in user space which is mapped to the bounds of the viewport established for the associated SVG element (not the [browser viewport](/en-US/docs/Glossary/Viewport)).
 
-You can use this attribute with the following SVG elements:
-
-- {{SVGElement("marker")}}
-- {{SVGElement("pattern")}}
-- {{SVGElement("svg")}}
-- {{SVGElement("symbol")}}
-- {{SVGElement("view")}}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-  vertical-align: top;
-}
-svg:not(:root) {
-  display: inline-block;
-}
-```
-
-```html
-<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <!--
-  with relative unit such as percentage, the visual size
-  of the square looks unchanged regardless of the viewBox
-  -->
-  <rect x="0" y="0" width="100%" height="100%" />
-
-  <!--
-  with a large viewBox the circle looks small
-  as it is using user units for the r attribute:
-  4 resolved against 100 as set in the viewBox
-  -->
-  <circle cx="50%" cy="50%" r="4" fill="white" />
-</svg>
-
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <!--
-  with relative unit such as percentage, the visual size
-  of the square looks unchanged regardless of the viewBox
-  -->
-  <rect x="0" y="0" width="100%" height="100%" />
-
-  <!--
-  with a small viewBox the circle looks large
-  as it is using user units for the r attribute:
-  4 resolved against 10 as set in the viewBox
-  -->
-  <circle cx="50%" cy="50%" r="4" fill="white" />
-</svg>
-
-<svg viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
-  <!--
-  The point of coordinate 0,0 is now in the center of the viewport,
-  and 100% is still resolve to a width or height of 10 user units so
-  the rectangle looks shifted to the bottom/right corner of the viewport
-  -->
-  <rect x="0" y="0" width="100%" height="100%" />
-
-  <!--
-  With the point of coordinate 0,0 in the center of the viewport the
-  value 50% is resolve to 5 which means the center of the circle is
-  in the bottom/right corner of the viewport.
-  -->
-  <circle cx="50%" cy="50%" r="4" fill="white" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
-
-The exact effect of this attribute is influenced by the {{ SVGAttr("preserveAspectRatio") }} attribute.
-
-> **Note:** Values for `width` or `height` lower or equal to `0` disable rendering of the element.
+You can use this attribute with the SVG elements described in the sections below.
 
 ## marker
 
@@ -296,6 +222,74 @@ For {{SVGElement('view')}}, `viewBox` defines the position and dimension for the
     </tr>
   </tbody>
 </table>
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+  vertical-align: top;
+}
+svg:not(:root) {
+  display: inline-block;
+}
+```
+
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!--
+  with relative unit such as percentage, the visual size
+  of the square looks unchanged regardless of the viewBox
+  -->
+  <rect x="0" y="0" width="100%" height="100%" />
+
+  <!--
+  with a large viewBox the circle looks small
+  as it is using user units for the r attribute:
+  4 resolved against 100 as set in the viewBox
+  -->
+  <circle cx="50%" cy="50%" r="4" fill="white" />
+</svg>
+
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <!--
+  with relative unit such as percentage, the visual size
+  of the square looks unchanged regardless of the viewBox
+  -->
+  <rect x="0" y="0" width="100%" height="100%" />
+
+  <!--
+  with a small viewBox the circle looks large
+  as it is using user units for the r attribute:
+  4 resolved against 10 as set in the viewBox
+  -->
+  <circle cx="50%" cy="50%" r="4" fill="white" />
+</svg>
+
+<svg viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
+  <!--
+  The point of coordinate 0,0 is now in the center of the viewport,
+  and 100% is still resolve to a width or height of 10 user units so
+  the rectangle looks shifted to the bottom/right corner of the viewport
+  -->
+  <rect x="0" y="0" width="100%" height="100%" />
+
+  <!--
+  With the point of coordinate 0,0 in the center of the viewport the
+  value 50% is resolve to 5 which means the center of the circle is
+  in the bottom/right corner of the viewport.
+  -->
+  <circle cx="50%" cy="50%" r="4" fill="white" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
+
+The exact effect of this attribute is influenced by the {{ SVGAttr("preserveAspectRatio") }} attribute.
+
+> **Note:** Values for `width` or `height` lower or equal to `0` disable rendering of the element.
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -11,9 +11,11 @@ The **`viewBox`** attribute defines the position and dimension, in user space, o
 
 The value of the `viewBox` attribute is a list of four numbers: `min-x`, `min-y`, `width` and `height`. The numbers `min-x` and `min-y` represent the top left coordinates of the viewport. The numbers `width` and `height` represent its dimensions. These numbers, which are separated by whitespace and/or a comma, specify a rectangle in user space which is mapped to the bounds of the viewport established for the associated SVG element (not the [browser viewport](/en-US/docs/Glossary/Viewport)).
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## marker
+### `<marker>`
 
 For {{SVGElement('marker')}}, `viewBox` defines the position and dimension for the content of the `<marker>` element.
 
@@ -55,7 +57,7 @@ For {{SVGElement('marker')}}, `viewBox` defines the position and dimension for t
   </tbody>
 </table>
 
-## pattern
+### `<pattern>`
 
 For {{SVGElement('pattern')}}, `viewBox` defines the position and dimension for the content of the pattern tile.
 
@@ -97,7 +99,7 @@ For {{SVGElement('pattern')}}, `viewBox` defines the position and dimension for 
   </tbody>
 </table>
 
-## svg
+### `<svg>`
 
 For {{SVGElement('svg')}}, `viewBox` defines the position and dimension for the content of the `<svg>` element.
 
@@ -139,7 +141,7 @@ For {{SVGElement('svg')}}, `viewBox` defines the position and dimension for the 
   </tbody>
 </table>
 
-## symbol
+### `<symbol>`
 
 For {{SVGElement('symbol')}}, `viewBox` defines the position and dimension for the content of the `<symbol>` element.
 
@@ -181,7 +183,7 @@ For {{SVGElement('symbol')}}, `viewBox` defines the position and dimension for t
   </tbody>
 </table>
 
-## view
+### `<view>`
 
 For {{SVGElement('view')}}, `viewBox` defines the position and dimension for the content of the `<view>` element.
 
@@ -241,48 +243,17 @@ The code snippet below includes three {{SVGElement("svg")}}s with different `vie
 
 ```html
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <!--
-  with relative unit such as percentage, the visual size
-  of the square looks unchanged regardless of the viewBox
-  -->
   <rect x="0" y="0" width="100%" height="100%" />
-
-  <!--
-  with a large viewBox the circle looks small
-  as it is using user units for the r attribute:
-  4 resolved against 100 as set in the viewBox
-  -->
   <circle cx="50%" cy="50%" r="4" fill="white" />
 </svg>
 
 <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <!--
-  with relative unit such as percentage, the visual size
-  of the square looks unchanged regardless of the viewBox
-  -->
   <rect x="0" y="0" width="100%" height="100%" />
-
-  <!--
-  with a small viewBox the circle looks large
-  as it is using user units for the r attribute:
-  4 resolved against 10 as set in the viewBox
-  -->
   <circle cx="50%" cy="50%" r="4" fill="white" />
 </svg>
 
 <svg viewBox="-5 -5 10 10" xmlns="http://www.w3.org/2000/svg">
-  <!--
-  The point of coordinate 0,0 is now in the center of the viewport,
-  and 100% is still resolve to a width or height of 10 user units so
-  the rectangle looks shifted to the bottom/right corner of the viewport
-  -->
   <rect x="0" y="0" width="100%" height="100%" />
-
-  <!--
-  With the point of coordinate 0,0 in the center of the viewport the
-  value 50% is resolve to 5 which means the center of the circle is
-  in the bottom/right corner of the viewport.
-  -->
   <circle cx="50%" cy="50%" r="4" fill="white" />
 </svg>
 ```

--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -237,7 +237,8 @@ svg:not(:root) {
 }
 ```
 
-The code snippet below includes three  {{SVGElement("svg")}}s  with different `viewbox` attribute values and identical {{SVGElement("rect")}} and {{SVGElement("circle")}} descendants creating very different results. The size of `<rect>` is defined using relative units, so the visual size of the square produced looks unchanged regardless of the `viewBox` value. The radius length {{SVGAttr("r")}} attribute of the `<circle>` is the same in each case, but this user unit value is resolved against the size defined in the `viewBox`, producing different results in each case.
+The code snippet below includes three {{SVGElement("svg")}}s with different `viewbox` attribute values and identical {{SVGElement("rect")}} and {{SVGElement("circle")}} descendants creating very different results. The size of `<rect>` is defined using relative units, so the visual size of the square produced looks unchanged regardless of the `viewBox` value. The radius length {{SVGAttr("r")}} attribute of the `<circle>` is the same in each case, but this user unit value is resolved against the size defined in the `viewBox`, producing different results in each case.
+
 ```html
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <!--

--- a/files/en-us/web/svg/attribute/visibility/index.md
+++ b/files/en-us/web/svg/attribute/visibility/index.md
@@ -36,7 +36,35 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("tspan")}}
 - {{SVGElement("video")}}
 
-## Example
+## Usage notes
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Value</th>
+      <td>
+        <code>visible</code> | <code>hidden</code> | <code>collapse</code>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Default value</th>
+      <td><code>visible</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Animatable</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
+
+- `visible`
+  - : This value indicates that the element will be painted.
+- `hidden`
+  - : This value indicates that the element will not be painted. Though it is still part of the rendering tree, i.e. it may receive pointer events depending on the {{SVGAttr("pointer-events")}} attribute, may receive focus depending on the {{SVGAttr("tabindex")}} attribute, contributes to bounding box calculations and clipping paths, and does affect text layout.
+- `collapse`
+  - : This value is equal to `hidden`.
+
+## Examples
 
 ### Example 1
 
@@ -125,34 +153,6 @@ button.addEventListener("click", (evt) => {
 #### Result
 
 {{EmbedLiveSample("Example 2", "100%", "80")}}
-
-## Usage notes
-
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Value</th>
-      <td>
-        <code>visible</code> | <code>hidden</code> | <code>collapse</code>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Default value</th>
-      <td><code>visible</code></td>
-    </tr>
-    <tr>
-      <th scope="row">Animatable</th>
-      <td>Yes</td>
-    </tr>
-  </tbody>
-</table>
-
-- `visible`
-  - : This value indicates that the element will be painted.
-- `hidden`
-  - : This value indicates that the element will not be painted. Though it is still part of the rendering tree, i.e. it may receive pointer events depending on the {{SVGAttr("pointer-events")}} attribute, may receive focus depending on the {{SVGAttr("tabindex")}} attribute, contributes to bounding box calculations and clipping paths, and does affect text layout.
-- `collapse`
-  - : This value is equal to `hidden`.
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/visibility/index.md
+++ b/files/en-us/web/svg/attribute/visibility/index.md
@@ -18,12 +18,12 @@ Depending on the value of attribute {{SVGAttr("pointer-events")}}, graphics elem
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("a")}}
-- {{SVGElement("audio")}}
-- {{SVGElement("canvas")}}
+- `<audio>`
+- `<canvas>`
 - {{SVGElement("circle")}}
 - {{SVGElement("ellipse")}}
 - {{SVGElement("foreignObject")}}
-- {{SVGElement("iframe")}}
+- `<iframe>`
 - {{SVGElement("image")}}
 - {{SVGElement("line")}}
 - {{SVGElement("path")}}
@@ -34,7 +34,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tref")}}
 - {{SVGElement("tspan")}}
-- {{SVGElement("video")}}
+- `<video>`
 
 ## Usage notes
 

--- a/files/en-us/web/svg/attribute/visibility/index.md
+++ b/files/en-us/web/svg/attribute/visibility/index.md
@@ -15,6 +15,8 @@ Depending on the value of attribute {{SVGAttr("pointer-events")}}, graphics elem
 
 > **Note:** As a presentation attribute, `visibility` can be used as a CSS property. See the {{cssxref("visibility", "CSS visibility")}} property for more information.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("a")}}

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -863,6 +863,7 @@ svg {
   height: 100%;
 }
 ```
+This example includes three {{SVGElement("rect")}} elements with varied `width` attribute values.  The first `<rect>` has a `width="0"` set.  SVG elements with a width of `0` or less are not rendered. 
 
 ```html
 <svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -863,7 +863,8 @@ svg {
   height: 100%;
 }
 ```
-This example includes three {{SVGElement("rect")}} elements with varied `width` attribute values.  The first `<rect>` has a `width="0"` set.  SVG elements with a width of `0` or less are not rendered. 
+
+This example includes three {{SVGElement("rect")}} elements with varied `width` attribute values. The first `<rect>` has a `width="0"` set. SVG elements with a width of `0` or less are not rendered.
 
 ```html
 <svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -14,54 +14,7 @@ spec-urls:
 
 The **`width`** attribute defines the horizontal length of an element in the user coordinate system.
 
-You can use this attribute with the following SVG elements:
-
-- {{SVGElement('feBlend')}}
-- {{SVGElement('feColorMatrix')}}
-- {{SVGElement('feComponentTransfer')}}
-- {{SVGElement('feComposite')}}
-- {{SVGElement('feConvolveMatrix')}}
-- {{SVGElement('feDiffuseLighting')}}
-- {{SVGElement('feDisplacementMap')}}
-- {{SVGElement('feDropShadow')}}
-- {{SVGElement('feFlood')}}
-- {{SVGElement('feGaussianBlur')}}
-- {{SVGElement('feImage')}}
-- {{SVGElement('feMerge')}}
-- {{SVGElement('feMorphology')}}
-- {{SVGElement('feOffset')}}
-- {{SVGElement('feSpecularLighting')}}
-- {{SVGElement('feTile')}}
-- {{SVGElement('feTurbulence')}}
-- {{SVGElement('filter')}}
-- {{SVGElement('foreignObject')}}
-- {{SVGElement('image')}}
-- {{SVGElement('mask')}}
-- {{SVGElement('pattern')}}
-- {{SVGElement('rect')}}
-- {{SVGElement('svg')}}
-- {{SVGElement('use')}}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
-  <!-- With a width of 0 or less, nothing will be rendered -->
-  <rect x="0" y="0" width="0" height="90" />
-  <rect x="0" y="100" width="60" height="90" />
-  <rect x="0" y="200" width="100%" height="90" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## feBlend
 
@@ -900,6 +853,27 @@ For {{SVGElement('use')}}, `width` defines the horizontal length for the referen
 > **Note:** `width` has no effect on `use` elements, unless the element referenced has a [viewBox](/en-US/docs/Web/SVG/Attribute/viewBox) - i.e. they only have an effect when `use` refers to a `svg` or `symbol` element.
 
 > **Note:** Starting with SVG2, `width` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
+  <!-- With a width of 0 or less, nothing will be rendered -->
+  <rect x="0" y="0" width="0" height="90" />
+  <rect x="0" y="100" width="60" height="90" />
+  <rect x="0" y="200" width="100%" height="90" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -871,9 +871,9 @@ This example includes three {{SVGElement("rect")}} elements with varied `width` 
 ```html
 <svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
   <!-- With a width of 0 or less, nothing will be rendered -->
-  <rect x="0" y="0" width="0" height="90" />
-  <rect x="0" y="100" width="60" height="90" />
-  <rect x="0" y="200" width="100%" height="90" />
+  <rect x="0" y="0" width="0" height="90" fill="red" stroke-width="5" stroke="black" />
+  <rect x="0" y="100" width="60" height="90" fill="red" stroke-width="5" stroke="black" />
+  <rect x="0" y="200" width="100%" height="90" fill="red" stroke-width="5" stroke="black" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -871,9 +871,30 @@ This example includes three {{SVGElement("rect")}} elements with varied `width` 
 ```html
 <svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
   <!-- With a width of 0 or less, nothing will be rendered -->
-  <rect x="0" y="0" width="0" height="90" fill="red" stroke-width="5" stroke="black" />
-  <rect x="0" y="100" width="60" height="90" fill="red" stroke-width="5" stroke="black" />
-  <rect x="0" y="200" width="100%" height="90" fill="red" stroke-width="5" stroke="black" />
+  <rect
+    x="0"
+    y="0"
+    width="0"
+    height="90"
+    fill="red"
+    stroke-width="5"
+    stroke="black" />
+  <rect
+    x="0"
+    y="100"
+    width="60"
+    height="90"
+    fill="red"
+    stroke-width="5"
+    stroke="black" />
+  <rect
+    x="0"
+    y="200"
+    width="100%"
+    height="90"
+    fill="red"
+    stroke-width="5"
+    stroke="black" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -14,9 +14,11 @@ spec-urls:
 
 The **`width`** attribute defines the horizontal length of an element in the user coordinate system.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## feBlend
+### `<feBlend>`
 
 For {{SVGElement('feBlend')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -49,7 +51,7 @@ For {{SVGElement('feBlend')}}, `width` defines the horizontal length for the ren
   </tbody>
 </table>
 
-## feColorMatrix
+### `<feColorMatrix>`
 
 For {{SVGElement('feColorMatrix')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -82,7 +84,7 @@ For {{SVGElement('feColorMatrix')}}, `width` defines the horizontal length for t
   </tbody>
 </table>
 
-## feComponentTransfer
+### `<feComponentTransfer>`
 
 For {{SVGElement('feComponentTransfer')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -115,7 +117,7 @@ For {{SVGElement('feComponentTransfer')}}, `width` defines the horizontal length
   </tbody>
 </table>
 
-## feComposite
+### `<feComposite>`
 
 For {{SVGElement('feComposite')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -148,7 +150,7 @@ For {{SVGElement('feComposite')}}, `width` defines the horizontal length for the
   </tbody>
 </table>
 
-## feConvolveMatrix
+### `<feConvolveMatrix>`
 
 For {{SVGElement('feConvolveMatrix')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -181,7 +183,7 @@ For {{SVGElement('feConvolveMatrix')}}, `width` defines the horizontal length fo
   </tbody>
 </table>
 
-## feDiffuseLighting
+### `<feDiffuseLighting>`
 
 For {{SVGElement('feDiffuseLighting')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -214,7 +216,7 @@ For {{SVGElement('feDiffuseLighting')}}, `width` defines the horizontal length f
   </tbody>
 </table>
 
-## feDisplacementMap
+### `<feDisplacementMap>`
 
 For {{SVGElement('feDisplacementMap')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -247,7 +249,7 @@ For {{SVGElement('feDisplacementMap')}}, `width` defines the horizontal length f
   </tbody>
 </table>
 
-## feDropShadow
+### `<feDropShadow>`
 
 For {{SVGElement('feDropShadow')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -280,7 +282,7 @@ For {{SVGElement('feDropShadow')}}, `width` defines the horizontal length for th
   </tbody>
 </table>
 
-## feFlood
+### `<feFlood>`
 
 For {{SVGElement('feFlood')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -313,7 +315,7 @@ For {{SVGElement('feFlood')}}, `width` defines the horizontal length for the ren
   </tbody>
 </table>
 
-## feGaussianBlur
+### `<feGaussianBlur>`
 
 For {{SVGElement('feGaussianBlur')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -346,7 +348,7 @@ For {{SVGElement('feGaussianBlur')}}, `width` defines the horizontal length for 
   </tbody>
 </table>
 
-## feImage
+### `<feImage>`
 
 For {{SVGElement('feImage')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -379,7 +381,7 @@ For {{SVGElement('feImage')}}, `width` defines the horizontal length for the ren
   </tbody>
 </table>
 
-## feMerge
+### `<feMerge>`
 
 For {{SVGElement('feMerge')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -412,7 +414,7 @@ For {{SVGElement('feMerge')}}, `width` defines the horizontal length for the ren
   </tbody>
 </table>
 
-## feMorphology
+### `<feMorphology>`
 
 For {{SVGElement('feMorphology')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -445,7 +447,7 @@ For {{SVGElement('feMorphology')}}, `width` defines the horizontal length for th
   </tbody>
 </table>
 
-## feOffset
+### `<feOffset>`
 
 For {{SVGElement('feOffset')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -478,7 +480,7 @@ For {{SVGElement('feOffset')}}, `width` defines the horizontal length for the re
   </tbody>
 </table>
 
-## feSpecularLighting
+### `<feSpecularLighting>`
 
 For {{SVGElement('feSpecularLighting')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -511,7 +513,7 @@ For {{SVGElement('feSpecularLighting')}}, `width` defines the horizontal length 
   </tbody>
 </table>
 
-## feTile
+### `<feTile>`
 
 For {{SVGElement('feTile')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -544,7 +546,7 @@ For {{SVGElement('feTile')}}, `width` defines the horizontal length for the rend
   </tbody>
 </table>
 
-## feTurbulence
+### `<feTurbulence>`
 
 For {{SVGElement('feTurbulence')}}, `width` defines the horizontal length for the rendering area of the primitive.
 
@@ -577,7 +579,7 @@ For {{SVGElement('feTurbulence')}}, `width` defines the horizontal length for th
   </tbody>
 </table>
 
-## filter
+### `<filter>`
 
 For {{SVGElement('filter')}}, `width` defines the horizontal length for the rendering area of the filter.
 
@@ -610,7 +612,7 @@ For {{SVGElement('filter')}}, `width` defines the horizontal length for the rend
   </tbody>
 </table>
 
-## foreignObject
+### `<foreignObject>`
 
 For {{SVGElement('foreignObject')}}, `width` defines the horizontal length for the rendering area for the referenced document.
 
@@ -646,7 +648,7 @@ For {{SVGElement('foreignObject')}}, `width` defines the horizontal length for t
 
 > **Note:** Starting with SVG2, `width` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<foreignObject>`.
 
-## image
+### `<image>`
 
 For {{SVGElement('image')}}, `width` defines the horizontal length for the image.
 
@@ -682,7 +684,7 @@ For {{SVGElement('image')}}, `width` defines the horizontal length for the image
 
 > **Note:** Starting with SVG2, `width` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for images.
 
-## mask
+### `<mask>`
 
 For {{SVGElement('mask')}}, `width` defines the horizontal length of its area of effect. The exact effect of this attribute is influenced by the {{SVGAttr('maskUnits')}} attribute.
 
@@ -715,7 +717,7 @@ For {{SVGElement('mask')}}, `width` defines the horizontal length of its area of
   </tbody>
 </table>
 
-## pattern
+### `<pattern>`
 
 For {{SVGElement('pattern')}}, `width` defines the horizontal length of the tile pattern. The exact effect of this attribute is influenced by the {{SVGAttr('patternUnits')}} and {{SVGAttr('patternTransform')}} attributes.
 
@@ -742,7 +744,7 @@ For {{SVGElement('pattern')}}, `width` defines the horizontal length of the tile
   </tbody>
 </table>
 
-## rect
+### `<rect>`
 
 For {{SVGElement('rect')}}, `width` defines the horizontal length for the rectangle.
 
@@ -778,7 +780,7 @@ For {{SVGElement('rect')}}, `width` defines the horizontal length for the rectan
 
 > **Note:** Starting with SVG2, `width` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rectangles.
 
-## svg
+### `<svg>`
 
 For {{SVGElement('svg')}}, `width` defines the horizontal length for the rendering area of the SVG viewport.
 
@@ -816,7 +818,7 @@ For {{SVGElement('svg')}}, `width` defines the horizontal length for the renderi
 
 > **Note:** Starting with SVG2, `width` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<svg>`.
 
-## use
+### `<use>`
 
 For {{SVGElement('use')}}, `width` defines the horizontal length for the referenced element.
 

--- a/files/en-us/web/svg/attribute/word-spacing/index.md
+++ b/files/en-us/web/svg/attribute/word-spacing/index.md
@@ -59,7 +59,7 @@ svg {
 
 ```html
 <svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
-  <text y="20" word-spacing="2">Bigger spacing between words</text>
+  <text y="20" word-spacing="4">Bigger spacing between words</text>
   <text x="0" y="40" word-spacing="-0.5">Smaller spacing between words</text>
 </svg>
 ```

--- a/files/en-us/web/svg/attribute/word-spacing/index.md
+++ b/files/en-us/web/svg/attribute/word-spacing/index.md
@@ -44,7 +44,7 @@ You can use this attribute with the following SVG elements:
 For a description of the values, please refer to the [CSS `letter-spacing`](/en-US/docs/Web/CSS/letter-spacing#values) property.
 
 ## Examples
-
+This example includes two {{SVGElement("text")}} elements with different `word-spacing` values.  
 ```css hidden
 html,
 body,

--- a/files/en-us/web/svg/attribute/word-spacing/index.md
+++ b/files/en-us/web/svg/attribute/word-spacing/index.md
@@ -44,7 +44,9 @@ You can use this attribute with the following SVG elements:
 For a description of the values, please refer to the [CSS `letter-spacing`](/en-US/docs/Web/CSS/letter-spacing#values) property.
 
 ## Examples
-This example includes two {{SVGElement("text")}} elements with different `word-spacing` values.  
+
+This example includes two {{SVGElement("text")}} elements with different `word-spacing` values.
+
 ```css hidden
 html,
 body,

--- a/files/en-us/web/svg/attribute/word-spacing/index.md
+++ b/files/en-us/web/svg/attribute/word-spacing/index.md
@@ -15,6 +15,8 @@ If a \<length> is provided with one of the unit identifiers (e.g. .25em or 1%), 
 
 > **Note:** As a presentation attribute, `word-spacing` can be used as a CSS property. See the {{cssxref("word-spacing", "CSS word-spacing")}} property for more information.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("text")}}

--- a/files/en-us/web/svg/attribute/word-spacing/index.md
+++ b/files/en-us/web/svg/attribute/word-spacing/index.md
@@ -22,25 +22,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("tref")}}
 - {{SVGElement("tspan")}}
 
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
-  <text y="20" word-spacing="2">Bigger spacing between words</text>
-  <text x="0" y="40" word-spacing="-0.5">Smaller spacing between words</text>
-</svg>
-```
-
-{{EmbedLiveSample("Example", "250", "100")}}
-
 ## Usage notes
 
 <table class="properties">
@@ -61,6 +42,25 @@ svg {
 </table>
 
 For a description of the values, please refer to the [CSS `letter-spacing`](/en-US/docs/Web/CSS/letter-spacing#values) property.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
+  <text y="20" word-spacing="2">Bigger spacing between words</text>
+  <text x="0" y="40" word-spacing="-0.5">Smaller spacing between words</text>
+</svg>
+```
+
+{{EmbedLiveSample("Examples", "250", "100")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -17,9 +17,11 @@ spec-urls:
 
 The **`x`** attribute defines an x-axis coordinate in the user coordinate system.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## feBlend
+### `<feBlend>`
 
 For {{SVGElement('feBlend')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -52,7 +54,7 @@ For {{SVGElement('feBlend')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feColorMatrix
+### `<feColorMatrix>`
 
 For {{SVGElement('feColorMatrix')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -85,7 +87,7 @@ For {{SVGElement('feColorMatrix')}}, `x` defines the minimum x coordinate for th
   </tbody>
 </table>
 
-## feComponentTransfer
+### `<feComponentTransfer>`
 
 For {{SVGElement('feComponentTransfer')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -118,7 +120,7 @@ For {{SVGElement('feComponentTransfer')}}, `x` defines the minimum x coordinate 
   </tbody>
 </table>
 
-## feComposite
+### `<feComposite>`
 
 For {{SVGElement('feComposite')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -151,7 +153,7 @@ For {{SVGElement('feComposite')}}, `x` defines the minimum x coordinate for the 
   </tbody>
 </table>
 
-## feConvolveMatrix
+### `<feConvolveMatrix>`
 
 For {{SVGElement('feConvolveMatrix')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -184,7 +186,7 @@ For {{SVGElement('feConvolveMatrix')}}, `x` defines the minimum x coordinate for
   </tbody>
 </table>
 
-## feDiffuseLighting
+### `<feDiffuseLighting>`
 
 For {{SVGElement('feDiffuseLighting')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -217,7 +219,7 @@ For {{SVGElement('feDiffuseLighting')}}, `x` defines the minimum x coordinate fo
   </tbody>
 </table>
 
-## feDisplacementMap
+### `<feDisplacementMap>`
 
 For {{SVGElement('feDisplacementMap')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -250,7 +252,7 @@ For {{SVGElement('feDisplacementMap')}}, `x` defines the minimum x coordinate fo
   </tbody>
 </table>
 
-## feDropShadow
+### `<feDropShadow>`
 
 For {{SVGElement('feDropShadow')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -283,7 +285,7 @@ For {{SVGElement('feDropShadow')}}, `x` defines the minimum x coordinate for the
   </tbody>
 </table>
 
-## feFlood
+### `<feFlood>`
 
 For {{SVGElement('feFlood')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -316,7 +318,7 @@ For {{SVGElement('feFlood')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feFuncA
+### `<feFuncA>`
 
 For {{SVGElement('feFuncA')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -349,7 +351,7 @@ For {{SVGElement('feFuncA')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feFuncB
+### `<feFuncB>`
 
 For {{SVGElement('feFuncB')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -382,7 +384,7 @@ For {{SVGElement('feFuncB')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feFuncG
+### `<feFuncG>`
 
 For {{SVGElement('feFuncG')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -415,7 +417,7 @@ For {{SVGElement('feFuncG')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feFuncR
+### `<feFuncR>`
 
 For {{SVGElement('feFuncR')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -448,7 +450,7 @@ For {{SVGElement('feFuncR')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feGaussianBlur
+### `<feGaussianBlur>`
 
 For {{SVGElement('feGaussianBlur')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -481,7 +483,7 @@ For {{SVGElement('feGaussianBlur')}}, `x` defines the minimum x coordinate for t
   </tbody>
 </table>
 
-## feImage
+### `<feImage>`
 
 For {{SVGElement('feImage')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -514,7 +516,7 @@ For {{SVGElement('feImage')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feMerge
+### `<feMerge>`
 
 For {{SVGElement('feMerge')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -547,7 +549,7 @@ For {{SVGElement('feMerge')}}, `x` defines the minimum x coordinate for the rend
   </tbody>
 </table>
 
-## feMergeNode
+### `<feMergeNode>`
 
 For {{SVGElement('feMergeNode')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -580,7 +582,7 @@ For {{SVGElement('feMergeNode')}}, `x` defines the minimum x coordinate for the 
   </tbody>
 </table>
 
-## feMorphology
+### `<feMorphology>`
 
 For {{SVGElement('feMorphology')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -613,7 +615,7 @@ For {{SVGElement('feMorphology')}}, `x` defines the minimum x coordinate for the
   </tbody>
 </table>
 
-## feOffset
+### `<feOffset>`
 
 For {{SVGElement('feOffset')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -646,7 +648,7 @@ For {{SVGElement('feOffset')}}, `x` defines the minimum x coordinate for the ren
   </tbody>
 </table>
 
-## fePointLight
+### `<fePointLight>`
 
 For {{SVGElement('fePointLight')}}, `x` defines the x location for the light source in the coordinate system defined by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element.
 
@@ -673,7 +675,7 @@ For {{SVGElement('fePointLight')}}, `x` defines the x location for the light sou
   </tbody>
 </table>
 
-## feSpecularLighting
+### `<feSpecularLighting>`
 
 For {{SVGElement('feSpecularLighting')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -706,7 +708,7 @@ For {{SVGElement('feSpecularLighting')}}, `x` defines the minimum x coordinate f
   </tbody>
 </table>
 
-## feSpotLight
+### `<feSpotLight>`
 
 For {{SVGElement('feSpotLight')}}, `x` defines the x location for the light source in the coordinate system defined by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element.
 
@@ -733,7 +735,7 @@ For {{SVGElement('feSpotLight')}}, `x` defines the x location for the light sour
   </tbody>
 </table>
 
-## feTile
+### `<feTile>`
 
 For {{SVGElement('feTile')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -766,7 +768,7 @@ For {{SVGElement('feTile')}}, `x` defines the minimum x coordinate for the rende
   </tbody>
 </table>
 
-## feTurbulence
+### `<feTurbulence>`
 
 For {{SVGElement('feTurbulence')}}, `x` defines the minimum x coordinate for the rendering area of the primitive.
 
@@ -799,7 +801,7 @@ For {{SVGElement('feTurbulence')}}, `x` defines the minimum x coordinate for the
   </tbody>
 </table>
 
-## filter
+### `<filter>`
 
 For {{SVGElement('filter')}}, `x` defines the x coordinate of the upper left corner for the rendering area of the filter.
 
@@ -832,7 +834,7 @@ For {{SVGElement('filter')}}, `x` defines the x coordinate of the upper left cor
   </tbody>
 </table>
 
-## foreignObject
+### `<foreignObject>`
 
 For {{SVGElement('foreignObject')}}, `x` defines the x coordinate of the upper left corner of its viewport.
 
@@ -867,7 +869,7 @@ For {{SVGElement('foreignObject')}}, `x` defines the x coordinate of the upper l
 
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<foreignObject>`.
 
-## glyphRef
+### `<glyphRef>`
 
 > **Warning:** As of SVG2 {{SVGElement('glyphRef')}} is deprecated and shouldn't be used.
 
@@ -900,7 +902,7 @@ For {{SVGElement('glyphRef')}}, `x` defines the x-axis coordinate of the glyph.
   </tbody>
 </table>
 
-## image
+### `<image>`
 
 For {{SVGElement('image')}}, `x` defines the x coordinate of the upper left corner of the image.
 
@@ -935,7 +937,7 @@ For {{SVGElement('image')}}, `x` defines the x coordinate of the upper left corn
 
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for images.
 
-## mask
+### `<mask>`
 
 For {{SVGElement('mask')}}, `x` defines the x coordinate of the upper left corner of its area of effect. The exact effect of this attribute is influenced by the {{SVGAttr('maskUnits')}} attribute.
 
@@ -968,7 +970,7 @@ For {{SVGElement('mask')}}, `x` defines the x coordinate of the upper left corne
   </tbody>
 </table>
 
-## pattern
+### `<pattern>`
 
 For {{SVGElement('pattern')}}, `x` defines the x coordinate of the upper left corner of the tile pattern. The exact effect of this attribute is influenced by the {{SVGAttr('patternUnits')}} and {{SVGAttr('patternTransform')}} attributes.
 
@@ -995,7 +997,7 @@ For {{SVGElement('pattern')}}, `x` defines the x coordinate of the upper left co
   </tbody>
 </table>
 
-## rect
+### `<rect>`
 
 For {{SVGElement('rect')}}, `x` defines the x coordinate of the upper left corner of the shape.
 
@@ -1030,7 +1032,7 @@ For {{SVGElement('rect')}}, `x` defines the x coordinate of the upper left corne
 
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rectangles.
 
-## svg
+### `<svg>`
 
 For {{SVGElement('svg')}}, `x` defines the x coordinate of the upper left corner of its viewport.
 
@@ -1065,7 +1067,7 @@ For {{SVGElement('svg')}}, `x` defines the x coordinate of the upper left corner
 
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<svg>`.
 
-## text
+### `<text>`
 
 For {{SVGElement('text')}}, if it contains a single value, `x` defines the x coordinate where the _content text position_ must be placed. The _content text position_ is usually a point on the baseline of the first line of text. The exact _content text position_ is influenced by other properties, such as {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
@@ -1142,7 +1144,7 @@ line {
 
 {{EmbedLiveSample('text', '100%', 100)}}
 
-## tref
+### `<tref>`
 
 > **Warning:** As of SVG2 {{SVGElement('tref')}} is deprecated and shouldn't be used.
 
@@ -1179,7 +1181,7 @@ If it contains multiple values, `x` defines the x coordinate of each individual 
   </tbody>
 </table>
 
-## tspan
+### `<tspan>`
 
 For {{SVGElement('tspan')}}, if it contains a single value, `x` defines the x coordinate where the _content text position_ must be placed. The _content text position_ is usually a point on the baseline of the first line of text. The exact _content text position_ is influenced by other properties, such as {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
@@ -1258,7 +1260,7 @@ line {
 
 {{EmbedLiveSample('tspan', '100%', 100)}}
 
-## use
+### `<use>`
 
 For {{SVGElement('use')}}, `x` defines the x coordinate of the upper left corner of the referenced element.
 

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -1294,7 +1294,8 @@ For {{SVGElement('use')}}, `x` defines the x coordinate of the upper left corner
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
 
 ## Examples
-This example contains three {{SVGElement("rect")}} elements, each with an `x` value smaller than the previous value. 
+
+This example contains three {{SVGElement("rect")}} elements, each with an `x` value smaller than the previous value.
 
 ```css hidden
 html,

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -1294,6 +1294,7 @@ For {{SVGElement('use')}}, `x` defines the x coordinate of the upper left corner
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
 
 ## Examples
+This example contains three {{SVGElement("rect")}} elements, each with an `x` value smaller than the previous value. 
 
 ```css hidden
 html,
@@ -1305,9 +1306,9 @@ svg {
 
 ```html
 <svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
-  <rect x="20" y="20" width="60" height="60" />
-  <rect x="120" y="20" width="60" height="60" />
-  <rect x="220" y="20" width="60" height="60" />
+  <rect x="220" y="20" width="60" height="60" fill="red" />
+  <rect x="120" y="20" width="60" height="60" fill="yellow" />
+  <rect x="20" y="20" width="60" height="60" fill="blue" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -17,66 +17,7 @@ spec-urls:
 
 The **`x`** attribute defines an x-axis coordinate in the user coordinate system.
 
-You can use this attribute with the following SVG elements:
-
-- {{SVGElement("cursor")}}
-- {{SVGElement("feBlend")}}
-- {{SVGElement("feColorMatrix")}}
-- {{SVGElement("feComponentTransfer")}}
-- {{SVGElement("feComposite")}}
-- {{SVGElement("feConvolveMatrix")}}
-- {{SVGElement("feDiffuseLighting")}}
-- {{SVGElement("feDisplacementMap")}}
-- {{SVGElement("feDropShadow")}}
-- {{SVGElement("feFlood")}}
-- {{SVGElement("feFuncA")}}
-- {{SVGElement("feFuncB")}}
-- {{SVGElement("feFuncG")}}
-- {{SVGElement("feFuncR")}}
-- {{SVGElement("feGaussianBlur")}}
-- {{SVGElement("feImage")}}
-- {{SVGElement("feMerge")}}
-- {{SVGElement("feMergeNode")}}
-- {{SVGElement("feMorphology")}}
-- {{SVGElement("feOffset")}}
-- {{SVGElement("fePointLight")}}
-- {{SVGElement("feSpecularLighting")}}
-- {{SVGElement("feSpotLight")}}
-- {{SVGElement("feTile")}}
-- {{SVGElement("feTurbulence")}}
-- {{SVGElement("filter")}}
-- {{SVGElement("foreignObject")}}
-- {{SVGElement("glyphRef")}}
-- {{SVGElement("image")}}
-- {{SVGElement("mask")}}
-- {{SVGElement("pattern")}}
-- {{SVGElement("rect")}}
-- {{SVGElement("svg")}}
-- {{SVGElement("symbol")}}
-- {{SVGElement("text")}}
-- {{SVGElement("tref")}}
-- {{SVGElement("tspan")}}
-- {{SVGElement("use")}}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
-  <rect x="20" y="20" width="60" height="60" />
-  <rect x="120" y="20" width="60" height="60" />
-  <rect x="220" y="20" width="60" height="60" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## feBlend
 
@@ -1351,6 +1292,26 @@ For {{SVGElement('use')}}, `x` defines the x coordinate of the upper left corner
 </table>
 
 > **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="20" width="60" height="60" />
+  <rect x="120" y="20" width="60" height="60" />
+  <rect x="220" y="20" width="60" height="60" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -11,30 +11,7 @@ spec-urls:
 
 The **`x1`** attribute is used to specify the first x-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("x")}} attribute instead.
 
-You can use this attribute with the following SVG elements:
-
-- {{ SVGElement("line") }}
-- {{ SVGElement("linearGradient") }}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="1" x2="5" y1="1" y2="9" stroke="red" />
-  <line x1="5" x2="5" y1="1" y2="9" stroke="green" />
-  <line x1="9" x2="5" y1="1" y2="9" stroke="blue" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## line
 
@@ -167,6 +144,26 @@ svg {
 ```
 
 {{EmbedLiveSample('linearGradient', '100%', 200)}}
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <line x1="1" x2="5" y1="1" y2="9" stroke="red" />
+  <line x1="5" x2="5" y1="1" y2="9" stroke="green" />
+  <line x1="9" x2="5" y1="1" y2="9" stroke="blue" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -158,10 +158,10 @@ svg {
 ```
 
 ```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="1" x2="5" y1="1" y2="9" stroke="red" />
-  <line x1="5" x2="5" y1="1" y2="9" stroke="green" />
-  <line x1="9" x2="5" y1="1" y2="9" stroke="blue" />
+<svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+  <line x1="2" x2="22" y1="5" y2="20" stroke="red" />
+  <line x1="12" x2="22" y1="5" y2="20" stroke="green" />
+  <line x1="22" x2="22" y1="5" y2="20" stroke="blue" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -11,9 +11,11 @@ spec-urls:
 
 The **`x1`** attribute is used to specify the first x-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("x")}} attribute instead.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## line
+### `<line>`
 
 For {{SVGElement('line')}}, `x1` defines the x coordinate of the starting point of the line.
 
@@ -70,7 +72,7 @@ svg {
 
 {{EmbedLiveSample('line', '100%', 200)}}
 
-## linearGradient
+### `<linearGradient>`
 
 For {{SVGElement('linearGradient')}}, `x1` defines the x coordinate of the starting point of the _gradient vector_ used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes
 

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -158,10 +158,10 @@ svg {
 ```
 
 ```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="5" x2="1" y1="1" y2="9" stroke="red" />
-  <line x1="5" x2="5" y1="1" y2="9" stroke="green" />
-  <line x1="5" x2="9" y1="1" y2="9" stroke="blue" />
+<svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+  <line x1="2" x2="2" y1="5" y2="20" stroke="red" />
+  <line x1="2" x2="12" y1="5" y2="20" stroke="green" />
+  <line x1="2" x2="22" y1="5" y2="20" stroke="blue" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -11,30 +11,7 @@ spec-urls:
 
 The **`x2`** attribute is used to specify the second x-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("x")}} attribute instead.
 
-You can use this attribute with the following SVG elements:
-
-- {{ SVGElement("line") }}
-- {{ SVGElement("linearGradient") }}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="5" x2="1" y1="1" y2="9" stroke="red" />
-  <line x1="5" x2="5" y1="1" y2="9" stroke="green" />
-  <line x1="5" x2="9" y1="1" y2="9" stroke="blue" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## line
 
@@ -167,6 +144,26 @@ svg {
 ```
 
 {{EmbedLiveSample('linearGradient', '100%', 200)}}
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <line x1="5" x2="1" y1="1" y2="9" stroke="red" />
+  <line x1="5" x2="5" y1="1" y2="9" stroke="green" />
+  <line x1="5" x2="9" y1="1" y2="9" stroke="blue" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -11,9 +11,11 @@ spec-urls:
 
 The **`x2`** attribute is used to specify the second x-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("x")}} attribute instead.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## line
+### `<line>`
 
 For {{SVGElement('line')}}, `x2` defines the x coordinate of the ending point of the line.
 
@@ -70,7 +72,7 @@ svg {
 
 {{EmbedLiveSample('line', '100%', 200)}}
 
-## linearGradient
+### `<linearGradient>`
 
 For {{SVGElement('linearGradient')}}, `x2` defines the x coordinate of the ending point of the _gradient vector_ used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes
 

--- a/files/en-us/web/svg/attribute/xchannelselector/index.md
+++ b/files/en-us/web/svg/attribute/xchannelselector/index.md
@@ -9,9 +9,9 @@ browser-compat: svg.elements.feDisplacementMap.xChannelSelector
 
 The **`xChannelSelector`** attribute indicates which color channel from {{SVGAttr("in2")}} to use to displace the pixels in {{SVGAttr("in")}} along the x-axis.
 
-You can use this attribute with the following SVG elements:
+## Elements
 
-- {{SVGElement("feDisplacementMap")}}
+You can use this attribute with the {{SVGElement("feDisplacementMap")}} SVG element.
 
 ## Usage notes
 

--- a/files/en-us/web/svg/attribute/xchannelselector/index.md
+++ b/files/en-us/web/svg/attribute/xchannelselector/index.md
@@ -13,7 +13,35 @@ You can use this attribute with the following SVG elements:
 
 - {{SVGElement("feDisplacementMap")}}
 
-## Example
+## Usage notes
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Value</th>
+      <td><code>R</code> | <code>G</code> | <code>B</code> | <code>A</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Default value</th>
+      <td><code>A</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Animatable</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
+
+- `R`
+  - : This keyword specifies that the red color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
+- `G`
+  - : This keyword specifies that the green color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
+- `B`
+  - : This keyword specifies that the blue color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
+- `A`
+  - : This keyword specifies that the alpha channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
+
+## Examples
 
 ```css hidden
 html,
@@ -63,35 +91,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "480", "200")}}
-
-## Usage notes
-
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Value</th>
-      <td><code>R</code> | <code>G</code> | <code>B</code> | <code>A</code></td>
-    </tr>
-    <tr>
-      <th scope="row">Default value</th>
-      <td><code>A</code></td>
-    </tr>
-    <tr>
-      <th scope="row">Animatable</th>
-      <td>Yes</td>
-    </tr>
-  </tbody>
-</table>
-
-- `R`
-  - : This keyword specifies that the red color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
-- `G`
-  - : This keyword specifies that the green color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
-- `B`
-  - : This keyword specifies that the blue color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
-- `A`
-  - : This keyword specifies that the alpha channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the x-axis.
+{{EmbedLiveSample("Examples", "480", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/xlink_colon_title/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_title/index.md
@@ -15,6 +15,8 @@ The use of this information is highly dependent on the type of processing being 
 
 > **Note:** New content should use a {{SVGElement("title")}} child element rather than a `xlink:title` attribute.
 
+## Elements
+
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("a")}}

--- a/files/en-us/web/svg/attribute/xlink_colon_title/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_title/index.md
@@ -37,7 +37,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("tref")}}
 - {{SVGElement("use")}}
 
-## Usage context
+## Usage notes
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.md
@@ -15,6 +15,8 @@ It is a universal attribute allowed in all XML dialects to mark up the natural h
 
 There is also a {{SVGAttr("lang")}} attribute (without namespace). If both of them are defined, the one with namespace is used and the one without is ignored.
 
+## Elements
+
 You can use this attribute with any SVG element.
 
 ## Usage notes

--- a/files/en-us/web/svg/attribute/xml_colon_lang/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_lang/index.md
@@ -17,14 +17,6 @@ There is also a {{SVGAttr("lang")}} attribute (without namespace). If both of th
 
 You can use this attribute with any SVG element.
 
-## Example
-
-```html
-<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-  <text xml:lang="en-US">This is some English text</text>
-</svg>
-```
-
 ## Usage notes
 
 <table class="properties">
@@ -49,6 +41,14 @@ You can use this attribute with any SVG element.
   - : This value specifies the language used for the element. The syntax of this value is defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
     The most common syntax is a value formed by a lowercase two-character part for the language and an uppercase two-character part for the region or country, separated by a minus sign, e.g. `en-US` for US English or `de-AT` for Austrian German.
+
+## Examples
+
+```html
+<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <text xml:lang="en-US">This is some English text</text>
+</svg>
+```
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/xml_colon_space/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_space/index.md
@@ -17,25 +17,6 @@ This attribute influences how browsers parse text content and therefore changes 
 
 You can use this attribute with any SVG element.
 
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html-nolint
-<svg viewBox="0 0 160 50" xmlns="http://www.w3.org/2000/svg">
-  <text y="20" xml:space="default">    Default    spacing</text>
-  <text y="40" xml:space="preserve">    Preserved    spacing</text>
-</svg>
-```
-
-{{EmbedLiveSample("Example", "160", "50")}}
-
 ## Usage notes
 
 <table class="properties">
@@ -69,6 +50,25 @@ svg {
   - : This value tells the user agent to convert all newline and tab characters into spaces. Then, it draws all space characters (including leading, trailing and multiple consecutive space characters).
 
     For example, the string "a&nbsp;&nbsp;&nbsp;b" (three spaces between "a" and "b") separates "a" and "b" more than "a b" (one space between "a" and "b").
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html-nolint
+<svg viewBox="0 0 160 50" xmlns="http://www.w3.org/2000/svg">
+  <text y="20" xml:space="default">    Default    spacing</text>
+  <text y="40" xml:space="preserve">    Preserved    spacing</text>
+</svg>
+```
+
+{{EmbedLiveSample("Examples", "160", "50")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/xml_colon_space/index.md
+++ b/files/en-us/web/svg/attribute/xml_colon_space/index.md
@@ -15,6 +15,8 @@ SVG supports the built-in XML **`xml:space`** attribute to handle whitespace cha
 
 This attribute influences how browsers parse text content and therefore changes the way the {{Glossary("DOM")}} is built. Therefore, changing this attribute's value through the DOM API may have no effect.
 
+## Elements
+
 You can use this attribute with any SVG element.
 
 ## Usage notes

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -17,66 +17,7 @@ spec-urls:
 
 The **`y`** attribute defines a y-axis coordinate in the user coordinate system.
 
-You can use this attribute with the following SVG elements:
-
-- {{SVGElement("cursor")}}
-- {{SVGElement("feBlend")}}
-- {{SVGElement("feColorMatrix")}}
-- {{SVGElement("feComponentTransfer")}}
-- {{SVGElement("feComposite")}}
-- {{SVGElement("feConvolveMatrix")}}
-- {{SVGElement("feDiffuseLighting")}}
-- {{SVGElement("feDisplacementMap")}}
-- {{SVGElement("feDropShadow")}}
-- {{SVGElement("feFlood")}}
-- {{SVGElement("feFuncA")}}
-- {{SVGElement("feFuncB")}}
-- {{SVGElement("feFuncG")}}
-- {{SVGElement("feFuncR")}}
-- {{SVGElement("feGaussianBlur")}}
-- {{SVGElement("feImage")}}
-- {{SVGElement("feMerge")}}
-- {{SVGElement("feMergeNode")}}
-- {{SVGElement("feMorphology")}}
-- {{SVGElement("feOffset")}}
-- {{SVGElement("fePointLight")}}
-- {{SVGElement("feSpecularLighting")}}
-- {{SVGElement("feSpotLight")}}
-- {{SVGElement("feTile")}}
-- {{SVGElement("feTurbulence")}}
-- {{SVGElement("filter")}}
-- {{SVGElement("foreignObject")}}
-- {{SVGElement("glyphRef")}}
-- {{SVGElement("image")}}
-- {{SVGElement("mask")}}
-- {{SVGElement("pattern")}}
-- {{SVGElement("rect")}}
-- {{SVGElement("svg")}}
-- {{SVGElement("symbol")}}
-- {{SVGElement("text")}}
-- {{SVGElement("tref")}}
-- {{SVGElement("tspan")}}
-- {{SVGElement("use")}}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
-  <rect y="20" x="20" width="60" height="60" />
-  <rect y="120" x="20" width="60" height="60" />
-  <rect y="220" x="20" width="60" height="60" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## feBlend
 
@@ -1347,6 +1288,26 @@ For {{SVGElement('use')}}, `y` defines the y coordinate of the upper left corner
 </table>
 
 > **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
+  <rect y="20" x="20" width="60" height="60" />
+  <rect y="120" x="20" width="60" height="60" />
+  <rect y="220" x="20" width="60" height="60" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -17,9 +17,11 @@ spec-urls:
 
 The **`y`** attribute defines a y-axis coordinate in the user coordinate system.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## feBlend
+### `<feBlend>`
 
 For {{SVGElement('feBlend')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -52,7 +54,7 @@ For {{SVGElement('feBlend')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feColorMatrix
+### `<feColorMatrix>`
 
 For {{SVGElement('feColorMatrix')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -85,7 +87,7 @@ For {{SVGElement('feColorMatrix')}}, `y` defines the minimum y coordinate for th
   </tbody>
 </table>
 
-## feComponentTransfer
+### `<feComponentTransfer>`
 
 For {{SVGElement('feComponentTransfer')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -118,7 +120,7 @@ For {{SVGElement('feComponentTransfer')}}, `y` defines the minimum y coordinate 
   </tbody>
 </table>
 
-## feComposite
+### `<feComposite>`
 
 For {{SVGElement('feComposite')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -151,7 +153,7 @@ For {{SVGElement('feComposite')}}, `y` defines the minimum y coordinate for the 
   </tbody>
 </table>
 
-## feConvolveMatrix
+### `<feConvolveMatrix>`
 
 For {{SVGElement('feConvolveMatrix')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -184,7 +186,7 @@ For {{SVGElement('feConvolveMatrix')}}, `y` defines the minimum y coordinate for
   </tbody>
 </table>
 
-## feDiffuseLighting
+### `<feDiffuseLighting>`
 
 For {{SVGElement('feDiffuseLighting')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -217,7 +219,7 @@ For {{SVGElement('feDiffuseLighting')}}, `y` defines the minimum y coordinate fo
   </tbody>
 </table>
 
-## feDisplacementMap
+### `<feDisplacementMap>`
 
 For {{SVGElement('feDisplacementMap')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -250,7 +252,7 @@ For {{SVGElement('feDisplacementMap')}}, `y` defines the minimum y coordinate fo
   </tbody>
 </table>
 
-## feDropShadow
+### `<feDropShadow>`
 
 For {{SVGElement('feDropShadow')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -283,7 +285,7 @@ For {{SVGElement('feDropShadow')}}, `y` defines the minimum y coordinate for the
   </tbody>
 </table>
 
-## feFlood
+### `<feFlood>`
 
 For {{SVGElement('feFlood')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -316,7 +318,7 @@ For {{SVGElement('feFlood')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feFuncA
+### `<feFuncA>`
 
 For {{SVGElement('feFuncA')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -349,7 +351,7 @@ For {{SVGElement('feFuncA')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feFuncB
+### `<feFuncB>`
 
 For {{SVGElement('feFuncB')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -382,7 +384,7 @@ For {{SVGElement('feFuncB')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feFuncG
+### `<feFuncG>`
 
 For {{SVGElement('feFuncG')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -415,7 +417,7 @@ For {{SVGElement('feFuncG')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feFuncR
+### `<feFuncR>`
 
 For {{SVGElement('feFuncR')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -448,7 +450,7 @@ For {{SVGElement('feFuncR')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feGaussianBlur
+### `<feGaussianBlur>`
 
 For {{SVGElement('feGaussianBlur')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -481,7 +483,7 @@ For {{SVGElement('feGaussianBlur')}}, `y` defines the minimum y coordinate for t
   </tbody>
 </table>
 
-## feImage
+### `<feImage>`
 
 For {{SVGElement('feImage')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -514,7 +516,7 @@ For {{SVGElement('feImage')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feMerge
+### `<feMerge>`
 
 For {{SVGElement('feMerge')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -547,7 +549,7 @@ For {{SVGElement('feMerge')}}, `y` defines the minimum y coordinate for the rend
   </tbody>
 </table>
 
-## feMergeNode
+### `<feMergeNode>`
 
 For {{SVGElement('feMergeNode')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -580,7 +582,7 @@ For {{SVGElement('feMergeNode')}}, `y` defines the minimum y coordinate for the 
   </tbody>
 </table>
 
-## feMorphology
+### `<feMorphology>`
 
 For {{SVGElement('feMorphology')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -613,7 +615,7 @@ For {{SVGElement('feMorphology')}}, `y` defines the minimum y coordinate for the
   </tbody>
 </table>
 
-## feOffset
+### `<feOffset>`
 
 For {{SVGElement('feOffset')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -646,7 +648,7 @@ For {{SVGElement('feOffset')}}, `y` defines the minimum y coordinate for the ren
   </tbody>
 </table>
 
-## fePointLight
+### `<fePointLight>`
 
 For {{SVGElement('fePointLight')}}, `y` defines the y location for the light source in the coordinate system defined by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element.
 
@@ -673,7 +675,7 @@ For {{SVGElement('fePointLight')}}, `y` defines the y location for the light sou
   </tbody>
 </table>
 
-## feSpecularLighting
+### `<feSpecularLighting>`
 
 For {{SVGElement('feSpecularLighting')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -706,7 +708,7 @@ For {{SVGElement('feSpecularLighting')}}, `y` defines the minimum y coordinate f
   </tbody>
 </table>
 
-## feSpotLight
+### `<feSpotLight>`
 
 For {{SVGElement('feSpotLight')}}, `y` defines the y location for the light source in the coordinate system defined by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element.
 
@@ -733,7 +735,7 @@ For {{SVGElement('feSpotLight')}}, `y` defines the y location for the light sour
   </tbody>
 </table>
 
-## feTile
+### `<feTile>`
 
 For {{SVGElement('feTile')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -766,7 +768,7 @@ For {{SVGElement('feTile')}}, `y` defines the minimum y coordinate for the rende
   </tbody>
 </table>
 
-## feTurbulence
+### `<feTurbulence>`
 
 For {{SVGElement('feTurbulence')}}, `y` defines the minimum y coordinate for the rendering area of the primitive.
 
@@ -799,7 +801,7 @@ For {{SVGElement('feTurbulence')}}, `y` defines the minimum y coordinate for the
   </tbody>
 </table>
 
-## filter
+### `<filter>`
 
 For {{SVGElement('filter')}}, `y` defines the y coordinate of the upper left corner for the rendering area of the filter.
 
@@ -832,7 +834,7 @@ For {{SVGElement('filter')}}, `y` defines the y coordinate of the upper left cor
   </tbody>
 </table>
 
-## foreignObject
+### `<foreignObject>`
 
 For {{SVGElement('foreignObject')}}, `y` defines the y coordinate of the upper left corner of its viewport.
 
@@ -867,7 +869,7 @@ For {{SVGElement('foreignObject')}}, `y` defines the y coordinate of the upper l
 
 > **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<foreignObject>`.
 
-## glyphRef
+### `<glyphRef>`
 
 > **Warning:** As of SVG2 {{SVGElement('glyphRef')}} is deprecated and shouldn't be used.
 
@@ -896,7 +898,7 @@ For {{SVGElement('glyphRef')}}, `y` defines the y-axis coordinate of the glyph.
   </tbody>
 </table>
 
-## image
+### `<image>`
 
 For {{SVGElement('image')}}, `y` defines the y coordinate of the upper left corner of the image.
 
@@ -931,7 +933,7 @@ For {{SVGElement('image')}}, `y` defines the y coordinate of the upper left corn
 
 > **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for images.
 
-## mask
+### `<mask>`
 
 For {{SVGElement('mask')}}, `y` defines the y coordinate of the upper left corner of its area of effect. The exact effect of this attribute is influenced by the {{SVGAttr('maskUnits')}} attribute.
 
@@ -964,7 +966,7 @@ For {{SVGElement('mask')}}, `y` defines the y coordinate of the upper left corne
   </tbody>
 </table>
 
-## pattern
+### `<pattern>`
 
 For {{SVGElement('pattern')}}, `y` defines the y coordinate of the upper left corner of the tile pattern. The exact effect of this attribute is influenced by the {{SVGAttr('patternUnits')}} and {{SVGAttr('patternTransform')}} attributes.
 
@@ -991,7 +993,7 @@ For {{SVGElement('pattern')}}, `y` defines the y coordinate of the upper left co
   </tbody>
 </table>
 
-## rect
+### `<rect>`
 
 For {{SVGElement('rect')}}, `y` defines the y coordinate of the upper left corner of the shape.
 
@@ -1026,7 +1028,7 @@ For {{SVGElement('rect')}}, `y` defines the y coordinate of the upper left corne
 
 > **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rectangles.
 
-## svg
+### `<svg>`
 
 For {{SVGElement('svg')}}, `y` defines the y coordinate of the upper left corner of its viewport.
 
@@ -1061,7 +1063,7 @@ For {{SVGElement('svg')}}, `y` defines the y coordinate of the upper left corner
 
 > **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<svg>`.
 
-## text
+### `<text>`
 
 For {{SVGElement('text')}}, if it contains a single value, `y` defines the y coordinate where the _content text position_ must be placed. The _content text position_ is usually a point on the baseline of the first line of text. The exact _content text position_ is influenced by other properties, such as {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
@@ -1138,7 +1140,7 @@ line {
 
 {{EmbedLiveSample('text', '100%', 100)}}
 
-## tref
+### `<tref>`
 
 > **Warning:** As of SVG2 {{SVGElement('tref')}} is deprecated and shouldn't be used.
 
@@ -1175,7 +1177,7 @@ If it contains multiple values, `y` defines the y coordinate of each individual 
   </tbody>
 </table>
 
-## tspan
+### `<tspan>`
 
 For {{SVGElement('tspan')}}, if it contains a single value, `y` defines the y coordinate where the _content text position_ must be placed. The _content text position_ is usually a point on the baseline of the first line of text. The exact _content text position_ is influenced by other properties, such as {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
@@ -1254,7 +1256,7 @@ line {
 
 {{EmbedLiveSample('tspan', '100%', 100)}}
 
-## use
+### `<use>`
 
 For {{SVGElement('use')}}, `y` defines the y coordinate of the upper left corner of the referenced element.
 

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -1293,6 +1293,8 @@ For {{SVGElement('use')}}, `y` defines the y coordinate of the upper left corner
 
 ## Examples
 
+This example contains three {{SVGElement("rect")}} elements, each with a `y` value smaller than the previous value.
+
 ```css hidden
 html,
 body,
@@ -1303,9 +1305,9 @@ svg {
 
 ```html
 <svg viewBox="0 0 100 300" xmlns="http://www.w3.org/2000/svg">
-  <rect y="20" x="20" width="60" height="60" />
-  <rect y="120" x="20" width="60" height="60" />
-  <rect y="220" x="20" width="60" height="60" />
+  <rect y="220" x="20" width="60" height="60" fill="red" />
+  <rect y="120" x="20" width="60" height="60" fill="yellow" />
+  <rect y="20" x="20" width="60" height="60" fill="purple" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -11,9 +11,11 @@ spec-urls:
 
 The **`y1`** attribute is used to specify the first y-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("y")}} attribute instead.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## line
+### `<line>`
 
 For {{SVGElement('line')}}, `y1` defines the y coordinate of the starting point of the line.
 
@@ -70,7 +72,7 @@ svg {
 
 {{EmbedLiveSample('line', '100%', 200)}}
 
-## linearGradient
+### `<linearGradient>`
 
 For {{SVGElement('linearGradient')}}, `y1` defines the y coordinate of the starting point of the _gradient vector_ used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes
 

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -160,10 +160,10 @@ svg {
 ```
 
 ```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="1" x2="9" y1="1" y2="5" stroke="red" />
-  <line x1="1" x2="9" y1="5" y2="5" stroke="green" />
-  <line x1="1" x2="9" y1="9" y2="5" stroke="blue" />
+<svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+  <line x1="2" x2="22" y1="0" y2="20" stroke="red" />
+  <line x1="2" x2="22" y1="10" y2="20" stroke="green" />
+  <line x1="2" x2="22" y1="20" y2="20" stroke="blue" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -11,30 +11,7 @@ spec-urls:
 
 The **`y1`** attribute is used to specify the first y-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("y")}} attribute instead.
 
-You can use this attribute with the following SVG elements:
-
-- {{ SVGElement("line") }}
-- {{ SVGElement("linearGradient") }}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="1" x2="9" y1="1" y2="5" stroke="red" />
-  <line x1="1" x2="9" y1="5" y2="5" stroke="green" />
-  <line x1="1" x2="9" y1="9" y2="5" stroke="blue" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## line
 
@@ -169,6 +146,26 @@ svg {
 ```
 
 {{EmbedLiveSample('linearGradient', '100%', 200)}}
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <line x1="1" x2="9" y1="1" y2="5" stroke="red" />
+  <line x1="1" x2="9" y1="5" y2="5" stroke="green" />
+  <line x1="1" x2="9" y1="9" y2="5" stroke="blue" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -11,9 +11,11 @@ spec-urls:
 
 The **`y2`** attribute is used to specify the second y-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("y")}} attribute instead.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## line
+### `<line>`
 
 For {{SVGElement('line')}}, `y2` defines the y coordinate of the ending point of the line.
 
@@ -70,7 +72,7 @@ svg {
 
 {{EmbedLiveSample('line', '100%', 200)}}
 
-## linearGradient
+### `<linearGradient>`
 
 For {{SVGElement('linearGradient')}}, `y2` defines the y coordinate of the ending point of the _gradient vector_ used to map the gradient stop values. The exact behavior of this attribute is influenced by the {{SVGAttr('gradientUnits')}} attributes
 

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -11,30 +11,7 @@ spec-urls:
 
 The **`y2`** attribute is used to specify the second y-coordinate for drawing an SVG element that requires more than one coordinate. Elements that only need one coordinate use the {{SVGAttr("y")}} attribute instead.
 
-You can use this attribute with the following SVG elements:
-
-- {{ SVGElement("line") }}
-- {{ SVGElement("linearGradient") }}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="1" x2="9" y1="5" y2="1" stroke="red" />
-  <line x1="1" x2="9" y1="5" y2="5" stroke="green" />
-  <line x1="1" x2="9" y1="5" y2="9" stroke="blue" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", '100%', 200)}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## line
 
@@ -169,6 +146,26 @@ svg {
 ```
 
 {{EmbedLiveSample('linearGradient', '100%', 200)}}
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <line x1="1" x2="9" y1="5" y2="1" stroke="red" />
+  <line x1="1" x2="9" y1="5" y2="5" stroke="green" />
+  <line x1="1" x2="9" y1="5" y2="9" stroke="blue" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -160,10 +160,10 @@ svg {
 ```
 
 ```html
-<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-  <line x1="1" x2="9" y1="5" y2="1" stroke="red" />
-  <line x1="1" x2="9" y1="5" y2="5" stroke="green" />
-  <line x1="1" x2="9" y1="5" y2="9" stroke="blue" />
+<svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+  <line x1="2" x2="22" y1="20" y2="0" stroke="red" />
+  <line x1="2" x2="22" y1="20" y2="10" stroke="green" />
+  <line x1="2" x2="22" y1="20" y2="20" stroke="blue" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/attribute/ychannelselector/index.md
+++ b/files/en-us/web/svg/attribute/ychannelselector/index.md
@@ -9,9 +9,9 @@ browser-compat: svg.elements.feDisplacementMap.yChannelSelector
 
 The **`yChannelSelector`** attribute indicates which color channel from {{SVGAttr("in2")}} to use to displace the pixels in {{SVGAttr("in")}} along the y-axis.
 
-You can use this attribute with the following SVG elements:
+## Elements
 
-- {{SVGElement("feDisplacementMap")}}
+You can use this attribute with the {{SVGElement("feDisplacementMap")}} SVG element.
 
 ## Usage notes
 

--- a/files/en-us/web/svg/attribute/ychannelselector/index.md
+++ b/files/en-us/web/svg/attribute/ychannelselector/index.md
@@ -13,7 +13,35 @@ You can use this attribute with the following SVG elements:
 
 - {{SVGElement("feDisplacementMap")}}
 
-## Example
+## Usage notes
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Value</th>
+      <td><code>R</code> | <code>G</code> | <code>B</code> | <code>A</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Default value</th>
+      <td><code>A</code></td>
+    </tr>
+    <tr>
+      <th scope="row">Animatable</th>
+      <td>Yes</td>
+    </tr>
+  </tbody>
+</table>
+
+- `R`
+  - : This keyword specifies that the red color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
+- `G`
+  - : This keyword specifies that the green color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
+- `B`
+  - : This keyword specifies that the blue color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
+- `A`
+  - : This keyword specifies that the alpha channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
+
+## Examples
 
 ```css hidden
 html,
@@ -63,35 +91,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "480", "200")}}
-
-## Usage notes
-
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Value</th>
-      <td><code>R</code> | <code>G</code> | <code>B</code> | <code>A</code></td>
-    </tr>
-    <tr>
-      <th scope="row">Default value</th>
-      <td><code>A</code></td>
-    </tr>
-    <tr>
-      <th scope="row">Animatable</th>
-      <td>Yes</td>
-    </tr>
-  </tbody>
-</table>
-
-- `R`
-  - : This keyword specifies that the red color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
-- `G`
-  - : This keyword specifies that the green color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
-- `B`
-  - : This keyword specifies that the blue color channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
-- `A`
-  - : This keyword specifies that the alpha channel of the input image defined in {{SVGAttr("in2")}} will be used to displace the pixels of the input image defined in {{SVGAttr("in")}} along the y-axis.
+{{EmbedLiveSample("Examples", "480", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/z/index.md
+++ b/files/en-us/web/svg/attribute/z/index.md
@@ -80,12 +80,7 @@ svg {
     </feDiffuseLighting>
   </filter>
 
-  <rect
-    x="0"
-    y="0"
-    width="200"
-    height="200"
-    filter="url(#diffuseLighting1)" />
+  <rect x="0" y="0" width="200" height="200" filter="url(#diffuseLighting1)" />
   <rect
     x="200"
     y="0"

--- a/files/en-us/web/svg/attribute/z/index.md
+++ b/files/en-us/web/svg/attribute/z/index.md
@@ -11,50 +11,7 @@ spec-urls:
 
 The **`z`** attribute defines the location along the z-axis for a light source in the coordinate system established by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element, assuming that, in the initial coordinate system, the positive z-axis comes out towards the person viewing the content and assuming that one unit along the z-axis equals one unit in x and y.
 
-You can use this attribute with the following SVG elements:
-
-- {{SVGElement("fePointLight")}}
-- {{SVGElement("feSpotLight")}}
-
-## Example
-
-```css hidden
-html,
-body,
-svg {
-  height: 100%;
-}
-```
-
-```html
-<svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg">
-  <filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%">
-    <feDiffuseLighting in="SourceGraphic">
-      <fePointLight x="60" y="60" z="10" />
-    </feDiffuseLighting>
-  </filter>
-  <filter id="diffuseLighting2" x="0" y="0" width="100%" height="100%">
-    <feDiffuseLighting in="SourceGraphic">
-      <fePointLight x="60" y="60" z="50" />
-    </feDiffuseLighting>
-  </filter>
-
-  <rect
-    x="0"
-    y="0"
-    width="200"
-    height="200"
-    style="filter: url(#diffuseLighting1);" />
-  <rect
-    x="0"
-    y="0"
-    width="200"
-    height="200"
-    style="filter: url(#diffuseLighting2); transform: translateX(220px);" />
-</svg>
-```
-
-{{EmbedLiveSample("Example", "420", "200")}}
+You can use this attribute with the SVG elements described in the sections below.
 
 ## fePointLight
 
@@ -97,6 +54,46 @@ For {{SVGElement("feSpotLight")}}, `z` defines the location along the z-axis for
     </tr>
   </tbody>
 </table>
+
+## Examples
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg">
+  <filter id="diffuseLighting1" x="0" y="0" width="100%" height="100%">
+    <feDiffuseLighting in="SourceGraphic">
+      <fePointLight x="60" y="60" z="10" />
+    </feDiffuseLighting>
+  </filter>
+  <filter id="diffuseLighting2" x="0" y="0" width="100%" height="100%">
+    <feDiffuseLighting in="SourceGraphic">
+      <fePointLight x="60" y="60" z="50" />
+    </feDiffuseLighting>
+  </filter>
+
+  <rect
+    x="0"
+    y="0"
+    width="200"
+    height="200"
+    style="filter: url(#diffuseLighting1);" />
+  <rect
+    x="0"
+    y="0"
+    width="200"
+    height="200"
+    style="filter: url(#diffuseLighting2); transform: translateX(220px);" />
+</svg>
+```
+
+{{EmbedLiveSample("Examples", "420", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/z/index.md
+++ b/files/en-us/web/svg/attribute/z/index.md
@@ -11,9 +11,11 @@ spec-urls:
 
 The **`z`** attribute defines the location along the z-axis for a light source in the coordinate system established by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element, assuming that, in the initial coordinate system, the positive z-axis comes out towards the person viewing the content and assuming that one unit along the z-axis equals one unit in x and y.
 
+## Elements
+
 You can use this attribute with the SVG elements described in the sections below.
 
-## fePointLight
+### `<fePointLight>`
 
 For {{SVGElement("fePointLight")}}, `z` defines the location along the z-axis for the light source in the coordinate system established by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element.
 
@@ -34,7 +36,7 @@ For {{SVGElement("fePointLight")}}, `z` defines the location along the z-axis fo
   </tbody>
 </table>
 
-## feSpotLight
+### `<feSpotLight>`
 
 For {{SVGElement("feSpotLight")}}, `z` defines the location along the z-axis for the light source in the coordinate system established by the {{SVGAttr("primitiveUnits")}} attribute on the {{SVGElement("filter")}} element.
 

--- a/files/en-us/web/svg/attribute/z/index.md
+++ b/files/en-us/web/svg/attribute/z/index.md
@@ -76,7 +76,7 @@ svg {
   </filter>
   <filter id="diffuseLighting2" x="0" y="0" width="100%" height="100%">
     <feDiffuseLighting in="SourceGraphic">
-      <fePointLight x="60" y="60" z="50" />
+      <fePointLight x="340" y="60" z="50" />
     </feDiffuseLighting>
   </filter>
 
@@ -85,13 +85,13 @@ svg {
     y="0"
     width="200"
     height="200"
-    style="filter: url(#diffuseLighting1);" />
+    filter="url(#diffuseLighting1)" />
   <rect
-    x="0"
+    x="200"
     y="0"
     width="200"
     height="200"
-    style="filter: url(#diffuseLighting2); transform: translateX(220px);" />
+    filter="url(#diffuseLighting2)" />
 </svg>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I came across the [SVG x attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x) page while triaging https://github.com/mdn/content/issues/32081.

The element list under "You can use this attribute with the following SVG elements:" resembles a Table of Contents (TOC) but it is not. I found this list alongside the "In this article" sidebar links confusing.

The links in the element list take you to the respective element pages whereas I was expecting navigation to sections on the attribute page itself.

Given that the sidebar is meant for in-page navigation, and each element section already includes a link to its  corresponding element page, the initial list of links appears to be redundant.

This PR:
- Removes the element list from attribute pages that contain subsequent sections for those elements. Each section contains a link to the corresponding element page, so that navigation aid is not lost.

- Renames "Example" to "Examples". This aligns with our use of the plural form for this section. For example, in the [SVG element page template](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/SVG_element_page_template#examples), the guideline is: "Note that we use the plural "Examples" even if the page only contains one example."

- Changes the position of the "Examples" section so that it follows "Usage notes" or appears before "Specifications" (as in [SVG element page template](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/SVG_element_page_template#examples) and various other templates).
  (The appearance of examples before an explanation of the values was reported as a problem in https://github.com/mdn/content/issues/31825.)

- Uses the section name "Usage notes" when a description of values is included and the name "Usage context" when the section contains only a table. The section name "Context notes" appears only on SVG attribute pages; it has been updated to "Usage notes" or "Usage context" as appropriate.

**Note:** The improvements in this PR focus on attributes with names starting from U to Z.

### Motivation

To help streamline navigation and improve consistency with other parts of MDN


