### PR TITLE
chore(l10n): add translation for 'section' for l10n-zh locale

### DIFF
--- a/files/jsondata/L10n-Common.json
+++ b/files/jsondata/L10n-Common.json
@@ -236,7 +236,9 @@
     "ja": "セクション",
     "ko": "섹션",
     "pt-BR": "sessão",
-    "ru": "раздел"
+    "ru": "раздел",
+    "zh-CN": "章节",
+    "zh-TW": "章節"
   },
   "summary": {
     "en-US": "The documentation about this has not yet been written; please consider contributing!",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

{{RFC}} macro was using this, and zh-CN/zh-TW document lacks correct localization.

/cc @mdn/yari-content-zh 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
