### PR TITLE
Doc and release note for manifest options_page key support

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
@@ -32,15 +32,13 @@ browser-compat: webextensions.manifest.options_page
   </tbody>
 </table>
 
-{{Deprecated_Header}}
+Use the `options_page` key to define an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) that opens in a new tab. You use this page to enable users to modify your extension's settings.
 
-> **Warning:** This manifest key has been deprecated. Use [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) instead.
+The way the user opens the page is browser-dependent. In Firefox, the page opens when the extension's icon is clicked. Your extension can also open the page using {{WebExtAPIRef("runtime.openOptionsPage()")}}.
 
-Use the `options_page` key to define an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) for your extension.
+Alternatively, you can use the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key with `open_in_tab` set to `true`. In Firefox, if `options_ui` is specified, `options page` is ignored.
 
-The options page contains settings for the extension. The user can access it from the browser's add-ons manager, and you can open it from within your extension using {{WebExtAPIRef("runtime.openOptionsPage()")}}.
-
-Unlike options pages specified using the newer `options_ui` key, options pages specified using the deprecated `options_page` key don't receive browser styles and always open in a normal browser tab.
+See [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) for more information on developing a settings page.
 
 ## Example
 
@@ -51,8 +49,3 @@ Unlike options pages specified using the newer `options_ui` key, options pages s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui)
-- [Options pages](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
@@ -36,7 +36,7 @@ Use the `options_page` key to define an [options page](/en-US/docs/Mozilla/Add-o
 
 The way the user opens the page is browser-dependent. In Firefox, the page opens when the extension's icon is clicked. Your extension can also open the page using {{WebExtAPIRef("runtime.openOptionsPage()")}}.
 
-Alternatively, you can use the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key with `open_in_tab` set to `true`. In Firefox, if `options_ui` is specified, `options page` is ignored.
+Alternatively, you can use the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key with `open_in_tab` set to `true`. If `options_ui` is specified, `options page` is ignored.
 
 See [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) for more information on developing a settings page.
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
@@ -34,16 +34,16 @@ browser-compat: webextensions.manifest.options_ui
   </tbody>
 </table>
 
-Use the `options_ui` key to define an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) for your extension.
+Use the `options_ui` key to define an [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) for your extension. You use this page to enable users to modify your extension's settings.
 
-The options page contains settings for the extension. The user can access it from the browser's add-ons manager, and you can open it from within your extension using {{WebExtAPIRef("runtime.openOptionsPage()")}}.
+The way the user opens the page is browser-dependent and also depends on the `open_in_tab` setting. Your extension can also open the page using {{WebExtAPIRef("runtime.openOptionsPage()")}}.
 
 You specify `options_ui` as a path to an HTML file packaged with your extension. The HTML file can include CSS and JavaScript files, just like a normal web page. Unlike a normal page, though, the JavaScript can use all the [WebExtension APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) that the extension has [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for. However, it runs in a different scope than your background scripts.
 
 If you want to **share** data or functions between the JavaScript on your **options page** and your **background script(s)**, you can do so directly by obtaining a reference to the [Window](/en-US/docs/Web/API/Window) of your background scripts by using {{WebExtAPIRef("extension.getBackgroundPage()")}}, or a reference to the {{domxref("Window")}} of any of the pages running within your extension with {{WebExtAPIRef("extension.getViews()")}}. Alternately, you can communicate between the JavaScript for your options page and your background script(s) using {{WebExtAPIRef("runtime.sendMessage()")}}, {{WebExtAPIRef("runtime.onMessage")}}, or {{WebExtAPIRef("runtime.connect()")}}.
 The latter (or {{WebExtAPIRef("runtime.Port")}} equivalents) can also be used to share options between your [background script(s)](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) and your **[content script(s).](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)**
 
-In general, you will want to store options changed on option pages using the {{WebExtAPIRef("storage", "storage API", "", "true")}} to either {{WebExtAPIRef("storage.sync")}} (if you want the settings synchronized across all instances of that browser that the user is logged into), or {{WebExtAPIRef("storage.local")}} (if the settings are local to the current machine/profile). If you do so and your [background script(s)](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) (or [content script(s)](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)) need to know about the change, your script(s) might choose to add a listener to {{WebExtAPIRef("storage.onChanged")}}.
+In general, you want to store options changed on option pages using the {{WebExtAPIRef("storage", "storage API", "", "true")}} to either {{WebExtAPIRef("storage.sync")}} (if you want the settings synchronized across all instances of that browser that the user is logged into), or {{WebExtAPIRef("storage.local")}} (if the settings are local to the current machine/profile). If you do so and your [background script(s)](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) (or [content script(s)](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)) need to know about the change, your script(s) might choose to add a listener to {{WebExtAPIRef("storage.onChanged")}}.
 
 ## Syntax
 
@@ -94,11 +94,14 @@ The `options_ui` key is an object with the following contents:
       <td><code>open_in_tab</code><br />{{optional_inline}}</td>
       <td><code>Boolean</code></td>
       <td>
+        <ul>
+          <li>If <code>false</code>, the options page opens in the browser's add-on manager.</li>
+        <li>
+          If <code>true</code>, the options page opens in a normal browser
+          tab.
+        </li>
+        </ul>
         <p>Defaults to <code>false</code>.</p>
-        <p>
-          If <code>true</code>, the options page will open in a normal browser
-          tab, rather than being integrated into the browser's add-ons manager.
-        </p>
       </td>
     </tr>
     <tr>

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -69,6 +69,7 @@ This article provides information about the changes in Firefox 126 that affect d
 
 - The {{WebExtAPIRef("commands.onCommand")}} event now passes the `tab` argument to the event listener. This enables extensions to apply a triggered shortcut to the page in which it was issued, without the need to call the `tabs.query()` method ([Firefox bug 1843866](https://bugzil.la/1843866)).
 - The {{WebExtAPIRef("runtime.MessageSender")}} type now includes the `origin` property. This enables message or connection requests to see the page or frame that opened the connection. This is useful for identifying if the origin can be trusted if it isn't apparent from the URL ([Firefox bug 1787379](https://bugzil.la/1787379)).
+- The [`options_page` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page) is provided as an alias of the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key. This has been provided to offer extensions better compatibility with Chrome ([Firefox bug 1816960](https://bugzil.la/1816960)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Added details of aliasing of options_ui.page to options_page and a release note.

#### Related issues

Addresses the content requirements of [Bug 1816960](https://bugzilla.mozilla.org/show_bug.cgi?id=1816960) Consider aliasing options_page to options_ui.page

BCD updates in https://github.com/mdn/browser-compat-data/pull/22877.