### PR TITLE
FF126 Relnote: CustomStateSet and CSS :state() selector

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1785,48 +1785,6 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
   </tbody>
 </table>
 
-#### CustomStateSet and the :state() pseudo-class: States for custom elements
-
-You can now define custom states for custom elements and match them using CSS.
-Custom states are represented as custom identifiers that can be added to, or removed from, the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument and matches the custom elements if the identifier is present in their set of states.
-(See [Firefox bug 1861466](https://bugzil.la/1861466) and [Firefox bug 1866351](https://bugzil.la/1866351) for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>121</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.element.customstateset.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ### Payment Request API
 
 #### Primary payment handling

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -40,6 +40,9 @@ This article provides information about the changes in Firefox 126 that affect d
 
 #### DOM
 
+- States can now be defined for custom elements and matched using CSS selectors.
+  The custom states are represented as custom identifiers that can be added to, or removed from, the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument and matches custom elements if the identifier is present in their set of states. ([Firefox bug 1861466](https://bugzil.la/1861466), [Firefox bug 1866351](https://bugzil.la/1866351), [Firefox bug 1887543](https://bugzil.la/1887543).)
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -40,8 +40,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
 #### DOM
 
-- States can now be defined for custom elements and matched using CSS selectors.
-  The custom states are represented as custom identifiers that can be added to, or removed from, the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument and matches custom elements if the identifier is present in their set of states. ([Firefox bug 1861466](https://bugzil.la/1861466), [Firefox bug 1866351](https://bugzil.la/1866351), [Firefox bug 1887543](https://bugzil.la/1887543).)
+- The ability to define states for custom elements and match them using CSS selectors is now available by default.
+  The custom states are represented as custom identifiers that can be added to or removed from the element's {{domxref("ElementInternals.states")}} property (a {{domxref("CustomStateSet")}}). The CSS [`:state()`](/en-US/docs/Web/CSS/:state) pseudo-class takes a custom identifier as an argument and matches custom elements if the identifier is present in their set of states. ([Firefox bug 1887543](https://bugzil.la/1887543)).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
FF126 supports `CustomStateSet` and the [CSS `:state()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:state) in https://bugzilla.mozilla.org/show_bug.cgi?id=1887543. This adds a release note and strips the info from Experimental features.

Related docs work can be tracked in #33018