### PR TITLE
Add the example using Intl.Segmenter for characters containing variant selectors

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -53,6 +53,20 @@ function getCharacterLength(str) {
 console.log(getCharacterLength("A\uD87E\uDC04Z")); // 3
 ```
 
+If you want to get the exact number of characters in a string containing variant selectors, use the [Intl.Segmenter()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter) constructor.
+You can first ｐass the string you want to split to the [segment()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method of the [Intl.Segmenter](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object. Then, split the returned [Segments](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) object with its [iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/@@iterator), which iterates by grapheme clusters:
+
+```js
+function getCharacterLength(str) {
+  const segmenter = new Intl.Segmenter("ja-JP", { granularity: "grapheme" });
+  // The Segments object iterator that is used here iterates over characters in grapheme clusters,
+  // not mere code units
+  return [...segmenter.segment(str)].length;
+}
+
+console.log(getCharacterLength("葛󠄀城市👨‍👩‍👧‍👧")); // 4
+```
+
 ## Examples
 
 ### Basic usage

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -53,7 +53,7 @@ function getCharacterLength(str) {
 console.log(getCharacterLength("A\uD87E\uDC04Z")); // 3
 ```
 
-If you want to count characters by _grapheme clusters_, use [`Intl.Segmenter()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter). You can first pass the string you want to split to the [`segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method, and then iterate over the returned `Segments` object to get the length:
+If you want to count characters by _grapheme clusters_, use [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter). You can first pass the string you want to split to the [`segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method, and then iterate over the returned `Segments` object to get the length:
 
 ```js
 function getGraphemeCount(str) {

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -53,18 +53,17 @@ function getCharacterLength(str) {
 console.log(getCharacterLength("A\uD87E\uDC04Z")); // 3
 ```
 
-If you want to get the exact number of characters in a string containing variant selectors, use the [Intl.Segmenter()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter) constructor.
-You can first ｐass the string you want to split to the [segment()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method of the [Intl.Segmenter](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) object. Then, split the returned [Segments](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments) object with its [iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment/Segments/@@iterator), which iterates by grapheme clusters:
+If you want to count characters by _grapheme clusters_, use [`Intl.Segmenter()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter). You can first pass the string you want to split to the [`segment()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment) method, and then iterate over the returned `Segments` object to get the length:
 
 ```js
-function getCharacterLength(str) {
-  const segmenter = new Intl.Segmenter("ja-JP", { granularity: "grapheme" });
+function getGraphemeCount(str) {
+  const segmenter = new Intl.Segmenter("en-US", { granularity: "grapheme" });
   // The Segments object iterator that is used here iterates over characters in grapheme clusters,
-  // not mere code units
+  // which may consist of multiple Unicode characters
   return [...segmenter.segment(str)].length;
 }
 
-console.log(getCharacterLength("葛󠄀城市👨‍👩‍👧‍👧")); // 4
+console.log(getGraphemeCount("👨‍👩‍👧‍👧")); // 1
 ```
 
 ## Examples


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

String iterators cannot count the exact number of characters containing [variant selectors](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)).
Could I add the example using Intl.Segmenter for it? 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Readers will know how to count the exact number of characters.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

```js
console.log('👨‍👩‍👧‍👧'.length); // > 11
console.log([...'👨‍👩‍👧‍👧'].length); // > 7

const segmenter = new Intl.Segmenter('ja-JP', { granularity: 'grapheme' });
console.log([...segmenter.segment('👨‍👩‍👧‍👧')].length); // > 1
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Relates to mdn/translated-content#19369

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
