### PR TITLE
URL.parse() static method docs

### DIFF
--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -16,7 +16,8 @@ If a browser doesn't yet support the {{domxref("URL.URL", "URL()")}} constructor
 ## Constructor
 
 - {{domxref("URL.URL", "URL()")}}
-  - : Creates and returns a `URL` object referencing the URL specified using an absolute URL string, or a relative URL string and a base URL string.
+  - : Creates and returns a `URL` object from a URL string and optional base URL string.
+    Throws if the passed arguments don't define a valid URL.
 
 ## Instance properties
 
@@ -51,6 +52,8 @@ If a browser doesn't yet support the {{domxref("URL.URL", "URL()")}} constructor
   - : Returns a boolean indicating whether or not a URL defined from a URL string and optional base URL string is parsable and valid.
 - {{domxref("URL.createObjectURL_static", "createObjectURL()")}}
   - : Returns a string containing a unique blob URL, that is a URL with `blob:` as its scheme, followed by an opaque string uniquely identifying the object in the browser.
+- {{domxref("URL.parse_static", "parse()")}}
+  - : Creates and returns a `URL` object from a URL string and optional base URL string, or returns `null` if the passed parameters define an invalid `URL`.
 - {{domxref("URL.revokeObjectURL_static", "revokeObjectURL()")}}
   - : Revokes an object URL previously created using {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}}.
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -51,7 +51,7 @@ This live example demonstrates how to use the `URL.parse()` static method for a 
 
 ```css hidden
 #log {
-  height: 250px;
+  height: 100px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -72,40 +72,38 @@ We also log the case when `URL.parse()` is not supported.
 
 ```js
 if ("parse" in URL) {
+  // Relative URL appended to valid base URL
   let result = URL.parse("en-US/docs", "https://developer.mozilla.org");
-  log("//Relative URL appended to valid base URL");
-  log(`Url.parse("${url}", "${base}")\n// ${result}`);
+  log(`[1]: ${result.href}`);
 
-  url = "https://example.org/some/docs";
-  result = URL.parse(url, base);
-  log("\n//Absolute URL (base URL ignored)");
-  log(`Url.parse("${url}", "${base}")\n// => ${result}`);
+  // Absolute url argument (base URL ignored)
+  result = URL.parse(
+    "https://example.org/some/docs",
+    "https://developer.mozilla.org",
+  );
+  log(`[2]: ${result.href}`);
 
-  log("\n//Invalid base URL (missing colon)");
-  base = "https//developer.mozilla.org";
-  result = URL.parse(url, base);
-  log(`Url.Parse("${url}", "${base}")\n// ${result}`);
+  // Invalid base URL (missing colon)
+  result = URL.parse("en-US/docs", "https//developer.mozilla.org");
+  log(`[3]: ${result}`);
 } else {
   log("URL.parse() not supported");
 }
 ```
 
-Last of all, the code below shows that the `baseUrl` doesn't have to be a string.
-Here we have passed a `URL` object.
+Last of all, the code below demonstrates that the arguments don't have to be strings, by passing an `URL` object for the `base` parameter.
 
 ```js
 if ("parse" in URL) {
-  log("\nRelative URL with base URL supplied as a URL object");
-  base = new URL("https://developer.mozilla.org/");
-  url = "/en-US/docs";
-  result = URL.parse(url, base);
-  log(`Url.parse("${url}", "${base}")\n// ${result}`);
+  // Relative URL with base URL supplied as a URL object
+  result = URL.parse("/en-US/docs", new URL("https://developer.mozilla.org/"));
+  log(`[4]: ${result.href}`);
 }
 ```
 
 The results of each of the checks are shown below.
 
-{{EmbedLiveSample('URL.parse()', '100%', '300')}}
+{{EmbedLiveSample('URL.parse()', '100%')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -31,8 +31,8 @@ URL.parse(url, base)
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
 
-    When specify a `base` URL, the resolved URL is not simply a concatenation of `url` and `base`.
-    Parent-relative and current-directory-relative URLS are relative to the current directory of the `base` URL, which includes only path segments up until the last forward-slash, but not any after.
+    When you specify a `base` URL, the resolved URL is not simply a concatenation of `url` and `base`.
+    Parent-relative and current-directory-relative URLs are relative to the current directory of the `base` URL, which includes only path segments up until the last forward-slash, but not any after.
     Root-relative URLs are relative to the base origin.
     For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -31,8 +31,9 @@ URL.parse(url, base)
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
 
-    When using a `base`, the resulting URL is not simply a concatenation of `url` and `base`.
-    For example, the scheme and domain of the `base` are used for resolving `url`, but any URL path after the last backslash, a given port, or query parameters, are not used.
+    When specify a `base` URL, the resolved URL is not simply a concatenation of `url` and `base`.
+    Parent-relative and current-directory-relative URLS are relative to the current directory of the `base` URL, which includes only path segments up until the last forward-slash, but not any after.
+    Root-relative URLs are relative to the base origin.
     For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -125,3 +125,4 @@ The results of each of the checks are shown below.
 ## See also
 
 - [`URL()` constructor](/en-US/docs/Web/API/URL/URL), which throws if the passed parameters define an invalid URL
+- [A polyfill of `URL.parse()`](https://github.com/zloirock/core-js#url-and-urlsearchparams) is available in [`core-js`](https://github.com/zloirock/core-js)

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -23,8 +23,8 @@ URL.parse(url, base)
 ### Parameters
 
 - `url`
-  - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute or relative URL.
-    If `url` is a relative URL, `base` is required, and is used to resolve the final absolute URL.
+  - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute URL or a relative reference to a URL.
+    If `url` is a relative reference, `base` is required, and is used to resolve the final URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
 
@@ -32,9 +32,9 @@ URL.parse(url, base)
     If not specified, it defaults to `undefined`.
 
     When you specify a `base` URL, the resolved URL is not simply a concatenation of `url` and `base`.
-    Parent-relative and current-directory-relative URLs are relative to the current directory of the `base` URL, which includes only path segments up until the last forward-slash, but not any after.
-    Root-relative URLs are relative to the base origin.
-    For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
+    Relative references to the parent and current directory are resolved are relative to the current directory of the `base` URL, which includes only path segments up until the last forward-slash, but not any after.
+    Relative references to the root are resolved relative to the base origin.
+    For more information see [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references).
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
 > In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified from the object's {{domxref("URL.href", "href")}} property.
@@ -45,11 +45,11 @@ A `URL` if the parameters can be resolved to a valid URL; `null` otherwise.
 
 ## Examples
 
-[Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls) and [`URL()` constructor](/en-US/docs/Web/API/URL/URL#examples) provide additional examples demonstrating how different `url` and `base` values are resolved to a final absolute URL (though primarily using `URL()`).
+[Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) and [`URL()` constructor](/en-US/docs/Web/API/URL/URL#examples) provide additional examples demonstrating how different `url` and `base` values are resolved to a final absolute URL (though primarily using `URL()`).
 
 ### Using URL.parse()
 
-This live example demonstrates how to use the `URL.parse()` static method for a few different absolute and relative URL values.
+This live example demonstrates how to use the `URL.parse()` static method for a few different absolute and relative reference values.
 
 ```html hidden
 <pre id="log"></pre>
@@ -72,7 +72,7 @@ function log(text) {
 ```
 
 First we check that the `URL.parse()` method is supported using the condition `"parse" in URL`.
-If the method is supported we log the result of checking an absolute URL, a relative URL with a base URL, a relative URL with a more [complicated base URL](/en-US/docs/Web/API/URL_API/Resolving_relative_urls), a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
+If the method is supported we log the result of checking an absolute URL, a relative reference and a base URL, a relative reference with a more [complicated base URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references), a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
 
 We also log the case when `URL.parse()` is not supported.
 
@@ -82,11 +82,11 @@ if ("parse" in URL) {
   let result = URL.parse("https://developer.mozilla.org/en-US/docs");
   log(`[1]: ${result.href}`);
 
-  // Relative URL resolved to valid base URL
+  // Relative reference to a valid base URL
   result = URL.parse("en-US/docs", "https://developer.mozilla.org");
   log(`[2]: ${result.href}`);
 
-  // Relative URL resolved to "complicated" valid base URL
+  // Relative reference to a "complicated" valid base URL
   // (only the scheme and domain are used to resolve url)
   result = URL.parse(
     "/different/place",
@@ -113,7 +113,7 @@ Last of all, the code below demonstrates that the arguments don't have to be str
 
 ```js
 if ("parse" in URL) {
-  // Relative URL with base URL supplied as a URL object
+  // Relative reference with base URL supplied as a URL object
   result = URL.parse("/en-US/docs", new URL("https://developer.mozilla.org/"));
   log(`[6]: ${result.href}`);
 }

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -23,21 +23,25 @@ URL.parse(url, base)
 ### Parameters
 
 - `url`
-  - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element — that represents an absolute or relative URL.
+  - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute or relative URL.
     If `url` is a relative URL, `base` is required, and will be used as the base URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
 
-> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, just like with other Web APIs that accept a string.
-> In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified to the object's {{domxref("URL.href", "href")}} property.
+> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
+> In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified from the object's {{domxref("URL.href", "href")}} property.
 
 ### Return value
 
 A `URL` if the parameters can be resolved to a valid URL; `null` otherwise.
 
 ## Examples
+
+The [`URL()` constructor](/en-US/docs/Web/API/URL/URL#examples) documentation provides many additional examples demonstrating how different `url` and `base` values are resolve to a final absolute URL.
+
+### Using URL.parse()
 
 This live example demonstrates how to use the `URL.parse()` static method for a few different absolute and relative URL values.
 
@@ -101,7 +105,7 @@ if ("parse" in URL) {
 
 The results of each of the checks are shown below.
 
-{{EmbedLiveSample('Examples', '100%', '300')}}
+{{EmbedLiveSample('URL.parse()', '100%', '300')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -27,9 +27,13 @@ URL.parse(url, base)
     If `url` is a relative URL, `base` is required, and is used to resolve the final absolute URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
+
   - : A string representing the base URL to use in cases where `url` is a relative URL.
-    Note that only the scheme and domain are used for resolving `url`: other URL parts, such as a port, path, or query parameters, are not used.
     If not specified, it defaults to `undefined`.
+
+    When using a `base`, the resulting URL is not simply a concatenation of `url` and `base`.
+    For example, the scheme and domain of the `base` are used for resolving `url`, but any URL path after the last backslash, a given port, or query parameters, are not used.
+    For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
 > In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified from the object's {{domxref("URL.href", "href")}} property.
@@ -67,7 +71,7 @@ function log(text) {
 ```
 
 First we check that the `URL.parse()` method is supported using the condition `"parse" in URL`.
-If the method is supported we log the result of checking a relative URL with a base URL, a relative URL with a more complicated base URL, a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
+If the method is supported we log the result of checking a relative URL with a base URL, a relative URL with a more [complicated base URL](/en-US/docs/Web/API/URL_API/Resolving_relative_urls), a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
 
 We also log the case when `URL.parse()` is not supported.
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -1,0 +1,119 @@
+---
+title: "URL: parse() static method"
+short-title: parse()
+slug: Web/API/URL/parse_static
+page-type: web-api-static-method
+browser-compat: api.URL.parse_static
+---
+
+{{ApiRef("URL API")}}
+
+The **`URL.parse()`** static method of the {{domxref("URL")}} interface returns a newly created {{domxref("URL")}} object representing the URL defined by the parameters.
+
+If the given base URL or the resulting URL are not parsable and valid URLs, `null` is returned.
+This is an alternative to using the normal constructor to construct a `URL` within a [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block, or using {{domxref("URL.canParse_static", "canParse()")}} to check the parameters and returning `null` if the method returns `false`.
+
+## Syntax
+
+```js-nolint
+URL.parse(url)
+URL.parse(url, base)
+```
+
+### Parameters
+
+- `url`
+  - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
+    If `url` is a relative URL, `base` is required, and will be used as the base URL.
+    If `url` is an absolute URL, a given `base` will be ignored.
+- `base` {{optional_inline}}
+  - : A string representing the base URL to use in cases where `url` is a relative URL.
+    If not specified, it defaults to `undefined`.
+
+> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, just like with other Web APIs that accept a string.
+> In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified to the object's {{domxref("URL.href", "href")}} property.
+
+### Return value
+
+A `URL` if the parameters can be resolved to a valid URL; `null` otherwise.
+
+## Examples
+
+This live example demonstrates how to use the `URL.parse()` static method for a few different absolute and relative URL values.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 250px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+First we check that the `URL.parse()` method is supported using the condition `"parse" in URL`.
+If the method is supported we log the result of checking a relative URL with a base URL, a valid absolute URL with a valid base URL (which gets ignored), and an invalid base URL that returns `null`.
+
+We also log the case when `URL.parse()` is not supported.
+
+```js
+if ("parse" in URL) {
+  let url = "en-US/docs";
+  let base = "https://developer.mozilla.org";
+  let result = URL.parse(url, base);
+  log("//Relative URL appended to valid base URL");
+  log(`Url.parse("${url}", "${base}")\n// ${result}`);
+
+  url = "https://example.org/some/docs";
+  result = URL.parse(url, base);
+  log("\n//Absolute URL (base URL ignored)");
+  log(`Url.parse("${url}", "${base}")\n// => ${result}`);
+
+  log("\n//Invalid base URL (missing colon)");
+  base = "https//developer.mozilla.org";
+  result = URL.parse(url, base);
+  log(`Url.Parse("${url}", "${base}")\n// ${result}`);
+} else {
+  log("URL.parse() not supported");
+}
+```
+
+Last of all, the code below shows that the `baseUrl` doesn't have to be a string.
+Here we have passed a `URL` object.
+
+```js
+if ("parse" in URL) {
+  log("\nRelative URL with base URL supplied as a URL object");
+  base = new URL("https://developer.mozilla.org/");
+  url = "/en-US/docs";
+  result = URL.parse(url, base);
+  log(`Url.parse("${url}", "${base}")\n// ${result}`);
+}
+```
+
+The results of each of the checks are shown below.
+
+{{EmbedLiveSample('Examples', '100%', '300')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`URL()` constructor](/en-US/docs/Web/API/URL/URL), which throws if the passed parameters define an invalid URL
+- [A polyfill of `URL.canParse()`](https://github.com/zloirock/core-js#url-and-urlsearchparams) is available in [`core-js`](https://github.com/zloirock/core-js)

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -11,7 +11,7 @@ browser-compat: api.URL.parse_static
 The **`URL.parse()`** static method of the {{domxref("URL")}} interface returns a newly created {{domxref("URL")}} object representing the URL defined by the parameters.
 
 If the given base URL or the resulting URL are not parsable and valid URLs, `null` is returned.
-This is an alternative to using the normal constructor to construct a `URL` within a [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block, or using {{domxref("URL.canParse_static", "canParse()")}} to check the parameters and returning `null` if the method returns `false`.
+This is an alternative to using the {{domxref("URL.URL", "URL()")}} constructor to construct a `URL` within a [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block, or using {{domxref("URL.canParse_static", "canParse()")}} to check the parameters and returning `null` if the method returns `false`.
 
 ## Syntax
 
@@ -23,9 +23,9 @@ URL.parse(url, base)
 ### Parameters
 
 - `url`
-  - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
+  - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element — that represents an absolute or relative URL.
     If `url` is a relative URL, `base` is required, and will be used as the base URL.
-    If `url` is an absolute URL, a given `base` will be ignored.
+    If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
@@ -68,9 +68,7 @@ We also log the case when `URL.parse()` is not supported.
 
 ```js
 if ("parse" in URL) {
-  let url = "en-US/docs";
-  let base = "https://developer.mozilla.org";
-  let result = URL.parse(url, base);
+  let result = URL.parse("en-US/docs", "https://developer.mozilla.org");
   log("//Relative URL appended to valid base URL");
   log(`Url.parse("${url}", "${base}")\n// ${result}`);
 
@@ -116,4 +114,3 @@ The results of each of the checks are shown below.
 ## See also
 
 - [`URL()` constructor](/en-US/docs/Web/API/URL/URL), which throws if the passed parameters define an invalid URL
-- [A polyfill of `URL.canParse()`](https://github.com/zloirock/core-js#url-and-urlsearchparams) is available in [`core-js`](https://github.com/zloirock/core-js)

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -45,7 +45,7 @@ A `URL` if the parameters can be resolved to a valid URL; `null` otherwise.
 
 ## Examples
 
-The [`URL()` constructor](/en-US/docs/Web/API/URL/URL#examples) documentation provides many additional examples demonstrating how different `url` and `base` values are resolve to a final absolute URL.
+[Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls) and [`URL()` constructor](/en-US/docs/Web/API/URL/URL#examples) provide additional examples demonstrating how different `url` and `base` values are resolved to a final absolute URL (though primarily using `URL()`).
 
 ### Using URL.parse()
 
@@ -72,15 +72,19 @@ function log(text) {
 ```
 
 First we check that the `URL.parse()` method is supported using the condition `"parse" in URL`.
-If the method is supported we log the result of checking a relative URL with a base URL, a relative URL with a more [complicated base URL](/en-US/docs/Web/API/URL_API/Resolving_relative_urls), a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
+If the method is supported we log the result of checking an absolute URL, a relative URL with a base URL, a relative URL with a more [complicated base URL](/en-US/docs/Web/API/URL_API/Resolving_relative_urls), a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
 
 We also log the case when `URL.parse()` is not supported.
 
 ```js
 if ("parse" in URL) {
-  // Relative URL resolved to valid base URL
-  let result = URL.parse("en-US/docs", "https://developer.mozilla.org");
+  // Absolute URL
+  let result = URL.parse("https://developer.mozilla.org/en-US/docs");
   log(`[1]: ${result.href}`);
+
+  // Relative URL resolved to valid base URL
+  result = URL.parse("en-US/docs", "https://developer.mozilla.org");
+  log(`[2]: ${result.href}`);
 
   // Relative URL resolved to "complicated" valid base URL
   // (only the scheme and domain are used to resolve url)
@@ -88,18 +92,18 @@ if ("parse" in URL) {
     "/different/place",
     "https://developer.mozilla.org:443/some/path?id=4",
   );
-  log(`[2]: ${result.href}`);
+  log(`[3]: ${result.href}`);
 
   // Absolute url argument (base URL ignored)
   result = URL.parse(
     "https://example.org/some/docs",
     "https://developer.mozilla.org",
   );
-  log(`[3]: ${result.href}`);
+  log(`[4]: ${result.href}`);
 
   // Invalid base URL (missing colon)
   result = URL.parse("en-US/docs", "https//developer.mozilla.org");
-  log(`[4]: ${result}`);
+  log(`[5]: ${result}`);
 } else {
   log("URL.parse() not supported");
 }
@@ -111,7 +115,7 @@ Last of all, the code below demonstrates that the arguments don't have to be str
 if ("parse" in URL) {
   // Relative URL with base URL supplied as a URL object
   result = URL.parse("/en-US/docs", new URL("https://developer.mozilla.org/"));
-  log(`[5]: ${result.href}`);
+  log(`[6]: ${result.href}`);
 }
 ```
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -24,10 +24,11 @@ URL.parse(url, base)
 
 - `url`
   - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute or relative URL.
-    If `url` is a relative URL, `base` is required, and will be used as the base URL.
+    If `url` is a relative URL, `base` is required, and is used to resolve the final absolute URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
   - : A string representing the base URL to use in cases where `url` is a relative URL.
+    Note that only the scheme and domain are used for resolving `url`: other URL parts, such as a port, path, or query parameters, are not used.
     If not specified, it defaults to `undefined`.
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
@@ -66,7 +67,7 @@ function log(text) {
 ```
 
 First we check that the `URL.parse()` method is supported using the condition `"parse" in URL`.
-If the method is supported we log the result of checking a relative URL with a base URL, a valid absolute URL with a valid base URL (which gets ignored), and an invalid base URL that returns `null`.
+If the method is supported we log the result of checking a relative URL with a base URL, a relative URL with a more complicated base URL, a valid absolute URL with a valid base URL (which is not used), and an invalid base URL that results in the method returning `null`.
 
 We also log the case when `URL.parse()` is not supported.
 
@@ -76,16 +77,24 @@ if ("parse" in URL) {
   let result = URL.parse("en-US/docs", "https://developer.mozilla.org");
   log(`[1]: ${result.href}`);
 
+  // Relative URL resolved to "complicated" valid base URL
+  // (only the scheme and domain are used to resolve url)
+  result = URL.parse(
+    "/different/place",
+    "https://developer.mozilla.org:443/some/path?id=4",
+  );
+  log(`[2]: ${result.href}`);
+
   // Absolute url argument (base URL ignored)
   result = URL.parse(
     "https://example.org/some/docs",
     "https://developer.mozilla.org",
   );
-  log(`[2]: ${result.href}`);
+  log(`[3]: ${result.href}`);
 
   // Invalid base URL (missing colon)
   result = URL.parse("en-US/docs", "https//developer.mozilla.org");
-  log(`[3]: ${result}`);
+  log(`[4]: ${result}`);
 } else {
   log("URL.parse() not supported");
 }
@@ -97,7 +106,7 @@ Last of all, the code below demonstrates that the arguments don't have to be str
 if ("parse" in URL) {
   // Relative URL with base URL supplied as a URL object
   result = URL.parse("/en-US/docs", new URL("https://developer.mozilla.org/"));
-  log(`[4]: ${result.href}`);
+  log(`[5]: ${result.href}`);
 }
 ```
 

--- a/files/en-us/web/api/url/parse_static/index.md
+++ b/files/en-us/web/api/url/parse_static/index.md
@@ -72,7 +72,7 @@ We also log the case when `URL.parse()` is not supported.
 
 ```js
 if ("parse" in URL) {
-  // Relative URL appended to valid base URL
+  // Relative URL resolved to valid base URL
   let result = URL.parse("en-US/docs", "https://developer.mozilla.org");
   log(`[1]: ${result.href}`);
 

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -22,15 +22,15 @@ new URL(url, base)
 ### Parameters
 
 - `url`
-  - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
+  - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute or relative URL.
     If `url` is a relative URL, `base` is required, and will be used as the base URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
 
-> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, just like with other Web APIs that accept a string.
-> In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will stringify to the object's {{domxref("URL.href", "href")}} property.
+> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
+> In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified from the object's {{domxref("URL.href", "href")}} property.
 
 The resulting URL is not simply a concatenation of `url` and `base`.
 The path sections of both arguments are merged according to [RFC 3986 - Relative Resolution](https://datatracker.ietf.org/doc/html/rfc3986.html#section-5.2).

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -8,11 +8,9 @@ browser-compat: api.URL.URL
 
 {{APIRef("URL API")}} {{AvailableInWorkers}}
 
-The **`URL()`** constructor returns a newly created
-{{domxref("URL")}} object representing the URL defined by the parameters.
+The **`URL()`** constructor returns a newly created {{domxref("URL")}} object representing the URL defined by the parameters.
 
-If the given base URL or the resulting URL are not valid URLs, the JavaScript
-{{jsxref("TypeError")}} exception is thrown.
+If the given base URL or the resulting URL are not valid URLs, the JavaScript {{jsxref("TypeError")}} exception is thrown.
 
 ## Syntax
 
@@ -25,33 +23,25 @@ new URL(url, base)
 
 - `url`
   - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
-    If `url` is a relative URL, `base` is
-    required, and will be used as the base URL. If `url` is an
-    absolute URL, a given `base` will be ignored.
+    If `url` is a relative URL, `base` is required, and will be used as the base URL.
+    If `url` is an absolute URL, a given `base` will be ignored.
 - `base` {{optional_inline}}
-  - : A string representing the base URL to use in cases where
-    `url` is a relative URL. If not specified, it defaults to
-    `undefined`.
+  - : A string representing the base URL to use in cases where `url` is a relative URL.
+    If not specified, it defaults to `undefined`.
 
-> **Note:** The `url` and `base` arguments will
-> each be stringified from whatever value you pass, just like with other Web APIs
-> that accept a string. In particular, you can use an existing
-> {{domxref("URL")}} object for either argument, and it will stringify to the
-> object's {{domxref("URL.href", "href")}} property.
+> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, just like with other Web APIs that accept a string.
+> In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will stringify to the object's {{domxref("URL.href", "href")}} property.
 
 The resulting URL is not simply a concatenation of `url` and `base`.
-The path sections of both arguments are merged according to
-[RFC 3986 - Relative Resolution](https://datatracker.ietf.org/doc/html/rfc3986.html#section-5.2).
+The path sections of both arguments are merged according to [RFC 3986 - Relative Resolution](https://datatracker.ietf.org/doc/html/rfc3986.html#section-5.2).
 Therefore a trailing slash in `base` or a leading slash in `url` affect how the resulting path is constructed.
-If you need a strict concatenation of the two arguments the `url` must not have a leading slash
-and the `base` must have a trailing slash.
+If you need a strict concatenation of the two arguments the `url` must not have a leading slash and the `base` must have a trailing slash.
 See the examples under [Examples - Merging of url and base paths](#merging_of_url_and_base_paths).
 
 ### Exceptions
 
-| Exception               | Explanation                                                                                               |
-| ----------------------- | --------------------------------------------------------------------------------------------------------- |
-| {{jsxref("TypeError")}} | `url` (in the case of absolute URLs) or `base` + `url` (in the case of relative URLs) is not a valid URL. |
+- {{jsxref("TypeError")}}
+  - : `url` (in the case of absolute URLs) or `base` + `url` (in the case of relative URLs) is not a valid URL.
 
 ## Examples
 
@@ -148,5 +138,6 @@ const H = new URL("../articles", "https://developer.mozilla.org/api/v1/");
 
 ## See also
 
+- {{domxref("URL.parse_static", "URL.parse()")}}, a non-throwing alternative to this constructor
 - [Polyfill of `URL` in `core-js`](https://github.com/zloirock/core-js#url-and-urlsearchparams)
 - The interface it belongs to: {{domxref("URL")}}.

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -24,7 +24,7 @@ new URL(url, base)
 - `url`
   - : A string or any other object with a {{Glossary("stringifier")}} — including, for example, an {{htmlelement("a")}} or {{htmlelement("area")}} element — that represents an absolute or relative URL.
     If `url` is a relative URL, `base` is required, and will be used as the base URL.
-    If `url` is an absolute URL, a given `base` will be ignored.
+    If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -22,18 +22,18 @@ new URL(url, base)
 ### Parameters
 
 - `url`
-  - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute or relative URL.
-    If `url` is a relative URL, `base` is required, and is used to resolve the final absolute URL.
+  - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute URL or a relative reference to a base URL.
+    If `url` is a relative reference, `base` is required, and is used to resolve the final URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
 
-  - : A string representing the base URL to use in cases where `url` is a relative URL.
+  - : A string representing the base URL to use in cases where `url` is a relative reference.
     If not specified, it defaults to `undefined`.
 
     When specify a `base` URL, the resolved URL is not simply a concatenation of `url` and `base`.
-    Parent-relative and current-directory-relative URLS are relative to the current directory of the `base` URL, which includes path segments up until the last forward-slash, but not any after.
-    Root-relative URLs are relative to the base origin.
-    For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
+    Relative references to the parent and current directory are resolved are relative to the current directory of the `base` URL, which includes path segments up until the last forward-slash, but not any after.
+    Relative references to the root are resolved relative to the base origin.
+    For more information see [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references).
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
 > In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified from the object's {{domxref("URL.href", "href")}} property.
@@ -41,13 +41,13 @@ new URL(url, base)
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : `url` (in the case of absolute URLs) or `base` + `url` (in the case of relative URLs) is not a valid URL.
+  - : `url` (in the case of absolute URLs) or `base` + `url` (in the case of relative references) is not a valid URL.
 
 ## Examples
 
 Here are some examples of using the constructor.
 
-> **Note:** [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls) provides additional examples demonstrating how different `url` and `base` values are resolved to a final absolute URL.
+> **Note:** [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) provides additional examples demonstrating how different `url` and `base` values are resolved to a final absolute URL.
 
 ```js
 // Base URLs:

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -23,10 +23,11 @@ new URL(url, base)
 
 - `url`
   - : A string or any other object with a {{Glossary("stringifier")}} that represents an absolute or relative URL.
-    If `url` is a relative URL, `base` is required, and will be used as the base URL.
+    If `url` is a relative URL, `base` is required, and is used to resolve the final absolute URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
   - : A string representing the base URL to use in cases where `url` is a relative URL.
+    Note that only the scheme and domain are used for resolving `url`: other URL parts, such as a port, path, or query parameters, are not used.
     If not specified, it defaults to `undefined`.
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -45,6 +45,10 @@ new URL(url, base)
 
 ## Examples
 
+Here are some examples of using the constructor.
+
+> **Note:** [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls) provides additional examples demonstrating how different `url` and `base` values are resolved to a final absolute URL.
+
 ```js
 // Base URLs:
 let baseUrl = "https://developer.mozilla.org";
@@ -69,9 +73,11 @@ new URL("/en-US/docs", A);
 
 new URL("/en-US/docs", "https://developer.mozilla.org/fr-FR/toto");
 // => 'https://developer.mozilla.org/en-US/docs'
+```
 
-// Invalid URLs:
+Here are some examples of invalid URLs:
 
+```js
 new URL("/en-US/docs", "");
 // Raises a TypeError exception as '' is not a valid URL
 
@@ -94,38 +100,6 @@ new URL("/a", "https://example.com/?query=1");
 
 new URL("//foo.com", "https://example.com");
 // => 'https://foo.com/' (see relative URLs)
-```
-
-### Merging of url and base paths
-
-```js
-/* base path without trailing slash */
-
-const A = new URL("articles", "https://developer.mozilla.org/api/v1");
-// => 'https://developer.mozilla.org/api/articles'
-
-const B = new URL("/articles", "https://developer.mozilla.org/api/v1");
-// => 'https://developer.mozilla.org/articles'
-
-const C = new URL("./articles", "https://developer.mozilla.org/api/v1");
-// => 'https://developer.mozilla.org/api/articles'
-
-const D = new URL("../articles", "https://developer.mozilla.org/api/v1");
-// => 'https://developer.mozilla.org/articles'
-
-/* base path with trailing slash */
-
-const E = new URL("articles", "https://developer.mozilla.org/api/v1/");
-// => 'https://developer.mozilla.org/api/v1/articles'
-
-const F = new URL("/articles", "https://developer.mozilla.org/api/v1/");
-// => 'https://developer.mozilla.org/articles'
-
-const G = new URL("./articles", "https://developer.mozilla.org/api/v1/");
-// => 'https://developer.mozilla.org/api/v1/articles'
-
-const H = new URL("../articles", "https://developer.mozilla.org/api/v1/");
-// => 'https://developer.mozilla.org/api/articles'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -26,18 +26,16 @@ new URL(url, base)
     If `url` is a relative URL, `base` is required, and is used to resolve the final absolute URL.
     If `url` is an absolute URL, a given `base` will not be used to create the resulting URL.
 - `base` {{optional_inline}}
+
   - : A string representing the base URL to use in cases where `url` is a relative URL.
-    Note that only the scheme and domain are used for resolving `url`: other URL parts, such as a port, path, or query parameters, are not used.
     If not specified, it defaults to `undefined`.
+
+    When using a `base`, the resulting URL is not simply a concatenation of `url` and `base`.
+    For example, the scheme and domain of the `base` are used for resolving `url`, but any URL path after the last backslash, a given port, or query parameters, are not used.
+    For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.
 > In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified from the object's {{domxref("URL.href", "href")}} property.
-
-The resulting URL is not simply a concatenation of `url` and `base`.
-The path sections of both arguments are merged according to [RFC 3986 - Relative Resolution](https://datatracker.ietf.org/doc/html/rfc3986.html#section-5.2).
-Therefore a trailing slash in `base` or a leading slash in `url` affect how the resulting path is constructed.
-If you need a strict concatenation of the two arguments the `url` must not have a leading slash and the `base` must have a trailing slash.
-See the examples under [Examples - Merging of url and base paths](#merging_of_url_and_base_paths).
 
 ### Exceptions
 

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -30,8 +30,9 @@ new URL(url, base)
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
 
-    When using a `base`, the resulting URL is not simply a concatenation of `url` and `base`.
-    For example, the scheme and domain of the `base` are used for resolving `url`, but any URL path after the last backslash, a given port, or query parameters, are not used.
+    When specify a `base` URL, the resolved URL is not simply a concatenation of `url` and `base`.
+    Parent-relative and current-directory-relative URLS are relative to the current directory of the `base` URL, which includes path segments up until the last forward-slash, but not any after.
+    Root-relative URLs are relative to the base origin.
     For more information see [Resolving relative URLs](/en-US/docs/Web/API/URL_API/Resolving_relative_urls).
 
 > **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, such as an {{domxref("HTMLAnchorElement")}} or {{domxref("HTMLAreaElement")}} element, just like with other Web APIs that accept a string.

--- a/files/en-us/web/api/url_api/resolving_relative_references/index.md
+++ b/files/en-us/web/api/url_api/resolving_relative_references/index.md
@@ -1,16 +1,16 @@
 ---
-title: Resolving relative URLs
-slug: Web/API/URL_API/Resolving_relative_urls
+title: Resolving relative references to a URL
+slug: Web/API/URL_API/Resolving_relative_references
 page-type: guide
 ---
 
 {{DefaultAPISidebar("URL API")}}
 
-The [`URL()` constructor](/en-US/docs/Web/API/URL/URL) or the {{domxref("URL.parse_static", "URL.parse()")}} static method of the [URL API](/en-US/docs/Web/API/URL_API) can be used to resolve a relative URL and a base URL to an absolute URL.
+The [`URL()` constructor](/en-US/docs/Web/API/URL/URL) or the {{domxref("URL.parse_static", "URL.parse()")}} static method of the [URL API](/en-US/docs/Web/API/URL_API) can be used to resolve a relative reference and a base URL to an absolute URL.
 
 Both methods take up to two string arguments and return a [`URL()`](/en-US/docs/Web/API/URL) object representing an absolute URL.
-The first argument represents either an absolute URL or a relative URL, while the second is a base URL that is used to resolve the relative URL — if one is specified in the first argument.
-The methods resolve the relative URL in the same way, except that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
+The first argument represents either an absolute URL or a relative reference to a URL, while the second is a base URL that is used to resolve the relative reference if one is specified in the first argument.
+The methods resolve the relative reference in the same way, except that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
 
 The code below shows how the methods are used with the same `url` and `base` URL values.
 
@@ -23,18 +23,18 @@ const parseResult = URL.parse(url, base);
 // => https://developer.mozilla.org/url/some/articles
 ```
 
-You can see from the example that resolving the `URL` from a supplied base URL and relative URL is not simply a concantenation of the supplied parameters.
+You can see from the example that resolving the `URL` from a supplied base URL and relative reference is not simply a concantenation of the supplied parameters.
 
 In this case a path relative to the current directory is passed (`articles`).
 The current directory of the `base` URL is the URL string up to the last forward slash.
 Here `https://developer.mozilla.org/some/path` has no trailing forward slash, so the current directory is `https://developer.mozilla.org/some/`, and hence resolves to a final URL of `https://developer.mozilla.org/url/some/articles`.
 
-Relative URLs are resolved against the base URL using a path reference that is relative to: the current directory (`./`), the parent directory of the current directory (`../`), or the site root (`/`).
+Relative references are resolved against the base URL using a path reference that is relative to: the current directory (`./`), the parent directory of the current directory (`../`), or the site root (`/`).
 The following sections show how resolution works for each type of relative path.
 
 ## Current directory relative
 
-A relative path prefixed with `./` or no prefix, such as `./article`, `article`, or `./article/`, is relative to the current directory of the URL represented by the `base` argument.
+A relative reference prefixed with `./` or no prefix, such as `./article`, `article`, or `./article/`, is relative to the current directory of the URL represented by the `base` argument.
 
 ```html hidden
 <pre id="log"></pre>
@@ -56,7 +56,7 @@ function log(text) {
 ```
 
 The current directory of the `base` URL is the URL string up to the last forward slash, which is `https://test.example.org/api/` for both of the `base` strings in the code block below.
-The current directory relative URL `article` is appended to this, resolving to `https://test.example.org/api/article`
+The current directory relative reference `article` is appended to this, resolving to `https://test.example.org/api/article`
 
 ```js
 log(new URL("./article", "https://test.example.org/api/").href);
@@ -66,7 +66,7 @@ log(new URL("article", "https://test.example.org/api/v1").href);
 ```
 
 Similarly, below both base URL strings have a current directory of `https://test.example.org/api/v2/`.
-We append `story/` and `story` to these to resolve the final absolute URL.
+We append `story/` and `story` to these to resolve the final URL.
 
 ```js
 log(new URL("./story/", "https://test.example.org/api/v2/").href);
@@ -79,7 +79,7 @@ log(new URL("./story", "https://test.example.org/api/v2/v3").href);
 
 ## Parent-directory relative
 
-A relative path prefixed with `../`, such as `../path`, is relative to the _parent_ of the current directory of the URL represented by the `base` argument.
+A relative reference prefixed with `../`, such as `../path`, is relative to the _parent_ of the current directory of the URL represented by the `base` argument.
 Each instance of `../` strips a folder from the current directory, and then any text after `../` is appended to the remaining base path.
 You can navigate up through parents by specifying `../` multiple times, but only to the level of the site-root.
 
@@ -105,7 +105,7 @@ function log(text) {
 ```
 
 The following examples demonstrate this in more detail.
-In all cases the current directory is `https://test.example.org/api/v1/v2/` (in the second case `v3` is after the last forward slash), with each relative path resolving to a different parent.
+In all cases the current directory is `https://test.example.org/api/v1/v2/` (in the second case `v3` is after the last forward slash), with each relative reference resolving to a different parent.
 
 ```js
 log(new URL("../path", "https://test.example.org/api/v1/v2/").href);
@@ -120,7 +120,7 @@ log(new URL("../../../../path", "https://test.example.org/api/v1/v2/").href);
 
 ## Root relative
 
-A relative path prefixed with `/`, such as `/path`, is relative to the site root of the URL specified in the `base` argument.
+A relative reference prefixed with `/`, such as `/path`, is relative to the site root of the URL specified in the `base` argument.
 For example, given a base URL of `https://test.example.com/api/v1` the resolved URL for the root-relative URL `/some/path` is `https://test.example.com/some/path`.
 
 > **Note:** The path part of the `base` URL doesn't matter when resolving root-relative URLs.

--- a/files/en-us/web/api/url_api/resolving_relative_urls/index.md
+++ b/files/en-us/web/api/url_api/resolving_relative_urls/index.md
@@ -1,0 +1,255 @@
+---
+title: Resolving relative URLs
+slug: Web/API/URL_API/Resolving_relative_urls
+page-type: guide
+---
+
+{{DefaultAPISidebar("URL API")}}
+
+The {{domxref("URL")}} interface of the [URL API](/en-US/docs/Web/API/URL_API) provides two methods for creating an `URL` objects: the [`URL()` constructor](/en-US/docs/Web/API/URL/URL) and the {{domxref("URL.parse_static", "parse()")}} static method.
+Both methods take string arguments for either an absolute URL, or for a relative URL and a base URL that is used to resolve it.
+The main difference between them is that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
+
+The usage for the methods is shown together below for the same `url` and `base` URL values.
+
+```js
+const url = "articles";
+const base = "https://developer.mozilla.org/some/path";
+const constructorResult = new URL(url, base);
+// => https://developer.mozilla.org/url/some/articles
+const parseResult = URL.parse(url, base);
+// => // => https://developer.mozilla.org/url/some/articles (same)
+```
+
+You can see from the example above that resolving the `URL` from a supplied base URL and relative URL is not simply a concantenation of the supplied parameters.
+Below we show how the resolution works.
+
+## Base URL
+
+Relative URLs are relative to either the current base directory, a parent of the current base directory, or the site root of the base URL.
+
+The current directory of the `base` URL is the URL string up to the last forward slash.
+If there is a path segment after the last forward slash then it represents a file name and gets ignored.
+In the previous exmaple the base string is `https://developer.mozilla.org/some/path`, so the current directory is `https://developer.mozilla.org/some/`.
+
+The live example below demonstrates this using the relative URL that resolves to "the current level" (`./`).
+Note how everything after the last backslash is removed:
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+log(new URL("./", "https://test.example.org").href); // => https://test.example.org/
+log(new URL("./", "https://test.example.org/").href); // => https://test.example.org/
+log(new URL("./", "https://test.example.org/api").href); // => https://test.example.org/
+log(new URL("./", "https://test.example.org/api/").href); // => https://test.example.org/api/
+log(new URL("./", "https://test.example.org/api/v1").href); // => https://test.example.org/api/
+log(new URL("./", "https://test.example.org/api/v1/").href); // => https://test.example.org/api/v1/
+log(
+  new URL("./", "https://user:pass@test.example.org:440/api/v1?param1=val1")
+    .href,
+); // => https://user:pass@test.example.org:440/api/
+```
+
+{{EmbedLiveSample('Base URL', '100%')}}
+
+## Relative URLs
+
+Relative URLs are resolved against the base URL using a path reference that is relative to: the current directory (`./`), the parent directory of the current directory (`../`), or the site root (`/`).
+These are demonstrated in the following sections.
+
+### Current directory relative
+
+You can specify a path relative to the current directory of the `base` by prefixing the path with `./` or by having no prefix.
+For example, `./article` or `article`.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+The example URLs below demonstrate how this works.
+These all resolve to the same absolute URL because `./article` and `article` are the same, and the current directory of the `base` URLs are the same (`v1` does not have a trailing forward slash and is omitted).
+
+```js
+log(new URL("./article", "https://test.example.org/api/").href);
+// => https://test.example.org/api/article
+log(new URL("./article", "https://test.example.org/api/v1").href);
+// => https://test.example.org/api/article
+log(new URL("article", "https://test.example.org/api/v1").href);
+// => https://test.example.org/api/article
+```
+
+{{EmbedLiveSample('Current directory relative', '100%')}}
+
+### Root relative
+
+A root-relative URL is one that is relative to the site root, and is specified by prefixing the URL with `/`.
+For example, given a base URL of `https://test.example.com/api/` the resolved URL for the root-relative URL `/some/path` is `https://test.example.com/some/path`.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+Below we see more examples.
+Note that the path of the `base` URL doesn't matter when resolving root-relative URLs.
+
+```js
+log(new URL("/some/path", "https://test.example.org/api/").href);
+// => https://test.example.org/some/path
+log(new URL("/", "https://test.example.org/api/v1/").href);
+// => https://test.example.org/
+log(new URL("/article", "https://test.example.org/api/v1/").href);
+// => https://test.example.org/article
+```
+
+{{EmbedLiveSample('Root relative', '100%')}}
+
+### Parent-directory relative
+
+A parent-relative URL is one that is relative to a parent directory of the base URL.
+For example, given a base URL of `https://test.example.com/test/api/v1/` the resolved URL for the parent-relative URL `../some/path` is `https://test.example.com/test/api/some/path`.
+You can navigate up through parents by specifying `../` multiple times, but only to the level of the site-root.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+This is shown below.
+
+```js
+log(new URL("../path", "https://test.example.org/api/v1/v2/").href);
+// => https://test.example.org/api/v1/path
+log(new URL("../../path", "https://test.example.org/api/v1/v2/").href);
+// => https://test.example.org/api/path
+log(new URL("../../../../path", "https://test.example.org/api/v1/v2/").href);
+// => https://test.example.org/path
+```
+
+{{EmbedLiveSample('Parent-directory relative', '100%')}}
+
+### More examples
+
+Here are a few more examples showing some different relative paths and base paths with and without a trailing forward slash.
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 150px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.getElementById("log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+Base path without trailing slash:
+
+```js
+log(new URL("articles", "https://developer.mozilla.org/api/v1").href);
+// => 'https://developer.mozilla.org/api/articles'
+
+log(new URL("./articles", "https://developer.mozilla.org/api/v1").href);
+// => 'https://developer.mozilla.org/api/articles'
+
+log(new URL("/articles", "https://developer.mozilla.org/api/v1").href);
+// => 'https://developer.mozilla.org/articles'
+
+log(new URL("../articles", "https://developer.mozilla.org/api/v1").href);
+// => 'https://developer.mozilla.org/articles'
+```
+
+Base path with trailing slash:
+
+```js
+log(new URL("articles", "https://developer.mozilla.org/api/v1/").href);
+// => 'https://developer.mozilla.org/api/v1/articles'
+
+log(new URL("/articles", "https://developer.mozilla.org/api/v1/").href);
+// => 'https://developer.mozilla.org/articles'
+
+log(new URL("./articles", "https://developer.mozilla.org/api/v1/").href);
+// => 'https://developer.mozilla.org/api/v1/articles'
+
+log(new URL("../articles", "https://developer.mozilla.org/api/v1/").href);
+// => 'https://developer.mozilla.org/api/articles'
+```
+
+{{EmbedLiveSample('More examples', '100%', '200px')}}
+
+## See also
+
+- [RFC 3986 - Relative Resolution](https://datatracker.ietf.org/doc/html/rfc3986.html#section-5.2), the specification for resolving base and relative URLs

--- a/files/en-us/web/api/url_api/resolving_relative_urls/index.md
+++ b/files/en-us/web/api/url_api/resolving_relative_urls/index.md
@@ -6,11 +6,13 @@ page-type: guide
 
 {{DefaultAPISidebar("URL API")}}
 
-The {{domxref("URL")}} interface of the [URL API](/en-US/docs/Web/API/URL_API) provides two methods for creating an `URL` objects: the [`URL()` constructor](/en-US/docs/Web/API/URL/URL) and the {{domxref("URL.parse_static", "parse()")}} static method.
-Both methods take string arguments for either an absolute URL, or for a relative URL and a base URL that is used to resolve it.
-The main difference between them is that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
+The [`URL()` constructor](/en-US/docs/Web/API/URL/URL) or the {{domxref("URL.parse_static", "URL.parse()")}} static method of the [URL API](/en-US/docs/Web/API/URL_API) can be used to resolve a relative URL and a base URL to an absolute URL.
 
-The usage for the methods is shown together below for the same `url` and `base` URL values.
+Both methods take up to two string arguments and return [`URL()`](/en-US/docs/Web/API/URL) object representing an absolute URL.
+The first argument represents either an absolute URL or a relative URL, while the second is a base URL that is used to resolve the relative URL — if one is specified in the first argument.
+The methods resolve the relative URL in the same way: the main difference between them is that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
+
+The code below shows how the methods are used with the same `url` and `base` URL values.
 
 ```js
 const url = "articles";
@@ -18,67 +20,21 @@ const base = "https://developer.mozilla.org/some/path";
 const constructorResult = new URL(url, base);
 // => https://developer.mozilla.org/url/some/articles
 const parseResult = URL.parse(url, base);
-// => // => https://developer.mozilla.org/url/some/articles (same)
+// => https://developer.mozilla.org/url/some/articles
 ```
 
-You can see from the example above that resolving the `URL` from a supplied base URL and relative URL is not simply a concantenation of the supplied parameters.
-Below we show how the resolution works.
+You can see from the example that resolving the `URL` from a supplied base URL and relative URL is not simply a concantenation of the supplied parameters.
 
-## Base URL
-
-Relative URLs are relative to either the current base directory, a parent of the current base directory, or the site root of the base URL.
-
+In this case a path relative to the current directory is passed (`article`).
 The current directory of the `base` URL is the URL string up to the last forward slash.
-If there is a path segment after the last forward slash then it represents a file name and gets ignored.
-In the previous exmaple the base string is `https://developer.mozilla.org/some/path`, so the current directory is `https://developer.mozilla.org/some/`.
-
-The live example below demonstrates this using the relative URL that resolves to "the current level" (`./`).
-Note how everything after the last backslash is removed:
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 200px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const logElement = document.getElementById("log");
-function log(text) {
-  logElement.innerText += `${text}\n`;
-}
-```
-
-```js
-log(new URL("./", "https://test.example.org").href); // => https://test.example.org/
-log(new URL("./", "https://test.example.org/").href); // => https://test.example.org/
-log(new URL("./", "https://test.example.org/api").href); // => https://test.example.org/
-log(new URL("./", "https://test.example.org/api/").href); // => https://test.example.org/api/
-log(new URL("./", "https://test.example.org/api/v1").href); // => https://test.example.org/api/
-log(new URL("./", "https://test.example.org/api/v1/").href); // => https://test.example.org/api/v1/
-log(
-  new URL("./", "https://user:pass@test.example.org:440/api/v1?param1=val1")
-    .href,
-); // => https://user:pass@test.example.org:440/api/
-```
-
-{{EmbedLiveSample('Base URL', '100%')}}
-
-## Relative URLs
+Here `https://developer.mozilla.org/some/path` has no trailing forward slash, so the current directory is `https://developer.mozilla.org/some/`, and hence resolves to a final URL of `https://developer.mozilla.org/url/some/articles`.
 
 Relative URLs are resolved against the base URL using a path reference that is relative to: the current directory (`./`), the parent directory of the current directory (`../`), or the site root (`/`).
-These are demonstrated in the following sections.
+The following sections show how resolution works for each type of relative path.
 
-### Current directory relative
+## Current directory relative
 
-You can specify a path relative to the current directory of the `base` by prefixing the path with `./` or by having no prefix.
-For example, `./article` or `article`.
+A relative path prefixed with `./` or no prefix, such as `./article` or `article`, is relative to the current directory of the URL represented by the `base` argument.
 
 ```html hidden
 <pre id="log"></pre>
@@ -86,8 +42,7 @@ For example, `./article` or `article`.
 
 ```css hidden
 #log {
-  height: 80px;
-  overflow: scroll;
+  height: 90px;
   padding: 0.5rem;
   border: 1px solid black;
 }
@@ -100,64 +55,35 @@ function log(text) {
 }
 ```
 
-The example URLs below demonstrate how this works.
-These all resolve to the same absolute URL because `./article` and `article` are the same, and the current directory of the `base` URLs are the same (`v1` does not have a trailing forward slash and is omitted).
+The current directory of the `base` URL is the URL string up to the last forward slash, which is `https://test.example.org/api/` for both of the `base` strings in the code block below.
+The current directory relative URL `article` is appended to this, resolving to `https://test.example.org/api/article`
 
 ```js
 log(new URL("./article", "https://test.example.org/api/").href);
-// => https://test.example.org/api/article
-log(new URL("./article", "https://test.example.org/api/v1").href);
 // => https://test.example.org/api/article
 log(new URL("article", "https://test.example.org/api/v1").href);
 // => https://test.example.org/api/article
 ```
 
-{{EmbedLiveSample('Current directory relative', '100%')}}
-
-### Root relative
-
-A root-relative URL is one that is relative to the site root, and is specified by prefixing the URL with `/`.
-For example, given a base URL of `https://test.example.com/api/` the resolved URL for the root-relative URL `/some/path` is `https://test.example.com/some/path`.
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 80px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const logElement = document.getElementById("log");
-function log(text) {
-  logElement.innerText += `${text}\n`;
-}
-```
-
-Below we see more examples.
-Note that the path of the `base` URL doesn't matter when resolving root-relative URLs.
+Similarly, below both base URL strings have a current directory of `https://test.example.org/api/v2/`.
+We append `story` and `story` to these to resolve the final absolute URL.
 
 ```js
-log(new URL("/some/path", "https://test.example.org/api/").href);
-// => https://test.example.org/some/path
-log(new URL("/", "https://test.example.org/api/v1/").href);
-// => https://test.example.org/
-log(new URL("/article", "https://test.example.org/api/v1/").href);
-// => https://test.example.org/article
+log(new URL("./story/", "https://test.example.org/api/v2/").href);
+// => https://test.example.org/api/v2/story
+log(new URL("./story", "https://test.example.org/api/v2/v3").href);
+// => https://test.example.org/api/v2/story
 ```
 
-{{EmbedLiveSample('Root relative', '100%')}}
+{{EmbedLiveSample('Current directory relative', '100%', '140px')}}
 
-### Parent-directory relative
+## Parent-directory relative
 
-A parent-relative URL is one that is relative to a parent directory of the base URL.
-For example, given a base URL of `https://test.example.com/test/api/v1/` the resolved URL for the parent-relative URL `../some/path` is `https://test.example.com/test/api/some/path`.
+A relative path prefixed with `../`, such as `../path`, is relative to the _parent_ of the current directory of the URL represented by the `base` argument.
+Each instance of `../` strips a folder from the current directory, and then any text after `../` is appended to the remaining base path.
 You can navigate up through parents by specifying `../` multiple times, but only to the level of the site-root.
+
+For example, given a base URL `https://test.example.com/test/api/v1/` and a parent-relative URL of `../some/path`, the current directory is `https://test.example.com/test/api/v1/`, the parent is `https://test.example.com/test/api/`, and the resolved absolute URL is `https://test.example.com/test/api/some/path`.
 
 ```html hidden
 <pre id="log"></pre>
@@ -166,7 +92,6 @@ You can navigate up through parents by specifying `../` multiple times, but only
 ```css hidden
 #log {
   height: 80px;
-  overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
 }
@@ -179,12 +104,13 @@ function log(text) {
 }
 ```
 
-This is shown below.
+The following examples demonstrate this in more detail.
+In all cases the current directory is `https://test.example.org/api/v1/v2/` (in the second case `v3` is after the last forward slash), with each relative path resolving to a different parent.
 
 ```js
 log(new URL("../path", "https://test.example.org/api/v1/v2/").href);
 // => https://test.example.org/api/v1/path
-log(new URL("../../path", "https://test.example.org/api/v1/v2/").href);
+log(new URL("../../path", "https://test.example.org/api/v1/v2/v3").href);
 // => https://test.example.org/api/path
 log(new URL("../../../../path", "https://test.example.org/api/v1/v2/").href);
 // => https://test.example.org/path
@@ -192,9 +118,12 @@ log(new URL("../../../../path", "https://test.example.org/api/v1/v2/").href);
 
 {{EmbedLiveSample('Parent-directory relative', '100%')}}
 
-### More examples
+## Root relative
 
-Here are a few more examples showing some different relative paths and base paths with and without a trailing forward slash.
+A relative path prefixed with `/`, such as `/path`, is relative to the site root of the URL specified in the `base` argument.
+For example, given a base URL of `https://test.example.com/api/v1` the resolved URL for the root-relative URL `/some/path` is `https://test.example.com/some/path`.
+
+> **Note:** The path part of the `base` URL doesn't matter when resolving root-relative URLs.
 
 ```html hidden
 <pre id="log"></pre>
@@ -202,8 +131,7 @@ Here are a few more examples showing some different relative paths and base path
 
 ```css hidden
 #log {
-  height: 150px;
-  overflow: scroll;
+  height: 80px;
   padding: 0.5rem;
   border: 1px solid black;
 }
@@ -216,39 +144,18 @@ function log(text) {
 }
 ```
 
-Base path without trailing slash:
+Below are a few more examples.
 
 ```js
-log(new URL("articles", "https://developer.mozilla.org/api/v1").href);
-// => 'https://developer.mozilla.org/api/articles'
-
-log(new URL("./articles", "https://developer.mozilla.org/api/v1").href);
-// => 'https://developer.mozilla.org/api/articles'
-
-log(new URL("/articles", "https://developer.mozilla.org/api/v1").href);
-// => 'https://developer.mozilla.org/articles'
-
-log(new URL("../articles", "https://developer.mozilla.org/api/v1").href);
-// => 'https://developer.mozilla.org/articles'
+log(new URL("/some/path", "https://test.example.org/api/").href);
+// => https://test.example.org/some/path
+log(new URL("/", "https://test.example.org/api/v1/").href);
+// => https://test.example.org/
+log(new URL("/article", "https://example.com/api/v1/").href);
+// => https://example.com/article
 ```
 
-Base path with trailing slash:
-
-```js
-log(new URL("articles", "https://developer.mozilla.org/api/v1/").href);
-// => 'https://developer.mozilla.org/api/v1/articles'
-
-log(new URL("/articles", "https://developer.mozilla.org/api/v1/").href);
-// => 'https://developer.mozilla.org/articles'
-
-log(new URL("./articles", "https://developer.mozilla.org/api/v1/").href);
-// => 'https://developer.mozilla.org/api/v1/articles'
-
-log(new URL("../articles", "https://developer.mozilla.org/api/v1/").href);
-// => 'https://developer.mozilla.org/api/articles'
-```
-
-{{EmbedLiveSample('More examples', '100%', '200px')}}
+{{EmbedLiveSample('Root relative', '100%')}}
 
 ## See also
 

--- a/files/en-us/web/api/url_api/resolving_relative_urls/index.md
+++ b/files/en-us/web/api/url_api/resolving_relative_urls/index.md
@@ -34,7 +34,7 @@ The following sections show how resolution works for each type of relative path.
 
 ## Current directory relative
 
-A relative path prefixed with `./` or no prefix, such as `./article` or `article`, is relative to the current directory of the URL represented by the `base` argument.
+A relative path prefixed with `./` or no prefix, such as `./article`, `article`, or `./article/`, is relative to the current directory of the URL represented by the `base` argument.
 
 ```html hidden
 <pre id="log"></pre>
@@ -66,11 +66,11 @@ log(new URL("article", "https://test.example.org/api/v1").href);
 ```
 
 Similarly, below both base URL strings have a current directory of `https://test.example.org/api/v2/`.
-We append `story` and `story` to these to resolve the final absolute URL.
+We append `story/` and `story` to these to resolve the final absolute URL.
 
 ```js
 log(new URL("./story/", "https://test.example.org/api/v2/").href);
-// => https://test.example.org/api/v2/story
+// => https://test.example.org/api/v2/story/
 log(new URL("./story", "https://test.example.org/api/v2/v3").href);
 // => https://test.example.org/api/v2/story
 ```

--- a/files/en-us/web/api/url_api/resolving_relative_urls/index.md
+++ b/files/en-us/web/api/url_api/resolving_relative_urls/index.md
@@ -8,9 +8,9 @@ page-type: guide
 
 The [`URL()` constructor](/en-US/docs/Web/API/URL/URL) or the {{domxref("URL.parse_static", "URL.parse()")}} static method of the [URL API](/en-US/docs/Web/API/URL_API) can be used to resolve a relative URL and a base URL to an absolute URL.
 
-Both methods take up to two string arguments and return [`URL()`](/en-US/docs/Web/API/URL) object representing an absolute URL.
+Both methods take up to two string arguments and return a [`URL()`](/en-US/docs/Web/API/URL) object representing an absolute URL.
 The first argument represents either an absolute URL or a relative URL, while the second is a base URL that is used to resolve the relative URL — if one is specified in the first argument.
-The methods resolve the relative URL in the same way: the main difference between them is that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
+The methods resolve the relative URL in the same way, except that the `URL()` constructor throws if invalid URLs are passed, while `parse()` returns `null`.
 
 The code below shows how the methods are used with the same `url` and `base` URL values.
 
@@ -25,7 +25,7 @@ const parseResult = URL.parse(url, base);
 
 You can see from the example that resolving the `URL` from a supplied base URL and relative URL is not simply a concantenation of the supplied parameters.
 
-In this case a path relative to the current directory is passed (`article`).
+In this case a path relative to the current directory is passed (`articles`).
 The current directory of the `base` URL is the URL string up to the last forward slash.
 Here `https://developer.mozilla.org/some/path` has no trailing forward slash, so the current directory is `https://developer.mozilla.org/some/`, and hence resolves to a final URL of `https://developer.mozilla.org/url/some/articles`.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1676,6 +1676,7 @@
     },
     "URL API": {
       "overview": ["URL API"],
+      "guides": ["Web/API/URL_API/Resolving_relative_urls"],
       "interfaces": ["URL", "URLSearchParams"],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
FF126 supports the `URL.parse` static method. This is just like the URL constructor except that it doesn't throw if the parameter strings define an invalid URL.

This adds a page with a live example, and does some fixes and cross linking to the `URL` constructor.

Related docs work can be tracked in #33080