### PR TITLE
typo: update glossary apple safari

### DIFF
--- a/files/en-us/glossary/apple_safari/index.md
+++ b/files/en-us/glossary/apple_safari/index.md
@@ -13,5 +13,5 @@ page-type: glossary-definition
 - [Safari](<https://en.wikipedia.org/wiki/Safari_(web_browser)>) on Wikipedia
 - [Safari on apple.com](https://www.apple.com/safari/)
 - [The WebKit project](https://webkit.org/)
-- [WebKit Build Archive](https://webkit.org/build-archives/)
+- [WebKit Build Archives](https://webkit.org/build-archives/)
 - [Reporting a bug for Safari](https://bugs.webkit.org/)

--- a/files/en-us/glossary/apple_safari/index.md
+++ b/files/en-us/glossary/apple_safari/index.md
@@ -13,5 +13,5 @@ page-type: glossary-definition
 - [Safari](<https://en.wikipedia.org/wiki/Safari_(web_browser)>) on Wikipedia
 - [Safari on apple.com](https://www.apple.com/safari/)
 - [The WebKit project](https://webkit.org/)
-- [WebKit nightly build](https://webkit.org/build-archives/)
+- [WebKit Build Archive](https://webkit.org/build-archives/)
 - [Reporting a bug for Safari](https://bugs.webkit.org/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

update link name `WebKit nightly build` => `WebKit Build Archive`

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

the link was updated due to redirection years ago, but the name of the link was unchanged.

at the moment the page redirected got a name defined:

```html
<title>  WebKit Build Archives | WebKit</title>
```

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
