### PR TITLE
fix minor typo

### DIFF
--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -101,7 +101,7 @@ align-content: unset;
 
 ## Examples
 
-In this example, you can switch between three different {{cssxref("display")}} property values, includ `flex`, `grid`, and `block`. You can also switch between the different values for `align-content`.
+In this example, you can switch between three different {{cssxref("display")}} property values, including `flex`, `grid`, and `block`. You can also switch between the different values for `align-content`.
 
 #### HTML
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix minor typo in [CSS `align-content` property](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).

### Motivation

I hope it's fine to make a commit for such a small change.

### Additional details

I haven't found any other issues on the page that need fixing, except for one issue related to the `{{CSSInfo}}` macro, which I have already filed in [mdn/yari](https://github.com/mdn/yari) - https://github.com/mdn/yari/issues/10965.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
