### PR TITLE
fix words tenses

### DIFF
--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -96,10 +96,10 @@ Link: </style.css>; rel=preload; as=style
 ```
 
 The early response restricts preloading to the same origin as the request.
-The stylesheet will preload if the origin matches.
+The stylesheet will be preloaded if the origin matches.
 
 The final response might set the CSP to `none`, as shown below.
-The stylesheet has already preloaded, but will not be used when rendering the page.
+The stylesheet has already been preloaded, but will not be used when rendering the page.
 
 ```http
 200 OK


### PR DESCRIPTION
preload should be action that is passive to the content early loaded by the server

see oxford dict *to load something in advance*

ps. this content does contains a word in passive tense

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

fix incorrect tense of word preload

### Motivation

incorrect tense makes the content hard to translate and understand

### Additional details

Oxford Modern Dict 10: *to load something in advance*

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
