### PR TITLE
Fix property name `iceTransport`

### DIFF
--- a/files/en-us/web/api/rtcicecandidatepair/local/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.md
@@ -8,22 +8,16 @@ browser-compat: api.RTCIceCandidatePair.local
 
 {{APIRef("WebRTC")}}
 
-The **`local`** property of the
-**{{domxref("RTCIceCandidatePair")}}** dictionary specifies the
-{{domxref("RTCIceCandidate")}} which describes the configuration of the local end of a
-viable WebRTC connection.
+The **`local`** property of the **{{domxref("RTCIceCandidatePair")}}** dictionary specifies the {{domxref("RTCIceCandidate")}} which describes the configuration of the local end of a viable WebRTC connection.
 
 ## Value
 
-An {{domxref("RTCIceCandidate")}} which describes the configuration of the local end of
-a viable pair of ICE candidates. The `RTCIceCandidatePair` is returned by the
-{{domxref("RTCIceTransport")}} method
-{{domxref("RTCIceTransport.getSelectedCandidatePair", "getSelectedCandidatePair()")}}.
+An {{domxref("RTCIceCandidate")}} which describes the configuration of the local end of a viable pair of ICE candidates.
+The `RTCIceCandidatePair` is returned by the {{domxref("RTCIceTransport")}} method {{domxref("RTCIceTransport.getSelectedCandidatePair", "getSelectedCandidatePair()")}}.
 
 ## Examples
 
-This one-line example obtains the current candidate pair and then from that gets the
-local candidate.
+This one-line example obtains the current candidate pair and then from that gets the local candidate.
 
 ```js
 const candidatePair = pc
@@ -32,11 +26,8 @@ const candidatePair = pc
 const localCandidate = candidatePair.local;
 ```
 
-The {{domxref("RTCIceTransport")}} is found by getting the list of
-{{domxref("RTCRtpSender")}} objects for the {{domxref("RTCPeerConnection")}}
-`pc`. In the first `RTCRtpSender`, we get the
-{{domxref("RTCDtlsTransport")}} over which the media data is being transmitted and
-finally, from that, the `RTCIceTransport`.
+The {{domxref("RTCIceTransport")}} is found by getting the list of {{domxref("RTCRtpSender")}} objects for the {{domxref("RTCPeerConnection")}} `pc`.
+In the first `RTCRtpSender`, we get the {{domxref("RTCDtlsTransport")}} over which the media data is being transmitted and finally, from that, the `RTCIceTransport`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicecandidatepair/local/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.md
@@ -28,7 +28,7 @@ local candidate.
 ```js
 const candidatePair = pc
   .getSenders()[0]
-  .transport.transport.getSelectedCandidatePair();
+  .transport.iceTransport.getSelectedCandidatePair();
 const localCandidate = candidatePair.local;
 ```
 


### PR DESCRIPTION
The property name `iceTransport` of `RTCDtlsTransport` is not `transport`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
