### PR TITLE
fix: remove BCD front matter keys on CSS layout cookbook pages

### DIFF
--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -2,7 +2,6 @@
 title: Breadcrumb navigation
 slug: Web/CSS/Layout_cookbook/Breadcrumb_Navigation
 page-type: guide
-browser-compat: css.properties.flex
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -2,7 +2,6 @@
 title: Card
 slug: Web/CSS/Layout_cookbook/Card
 page-type: guide
-browser-compat: css.properties.grid
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.md
@@ -2,7 +2,6 @@
 title: Center an element
 slug: Web/CSS/Layout_cookbook/Center_an_element
 page-type: guide
-browser-compat: css.properties.grid
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/en-us/web/css/layout_cookbook/column_layouts/index.md
@@ -2,7 +2,6 @@
 title: Column layouts
 slug: Web/CSS/Layout_cookbook/Column_layouts
 page-type: guide
-browser-compat: css.properties.flex
 ---
 
 {{CSSRef}}
@@ -15,9 +14,9 @@ You will often need to create a layout which has a number of columns, and CSS pr
 
 There are a number of design patterns you might want to achieve with your columns:
 
-- [A continuous thread of content broken up into newspaper-style columns](#a-continuous-thread-of-content--multi-column-layout).
-- [A single row of items arranged as columns, with all heights being equal](#a-single-row-of-items-with-equal-heights--flexbox).
-- [Multiple rows of columns lined up by row and column](#lining-items-up-in-rows-and-columns--grid-layout).
+- [A continuous thread of content broken up into newspaper-style columns](#a_continuous_thread_of_content_—_multi-column_layout).
+- [A single row of items arranged as columns, with all heights being equal](#a_single_row_of_items_with_equal_heights_—_flexbox).
+- [Multiple rows of columns lined up by row and column](#lining_items_up_in_rows_and_columns_—_grid_layout).
 
 ## The recipes
 

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -37,10 +37,6 @@ _If there are useful alternative methods for building the recipe, or fallback re
 
 _Include this is there are any specific things to watch out for in regard to accessibility. If not relevant for your pattern this can be omitted._
 
-## Browser compatibility
-
-_List the key properties you used in the `browser-compat` frontmatter metadata key. Then use the `\{{Compat}}` macro in this section to automatically generate a compatibility table for the listed properties._
-
 ## See also
 
 - _Links of link of related properties: {{Cssxref("example-property")}}_

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -2,7 +2,6 @@
 title: Grid wrapper
 slug: Web/CSS/Layout_cookbook/Grid_wrapper
 page-type: guide
-browser-compat: css.properties.grid
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -2,7 +2,6 @@
 title: List group with badges
 slug: Web/CSS/Layout_cookbook/List_group_with_badges
 page-type: guide
-browser-compat: css.properties.flex
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.md
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.md
@@ -2,7 +2,6 @@
 title: "Recipe: Media objects"
 slug: Web/CSS/Layout_cookbook/Media_objects
 page-type: guide
-browser-compat: css.properties.grid
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -2,7 +2,6 @@
 title: Pagination
 slug: Web/CSS/Layout_cookbook/Pagination
 page-type: guide
-browser-compat: css.properties.flex
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/split_navigation/index.md
@@ -2,7 +2,6 @@
 title: Split navigation
 slug: Web/CSS/Layout_cookbook/Split_Navigation
 page-type: guide
-browser-compat: css.properties.flex
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -2,7 +2,6 @@
 title: Sticky footers
 slug: Web/CSS/Layout_cookbook/Sticky_footers
 page-type: guide
-browser-compat: css.properties.grid
 ---
 
 {{CSSRef}}
@@ -23,8 +22,7 @@ The Sticky footer pattern needs to meet the following requirements:
 {{EmbedGHLiveSample("css-examples/css-cookbook/sticky-footer.html", '100%', 720)}}
 
 > **Callout:**
->
-> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/sticky-footer--download.html)
+> To take a look at the code, you can [download the full example](https://github.com/mdn/css-examples/blob/main/css-cookbook/sticky-footer--download.html).
 
 > **Note:** In this example and the following one we are using a wrapper set to `min-height: 100%`. You can also achieve this for a full page by setting a {{cssxref("min-height")}} of `100vh` on the {{htmlelement("body")}} and then using it as your grid container.
 


### PR DESCRIPTION
### Description

These pages are showing Baseline banners and do not have BCD tables anymore following: https://github.com/openwebdocs/project/issues/184

### Motivation

Removing Baseline banners on guide pages

### Additional details

Also fixes some links to section titles on same page
