### PR TITLE
release 126 add option to disable split console

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -12,6 +12,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
 ### Developer Tools
 
+- Added an option to disable split console ([Firefox bug 1731635](https://bugzil.la/1731635)).
+
 ### HTML
 
 #### Removals


### PR DESCRIPTION
### Description

Added "enable split console" into devtools settings, when it's checked off all split console features will be disabled (pressing esc key, use in console, show split console on clicking error counter)

### Motivation

nominated for a release note, it's added here already
https://www.mozilla.org/en-US/firefox/126.0a1/releasenotes/

### Additional details

https://bugzilla.mozilla.org/show_bug.cgi?id=1731635

### Related issues and pull requests
