### PR TITLE
feat: Note about startViewTransition skipping if page not visible. Fix auto-playing audio in live sample

### DIFF
--- a/files/en-us/web/api/view_transitions_api/index.md
+++ b/files/en-us/web/api/view_transitions_api/index.md
@@ -89,6 +89,9 @@ Let's walk through how this works:
 5. The old page view animates from {{cssxref("opacity")}} 1 to 0, while the new view animates from `opacity` 0 to 1, which is what creates the default cross-fade.
 6. When the transition animation has reached its end state, the {{domxref("ViewTransition.finished")}} promise fulfills, allowing you to respond.
 
+> **Note:**
+> If the document's [page visibility state](/en-US/docs/Web/API/Page_Visibility_API) is `hidden` (for example if the document is obscured by a window, the browser is minimized, or another browser tab is active) during a {{domxref("Document.startViewTransition()", "document.startViewTransition()")}} call, the view transition is skipped entirely.
+
 ### Different transitions for different elements
 
 At the moment, all of the different elements that change when the DOM updates are transitioned using the same animation. If you want different elements to animate differently from the default "root" animation, you can separate them out using the {{cssxref("view-transition-name")}} property. For example:


### PR DESCRIPTION
### Description

Adds a note to View Transitions API page that the transition is skipped if the page is hidden, small improvements to what it means for a page (document) to be hidden.

In parallel, the page visibility API has an example where the audio would auto-play when switching tabs, even if the user had no interaction with the media element before. This is not a good example to propagate, so we should gate the `audio.play()` call behind a `playingOnHide` boolean. It looks like this was raised in https://github.com/mdn/content/issues/26745, but we actually fixed a different example?

### Related issues and pull requests

Fixes #32748
Fixes #26745

__View transitions spec links:__

* https://drafts.csswg.org/css-view-transitions-1/#page-visibility-change-steps
* https://drafts.csswg.org/css-view-transitions/#dom-document-startviewtransition