### PR TITLE
runtime.MessageSender.origin support release note

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
 ## Changes for add-on developers
 
+- The {{WebExtAPIRef("runtime.MessageSender")}} type now includes the `origin` property. This enables message or connection requests to see the page or frame that opened the connection. This is useful for identifying if the origin can be trusted if it isn't apparent from the URL ([Firefox bug 1787379](https://bugzil.la/1787379)).
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
#### Summary

Add a release note for the introduction of runtime.MessageSender.origin support in Firefox 126.

#### Related issues

Addresses the dev-docs-needed request for [Bug 1787379](https://bugzilla.mozilla.org/show_bug.cgi?id=1787379) Support MessageSender.origin for extension messages

BCD changes in https://github.com/mdn/browser-compat-data/pull/22830

