### PR TITLE
Eradicate typo

### DIFF
--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -36,7 +36,7 @@ The status is set to `loaded` when the font face data has been successfully fetc
 Font faces are created using the [`FontFace` constructor](/en-US/docs/Web/API/FontFace/FontFace), which takes as parameters: the font family, the font source, and optional descriptors.
 The format and grammar of these arguments is the same as the equivalent [`@font-face`](/en-US/docs/Web/CSS/@font-face) definition.
 
-The font source can either be binary data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or a font resource at an URL.
+The font source can either be binary data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or a font resource at a URL.
 A typical font face definition using a URL source might be as shown below.
 Note that the `url()` function is required for URL font sources.
 


### PR DESCRIPTION
an URL => a URL

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There was a typo/grammar mistake ("an URL"). In the following sentence "a URL" is used, which makes this one extra jarring.

### Motivation

Fixing typos and grammar mistakes helps the documentation overall.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
