### PR TITLE
Clarify the return value of `getAttribute`

### DIFF
--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -29,7 +29,7 @@ getAttribute(attributeName)
 
 ### Return value
 
-A string containing the value of `attributeName`.
+A string containing the value of `attributeName` if the attribute exists, otherwise `null`.
 
 ## Examples
 
@@ -56,10 +56,6 @@ const align = div1.getAttribute("align");
 
 When called on an HTML element in a DOM flagged as an HTML document,
 `getAttribute()` lower-cases its argument before proceeding.
-
-### Non-existing attributes
-
-All modern web browsers return `null` when the specified attribute does not exist on the specified element.
 
 ### Retrieving nonce values
 

--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -12,8 +12,7 @@ The **`getAttribute()`** method of the
 {{domxref("Element")}} interface returns the value of a specified attribute on the
 element.
 
-If the given attribute does not exist, the value returned will
-be `null`. See [Non-existing attributes](#non-existing_attributes) for details.
+If the given attribute does not exist, the value returned will be `null`.
 
 If you need to inspect the {{domxref("Attr")}} node's properties, you can use the {{domxref("Element.getAttributeNode()", "getAttributeNode()")}} method instead.
 


### PR DESCRIPTION
The returned value may not be a string. Absorb one subsection in "Description" to be more concisely explained under the "Return value" section.

