### PR TITLE
Update {{AvailableInWorkers}} macros usage for Service Worker API - part I

### DIFF
--- a/files/en-us/web/api/navigationpreloadmanager/disable/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/disable/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.NavigationPreloadManager.disable
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`disable()`** method of the {{domxref("NavigationPreloadManager")}} interface halts the automatic preloading of service-worker-managed resources previously started using {{domxref("NavigationPreloadManager.enable()","enable()")}}
 It returns a promise that resolves with `undefined`.

--- a/files/en-us/web/api/navigationpreloadmanager/enable/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/enable/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.NavigationPreloadManager.enable
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`enable()`** method of the {{domxref("NavigationPreloadManager")}} interface is used to enable preloading of resources managed by the service worker.
 It returns a promise that resolves with `undefined`.

--- a/files/en-us/web/api/navigationpreloadmanager/getstate/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/getstate/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.NavigationPreloadManager.getState
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`getState()`** method of the {{domxref("NavigationPreloadManager")}} interface returns a {{jsxref("Promise")}} that resolves to an object with properties that indicate whether preload is enabled and what value will be sent in the {{HTTPHeader("Service-Worker-Navigation-Preload")}} HTTP header.
 

--- a/files/en-us/web/api/navigationpreloadmanager/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/index.md
@@ -12,7 +12,7 @@ The **`NavigationPreloadManager`** interface of the [Service Worker API](/en-US/
 If supported, an object of this type is returned by {{domxref("ServiceWorkerRegistration.navigationPreload")}}.
 The result of a preload fetch request is waited on using the promise returned by {{domxref("FetchEvent.preloadResponse")}}.
 
-Currently the `NavigationPreloadManager` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Firefox.
+Currently the `NavigationPreloadManager` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Firefox.
 
 ## Instance methods
 

--- a/files/en-us/web/api/navigationpreloadmanager/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/index.md
@@ -5,12 +5,14 @@ page-type: web-api-interface
 browser-compat: api.NavigationPreloadManager
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`NavigationPreloadManager`** interface of the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) provides methods for managing the preloading of resources in parallel with service worker bootup.
 
 If supported, an object of this type is returned by {{domxref("ServiceWorkerRegistration.navigationPreload")}}.
 The result of a preload fetch request is waited on using the promise returned by {{domxref("FetchEvent.preloadResponse")}}.
+
+Currently the `NavigationPreloadManager` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Firefox.
 
 ## Instance methods
 

--- a/files/en-us/web/api/navigationpreloadmanager/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/index.md
@@ -12,8 +12,6 @@ The **`NavigationPreloadManager`** interface of the [Service Worker API](/en-US/
 If supported, an object of this type is returned by {{domxref("ServiceWorkerRegistration.navigationPreload")}}.
 The result of a preload fetch request is waited on using the promise returned by {{domxref("FetchEvent.preloadResponse")}}.
 
-Currently the `NavigationPreloadManager` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Firefox.
-
 ## Instance methods
 
 - {{domxref("NavigationPreloadManager.enable()")}}

--- a/files/en-us/web/api/navigationpreloadmanager/setheadervalue/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/setheadervalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.NavigationPreloadManager.setHeaderValue
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`setHeaderValue()`** method of the {{domxref("NavigationPreloadManager")}} interface sets the value of the {{HTTPHeader("Service-Worker-Navigation-Preload")}} header that will be sent with requests resulting from a {{domxref("fetch()")}} operation made during service worker navigation preloading.
 It returns an empty {{jsxref("Promise")}} that resolves with `undefined`.

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -5,7 +5,7 @@ page-type: web-api-overview
 spec-urls: https://w3c.github.io/ServiceWorker/
 ---
 
-{{DefaultAPISidebar("Service Workers API")}}
+{{DefaultAPISidebar("Service Workers API")}}{{AvailableInWorkers}}
 
 Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 

--- a/files/en-us/web/api/serviceworker/error_event/index.md
+++ b/files/en-us/web/api/serviceworker/error_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorker.error_event
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The `error` event fires whenever an error occurs in the service worker.
 

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.ServiceWorker
 ---
 
-{{securecontext_header}}{{APIRef("Service Workers API")}}
+{{securecontext_header}}{{APIRef("Service Workers API")}}{{AvailableInWorkers}}
 
 The **`ServiceWorker`** interface of the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) provides a reference to a service worker. Multiple {{glossary("browsing context", "browsing contexts")}} (e.g. pages, workers, etc.) can be associated with the same service worker, each through a unique `ServiceWorker` object.
 
@@ -21,6 +21,8 @@ The `ServiceWorker` interface is dispatched a set of lifecycle events — `insta
 
 Service workers allow static import of [ECMAScript modules](/en-US/docs/Web/JavaScript/Guide/Modules), if supported, using [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import).
 Dynamic import is disallowed by the specification — calling [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import) will throw.
+
+Currently the `ServiceWorker` object is only exposed to {{domxref("Window")}} global scope and {{domxref("ServiceWorkerGlobalScope", "service worker global scope", "", "nocode")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -22,7 +22,7 @@ The `ServiceWorker` interface is dispatched a set of lifecycle events — `insta
 Service workers allow static import of [ECMAScript modules](/en-US/docs/Web/JavaScript/Guide/Modules), if supported, using [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import).
 Dynamic import is disallowed by the specification — calling [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import) will throw.
 
-Currently the `ServiceWorker` object is only exposed to {{domxref("Window")}} global scope and {{domxref("ServiceWorkerGlobalScope", "service worker global scope", "", "nocode")}}.
+Currently the `ServiceWorker` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Chrome and Firefox.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -22,9 +22,8 @@ The `ServiceWorker` interface is dispatched a set of lifecycle events — `insta
 Service workers allow static import of [ECMAScript modules](/en-US/docs/Web/JavaScript/Guide/Modules), if supported, using [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import).
 Dynamic import is disallowed by the specification — calling [`import()`](/en-US/docs/Web/JavaScript/Reference/Operators/import) will throw.
 
-Currently the `ServiceWorker` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Chrome and Firefox.
-
-Service workers can currently only be registered in the Window scope, because the `ServiceWorker` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} in some or all browsers. Check [browser compatibility](#browser_compatibility) for information.
+Service workers can only be registered in the Window scope in some or all browsers, because the `ServiceWorker` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}}.
+Check the [browser compatibility](#browser_compatibility) for information.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -24,6 +24,8 @@ Dynamic import is disallowed by the specification — calling [`import()`](/en-U
 
 Currently the `ServiceWorker` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Chrome and Firefox.
 
+Service workers can currently only be registered in the Window scope, because the `ServiceWorker` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} in some or all browsers. Check [browser compatibility](#browser_compatibility) for information.
+
 {{InheritanceDiagram}}
 
 ## Instance properties

--- a/files/en-us/web/api/serviceworker/postmessage/index.md
+++ b/files/en-us/web/api/serviceworker/postmessage/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorker.postMessage
 ---
 
-{{APIRef("Service Workers API")}}{{securecontext_header}}
+{{APIRef("Service Workers API")}}{{securecontext_header}}{{AvailableInWorkers}}
 
 The **`postMessage()`** method of the {{domxref("ServiceWorker")}} interface sends a message to the worker. The first parameter is the data to send to the worker. The data may be any JavaScript object which can be handled by the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 

--- a/files/en-us/web/api/serviceworker/scripturl/index.md
+++ b/files/en-us/web/api/serviceworker/scripturl/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorker.scriptURL
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 Returns the `ServiceWorker` serialized script URL defined as part of [`ServiceWorkerRegistration`](/en-US/docs/Web/API/ServiceWorkerRegistration).
 Must be on the same origin as the document that registers the

--- a/files/en-us/web/api/serviceworker/state/index.md
+++ b/files/en-us/web/api/serviceworker/state/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorker.state
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`state`** read-only property of the
 {{domxref("ServiceWorker")}} interface returns a string representing the current state

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorker.statechange_event
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The `statechange` event fires anytime the {{domxref("ServiceWorker.state")}} changes.
 

--- a/files/en-us/web/api/serviceworkercontainer/controller/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/controller/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorkerContainer.controller
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`controller`** read-only
 property of the {{domxref("ServiceWorkerContainer")}} interface returns a

--- a/files/en-us/web/api/serviceworkercontainer/controllerchange_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/controllerchange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerContainer.controllerchange_event
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`controllerchange`** event of the {{domxref("ServiceWorkerContainer")}} interface fires when the document's associated {{domxref("ServiceWorkerRegistration")}} acquires a new {{domxref("ServiceWorkerRegistration.active","active")}} worker.
 

--- a/files/en-us/web/api/serviceworkercontainer/error_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/error_event/index.md
@@ -9,7 +9,7 @@ status:
 browser-compat: api.ServiceWorkerContainer.error_event
 ---
 
-{{APIRef("Service Workers API")}}{{Deprecated_header}}{{Non-standard_header}}
+{{APIRef("Service Workers API")}}{{Deprecated_header}}{{Non-standard_header}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The `error` event fires when an error occurs in the service worker.
 

--- a/files/en-us/web/api/serviceworkercontainer/getregistration/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/getregistration/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerContainer.getRegistration
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`getRegistration()`** method of the
 {{domxref("ServiceWorkerContainer")}} interface gets a

--- a/files/en-us/web/api/serviceworkercontainer/getregistrations/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/getregistrations/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerContainer.getRegistrations
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`getRegistrations()`** method of the
 {{domxref("ServiceWorkerContainer")}} interface gets all

--- a/files/en-us/web/api/serviceworkercontainer/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/index.md
@@ -5,11 +5,13 @@ page-type: web-api-interface
 browser-compat: api.ServiceWorkerContainer
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`ServiceWorkerContainer`** interface of the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) provides an object representing the service worker as an overall unit in the network ecosystem, including facilities to register, unregister and update service workers, and access the state of service workers and their registrations.
 
 Most importantly, it exposes the {{domxref("ServiceWorkerContainer.register()")}} method used to register service workers, and the {{domxref("ServiceWorkerContainer.controller")}} property used to determine whether or not the current page is actively controlled.
+
+Currently the `ServiceWorkerContainer` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Chrome and Firefox.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworkercontainer/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/index.md
@@ -11,7 +11,7 @@ The **`ServiceWorkerContainer`** interface of the [Service Worker API](/en-US/do
 
 Most importantly, it exposes the {{domxref("ServiceWorkerContainer.register()")}} method used to register service workers, and the {{domxref("ServiceWorkerContainer.controller")}} property used to determine whether or not the current page is actively controlled.
 
-Service workers can currently only be registered in the Window scope, because the `ServiceWorkerContainer` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} in some or all browsers. Check [browser compatibility](#browser_compatibility) for information.
+Service workers can currently only be registered in the Window scope in some or all browsers, because the `ServiceWorkerContainer` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}}. Check the [browser compatibility](#browser_compatibility) for information.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworkercontainer/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/index.md
@@ -11,7 +11,7 @@ The **`ServiceWorkerContainer`** interface of the [Service Worker API](/en-US/do
 
 Most importantly, it exposes the {{domxref("ServiceWorkerContainer.register()")}} method used to register service workers, and the {{domxref("ServiceWorkerContainer.controller")}} property used to determine whether or not the current page is actively controlled.
 
-Currently the `ServiceWorkerContainer` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Chrome and Firefox.
+Service workers can currently only be registered in the Window scope, because the `ServiceWorkerContainer` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} in some or all browsers. Check [browser compatibility](#browser_compatibility) for information.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworkercontainer/message_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/message_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerContainer.message_event
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`message`** event is used in a page controlled by a service worker to receive messages from the service worker.
 

--- a/files/en-us/web/api/serviceworkercontainer/messageerror_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/messageerror_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.ServiceWorkerContainer.messageerror_event
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`messageerror`** event is fired to the {{domxref("ServiceWorkerContainer")}} when an incoming message sent to the associated worker can't be deserialized.
 

--- a/files/en-us/web/api/serviceworkercontainer/ready/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/ready/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ServiceWorkerContainer.ready
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`ready`** read-only property of
 the {{domxref("ServiceWorkerContainer")}} interface provides a way of delaying code

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerContainer.register
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`register()`** method of the
 {{domxref("ServiceWorkerContainer")}} interface creates or updates a

--- a/files/en-us/web/api/serviceworkercontainer/startmessages/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/startmessages/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ServiceWorkerContainer.startMessages
 ---
 
-{{APIRef("Service Workers API")}}{{SecureContext_Header}}
+{{APIRef("Service Workers API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`startMessages()`** method of
 the {{domxref("ServiceWorkerContainer")}} interface explicitly starts the flow of

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -11,6 +11,8 @@ The **`ServiceWorkerRegistration`** interface of the [Service Worker API](/en-US
 
 The lifetime of a service worker registration is beyond that of the `ServiceWorkerRegistration` objects that represent them within the lifetime of their corresponding service worker clients. The browser maintains a persistent list of active `ServiceWorkerRegistration` objects.
 
+Currently the `ServiceWorkerRegistration` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Chrome and Firefox.
+
 {{InheritanceDiagram}}
 
 ## Instance properties

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -11,8 +11,6 @@ The **`ServiceWorkerRegistration`** interface of the [Service Worker API](/en-US
 
 The lifetime of a service worker registration is beyond that of the `ServiceWorkerRegistration` objects that represent them within the lifetime of their corresponding service worker clients. The browser maintains a persistent list of active `ServiceWorkerRegistration` objects.
 
-Currently the `ServiceWorkerRegistration` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Firefox.
-
 {{InheritanceDiagram}}
 
 ## Instance properties

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -11,7 +11,7 @@ The **`ServiceWorkerRegistration`** interface of the [Service Worker API](/en-US
 
 The lifetime of a service worker registration is beyond that of the `ServiceWorkerRegistration` objects that represent them within the lifetime of their corresponding service worker clients. The browser maintains a persistent list of active `ServiceWorkerRegistration` objects.
 
-Currently the `ServiceWorkerRegistration` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Firefox.
+Currently the `ServiceWorkerRegistration` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}} and {{domxref("SharedWorkerGlobalScope")}} for Firefox.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/serviceworkerregistration/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index.md
@@ -11,7 +11,7 @@ The **`ServiceWorkerRegistration`** interface of the [Service Worker API](/en-US
 
 The lifetime of a service worker registration is beyond that of the `ServiceWorkerRegistration` objects that represent them within the lifetime of their corresponding service worker clients. The browser maintains a persistent list of active `ServiceWorkerRegistration` objects.
 
-Currently the `ServiceWorkerRegistration` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Chrome and Firefox.
+Currently the `ServiceWorkerRegistration` object is not exposed to {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} and {{domxref("ServiceWorkerGlobalScope")}} for Firefox.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/workernavigator/serviceworker/index.md
+++ b/files/en-us/web/api/workernavigator/serviceworker/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.WorkerNavigator.serviceWorker
 ---
 
-{{securecontext_header}}{{APIRef("Service Workers API")}}
+{{securecontext_header}}{{APIRef("Service Workers API")}}{{AvailableInWorkers}}
 
 The **`serviceWorker`** read-only property of the {{domxref("WorkerNavigator")}} interface returns the {{domxref("ServiceWorkerContainer")}} object for the [associated document](https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window), which provides access to registration, removal, upgrade, and communication with the {{domxref("ServiceWorker")}}.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update usage for {{AvailableInWorkers}} for Service Worker API

---

in most current browser implement, register service worker is only available in window global scope (for chromium and firefox)

that is, though `ServiceWorker`, `ServiceWorkerRegistration`, `ServiceWorkerContainer`, `NavigationPreloadManager` should expose to both `Window` and `ServiceWorker` according to the specification, and `WorkerNavigator.serviceWorker` should expose to all kinds of worker

`ServiceWorker`, `NavigationPreloadManager` (for firefox) and `ServiceWorkerRegistration` (for firefox) is not exposed to `DedicatedWorker` and `SharedWorker`, `WorkerNavigator.serviceWorker` and `ServiceWorkerContainer` is not exposed to all kinds of worker

test using https://worker-playground.glitch.me/

---

some related browser issues includes:

- https://issues.chromium.org/issues/40364838
- https://bugzilla.mozilla.org/show_bug.cgi?id=1113522
- https://bugzilla.mozilla.org/show_bug.cgi?id=1131324


<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

part of the #31675 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
