### PR TITLE
fix: update the discussion channels for `l10n-zh`

### DIFF
--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -25,7 +25,7 @@ If you need help or have any questions, feel free to get in touch with one of th
 
 ### Chinese (`zh-CN`, `zh-TW`)
 
-- Discussions: [Telegram (`Mozilla China`)](https://t.me/mozilla_china), [Telegram (`MozTW L10n`)](https://moztw.org/community/telegram/)
+- Discussions: [Discord (`#zh-cn`)](/discord), [Discord (`#zh-tw`)](/discord), [Telegram (`MozTW L10n`)](https://moztw.org/community/telegram/)
 - Current maintainers: [Irvin](https://github.com/irvin), [t7yang](https://github.com/t7yang), [yin1999](https://github.com/yin1999), [jasonren0403](https://github.com/jasonren0403), [JasonLamv-t](https://github.com/JasonLamv-t)
 
 ### French (`fr`)


### PR DESCRIPTION
### Description

Update the discussion channels for `l10n-zh`. We have localization channels (for `zh-CN` and `zh-TW`) on the official MDN server now.

### Motivation

The "Mozilla China" Telegram channel has been disbanded, see: mdn/translated-content#19534.
