### PR TITLE
Update `Web/API/FocusEvent/relatedTarget` sidebar

### DIFF
--- a/files/en-us/web/api/focusevent/relatedtarget/index.md
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.md
@@ -6,10 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.FocusEvent.relatedTarget
 ---
 
-{{ apiref("DOM Events") }}
+{{APIRef("UI Events")}}
 
-The **`FocusEvent.relatedTarget`** read-only property is the
-secondary target, depending on the type of event:
+The **`FocusEvent.relatedTarget`** read-only property is the secondary target, depending on the type of event:
 
 <table class="no-markdown">
   <thead>
@@ -23,9 +22,7 @@ secondary target, depending on the type of event:
     <tr>
       <td>{{domxref("Element/blur_event", "blur")}}</td>
       <td>The {{domxref("EventTarget")}} losing focus</td>
-      <td>
-        The {{domxref("EventTarget")}} receiving focus (if any).
-      </td>
+      <td>The {{domxref("EventTarget")}} receiving focus (if any).</td>
     </tr>
     <tr>
       <td>{{domxref("Element/focus_event", "focus")}}</td>
@@ -45,9 +42,7 @@ secondary target, depending on the type of event:
   </tbody>
 </table>
 
-Note that [many elements can't have focus](https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null/42764495), which is a common reason for `relatedTarget` to be
-`null`. `relatedTarget` may also be set to `null` for
-security reasons, like when tabbing in or out of a page.
+Note that [many elements can't have focus](https://stackoverflow.com/questions/42764494/blur-event-relatedtarget-returns-null/42764495), which is a common reason for `relatedTarget` to be `null`. `relatedTarget` may also be set to `null` for security reasons, like when tabbing in or out of a page.
 
 {{domxref("MouseEvent.relatedTarget")}} is a similar property for mouse events.
 
@@ -65,4 +60,5 @@ An instance of {{domxref("EventTarget")}}.
 
 ## See also
 
-- The {{domxref("FocusEvent")}} interface it belongs to.
+- {{ domxref("FocusEvent") }}
+- [Comparison of Event Targets](/en-US/docs/Web/API/Event/Comparison_of_Event_Targets)

--- a/files/en-us/web/api/focusevent/relatedtarget/index.md
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.md
@@ -8,7 +8,7 @@ browser-compat: api.FocusEvent.relatedTarget
 
 {{APIRef("UI Events")}}
 
-The **`FocusEvent.relatedTarget`** read-only property is the secondary target, depending on the type of event:
+The **`relatedTarget`** read-only property of the {{domxref("FocusEvent")}} interface is the secondary target, depending on the type of event:
 
 <table class="no-markdown">
   <thead>


### PR DESCRIPTION
### Description

This PR changes `Web/API/FocusEvent/relatedTarget` sidebar to `{{APIRef("UI Events")}}`.
I also updated the section "See also" similar to `Web/API/MouseEvent/relatedTarget` and removed unnecessary line breaks.

Before:
![image](https://github.com/mdn/content/assets/1682136/90a4f265-635d-41db-bc22-761846de6c12)

After:
![image](https://github.com/mdn/content/assets/1682136/1d34de25-855c-4a59-809c-cacee316112e)

### Additional details

This was the last document containing the `{{APIRef("DOM Events")}}` in `en-us`.
If I understand correctly, now we can create a task to change it in all locales:
![image](https://github.com/mdn/content/assets/1682136/2504df0f-5231-4382-954d-8a67885637d7)

### Related issues and pull requests

Relates to #15880
