### PR TITLE
add 'pixels' units for mouseevent coordinates

### DIFF
--- a/files/en-us/web/api/mouseevent/clientx/index.md
+++ b/files/en-us/web/api/mouseevent/clientx/index.md
@@ -14,7 +14,7 @@ For example, clicking on the left edge of the viewport will always result in a m
 
 ## Value
 
-A `double` floating point value.
+A `double` floating point value in pixels.
 
 ## Examples
 

--- a/files/en-us/web/api/mouseevent/clienty/index.md
+++ b/files/en-us/web/api/mouseevent/clienty/index.md
@@ -14,7 +14,7 @@ For example, clicking on the top edge of the viewport will always result in a mo
 
 ## Value
 
-A `double` floating point value.
+A `double` floating point value in pixels.
 
 ## Examples
 

--- a/files/en-us/web/api/mouseevent/offsetx/index.md
+++ b/files/en-us/web/api/mouseevent/offsetx/index.md
@@ -12,7 +12,7 @@ The **`offsetX`** read-only property of the {{domxref("MouseEvent")}} interface 
 
 ## Value
 
-A `double` floating point value.
+A `double` floating point value in pixels.
 
 Early versions of the spec defined this as an integer.
 

--- a/files/en-us/web/api/mouseevent/offsety/index.md
+++ b/files/en-us/web/api/mouseevent/offsety/index.md
@@ -12,7 +12,7 @@ The **`offsetY`** read-only property of the {{domxref("MouseEvent")}} interface 
 
 ## Value
 
-A `double` floating point value.
+A `double` floating point value in pixels.
 
 Early versions of the spec defined this as an integer.
 

--- a/files/en-us/web/api/mouseevent/pagex/index.md
+++ b/files/en-us/web/api/mouseevent/pagex/index.md
@@ -22,7 +22,7 @@ See [Coordinate systems](/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#page)
 
 ## Value
 
-A floating-point number of pixels from the left edge of the _document_ at which the mouse was clicked, regardless of any scrolling or viewport positioning that may be in effect.
+A `double` floating-point number of pixels from the left edge of the _document_ at which the mouse was clicked, regardless of any scrolling or viewport positioning that may be in effect.
 
 This property was originally specified in the Touch Events specification as a long integer, but was redefined in the CSSOM View Module to be a double-precision
 floating-point number to allow for subpixel precision.

--- a/files/en-us/web/api/mouseevent/pagey/index.md
+++ b/files/en-us/web/api/mouseevent/pagey/index.md
@@ -11,35 +11,15 @@ browser-compat: api.MouseEvent.pageY
 The **`pageY`** read-only property of the {{domxref("MouseEvent")}} interface returns the Y (vertical) coordinate (in pixels) at which the mouse was clicked, relative to the top edge of the entire document.
 This includes any portion of the document not currently visible.
 
-Being based on the edge of the document as it is, this property takes into account any vertical scrolling of the page.
-For example, if the page is scrolled such that 200 pixels of the top side of the document are scrolled out of view, and the mouse is clicked 100 pixels below the top edge of the view, the value returned by `pageY` will be 300.
-
-Originally, this property was defined as a `long` integer. The [CSSOM View Module](/en-US/docs/Web/CSS/CSSOM_view) redefined it as a `double` float.
-See the [Browser compatibility](#browser_compatibility) section for details.
-
-See [Coordinate systems](/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#page) for additional information about coordinates specified in this fashion.
+See {{domxref("MoseEvent.pageX")}} for more information.
 
 ## Value
 
-A `double` floating-point number of pixels from the top edge of the _document_ at which the mouse was clicked, regardless of any scrolling or viewport positioning that may be in effect.
-
-This property was originally specified in the Touch Events specification as a long integer, but was redefined in the CSSOM View Module to be a double-precision
-floating-point number to allow for subpixel precision.
-Even though numeric types both are represented by `Number` in JavaScript, they may be handled differently internally in the browser's code, resulting in potential behavior differences.
-
-See [Browser compatibility](#browser_compatibility) to learn which browsers have been updated to use the revised data type.
-
-## Examples
-
-```js
-let pageY = event.pageY;
-```
+A `double` floating point value in pixels.
 
 ## Specifications
 
 {{Specifications}}
-
-Prior to being added to the CSSOM View specification, `pageX` and `pageY` were available on the {{domxref("UIEvent")}} interface in a limited subset of browsers for a short time.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/mouseevent/pagey/index.md
+++ b/files/en-us/web/api/mouseevent/pagey/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MouseEvent.pageY
 
 {{APIRef("UI Events")}}
 
-The **`pageY`** read-only property of the {{domxref("MouseEvent")}} interface returns the Y (vertical) coordinate (in pixels) at which the mouse was clicked, relative to the left edge of the entire document.
+The **`pageY`** read-only property of the {{domxref("MouseEvent")}} interface returns the Y (vertical) coordinate (in pixels) at which the mouse was clicked, relative to the top edge of the entire document.
 This includes any portion of the document not currently visible.
 
 Being based on the edge of the document as it is, this property takes into account any vertical scrolling of the page.

--- a/files/en-us/web/api/mouseevent/pagey/index.md
+++ b/files/en-us/web/api/mouseevent/pagey/index.md
@@ -8,12 +8,26 @@ browser-compat: api.MouseEvent.pageY
 
 {{APIRef("UI Events")}}
 
-The **`pageY`** read-only property of the {{domxref("MouseEvent")}} interface returns the Y (vertical) coordinate in pixels of the event relative to the whole document.
-This property takes into account any vertical scrolling of the page.
+The **`pageY`** read-only property of the {{domxref("MouseEvent")}} interface returns the Y (vertical) coordinate (in pixels) at which the mouse was clicked, relative to the left edge of the entire document.
+This includes any portion of the document not currently visible.
+
+Being based on the edge of the document as it is, this property takes into account any vertical scrolling of the page.
+For example, if the page is scrolled such that 200 pixels of the top side of the document are scrolled out of view, and the mouse is clicked 100 pixels below the top edge of the view, the value returned by `pageY` will be 300.
+
+Originally, this property was defined as a `long` integer. The [CSSOM View Module](/en-US/docs/Web/CSS/CSSOM_view) redefined it as a `double` float.
+See the [Browser compatibility](#browser_compatibility) section for details.
+
+See [Coordinate systems](/en-US/docs/Web/CSS/CSSOM_view/Coordinate_systems#page) for additional information about coordinates specified in this fashion.
 
 ## Value
 
-A `double` floating point value.
+A `double` floating-point number of pixels from the top edge of the _document_ at which the mouse was clicked, regardless of any scrolling or viewport positioning that may be in effect.
+
+This property was originally specified in the Touch Events specification as a long integer, but was redefined in the CSSOM View Module to be a double-precision
+floating-point number to allow for subpixel precision.
+Even though numeric types both are represented by `Number` in JavaScript, they may be handled differently internally in the browser's code, resulting in potential behavior differences.
+
+See [Browser compatibility](#browser_compatibility) to learn which browsers have been updated to use the revised data type.
 
 ## Examples
 
@@ -24,6 +38,8 @@ let pageY = event.pageY;
 ## Specifications
 
 {{Specifications}}
+
+Prior to being added to the CSSOM View specification, `pageX` and `pageY` were available on the {{domxref("UIEvent")}} interface in a limited subset of browsers for a short time.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/mouseevent/pagey/index.md
+++ b/files/en-us/web/api/mouseevent/pagey/index.md
@@ -11,7 +11,7 @@ browser-compat: api.MouseEvent.pageY
 The **`pageY`** read-only property of the {{domxref("MouseEvent")}} interface returns the Y (vertical) coordinate (in pixels) at which the mouse was clicked, relative to the top edge of the entire document.
 This includes any portion of the document not currently visible.
 
-See {{domxref("MoseEvent.pageX")}} for more information.
+See {{domxref("MouseEvent.pageX")}} for more information.
 
 ## Value
 

--- a/files/en-us/web/api/mouseevent/screenx/index.md
+++ b/files/en-us/web/api/mouseevent/screenx/index.md
@@ -14,7 +14,7 @@ The **`screenX`** read-only property of the {{domxref("MouseEvent")}} interface 
 
 ## Value
 
-A `double` floating point value.
+A `double` floating point value in pixels.
 
 Early versions of the spec defined this as an integer referring to the number of pixels.
 

--- a/files/en-us/web/api/mouseevent/screeny/index.md
+++ b/files/en-us/web/api/mouseevent/screeny/index.md
@@ -12,7 +12,7 @@ The **`screenY`** read-only property of the {{domxref("MouseEvent")}} interface 
 
 ## Value
 
-A `double` floating point value.
+A `double` floating point value in pixels.
 
 Early versions of the spec defined this as an integer referring to the number of pixels.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added an explicit 'pixels' unit to the various coordinates associated with MouseEvent.
This was already the case for layerX, layerY, pageX and pageY.
Also made pageY more similar to pageX.

### Motivation

There might be some confusion as to what units these coordinates are given in. I personally went to look outside of MDN to make sure it was indeed in pixels.

### Additional details

I chose to adopt the way layerX, layerY, pageX and pageY specified the unit, by putting it in the __value__ section.

Along the way, I noticed the pageX was more extensive than pageY, so I duplicated (mutatis mutandis) the info.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
