### PR TITLE
Django auth - cross link to logout template once logout button enabled

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -461,7 +461,7 @@ You also need to append the following styles to **/django-locallibrary-tutorial/
 ```
 
 Try it out by clicking the Login/Logout links in the sidebar.
-You should be taken to the logout/login pages that you defined in the [Template directory](/en-US/docs/Learn/Server-side/Django/Authentication#template_directory) above.
+You should be taken to the logout/login pages that you defined in the [Template directory](#template_directory) above.
 
 ### Testing in views
 

--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -461,7 +461,7 @@ You also need to append the following styles to **/django-locallibrary-tutorial/
 ```
 
 Try it out by clicking the Login/Logout links in the sidebar.
-You should be taken to the logout/login pages that you defined in the [Template directory](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Authentication#template_directory) above.
+You should be taken to the logout/login pages that you defined in the [Template directory](/en-US/docs/Learn/Server-side/Django/Authentication#template_directory) above.
 
 ### Testing in views
 

--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -461,6 +461,7 @@ You also need to append the following styles to **/django-locallibrary-tutorial/
 ```
 
 Try it out by clicking the Login/Logout links in the sidebar.
+You should be taken to the logout/login pages that you defined in the [Template directory](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Authentication#template_directory) above.
 
 ### Testing in views
 


### PR DESCRIPTION
In https://github.com/mdn/django-locallibrary-tutorial/issues/141 there is a question about whether the logout behaviour takes you to the admin logout view. It does not (if you have followed the tutorial). This makes it clear that you end up in the logout template page created earlier in this same topic/