### PR TITLE
Update defaults for Intl.Collator's `ignorePunctuation` parameter 

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
@@ -76,7 +76,7 @@ Intl.Collator(locales, options)
         The default is `"variant"` for usage `"sort"`; it's locale dependent for usage `"search"` per spec, but the core functionality of `"search"` is accent-insensitive and case-insensitive filtering, so `"base"` makes the most sense (and perhaps `"case"`).
 
     - `ignorePunctuation`
-      - : Whether punctuation should be ignored. Possible values are `true` and `false`. The default is `true` for Thai and `false` for all other languages.
+      - : Whether punctuation should be ignored. Possible values are `true` and `false`. The default is `true` for Thai (`th`) and `false` for all other languages.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
@@ -76,7 +76,7 @@ Intl.Collator(locales, options)
         The default is `"variant"` for usage `"sort"`; it's locale dependent for usage `"search"` per spec, but the core functionality of `"search"` is accent-insensitive and case-insensitive filtering, so `"base"` makes the most sense (and perhaps `"case"`).
 
     - `ignorePunctuation`
-      - : Whether punctuation should be ignored. Possible values are `true` and `false`; the default is `false`.
+      - : Whether punctuation should be ignored. Possible values are `true` and `false`. The default is `true` for Thai and `false` for all other languages.
 
 ### Exceptions
 


### PR DESCRIPTION
### Description

Updates the description of the `ignorePunctuation` parameter in `Intl.Collator` to reflect that the default is locale dependent after the merging of https://github.com/tc39/ecma402/pull/833. Previously the default for this parameter was `false` in all cases; now it's `true` for Thai and `false` for all other languages.

### Motivation

Current version is inaccurate after recent changes to `Intl.Collator` spec.

