### PR TITLE
Fix incorrect link

### DIFF
--- a/files/en-us/web/media/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{QuickLinksWithSubPages("/en-US/docs/Web/Media")}}
 
-In the previous [Cross browser video player article](/en-US/docs/Web/Media) we described how to build a cross-browser HTML video player using the Media and Fullscreen APIs. This follow-up article looks at how to style this custom player, including making it responsive.
+In the previous [Cross browser video player article](/en-US/docs/Web/Media/Audio_and_video_delivery/cross_browser_video_player) we described how to build a cross-browser HTML video player using the Media and Fullscreen APIs. This follow-up article looks at how to style this custom player, including making it responsive.
 
 ## The example in action
 


### PR DESCRIPTION
### Description

Change the *previous article* link to point to the actual previous article instead of the *Web media technologies* page.