### PR TITLE
Add HTMLTable*Element members for cell position in a row

### DIFF
--- a/files/en-us/web/api/htmltablecellelement/cellindex/index.md
+++ b/files/en-us/web/api/htmltablecellelement/cellindex/index.md
@@ -1,0 +1,82 @@
+---
+title: "HTMLTableCellElement: cellIndex property"
+short-title: cellIndex
+slug: Web/API/HTMLTableCellElement/cellIndex
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableCellElement.cellIndex
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`cellIndex`** read-only property of the {{domxref("HTMLTableCellElement")}} interface
+represents the position of a cell within its row ({{htmlelement("tr")}}). The first cell has an index of `0`.
+
+## Value
+
+Returns the index of the cell, or `-1` if the cell is not part of any row.
+
+## Examples
+
+This example adds a label all the cell numbers of the first row of the `tbody`.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Item</th>
+      <th>Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bananas</td>
+      <td>$2</td>
+    </tr>
+    <tr>
+      <td>Rice</td>
+      <td>$2.5</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td,
+table {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### JavaScript
+
+```js
+const rows = document.querySelectorAll("tbody tr");
+const cells = rows[0].cells;
+
+for (const cell of cells) {
+  cell.textContent = `${cell.textContent} (cell #${cell.cellIndex})`;
+}
+```
+
+### Result
+
+{{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -16,9 +16,9 @@ The **`HTMLTableCellElement`** interface provides special properties and methods
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTableCellElement.abbr")}}
-  - : A string that can be used on `<th>` elements (not on {{HTMLElement("td")}}), specifying an alternative label for the header cell. This alternate label can be used in other contexts, such as when describing the headers that apply to a data cell. This is used to offer a shorter term for use by screen readers in particular, and is a valuable accessibility tool. Usually, the value of `abbr` is an abbreviation or acronym, but can be any text that's appropriate contextually.
+  - : A string that can be used on `<th>` elements (not on {{HTMLElement("td")}}), specifying an alternative label for the header cell. This alternate label can be used in other contexts, such as when describing the headers that apply to a data cell. This is used to offer a shorter term for use by screen readers in particular; and is a valuable accessibility tool. Usually, the value of `abbr` is an abbreviation or acronym, but can be any text that's appropriate contextually.
 - {{domxref("HTMLTableCellElement.cellIndex")}} {{ReadOnlyInline}}
-  - : A long integer representing the cell's position in the {{domxref("HTMLTableRowElement.cells", "cells")}} collection of the {{HTMLElement("tr")}} the cell is contained within. If the cell doesn't belong to a `<tr>`, it returns `-1`.
+  - : A number representing the cell's position in the {{domxref("HTMLTableRowElement.cells", "cells")}} collection of the {{HTMLElement("tr")}} the cell is contained within. If the cell doesn't belong to a `<tr>`, it returns `-1`.
 - {{domxref("HTMLTableCellElement.colSpan")}}
   - : An unsigned long integer indicating the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the [`colspan`](/en-US/docs/Web/HTML/Element/td#colspan) attribute.
 - {{domxref("HTMLTableCellElement.headers")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/htmltablerowelement/cells/index.md
+++ b/files/en-us/web/api/htmltablerowelement/cells/index.md
@@ -1,52 +1,23 @@
 ---
-title: "HTMLTableRowElement: insertCell() method"
-short-title: insertCell()
-slug: Web/API/HTMLTableRowElement/insertCell
-page-type: web-api-instance-method
-browser-compat: api.HTMLTableRowElement.insertCell
+title: "HTMLTableRowElement: cells property"
+short-title: cells
+slug: Web/API/HTMLTableRowElement/cells
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableRowElement.cells
 ---
 
-{{APIRef("HTML DOM")}}
+{{ APIRef("HTML DOM") }}
 
-The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface inserts a new
-cell ({{HtmlElement("td")}}) into a table row ({{HtmlElement("tr")}}) and returns a
-reference to the cell.
+The **`cells`** read-only property of the {{domxref("HTMLTableRowElement")}} interface
+returns a live {{domxref("HTMLCollection")}} containing the cells in the row. The `HTMLCollection` is live and is automatically updated when cells are added or removed.
 
-> **Note:** `insertCell()` inserts the cell directly into the
-> row. The cell does not need to be appended separately
-> with {{domxref("Node.appendChild()")}} as would be the case if
-> {{domxref("Document.createElement()")}} had been used to create the new
-> `<td>` element.
->
-> You can not use `insertCell()` to create a new `<th>`
-> element though.
+## Value
 
-## Syntax
-
-```js-nolint
-insertCell()
-insertCell(index)
-```
-
-### Parameters
-
-- `index` {{optional_inline}}
-  - : The cell index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted it defaults to `-1`.
-
-### Return value
-
-An {{domxref("HTMLTableCellElement")}} that references the new
-cell.
-
-### Exceptions
-
-- `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than the number of cells.
+A live {{domxref("HTMLCollection")}} of {{domxref("HTMLTableCellElement")}} objects.
 
 ## Examples
 
-This example uses {{domxref("HTMLTableRowElement.insertCell()")}} to append a new cell to a
-row.
+This example uses `HTMLTableRowElement.cells` to display the number of cell in a row.
 
 ### HTML
 
@@ -138,5 +109,5 @@ removeButton.addEventListener("click", () => {
 
 ## See also
 
-- {{domxref("HTMLTableElement.insertRow()")}}
-- The HTML element representing cells: {{domxref("HTMLTableCellElement")}}
+- {{domxref("HTMLTableRowElement.insertCell()")}}
+- {{domxref("HTMLTableRowElement.deleteCell()")}}

--- a/files/en-us/web/api/htmltablerowelement/deletecell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/deletecell/index.md
@@ -1,47 +1,35 @@
 ---
-title: "HTMLTableRowElement: insertCell() method"
-short-title: insertCell()
-slug: Web/API/HTMLTableRowElement/insertCell
+title: "HTMLTableRowElement: deleteCell() method"
+short-title: deleteCell()
+slug: Web/API/HTMLTableRowElement/deleteCell
 page-type: web-api-instance-method
-browser-compat: api.HTMLTableRowElement.insertCell
+browser-compat: api.HTMLTableRowElement.deleteCell
 ---
 
 {{APIRef("HTML DOM")}}
 
-The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface inserts a new
-cell ({{HtmlElement("td")}}) into a table row ({{HtmlElement("tr")}}) and returns a
-reference to the cell.
-
-> **Note:** `insertCell()` inserts the cell directly into the
-> row. The cell does not need to be appended separately
-> with {{domxref("Node.appendChild()")}} as would be the case if
-> {{domxref("Document.createElement()")}} had been used to create the new
-> `<td>` element.
->
-> You can not use `insertCell()` to create a new `<th>`
-> element though.
+The **`deleteCell()`** method of the {{domxref("HTMLTableRowElement")}} interface removes a
+specific row cell from a given {{htmlelement("tr")}}.
 
 ## Syntax
 
 ```js-nolint
-insertCell()
-insertCell(index)
+deleteCell(index)
 ```
 
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The cell index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted it defaults to `-1`.
+  - : The cell index of the cell to remove. If `index` is `-1` or equal to the number of cells, the last cell of the row is removed.
 
 ### Return value
 
-An {{domxref("HTMLTableCellElement")}} that references the new
-cell.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than the number of cells.
+  - : Thrown if `index` is greater than the number of cells or if it is smaller than `-1`.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltablerowelement/index.md
+++ b/files/en-us/web/api/htmltablerowelement/index.md
@@ -18,29 +18,29 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLTableRowElement.cells")}} {{ReadOnlyInline}}
   - : Returns a live {{domxref("HTMLCollection")}} containing the cells in the row. The `HTMLCollection` is live and is automatically updated when cells are added or removed.
 - {{domxref("HTMLTableRowElement.rowIndex")}} {{ReadOnlyInline}}
-  - : Returns a `long` value which gives the logical position of the row within the entire table. If the row is not part of a table, returns `-1`.
+  - : Returns a number that gives the logical position of the row within the entire table. If the row is not part of a table, returns `-1`.
 - {{domxref("HTMLTableRowElement.sectionRowIndex")}} {{ReadOnlyInline}}
-  - : Returns a `long` value which gives the logical position of the row within the table section it belongs to. If the row is not part of a section, returns `-1`.
+  - : Returns a number that gives the logical position of the row within the table section it belongs to. If the row is not part of a section, returns `-1`.
 
 ## Instance methods
 
 _Inherits methods from its parent, {{domxref("HTMLElement")}}_.
 
-- {{domxref("HTMLTableRowElement.deleteCell()", "deleteCell(index)")}}
+- {{domxref("HTMLTableRowElement.deleteCell()")}}
   - : Removes the cell corresponding to `index`. If `index` is `-1`, the last cell of the row is removed. If `index` is less than `-1` or greater than the amount of cells in the collection, a {{DOMxRef("DOMException")}} with the value `IndexSizeError` is raised.
-- {{domxref("HTMLTableRowElement.insertCell()", "insertCell(index)")}}
-  - : Returns an {{DOMxRef("HTMLTableCellElement")}} representing a new cell of the row. The cell is inserted in the collection of cells immediately before the given `index` position in the row. If `index` is `-1`, the new cell is appended to the collection. If `index` is less than `-1` or greater than the number of cells in the collection, a {{DOMxRef("DOMException")}} with the value `IndexSizeError` is raised.
+- {{domxref("HTMLTableRowElement.insertCell()")}}
+  - : Returns an {{domxref("HTMLTableCellElement")}} representing a new cell of the row. The cell is inserted in the collection of cells immediately before the given `index` position in the row. If `index` is `-1`, the new cell is appended to the collection. If `index` is less than `-1` or greater than the number of cells in the collection, a {{DOMxRef("DOMException")}} with the value `IndexSizeError` is raised.
 
 ## Deprecated properties
 
 > **Warning:** These properties have been deprecated and should no longer be used. They are documented primarily to help understand older code bases.
 
 - {{domxref("HTMLTableRowElement.align")}} {{deprecated_inline}}
-  - : A string containing an enumerated value reflecting the [`align`](/en-US/docs/Web/HTML/Element/tr#align) attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
+  - : A string containing an enumerated value reflecting the [`align`](/en-US/docs/Web/HTML/Element/tr#align) attribute. It indicates the alignment of the element's contents to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
 - {{domxref("HTMLTableRowElement.bgColor")}} {{deprecated_inline}}
   - : A string containing the background color of the cells. It reflects the obsolete [`bgColor`](/en-US/docs/Web/HTML/Element/tr#bgcolor) attribute.
 - {{domxref("HTMLTableRowElement.ch")}} {{deprecated_inline}}
-  - : A string containing one single character. This character is the one to align all the cell of a column on. It reflects the [`char`](/en-US/docs/Web/HTML/Element/tr#char) and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
+  - : A string containing one single character. This character is the one to align all the cell of a column on. It reflects the [`char`](/en-US/docs/Web/HTML/Element/tr#char) and defaults to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
 - {{domxref("HTMLTableRowElement.chOff")}} {{deprecated_inline}}
   - : A string containing an integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableRowElement.ch`. This property was optional and was not very well supported.
 - {{domxref("HTMLTableRowElement.vAlign")}} {{deprecated_inline}}

--- a/files/en-us/web/api/htmltablerowelement/rowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/rowindex/index.md
@@ -61,10 +61,10 @@ This example uses JavaScript to label all the row numbers in a table.
 ### JavaScript
 
 ```js
-let rows = document.querySelectorAll("tr");
+const rows = document.querySelectorAll("tr");
 
 rows.forEach((row) => {
-  let z = document.createElement("td");
+  const z = document.createElement("td");
   z.textContent = `(row #${row.rowIndex})`;
   row.appendChild(z);
 });
@@ -73,6 +73,10 @@ rows.forEach((row) => {
 ### Result
 
 {{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
@@ -1,6 +1,6 @@
 ---
 title: "HTMLTableRowElement: sectionRowIndex property"
-short-title: rowIndex
+short-title: sectionRowIndex
 slug: Web/API/HTMLTableRowElement/sectionRowIndex
 page-type: web-api-instance-property
 browser-compat: api.HTMLTableRowElement.sectionRowIndex
@@ -55,10 +55,10 @@ This example uses JavaScript to label all the row numbers of the `tbody`.
 ### JavaScript
 
 ```js
-let rows = document.querySelectorAll("tbody tr");
+const rows = document.querySelectorAll("tbody tr");
 
 rows.forEach((row) => {
-  let z = document.createElement("td");
+  const z = document.createElement("td");
   z.textContent = `(row #${row.rowIndex})`;
   row.appendChild(z);
 });
@@ -67,6 +67,10 @@ rows.forEach((row) => {
 ### Result
 
 {{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds docs for the following properties and methods:
- `HTMLTableRowElement.insertCell()`
- `HTMLTableRowElement.deleteCell()`
- `HTMLTableRowElement.cells()`
- `HTMLTableCellElement.cellIndex`

and does minor fixes to related pages

### Motivation

All engines support these properties.

### Related issues and pull requests

It is part of https://github.com/mdn/mdn/issues/520
