### PR TITLE
Added "period" for clarity of what a "full stop" is.

### DIFF
--- a/files/en-us/learn/css/first_steps/getting_started/index.md
+++ b/files/en-us/learn/css/first_steps/getting_started/index.md
@@ -151,7 +151,7 @@ So far, we have styled elements based on their HTML element names. This works as
    </ul>
    ```
 
-2. In your CSS, you can target the class of `special` by creating a selector that starts with a full stop character. Add the following to your CSS file:
+2. In your CSS, you can target the class of `special` by creating a selector that starts with a period/full stop character. Add the following to your CSS file:
 
    ```css
    .special {

--- a/files/en-us/learn/css/first_steps/getting_started/index.md
+++ b/files/en-us/learn/css/first_steps/getting_started/index.md
@@ -151,7 +151,7 @@ So far, we have styled elements based on their HTML element names. This works as
    </ul>
    ```
 
-2. In your CSS, you can target the class of `special` by creating a selector that starts with a period/full stop character. Add the following to your CSS file:
+2. In your CSS, you can target the class of `special` by creating a selector that starts with a period. Add the following to your CSS file:
 
    ```css
    .special {


### PR DESCRIPTION
### Description

Tiny change, added the word "period" for clarity of what a "full stop" character is to avoid confusion for NA English readers.

### Motivation

I have only rarely seen a period referred to as a full stop, despite it being the technically correct name for the character. I believe this adds a touch of clarity for readers who may be unfamiliar with the term.
