### PR TITLE
FF126 Content-Encoding: zstd supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -30,6 +30,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
 ### HTTP
 
+- The [`zstd`](/en-US/docs/Web/HTTP/Headers/Content-Encoding#zstd) directive of the `Content-Encoding` HTTP header is now supported, allowing decoding of server-sent content encoded with the {{glossary("Zstandard compression")}} algorithm ([Firefox bug 1871963](https://bugzil.la/1871963)).
+
 #### Removals
 
 ### Security

--- a/files/en-us/web/http/headers/content-encoding/index.md
+++ b/files/en-us/web/http/headers/content-encoding/index.md
@@ -44,25 +44,19 @@ Content-Encoding: deflate, gzip
 ## Directives
 
 - `gzip`
-  - : A format using the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77)
-    (LZ77), with a 32-bit CRC. This is the original format of the UNIX _gzip_
-    program. The HTTP/1.1 standard also recommends that the servers supporting this
-    content-encoding should recognize `x-gzip` as an alias, for compatibility
-    purposes.
+  - : A format using the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) (LZ77), with a 32-bit CRC.
+    This is the original format of the UNIX _gzip_ program.
+    The HTTP/1.1 standard also recommends that the servers supporting this content-encoding should recognize `x-gzip` as an alias, for compatibility purposes.
 - `compress`
-  - : A format using the [Lempel-Ziv-Welch](https://en.wikipedia.org/wiki/LZW) (LZW) algorithm. The
-    value name was taken from the UNIX _compress_ program, which implemented this
-    algorithm. Like the compress program, which has disappeared from most UNIX
-    distributions, this content-encoding is not used by many browsers today, partly
-    because of a patent issue (it expired in 2003).
+  - : A format using the [Lempel-Ziv-Welch](https://en.wikipedia.org/wiki/LZW) (LZW) algorithm.
+    The value name was taken from the UNIX _compress_ program, which implemented this algorithm.
+    Like the compress program, which has disappeared from most UNIX distributions, this content-encoding is not used by many browsers today, partly because of a patent issue (it expired in 2003).
 - `deflate`
-  - : Using the [zlib](https://en.wikipedia.org/wiki/Zlib)
-    structure (defined in {{rfc(1950)}}) with the [deflate](https://en.wikipedia.org/wiki/Deflate) compression
-    algorithm (defined in {{rfc(1951)}}).
+  - : Using the [zlib](https://en.wikipedia.org/wiki/Zlib) structure (defined in {{rfc(1950)}}) with the [deflate](https://en.wikipedia.org/wiki/Deflate) compression algorithm (defined in {{rfc(1951)}}).
 - `br`
-  - : A format using the [Brotli](https://en.wikipedia.org/wiki/Brotli) algorithm structure (defined in {{rfc(7932)}}).
+  - : A format using the {{glossary("Brotli compression","Brotli")}} algorithm structure (defined in {{rfc(7932)}}).
 - `zstd`
-  - : A format using the [Zstandard](https://en.wikipedia.org/wiki/Zstd) algorithm structure (defined in {{rfc(8878)}}).
+  - : A format using the {{glossary("Zstandard compression","Zstandard")}} algorithm structure (defined in {{rfc(8878)}}).
 
 ## Examples
 


### PR DESCRIPTION
FF now imports the zstd library and uses it to decode content sent in an HTTP response with header `Content-Encoding: zstd`.

This add a release note and an update to the `Content-Encoding` to link to our Glossary entries rather than wikipedia for the algorithms.

Note that the zstd might be used for other things, it's just that all that I can see being implemented is support for this header. I'm asking, but this will not be wrong.

Related docs work can be tracked in #33086