### PR TITLE
<image> -> <img>

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -291,7 +291,7 @@ The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is u
 - {{domxref("HTMLCanvasElement.toDataURL", "canvas.toDataURL('image/jpeg', quality)")}}
   - : Creates a JPG image. Optionally, you can provide a quality in the range from 0 to 1, with one being the best quality and with 0 almost not recognizable but small in file size.
 
-Once you have generated a data URL from your canvas, you are able to use it as the source of any {{HTMLElement("image")}} or put it into a hyperlink with a [download attribute](/en-US/docs/Web/HTML/Element/a#download) to save it to disc, for example.
+Once you have generated a data URL from your canvas, you are able to use it as the source of any {{HTMLElement("img")}} or put it into a hyperlink with a [download attribute](/en-US/docs/Web/HTML/Element/a#download) to save it to disc, for example.
 
 You can also create a {{domxref("Blob")}} from the canvas.
 

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.md
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.md
@@ -20,7 +20,7 @@ An unsigned 32-bit integer (unsigned long) which is the intrinsic height of the 
 
 ### Logging `naturalHeight`
 
-In this example an {{HTMLElement("image")}} element is being observed by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute. A {{domxref("PerformanceObserver")}} is registered to get all performance entries of type `"element"` and the `buffered` flag is used to access data from before observer creation. The image file has a width of 1000px and a height of 750px. Calling `entry.naturalHeight` returns `750`, that being the intrinsic height in pixels.
+In this example an {{HTMLElement("img")}} element is being observed by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute. A {{domxref("PerformanceObserver")}} is registered to get all performance entries of type `"element"` and the `buffered` flag is used to access data from before observer creation. The image file has a width of 1000px and a height of 750px. Calling `entry.naturalHeight` returns `750`, that being the intrinsic height in pixels.
 
 ```html
 <img

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.md
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.md
@@ -20,7 +20,7 @@ An unsigned 32-bit integer (unsigned long) which is the intrinsic width of the i
 
 ### Logging `naturalWidth`
 
-In this example an {{HTMLElement("image")}} element is being observed by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute. A {{domxref("PerformanceObserver")}} is registered to get all performance entries of type `"element"` and the `buffered` flag is used to access data from before observer creation. The image file has a width of 1000px and a height of 750px. Calling `entry.naturalWidth` returns `1000`, that being the intrinsic width in pixels.
+In this example an {{HTMLElement("img")}} element is being observed by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute. A {{domxref("PerformanceObserver")}} is registered to get all performance entries of type `"element"` and the `buffered` flag is used to access data from before observer creation. The image file has a width of 1000px and a height of 750px. Calling `entry.naturalWidth` returns `1000`, that being the intrinsic width in pixels.
 
 ```html
 <img

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.md
@@ -24,7 +24,7 @@ For text nodes this will be the **text rendering timestamp**. This is defined as
 
 ### Logging `renderTime`
 
-In this example an {{HTMLElement("image")}} element is being observed by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute. A {{domxref("PerformanceObserver")}} is registered to get all performance entries of type `"element"` and the `buffered` flag is used to access data from before observer creation. Calling `entry.renderTime` returns the render time of the image element.
+In this example an {{HTMLElement("img")}} element is being observed by adding the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute. A {{domxref("PerformanceObserver")}} is registered to get all performance entries of type `"element"` and the `buffered` flag is used to access data from before observer creation. Calling `entry.renderTime` returns the render time of the image element.
 
 ```html
 <img

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -40,7 +40,7 @@ Each card is laid out using [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_grid_layou
 
 {{cssxref("display", "display: grid")}} converts the element into a grid container. The three values of the {{cssxref("grid-template-rows")}} property divide the grid into a minimum of three rows, defining the height of the first three children of the card, in order.
 
-Each `card` contains a {{HTMLElement("header")}}, {{HTMLElement("image")}}, and {{HTMLElement("div")}}, in that order, with some also containing a {{HTMLElement("footer")}}.
+Each `card` contains a {{HTMLElement("header")}}, {{HTMLElement("img")}}, and {{HTMLElement("div")}}, in that order, with some also containing a {{HTMLElement("footer")}}.
 
 The heading row, or track, is set to {{cssxref("max-content")}}, which prevents it from stretching. The image track is set to 200 pixels tall. The third track, where the content lives, is set to `1fr`. This means it will fill any additional space.
 


### PR DESCRIPTION
`<image>` doesn't exist. It was a typo.