### PR TITLE
Yari request relative path for images in PerformanceNavigationTiming

### DIFF
--- a/files/en-us/web/api/performance_api/navigation_timing/index.md
+++ b/files/en-us/web/api/performance_api/navigation_timing/index.md
@@ -14,7 +14,7 @@ Only the current document is included, so usually there is only one {{domxref("P
 
 ## Navigation timestamps
 
-![Timestamp diagram listing timestamps in the order in which they are recorded for the fetching of a document](/en-US/docs/Web/API/PerformanceNavigationTiming/timestamp-diagram.svg)
+![Timestamp diagram listing timestamps in the order in which they are recorded for the fetching of a document](../../PerformanceNavigationTiming/timestamp-diagram.svg)
 Figure 1. Navigation timestamps ([source](https://w3c.github.io/navigation-timing/#process)).
 
 The document navigation timestamps (in addition to those from [Resource Timing](/en-US/docs/Web/API/Performance_API/Resource_timing)) are:


### PR DESCRIPTION
This fixes the flaw created as Yari now request relative path for images. It also improve results in local editors, as well as GitHub, and there are very few (< 3) occurrences of this kind in the whole of MDN.