### PR TITLE
Add HTMLTable*Element members for col and row spans

### DIFF
--- a/files/en-us/web/api/htmltablecellelement/colspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/colspan/index.md
@@ -1,0 +1,113 @@
+---
+title: "HTMLTableCellElement: colSpan property"
+short-title: colSpan
+slug: Web/API/HTMLTableCellElement/colSpan
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableCellElement.colSpan
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`colSpan`** read-only property of the {{domxref("HTMLTableCellElement")}} interface represents the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the [`colspan`](/en-US/docs/Web/HTML/Element/td#colspan) attribute.
+
+## Value
+
+A positive number representing the number of columns.
+
+> **Note:** When setting a new value, the value is _clamped_ to the nearest strictly positive number.
+
+## Examples
+
+This example provides two buttons to modify the column span of the first cell of the body.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Col 1</th>
+      <th>Col 2</th>
+      <th>Col 3</th>
+      <th>Col 4</th>
+      <th>Col 5</th>
+      <th>Col 6</th>
+      <th>Col 7</th>
+      <th>Col 8</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td colspan="2">1</td>
+      <td>2</td>
+      <td>3</td>
+      <td>4</td>
+      <td>5</td>
+      <td>6</td>
+      <td>7</td>
+      <td>8</td>
+    </tr>
+  </tbody>
+</table>
+<button id="increase">Increase colspan</button>
+<button id="decrease">Decrease colspan</button>
+<div>The first cell spans <output>2</output> column(s).</div>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td,
+table {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### Javascript
+
+```js
+// Obtain relevant interface elements
+const cell = document.querySelectorAll("tbody tr td")[0];
+const output = document.querySelectorAll("output")[0];
+
+const increaseButton = document.getElementById("increase");
+const decreaseButton = document.getElementById("decrease");
+
+increaseButton.addEventListener("click", () => {
+  cell.colSpan = cell.colSpan + 1;
+
+  // Update the display
+  output.textContent = cell.colSpan;
+});
+
+decreaseButton.addEventListener("click", () => {
+  cell.colSpan = cell.colSpan - 1;
+
+  // Update the display
+  output.textContent = cell.colSpan;
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 175)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableCellElement.rowSpan")}}
+- {{domxref("HTMLTableColElement.span")}}

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -20,7 +20,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLTableCellElement.cellIndex")}} {{ReadOnlyInline}}
   - : A long integer representing the cell's position in the {{domxref("HTMLTableRowElement.cells", "cells")}} collection of the {{HTMLElement("tr")}} the cell is contained within. If the cell doesn't belong to a `<tr>`, it returns `-1`.
 - {{domxref("HTMLTableCellElement.colSpan")}}
-  - : An unsigned long integer indicating the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the [`colspan`](/en-US/docs/Web/HTML/Element/td#colspan) attribute.
+  - : A positive number indicating the number of columns this cell must span; this lets the cell occupy space across multiple columns of the table. It reflects the [`colspan`](/en-US/docs/Web/HTML/Element/td#colspan) attribute.
 - {{domxref("HTMLTableCellElement.headers")}} {{ReadOnlyInline}}
   - : A {{domxref("DOMTokenList")}} describing a list of `id` of {{HTMLElement("th")}} elements that represent headers associated with the cell. It reflects the [`headers`](/en-US/docs/Web/HTML/Element/td#headers) attribute.
 - {{domxref("HTMLTableCellElement.rowSpan")}}

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -24,7 +24,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLTableCellElement.headers")}} {{ReadOnlyInline}}
   - : A {{domxref("DOMTokenList")}} describing a list of `id` of {{HTMLElement("th")}} elements that represent headers associated with the cell. It reflects the [`headers`](/en-US/docs/Web/HTML/Element/td#headers) attribute.
 - {{domxref("HTMLTableCellElement.rowSpan")}}
-  - : An unsigned long integer indicating the number of rows this cell must span; this lets a cell occupy space across multiple rows of the table. It reflects the [`rowspan`](/en-US/docs/Web/HTML/Element/td#rowspan) attribute.
+  - : An positive number indicating the number of rows this cell must span; this lets a cell occupy space across multiple rows of the table. It reflects the [`rowspan`](/en-US/docs/Web/HTML/Element/td#rowspan) attribute.
 - {{domxref("HTMLTableCellElement.scope")}}
 
   - : A string indicating the scope of a {{HTMLElement("th")}} cell. Header cells can be configured, using the `scope` property, the apply to a specified row or column, or to the not-yet-scoped cells within the current row group (that is, the same ancestor {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, or {{HTMLElement("tfoot")}} element). If no value is specified for `scope`, the header is not associated directly with cells in this way. Permitted values for `scope` are:

--- a/files/en-us/web/api/htmltablecellelement/rowspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/rowspan/index.md
@@ -1,0 +1,114 @@
+---
+title: "HTMLTableCellElement: rowSpan property"
+short-title: rowSpan
+slug: Web/API/HTMLTableCellElement/rowSpan
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableCellElement.rowSpan
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`rowSpan`** read-only property of the {{domxref("HTMLTableCellElement")}} interface represents the number of rows this cell must span; this lets the cell occupy space across multiple rows of the table. It reflects the [`rowspan`](/en-US/docs/Web/HTML/Element/td#colspan) attribute.
+
+## Value
+
+A positive number representing the number of rows. If it is `0`, it means all remaining rows in the column.
+
+> **Note:** When setting a new value, a value different from 0 is _clamped_ to the nearest strictly positive number.
+
+## Examples
+
+This example provides two buttons to modify the row span of the first cell of the body.
+
+### HTML
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Col 1</th>
+      <th>Col 2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td rowspan="2">2</td>
+      <td>2</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>3</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>4</td>
+    </tr>
+  </tbody>
+</table>
+<button id="increase">Increase rowspan</button>
+<button id="decrease">Decrease rowspan</button>
+<div>The second cell of the first column spans <output>2</output> row(s).</div>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td,
+table {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### Javascript
+
+```js
+// Obtain relevant interface elements
+const row = document.querySelectorAll("tbody tr")[1];
+const cell = row.cells[0];
+const output = document.querySelectorAll("output")[0];
+
+const increaseButton = document.getElementById("increase");
+const decreaseButton = document.getElementById("decrease");
+
+increaseButton.addEventListener("click", () => {
+  cell.rowSpan = cell.rowSpan + 1;
+
+  // Update the display
+  output.textContent = cell.rowSpan;
+});
+
+decreaseButton.addEventListener("click", () => {
+  cell.rowSpan = cell.rowSpan - 1;
+
+  // Update the display
+  output.textContent = `${cell.rowSpan == 0 ? "all remaining" : cell.rowSpan}`;
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 180)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableCellElement.colSpan")}}
+- {{domxref("HTMLTableColElement.span")}}

--- a/files/en-us/web/api/htmltablecolelement/index.md
+++ b/files/en-us/web/api/htmltablecolelement/index.md
@@ -22,7 +22,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 - {{domxref("HTMLTableColElement.chOff")}} {{deprecated_inline}}
   - : A string representing the offset for the alignment character.
 - {{domxref("HTMLTableColElement.span")}}
-  - : An `unsigned long` that reflects the [`span`](/en-US/docs/Web/HTML/Element/col#span) HTML attribute, indicating the number of columns to apply this object's attributes to. Must be a positive integer.
+  - : A positive number that reflects the [`span`](/en-US/docs/Web/HTML/Element/col#span) HTML attribute, indicating the number of columns to apply this object's attributes to.
 - {{domxref("HTMLTableColElement.vAlign")}} {{deprecated_inline}}
   - : A string that indicates the vertical alignment of the cell data in the column.
 - {{domxref("HTMLTableColElement.width")}} {{deprecated_inline}}

--- a/files/en-us/web/api/htmltablecolelement/span/index.md
+++ b/files/en-us/web/api/htmltablecolelement/span/index.md
@@ -1,0 +1,116 @@
+---
+title: "HTMLTableColElement: span property"
+short-title: span
+slug: Web/API/HTMLTableColElement/span
+page-type: web-api-instance-property
+browser-compat: api.HTMLTableColElement.span
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`span`** read-only property of the {{domxref("HTMLTableColElement")}} interface represents the number of columns this {{htmlelement("col")}} or {{htmlelement("colgroup")}} must span; this lets the column occupy space across multiple columns of the table. It reflects the [`span`](/en-US/docs/Web/HTML/Element/col#colspan) attribute.
+
+## Value
+
+A positive number representing the number of columns.
+
+> **Note:** When setting a new value, the value is _clamped_ to the nearest strictly positive number (up to 1000).
+
+## Examples
+
+This example provides two buttons to modify the column span of the first cell of the body.
+
+### HTML
+
+```html
+<table>
+  <colgroup>
+    <col />
+    <col span="2" class="multiColumn" />
+  </colgroup>
+  <thead>
+    <th></th>
+    <th scope="col">C1</th>
+    <th scope="col">C2</th>
+    <th scope="col">C3</th>
+    <th scope="col">C4</th>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Row 1</th>
+      <td>cell</td>
+      <td>cell</td>
+      <td>cell</td>
+      <td>cell</td>
+    </tr>
+  </tbody>
+</table>
+<button id="increase">Increase column span</button>
+<button id="decrease">Decrease column span</button>
+<div>The first &lt;col&gt; spans <output>2</output> actual column(s).</div>
+```
+
+```css hidden
+table {
+  border-collapse: collapse;
+}
+
+th,
+td,
+table {
+  border: 1px solid black;
+}
+
+button {
+  margin: 1em 1em 1em 0;
+}
+```
+
+### CSS
+
+```css
+.multiColumn {
+  background-color: #d7d9f2;
+}
+```
+
+### Javascript
+
+```js
+// Obtain relevant interface elements
+const col = document.querySelectorAll("col")[1];
+const output = document.querySelectorAll("output")[0];
+
+const increaseButton = document.getElementById("increase");
+const decreaseButton = document.getElementById("decrease");
+
+increaseButton.addEventListener("click", () => {
+  col.span = col.span + 1;
+
+  // Update the display
+  output.textContent = col.span;
+});
+
+decreaseButton.addEventListener("click", () => {
+  col.span = col.span - 1;
+
+  // Update the display
+  output.textContent = col.span;
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Examples", "100%", 175)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableCellElement.colSpan")}}

--- a/files/en-us/web/api/htmltablerowelement/rowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/rowindex/index.md
@@ -19,7 +19,7 @@ table in the right order. Therefore the rows count from `<thead>` to
 
 ## Value
 
-Returns the index of the row, or `-1` if the row is not part of a table.
+The index of the row, or `-1` if the row is not part of a table.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
@@ -13,7 +13,7 @@ represents the position of a row within the current section ({{htmlelement("thea
 
 ## Value
 
-Returns the index of the row, or `-1` if the row is not part of the section.
+The index of the row, or `-1` if the row is not part of the section.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR adds docs for the following properties and methods:
- `HTMLTableCellElement.rowSpan`
- `HTMLTableCellElement.colSpan`
- `HTMLTableColElement.span`

and does minor fixes to related pages

### Motivation

All engines support these properties.

### Related issues and pull requests

It is part of https://github.com/mdn/mdn/issues/520
