### PR TITLE
fix(svg): remove not working csssyntax macros

### DIFF
--- a/files/en-us/web/svg/attribute/display/index.md
+++ b/files/en-us/web/svg/attribute/display/index.md
@@ -67,7 +67,7 @@ svg {
     </tr>
     <tr>
       <th scope="row">Value</th>
-      <td>{{csssyntax("display")}}</td>
+      <td>See {{cssxref("display", "", "#formal_syntax")}}</td>
     </tr>
     <tr>
       <th scope="row">Animatable</th>

--- a/files/en-us/web/svg/attribute/font-family/index.md
+++ b/files/en-us/web/svg/attribute/font-family/index.md
@@ -43,7 +43,7 @@ svg {
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{csssyntax("font-family")}}</td>
+      <td>See {{cssxref("font-family", "", "#formal_syntax")}}</td>
     </tr>
     <tr>
       <th scope="row">Default value</th>

--- a/files/en-us/web/svg/attribute/font-stretch/index.md
+++ b/files/en-us/web/svg/attribute/font-stretch/index.md
@@ -24,7 +24,7 @@ You can use this attribute with the following SVG elements:
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{csssyntax("font-stretch")}}</td>
+      <td>See {{cssxref("font-stretch", "", "#formal_syntax")}}</td>
     </tr>
     <tr>
       <th scope="row">Default value</th>

--- a/files/en-us/web/svg/attribute/transform-origin/index.md
+++ b/files/en-us/web/svg/attribute/transform-origin/index.md
@@ -19,7 +19,7 @@ You can use this attribute with any SVG element.
   <tbody>
     <tr>
       <td><strong>Values</strong></td>
-      <td>{{csssyntax("transform-origin")}}</td>
+      <td>See {{cssxref("transform-origin", "", "#formal_syntax")}}</td>
     </tr>
     <tr>
       <td><strong>Default value</strong></td>

--- a/files/en-us/web/svg/attribute/unicode-bidi/index.md
+++ b/files/en-us/web/svg/attribute/unicode-bidi/index.md
@@ -26,7 +26,7 @@ You can use this attribute with the following SVG elements:
   <tbody>
     <tr>
       <th scope="row">Value</th>
-      <td>{{csssyntax("unicode-bidi")}}</td>
+      <td>See {{cssxref("unicode-bidi", "", "#formal_syntax")}}</td>
     </tr>
     <tr>
       <th scope="row">Default value</th>


### PR DESCRIPTION
### Description

csssyntax requires a CSS page type and is broken on SVG pages. Link to the #formal_syntax on the according page instead.

### Before

![image](https://github.com/mdn/content/assets/3604775/3d0f39f4-9db4-4a98-a514-c85c8334f38a)

### After

![image](https://github.com/mdn/content/assets/3604775/c60a29cf-5383-4290-b880-1132ed2e8c9e)

