### PR TITLE
Add note about anchors and host elements being focusable.

### DIFF
--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -50,7 +50,7 @@ setValidity(flags, message, anchor)
 - `message` {{Optional_Inline}}
   - : A string containing a message, which will be set if any `flags` are `true`. This parameter is only optional if all `flags` are `false`.
 - `anchor` {{Optional_Inline}}
-  - : An {{domxref("HTMLElement")}} which can be used by the user agent to report problems with this form submission. An anchor should be focusable, or it may result in an error, or your validation message may not appear at all depending on your browser.
+  - : An {{domxref("HTMLElement")}} which can be used by the user agent to report problems with this form submission. An anchor should be focusable, or it may result in an error, or your validation message may not appear at all depending on your browser. If no anchor is provided, ensure the host custom element is focusable, or that it has `{ delegatesFocus: true }` and a focusable element in it's shadowRoot.
 
 ### Return value
 

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -50,7 +50,7 @@ setValidity(flags, message, anchor)
 - `message` {{Optional_Inline}}
   - : A string containing a message, which will be set if any `flags` are `true`. This parameter is only optional if all `flags` are `false`.
 - `anchor` {{Optional_Inline}}
-  - : An {{domxref("HTMLElement")}} which can be used by the user agent to report problems with this form submission.
+  - : An {{domxref("HTMLElement")}} which can be used by the user agent to report problems with this form submission. An anchor should be focusable, or it may result in an error, or your validation message may not appear at all depending on your browser.
 
 ### Return value
 


### PR DESCRIPTION
### Description
Add note about anchors needing to be focusable.

### Motivation

So no one else need to spend hours wondering why their custom validations aren't working as expected.

### Additional details

Codepen of different behavior across browsers if the host element is not focusable, or if the anchor is not focusable:

### Related issues and pull requests

