### PR TITLE
glossary: update baseline

### DIFF
--- a/files/en-us/glossary/baseline/compatibility/index.md
+++ b/files/en-us/glossary/baseline/compatibility/index.md
@@ -61,3 +61,4 @@ If you have questions, feedback, or want to help update and expand the features 
 - [web-platform-dx/web-features repository](https://github.com/web-platform-dx/web-features)
 - [W3C WebDX Community Group](https://www.w3.org/community/webdx/)
 - [mdn/browser-compat-data repository](https://github.com/mdn/browser-compat-data)
+- [Baseline (Configuration Management)](<https://en.wikipedia.org/wiki/Baseline_(configuration_management)>) on Wikipedia

--- a/files/en-us/glossary/baseline/compatibility/index.md
+++ b/files/en-us/glossary/baseline/compatibility/index.md
@@ -61,4 +61,3 @@ If you have questions, feedback, or want to help update and expand the features 
 - [web-platform-dx/web-features repository](https://github.com/web-platform-dx/web-features)
 - [W3C WebDX Community Group](https://www.w3.org/community/webdx/)
 - [mdn/browser-compat-data repository](https://github.com/mdn/browser-compat-data)
-- [Baseline (Configuration Management)](<https://en.wikipedia.org/wiki/Baseline_(configuration_management)>) on Wikipedia

--- a/files/en-us/glossary/baseline/index.md
+++ b/files/en-us/glossary/baseline/index.md
@@ -9,7 +9,3 @@ page-type: glossary-disambiguation
 The term **baseline** can have several meanings depending on the context. It may refer to:
 
 {{GlossaryDisambiguation}}
-
-## See also
-
-- [Baseline](https://en.wikipedia.org/wiki/Baseline) on Wikipedia

--- a/files/en-us/glossary/baseline/typography/index.md
+++ b/files/en-us/glossary/baseline/typography/index.md
@@ -6,7 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The **baseline** is a term used in European and West Asian typography meaning an imaginary line upon which the characters of a font rest.
+The **baseline** is a term used in European and West Asian typography meaning an imaginary line upon which the most characters of a font rest.
+
+East Asian scripts have no baseline; each glyph sits in a square box, with neither ascenders nor descenders. When mixed with scripts with a low baseline, East Asian characters should be set so that the bottom of the character is between the baseline and the descender height.
 
 {{GlossaryDisambiguation}}
 

--- a/files/en-us/glossary/baseline/typography/index.md
+++ b/files/en-us/glossary/baseline/typography/index.md
@@ -12,5 +12,5 @@ The **baseline** is a term used in European and West Asian typography meaning an
 
 ## See also
 
-- [Baseline](<https://en.wikipedia.org/wiki/Baseline_(typography)>) on Wikipedia
+- [Baseline (Typography)](<https://en.wikipedia.org/wiki/Baseline_(typography)>) on Wikipedia
 - [CSS Box Alignment](/en-US/docs/Web/CSS/CSS_box_alignment#types_of_alignment) on MDN


### PR DESCRIPTION
### Description

links modification

1. `baseline/index.md` wikipedia link removal
2. `baseline/typography/index.md` 
    1. wikipedia link name modified from `baseline` => `baseline (typography)`
    2. `chars of font` => `most chars of font`
    3. add east-asian baseline description
4. ~~`baseline/compatibility/index.md` wikipedia link added: `Baseline_(configuration_management)`~~

### Motivation

1. & 2.1 the wikipedia disambigious page got so many unrelated information that is unrelevent to the glossary (baseline*) we describe here.

    will it be better to link to baseline(typograph) and add a link to baseline(configuration management?), or just delete the link in baseline, add it respectively in baseline/compatibility & baseline/typography

2.2 some chars, like those have `descenders`(e.g. `y`), does not rest on it, but below the baseline its descender extends.

2.3 add description for east-asian chars baseline

### Additional details

![image](https://github.com/mdn/content/assets/41184947/54199fbd-e890-4f15-9681-2774174bcfdd)

[w: baseline_(configuration management)](https://en.wikipedia.org/wiki/Baseline_(configuration_management)) is related to baseline in Configuration, or in VCS, where it defines:

> a baseline is an agreed description of the attributes of a product, at a point in time, which serves as a basis for defining change.[[1]](https://en.wikipedia.org/wiki/Baseline_(configuration_management)#cite_note-1) A change is a movement from this baseline [state](https://en.wikipedia.org/wiki/State_(computer_science)) to a next state. The identification of significant changes from the baseline state is the central purpose of baseline identification.

[w: baseline_(typography)](https://en.wikipedia.org/wiki/Baseline_(typography)) is related to baseline in typography, where it defines:

> In European and West Asian [typography](https://en.wikipedia.org/wiki/Typography) and [penmanship](https://en.wikipedia.org/wiki/Penmanship), the baseline is the line upon which most letters sit and below which [descenders](https://en.wikipedia.org/wiki/Descender) extend.

### Related issues and pull requests

Fixes #33349 
Related PR #26676 where in the merge, baseline/compatibilitiy was added and baseline's link to wikipedia was modified to a disambigious link (`w: baseline_(typography)` => `w: baseline`).
