### PR TITLE
Link Intl and Keyboard.getLayoutMap via See also

### DIFF
--- a/files/en-us/web/api/keyboard/getlayoutmap/index.md
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.md
@@ -55,3 +55,7 @@ keyboard.getLayoutMap().then((keyboardLayoutMap) => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{jsxref("Intl")}}

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -156,7 +156,7 @@ const formattedCount = new Intl.NumberFormat(navigator.languages).format(count);
 - {{jsxref("Date.prototype.toLocaleString()")}}
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
-- {{jsxref("Keyboard.getLayoutMap()")}}
+- {{domxref("Keyboard.getLayoutMap()")}}
 - {{domxref("navigator.language")}}
 - {{domxref("navigator.languages")}}
 - [The ECMAScript Internationalization API](https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html) by Norbert Lindenberg (2012)

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -156,6 +156,7 @@ const formattedCount = new Intl.NumberFormat(navigator.languages).format(count);
 - {{jsxref("Date.prototype.toLocaleString()")}}
 - {{jsxref("Date.prototype.toLocaleDateString()")}}
 - {{jsxref("Date.prototype.toLocaleTimeString()")}}
+- {{jsxref("Keyboard.getLayoutMap()")}}
 - {{domxref("navigator.language")}}
 - {{domxref("navigator.languages")}}
 - [The ECMAScript Internationalization API](https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html) by Norbert Lindenberg (2012)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds mutual "See also" enties to link "Intl" to "Keyboard.getLayoutMap()".

### Motivation

I wanted to find out information about detecting the keyboard layout, and thought the `Intl` could have something related to it.
I was surprised not to find any mention of either "keyboard" or "layout" in that page, so this PR adds the two-way link, to allow people to locate these pages coming from the other.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
