### PR TITLE
Fix the code example to show output values in the correct order.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/symmetricdifference/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/symmetricdifference/index.md
@@ -47,7 +47,7 @@ The following example computes the symmetric difference between the set of even 
 ```js
 const evens = new Set([2, 4, 6, 8]);
 const squares = new Set([1, 4, 9]);
-console.log(evens.symmetricDifference(squares)); // Set(5) { 1, 2, 6, 8, 9 }
+console.log(evens.symmetricDifference(squares)); // Set(5) { 2, 6, 8, 1, 9 }
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
This PR fixes a mistake in the code example in the documentation for `Set.prototype.symmetricDifference()` method.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
According to the [official documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/symmetricDifference#:~:text=The%20order%20of%20elements%20in%20the%20returned%20set%20is%20first%20those%20in%20this%20followed%20by%20those%20in%20other.):

> The order of elements in the returned set is first those in this followed by those in other.

The proposed changes fixes the example to conform with the docs (and actual behaviour).

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
