### PR TITLE
Update custom state set examples

### DIFF
--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -462,7 +462,6 @@ The downside to this approach is that the dashes must be included when using the
 
 ```js
 class CompatibleStateElement extends HTMLElement {
-  #internals;
   constructor() {
     super();
     this._internals = this.attachInternals();

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -462,8 +462,8 @@ The downside to this approach is that the dashes must be included when using the
 
 ```js
 class CompatibleStateElement extends HTMLElement {
-  #internals
-  constructor () {
+  #internals;
+  constructor() {
     super();
     this._internals = this.attachInternals();
   }

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -90,7 +90,9 @@ This is mapped to the `checked` custom state, allowing styling to be applied usi
 #### JavaScript
 
 First we define our class `LabeledCheckbox` which extends from `HTMLElement`.
-In the constructor we call the `super()` method, leaving most of the "work" to `connectedCallback()`, which is invoked when a custom element is added to the page.
+In the constructor we call the `super()` method, add a listener for the click event, and call {{domxref("HTMLElement.attachInternals()", "this.attachInternals()")}} to attach an {{domxref("ElementInternals", "ElementInternals")}} object.
+
+Most of the rest of the "work" is then left to `connectedCallback()`, which is invoked when a custom element is added to the page.
 The content of the element is defined using a `<style>` element to be the text `[]` or `[x]` followed by a label.
 What's noteworthy here is that the custom state pseudo class is used to select the text to display: `:host(:state(checked))`.
 After the example below, we'll cover what's happening in the snippet in more detail.
@@ -143,7 +145,6 @@ class LabeledCheckbox extends HTMLElement {
 
 In the `LabeledCheckbox` class:
 
-- The `connectedCallback()` method uses {{domxref("HTMLElement.attachInternals()", "`this.attachInternals()`")}} to attach an {{domxref("ElementInternals", "`ElementInternals`")}} object.
 - In the `get checked()` and `set checked()` we use `ElementInternals.states` to get the `CustomStateSet`.
 - The `set checked(flag)` method adds the `"checked"` identifier to the `CustomStateSet` if the flag is set and delete the identifier if the flag is `false`.
 - The `get checked()` method just checks whether the `checked` property is defined in the set.
@@ -418,11 +419,11 @@ Click the element to see a different border being applied as the state changes.
 
 Previously custom elements with custom states were selected using a `<dashed-ident>` instead of the [`:state()`](/en-US/docs/Web/CSS/:state) function.
 Browsers that don't support `:state()`, including versions of Chrome, will throw an error when supplied with an ident that is not prefixed with the double dash.
-If support for these browsers is required, either use a [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block to support both syntaxes, or use a `<dashed-ident>` as the state's value and select it with both the `:--mystate` and `:state(--mystate)` CSS selector:
+If support for these browsers is required, either use a [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block to support both syntaxes, or use a `<dashed-ident>` as the state's value and select it with both the `:--mystate` and `:state(--mystate)` CSS selector.
 
 ### Using a try...catch block
 
-Setting the state to a name without the two dashes will cause an error in some versions of Chrome, catching this error and providing the `<dashed-ident>` alternative allows both to be selected for in CSS:
+Setting the state to a name without the two dashes will cause an error in some versions of Chrome, catching this error and providing the `<dashed-ident>` alternative allows both to be selected for in CSS.
 
 #### JavaScript
 
@@ -456,7 +457,7 @@ compatible-state-element:is(:--loaded, :state(loaded)) {
 ### Using double dash prefixed idents
 
 An alternative solution can be to use the `<dashed-ident>` within JavaScript.
-The downside to this approach is that the dashes must be included when using the CSS `:state()` syntax:
+The downside to this approach is that the dashes must be included when using the CSS `:state()` syntax.
 
 #### JavaScript
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -428,7 +428,7 @@ Setting the state to a name without the two dashes will cause an error in some v
 
 ```js
 class CompatibleStateElement extends HTMLElement {
-  constructor () {
+  constructor() {
     super();
     this._internals = this.attachInternals();
   }

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -99,13 +99,14 @@ After the example below, we'll cover what's happening in the snippet in more det
 class LabeledCheckbox extends HTMLElement {
   constructor() {
     super();
+    this._boundOnClick = this._onClick.bind(this);
+    this.addEventListener("click", this._boundOnClick);
+
+    // Attach an ElementInternals to get states property
+    this._internals = this.attachInternals();
   }
 
   connectedCallback() {
-    // Attach an ElementInternals to get states property
-    this._internals = this.attachInternals();
-    this.addEventListener("click", this._onClick.bind(this));
-
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
         :host {
@@ -195,13 +196,13 @@ The element uses the `<labeled-checkbox>` defined in the [previous example](#mat
 class LabeledCheckbox extends HTMLElement {
   constructor() {
     super();
+    this._boundOnClick = this._onClick.bind(this);
+    this.addEventListener("click", this._boundOnClick);
+    // Attach an ElementInternals to get states property
+    this._internals = this.attachInternals();
   }
 
   connectedCallback() {
-    // Attach an ElementInternals to get states property
-    this._internals = this.attachInternals();
-    this.addEventListener("click", this._onClick.bind(this));
-
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
         :host {
@@ -318,13 +319,14 @@ Most of the remaining code is similar to the example that demonstrates a single 
 class ManyStateElement extends HTMLElement {
   constructor() {
     super();
+    this._boundOnClick = this._onClick.bind(this);
+    this.addEventListener("click", this._boundOnClick);
+    // Attach an ElementInternals to get states property
+    this._internals = this.attachInternals();
   }
 
   connectedCallback() {
-    // Attach an ElementInternals to get states property
-    this._internals = this.attachInternals();
     this.state = "loading";
-    this.addEventListener("click", this._onClick.bind(this));
 
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
@@ -426,14 +428,18 @@ Setting the state to a name without the two dashes will cause an error in some v
 
 ```js
 class CompatibleStateElement extends HTMLElement {
+  constructor () {
+    super();
+    this._internals = this.attachInternals();
+  }
+
   connectedCallback() {
-    const internals = this.attachInternals();
     // The double dash is required in browsers with the
     // legacy syntax, not supplying it will throw
     try {
-      internals.states.add("loaded");
+      this._internals.states.add("loaded");
     } catch {
-      internals.states.add("--loaded");
+      this._internals.states.add("--loaded");
     }
   }
 }
@@ -456,11 +462,15 @@ The downside to this approach is that the dashes must be included when using the
 
 ```js
 class CompatibleStateElement extends HTMLElement {
+  #internals
+  constructor () {
+    super();
+    this._internals = this.attachInternals();
+  }
   connectedCallback() {
-    const internals = this.attachInternals();
     // The double dash is required in browsers with the
     // legacy syntax, but works with the modern syntax
-    internals.states.add("--loaded");
+    this._internals.states.add("--loaded");
   }
 }
 ```


### PR DESCRIPTION
### Description

Update documentation to get rid of memory leak and only call `attachInternals` once.

### Motivation

The examples can lead to errors and unexpected behaviors.

### Additional details

Custom state set examples have 2 problems:

1. Calling `this.attachInternals()` in `connectedCallback()` can fire X number of times, which will lead to an error message in the browser about attach internals already being called.

2. An event listener is being added by calling `this._onClick.bind(this)` in the connectedCallback which can fire X number of times and won't get deduped by the browser, so every time the element connects, it will add a new listener, rathering than deduping the existing listener and can lead to unexpected behavior.

### Related issues and pull requests

