### PR TITLE
FF125 Relnote - WASM Multi-memory

### DIFF
--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -81,8 +81,8 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ### WebAssembly
 
-- WebAssembly now allows WASM modules to use multiple independent linear memories.
-  Multiple memories enable more efficient interoperability between modules, and better polyfills for upcoming wasm standards. They can be used, for example, to create separate memory for internal and shared data, ephemeral and persisted data, or data that needs to be shared between threads.
+- Support has been added for Wasm modules to use multiple independent linear memories.
+  Multiple memories enable more efficient interoperability between modules and better polyfills for upcoming Wasm standards. They can be used, for example, to create separate memory for internal and shared data, ephemeral and persisted data, or data that needs to be shared between threads.
   The memory can be created in JavaScript and imported into the WASM module, or created in the WASM module and exported.
   Each new linear memory in a WASM instance is given a sequential index, starting from zero.
   WASM [memory instructions](/en-US/docs/WebAssembly/Reference/Memory) use the index to reference the memory on which they are operating, defaulting to the first memory defined if no index is specified.

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -81,6 +81,14 @@ This article provides information about the changes in Firefox 125 that affect d
 
 ### WebAssembly
 
+- WebAssembly now allows WASM modules to use multiple independent linear memories.
+  Multiple memories enable more efficient interoperability between modules, and better polyfills for upcoming wasm standards. They can be used, for example, to create separate memory for internal and shared data, ephemeral and persisted data, or data that needs to be shared between threads.
+  The memory can be created in JavaScript and imported into the WASM module, or created in the WASM module and exported.
+  Each new linear memory in a WASM instance is given a sequential index, starting from zero.
+  WASM [memory instructions](/en-US/docs/WebAssembly/Reference/Memory) use the index to reference the memory on which they are operating, defaulting to the first memory defined if no index is specified.
+  For more information, see [WebAssembly Memory](/en-US/docs/WebAssembly/Understanding_the_text_format#webassembly_memory) in _Understanding WebAssembly text format_.
+  ([Firefox bug 1860816](https://bugzil.la/1860816)).
+
 #### Removals
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)

--- a/files/en-us/mozilla/firefox/releases/125/index.md
+++ b/files/en-us/mozilla/firefox/releases/125/index.md
@@ -83,9 +83,9 @@ This article provides information about the changes in Firefox 125 that affect d
 
 - Support has been added for Wasm modules to use multiple independent linear memories.
   Multiple memories enable more efficient interoperability between modules and better polyfills for upcoming Wasm standards. They can be used, for example, to create separate memory for internal and shared data, ephemeral and persisted data, or data that needs to be shared between threads.
-  The memory can be created in JavaScript and imported into the WASM module, or created in the WASM module and exported.
-  Each new linear memory in a WASM instance is given a sequential index, starting from zero.
-  WASM [memory instructions](/en-US/docs/WebAssembly/Reference/Memory) use the index to reference the memory on which they are operating, defaulting to the first memory defined if no index is specified.
+  The memory can be created in JavaScript and imported into the Wasm module, or created in the Wasm module and exported.
+  Each new linear memory in a Wasm instance is given a sequential index, starting from zero.
+  WebAssembly [memory instructions](/en-US/docs/WebAssembly/Reference/Memory) use the index to reference the memory on which they are operating, defaulting to the first memory defined if no index is specified.
   For more information, see [WebAssembly Memory](/en-US/docs/WebAssembly/Understanding_the_text_format#webassembly_memory) in _Understanding WebAssembly text format_.
   ([Firefox bug 1860816](https://bugzil.la/1860816)).
 


### PR DESCRIPTION
FF125 adds support for the WASM multi-memory proposal in https://bugzilla.mozilla.org/show_bug.cgi?id=1860816

This adds a release note.
Note that I am not certain I'll get a review on the associated docs in time, so this release note links to a document that will exist, but might not yet include the right information. I might update this again with a more precise link in future.

Related docs work tracked in #32777