### PR TITLE
Update user-valid algorithm

### DIFF
--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -9,10 +9,13 @@ browser-compat: css.selectors.user-valid
 
 The **`:user-valid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents any validated form element whose value validates correctly based on its [validation constraints](/en-US/docs/Learn/Forms#constraint_validation). However, unlike {{cssxref(":valid")}} it only matches once the user has interacted with it.
 
-This pseudo-class is applied according to the following rules:
+This pseudo-class is applied if the form control is valid and any of the following has occurred:
 
-- The following rules apply only if the user has committed a changed value or attempted to submit the form.
-- If the value is valid, apply this pseudo-class.
+- The user made a change to the form control and committed the change such as by moving focus elsewhere
+- The user has attempted to submit the form, even if no change was made to the control.
+- The value was invalid when it gained focus, and the user made a change making it valid, even if focus is still in the control.
+
+Once this pseudo-class has been applied, the user-agent re-validates whether the control is valid at every keystroke when the control has focus.
 - If the control has focus, and the value was invalid when it gained focus, re-validate on every keystroke.
 
 The result is that if the control was valid when the user started interacting with it, the validity styling is changed only when the user shifts focus to another control. However, if the user is trying to correct a previously-flagged value, the control shows immediately when the value becomes valid. Required items are flagged as invalid only if the user changes them or attempts to submit an unchanged invalid value.

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -11,10 +11,9 @@ The **`:user-valid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) rep
 
 This pseudo-class is applied according to the following rules:
 
-- If the control does not have focus, and the value is valid, apply this pseudo-class.
-- If the control has focus, and the value was valid (including empty) when it gained focus, apply this pseudo-class.
+- The following rules apply only if the user has committed a changed value or attempted to submit the form.
+- If the value is valid, apply this pseudo-class.
 - If the control has focus, and the value was invalid when it gained focus, re-validate on every keystroke.
-- If the element is required, the preceding rules apply only if the user has changed the value or attempted to submit the form.
 
 The result is that if the control was valid when the user started interacting with it, the validity styling is changed only when the user shifts focus to another control. However, if the user is trying to correct a previously-flagged value, the control shows immediately when the value becomes valid. Required items are flagged as invalid only if the user changes them or attempts to submit an unchanged invalid value.
 

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -11,7 +11,7 @@ The **`:user-valid`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) rep
 
 This pseudo-class is applied if the form control is valid and any of the following has occurred:
 
-- The user made a change to the form control and committed the change such as by moving focus elsewhere
+- The user made a change to the form control and committed the change such as by moving focus elsewhere.
 - The user has attempted to submit the form, even if no change was made to the control.
 - The value was invalid when it gained focus, and the user made a change making it valid, even if focus is still in the control.
 

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -16,6 +16,7 @@ This pseudo-class is applied if the form control is valid and any of the followi
 - The value was invalid when it gained focus, and the user made a change making it valid, even if focus is still in the control.
 
 Once this pseudo-class has been applied, the user-agent re-validates whether the control is valid at every keystroke when the control has focus.
+
 - If the control has focus, and the value was invalid when it gained focus, re-validate on every keystroke.
 
 The result is that if the control was valid when the user started interacting with it, the validity styling is changed only when the user shifts focus to another control. However, if the user is trying to correct a previously-flagged value, the control shows immediately when the value becomes valid. Required items are flagged as invalid only if the user changes them or attempts to submit an unchanged invalid value.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

As demonstrated by removing required from the example further in the page ([exemple duplicated on CodePen](https://codepen.io/Mintoo201/pen/RwOYbmR)), the pseudo-class matches the input only after the user interacts with it.
Given the above algorithm, the "control does not have focus, and the value is valid" and should therefore apply the pseudo-class.
[The HTML specification](https://drafts.csswg.org/selectors/#user-valid-pseudo), linked to by the page, does not mention required at all but also does not present the expected algorithm, so hard to tell if the problem is with the doc or the current implementation.
### Motivation

### Additional details

### Related issues and pull requests

Fixes #33104

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
