### PR TITLE
Several minor edits regarding CSS colors

### DIFF
--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -4,7 +4,6 @@ slug: Web/Accessibility/Understanding_Colors_and_Luminance
 page-type: guide
 ---
 
-
 <section id="Quick_links">
   {{ListSubpagesForSidebar("Web/Accessibility", 1)}}
 </section>

--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -4,6 +4,8 @@ slug: Web/Accessibility/Understanding_Colors_and_Luminance
 page-type: guide
 ---
 
+- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+
 <section id="Quick_links">
   {{ListSubpagesForSidebar("Web/Accessibility", 1)}}
 </section>
@@ -38,7 +40,7 @@ When working with color, it's important to know which "color space" you are work
 
 In color printing, your printer likely has cyan, magenta, yellow, and black (CMYK) ink cartridges. CMYK is a subtractive model wherein the four inks _remove_ specific wavelengths of light, reflecting only the narrow range each is associated with. RGB is an additive color model that adds different proportions of red, green, and blue lights.
 
-Currently, the RGB color space predominates as the space web developers work in. While HEX, RGB, and HSL color spaces are notated differently, browsers automatically convert values between these color notations. [CSS color modules](/en-US/docs/Web/CSS/CSS_colors) provide additional color spaces. Still, because of the current domination of the RGB color space in measuring color output, most calculations in this document are presumed to be in the RGB color space and, very specifically, in the sRGB color space.
+Currently, the {{glossary("RGB", "RGB color space")}} predominates as the space web developers work in. While HEX, RGB, and HSL color spaces are notated differently, browsers automatically convert values between these color notations. [CSS color modules](/en-US/docs/Web/CSS/CSS_colors) provide additional color spaces. Still, because of the current domination of the RGB color space in measuring color output, most calculations in this document are presumed to be in the RGB color space and, very specifically, in the sRGB color space.
 
 ## The sRGB color space
 

--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -4,7 +4,6 @@ slug: Web/Accessibility/Understanding_Colors_and_Luminance
 page-type: guide
 ---
 
-- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
 
 <section id="Quick_links">
   {{ListSubpagesForSidebar("Web/Accessibility", 1)}}

--- a/files/en-us/web/css/color/index.md
+++ b/files/en-us/web/css/color/index.md
@@ -142,3 +142,4 @@ p {
 - The {{cssxref("&lt;color&gt;")}} data type
 - Other color-related properties: {{cssxref("background-color")}}, {{cssxref("border-color")}}, {{cssxref("outline-color")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-emphasis-color")}}, {{cssxref("text-shadow")}}, {{cssxref("caret-color")}}, {{cssxref("column-rule-color")}}, and {{cssxref("print-color-adjust")}}
 - [Applying color to HTML elements using CSS](/en-US/docs/Web/CSS/CSS_colors/Applying_color)
+- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)

--- a/files/en-us/web/css/color_value/color-contrast/index.md
+++ b/files/en-us/web/css/color_value/color-contrast/index.md
@@ -46,7 +46,7 @@ Functional notation: `color-contrast(color vs color-list)`
 
 - {{cssxref("color_value", "&lt;color>")}} data type
 - [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
-- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) {{cssxref("@media")}} feature
+- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) and [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) {{cssxref("@media")}} features
 - [`contrast()`](/en-US/docs/Web/CSS/filter-function/contrast)
 - [WCAG: color contrast](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
 - {{cssxref('--*', 'CSS custom properties')}} and {{cssxref("var")}}

--- a/files/en-us/web/css/color_value/color-contrast/index.md
+++ b/files/en-us/web/css/color_value/color-contrast/index.md
@@ -41,3 +41,12 @@ Functional notation: `color-contrast(color vs color-list)`
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{cssxref("color_value", "&lt;color>")}} data type
+- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
+- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) {{cssxref("@media")}} feature
+- [`contrast()`](/en-US/docs/Web/CSS/filter-function/contrast)
+- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+- {{cssxref('--*', 'CSS custom properties')}} and {{cssxref("var")}}

--- a/files/en-us/web/css/color_value/device-cmyk/index.md
+++ b/files/en-us/web/css/color_value/device-cmyk/index.md
@@ -10,7 +10,7 @@ spec-urls: https://drafts.csswg.org/css-color-5/#device-cmyk
 
 The **`device-cmyk()`** functional notation is used to express CMYK colors in a device dependent way, specifying the cyan, magenta, yellow, and black components.
 
-This approach to color is useful when creating material to be output to a particular printer, when the output for particular ink combinations is known. CSS processors may attempt to approximate the color, however the end result is likely to be different to the printed result.
+This approach to color is useful when creating material to be output to a particular printer, when the output for particular ink combinations is known. CSS processors may attempt to approximate the color, however, the end result is likely to be different from the printed result.
 
 ## Syntax
 
@@ -47,3 +47,8 @@ Functional notation: `device-cmyk(C M Y K[ / A][, color])`
 ## Browser compatibility
 
 There is no browser implementing this feature.
+
+## See also
+
+- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
+- {{cssxref("@page")}}

--- a/files/en-us/web/css/color_value/light-dark/index.md
+++ b/files/en-us/web/css/color_value/light-dark/index.md
@@ -141,4 +141,8 @@ section {
 
 - {{CSSXref("color-scheme")}}
 - {{CSSXref("&lt;color&gt;")}}
-- [CSS color](/en-US/docs/Web/CSS/CSS_colors) module
+- [CSS colors](/en-US/docs/Web/CSS/CSS_colors) module
+- [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) {{cssxref("@media")}} feature
+- [`contrast()`](/en-US/docs/Web/CSS/filter-function/contrast)
+- [WCAG: color contrast](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+- {{cssxref('--*', 'CSS custom properties')}} and {{cssxref("var")}}

--- a/files/en-us/web/css/css_colors/index.md
+++ b/files/en-us/web/css/css_colors/index.md
@@ -48,7 +48,7 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
   - [`oklab()`](/en-US/docs/Web/CSS/color_value/oklab)
   - [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch)
   - [`color()`](/en-US/docs/Web/CSS/color_value/color)
-- [`color-contrast()`](/en-US/docs/Web/CSS/color_value/color-contrast)
+- [`color-contrast()`](/en-US/docs/Web/CSS/color_value/color-contrast) {{experimental_inline}}
 - [`color-mix()`](/en-US/docs/Web/CSS/color_value/color-mix)
 - [`device-cmyk()`](/en-US/docs/Web/CSS/color_value/device-cmyk)
 - {{CSSXref("color_value/light-dark", "light-dark()")}}
@@ -68,6 +68,8 @@ To see the code for this color syntax converter, [view the source on GitHub](htt
 
 - {{glossary("color space")}}
 - [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
+- {{glossary("interpolation")}}
+- {{glossary("RGB")}}
 - [`transparent`](/en-US/docs/Web/CSS/named-color#transparent)
 
 ### Interfaces


### PR DESCRIPTION
This PR includes several little tweaks i noticed needed edits during my work on CSS colors

- CMYK function page: grammar nit and  added a see also section
- CSS colors module: added experiemental inline to colors level 6 feature. Added 2 glossary terms
- `color-contrast()` function: added a see also section
- A11y page on color and luminance: link to rgb glossary page
- `color` property: add WCAG color contrast to see also