### PR TITLE
Add HTMLTable*Element member to add/remove rows

### DIFF
--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -79,3 +79,7 @@ table.deleteRow(1);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableSectionElement.deleteRow()")}}

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -8,18 +8,13 @@ browser-compat: api.HTMLTableElement.insertRow
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.insertRow()`** method inserts a new row
+The **`insertRow()`** method of the {{domxref("HTMLTableElement")}} interface inserts a new row
 ({{HtmlElement("tr")}}) in a given {{HtmlElement("table")}}, and returns a reference to
 the new row.
 
 If a table has multiple {{HtmlElement("tbody")}} elements, by default, the new row is
-inserted into the last `<tbody>`. To insert the row into a specific
-`<tbody>`:
-
-```js
-let specific_tbody = document.getElementById(tbody_id);
-let row = specific_tbody.insertRow(index);
-```
+inserted into the last `<tbody>`.
+To insert the row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}
 
 > **Note:** `insertRow()` inserts the row directly into the
 > table. The row does not need to be appended separately as would be the case if
@@ -115,4 +110,4 @@ addRow("my-table");
 ## See also
 
 - {{domxref("HTMLTableRowElement.insertCell()")}}
-- The HTML element representing rows: {{domxref("HTMLTableRowElement")}}
+- {{domxref("HTMLTableSectionElement.insertRow()")}}

--- a/files/en-us/web/api/htmltablerowelement/rowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/rowindex/index.md
@@ -8,8 +8,8 @@ browser-compat: api.HTMLTableRowElement.rowIndex
 
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLTableRowElement.rowIndex`** read-only property
-represents the position of a row in relation to the whole {{HtmlElement("table")}}.
+The **`rowIndex`** read-only property of the {{domxref("HTMLTableRowElement")}} interface
+represents the position of a row within the whole {{HtmlElement("table")}}.
 
 Even when the {{HtmlElement("thead")}}, {{HtmlElement("tbody")}}, and
 {{HtmlElement("tfoot")}} elements are out of order in the HTML, browsers render the
@@ -77,3 +77,7 @@ rows.forEach((row) => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableRowElement.sectionRowIndex")}}

--- a/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
@@ -1,0 +1,77 @@
+---
+title: "HTMLTableRowElement: sectionRowIndex property"
+short-title: rowIndex
+slug: Web/API/HTMLTableRowElement/sectionRowIndex
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableRowElement.sectionRowIndex
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`sectionRowIndex`** read-only property of the {{domxref("HTMLTableRowElement")}} interface
+represents the position of a row within the current section ({{htmlelement("thead")}}, {{htmlelement("tbody")}}, or {{htmlelement("tfoot")}}).
+
+## Value
+
+Returns the index of the row, or `-1` if the row is not part of the section.
+
+## Examples
+
+This example uses JavaScript to label all the row numbers of the `tbody`.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Item</th>
+      <th>Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bananas</td>
+      <td>$2</td>
+    </tr>
+    <tr>
+      <td>Oranges</td>
+      <td>$8</td>
+    </tr>
+    <tr>
+      <td>Top Sirloin</td>
+      <td>$20</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td>Total</td>
+      <td>$30</td>
+    </tr>
+  </tfoot>
+</table>
+```
+
+### JavaScript
+
+```js
+let rows = document.querySelectorAll("tbody tr");
+
+rows.forEach((row) => {
+  let z = document.createElement("td");
+  z.textContent = `(row #${row.rowIndex})`;
+  row.appendChild(z);
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples")}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableRowElement.rowIndex")}}

--- a/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
@@ -1,0 +1,128 @@
+---
+title: "HTMLTableSectionElement: deleteRow() method"
+short-title: deleteRow()
+slug: Web/API/HTMLTableSectionElement/deleteRow
+page-type: web-api-instance-method
+browser-compat: api.HTMLTableSectionElement.deleteRow
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`deleteRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface removes a
+specific row ({{HtmlElement("tr")}}) from a given {{HtmlElement("section")}}.
+
+## Syntax
+
+```js-nolint
+deleteRow(index)
+```
+
+### Parameters
+
+- `index`
+  - : `index` is an integer representing the row that should be deleted.
+    However, the special index `-1` can be used to remove the very last row of
+    the section.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if `index` is greater than or equal to the number of available rows or is a negative value other than `-1`.
+
+## Examples
+
+In this example, two buttons allow you to add and remove rows from the table body section; it also updates a {{HTMLElement("output")}} element with the number of rows currently in the table.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <th>Col 1</th>
+    <th>Col 2</th>
+    <th>Col 3</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>X</td>
+      <td>Y</td>
+      <td>Z</td>
+    </tr>
+  </tbody>
+</table>
+<button id="add">Add a row</button>
+<button id="remove">Remove last row</button>
+<div>This table's body has <output>1</output> row(s).</div>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### Javascript
+
+```js
+// Obtain relevant interface elements
+const bodySection = document.querySelectorAll("tbody")[0];
+const rows = bodySection.rows; // The collection is live, therefore always up-to-date
+const rowNumberDisplay = document.querySelectorAll("output")[0];
+
+const addButton = document.getElementById("add");
+const removeButton = document.getElementById("remove");
+
+function updateRowNumber() {
+  rowNumberDisplay.textContent = rows.length;
+}
+
+addButton.addEventListener("click", () => {
+  // Add a new row at the end of the body
+  const newRow = bodySection.insertRow();
+
+  // Add cells inside the new row
+  ["A", "B", "C"].forEach(
+    (elt) => (newRow.insertCell().textContent = `${elt}${rows.length}`),
+  );
+
+  // Update the row counter
+  updateRowNumber();
+});
+
+removeButton.addEventListener("click", () => {
+  // Delete the row from the body
+  bodySection.deleteRow(-1);
+
+  // Update the row counter
+  updateRowNumber();
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 175)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.deleteRow()")}}

--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -1,0 +1,136 @@
+---
+title: "HTMLTableSectionElement: insertRow() method"
+short-title: insertRow()
+slug: Web/API/HTMLTableSectionElement/insertRow
+page-type: web-api-instance-method
+browser-compat: api.HTMLTableSectionElement.insertRow
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface inserts a new row
+({{HtmlElement("tr")}}) in the given {{HtmlElement("section")}}, and returns a reference to
+this new row.
+
+> **Note:** `insertRow()` inserts the row directly into the
+> section. The row does not need to be appended separately as would be the case if
+> {{domxref("Document.createElement()")}} had been used to create the new
+> `<tr>` element.
+
+## Syntax
+
+```js-nolint
+insertRow()
+insertRow(index)
+```
+
+### Parameters
+
+- `index` {{optional_inline}}
+  - : The row index of the new row. If `index` is `-1` or equal to
+    the number of rows, the row is appended as the last row.
+    If `index` is omitted it defaults to `-1`.
+
+### Return value
+
+An {{domxref("HTMLTableRowElement")}} that references the new row.
+
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if `index` is greater than the number of rows, or smaller than `-1`.
+
+## Examples
+
+In this example, two buttons allow you to add and remove rows from the table body section; it also updates a {{HTMLElement("output")}} element with the number of rows currently in the table.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <th>Col 1</th>
+    <th>Col 2</th>
+    <th>Col 3</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>X</td>
+      <td>Y</td>
+      <td>Z</td>
+    </tr>
+  </tbody>
+</table>
+<button id="add">Add a row</button>
+<button id="remove">Remove last row</button>
+<div>This table's body has <output>1</output> row(s).</div>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### Javascript
+
+```js
+// Obtain relevant interface elements
+const bodySection = document.querySelectorAll("tbody")[0];
+const rows = bodySection.rows; // The collection is live, therefore always up-to-date
+const rowNumberDisplay = document.querySelectorAll("output")[0];
+
+const addButton = document.getElementById("add");
+const removeButton = document.getElementById("remove");
+
+function updateRowNumber() {
+  rowNumberDisplay.textContent = rows.length;
+}
+
+addButton.addEventListener("click", () => {
+  // Add a new row at the end of the body
+  const newRow = bodySection.insertRow();
+
+  // Add cells inside the new row
+  ["A", "B", "C"].forEach(
+    (elt) => (newRow.insertCell().textContent = `${elt}${rows.length}`),
+  );
+
+  // Update the row counter
+  updateRowNumber();
+});
+
+removeButton.addEventListener("click", () => {
+  // Delete the row from the body
+  bodySection.deleteRow(-1);
+
+  // Update the row counter
+  updateRowNumber();
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 175)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableRowElement.insertCell()")}}
+- {{domxref("HTMLTableElement.insertRow()")}}

--- a/files/en-us/web/api/htmltablesectionelement/rows/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/rows/index.md
@@ -1,0 +1,109 @@
+---
+title: "HTMLTableSectionElement: rows property"
+short-title: rows
+slug: Web/API/HTMLTableSectionElement/rows
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableSectionElement.rows
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`rows`** read-only property of the {{domxref("HTMLTableSectionElement")}} interface returns a live {{domxref("HTMLCollection")}} containing the rows in the section. The `HTMLCollection` is live and is automatically updated when rows are added or removed.
+
+## Value
+
+A live {{domxref("HTMLCollection")}} of {{domxref("HTMLTableRowElement")}} objects.
+
+## Examples
+
+In this example, two buttons allow you to add and remove rows from the table body section; it also updates a {{HTMLElement("output")}} element with the number of rows currently in the table.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <th>Col 1</th>
+    <th>Col 2</th>
+    <th>Col 3</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>X</td>
+      <td>Y</td>
+      <td>Z</td>
+    </tr>
+  </tbody>
+</table>
+<button id="add">Add a row</button>
+<button id="remove">Remove last row</button>
+<div>This table's body has <output>1</output> row(s).</div>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### Javascript
+
+```js
+// Obtain relevant interface elements
+const bodySection = document.querySelectorAll("tbody")[0];
+const rows = bodySection.rows; // The collection is live, therefore always up-to-date
+const rowNumberDisplay = document.querySelectorAll("output")[0];
+
+const addButton = document.getElementById("add");
+const removeButton = document.getElementById("remove");
+
+function updateRowNumber() {
+  rowNumberDisplay.textContent = rows.length;
+}
+
+addButton.addEventListener("click", () => {
+  // Add a new row at the end of the body
+  const newRow = bodySection.insertRow();
+
+  // Add cells inside the new row
+  ["A", "B", "C"].forEach(
+    (elt) => (newRow.insertCell().textContent = `${elt}${rows.length}`),
+  );
+
+  // Update the row counter
+  updateRowNumber();
+});
+
+removeButton.addEventListener("click", () => {
+  // Delete the row from the body
+  bodySection.deleteRow(-1);
+
+  // Update the row counter
+  updateRowNumber();
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 175)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{cssxref("text-align")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds docs for the following properties and methods:
- `HTMLTablelSectionElement.rows`
- `HTMLTablelSectionElement.insertRow()`
- `HTMLTablelSectionElement.deleteRow()`
- `HTMLTableRowElement.sectionRowIndex`

and does minor fixes to related page

### Motivation

All engines support these properties.

### Related issues and pull requests

It is part of https://github.com/mdn/mdn/issues/520
