### PR TITLE
glossary: lint link

### DIFF
--- a/files/en-us/glossary/code_splitting/index.md
+++ b/files/en-us/glossary/code_splitting/index.md
@@ -14,7 +14,6 @@ Code splitting is a feature supported by bundlers like [Webpack](https://webpack
 
 ## See also
 
-- Bundling
 - [Lazy loading](/en-US/docs/Web/Performance/Lazy_loading)
 - [HTTP/2](/en-US/docs/Glossary/HTTP_2)
 - [Tree shaking](/en-US/docs/Glossary/Tree_shaking)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

remove a text in the see also section

### Motivation

no link was assigned to the text, and no similar entry can be found on either MDN or wikipedia

the link was here since commit `cbe151a06d6e5b4d1fbb46081bd16e69ef4c1630` on html file checkin
