### PR TITLE
fix(pr-test): do not use pull_request_target

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -19,17 +19,25 @@ jobs:
       - name: "Download artifact"
         uses: actions/download-artifact@v4
         with:
-          name: build
+          pattern: build
           path: build
+          merge-multiple: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      - name: Check for artifacts
+        if: ${{ hashFiles('build/') != '' }}
+        run: |
+          echo "HAS_ARTIFACT=true" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+        if: ${{ env.HAS_ARTIFACT }}
         with:
           repository: mdn/yari
           path: yari
 
       - name: Install Python
+        if: ${{ env.HAS_ARTIFACT }}
         id: setup-python
         uses: actions/setup-python@v5
         with:
@@ -37,6 +45,7 @@ jobs:
 
       # See https://www.peterbe.com/plog/install-python-poetry-github-actions-faster
       - name: Load cached ~/.local
+        if: ${{ env.HAS_ARTIFACT }}
         uses: actions/cache@v4
         with:
           path: ~/.local
@@ -45,12 +54,14 @@ jobs:
           key: dotlocal-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-0
 
       - name: Install Python poetry
+        if: ${{ env.HAS_ARTIFACT }}
         uses: snok/install-poetry@v1.3
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Load cached venv
+        if: ${{ env.HAS_ARTIFACT }}
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
@@ -60,17 +71,19 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ steps.setup-python.outputs.python-version }}-0
 
       - name: Install poetry dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        if: ${{ env.HAS_ARTIFACT && steps.cached-poetry-dependencies.outputs.cache-hit != 'true' }}
         run: |
           cd yari/deployer
           poetry install --no-interaction --no-root
 
       - name: Install Deployer
+        if: ${{ env.HAS_ARTIFACT }}
         run: |
           cd yari/deployer
           poetry install --no-interaction
 
       - name: Deploy and analyze built content
+        if: ${{ env.HAS_ARTIFACT }}
         env:
           BUILD_OUT_ROOT: ${{ github.workspace }}/build
 

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -5,7 +5,11 @@
 
 name: PR review companion
 
-on: workflow_call
+on:
+  workflow_run:
+    workflows: ["PR Test"]
+    types:
+      - completed
 
 jobs:
   review:
@@ -16,6 +20,8 @@ jobs:
         with:
           name: build
           path: build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: "Download artifact"
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,11 +7,7 @@
 name: PR Test
 
 on:
-  # The `GITHUB_TOKEN` in workflows triggered by the `pull_request_target` event
-  # is granted read/write repository access.
-  # Please pay attention to limit the permissions of each job!
-  # https://docs.github.com/actions/using-jobs/assigning-permissions-to-jobs
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -35,8 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: "${{ env.HEAD_SHA }}"
 
       - name: Get changed files
         run: |
@@ -143,13 +137,3 @@ jobs:
 
           export CONTENT_ROOT=$(pwd)/files
           yarn filecheck ${{ env.GIT_DIFF_FILES }}
-
-  review:
-    needs: tests
-    if: ${{ needs.tests.outputs.has_assets }}
-    # write permissions are required to create a comment in the corresponding PR
-    permissions: write-all
-    uses: ./.github/workflows/pr-review-companion.yml
-    # inherit the secrets from the parent workflow
-    # https://docs.github.com/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow
-    secrets: inherit

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,8 +18,6 @@ jobs:
     # Set the permissions to `read-all`, preventing the workflow from
     # any accidental write access to the repository.
     permissions: read-all
-    outputs:
-      has_assets: ${{ steps.build-content.outputs.has_assets }}
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -112,9 +110,6 @@ jobs:
           # The purpose of this is for the PR Review Companion to later
           # be able to use this raw diff file for the benefit of analyzing.
           wget https://github.com/${{ github.repository }}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }}.diff -O ${{ env.BUILD_OUT_ROOT }}/DIFF
-
-          # Set the output variable so the next job could skip if there are no assets
-          echo "has_assets=true" >> "$GITHUB_OUTPUT"
 
       - name: Merge static assets with built documents
         if: ${{ env.GIT_DIFF_CONTENT }}


### PR DESCRIPTION
### Description

Changes the pr-test and pr-review-companion to not use `pull_request_target` as trigger.

### Motivation

See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

### Additional details

Testing on my fork (without AWS upload):
- pr-test: https://github.com/fiji-flo/content/actions/runs/8602034448/job/23570628639
- pr-review-companion: https://github.com/fiji-flo/content/actions/runs/8602046014/job/23570669294

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
