### PR TITLE
Update Firefox 125 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -98,7 +98,6 @@ This article provides information about the changes in Firefox 125 that affect d
 - Fixed an issue where recommended preferences would not be applied if only WebDriver BiDi as remote protocol, which means CDP is disabled, was enabled ([Firefox bug 1882748](https://bugzil.la/1882748)).
 - Fixed an issue where creating and switching to a new tab would not wait for the `visibilityState` to be updated ([Firefox bug 1877469](https://bugzil.la/1877469)).
 
-
 ## Changes for add-on developers
 
 ### Removals

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -87,9 +87,17 @@ This article provides information about the changes in Firefox 125 that affect d
 
 #### General
 
+- Added support for the ["userAgent" capability](https://w3c.github.io/webdriver/#capabilities) which identifies the default User-Agent value of the endpoint node ([Firefox bug 1885495](https://bugzil.la/1885495)).
+
 #### WebDriver BiDi
 
-#### Marionette
+- Added support for the [input.setFiles](https://w3c.github.io/webdriver-bidi/#command-input-setFiles) command which allows to set or update the files for `<input>` elements with `type="file"` ([Firefox bug 1855040](https://bugzil.la/1855040)).
+- Added support for the [storage.deleteCookies](https://w3c.github.io/webdriver-bidi/#command-storage-deleteCookies) command to delete cookies ([Firefox bug 1854581](https://bugzil.la/1854581)).
+- Added support for "userContext" as a field of the "partition" argument for cookie commands ([Firefox bug 1875255](https://bugzil.la/1875255)).
+- Fixed an issue where [storage.getCookies](https://w3c.github.io/webdriver-bidi/#command-storage-getCookies) would not retrieve all expected cookies for a given "sourceOrigin" ([Firefox bug 1884647](https://bugzil.la/1884647)).
+- Fixed an issue where recommended preferences would not be applied if only WebDriver BiDi was enabled ([Firefox bug 1882748](https://bugzil.la/1882748)).
+- Fixed an issue where creating and switching to a new tab would not wait for the `visibilityState` to be updated ([Firefox bug 1877469](https://bugzil.la/1877469)).
+
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -95,7 +95,7 @@ This article provides information about the changes in Firefox 125 that affect d
 - Added support for the [storage.deleteCookies](https://w3c.github.io/webdriver-bidi/#command-storage-deleteCookies) command to delete cookies ([Firefox bug 1854581](https://bugzil.la/1854581)).
 - Added support for "userContext" as a field of the "partition" argument for cookie commands ([Firefox bug 1875255](https://bugzil.la/1875255)).
 - Fixed an issue where [storage.getCookies](https://w3c.github.io/webdriver-bidi/#command-storage-getCookies) would not retrieve all expected cookies for a given "sourceOrigin" ([Firefox bug 1884647](https://bugzil.la/1884647)).
-- Fixed an issue where recommended preferences would not be applied if only WebDriver BiDi was enabled ([Firefox bug 1882748](https://bugzil.la/1882748)).
+- Fixed an issue where recommended preferences would not be applied if only WebDriver BiDi as remote protocol, which means CDP is disabled, was enabled ([Firefox bug 1882748](https://bugzil.la/1882748)).
 - Fixed an issue where creating and switching to a new tab would not wait for the `visibilityState` to be updated ([Firefox bug 1877469](https://bugzil.la/1877469)).
 
 


### PR DESCRIPTION
This updates the WebDriver section of the Firefox 125 release notes for all the [note-worthy WebDriver changes in this release](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox124&query_format=advanced&o1=equals&f1=cf_status_firefox125&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed).