### PR TITLE
Circle farthest -side - farthest in any dimension

### DIFF
--- a/files/en-us/web/css/basic-shape/circle/index.md
+++ b/files/en-us/web/css/basic-shape/circle/index.md
@@ -27,7 +27,7 @@ clip-path: circle(6rem at 12rem 8rem);
     - `closest-side`
       - : Uses the length from the center of the shape to the closest side of the reference box. For circles, this is the closest side in any dimension.
     - `farthest-side`
-      - : Uses the length from the center of the shape to the farthest side of the reference box. For circles, this is the closest side in any dimension.
+      - : Uses the length from the center of the shape to the farthest side of the reference box. For circles, this is the farthest side in any dimension.
 
 - `<position>`
   - : Moves the center of the circle. May be a {{cssxref("length")}}, or a {{cssxref("percentage")}}, or a values such as `left`. The `<position>` value defaults to center if omitted.


### PR DESCRIPTION
Fixes #33107

I THINK this is correct. My logic is that if you modify the last example in [the circle doc](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/circle) to move the centre down - e.g. `clip-path: circle(farthest-side at 50% 80%);` the size of the radius increases as you get closer to the bounding box. That implies that the 'farthest-side' is calculated, as you would expect, from the side furthest away from the closest edge.