### PR TITLE
fix(kitchensink): remove csssyntax

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -103,12 +103,6 @@ class BookListView(generic.ListView):
     template_name = 'books/my_arbitrary_template_name_list.html'
 ```
 
-### Formal syntax
-
-_The formal syntax must be taken from the spec and added to the [MDN data repository](https://github.com/mdn/data). It is an important tool to get precise syntax information for advanced users._
-
-{{CSSSyntax("font-stretch")}}
-
 ## Interactive Examples
 
 {{EmbedInteractiveExample("pages/tabbed/abbr.html", "tabbed-shorter")}} {{EmbedInteractiveExample("pages/css/order.html")}} {{EmbedInteractiveExample("pages/js/regexp-assertions.html", "taller")}}


### PR DESCRIPTION
### Description

csssyntax only works on css page types. So we remove it from the kitchensink as it only renders and error.