### PR TITLE
Clarify `font` description for `<var>`

### DIFF
--- a/files/en-us/web/html/element/var/index.md
+++ b/files/en-us/web/html/element/var/index.md
@@ -57,7 +57,7 @@ Here's a simple example, using `<var>` to denote variable names in a mathematica
 
 ### Overriding the default style
 
-Using CSS, you can override the default style for the `<var>` element. In this example, variable names are rendered using bold Courier if it's available, otherwise it falls back to the default monospace font.
+Using CSS, you can override the default style for the `<var>` element. In this example, variable names are rendered in bold, using Courier if it's available, otherwise it falls back to the default monospace font.
 
 #### CSS
 


### PR DESCRIPTION
### Description

The `font` property doesn’t permit selectively applying different font weights depending on available fonts, as the text previously suggested.

### Motivation

I was reading this documentation and was startled by what the description seemed to suggest ^^ that is to say, you _can’t_ actually do this:

```css
/* Font A naturally looks bigger and bolder than Font B, make them look more similar (we don’t know which one’s available) */
font: 12px "Font A", 15px bold "Font B";
```