### PR TITLE
Clarify Access-Control-Request-Headers (#33313)

### DIFF
--- a/files/en-us/glossary/preflight_request/index.md
+++ b/files/en-us/glossary/preflight_request/index.md
@@ -17,7 +17,7 @@ For example, a client might be asking a server if it would allow a {{HTTPMethod(
 ```http
 OPTIONS /resource/foo
 Access-Control-Request-Method: DELETE
-Access-Control-Request-Headers: Origin, X-Requested-With
+Access-Control-Request-Headers: x-requested-with
 Origin: https://foo.bar.org
 ```
 
@@ -28,7 +28,7 @@ HTTP/1.1 204 No Content
 Connection: keep-alive
 Access-Control-Allow-Origin: https://foo.bar.org
 Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
-Access-Control-Allow-Headers: Origin, X-Requested-With
+Access-Control-Allow-Headers: X-Requested-With
 Access-Control-Max-Age: 86400
 ```
 

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -180,7 +180,7 @@ Accept-Encoding: gzip,deflate
 Connection: keep-alive
 Origin: https://foo.example
 Access-Control-Request-Method: POST
-Access-Control-Request-Headers: X-PINGOTHER, Content-Type
+Access-Control-Request-Headers: content-type,x-pingother
 
 HTTP/1.1 204 No Content
 Date: Mon, 01 Dec 2008 01:15:39 GMT
@@ -198,7 +198,7 @@ Lines 1 - 10 above represent the preflight request with the {{HTTPMethod("OPTION
 
 ```http
 Access-Control-Request-Method: POST
-Access-Control-Request-Headers: X-PINGOTHER, Content-Type
+Access-Control-Request-Headers: content-type,x-pingother
 ```
 
 The {{HTTPHeader("Access-Control-Request-Method")}} header notifies the server as part of a preflight request that when the actual request is sent, it will do so with a `POST` request method. The {{HTTPHeader("Access-Control-Request-Headers")}} header notifies the server that when the actual request is sent, it will do so with `X-PINGOTHER` and `Content-Type` custom headers. Now the server has an opportunity to determine whether it can accept a request under these conditions.
@@ -476,7 +476,7 @@ Examples of this usage can be [found above.](#preflighted_requests)
 The {{HTTPHeader("Access-Control-Request-Headers")}} header is used when issuing a preflight request to let the server know what HTTP headers will be used when the actual request is made (for example, by passing them as the [`headers`](/en-US/docs/Web/API/Request/Request#headers) option to the {{domxref("Request.Request()", "Request()")}} constructor). This browser-side header will be answered by the complementary server-side header of {{HTTPHeader("Access-Control-Allow-Headers")}}.
 
 ```http
-Access-Control-Request-Headers: <field-name>[, <field-name>]*
+Access-Control-Request-Headers: <field-name>[,<field-name>]*
 ```
 
 Examples of this usage can be [found above](#preflighted_requests).

--- a/files/en-us/web/http/headers/access-control-allow-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-headers/index.md
@@ -74,12 +74,12 @@ Let's look at an example of a {{glossary("preflight request")}} involving `Acces
 
 First, the request. The preflight request is an {{HTTPMethod("OPTIONS")}} request that includes some combination of the three preflight request headers: {{HTTPHeader("Access-Control-Request-Method")}}, {{HTTPHeader("Access-Control-Request-Headers")}}, and {{HTTPHeader("Origin")}}.
 
-The preflight request below tells the server that we want to send a CORS `GET` request with the headers listed in {{HTTPHeader("Access-Control-Request-Headers")}} ({{HTTPHeader("Content-Type")}} and `x-requested-with`).
+The preflight request below tells the server that we want to send a CORS `GET` request with the headers listed in {{HTTPHeader("Access-Control-Request-Headers")}} ({{HTTPHeader("Content-Type")}} and `X-Requested-With`).
 
 ```http
 OPTIONS /resource/foo
 Access-Control-Request-Method: GET
-Access-Control-Request-Headers: Content-Type, x-requested-with
+Access-Control-Request-Headers: content-type,x-requested-with
 Origin: https://foo.bar.org
 ```
 

--- a/files/en-us/web/http/headers/access-control-request-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-request-headers/index.md
@@ -25,18 +25,18 @@ The **`Access-Control-Request-Headers`** request header is used by browsers when
 ## Syntax
 
 ```http
-Access-Control-Request-Headers: <header-name>, <header-name>, …
+Access-Control-Request-Headers: <header-name>,<header-name>,…
 ```
 
 ## Directives
 
 - \<header-name>
-  - : A comma-delimited list of [HTTP headers](/en-US/docs/Web/HTTP/Headers) that are included in the request.
+  - : A sorted list of unique, comma-separated, lowercase [HTTP headers](/en-US/docs/Web/HTTP/Headers) that are included in the request.
 
 ## Examples
 
 ```http
-Access-Control-Request-Headers: X-PINGOTHER, Content-Type
+Access-Control-Request-Headers: content-type,x-pingother
 ```
 
 ## Specifications

--- a/files/en-us/web/http/methods/options/index.md
+++ b/files/en-us/web/http/methods/options/index.md
@@ -81,7 +81,7 @@ Accept-Encoding: gzip,deflate
 Connection: keep-alive
 Origin: https://foo.example
 Access-Control-Request-Method: POST
-Access-Control-Request-Headers: X-PINGOTHER, Content-Type
+Access-Control-Request-Headers: content-type,x-pingother
 ```
 
 The server now can respond if it will accept a request under these circumstances. In this example, the server response says that:


### PR DESCRIPTION
### Description

Be more precise about the format of the `Access-Control-Request-Headers` header.

### Motivation

Imprecision can give practitioners false expectations.

### Related issues and pull requests

Fixes #33313 