### PR TITLE
Using promises: add Cancellation section (and link to AbortController)

### DIFF
--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -422,6 +422,10 @@ for (const f of [func1, func2, func3]) {
 
 However, before you compose promises sequentially, consider if it's really necessary — it's always better to run promises concurrently so that they don't unnecessarily block each other unless one promise's execution depends on another's result.
 
+## Cancellation
+
+There's no way to cancel any given {{jsxref("Promise")}}, but asyncronous operations can implement "cooperative cancellation", typically using [AbortController](docs/Web/API/AbortController).
+
 ## Creating a Promise around an old callback API
 
 A {{jsxref("Promise")}} can be created from scratch using its [constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise). This should be needed only to wrap old APIs.

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -424,7 +424,7 @@ However, before you compose promises sequentially, consider if it's really neces
 
 ## Cancellation
 
-There's no way to cancel any given {{jsxref("Promise")}}, but asyncronous operations can implement "cooperative cancellation", typically using [AbortController](docs/Web/API/AbortController).
+`Promise` itself has no first-class protocol for cancellation, but you may be able to directly cancel the underlying asynchronous operation, typically using [`AbortController`](/en-US/docs/Web/API/AbortController).
 
 ## Creating a Promise around an old callback API
 


### PR DESCRIPTION
### Description

Adding a very simple section describing cancellation. 

### Motivation

Because how do you cancel a promise?

related: #33346

I'm not sure if there is a more JavaScripty term than "cancellation", but we probably don't want the noun of "abort".