### PR TITLE
glossary: update entry arpa

### DIFF
--- a/files/en-us/glossary/arpa/index.md
+++ b/files/en-us/glossary/arpa/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 **.arpa** (address and routing parameter area) is a {{glossary("TLD","top-level domain")}} in the Domain Name System (DNS) used for Internet infrastructure purposes, especially reverse DNS lookup (i.e., find the {{glossary('domain name')}} for a given {{glossary("IP address")}}).
 
-The name came from **ARPA**, currently known as [DARPA](https://en.wikipedia.org/wiki/DARPA), the Defense Advanced Research Projects Agency. DARPA is credited with developing precursors to the Internet ({{glossary("ARPANET")}}), GPS, artificial intelligence, and virtual reality. The domain was originally intended only to serve in a temporary function for facilitating the systematic naming of the ARPANET computers, but failed to remove it after infrastructural uses had been sanctioned. As a result, the name was backronym as address and routing parameter area.
+The name came from **ARPA**, currently known as [DARPA](https://en.wikipedia.org/wiki/DARPA), the Defense Advanced Research Projects Agency. DARPA is credited with developing precursors to the Internet ({{glossary("ARPANET")}}), GPS, artificial intelligence, and virtual reality. The domain was originally intended only to serve a temporary function for facilitating the systematic naming of the ARPANET computers, but failed to remove it after infrastructural uses had been sanctioned. As a result, the ARPA domain name is a backronym for “Address and Routing Parameter Area”.
 
 {{glossary("TLD")}} was designed at DARPA during a time when it was called ARPA, hence the `.arpa` domain name.
 

--- a/files/en-us/glossary/arpa/index.md
+++ b/files/en-us/glossary/arpa/index.md
@@ -8,11 +8,11 @@ page-type: glossary-definition
 
 **.arpa** (address and routing parameter area) is a {{glossary("TLD","top-level domain")}} in the Domain Name System (DNS) used for Internet infrastructure purposes, especially reverse DNS lookup (i.e., find the {{glossary('domain name')}} for a given {{glossary("IP address")}}).
 
-The name comes from **ARPA**, currently known as [DARPA](https://en.wikipedia.org/wiki/DARPA), the Defense Advanced Research Projects Agency. DARPA is credited with developing precursors to the Internet ({{glossary("ARPANET")}}), GPS, artificial intelligence, and virtual reality.
+The name came from **ARPA**, currently known as [DARPA](https://en.wikipedia.org/wiki/DARPA), the Defense Advanced Research Projects Agency. DARPA is credited with developing precursors to the Internet ({{glossary("ARPANET")}}), GPS, artificial intelligence, and virtual reality. The domain was originally intended only to serve in a temporary function for facilitating the systematic naming of the ARPANET computers, but failed to remove it after infrastructural uses had been sanctioned. As a result, the name was backronym as address and routing parameter area.
 
 {{glossary("TLD")}} was designed at DARPA during a time when it was called ARPA, hence the `.arpa` domain name.
 
-The most prominent `.arpa` domains include `addr.arpa` and `ip6.arpa`, which provide namespaces for reverse DNS lookup of IPv4 and IPv6 addresses respectively.
+The most prominent `.arpa` domains include `in-addr.arpa` and `ip6.arpa`, which provide namespaces for reverse DNS lookup of IPv4 and IPv6 addresses respectively.
 
 ## See also
 


### PR DESCRIPTION
### Description

1. fix incorrect link from `addr.arpa` to `in-addr.arpa`
2. add incomplete the domain's history (arpa's name, formerly **A**dvanced..., now **A**ddress...)

### Motivation

1. https://www.iana.org/domains/arpa actually points ipv4's resolving to `in-addr.arpa`, and NO `addr.arpa` was on the list
2. missing information

### Additional details

### Related issues and pull requests