### PR TITLE
Add guidance about how to describe the value of a property

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -88,7 +88,11 @@ You could copy most of this from the property's summary on the corresponding API
 
 ## Value
 
-Include a description of the property's value, including data type and what it represents.
+Include a description of the property's value, including data type and what it represents. This should be in the form: "A [name of the property type] representing ...". For example:
+
+> A string representing...
+
+Note that some property pages are written in the form "Returns a [name of the property type] representing..." but this is not the recommended form.
 
 ## Examples
 


### PR DESCRIPTION
This is intended to clarify how we describe property values, and in particular to discourage people from documenting a property value like "Returns a string...", as resolved in the #writing-docs meeting: https://docs.google.com/document/d/1AtzS1D6H4fsyHoSY52sJPHG57MBBqjGWievQV4kAuHY/edit#heading=h.jxjowp9ndtkc.