### PR TITLE
Add HTMLTableCellElement.noWrap

### DIFF
--- a/files/en-us/web/api/htmltablecellelement/nowrap/index.md
+++ b/files/en-us/web/api/htmltablecellelement/nowrap/index.md
@@ -1,0 +1,29 @@
+---
+title: "HTMLTableCellElement: noWrap property"
+short-title: noWrap
+slug: Web/API/HTMLTableCellElement/noWrap
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableCellElement.noWrap
+---
+
+{{APIRef("HTML DOM API")}}{{deprecated_header}}
+
+The **`noWrap`** property of the {{domxref("HTMLTableCellElement")}} interface returns a Boolean value indicating if the text of the cell may be wrapped on several lines or not.
+
+**Note:** This property is deprecated and you should use the CSS {{cssxref("white-space")}} property with the value `nowrap` instead.
+
+## Value
+
+A Boolean value.
+
+## Examples
+
+Use CSS `white-space` instead. An [example](/en-US/docs/Web/CSS/white-space#controlling_line_wrapping_in_tables) is available on the {{cssxref("white-space")}} page.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/css/white-space/index.md
+++ b/files/en-us/web/css/white-space/index.md
@@ -262,6 +262,47 @@ text {
 
 {{EmbedLiveSample("multiple_lines_in_svg_text_element", "100%", 150)}}
 
+### Controlling line wrapping in tables
+
+#### HTML
+
+```html
+<table>
+  <tr>
+    <td></td>
+    <td>Very long content that splits</td>
+    <td class="nw">Very long content that don't split</td>
+  </tr>
+  <tr>
+    <td class="nw">white-space:</td>
+    <td>normal</td>
+    <td>nowrap</td>
+  </tr>
+</table>
+```
+
+#### CSS
+
+```css
+table {
+  border-collapse: collapse;
+  border: solid black 1px;
+  width: 250px;
+  height: 150px;
+}
+td {
+  border: solid 1px black;
+  text-align: center;
+}
+.nw {
+  white-space: nowrap;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Controlling line wrapping in tables', "100%", "100%")}}
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
### Description

This PR adds docs for the two properties:
- `HTMLTableCellElement.noWrap`

### Motivation

This property is supported by all engines.

Though deprecated, it is a common beginners' task: we need documentation that points to the right way of doing this (TM), using `white-space`.

### Additional details

There is no example as this is deprecated: the example sections point to examples using the modern (CSS) way of doing it so that they are one click away.

### Related issues and pull requests

It is part of https://github.com/mdn/mdn/issues/520