### PR TITLE
Intl.DateTimeFormat.formatToParts: fix 'timeZoneName' type

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -66,7 +66,7 @@ Possible types are the following:
     calendar's representation would be a yearName instead of a year, for example `"2019"`.
 - `second`
   - : The string used for the second, for example `"07"` or `"42"`.
-- `timeZone`
+- `timeZoneName`
   - : The string used for the name of the time zone, for example `"UTC"`. Default is the timezone of the current environment.
 - `weekday`
   - : The string used for the weekday, for example `"M"`, `"Monday"`, or `"Montag"`.


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The actual type is `timeZoneName`; see the [spec](https://tc39.es/ecma402/#sec-formatdatetimepattern).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current page lists the type as `timeZone`, which is incorrect and can mislead readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Specification: https://tc39.es/ecma402/#sec-formatdatetimepattern

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
