### PR TITLE
Add more reviewers for SVG content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,11 +52,6 @@
 /files/en-us/web/api/    @mdn/yari-content-web-api
 
 # ----------------------------------------------------------------------------
-# ENGLISH SVG CONTENT OWNER(S)
-# ----------------------------------------------------------------------------
-/files/en-us/web/svg/    @mdn/yari-content-svg
-
-# ----------------------------------------------------------------------------
 # ENGLISH MOZILLA ADD-ONS CONTENT OWNER(S)
 # ----------------------------------------------------------------------------
 /files/en-us/mozilla/add-ons/    @mdn/yari-content-mozilla-add-ons


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

We want to expand the pool of reviewers who can review the PRs being opened in the SVG content area. With the removal of SVG-specific section from CODEOWNERS, PRs can fallback to the default [yari-content-mdn](https://github.com/orgs/mdn/teams/yari-content-mdn) team:

```
# ----------------------------------------------------------------------------
# DEFAULT ENGLISH CONTENT OWNER(S)
# ----------------------------------------------------------------------------
/files/en-us/    @mdn/yari-content-mdn
```

### To Do:

- [x] Remove [yari-content-svg](https://github.com/orgs/mdn/teams/yari-content-svg) team. Members include @Rumyra and @Ryuno-Ki
