### PR TITLE
chore: remove the inconsistent UA string format

### DIFF
--- a/files/en-us/web/api/navigator/useragent/index.md
+++ b/files/en-us/web/api/navigator/useragent/index.md
@@ -39,20 +39,14 @@ methods on the {{domxref("Navigator")}} object.
 
 The user agent string is built on a formal structure which can be decomposed into
 several pieces of info. Each of these pieces of info comes from other navigator
-properties which are also settable by the user. Gecko-based browsers comply with the
-following general structure:
-
-```plain
-userAgent = appCodeName/appVersion number (Platform; Security; OS-or-CPU;
-Localization; rv: revision-version-number) product/productSub
-Application-Name Application-Name-version
-```
+properties which are also settable by the user. For more information about the
+form of the user agent string, see the {{HTTPHeader("User-agent")}} HTTP header.
 
 ## Examples
 
 ```js
 alert(window.navigator.userAgent);
-// alerts "Mozilla/5.0 (Windows; U; Win98; en-US; rv:0.9.2) Gecko/20010725 Netscape6/6.1"
+// alerts "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0"
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

remove the inconsistent UA string format

### Motivation

The UA string format has been changed in the past. While the current page lists an obsolete format (there are no `Localization` in the UA string of the latest version of Firefox), I thought a better way would be to link the page that covers most of the UA string formats to here, rather than maintaining the format of UA strings in so many places.
