### PR TITLE
Ff126 Removes marquee events

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
 #### Removals
 
+- The marquee events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handlers](/en-US/docs/Web/HTML/Element/marquee#event_handlers) defined in the [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) ([Firefox bug 1689705](https://bugzil.la/1689705)).
+
 ### WebAssembly
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -53,7 +53,7 @@ This article provides information about the changes in Firefox 126 that affect d
 
 #### Removals
 
-- The marquee events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handlers](/en-US/docs/Web/HTML/Element/marquee#event_handlers) defined in the [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) ([Firefox bug 1689705](https://bugzil.la/1689705)).
+- The marquee events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handler attributes](/en-US/docs/Web/HTML/Element/marquee#event_handlers) defined on the [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) ([Firefox bug 1689705](https://bugzil.la/1689705)).
 
 ### WebAssembly
 

--- a/files/en-us/web/api/htmlmarqueeelement/index.md
+++ b/files/en-us/web/api/htmlmarqueeelement/index.md
@@ -19,45 +19,45 @@ It inherits properties and methods from the {{DOMxRef("HTMLElement")}} interface
 
 _Inherits properties from its parent, {{DOMxRef("HTMLElement")}}._
 
-- {{DOMxRef("HTMLMarqueeElement.behavior")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.behavior` {{Deprecated_Inline}}
   - : Sets how the text is scrolled within the marquee. Possible values are `scroll`, `slide` and `alternate`. If no value is specified, the default value is `scroll`.
-- {{DOMxRef("HTMLMarqueeElement.bgColor")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.bgColor` {{Deprecated_Inline}}
   - : Sets the background color through color name or hexadecimal value.
-- {{DOMxRef("HTMLMarqueeElement.direction")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.direction` {{Deprecated_Inline}}
   - : Sets the direction of the scrolling within the marquee. Possible values are `left`, `right`, `up` and `down`. If no value is specified, the default value is `left`.
-- {{DOMxRef("HTMLMarqueeElement.height")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.height` {{Deprecated_Inline}}
   - : Sets the height in pixels or percentage value.
-- {{DOMxRef("HTMLMarqueeElement.hspace")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.hspace` {{Deprecated_Inline}}
   - : Sets the horizontal margin.
-- {{DOMxRef("HTMLMarqueeElement.loop")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.loop` {{Deprecated_Inline}}
   - : Sets the number of times the marquee will scroll. If no value is specified, the default value is −1, which means the marquee will scroll continuously.
-- {{DOMxRef("HTMLMarqueeElement.scrollAmount")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.scrollAmount` {{Deprecated_Inline}}
   - : Sets the amount of scrolling at each interval in pixels. The default value is 6.
-- {{DOMxRef("HTMLMarqueeElement.scrollDelay")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.scrollDelay` {{Deprecated_Inline}}
   - : Sets the interval between each scroll movement in milliseconds. The default value is 85. Note that any value smaller than 60 is ignored and the value 60 is used instead, unless `trueSpeed` is `true`.
-- {{DOMxRef("HTMLMarqueeElement.trueSpeed")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.trueSpeed` {{Deprecated_Inline}}
   - : By default, `scrollDelay` values lower than 60 are ignored. If `trueSpeed` is `true`, then those values are not ignored.
-- {{DOMxRef("HTMLMarqueeElement.vspace")}} {{Deprecated_Inline}}
+- `"HTMLMarqueeElement.vspace` {{Deprecated_Inline}}
   - : Sets the vertical margin.
-- {{DOMxRef("HTMLMarqueeElement.width")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.width` {{Deprecated_Inline}}
   - : Sets the width in pixels or percentage value.
 
 ## Instance methods
 
 _Inherits methods from its parent, {{DOMxRef("HTMLElement")}}._
 
-- {{DOMxRef("HTMLMarqueeElement.start()")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.start()` {{Deprecated_Inline}}
   - : Starts scrolling of the marquee.
-- {{DOMxRef("HTMLMarqueeElement.stop()")}} {{Deprecated_Inline}}
+- `HTMLMarqueeElement.stop()` {{Deprecated_Inline}}
   - : Stops scrolling of the marquee.
 
 ## Events
 
-- {{DOMxRef("HTMLMarqueeElement/bounce_event", "bounce")}} {{Deprecated_Inline}}
+- `bounce` {{Deprecated_Inline}}
   - : Fires when the marquee has reached the end of its scroll position. It can only fire when the behavior attribute is set to `alternate`.
-- {{DOMxRef("HTMLMarqueeElement/finish_event", "finish")}} {{Deprecated_Inline}}
+- `finish` {{Deprecated_Inline}}
   - : Fires when the marquee has finished the amount of scrolling that is set by the loop attribute. It can only fire when the loop attribute is set to some number that is greater than 0.
-- {{DOMxRef("HTMLMarqueeElement/start_event", "start")}} {{Deprecated_Inline}}
+- `start` {{Deprecated_Inline}}
   - : Fires when the marquee starts scrolling.
 
 ## Examples

--- a/files/en-us/web/html/element/marquee/index.md
+++ b/files/en-us/web/html/element/marquee/index.md
@@ -38,18 +38,18 @@ The **`<marquee>`** [HTML](/en-US/docs/Web/HTML) element is used to insert a scr
 
 ## Event handlers
 
-- `onbounce`
+- `onbounce` {{deprecated_inline}}
   - : Fires when the marquee has reached the end of its scroll position. It can only fire when the behavior attribute is set to `alternate`.
-- `onfinish`
+- `onfinish` {{deprecated_inline}}
   - : Fires when the marquee has finished the amount of scrolling that is set by the loop attribute. It can only fire when the loop attribute is set to some number that is greater than 0.
-- `onstart`
+- `onstart` {{deprecated_inline}}
   - : Fires when the marquee starts scrolling.
 
 ## Methods
 
-- `start()`
+- `start()` {{deprecated_inline}}
   - : Starts scrolling of the marquee.
-- `stop()`
+- `stop()` {{deprecated_inline}}
   - : Stops scrolling of the marquee.
 
 ## Examples


### PR DESCRIPTION
FF126 removes the [`HTMLMarqueeElement` events](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMarqueeElement#events) and corresponding [`<marquee>` event handlers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/marquee#event_handlers).

This PR
- Adds a release note
- Adds deprecated to onEvent handlers  `<marquee>` that are  removed (since they aren't in the BCD and wouldn't necessarily get updated automatically).
- Add deprecated to the events in `HTMLMarqueeElement`. Also removed links from the properties - no one should bother documenting these individually now they are deprecated.

Related docs work can be tracked in #33178