### PR TITLE
Remove {{Specifications}} from Layout cookbook

### DIFF
--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -48,10 +48,6 @@ We have also added some additional content that would be read by a screen reader
 
 The "See Also" section at the end of this document has links to related accessibility topics.
 
-## Specifications
-
-{{Specifications}}
-
 ## See also
 
 - {{Cssxref("justify-content")}}, {{Cssxref("gap")}}


### PR DESCRIPTION
This was forgotten last week when the others were removed. (Detected via the flaw dashboard)