### PR TITLE
Update Navigator.productSub info

### DIFF
--- a/files/en-us/web/api/navigator/productsub/index.md
+++ b/files/en-us/web/api/navigator/productsub/index.md
@@ -10,12 +10,11 @@ browser-compat: api.Navigator.productSub
 
 {{ ApiRef("HTML DOM") }} {{Deprecated_Header}}
 
-The **`Navigator.productSub`** read-only property returns the
-build number of the current browser.
+The **`Navigator.productSub`** read-only property that returns either the string "20030107", or the string "20100101".
 
 ## Value
 
-A string.
+Either "20030107", or "20100101".
 
 ## Examples
 
@@ -30,6 +29,8 @@ document.body.textContent = `productSub: ${navigator.productSub}`;
 On IE, this property returns undefined.
 
 On Apple Safari and Google Chrome this property always returns `20030107`.
+
+On Firefox, this property always returns `20100101`.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updated Navigator.productSub to better reflect what's specified in HTML Standard, namely clarified that returned value is always either "20030107" or "20100101".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
While I'm doubtful anyone will ever need this information, I think it'd be nice if MDN was accurate even when it comes deprecated APIs that no one should ever use again.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
