### PR TITLE
glossary: fix blink typo

### DIFF
--- a/files/en-us/glossary/blink/index.md
+++ b/files/en-us/glossary/blink/index.md
@@ -14,7 +14,6 @@ Blink is an open-source browser rendering engine developed by Google as part of 
 - [Blink](<https://en.wikipedia.org/wiki/Blink_(browser_engine)>) on Wikipedia
 - [FAQ](https://www.chromium.org/blink/developer-faq/) on Blink
 - [Glossary](/en-US/docs/Glossary)
-
   - {{glossary("Google Chrome")}}
   - {{glossary("Gecko")}}
   - {{glossary("Trident")}}

--- a/files/en-us/glossary/blink/index.md
+++ b/files/en-us/glossary/blink/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Blink is an open-source browser layout engine developed by Google as part of Chromium (and therefore part of {{glossary("Google Chrome", "Chrome")}} as well). Specifically, Blink began as a fork of the WebCore library in {{glossary("WebKit")}}, which handles layout, rendering, and {{glossary("DOM")}}, but now stands on its own as a separate {{glossary("rendering engine")}}.
+Blink is an open-source browser rendering engine developed by Google as part of Chromium (and therefore part of {{glossary("Google Chrome", "Chrome")}} as well). Specifically, Blink began as a fork of the WebCore library in {{glossary("WebKit")}}, which handles layout, rendering, and {{glossary("DOM")}}, but now stands on its own as a separate {{glossary("rendering engine")}}.
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

`layout engine` => `rendering engine`

### Motivation

Blink is now a rendering engine

- last sentence of line 9: `but now stands on its own as a separate {{glossary("rendering engine")}}.`
- chromium: [Blink is the name of the rendering engine used by Chromium and particularly refers to the code living under src/third_party/blink.](https://www.chromium.org/blink/)
- see also: {{glossary("Rendering engine")}}
 