### PR TITLE
Link overflow-wrap and word-break to white-space

### DIFF
--- a/files/en-us/web/css/overflow-wrap/index.md
+++ b/files/en-us/web/css/overflow-wrap/index.md
@@ -138,6 +138,7 @@ p {
 ## See also
 
 - {{cssxref("word-break")}}
+- {{cssxref("white-space")}}
 - {{cssxref("hyphens")}}
 - {{cssxref("text-overflow")}}
 - [Guide to wrapping and breaking text](/en-US/docs/Web/CSS/CSS_text/Wrapping_breaking_text)

--- a/files/en-us/web/css/word-break/index.md
+++ b/files/en-us/web/css/word-break/index.md
@@ -155,6 +155,7 @@ The specification also lists an additional value, `manual`, which is not current
 ## See also
 
 - {{cssxref("overflow-wrap")}}
+- {{cssxref("white-space")}}
 - {{cssxref("hyphens")}}
 - {{cssxref("line-break")}}
 - [Guide to wrapping and breaking text](/en-US/docs/Web/CSS/CSS_text/Wrapping_breaking_text)


### PR DESCRIPTION
### Description
I always search for "wrap" and "break" when I need the white-space property.

### Motivation
Make it easier to find the right property.
