### PR TITLE
Updated Intl.DateTimeFormat's `timeZone` parameter description to reflect current requirements for conforming ECMA-402 implementations"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -59,7 +59,7 @@ Intl.DateTimeFormat(locales, options)
 - `hourCycle`
   - : The hour cycle to use. Possible values are `"h11"`, `"h12"`, `"h23"`, and `"h24"`. This option can also be set through the `hc` Unicode extension key; if both are provided, this `options` property takes precedence.
 - `timeZone`
-  - : The time zone to use. Time zones names correspond to the Zone and Link names of the [IANA Time Zone Database](https://www.iana.org/time-zones), such as `"Asia/Shanghai"`, `"Asia/Kolkata"`, and `"America/New_York"`. Additionally, time zones can be given as UTC offsets in the format "±hh:mm", "±hhmm", or "±hh", for example as `"+01:00"`, `"-2359"`, or `"+23"`. The default is the runtime's default time zone.
+  - : The time zone to use. Time zone names correspond to the Zone and Link names of the [IANA Time Zone Database](https://www.iana.org/time-zones), such as `"UTC"`, `"Asia/Shanghai"`, `"Asia/Kolkata"`, and `"America/New_York"`. Additionally, time zones can be given as UTC offsets in the format "±hh:mm", "±hhmm", or "±hh", for example as `"+01:00"`, `"-2359"`, or `"+23"`. The default is the runtime's default time zone.
 
 #### Date-time component options
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -59,7 +59,7 @@ Intl.DateTimeFormat(locales, options)
 - `hourCycle`
   - : The hour cycle to use. Possible values are `"h11"`, `"h12"`, `"h23"`, and `"h24"`. This option can also be set through the `hc` Unicode extension key; if both are provided, this `options` property takes precedence.
 - `timeZone`
-  - : The time zone to use. The only value implementations must recognize is `"UTC"`; the default is the runtime's default time zone. Implementations may also recognize the time zone names of the [IANA time zone database](https://www.iana.org/time-zones), such as `"Asia/Shanghai"`, `"Asia/Kolkata"`, `"America/New_York"`.
+  - : The time zone to use. Time zones names correspond to the Zone and Link names of the [IANA Time Zone Database](https://www.iana.org/time-zones), such as `"Asia/Shanghai"`, `"Asia/Kolkata"`, and `"America/New_York"`. Additionally, time zones can be given as UTC offsets in the format "±hh:mm", "±hhmm", or "±hh", for example as `"+01:00"`, `"-2359"`, or `"+23"`. The default is the runtime's default time zone.
 
 #### Date-time component options
 


### PR DESCRIPTION

### Description

Update valid values for `timeZone` parameter of `Intl.DateTimeFormat` to reflect that conforming implementations of ECMA-402 must be [time zone aware](https://tc39.es/ecma402/#sec-use-of-iana-time-zone-database). Also include examples of valid UTC offset time zones.

### Motivation

https://github.com/tc39/ecma402/pull/788/ updates `Intl.DateTimeFormat` to allow the use of UTC offset time zones. 

### Additional details

The previous language about implementations only being required to recognize the time zone `"UTC"` only apply to implementations of [ECMA-262 without ECMA-402](https://tc39.es/ecma262/#sec-time-zone-identifiers). ECMA-402 implementations must be time zone aware.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
