### PR TITLE
Add sameSiteCookies option to SharedWorker options

### DIFF
--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -52,11 +52,20 @@ new SharedWorker(aURL, options)
       - : A string specifying an
         identifying name for the {{domxref("SharedWorkerGlobalScope")}} representing the
         scope of the worker, which is mainly useful for debugging purposes.
+    - `sameSiteCookies`
+      - : A string indicating which [`SameSite` cookies](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value)
+        should be available to the worker. Can have one of the following two values:
+        - 'all'
+          - : `SameSite=Strict`, `SameSite=Lax`, and `SameSite=None` cookies will all be available to the worker.
+            This option is only supported in first-party contexts.
+        - 'none'
+          - : Only `SameSite=None` cookies will be available to the worker. This option is supported in first-party
+            and third-party contexts.
 
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the document is not allowed to start workers, for example if the URL has an invalid syntax or if the same-origin policy is violated.
+  - : Thrown if the document is not allowed to start workers, for example if the URL has an invalid syntax or if the same-origin policy is violated, or if the `sameSiteCookies` value is not supported in the given context.
 - `NetworkError` {{domxref("DOMException")}}
   - : Thrown if the MIME type of the worker script is incorrect. It should _always_ be `text/javascript` (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript) may be accepted).
 - `SyntaxError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -57,10 +57,10 @@ new SharedWorker(aURL, options)
         should be available to the worker. Can have one of the following two values:
         - 'all'
           - : `SameSite=Strict`, `SameSite=Lax`, and `SameSite=None` cookies will all be available to the worker.
-            This option is only supported in first-party contexts.
+            This option is only supported in first-party contexts, and is the default in first-party contexts.
         - 'none'
           - : Only `SameSite=None` cookies will be available to the worker. This option is supported in first-party
-            and third-party contexts.
+            and third-party contexts, and is the default in third-party contexts.
 
 ### Exceptions
 

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -4,6 +4,7 @@ short-title: SharedWorker()
 slug: Web/API/SharedWorker/SharedWorker
 page-type: web-api-constructor
 browser-compat: api.SharedWorker.SharedWorker
+spec-urls: https://privacycg.github.io/saa-non-cookie-storage/
 ---
 
 {{APIRef("Web Workers API")}}

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -4,7 +4,9 @@ short-title: SharedWorker()
 slug: Web/API/SharedWorker/SharedWorker
 page-type: web-api-constructor
 browser-compat: api.SharedWorker.SharedWorker
-spec-urls: https://privacycg.github.io/saa-non-cookie-storage/
+spec-urls:
+  - https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworker-dev
+  - https://privacycg.github.io/saa-non-cookie-storage/
 ---
 
 {{APIRef("Web Workers API")}}

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -4,9 +4,6 @@ short-title: SharedWorker()
 slug: Web/API/SharedWorker/SharedWorker
 page-type: web-api-constructor
 browser-compat: api.SharedWorker.SharedWorker
-spec-urls:
-  - https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworker-dev
-  - https://privacycg.github.io/saa-non-cookie-storage/
 ---
 
 {{APIRef("Web Workers API")}}


### PR DESCRIPTION
### Description

This is the second of 3 PRs adding spec changes from https://privacycg.github.io/saa-non-cookie-storage/ launching in Chrome 125.

### Motivation

sameSiteCookies is a new option for SharedWorker construction that allows a given worker to be restricted to `SameSite=None` cookies even when created in a first-party context. This is important as only workers without access to `SameSite=Lax` and `SameSite=Strict` cookies can be accessed via requestStorageAccess.

### Additional details

https://chromestatus.com/feature/5175585823522816

### Related issues and pull requests

Relates to https://github.com/mdn/mdn/issues/543