### PR TITLE
Fix typo in index.md

### DIFF
--- a/files/en-us/web/css/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/using_css_custom_properties/index.md
@@ -279,7 +279,7 @@ The property is only set for the matching selector and its descendants.
 
 ### Using `@property` to control inheritance
 
-The `@property` at-rule lets you explicity state whether the property inherits or not.
+The `@property` at-rule lets you explicitly state whether the property inherits or not.
 The following example creates a custom property using the `@property` at-rule.
 Inheritance is disabled, there's a [`<color>`](/en-US/docs/Web/CSS/color_value) data type defined, and an intital value of `cornflowerblue`.
 


### PR DESCRIPTION
### Description
Corrected a typo in the [Using CSS custom properties ](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) document by fixing the spelling of "explicitly" in the sentence describing the `@property` at-rule.

Location:
https://github.com/mdn/content/blob/c40fe6508ac4add549d315aa20f6bc2fca49c27e/files/en-us/web/css/using_css_custom_properties/index.md?plain=1#L282

### Motivation
The typo could potentially lead to confusion for readers, and correcting it improves the clarity of the documentation.
