### PR TITLE
fix: wrong sidebar of CSSCounterStyleRule property

### DIFF
--- a/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.additiveSymbols
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`additiveSymbols`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/additive-symbols","additive-symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.md
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.fallback
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`fallback`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/fallback","fallback")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/name/index.md
+++ b/files/en-us/web/api/csscounterstylerule/name/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.name
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`name`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the `name` for the associated rule.
 

--- a/files/en-us/web/api/csscounterstylerule/negative/index.md
+++ b/files/en-us/web/api/csscounterstylerule/negative/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.negative
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`negative`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/negative","negative")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/pad/index.md
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.pad
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`pad`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/pad", "pad")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/prefix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/prefix/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.prefix
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`prefix`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/prefix","prefix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/range/index.md
+++ b/files/en-us/web/api/csscounterstylerule/range/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.range
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`range`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/range","range")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/speakas/index.md
+++ b/files/en-us/web/api/csscounterstylerule/speakas/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.speakAs
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`speakAs`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/speak-as","speak-as")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/suffix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/suffix/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.suffix
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`suffix`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/suffix","suffix")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/symbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/symbols/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.symbols
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`symbols`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/symbols","symbols")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 

--- a/files/en-us/web/api/csscounterstylerule/system/index.md
+++ b/files/en-us/web/api/csscounterstylerule/system/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSCounterStyleRule.system
 ---
 
-{{DefaultAPISidebar("CSS Counter Styles")}}
+{{APIRef("CSS Counter Styles")}}
 
 The **`system`** property of the {{domxref("CSSCounterStyleRule")}} interface gets and sets the value of the {{cssxref("@counter-style/system", "system")}} descriptor. If the descriptor does not have a value set, this attribute returns an empty string.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

use "APIRef" instead of "DefaultAPISidebar"

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Quick switch page between CSSCounterStyleRule properties 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Note

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

https://github.com/mdn/translated-content/pull/19608

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
