### PR TITLE
Put rounding-related `resolvedOptions` properties in alphabetical order

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -52,15 +52,15 @@ The resulting object has the following properties:
 - `numberingSystem`
   - : The numbering system.
     This is the value provided in the [`options.numberingSystem`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#numberingsystem) argument of the constructor, if present, or the value set using the Unicode extension key [`nu`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#nu), or filled in as a default.
+- `roundingIncrement`
+  - : The rounding-increment precision (the increment used when rounding numbers).
+    This is the value specified in the [`options.roundingIncrement`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingincrement) argument in the constructor.
 - `roundingMode`
   - : The rounding mode.
     This is the value provided for the [`options.roundingMode`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode) argument in the constructor, or the default value: `halfExpand`.
 - `roundingPriority`
   - : The priority for resolving rounding conflicts if both "FractionDigits" and "SignificantDigits" are specified.
     This is the value provided for the [`options.roundingPriority`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingpriority) argument in the constructor, or the default value: `auto`.
-- `roundingIncrement`
-  - : The rounding-increment precision (the increment used when rounding numbers).
-    This is the value specified in the [`options.roundingIncrement`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingincrement) argument in the constructor.
 - `signDisplay`
   - : Whether or not to display the positive/negative sign.
     This is the value specified in the [`options.signDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#signdisplay) argument in the constructor, or the default value: `"auto"`.

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
@@ -35,15 +35,15 @@ The object has the following properties:
 
   - : The type used (`cardinal` or `ordinal`).
 
+- `roundingIncrement` {{experimental_inline}}
+  - : The rounding-increment precision (the increment used when rounding numbers).
+    This is the value specified in the [`options.roundingIncrement`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules#roundingincrement) argument in the constructor.
 - `roundingMode` {{experimental_inline}}
   - : The rounding mode.
     This is the value provided for the [`options.roundingMode`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules#roundingmode) argument in the constructor, or the default value: `halfExpand`.
 - `roundingPriority` {{experimental_inline}}
   - : The priority for resolving rounding conflicts if both "FractionDigits" and "SignificantDigits" are specified.
     This is the value provided for the [`options.roundingPriority`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules#roundingpriority) argument in the constructor, or the default value: `auto`.
-- `roundingIncrement` {{experimental_inline}}
-  - : The rounding-increment precision (the increment used when rounding numbers).
-    This is the value specified in the [`options.roundingIncrement`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules#roundingincrement) argument in the constructor.
 - `trailingZeroDisplay` {{experimental_inline}}
   - : The strategy for displaying trailing zeros on whole numbers.
     This is the value specified in the [`options.trailingZeroDisplay`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules#trailingzerodisplay) argument in the constructor, or the default value: `"auto"`.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This is a very small change -- it just puts the rounding-related properties of the object returned by `Intl.NumberFormat.resolvedOptions()` and `Intl.PluralRules.resolvedOptions()` in alphabetical order. 

### Motivation

This makes the text marginally more readable, and has the advantage of reflecting the output order as currently defined in the spec. 

### Additional details

See https://github.com/tc39/ecma402/pull/811