### PR TITLE
Update web/javascript/guide/grammar_and_types

### DIFF
--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -144,8 +144,8 @@ console.log(x); // x is 5
 ```
 
 ### Variable hoisting
+`var`-declared variables are [hoisted](/en-US/docs/Glossary/Hoisting), meaning you can refer to the variable anywhere in its scope, even if its declaration isn't reached yet. You can see `var` declarations as being "lifted" to the top of its function or global scope. However, if you access a variable before it's declared, the value is always `undefined`, because only its _declaration_ and _default initialization(with `undefined`)_ is hoisted, but not its _value assignment_.
 
-`var`-declared variables are [hoisted](/en-US/docs/Glossary/Hoisting), meaning you can refer to the variable anywhere in its scope, even if its declaration isn't reached yet. You can see `var` declarations as being "lifted" to the top of its function or global scope. However, if you access a variable before it's declared, the value is always `undefined`, because only its _declaration_ is hoisted, but not its _initialization_.
 
 ```js
 console.log(x === undefined); // true

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -144,7 +144,6 @@ console.log(x); // x is 5
 ```
 
 ### Variable hoisting
-`var`-declared variables are [hoisted](/en-US/docs/Glossary/Hoisting), meaning you can refer to the variable anywhere in its scope, even if its declaration isn't reached yet. You can see `var` declarations as being "lifted" to the top of its function or global scope. However, if you access a variable before it's declared, the value is always `undefined`, because only its _declaration_ and _default initialization(with `undefined`)_ is hoisted, but not its _value assignment_.
 
 
 ```js


### PR DESCRIPTION
### Description

Changed the line 
```
because only its declaration is hoisted, but not its initialization.
```
which is about variables declared with `var` to 
```
because only its declaration and default initialization(with undefined) is hoisted, but not its value assignment.
```

### Motivation

Consider variables declared with `var` keyword. During the creation phase they are stored in the variable object of their execution context with the default initialization value of undefined. So if we use them in their scope before their declaration, they won't throw the error `cannot access before initialization` and they are initialized with the default value of `undefined`. But they are not yet assigned a value.

### Additional details

[link to You don't know js book, chapter 6, section Unitialized variables (aka TDZ)](https://github.com/getify/You-Dont-Know-JS/blob/2nd-ed/scope-closures/ch5.md#uninitialized-variables-aka-tdz)
> With var declarations, the variable is "hoisted" to the top of its scope. But it's also automatically initialized to the undefined value, so that the variable can be used throughout the entire scope.
