### PR TITLE
Note in the CSS `calc` function that specifically the right operand needs to be unitless

### DIFF
--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -44,7 +44,7 @@ In addition, the following notes apply:
 - It is permitted to nest `calc()` functions, in which case the inner ones are treated as simple parentheses.
 - For lengths, you can't use `0` to mean `0px` (or another length unit); instead, you must use the version with the unit: `margin-top: calc(0px + 20px);` is valid, while `margin-top: calc(0 + 20px);` is invalid.
 - The `calc()` function cannot directly substitute the numeric value for percentage types; for instance `calc(100 / 4)%` is invalid, while `calc(100% / 4)` is valid.
-- The `*` operator requires one of the operands to be unitless. For example `font-size: calc(1.25rem * 1.25)` is valid but `font-size: calc(1.25rem * 125%)` is invalid.
+- The `*` operator requires one of the operands to be unitless and the `/` operator requires the right operand to be unitless. For example `font-size: calc(1.25rem * 1.25)` is valid but `font-size: calc(1.25rem * 125%)` is invalid.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -44,7 +44,7 @@ In addition, the following notes apply:
 - It is permitted to nest `calc()` functions, in which case the inner ones are treated as simple parentheses.
 - For lengths, you can't use `0` to mean `0px` (or another length unit); instead, you must use the version with the unit: `margin-top: calc(0px + 20px);` is valid, while `margin-top: calc(0 + 20px);` is invalid.
 - The `calc()` function cannot directly substitute the numeric value for percentage types; for instance `calc(100 / 4)%` is invalid, while `calc(100% / 4)` is valid.
-- The `*` operator requires one of the operands to be unitless and the `/` operator requires the right operand to be unitless. For example `font-size: calc(1.25rem * 1.25)` is valid but `font-size: calc(1.25rem * 125%)` is invalid.
+- Current implementations require that for the `*`and `/` operators, one of the operands has to be unitless. For `/`, the right operand must be unitless. For example `font-size: calc(1.25rem / 1.25)` is valid but `font-size: calc(1.25rem / 125%)` is invalid.
 
 ### Formal syntax
 

--- a/files/en-us/web/css/calc/index.md
+++ b/files/en-us/web/css/calc/index.md
@@ -44,7 +44,7 @@ In addition, the following notes apply:
 - It is permitted to nest `calc()` functions, in which case the inner ones are treated as simple parentheses.
 - For lengths, you can't use `0` to mean `0px` (or another length unit); instead, you must use the version with the unit: `margin-top: calc(0px + 20px);` is valid, while `margin-top: calc(0 + 20px);` is invalid.
 - The `calc()` function cannot directly substitute the numeric value for percentage types; for instance `calc(100 / 4)%` is invalid, while `calc(100% / 4)` is valid.
-- Current implementations require that for the `*`and `/` operators, one of the operands has to be unitless. For `/`, the right operand must be unitless. For example `font-size: calc(1.25rem / 1.25)` is valid but `font-size: calc(1.25rem / 125%)` is invalid.
+- Current implementations require that for the `*` and `/` operators, one of the operands has to be unitless. For `/`, the right operand must be unitless. For example `font-size: calc(1.25rem / 1.25)` is valid but `font-size: calc(1.25rem / 125%)` is invalid.
 
 ### Formal syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

With css `calc()`, the `*` operator needs at least one side be unitless. This is mentioned, but the fact the `/` operator expects specifically the **right** operand to be unitless is not mentioned.

### Motivation

This clarifies missing information to readers important for using `calc()` in CSS with division.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
