### PR TITLE
correct document picture-in-picture example

### DIFF
--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -73,7 +73,7 @@ The `width` and `height` options of `requestWindow()` set the Picture-in-Picture
 ```js
 async function togglePictureInPicture() {
   // Returns null if no pip window is currently open
-  if (!!window.documentPictureInPicture.window) {
+  if (!window.documentPictureInPicture.window) {
     // Open a Picture-in-Picture window.
     const pipWindow = await documentPictureInPicture.requestWindow({
       width: videoPlayer.clientWidth,

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -89,7 +89,7 @@ async function togglePictureInPicture() {
   pipWindow.document.body.append(videoPlayer);
 
   // Display a message to say it has been moved
-  inPipMessage.style.display = 'block';
+  inPipMessage.style.display = "block";
 }
 ```
 

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -78,7 +78,7 @@ async function togglePictureInPicture() {
   }
 
   // Open a Picture-in-Picture window.
-  const pipWindow = await documentPictureInPicture.requestWindow({
+  const pipWindow = await window.documentPictureInPicture.requestWindow({
     width: videoPlayer.clientWidth,
     height: videoPlayer.clientHeight,
   });

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -73,7 +73,7 @@ The `width` and `height` options of `requestWindow()` set the Picture-in-Picture
 ```js
 async function togglePictureInPicture() {
   // Early return if there's already a Picture-in-Picture window open
-  if (window.documentPictureInPicture.window != null) {
+  if (window.documentPictureInPicture.window) {
     return;
   }
 

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -72,22 +72,24 @@ The `width` and `height` options of `requestWindow()` set the Picture-in-Picture
 
 ```js
 async function togglePictureInPicture() {
-  // Returns null if no pip window is currently open
-  if (!window.documentPictureInPicture.window) {
-    // Open a Picture-in-Picture window.
-    const pipWindow = await documentPictureInPicture.requestWindow({
-      width: videoPlayer.clientWidth,
-      height: videoPlayer.clientHeight,
-    });
-
-    // ...
-
-    // Move the player to the Picture-in-Picture window.
-    pipWindow.document.body.append(videoPlayer);
-
-    // Display a message to say it has been moved
-    inPipMessage.style.display = "block";
+  // Early return if there's already a Picture-in-Picture window open
+  if (window.documentPictureInPicture.window) {
+    return;
   }
+
+  // Open a Picture-in-Picture window.
+  const pipWindow = await documentPictureInPicture.requestWindow({
+    width: videoPlayer.clientWidth,
+    height: videoPlayer.clientHeight,
+  });
+
+  // ...
+
+  // Move the player to the Picture-in-Picture window.
+  pipWindow.document.body.append(videoPlayer);
+
+  // Display a message to say it has been moved
+  inPipMessage.style.display = 'block';
 }
 ```
 

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -73,7 +73,7 @@ The `width` and `height` options of `requestWindow()` set the Picture-in-Picture
 ```js
 async function togglePictureInPicture() {
   // Early return if there's already a Picture-in-Picture window open
-  if (window.documentPictureInPicture.window) {
+  if (window.documentPictureInPicture.window != null) {
     return;
   }
 

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 This guide provides a walkthrough of typical usage of the {{domxref("Document Picture-in-Picture API", "Document Picture-in-Picture API", "", "nocode")}}.
 
-> **Note:** You can see the featured demo in action at [Document Picture-in-Picture API Example](https://mdn.github.io/dom-examples/document-picture-in-picture/) (see the full [source code](https://github.com/chrisdavidmills/dom-examples/tree/main/document-picture-in-picture) also).
+> **Note:** You can see the featured demo in action at [Document Picture-in-Picture API Example](https://mdn.github.io/dom-examples/document-picture-in-picture/) (see the full [source code](https://github.com/mdn/dom-examples/tree/main/document-picture-in-picture) also).
 
 ## Sample HTML
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Correct mistake in Document Picture-in-Picture API example and improve clarity of docs.

### Motivation

I copy/pasted the current example and it didn't work, so I've tweaked the example a bit to both fix it, and hopefully make it clearer.

### Additional details

N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
