### PR TITLE
vary the response replace Caching and Client Hints

### DIFF
--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -46,7 +46,7 @@ Accept-CH: Viewport-Width, Width
 Vary: Viewport-Width, Width
 ```
 
-> **Note:** Remember to [vary the response](/en-US/docs/Web/HTTP/Client_hints#varying_client_hints)
+> **Note:** Remember to [Caching and Client Hints](/en-US/docs/Web/HTTP/Client_hints#Caching_and_Client_Hints)
 > based on the accepted client hints.
 
 ## Specifications

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -46,8 +46,7 @@ Accept-CH: Viewport-Width, Width
 Vary: Viewport-Width, Width
 ```
 
-> **Note:** Remember to [Caching and Client Hints](/en-US/docs/Web/HTTP/Client_hints#Caching_and_Client_Hints)
-> based on the accepted client hints.
+> **Note:** Remember to [vary the response](/en-US/docs/Web/HTTP/Client_hints#Caching_and_Client_Hints) based on the accepted client hints.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
the [Client hints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Client_hints) page not found this `#vary_the_response`, I replaced it with `#Caching_and_Client_Hints`.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-CH#examples
https://developer.mozilla.org/en-US/docs/Web/HTTP/Client_hints
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
