### PR TITLE
Clarify the return value of Number() constructor

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/boolean/index.md
@@ -27,9 +27,9 @@ Boolean(value)
 
 ### Return value
 
-When `Boolean()` is called as a constructor (with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it creates a {{jsxref("Boolean")}} object, which is **not** a primitive.
+When `Boolean()` is called as a function (without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it returns `value` [coerced to a boolean primitive](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
 
-When `Boolean()` is called as a function (without `new`), it coerces the parameter to a boolean primitive.
+When `Boolean()` is called as a constructor (with `new`), it coerces `value` to a boolean primitive and returns a wrapping {{jsxref("Boolean")}} object, which is **not** a primitive.
 
 > **Warning:** You should rarely find yourself using `Boolean` as a constructor.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/number/index.md
@@ -25,9 +25,11 @@ Number(value)
 
 ### Return value
 
-When `Number` is called as a constructor (with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it creates a {{jsxref("Number")}} object, which is **not** a primitive.
+Whether you called `Number` as a constructor or as a function, it [coerces the parameter to a number primitive](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion). [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) are converted to numbers. If the value can't be converted, it will be coerced as {{jsxref("NaN")}}.
 
-When `Number` is called as a function, it [coerces the parameter to a number primitive](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion). [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) are converted to numbers. If the value can't be converted, it returns {{jsxref("NaN")}}.
+When `Number` is called as a constructor (with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it creates a {{jsxref("Number")}} object that wraps the coerced value and returns it, which is **not** a primitive.
+
+When `Number` is called as a function, it returns the coerced value itself as a primitive value.
 
 > **Warning:** You should rarely find yourself using `Number` as a constructor.
 

--- a/files/en-us/web/javascript/reference/global_objects/number/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/number/index.md
@@ -25,11 +25,9 @@ Number(value)
 
 ### Return value
 
-Whether you called `Number` as a constructor or as a function, it [coerces the parameter to a number primitive](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion). [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) are converted to numbers. If the value can't be converted, it will be coerced as {{jsxref("NaN")}}.
+When `Number()` is called as a function (without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it returns `value` [coerced to a number primitive](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion). Specially, [BigInts](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) values are converted to numbers instead of throwing. If `value` is absent, it becomes `0`.
 
-When `Number` is called as a constructor (with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it creates a {{jsxref("Number")}} object that wraps the coerced value and returns it, which is **not** a primitive.
-
-When `Number` is called as a function, it returns the coerced value itself as a primitive value.
+When `Number()` is called as a constructor (with `new`), it uses the coercion process above and returns a wrapping {{jsxref("Number")}} object, which is **not** a primitive.
 
 > **Warning:** You should rarely find yourself using `Number` as a constructor.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/string/index.md
@@ -25,9 +25,9 @@ String(thing)
 
 ### Return value
 
-When `String` is called as a constructor (with `new`), it creates a {{jsxref("String")}} object, which is **not** a primitive.
+When `String()` is called as a function (without [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new)), it returns `value` [coerced to a string primitive](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion). Specially, [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) values are converted to `"Symbol(description)"`, where `description` is the [description](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description) of the Symbol, instead of throwing.
 
-When `String` is called as a function, it coerces the parameter to a string primitive. [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) values would be converted to `"Symbol(description)"`, where `description` is the [description](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description) of the Symbol, instead of throwing.
+When `String()` is called as a constructor (with `new`), it coerces `value` to a string primitive (without special symbol handling) and returns a wrapping {{jsxref("String")}} object, which is **not** a primitive.
 
 > **Warning:** You should rarely find yourself using `String` as a constructor.
 


### PR DESCRIPTION
The current state of the return value may be mistaken that only type coercion happens when the Number() called as a function, so I clarified that type coercion happens in both cases (called as a constructor or as a function)