### PR TITLE
chore: remove the description of the table's source

### DIFF
--- a/files/en-us/web/http/status/412/index.md
+++ b/files/en-us/web/http/status/412/index.md
@@ -58,8 +58,6 @@ If the hashes don't match, it means that the document has been edited in-between
 
 ## Browser compatibility
 
-The information below has been pulled from MDN's GitHub (<https://github.com/mdn/browser-compat-data>).
-
 {{Compat}}
 
 ## See also


### PR DESCRIPTION
### Description

remove the description of the table's source. I believe the information above the table already illustrates this.
