### PR TITLE
Update BCD path for -webkit-line-clamp

### DIFF
--- a/files/en-us/web/css/-webkit-line-clamp/index.md
+++ b/files/en-us/web/css/-webkit-line-clamp/index.md
@@ -2,7 +2,7 @@
 title: "-webkit-line-clamp"
 slug: Web/CSS/-webkit-line-clamp
 page-type: css-property
-browser-compat: css.properties.-webkit-line-clamp
+browser-compat: css.properties.line-clamp
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
It was renamed in BCD:
https://github.com/mdn/browser-compat-data/pull/22951