### PR TITLE
fix(CSS): remove not-yet implemented string value for text-align prop

### DIFF
--- a/files/en-us/web/css/text-align/index.md
+++ b/files/en-us/web/css/text-align/index.md
@@ -36,11 +36,7 @@ text-align: revert-layer;
 text-align: unset;
 ```
 
-The `text-align` property is specified in one of the following ways:
-
-- Using the keyword values `start`, `end`, `left`, `right`, `center`, `justify`, `justify-all`, or `match-parent`.
-- Using a `<string>` value only, in which case the other value defaults to `right`.
-- Using both a keyword value and a [`<string>`](#string) value.
+The `text-align` property is specified as a single keyword from the list below.
 
 ### Values
 


### PR DESCRIPTION
### Description

The string value is not yet supported by any browser, but we're talking about it in the prose and linking to a section that's been removed.

The prose has been here since code check-in, so there's no PR / git history to link to the additions.

### Additional details

Onkar summed it up pretty well in this comment: https://github.com/mdn/content/issues/30889#issuecomment-1858796006

* https://drafts.csswg.org/css-text-4/#text-align-property
* https://drafts.csswg.org/css-text/#text-align-property

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/31119