### PR TITLE
fix: Tidy up fetch with init examples on Request and Fetch pages

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -295,50 +295,44 @@ fetch(myRequest)
   });
 ```
 
-In the [Fetch with init then Request example](https://github.com/mdn/dom-examples/tree/main/fetch/fetch-with-init-then-request/index.html) (see [Fetch Request init live](https://mdn.github.io/dom-examples/fetch/fetch-with-init-then-request/)), we do the same thing except that we pass in an
-`init` object when we invoke `fetch()`:
+In our [Fetch Request with init example](https://github.com/mdn/dom-examples/tree/main/fetch/fetch-request-with-init) (see [Fetch Request init live](https://mdn.github.io/dom-examples/fetch/fetch-request-with-init)) we do the same thing except that we pass in an _options_ object when we invoke `fetch()`.
+In this case, we can set a {{httpheader("Cache-Control")}} value to indicate what kind of cached responses we're okay with:
 
 ```js
 const myImage = document.querySelector("img");
+const reqHeaders = new Headers();
 
-const myHeaders = new Headers();
-myHeaders.append("Accept", "image/jpeg");
+// a cached response is okay unless it's more than a week old
+reqHeaders.set("Cache-Control", "max-age=604800");
 
-const myInit = {
-  method: "GET",
-  headers: myHeaders,
-  mode: "cors",
-  cache: "default",
+const options = {
+  headers: reqHeaders,
 };
 
-const myRequest = new Request("flowers.jpg");
+// pass init as an "options" object with our headers
+const req = new Request("flowers.jpg", options);
 
-fetch(myRequest, myInit).then((response) => {
-  // …
+fetch(req).then((response) => {
+  // ...
 });
 ```
 
-You could also pass the `init` object in with the
-`Request` constructor to get the same effect:
+You could also pass the `init` object in with the `Request` constructor to get the same effect:
 
 ```js
-const myRequest = new Request("flowers.jpg", myInit);
+const req = new Request("flowers.jpg", options);
 ```
 
-You can also use an object literal as `headers` in
-`init`.
+You can also use an object literal as `headers` in `init`:
 
 ```js
-const myInit = {
-  method: "GET",
+const options = {
   headers: {
-    Accept: "image/jpeg",
+    "Cache-Control": "max-age=60480",
   },
-  mode: "cors",
-  cache: "default",
 };
 
-const myRequest = new Request("flowers.jpg", myInit);
+const req = new Request("flowers.jpg", options);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -302,14 +302,14 @@ In this case, we can set a {{httpheader("Cache-Control")}} value to indicate wha
 const myImage = document.querySelector("img");
 const reqHeaders = new Headers();
 
-// a cached response is okay unless it's more than a week old
+// A cached response is okay unless it's more than a week old
 reqHeaders.set("Cache-Control", "max-age=604800");
 
 const options = {
   headers: reqHeaders,
 };
 
-// pass init as an "options" object with our headers
+// Pass init as an "options" object with our headers.
 const req = new Request("flowers.jpg", options);
 
 fetch(req).then((response) => {

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -148,7 +148,7 @@ In this case, we can set a {{httpheader("Cache-Control")}} value to indicate wha
 const myImage = document.querySelector("img");
 const reqHeaders = new Headers();
 
-// a cached response is okay unless it's more than a week old
+// A cached response is okay unless it's more than a week old.
 reqHeaders.set("Cache-Control", "max-age=604800");
 
 const options = {

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -131,7 +131,6 @@ handled properly, then create an Object URL of it and display it in an
 
 ```js
 const myImage = document.querySelector("img");
-
 const myRequest = new Request("flowers.jpg");
 
 fetch(myRequest)
@@ -142,51 +141,46 @@ fetch(myRequest)
   });
 ```
 
-In our [Fetch Request with init example](https://github.com/mdn/dom-examples/tree/main/fetch/fetch-with-init-then-request) (see [Fetch Request init live](https://mdn.github.io/dom-examples/fetch/fetch-with-init-then-request/)) we do the same thing except that we pass in an _options_ object when we
-invoke `fetch()`:
+In our [Fetch Request with init example](https://github.com/mdn/dom-examples/tree/main/fetch/fetch-request-with-init) (see [Fetch Request init live](https://mdn.github.io/dom-examples/fetch/fetch-request-with-init)) we do the same thing except that we pass in an _options_ object when we invoke `fetch()`.
+In this case, we can set a {{httpheader("Cache-Control")}} value to indicate what kind of cached responses we're okay with:
 
 ```js
 const myImage = document.querySelector("img");
+const reqHeaders = new Headers();
 
-const myHeaders = new Headers();
-myHeaders.append("Content-Type", "image/jpeg");
+// a cached response is okay unless it's more than a week old
+reqHeaders.set("Cache-Control", "max-age=604800");
 
-const myOptions = {
-  method: "GET",
-  headers: myHeaders,
-  mode: "cors",
-  cache: "default",
+const options = {
+  headers: reqHeaders,
 };
 
-const myRequest = new Request("flowers.jpg", myOptions);
+// pass init as an "options" object with our headers
+const req = new Request("flowers.jpg", options);
 
-fetch(myRequest).then((response) => {
+fetch(req).then((response) => {
   // ...
 });
 ```
 
-Note that you could also pass `myOptions` into the `fetch` call to get
-the same effect, e.g.:
+Note that you could also pass `options` into the `fetch` call to get the same effect, e.g.:
 
 ```js
-fetch(myRequest, myOptions).then((response) => {
+fetch(req, options).then((response) => {
   // ...
 });
 ```
 
-You can also use an object literal as `headers` in `myOptions`.
+You can also use an object literal as `headers` in `options`.
 
 ```js
-const myOptions = {
-  method: "GET",
+const options = {
   headers: {
-    "Content-Type": "image/jpeg",
+    "Cache-Control": "max-age=60480",
   },
-  mode: "cors",
-  cache: "default",
 };
 
-const myRequest = new Request("flowers.jpg", myOptions);
+const req = new Request("flowers.jpg", options);
 ```
 
 You may also pass a {{domxref("Request")}} object to the `Request()`
@@ -194,7 +188,7 @@ constructor to create a copy of the Request (This is similar to calling the
 {{domxref("Request.clone","clone()")}} method.)
 
 ```js
-const copy = new Request(myRequest);
+const copy = new Request(req);
 ```
 
 > **Note:** This last usage is probably only useful in [ServiceWorkers](/en-US/docs/Web/API/Service_Worker_API).


### PR DESCRIPTION
### Description

I'm reflecting some changes that landed in the DOM examples repo already.

### Motivation

Get rid of some redundant info in the request, add in some practical options for cache control preferences, linking to Cache-Control header.

### Related issues and pull requests

- [x] Related changes: https://github.com/mdn/dom-examples/pull/270
- [x] Original issue: https://github.com/mdn/dom-examples/issues/151