### PR TITLE
Release note for addition of commands.onCommand.tab support

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -34,7 +34,7 @@ Events have three functions:
 
 - `listener`
 
-  - : The function called when a user enters the command's shortcut. The function is passed this argument:
+  - : The function called when a user enters the command's shortcut. The function is passed these arguments:
 
     - `name`
       - : `string`. Name of the command. This matches the name given to the command in its [manifest.json entry](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands).

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -58,7 +58,7 @@ This article provides information about the changes in Firefox 126 that affect d
 
 ## Changes for add-on developers
 
-- The {{WebExtAPIRef("commands.onCommand")}} event now passes the `tab` argument to the event listener. This enables extensions to apply a triggered shortcut to the page in which it was issued without the need to call `tabs.query()` API ([Firefox bug 1843866](https://bugzil.la/1843866)).
+- The {{WebExtAPIRef("commands.onCommand")}} event now passes the `tab` argument to the event listener. This enables extensions to apply a triggered shortcut to the page in which it was issued, without the need to call the `tabs.query()` method ([Firefox bug 1843866](https://bugzil.la/1843866)).
 - The {{WebExtAPIRef("runtime.MessageSender")}} type now includes the `origin` property. This enables message or connection requests to see the page or frame that opened the connection. This is useful for identifying if the origin can be trusted if it isn't apparent from the URL ([Firefox bug 1787379](https://bugzil.la/1787379)).
 
 ### Removals

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
 ## Changes for add-on developers
 
+- The {{WebExtAPIRef("commands.onCommand")}} event now passes the `tab` argument to the event listener. This enables extensions to apply a triggered shortcut to the page in which it was issued without the need to call `tabs.query()` API ([Firefox bug 1843866](https://bugzil.la/1843866)).
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
#### Summary

In support of dev-doc-needed for [Bug 1843866](https://bugzilla.mozilla.org/show_bug.cgi?id=1843866) Add tab parameter to commands.onCommand

- Adds release note for commands.onCommand.tab support
- Corrects grammar in commands.onCommand page

### Related issues and pull requests

BCD data update in https://github.com/mdn/browser-compat-data/pull/22827
