### PR TITLE
Add HTML*Element.{ch|chOff}} properties

### DIFF
--- a/files/en-us/web/api/htmltablecellelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecellelement/ch/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableCellElement.ch
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 
-The **`ch`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `ch` attribute of the cell element.
+The **`ch`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `char` attribute of the cell element.
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >

--- a/files/en-us/web/api/htmltablecellelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecellelement/ch/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableCellElement: ch property"
+short-title: ch
+slug: Web/API/HTMLTableCellElement/ch
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableCellElement.ch
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`ch`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `ch` attribute of the cell element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+A single character.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablecellelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecellelement/ch/index.md
@@ -14,7 +14,7 @@ The **`ch`** property of the {{domxref("HTMLTableCellElement")}} interface does 
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ A single character.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablecellelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecellelement/choff/index.md
@@ -14,7 +14,7 @@ The **`chOff`** property of the {{domxref("HTMLTableCellElement")}} interface do
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ An integer.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablecellelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecellelement/choff/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableCellElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `charoff` attribute of the cell element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablecellelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecellelement/choff/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableCellElement: chOff property"
+short-title: chOff
+slug: Web/API/HTMLTableCellElement/chOff
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableCellElement.chOff
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`chOff`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `charoff` attribute of the cell element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+An integer.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablecolelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecolelement/ch/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableColElement.ch
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 
-The **`ch`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `ch` attribute of the {{HTMLElement("col")}} element.
+The **`ch`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `char` attribute of the {{HTMLElement("col")}} element.
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >

--- a/files/en-us/web/api/htmltablecolelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecolelement/ch/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableColElement: ch property"
+short-title: ch
+slug: Web/API/HTMLTableColElement/ch
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableColElement.ch
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`ch`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `ch` attribute of the {{HTMLElement("col")}} element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+A single character.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablecolelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecolelement/ch/index.md
@@ -14,7 +14,7 @@ The **`ch`** property of the {{domxref("HTMLTableColElement")}} interface does n
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ A single character.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablecolelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecolelement/choff/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableColElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `charoff` attribute of the {{HTMLElement("col")}} element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablecolelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecolelement/choff/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableColElement: chOff property"
+short-title: chOff
+slug: Web/API/HTMLTableColElement/chOff
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableColElement.chOff
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`chOff`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `charoff` attribute of the {{HTMLElement("col")}} element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+An integer.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablecolelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecolelement/choff/index.md
@@ -14,7 +14,7 @@ The **`chOff`** property of the {{domxref("HTMLTableColElement")}} interface doe
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ An integer.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablerowelement/ch/index.md
+++ b/files/en-us/web/api/htmltablerowelement/ch/index.md
@@ -14,7 +14,7 @@ The **`ch`** property of the {{domxref("HTMLTableRowElement")}} interface does n
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ A single character.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablerowelement/ch/index.md
+++ b/files/en-us/web/api/htmltablerowelement/ch/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableRowElement.ch
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 
-The **`ch`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `ch` attribute of the {{HTMLElement("tr")}} element.
+The **`ch`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `char` attribute of the {{HTMLElement("tr")}} element.
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >

--- a/files/en-us/web/api/htmltablerowelement/ch/index.md
+++ b/files/en-us/web/api/htmltablerowelement/ch/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableRowElement: ch property"
+short-title: ch
+slug: Web/API/HTMLTableRowElement/ch
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableRowElement.ch
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`ch`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `ch` attribute of the {{HTMLElement("tr")}} element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+A single character.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablerowelement/choff/index.md
+++ b/files/en-us/web/api/htmltablerowelement/choff/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLTableRowElement/chOff
 page-type: web-api-instance-property
 status:
   - deprecated
-browser-compat: api.HTMLTableRowlement.chOff
+browser-compat: api.HTMLTableRowElement.chOff
 ---
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}

--- a/files/en-us/web/api/htmltablerowelement/choff/index.md
+++ b/files/en-us/web/api/htmltablerowelement/choff/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableRowElement: chOff property"
+short-title: chOff
+slug: Web/API/HTMLTableRowElement/chOff
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableRowlement.chOff
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`chOff`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `charoff` attribute of the {{HTMLElement("tr")}} element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+An integer.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablerowelement/choff/index.md
+++ b/files/en-us/web/api/htmltablerowelement/choff/index.md
@@ -14,7 +14,7 @@ The **`chOff`** property of the {{domxref("HTMLTableRowElement")}} interface doe
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ An integer.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablerowelement/choff/index.md
+++ b/files/en-us/web/api/htmltablerowelement/choff/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableRowElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `charoff` attribute of the {{HTMLElement("tr")}} element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablesectionelement/ch/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/ch/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableSectionElement.ch
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}
 
-The **`ch`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `ch` attribute of the section element.
+The **`ch`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `char` attribute of the section element.
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >

--- a/files/en-us/web/api/htmltablesectionelement/ch/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/ch/index.md
@@ -14,7 +14,7 @@ The **`ch`** property of the {{domxref("HTMLTableSectionElement")}} interface do
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ A single character.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablesectionelement/ch/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/ch/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableSectionElement: ch property"
+short-title: ch
+slug: Web/API/HTMLTableSectionElement/ch
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableSectionElement.ch
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`ch`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `ch` attribute of the section element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+A single character.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablesectionelement/choff/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/choff/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLTableSectionElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `charoff` attribute of the section element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablesectionelement/choff/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/choff/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTableSectionlement: chOff property"
+short-title: chOff
+slug: Web/API/HTMLTableSectionElement/chOff
+page-type: web-api-instance-property
+status:
+  - deprecated
+browser-compat: api.HTMLTableSectionlement.chOff
+---
+
+{{APIRef("HTML DOM")}}{{deprecated_header}}
+
+The **`chOff`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `charoff` attribute of the section element.
+
+> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+>
+> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+
+## Value
+
+An integer.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("text-align")}}

--- a/files/en-us/web/api/htmltablesectionelement/choff/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/choff/index.md
@@ -14,7 +14,7 @@ The **`chOff`** property of the {{domxref("HTMLTableSectionElement")}} interface
 
 > **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
-> To achieve such alignment, watch for the support of a string value with the {{domxref("text-align")}} CSS property.
+> To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 
 ## Value
 
@@ -30,4 +30,4 @@ An integer.
 
 ## See also
 
-- {{domxref("text-align")}}
+- {{cssxref("text-align")}}

--- a/files/en-us/web/api/htmltablesectionelement/choff/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/choff/index.md
@@ -5,7 +5,7 @@ slug: Web/API/HTMLTableSectionElement/chOff
 page-type: web-api-instance-property
 status:
   - deprecated
-browser-compat: api.HTMLTableSectionlement.chOff
+browser-compat: api.HTMLTableSectionElement.chOff
 ---
 
 {{APIRef("HTML DOM")}}{{deprecated_header}}

--- a/files/en-us/web/html/element/col/index.md
+++ b/files/en-us/web/html/element/col/index.md
@@ -38,11 +38,11 @@ The following attributes are deprecated and should not be used. They are documen
 
 - `char` {{deprecated_inline}}
 
-  - : Specifies the alignment of the content to a character of each column cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored, though it will still override the specified [`char`](/en-US/docs/Web/HTML/Element/colgroup#char) of its {{HTMLElement("colgroup")}} parent element.
+  - : Does nothing. It was originally intended to specify the alignment of the content to a character of each column cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored, though it will still override the specified [`char`](/en-US/docs/Web/HTML/Element/colgroup#char) of its {{HTMLElement("colgroup")}} parent element.
 
 - `charoff` {{deprecated_inline}}
 
-  - : Specifies the number of characters to offset the column cell content from the alignment character specified by the [`char`](#char) attribute.
+  - : Does nothing. It was originally intended to specify the number of characters to offset the column cell content from the alignment character specified by the [`char`](#char) attribute.
 
 - `valign` {{deprecated_inline}}
 

--- a/files/en-us/web/html/element/colgroup/index.md
+++ b/files/en-us/web/html/element/colgroup/index.md
@@ -41,11 +41,11 @@ The following attributes are deprecated and should not be used. They are documen
 
 - `char` {{deprecated_inline}}
 
-  - : Specifies the alignment of the content to a character of each column group cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored, though it will still be used as the default value for the [`align`](/en-US/docs/Web/HTML/Element/col#align) of the {{HTMLElement("col")}} elements which are members of this column group.
+  - : Does nothing. It was originally intended to specify the alignment of the content to a character of each column group cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored, though it will still be used as the default value for the [`align`](/en-US/docs/Web/HTML/Element/col#align) of the {{HTMLElement("col")}} elements which are members of this column group.
 
 - `charoff` {{deprecated_inline}}
 
-  - : Specifies the number of characters to offset the column group cell content from the alignment character specified by the [`char`](#char) attribute.
+  - : Does nothing. It was originally intended to specify the number of characters to offset the column group cell content from the alignment character specified by the [`char`](#char) attribute.
 
 - `valign` {{deprecated_inline}}
 

--- a/files/en-us/web/html/element/td/index.md
+++ b/files/en-us/web/html/element/td/index.md
@@ -44,11 +44,11 @@ The following attributes are deprecated and should not be used. They are documen
 
 - `char` {{deprecated_inline}}
 
-  - : Specifies the alignment of the content to a character of the data cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored.
+  - : Does nothing. It was originally intended to specify the alignment of the content to a character of the data cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored.
 
 - `charoff` {{deprecated_inline}}
 
-  - : Specifies the number of characters to offset the data cell content from the alignment character specified by the [`char`](#char) attribute.
+  - : Does nothing. It was originally intended to specify the number of characters to offset the data cell content from the alignment character specified by the [`char`](#char) attribute.
 
 - `height` {{deprecated_inline}}
 

--- a/files/en-us/web/html/element/tfoot/index.md
+++ b/files/en-us/web/html/element/tfoot/index.md
@@ -29,11 +29,11 @@ The following attributes are deprecated and should not be used. They are documen
 
 - `char` {{deprecated_inline}}
 
-  - : Specifies the alignment of the content to a character of each foot cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored.
+  - : Does nothing. It was originally intended to specify the alignment of the content to a character of each foot cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored.
 
 - `charoff` {{deprecated_inline}}
 
-  - : Specifies the number of characters to offset the foot cell content from the alignment character specified by the [`char`](#char) attribute.
+  - : Does nothing. It was originally intended to specify the number of characters to offset the foot cell content from the alignment character specified by the [`char`](#char) attribute.
 
 - `valign` {{deprecated_inline}}
 

--- a/files/en-us/web/html/element/th/index.md
+++ b/files/en-us/web/html/element/th/index.md
@@ -52,11 +52,11 @@ The following attributes are deprecated and should not be used. They are documen
 
 - `char` {{deprecated_inline}}
 
-  - : Specifies the alignment of the content to a character of the header cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored.
+  - : Does nothing. It was originally intended to specify the alignment of the content to a character of the header cell. Typical values for this include a period (`.`) when attempting to align numbers or monetary values. If [`align`](#align) is not set to `char`, this attribute is ignored.
 
 - `charoff` {{deprecated_inline}}
 
-  - : Specifies the number of characters to offset the header cell content from the alignment character specified by the [`char`](#char) attribute.
+  - : Does nothing. It was originally intended to specify the number of characters to offset the header cell content from the alignment character specified by the [`char`](#char) attribute.
 
 - `height` {{deprecated_inline}}
 

--- a/files/en-us/web/html/element/thead/index.md
+++ b/files/en-us/web/html/element/thead/index.md
@@ -29,11 +29,11 @@ The following attributes are deprecated and should not be used. They are documen
 
 - `char` {{deprecated_inline}}
 
-  - : Specifies the alignment of the content to a character of each head cell. If [`align`](#align) is not set to `char`, this attribute is ignored.
+  - : Does nothing. It was originally intended to specify the alignment of the content to a character of each head cell. If [`align`](#align) is not set to `char`, this attribute is ignored.
 
 - `charoff` {{deprecated_inline}}
 
-  - : Specifies the number of characters to offset the head cell content from the alignment character specified by the [`char`](#char) attribute.
+  - : Does nothing. It was originally intended to specify the number of characters to offset the head cell content from the alignment character specified by the [`char`](#char) attribute.
 
 - `valign` {{deprecated_inline}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds docs for the following properties:
- `HTMLTableRowlElement.ch`
- `HTMLTableRowElement.chOff`
- `HTMLTableCellElement.ch`
- `HTMLTableCellElement.chOff`
- `HTMLTableSectionElement.ch`
- `HTMLTableSectionElement.chOff`
- `HTMLTableColElement.ch`
- `HTMLTableColElement.chOff`

### Motivation

All engines support these properties but do nothing. I also updated the description of the relevant HTML attributes.

There is no real alternative so I only pointed to the future CSS way of doing it and didn't add an Example section

### Related issues and pull requests

It is part of https://github.com/mdn/mdn/issues/520
