### PR TITLE
glossary: update attribute

### DIFF
--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -10,14 +10,20 @@ An **attribute** extends an HTML or XML {{Glossary("element")}}, changing its be
 
 An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value).
 
-You may see attributes without the equals sign or a value. That is a shorthand for providing the empty string in HTML, or the attribute's name in XML.
+You may see attributes without the equals sign or a value. That is a shorthand for providing the empty string in HTML, which is considered as a [boolean attribute](/en-US/docs/Web/HTML/Attributes#boolean_attributes). However, this is not allowed in XML, as XML required attribute name must follows an equals sign.
+
+The following code shows a good example of a boolean attribute in HTML:
 
 ```html
 <input required />
-<!-- is the same as… -->
+<!-- equivalent in HTML -->
 <input required="" />
-<!-- or -->
-<input required="required" />
+```
+
+While in XML, code like this will throw a syntax error:
+
+```xml-nolint example-bad
+<tag id />
 ```
 
 ## Reflection of an attribute
@@ -51,3 +57,4 @@ console.log(attr.value); // Prints `Modified placeholder`
 
 - [HTML attribute reference](/en-US/docs/Web/HTML/Attributes)
 - Information about HTML's [global attributes](/en-US/docs/Web/HTML/Global_attributes)
+- XML StartTag Attribute Recommendation in [W3C XML Recommendation](https://www.w3.org/TR/xml#sec-starttags)

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -10,17 +10,17 @@ An **attribute** extends an HTML or XML {{Glossary("element")}}, changing its be
 
 An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value).
 
-You may see attributes without the equals sign or a value. That is a shorthand for providing the empty string in HTML, which is considered as a [boolean attribute](/en-US/docs/Web/HTML/Attributes#boolean_attributes). However, this is not allowed in XML, as XML required attribute name must follows an equals sign.
+You may see attributes without an equals sign or a value. That is a shorthand for providing the empty string in HTML; such attributes are considered to be [boolean attributes](/en-US/docs/Web/HTML/Attributes#boolean_attributes). However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
 
-The following code shows a good example of a boolean attribute in HTML:
+The following code provides examples of different boolean attribute forms in HTML:
 
-```html
+```html example-good
 <input required />
-<!-- equivalent in HTML -->
+<!-- is equivalent to -->
 <input required="" />
 ```
 
-While in XML, code like this will throw a syntax error:
+In XML, attributes without equals sign or value will throw a syntax error:
 
 ```xml-nolint example-bad
 <tag id />

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -18,6 +18,8 @@ The following code provides examples of different boolean attribute forms in HTM
 <input required />
 <!-- is equivalent to -->
 <input required="" />
+<!-- or -->
+<input required="anything" />
 ```
 
 In XML, attributes without equals sign or value will throw a syntax error:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

xml attribute behaviour fixes

### Motivation

1. in most compiler/parser, xml attribute with no `=` and `"value"` is not allowed and will throw an error of "the spec mandates value for attribute #attr"
2. in w3c recommendation of XML, attribute is defined as `attr eq value`

### Additional details

1. w3c https://www.w3.org/TR/xml#sec-starttags
2. xml validator (searched google and chose first five parser, all throw the same error)

tested that will throw an error:

```xml
<tag id />
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
