### PR TITLE
Remove allow-downloads-without-user-activation sandbox value

### DIFF
--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -97,8 +97,6 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     - `allow-downloads`
       - : Allows downloading files through an {{HTMLElement("a")}} or {{HTMLElement("area")}} element with the [download](/en-US/docs/Web/HTML/Element/a#download) attribute, as well as through the navigation that leads to a download of a file. This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction.
-    - `allow-downloads-without-user-activation` {{experimental_inline}}
-      - : Allows for downloads to occur without a gesture from the user.
     - `allow-forms`
       - : Allows the page to submit forms. If this keyword is not used, form will be displayed as normal, but submitting it will not trigger input validation, sending data to a web server or closing a dialog.
     - `allow-modals`

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -45,8 +45,6 @@ where `<value>` can optionally be one of the following values:
 
 - `allow-downloads`
   - : Allows downloading files through an {{HTMLElement("a")}} or {{HTMLElement("area")}} element with the [download](/en-US/docs/Web/HTML/Element/a#download) attribute, as well as through the navigation that leads to a download of a file. This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction.
-- `allow-downloads-without-user-activation` {{experimental_inline}}
-  - : Allows for downloads to occur without a gesture from the user.
 - `allow-forms`
   - : Allows the page to submit forms. If this keyword is not used, form will be displayed as normal, but submitting it will not trigger input validation, sending data to a web server or closing a dialog.
 - `allow-modals`


### PR DESCRIPTION
This was implemented in Chrome at one time, but has been removed. No browser seems to support this currently. There is an open issue with a request to implement this, but that does not seem very active and that does not seem enough to document it on MDN, even as experimental.

- https://groups.google.com/a/chromium.org/g/blink-dev/c/JdAQ6HNoZvk?pli=1
- https://chromestatus.com/feature/5706745674465280
- https://github.com/whatwg/html/issues/3236
- https://github.com/whatwg/html/issues/5513

Slightly relates to #33334.