### PR TITLE
Add OffScreenCanvas context lost/restored events

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/contextlost_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/contextlost_event/index.md
@@ -64,3 +64,4 @@ canvas.addEventListener("contextlost", (event) => {
 
 - [`HTMLCanvasElement: contextrestored` event](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event)
 - [`CanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/CanvasRenderingContext2D/isContextLost)
+- [`OffscreenCanvas: contextlost` event](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event)

--- a/files/en-us/web/api/htmlcanvaselement/contextrestored_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/contextrestored_event/index.md
@@ -57,3 +57,4 @@ canvas.addEventListener(
 
 - [`HTMLCanvasElement: contextlost` event](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event)
 - [`CanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/CanvasRenderingContext2D/isContextLost)
+- [OffboardCanvas: contextlost` event](/en-US/docs/Web/API/OffboardCanvas/contextlost_event)

--- a/files/en-us/web/api/htmlcanvaselement/contextrestored_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/contextrestored_event/index.md
@@ -57,4 +57,4 @@ canvas.addEventListener(
 
 - [`HTMLCanvasElement: contextlost` event](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event)
 - [`CanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/CanvasRenderingContext2D/isContextLost)
-- [OffboardCanvas: contextlost` event](/en-US/docs/Web/API/OffboardCanvas/contextlost_event)
+- [OffscreenCanvas: contextlost` event](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event)

--- a/files/en-us/web/api/htmlcanvaselement/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/index.md
@@ -46,9 +46,9 @@ _Inherits events from its parent, {{domxref("HTMLElement")}}._
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
 - [`contextlost`](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event) {{Experimental_Inline}}
-  - : Fired if the user agent detects that the backing storage associated with a `CanvasRenderingContext2D` or an `OffscreenCanvasRenderingContext2D` context has been lost.
+  - : Fired if the user agent detects that the backing storage associated with a `CanvasRenderingContext2D` context has been lost.
 - [`contextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event) {{Experimental_Inline}}
-  - : Fired if the user agent successfully restores a `CanvasRenderingContext2D` or an `OffscreenCanvasRenderingContext2D` context.
+  - : Fired if the user agent successfully restores a `CanvasRenderingContext2D` context.
 - [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)
   - : Fired if the user agent is unable to create a `WebGLRenderingContext` or `WebGL2RenderingContext` context.
 - [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)

--- a/files/en-us/web/api/htmlcanvaselement/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/index.md
@@ -46,9 +46,9 @@ _Inherits events from its parent, {{domxref("HTMLElement")}}._
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
 - [`contextlost`](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event) {{Experimental_Inline}}
-  - : Fired if the user agent detects that the backing storage associated with a `CanvasRenderingContext2D` context has been lost.
+  - : Fired if the browser detects that the underlying system that provides resources for a `CanvasRenderingContext2D` context, such as a GPU, has been lost.
 - [`contextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event) {{Experimental_Inline}}
-  - : Fired if the user agent successfully restores a `CanvasRenderingContext2D` context.
+  - : Fired if the browser successfully restores the underlying system that provides resources for a `CanvasRenderingContext2D` context.
 - [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)
   - : Fired if the user agent is unable to create a `WebGLRenderingContext` or `WebGL2RenderingContext` context.
 - [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)

--- a/files/en-us/web/api/htmlcanvaselement/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/index.md
@@ -46,9 +46,9 @@ _Inherits events from its parent, {{domxref("HTMLElement")}}._
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
 - [`contextlost`](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event) {{Experimental_Inline}}
-  - : Fired if the browser detects that the underlying system that provides resources for a `CanvasRenderingContext2D` context, such as a GPU, has been lost.
+  - : Fired if the browser detects that the `CanvasRenderingContext2D` context has been lost.
 - [`contextrestored`](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event) {{Experimental_Inline}}
-  - : Fired if the browser successfully restores the underlying system that provides resources for a `CanvasRenderingContext2D` context.
+  - : Fired if the browser successfully restores a `CanvasRenderingContext2D` context
 - [`webglcontextcreationerror`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextcreationerror_event)
   - : Fired if the user agent is unable to create a `WebGLRenderingContext` or `WebGL2RenderingContext` context.
 - [`webglcontextlost`](/en-US/docs/Web/API/HTMLCanvasElement/webglcontextlost_event)

--- a/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
@@ -8,9 +8,9 @@ status:
 browser-compat: api.OffscreenCanvas.contextlost_event
 ---
 
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
-The **`contextlost`** event of the [Canvas API](/en-US/docs/Web/API/Canvas_API) is fired if the user agent detects that the backing storage associated with a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
+The **`contextlost`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the user agent detects that the backing storage associated with a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
 Contexts can be lost for several reasons like driver crashes or the application runs out of memory, etc.
 
 By default the user agent will attempt to restore the context and then fire the [`contextrestored` event](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event).
@@ -30,7 +30,7 @@ oncontextlost = (event) => {};
 
 A generic {{domxref("Event")}}.
 
-## Example
+## Examples
 
 The code fragment below detects the `contextlost` event.
 

--- a/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.OffscreenCanvas.contextlost_event
 
 {{APIRef("Canvas API")}}{{SeeCompatTable}}
 
-The **`contextlost`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the user agent detects that the backing storage associated with a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
+The **`contextlost`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the browser detects that the underlying system that provides the resources used by a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
 Contexts can be lost for several reasons like driver crashes or the application runs out of memory, etc.
 
 By default the user agent will attempt to restore the context and then fire the [`contextrestored` event](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event).

--- a/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
@@ -1,0 +1,68 @@
+---
+title: "OffscreenCanvas: contextlost event"
+short-title: contextlost
+slug: Web/API/OffscreenCanvas/contextlost_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.OffscreenCanvas.contextlost_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`contextlost`** event of the [Canvas API](/en-US/docs/Web/API/Canvas_API) is fired if the user agent detects that the backing storage associated with a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
+Contexts can be lost for several reasons like driver crashes or the application runs out of memory, etc.
+
+By default the user agent will attempt to restore the context and then fire the [`contextrestored` event](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event).
+User code can prevent the context from being restored by calling [`Event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault) during event handling.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("contextlost", (event) => {});
+
+oncontextlost = (event) => {};
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
+## Example
+
+The code fragment below detects the `contextlost` event.
+
+```js
+const canvas = new OffscreenCanvas(256, 256);
+const gl = offscreen.getContext("2d");
+
+// Do drawing etc
+
+canvas.addEventListener("contextlost", (event) => {
+  console.log(event);
+});
+```
+
+To prevent the context from being restored the event handler code might instead look like this:
+
+```js
+canvas.addEventListener("contextlost", (event) => {
+  event.preventDefault();
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`OffScreenCanvas: contextrestored` event](/en-US/docs/Web/API/OffScreenCanvas/contextrestored_event)
+- [`OffscreenCanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.iscontextlost)
+- [`HTMLCanvasElement: contextlost` event](/en-US/docs/Web/API/HTMLCanvasElement/contextlost_event)

--- a/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextlost_event/index.md
@@ -10,8 +10,8 @@ browser-compat: api.OffscreenCanvas.contextlost_event
 
 {{APIRef("Canvas API")}}{{SeeCompatTable}}
 
-The **`contextlost`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the browser detects that the underlying system that provides the resources used by a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
-Contexts can be lost for several reasons like driver crashes or the application runs out of memory, etc.
+The **`contextlost`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the browser detects that the [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
+Contexts can be lost for several reasons, such as an associated GPU driver crashes, or the application runs out of memory, and so on.
 
 By default the user agent will attempt to restore the context and then fire the [`contextrestored` event](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event).
 User code can prevent the context from being restored by calling [`Event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault) during event handling.

--- a/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.OffscreenCanvas.contextrestored_event
 
 {{APIRef("Canvas API")}}{{SeeCompatTable}}
 
-The **`contextrestored`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the user agent restores the backing storage for a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D).
+The **`contextrestored`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the browser restores the underlying system, such as a GPU, that provides resources for a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
 
 You can redraw, re-retrieve resources, and reinitialize the state of your context after receiving this event.
 

--- a/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
@@ -8,9 +8,9 @@ status:
 browser-compat: api.OffscreenCanvas.contextrestored_event
 ---
 
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
-The **`contextrestored`** event of the [Canvas API](/en-US/docs/Web/API/Canvas_API) is fired if the user agent restores the backing storage for a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D).
+The **`contextrestored`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the user agent restores the backing storage for a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D).
 
 You can redraw, re-retrieve resources, and reinitialize the state of your context after receiving this event.
 
@@ -28,7 +28,7 @@ oncontextrestored = (event) => {};
 
 A generic {{domxref("Event")}}.
 
-## Example
+## Examples
 
 The code fragment below detects the context restored event.
 

--- a/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
@@ -1,0 +1,61 @@
+---
+title: "OffscreenCanvas: contextrestored event"
+short-title: contextrestored
+slug: Web/API/OffscreenCanvas/contextrestored_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.OffscreenCanvas.contextrestored_event
+---
+
+{{APIRef}}{{SeeCompatTable}}
+
+The **`contextrestored`** event of the [Canvas API](/en-US/docs/Web/API/Canvas_API) is fired if the user agent restores the backing storage for a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D).
+
+You can redraw, re-retrieve resources, and reinitialize the state of your context after receiving this event.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener("contextrestored", (event) => {});
+
+oncontextrestored = (event) => {};
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
+## Example
+
+The code fragment below detects the context restored event.
+
+```js
+const canvas = new OffscreenCanvas(256, 256);
+const gl = offscreen.getContext("2d");
+
+canvas.addEventListener(
+  "contextrestored",
+  (e) => {
+    console.log(e);
+    // call to redrawCanvas() or similar
+  },
+  false,
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`OffscreenCanvas: contextlost` event](/en-US/docs/Web/API/OffScreenCanvas/contextlost_event)
+- [`OffscreenCanvasRenderingContext2D.isContextLost()`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.iscontextlost)
+- [`HTMLCanvasElement: contextrestored` event](/en-US/docs/Web/API/HTMLCanvasElement/contextrestored_event)

--- a/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
+++ b/files/en-us/web/api/offscreencanvas/contextrestored_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.OffscreenCanvas.contextrestored_event
 
 {{APIRef("Canvas API")}}{{SeeCompatTable}}
 
-The **`contextrestored`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the browser restores the underlying system, such as a GPU, that provides resources for a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
+The **`contextrestored`** event of the {{domxref("OffscreenCanvas")}} interface is fired if the browser restores a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context that was [previously lost](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event).
 
 You can redraw, re-retrieve resources, and reinitialize the state of your context after receiving this event.
 

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -45,9 +45,9 @@ _Inherits events from its parent, {{domxref("EventTarget")}}._
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
 - [`contextlost`](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event) {{Experimental_Inline}}
-  - : Fired if the browser detects that the underlying system that provides the resources used by an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context, such as a GPU, has been lost.
+- : Fired if the browser detects that an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context is lost.
 - [`contextrestored`](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event) {{Experimental_Inline}}
-  - : Fired if the browser successfully restores the underlying system that provides the resources used by an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
+  - : Fired if the browser successfully restores an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
 
 ## Examples
 

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -45,9 +45,9 @@ _Inherits events from its parent, {{domxref("EventTarget")}}._
 Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
 
 - [`contextlost`](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event) {{Experimental_Inline}}
-  - : Fired if the user agent detects that the backing storage associated with an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context has been lost.
+  - : Fired if the browser detects that the underlying system that provides the resources used by an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context, such as a GPU, has been lost.
 - [`contextrestored`](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event) {{Experimental_Inline}}
-  - : Fired if the user agent successfully restores a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
+  - : Fired if the browser successfully restores the underlying system that provides the resources used by an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
 
 ## Examples
 

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -38,6 +38,17 @@ Rendering operations can also be run inside a [worker](/en-US/docs/Web/API/Web_W
 - {{domxref("OffscreenCanvas.transferToImageBitmap()")}}
   - : Creates an {{domxref("ImageBitmap")}} object from the most recently rendered image of the `OffscreenCanvas`. See the {{domxref("OffscreenCanvas.transferToImageBitmap()", "API description")}} for important notes on managing this {{domxref("ImageBitmap")}}.
 
+## Events
+
+_Inherits events from its parent, {{domxref("EventTarget")}}._
+
+Listen to these events using {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
+- [`contextlost`](/en-US/docs/Web/API/OffscreenCanvas/contextlost_event) {{Experimental_Inline}}
+  - : Fired if the user agent detects that the backing storage associated with an [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context has been lost.
+- [`contextrestored`](/en-US/docs/Web/API/OffscreenCanvas/contextrestored_event) {{Experimental_Inline}}
+  - : Fired if the user agent successfully restores a [`OffscreenCanvasRenderingContext2D`](/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D) context.
+
 ## Examples
 
 ### Synchronous display of frames produced by an `OffscreenCanvas`


### PR DESCRIPTION
FF125 adds support for canvas context lost and restored events. These are documented for the HTMLCanvasElement, but missing for the OffScreenCanvas (though there was a partial attempt to make them serve for both interfaces. I decided that it was better to make these separate. They have different BCD and most of the other sidebar stuff is separate for the offscreen case.

Anyway, this adds the offscreen canvas event docs for context lost and restored. They are virtually identical to the HTMLCanvas version except for the names of the associated APIs, and BCD.

This is part of work for #33090