### PR TITLE
Remove reference to setHTML from innerHTML page.

### DIFF
--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -53,7 +53,7 @@ This lets you look at the HTML markup of the element's content nodes.
 Setting the value of `innerHTML` lets you easily replace the existing contents of an element with new content.
 
 > **Note:** This is a [security risk](#security_considerations) if the string to be inserted might contain potentially malicious content.
-> When inserting user-supplied data you should always consider using {{domxref("Element.setHTML()")}} instead, in order to sanitize the content before it is inserted.
+> When inserting user-supplied data you should always consider using a sanitizer library, in order to sanitize the content before it is inserted.
 
 For example, you can erase the entire contents of a document by clearing the contents of the document's {{domxref("Document.body", "body")}} attribute:
 
@@ -142,7 +142,6 @@ el.innerHTML = name; // shows the alert
 
 For that reason, it is recommended that instead of `innerHTML` you use:
 
-- {{domxref("Element.setHTML()")}} to sanitize the text before it is inserted into the DOM.
 - {{domxref("Node.textContent")}} when inserting plain text, as this inserts it as raw text rather than parsing it as HTML.
 
 > **Warning:** If your project is one that will undergo any form of security review, using `innerHTML` most likely will result in your code being rejected.
@@ -248,6 +247,5 @@ You can see output into the log by moving the mouse in and out of the box, click
 - {{domxref("Node.textContent")}} and {{domxref("HTMLElement.innerText")}}
 - {{domxref("Element.insertAdjacentHTML()")}}
 - {{domxref("Element.outerHTML")}}
-- {{domxref("Element.setHTML")}}
 - Parsing HTML or XML into a DOM tree: {{domxref("DOMParser")}}
 - Serializing a DOM tree into an XML string: {{domxref("XMLSerializer")}}


### PR DESCRIPTION
This isn't a useful reference to include on the innerHTML page until the sanitizer API is finished and shipping again.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove reference to setHTML from innerHTML page.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

setHTML isn't usable in any current browsers (the brower compat data says Samsung Internet ships it still but thats wrong see https://github.com/mdn/browser-compat-data/pull/22860)

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

This API shipped in Chrome for a few versions before unshipping. However the API is being standardised and will eventually ship, linking to it in it's current state will only lead to user confusion both now and in the future.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See https://github.com/mdn/content/pull/33141

See https://github.com/mdn/content/issues/32731

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
