### PR TITLE
Add an escape so Yari don't believe this is a macro

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -243,7 +243,7 @@ import { Component } from "@angular/core";
 @Component({
   selector: "app-root",
   standalone: true,
-  template: "<h1>{{ title }}</h1>",
+  template: "<h1>\{{ title }}</h1>",
   styleUrls: ["./app.component.css"],
 })
 export class AppComponent {

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/angular_getting_started/index.md
@@ -237,7 +237,7 @@ One use of this feature is inserting dynamic text, as shown in the following exa
 The double curly braces instruct Angular to interpolate the contents within them.
 The value for `title` comes from the component class:
 
-```js
+```js-nolint
 import { Component } from "@angular/core";
 
 @Component({


### PR DESCRIPTION
`{{ title }}` is not a macro.

Like we did at line 234, we need to escape it so Yari doesn't try to interpret this as a macro.