### PR TITLE
Include "Linux" in Firefox for Android's platform token

### DIFF
--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -83,8 +83,8 @@ Beginning in version 41, Firefox for Android will contain the Android version as
 
 Beginning in version 126, Firefox for Android will include "Linux" as part of the _platform_ token.
 
-| Form factor | Gecko user agent string                                            |
-| ----------- | ------------------------------------------------------------------ |
+| Form factor | Gecko user agent string                                                      |
+| ----------- | ---------------------------------------------------------------------------- |
 | Phone       | Mozilla/5.0 (Linux; Android 5.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0 |
 | Tablet      | Mozilla/5.0 (Linux; Android 5.0; Tablet; rv:126.0) Gecko/126.0 Firefox/126.0 |
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -105,7 +105,7 @@ Starting in Version 6, users can opt into using a GeckoView-based Focus for Andr
 | 1.0 (WebView Mobile)             | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.0 Chrome/59.0.3029.83 Mobile Safari/537.36 |
 | 1.0 (WebView Tablet)             | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.0 Chrome/59.0.3029.83 Safari/537.36        |
 | 6.0 (GeckoView)                  | Mozilla/5.0 (Android 7.0; Mobile; rv:62.0) Gecko/62.0 Firefox/62.0                                                                     |
-| 126.0 (GeckoView)                | Mozilla/5.0 (Linux; Android 7.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0 |
+| 126.0 (GeckoView)                | Mozilla/5.0 (Linux; Android 7.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0                                                           |
 
 ## Klar for Android
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -81,7 +81,7 @@ Beginning in version 41, Firefox for Android will contain the Android version as
 
 ## Android (version 126 and above)
 
-Beginning in version 126, Firefox for Android will include "Linux" as part of the _platform_ token.
+Beginning in version 126, Firefox for Android includes `Linux` as part of the _platform_ token.
 
 | Form factor | Gecko user agent string                                                      |
 | ----------- | ---------------------------------------------------------------------------- |

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -116,7 +116,7 @@ Since version 4.1, Klar for Android uses the same UA string as [Focus for Androi
 | 1.0 (WebView)                   | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Klar/1.0 Chrome/58.0.3029.83 Mobile Safari/537.36  |
 | 4.1+ (WebView)                  | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/4.1 Chrome/62.0.3029.83 Mobile Safari/537.36 |
 | 6.0+ (GeckoView)                | Mozilla/5.0 (Android 7.0; Mobile; rv:62.0) Gecko/62.0 Firefox/62.0                                                                     |
-| 126.0+ (GeckoView)              | Mozilla/5.0 (Linux; Android 7.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0 |
+| 126.0+ (GeckoView)              | Mozilla/5.0 (Linux; Android 7.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0                                                           |
 
 ## Focus for iOS
 

--- a/files/en-us/web/http/headers/user-agent/firefox/index.md
+++ b/files/en-us/web/http/headers/user-agent/firefox/index.md
@@ -79,6 +79,15 @@ Beginning in version 41, Firefox for Android will contain the Android version as
 | Phone       | Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0 |
 | Tablet      | Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0 |
 
+## Android (version 126 and above)
+
+Beginning in version 126, Firefox for Android will include "Linux" as part of the _platform_ token.
+
+| Form factor | Gecko user agent string                                            |
+| ----------- | ------------------------------------------------------------------ |
+| Phone       | Mozilla/5.0 (Linux; Android 5.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0 |
+| Tablet      | Mozilla/5.0 (Linux; Android 5.0; Tablet; rv:126.0) Gecko/126.0 Firefox/126.0 |
+
 ## Focus for Android
 
 From version 1, Focus is powered by Android WebView and uses the following user agent string format:
@@ -96,6 +105,7 @@ Starting in Version 6, users can opt into using a GeckoView-based Focus for Andr
 | 1.0 (WebView Mobile)             | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.0 Chrome/59.0.3029.83 Mobile Safari/537.36 |
 | 1.0 (WebView Tablet)             | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.0 Chrome/59.0.3029.83 Safari/537.36        |
 | 6.0 (GeckoView)                  | Mozilla/5.0 (Android 7.0; Mobile; rv:62.0) Gecko/62.0 Firefox/62.0                                                                     |
+| 126.0 (GeckoView)                | Mozilla/5.0 (Linux; Android 7.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0 |
 
 ## Klar for Android
 
@@ -106,6 +116,7 @@ Since version 4.1, Klar for Android uses the same UA string as [Focus for Androi
 | 1.0 (WebView)                   | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Klar/1.0 Chrome/58.0.3029.83 Mobile Safari/537.36  |
 | 4.1+ (WebView)                  | Mozilla/5.0 (Linux; Android 7.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/4.1 Chrome/62.0.3029.83 Mobile Safari/537.36 |
 | 6.0+ (GeckoView)                | Mozilla/5.0 (Android 7.0; Mobile; rv:62.0) Gecko/62.0 Firefox/62.0                                                                     |
+| 126.0+ (GeckoView)              | Mozilla/5.0 (Linux; Android 7.0; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0 |
 
 ## Focus for iOS
 


### PR DESCRIPTION
### Description

Beginning in version 126, Firefox for Android will include "Linux" as part of the platform token.

### Motivation

Web developers will want to know that Firefox for Android's User-Agent string is changing in version 126.

### Additional details

Firefox for Android's User-Agent string was changed in Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1860417.

### Related issues and pull requests

None

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
