### PR TITLE
HTML Sanitizer API - mark as deprecated

### DIFF
--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -3,16 +3,15 @@ title: HTML Sanitizer API
 slug: Web/API/HTML_Sanitizer_API
 page-type: web-api-overview
 status:
+  - deprecated
   - experimental
+  - non-standard
 browser-compat: api.Sanitizer
 ---
 
-{{DefaultAPISidebar("HTML Sanitizer API")}}{{SeeCompatTable}}
+{{DefaultAPISidebar("HTML Sanitizer API")}}{{deprecated_header}}
 
 {{securecontext_header}}
-
-> **Warning:** This documentation reflects stale browser implementations.
-> The specification has changed significantly since the docs were written, and they will need to be updated once browser implementations catch up.
 
 The **HTML Sanitizer API** allow developers to take untrusted strings of HTML and {{domxref('Document')}} or {{domxref('DocumentFragment')}} objects, and sanitize them for safe insertion into a document's DOM.
 


### PR DESCRIPTION
HTML Sanitizer API as documented is non-standard and  deprecated (already removed from web platform). It's likely to evolve, but for now nothing that is on MDN is  going to stay. To make this more clear I've modified the API page to say that this is deprecated rather than experimental. 

Also added https://github.com/mdn/browser-compat-data/pull/22901 which will auto-update the other pages.

This fell out of https://github.com/mdn/content/pull/33141