### PR TITLE
glossary: remove self ref

### DIFF
--- a/files/en-us/glossary/cipher/index.md
+++ b/files/en-us/glossary/cipher/index.md
@@ -26,7 +26,6 @@ They also are classified according to how their {{glossary("key", "keys")}} are 
 - [MDN Web Docs Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("Block cipher mode of operation")}}
-  - {{Glossary("Cipher")}}
   - {{Glossary("Ciphertext")}}
   - {{Glossary("Cipher suite")}}
   - {{Glossary("Cryptanalysis")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

remove glossary link to the current page

### Motivation

`see also` section's name infers that references in the section should be something other than the document itself