### PR TITLE
GetAttribute returns null for non-existing attributes

### DIFF
--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -13,7 +13,7 @@ The **`getAttribute()`** method of the
 element.
 
 If the given attribute does not exist, the value returned will
-either be `null` or `""` (the empty string); see [Non-existing attributes](#non-existing_attributes) for details.
+be `null`. See [Non-existing attributes](#non-existing_attributes) for details.
 
 If you need to inspect the {{domxref("Attr")}} node's properties, you can use the {{domxref("Element.getAttributeNode()", "getAttributeNode()")}} method instead.
 


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Following up fc294fbbf432b5b210e0394e23b5c8950e81d734. The legacy behavior of returning `""` for non-existing attributes has gone in modern browsers.

