### PR TITLE
feat: improvements on glossary articles

### DIFF
--- a/files/en-us/glossary/abstraction/index.md
+++ b/files/en-us/glossary/abstraction/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Abstraction in {{Glossary("computer programming")}} is a way to reduce complexity and allow efficient design and implementation in complex software systems. It hides the technical complexity of systems behind simpler {{Glossary("API", "APIs")}}.
+**Abstraction** in {{Glossary("computer programming")}} is a way to reduce complexity and allow efficient design and implementation in complex software systems. It hides the technical complexity of systems behind simpler {{Glossary("API", "APIs")}}.
 
 ## Advantages of Data Abstraction
 

--- a/files/en-us/glossary/accessibility/index.md
+++ b/files/en-us/glossary/accessibility/index.md
@@ -14,6 +14,6 @@ page-type: glossary-definition
 - [Learn accessibility](/en-US/docs/Learn/Accessibility)
 - [ARIA documentation](/en-US/docs/Web/Accessibility/ARIA)
 - [Web accessibility](https://en.wikipedia.org/wiki/Web_accessibility) on Wikipedia
-- [The WAI-ARIA recommendation](https://www.w3.org/TR/wai-aria/)
+- [Accessible Rich Internet Applications (WAI-ARIA)](https://w3c.github.io/aria/)
 - [The W3C Web Accessibility Initiative](https://www.w3.org/WAI/)
 - [Web Accessibility In Mind](https://webaim.org/)

--- a/files/en-us/glossary/accessibility/index.md
+++ b/files/en-us/glossary/accessibility/index.md
@@ -6,14 +6,14 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-_Web Accessibility_ (**A11Y**) refers to best practices for keeping a website usable despite physical and technical restrictions. Web accessibility is formally defined and discussed at the {{Glossary("W3C")}} through the {{Glossary("WAI","Web Accessibility Initiative")}} (WAI).
+**Accessibility** (**A11Y**) refers to best practices for keeping a website usable despite physical and technical restrictions. Web accessibility is formally defined and discussed at the {{Glossary("W3C")}} through the {{Glossary("WAI","Web Accessibility Initiative")}} (WAI).
 
 ## See also
 
-- [Accessibility resources at MDN](/en-US/docs/Web/Accessibility)
-- [Learn accessibility on MDN](/en-US/docs/Learn/Accessibility)
-- [ARIA documentation on MDN](/en-US/docs/Web/Accessibility/ARIA)
-- [The WAI-ARIA recommendation](https://www.w3.org/TR/wai-aria/)
+- [Accessibility resources](/en-US/docs/Web/Accessibility)
+- [Learn accessibility](/en-US/docs/Learn/Accessibility)
+- [ARIA documentation](/en-US/docs/Web/Accessibility/ARIA)
 - [Web accessibility](https://en.wikipedia.org/wiki/Web_accessibility) on Wikipedia
-- [Web Accessibility In Mind](https://webaim.org/)
+- [The WAI-ARIA recommendation](https://www.w3.org/TR/wai-aria/)
 - [The W3C Web Accessibility Initiative](https://www.w3.org/WAI/)
+- [Web Accessibility In Mind](https://webaim.org/)

--- a/files/en-us/glossary/adobe_flash/index.md
+++ b/files/en-us/glossary/adobe_flash/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-[Flash](https://en.wikipedia.org/wiki/Adobe_Flash) is an obsolete technology developed by Adobe for viewing expressive web applications, multimedia content, and streaming media.
+[**Flash**](https://en.wikipedia.org/wiki/Adobe_Flash) is an obsolete technology developed by Adobe for viewing expressive web applications, multimedia content, and streaming media.
 
 As of 2021, Flash is no longer supported by Adobe or any major web browsers.
 

--- a/files/en-us/glossary/api/index.md
+++ b/files/en-us/glossary/api/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An API (Application Programming Interface) is a set of features and rules that exist inside a software program (the application) enabling interaction with it through software - as opposed to a human user interface. The API can be seen as a simple contract (the interface) between the application offering it and other items, such as third-party software or hardware.
+An **API** (Application Programming Interface) is a set of features and rules that exist inside a software program (the application) enabling interaction with it through software - as opposed to a human user interface. The API can be seen as a simple contract (the interface) between the application offering it and other items, such as third-party software or hardware.
 
 In Web development, an API is generally a set of code features (e.g. {{glossary("method","methods")}}, {{Glossary("property","properties")}}, events, and {{Glossary("URL","URLs")}}) that a developer can use in their apps for interacting with components of a user's web browser, other software/hardware on the user's computer, or third-party websites and services.
 

--- a/files/en-us/glossary/apple_safari/index.md
+++ b/files/en-us/glossary/apple_safari/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-[Safari](https://www.apple.com/safari/) is a {{Glossary("Browser","Web browser")}} developed by Apple and bundled with macOS, iPadOS, and iOS. It's based on the open-source [WebKit](https://webkit.org/) engine.
+[**Safari**](https://www.apple.com/safari/) is a {{Glossary("Browser","Web browser")}} developed by Apple and bundled with macOS, iPadOS, and iOS. It's based on the open-source [WebKit](https://webkit.org/) engine.
 
 ## See also
 

--- a/files/en-us/glossary/array/index.md
+++ b/files/en-us/glossary/array/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An _array_ is an ordered collection of data (either {{Glossary("primitive")}} or {{Glossary("object")}} depending upon the language). Arrays are used to store multiple values under a single variable name. A regular variable, on the other hand, can store only one value.
+An **array** is an ordered collection of data (either {{Glossary("primitive")}} or {{Glossary("object")}} depending upon the language). Arrays are used to store multiple values under a single variable name. A regular variable, on the other hand, can store only one value.
 
 Each item in an array has a number attached to it, called a numeric index, that allows you to access it. In JavaScript, arrays start at index zero and can be manipulated with various {{Glossary("Method", "methods")}}.
 
@@ -24,4 +24,4 @@ console.log(barbieDollNamesArray[2]); // output: "Midge"
 
 ## See also
 
-- JavaScript {{jsxref("Array")}} on MDN
+- JavaScript {{jsxref("Array")}}

--- a/files/en-us/glossary/atag/index.md
+++ b/files/en-us/glossary/atag/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-ATAG (Authoring Tool {{glossary("Accessibility")}} Guidelines) is a {{Glossary("W3C")}} recommendation for building accessible-authoring tools that produce accessible contents.
+**ATAG** (Authoring Tool {{glossary("Accessibility")}} Guidelines) is a {{Glossary("W3C")}} recommendation for building accessible-authoring tools that produce accessible contents.
 
 ## See also
 

--- a/files/en-us/glossary/atag/index.md
+++ b/files/en-us/glossary/atag/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**ATAG** (Authoring Tool {{glossary("Accessibility")}} Guidelines) is a {{Glossary("W3C")}} recommendation for building accessible-authoring tools that produce accessible contents.
+**Authoring Tool {{glossary("Accessibility")}} Guidelines (ATAG)** is a {{Glossary("W3C")}} recommendation for building accessible-authoring tools that produce accessible contents.
 
 ## See also
 

--- a/files/en-us/glossary/bandwidth/index.md
+++ b/files/en-us/glossary/bandwidth/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Bandwidth is the measure of how much information can pass through a data connection in a given amount of time. It is usually measured in multiples of bits-per-second (bps), for example megabits-per-second (Mbps) or gigabits-per-second (Gbps).
+**Bandwidth** is the measure of how much information can pass through a data connection in a given amount of time. It is usually measured in multiples of bits-per-second (bps), for example megabits-per-second (Mbps) or gigabits-per-second (Gbps).
 
 ## See also
 

--- a/files/en-us/glossary/baseline/typography/index.md
+++ b/files/en-us/glossary/baseline/typography/index.md
@@ -14,5 +14,5 @@ East Asian scripts have no baseline; each glyph sits in a square box, with neith
 
 ## See also
 
-- [CSS Box Alignment](/en-US/docs/Web/CSS/CSS_box_alignment#types_of_alignment)
+- [CSS box alignment](/en-US/docs/Web/CSS/CSS_box_alignment#types_of_alignment)
 - [Baseline (Typography)](<https://en.wikipedia.org/wiki/Baseline_(typography)>) on Wikipedia

--- a/files/en-us/glossary/baseline/typography/index.md
+++ b/files/en-us/glossary/baseline/typography/index.md
@@ -14,5 +14,5 @@ East Asian scripts have no baseline; each glyph sits in a square box, with neith
 
 ## See also
 
+- [CSS Box Alignment](/en-US/docs/Web/CSS/CSS_box_alignment#types_of_alignment)
 - [Baseline (Typography)](<https://en.wikipedia.org/wiki/Baseline_(typography)>) on Wikipedia
-- [CSS Box Alignment](/en-US/docs/Web/CSS/CSS_box_alignment#types_of_alignment) on MDN

--- a/files/en-us/glossary/blink/index.md
+++ b/files/en-us/glossary/blink/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Blink is an open-source browser rendering engine developed by Google as part of Chromium (and therefore part of {{glossary("Google Chrome", "Chrome")}} as well). Specifically, Blink began as a fork of the WebCore library in {{glossary("WebKit")}}, which handles layout, rendering, and {{glossary("DOM")}}, but now stands on its own as a separate {{glossary("rendering engine")}}.
+**Blink** is an open-source browser rendering engine developed by Google as part of Chromium (and therefore part of {{glossary("Google Chrome", "Chrome")}} as well). Specifically, Blink began as a fork of the WebCore library in {{glossary("WebKit")}}, which handles layout, rendering, and {{glossary("DOM")}}, but now stands on its own as a separate {{glossary("rendering engine")}}.
 
 ## See also
 

--- a/files/en-us/glossary/block/scripting/index.md
+++ b/files/en-us/glossary/block/scripting/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In {{glossary("JavaScript")}}, a block is a collection of related {{glossary("statement","statements")}} enclosed in braces ("{}"). For example, you can put a block of statements after an {{jsxref("Statements/if...else","if (condition)")}} block, indicating that the interpreter should run the code inside the block if the condition is true, or skip the whole block if the condition is false.
+In {{glossary("JavaScript")}}, a **block** is a collection of related {{glossary("statement","statements")}} enclosed in braces ("{}"). For example, you can put a block of statements after an {{jsxref("Statements/if...else","if (condition)")}} block, indicating that the interpreter should run the code inside the block if the condition is true, or skip the whole block if the condition is false.
 
 ## See also
 

--- a/files/en-us/glossary/block_cipher_mode_of_operation/index.md
+++ b/files/en-us/glossary/block_cipher_mode_of_operation/index.md
@@ -6,6 +6,6 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A block cipher mode of operation, usually just called a "mode" in context, specifies how a block cipher should be used to encrypt or decrypt messages that are longer than the block size.
+A **block cipher mode of operation**, usually just called a "mode" in context, specifies how a block cipher should be used to encrypt or decrypt messages that are longer than the block size.
 
 Most symmetric-key algorithms currently in use are block ciphers: this means that they encrypt data a block at a time. The size of each block is fixed and determined by the algorithm: for example AES uses 16-byte blocks. Block ciphers are always used with a _mode_, which specifies how to securely encrypt messages that are longer than the block size. For example, AES is a cipher, while CTR, CBC, and GCM are all modes. Using an inappropriate mode, or using a mode incorrectly, can completely undermine the security provided by the underlying cipher.

--- a/files/en-us/glossary/bounding_box/index.md
+++ b/files/en-us/glossary/bounding_box/index.md
@@ -6,4 +6,4 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The bounding box of an element is the smallest possible rectangle (aligned with the axes of that element's user coordinate system) that entirely encloses it and its descendants.
+The **bounding box** of an element is the smallest possible rectangle (aligned with the axes of that element's user coordinate system) that entirely encloses it and its descendants.

--- a/files/en-us/glossary/buffer/index.md
+++ b/files/en-us/glossary/buffer/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A buffer is a storage in physical memory used to temporarily store data while it is being transferred from one place to another.
+A **buffer** is a storage in physical memory used to temporarily store data while it is being transferred from one place to another.
 
 ## See also
 

--- a/files/en-us/glossary/caldav/index.md
+++ b/files/en-us/glossary/caldav/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-CalDAV (Calendaring extensions to {{Glossary("WebDAV")}}) is a {{glossary("protocol")}} standardized by the {{Glossary("IETF")}} and used to remotely access calendar data from a {{glossary("server")}}.
+**CalDAV** (Calendaring extensions to {{Glossary("WebDAV")}}) is a {{glossary("protocol")}} standardized by the {{Glossary("IETF")}} and used to remotely access calendar data from a {{glossary("server")}}.
 
 ## See also
 

--- a/files/en-us/glossary/canonical_order/index.md
+++ b/files/en-us/glossary/canonical_order/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In CSS, canonical order is used to refer to the order in which separate values need to be specified (or {{Glossary("parse", "parsed")}}) or are to be {{Glossary("serialization", "serialized")}} as part of a CSS property value. It is defined by the formal {{Glossary("syntax")}} of the property and normally refers to the order in which longhand values should be specified as part of a single shorthand value.
+In CSS, **canonical order** is used to refer to the order in which separate values need to be specified (or {{Glossary("parse", "parsed")}}) or are to be {{Glossary("serialization", "serialized")}} as part of a CSS property value. It is defined by the formal {{Glossary("syntax")}} of the property and normally refers to the order in which longhand values should be specified as part of a single shorthand value.
 
 For example, {{cssxref("background")}} shorthand property values are made up of several `background-*` longhand properties. The canonical order of those longhand values is defined as
 
@@ -23,5 +23,5 @@ Furthermore, its syntax defines, that if a value for the {{cssxref("background-s
 
 ## See also
 
+- [The Description of the formal syntax used for CSS values](/en-US/docs/Web/CSS/Value_definition_syntax)
 - [What does "canonical order" mean with respect to CSS properties?](https://stackoverflow.com/questions/28963536/what-does-canonical-order-mean-with-respect-to-css-properties) on Stack Overflow provides useful further discussion.
-- The [description of the formal syntax used for CSS values](/en-US/docs/Web/CSS/Value_definition_syntax) on MDN

--- a/files/en-us/glossary/canonical_order/index.md
+++ b/files/en-us/glossary/canonical_order/index.md
@@ -23,5 +23,5 @@ Furthermore, its syntax defines, that if a value for the {{cssxref("background-s
 
 ## See also
 
-- [The Description of the formal syntax used for CSS values](/en-US/docs/Web/CSS/Value_definition_syntax)
+- [CSS value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
 - [What does "canonical order" mean with respect to CSS properties?](https://stackoverflow.com/questions/28963536/what-does-canonical-order-mean-with-respect-to-css-properties) on Stack Overflow provides useful further discussion.

--- a/files/en-us/glossary/canvas/index.md
+++ b/files/en-us/glossary/canvas/index.md
@@ -12,9 +12,9 @@ It is a low level, procedural model that updates a [bitmap](https://en.wikipedia
 
 ## See also
 
-- [The Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial)
-- The HTML {{HTMLElement("canvas")}} element
+- [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial)
+- {{HTMLElement("canvas")}} element
 - {{domxref("CanvasRenderingContext2D")}}: The canvas 2D drawing API
-- [The Canvas general documentation](/en-US/docs/Web/API/Canvas_API)
+- [Canvas API](/en-US/docs/Web/API/Canvas_API)
 - [Canvas](https://en.wikipedia.org/wiki/Canvas_element) on Wikipedia
 - [The Canvas 2D API specification](https://html.spec.whatwg.org/multipage/)

--- a/files/en-us/glossary/canvas/index.md
+++ b/files/en-us/glossary/canvas/index.md
@@ -12,9 +12,9 @@ It is a low level, procedural model that updates a [bitmap](https://en.wikipedia
 
 ## See also
 
-- [Canvas](https://en.wikipedia.org/wiki/Canvas_element) on Wikipedia
-- [The Canvas tutorial on MDN](/en-US/docs/Web/API/Canvas_API/Tutorial)
-- The HTML {{HTMLElement("canvas")}} element on MDN
-- [The Canvas general documentation on MDN](/en-US/docs/Web/API/Canvas_API)
+- [The Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial)
+- The HTML {{HTMLElement("canvas")}} element
 - {{domxref("CanvasRenderingContext2D")}}: The canvas 2D drawing API
+- [The Canvas general documentation](/en-US/docs/Web/API/Canvas_API)
+- [Canvas](https://en.wikipedia.org/wiki/Canvas_element) on Wikipedia
 - [The Canvas 2D API specification](https://html.spec.whatwg.org/multipage/)

--- a/files/en-us/glossary/card_sorting/index.md
+++ b/files/en-us/glossary/card_sorting/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Card sorting is a simple technique used in {{glossary("Information architecture")}} whereby people involved in the design of a website (or other type of product) are invited to write down the content / services / features they feel the product should contain, and then organize those features into categories or groupings. This can be used for example to work out what should go on each page of a website. The name comes from the fact that often card sorting is carried out by literally writing the items to sort onto cards, and then arranging the cards into piles.
+**Card sorting** is a simple technique used in {{glossary("Information architecture")}} whereby people involved in the design of a website (or other type of product) are invited to write down the content / services / features they feel the product should contain, and then organize those features into categories or groupings. This can be used for example to work out what should go on each page of a website. The name comes from the fact that often card sorting is carried out by literally writing the items to sort onto cards, and then arranging the cards into piles.
 
 ## See also
 

--- a/files/en-us/glossary/certificate_authority/index.md
+++ b/files/en-us/glossary/certificate_authority/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A certificate authority (CA) is an organization that {{Glossary("Signature/Security", "signs")}} {{Glossary("Digital certificate", "digital certificates")}} and their associated {{Glossary("Key", "public keys")}}, thereby asserting that the contained information and keys are correct.
+A **certificate authority** (CA) is an organization that {{Glossary("Signature/Security", "signs")}} {{Glossary("Digital certificate", "digital certificates")}} and their associated {{Glossary("Key", "public keys")}}, thereby asserting that the contained information and keys are correct.
 
 For a website digital certificate, this information minimally includes the name of the organization that requested the digital certificate (e.g., Mozilla Corporation), the site that it is for (e.g., mozilla.org), and the certificate authority.
 

--- a/files/en-us/glossary/challenge/index.md
+++ b/files/en-us/glossary/challenge/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In security protocols, a _challenge_ is some data sent to the client by the server in order to generate a different response each time. Challenge-response protocols are one way to fight against {{glossary("replay attack", "replay attacks")}} where an attacker listens to the previous messages and resends them at a later time to get the same credentials as the original message.
+In security protocols, a **challenge** is some data sent to the client by the server in order to generate a different response each time. Challenge-response protocols are one way to fight against {{glossary("replay attack", "replay attacks")}} where an attacker listens to the previous messages and resends them at a later time to get the same credentials as the original message.
 
 The [HTTP authentication protocol](/en-US/docs/Web/HTTP/Authentication) is challenge-response based, though the "Basic" protocol isn't using a real challenge (the realm is always the same).
 

--- a/files/en-us/glossary/character/index.md
+++ b/files/en-us/glossary/character/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **character** is either a symbol (letters, numbers, punctuation) or non-printing "control" (e.g., carriage return or soft hyphen). {{glossary("UTF-8")}} is the most common character set and includes the graphemes of the most popular human languages.
+A **character** is either a symbol (letter, number, punctuation) or a non-printing "control" (e.g., carriage return or soft hyphen). {{glossary("UTF-8")}} is the most common character set and includes the graphemes of the most popular human languages.
 
 ## See also
 

--- a/files/en-us/glossary/character/index.md
+++ b/files/en-us/glossary/character/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A _character_ is either a symbol (letters, numbers, punctuation) or non-printing "control" (e.g., carriage return or soft hyphen). {{glossary("UTF-8")}} is the most common character set and includes the graphemes of the most popular human languages.
+A **character** is either a symbol (letters, numbers, punctuation) or non-printing "control" (e.g., carriage return or soft hyphen). {{glossary("UTF-8")}} is the most common character set and includes the graphemes of the most popular human languages.
 
 ## See also
 

--- a/files/en-us/glossary/character_encoding/index.md
+++ b/files/en-us/glossary/character_encoding/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An encoding defines a mapping between bytes and text. A sequence of bytes allows for different textual interpretations. By specifying a particular encoding (such as UTF-8), we specify how the sequence of bytes is to be interpreted.
+An **character encoding** defines a mapping between bytes and text. A sequence of bytes allows for different textual interpretations. By specifying a particular encoding (such as UTF-8), we specify how the sequence of bytes is to be interpreted.
 
 For example, in HTML we normally declare a character encoding of UTF-8, using the following line:
 

--- a/files/en-us/glossary/character_encoding/index.md
+++ b/files/en-us/glossary/character_encoding/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **character encoding** defines a mapping between bytes and text. A sequence of bytes allows for different textual interpretations. By specifying a particular encoding (such as UTF-8), we specify how the sequence of bytes is to be interpreted.
+**Character encoding** defines a mapping between bytes and text. A sequence of bytes allows for different textual interpretations. By specifying a particular encoding (such as UTF-8), we specify how the sequence of bytes is to be interpreted.
 
 For example, in HTML we normally declare a character encoding of UTF-8, using the following line:
 

--- a/files/en-us/glossary/chrome/index.md
+++ b/files/en-us/glossary/chrome/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In a browser, the chrome is any visible aspect of a browser aside from the webpages themselves (e.g., toolbars, menu bar, tabs). This is not to be confused with the {{glossary("Google Chrome")}} browser.
+In a browser, the **chrome** is any visible aspect of a browser aside from the webpages themselves (e.g., toolbars, menu bar, tabs). This is not to be confused with the {{glossary("Google Chrome")}} browser.
 
 ## See also
 

--- a/files/en-us/glossary/cia/index.md
+++ b/files/en-us/glossary/cia/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**CIA** (Confidentiality, Integrity, Availability) (also called the CIA triad or AIC triad) is a model that guides an organization's policies for information security.
+**CIA (Confidentiality, Integrity, Availability)** (also called the CIA triad or AIC triad) is a model that guides an organization's policies for information security.
 
 ## See also
 

--- a/files/en-us/glossary/cia/index.md
+++ b/files/en-us/glossary/cia/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-CIA (Confidentiality, Integrity, Availability) (also called the CIA triad or AIC triad) is a model that guides an organization's policies for information security.
+**CIA** (Confidentiality, Integrity, Availability) (also called the CIA triad or AIC triad) is a model that guides an organization's policies for information security.
 
 ## See also
 

--- a/files/en-us/glossary/cipher_suite/index.md
+++ b/files/en-us/glossary/cipher_suite/index.md
@@ -6,9 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A cipher suite is a combination of a key exchange algorithm, authentication method, bulk encryption {{Glossary("cipher")}}, and message authentication code.
+**Cipher suite** is a combination of a key exchange algorithm, authentication method, bulk encryption {{Glossary("cipher")}}, and message authentication code.
 
-In a {{Glossary("cryptosystem")}} like {{Glossary("TLS")}}, the client and server must agree on a cipher suite before they can begin communicating securely. A typical cipher suite looks like ECDHE_RSA_WITH_AES_128_GCM_SHA256 or ECDHE-RSA-AES128-GCM-SHA256, indicating:
+In a {{Glossary("cryptosystem", "crypto system")}} like {{Glossary("TLS")}}, the client and server must agree on a cipher suite before they can begin communicating securely. A typical cipher suite looks like ECDHE_RSA_WITH_AES_128_GCM_SHA256 or ECDHE-RSA-AES128-GCM-SHA256, indicating:
 
 - ECDHE (elliptic curve Diffie-Hellman ephemeral) for key exchange
 - RSA for authentication

--- a/files/en-us/glossary/cipher_suite/index.md
+++ b/files/en-us/glossary/cipher_suite/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 **Cipher suite** is a combination of a key exchange algorithm, authentication method, bulk encryption {{Glossary("cipher")}}, and message authentication code.
 
-In a {{Glossary("cryptosystem", "crypto system")}} like {{Glossary("TLS")}}, the client and server must agree on a cipher suite before they can begin communicating securely. A typical cipher suite looks like ECDHE_RSA_WITH_AES_128_GCM_SHA256 or ECDHE-RSA-AES128-GCM-SHA256, indicating:
+In a crypto system like {{Glossary("TLS")}}, the client and server must agree on a cipher suite before they can begin communicating securely. A typical cipher suite looks like ECDHE_RSA_WITH_AES_128_GCM_SHA256 or ECDHE-RSA-AES128-GCM-SHA256, indicating:
 
 - ECDHE (elliptic curve Diffie-Hellman ephemeral) for key exchange
 - RSA for authentication

--- a/files/en-us/glossary/ciphertext/index.md
+++ b/files/en-us/glossary/ciphertext/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In {{glossary("cryptography")}}, a ciphertext is a scrambled message that conveys information but is not legible unless {{glossary("decryption","decrypted")}} with the right {{glossary("cipher")}} and the right secret (usually a {{glossary("key")}}), reproducing the original {{glossary("Plaintext")}}. A ciphertext's security, and therefore the secrecy of the contained information, depends on using a secure cipher and keeping the key secret.
+In {{glossary("cryptography")}}, **ciphertext** is a scrambled message that conveys information but is not legible unless {{glossary("decryption","decrypted")}} with the right {{glossary("cipher")}} and the right secret (usually a {{glossary("key")}}), reproducing the original {{glossary("Plaintext")}}. A ciphertext's security, and therefore the secrecy of the contained information, depends on using a secure cipher and keeping the key secret.
 
 ## See also
 

--- a/files/en-us/glossary/class/index.md
+++ b/files/en-us/glossary/class/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In {{glossary("OOP","object-oriented programming")}}, a _class_ defines an {{glossary("object","object's")}} characteristics. Class is a template definition of an object's {{glossary("property","properties")}} and {{glossary("method","methods")}}, the "blueprint" from which other more specific instances of the object are drawn.
+In {{glossary("OOP","object-oriented programming")}}, a **class** defines an {{glossary("object","object's")}} characteristics. Class is a template definition of an object's {{glossary("property","properties")}} and {{glossary("method","methods")}}, the "blueprint" from which other more specific instances of the object are drawn.
 
 ## See also
 

--- a/files/en-us/glossary/clickjacking/index.md
+++ b/files/en-us/glossary/clickjacking/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Clickjacking is an interface-based attack that tricks website users into unwittingly clicking on malicious links. In clickjacking, the attackers embed their malicious links into buttons or legitimate pages in a website. In an infected {{glossary("Site")}}, whenever a user clicks on a legitimate link, the attacker gets the confidential information of that user, which ultimately compromises the user's privacy on the Internet.
+**Clickjacking** is an interface-based attack that tricks website users into unwittingly clicking on malicious links. In clickjacking, the attackers embed their malicious links into buttons or legitimate pages in a website. In an infected {{glossary("Site")}}, whenever a user clicks on a legitimate link, the attacker gets the confidential information of that user, which ultimately compromises the user's privacy on the Internet.
 
 Clickjacking can be prevented by implementing a [Content Security Policy (frame-ancestors)](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) and implementing [Set-Cookie attributes](/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes).
 

--- a/files/en-us/glossary/closure/index.md
+++ b/files/en-us/glossary/closure/index.md
@@ -6,9 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In Computer Programming, a **closure** is a technique for implementing lexically {{glossary("scope", "scoped")}} name binding in a language with first-class {{glossary("function", "functions")}}. In {{glossary("JavaScript")}}, a function creates a closure context.
+In computer programming, a **closure** is a technique for implementing lexically {{glossary("scope", "scoped")}} name binding in a language with first-class {{glossary("function", "functions")}}. In {{glossary("JavaScript")}}, a function creates a closure context.
 
 ## See also
 
-- [Closure in JavaScript](/en-US/docs/Web/JavaScript/Closures)
+- [Closures in JavaScript](/en-US/docs/Web/JavaScript/Closures)
 - [Closure](https://en.wikipedia.org/wiki/Closure_%28computer_programming%29) on Wikipedia

--- a/files/en-us/glossary/closure/index.md
+++ b/files/en-us/glossary/closure/index.md
@@ -6,9 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The binding which defines the **{{glossary("scope")}}** of execution. In {{glossary("JavaScript")}}, **{{glossary("function","functions")}}** create a closure context.
+In Computer Programming, a **closure** is a technique for implementing lexically {{glossary("scope", "scoped)}} name binding in a language with first-class {{glossary("function","functions")}}. In {{glossary("JavaScript")}}, a function creates a closure context.
 
 ## See also
 
+- [Closure in JavaScript](/en-US/docs/Web/JavaScript/Closures)
 - [Closure](https://en.wikipedia.org/wiki/Closure_%28computer_programming%29) on Wikipedia
-- [Closure](/en-US/docs/Web/JavaScript/Closures) on MDN

--- a/files/en-us/glossary/closure/index.md
+++ b/files/en-us/glossary/closure/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In Computer Programming, a **closure** is a technique for implementing lexically {{glossary("scope", "scoped)}} name binding in a language with first-class {{glossary("function","functions")}}. In {{glossary("JavaScript")}}, a function creates a closure context.
+In Computer Programming, a **closure** is a technique for implementing lexically {{glossary("scope", "scoped")}} name binding in a language with first-class {{glossary("function", "functions")}}. In {{glossary("JavaScript")}}, a function creates a closure context.
 
 ## See also
 

--- a/files/en-us/glossary/cms/index.md
+++ b/files/en-us/glossary/cms/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**CMS** (Content Management System) is the software that allows users to publish, organize, change, or remove various kinds of content, not only text but also embedded images, video, audio, and interactive code.
+A **Content Management System (CMS)** is software that allows users to publish, organize, change, or remove various kinds of content, not only text but also embedded images, video, audio, and interactive code.
 
 ## See also
 

--- a/files/en-us/glossary/cms/index.md
+++ b/files/en-us/glossary/cms/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A CMS (Content Management System) is software that allows users to publish, organize, change, or remove various kinds of content, not only text but also embedded images, video, audio, and interactive code.
+**CMS** (Content Management System) is the software that allows users to publish, organize, change, or remove various kinds of content, not only text but also embedded images, video, audio, and interactive code.
 
 ## See also
 

--- a/files/en-us/glossary/color_wheel/index.md
+++ b/files/en-us/glossary/color_wheel/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Color wheel**, or _color circle_, is a chart representing a palette of colors in a circle. A color wheel can display colors identified by two polar coordinates, the _angle_ and the _distance_ from the origin, the circle's center.
+A **color wheel**, or a _color circle_, represents a palette of colors in chart form, arranged in a circle. A color wheel can display colors identified by two polar coordinates, the _angle_ and the _distance_ from the origin, the circle's center.
 
 Color wheels are convenient for comparing colors expressed in polar or cylindrical coordinates, like [`hsl()`](/en-US/docs/Web/CSS/color_value/hsl), [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb), or [`lch()`](/en-US/docs/Web/CSS/color_value/lch).
 

--- a/files/en-us/glossary/color_wheel/index.md
+++ b/files/en-us/glossary/color_wheel/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A **color wheel**, or _color circle_, is a chart representing a palette of colors in a circle. A color wheel can display colors identified by two polar coordinates, the _angle_ and the _distance_ from the origin, the circle's center.
+**Color wheel**, or _color circle_, is a chart representing a palette of colors in a circle. A color wheel can display colors identified by two polar coordinates, the _angle_ and the _distance_ from the origin, the circle's center.
 
 Color wheels are convenient for comparing colors expressed in polar or cylindrical coordinates, like [`hsl()`](/en-US/docs/Web/CSS/color_value/hsl), [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb), or [`lch()`](/en-US/docs/Web/CSS/color_value/lch).
 

--- a/files/en-us/glossary/compile_time/index.md
+++ b/files/en-us/glossary/compile_time/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The _compile time_ is the time from when the program is first loaded until the program is {{Glossary("parse","parsed")}}.
+**Compile time** is the time from when the program is first loaded until the program is {{Glossary("parse","parsed")}}.
 
 ## See also
 

--- a/files/en-us/glossary/composite_operation/index.md
+++ b/files/en-us/glossary/composite_operation/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 In CSS, the value of a property in a CSS rule is the _underlying value_ of that property, and the value of that same property in a [keyframe](/en-US/docs/Web/CSS/@keyframes) is its _effect value_.
 
-The _composite operation_ is the specific operation that is used to combine an effect value with an underlying value to produce the final keyframe effect value. There are three types of composite operations:
+**Composite operation** is the specific operation that is used to combine an effect value with an underlying value to produce the final keyframe effect value. There are three types of composite operations:
 
 - **replace**: The effect value replaces the underlying value. The final effect value in this case is the original effect value itself.
 - **add**: The effect value is added to the underlying value.

--- a/files/en-us/glossary/computer_programming/index.md
+++ b/files/en-us/glossary/computer_programming/index.md
@@ -6,11 +6,11 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Computer programming is a process of composing and organizing a collection of instructions. These tell a computer/software program what to do in a language which the computer understands. These instructions come in the form of many different languages such as C++, Java, JavaScript, HTML, Python, Ruby, and Rust.
+**Computer programming** is the process of composing and organizing a collection of instructions. These tell a computer/software program what to do in a language which the computer understands. These instructions come in the form of many different languages such as C++, Java, JavaScript, HTML, Python, Ruby, and Rust.
 
 Using an appropriate language, you can program/create all sorts of software. For example, a program that helps scientists with complex calculations, a database that stores huge amounts of data, a website that allows people to download music, or animation software that allows people to create animated movies.
 
 ## See also
 
 - [Computer programming](https://en.wikipedia.org/wiki/Computer_programming) on Wikipedia
-- [List of Programming Languages: Wikipedia](https://en.wikipedia.org/wiki/List_of_programming_languages)
+- [List of Programming Languages](https://en.wikipedia.org/wiki/List_of_programming_languages) on Wikipedia

--- a/files/en-us/glossary/conditional/index.md
+++ b/files/en-us/glossary/conditional/index.md
@@ -12,7 +12,7 @@ An instruction or a set of instructions is executed if a specific condition is f
 
 ## See also
 
-- [Condition](https://en.wikipedia.org/wiki/Exception_handling#Condition_systems) on Wikipedia
-- [Control flow](/en-US/docs/Glossary/Control_flow) on MDN
+- {{glossary("Control_flow", "Control flow")}}
 - [Making decisions in your code — conditionals](/en-US/docs/Learn/JavaScript/Building_blocks/conditionals)
-- [Control flow and error handling in JavaScript](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling) on MDN
+- [Control flow and error handling in JavaScript](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)
+- [Condition](https://en.wikipedia.org/wiki/Exception_handling#Condition_systems) on Wikipedia

--- a/files/en-us/glossary/conditional/index.md
+++ b/files/en-us/glossary/conditional/index.md
@@ -15,4 +15,4 @@ An instruction or a set of instructions is executed if a specific condition is f
 - {{glossary("Control_flow", "Control flow")}}
 - [Making decisions in your code — conditionals](/en-US/docs/Learn/JavaScript/Building_blocks/conditionals)
 - [Control flow and error handling in JavaScript](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)
-- [Condition](https://en.wikipedia.org/wiki/Exception_handling#Condition_systems) on Wikipedia
+- [Conditional](<https://en.wikipedia.org/wiki/Conditional_(computer_programming)>) on Wikipedia

--- a/files/en-us/glossary/constant/index.md
+++ b/files/en-us/glossary/constant/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A constant is a value that the programmer cannot change, for example numbers (1, 2, 42). With {{glossary("variable","variables")}}, on the other hand, the programmer can assign a new {{glossary("value")}} to a variable name already in use.
+A **constant** is a value that the programmer cannot change, for example numbers (1, 2, 42). With {{glossary("variable","variables")}}, on the other hand, the programmer can assign a new {{glossary("value")}} to a variable name already in use.
 
 Like variables, some constants are bound to identifiers. For example, the identifier `pi` could be bound to the value 3.14… .
 

--- a/files/en-us/glossary/constructor/index.md
+++ b/files/en-us/glossary/constructor/index.md
@@ -32,5 +32,5 @@ const defaultReference = new Default();
 ## See also
 
 - [Constructor](https://en.wikipedia.org/wiki/Constructor_%28object-oriented_programming%29) on Wikipedia
-- [The constructor in object oriented programming for JavaScript](/en-US/docs/Learn/JavaScript/Objects/Classes_in_JavaScript#classes_and_constructors) on MDN
-- [New operator in JavaScript](/en-US/docs/Web/JavaScript/Reference/Operators/new) on MDN
+- [The constructor in object oriented programming for JavaScript](/en-US/docs/Learn/JavaScript/Objects/Classes_in_JavaScript#classes_and_constructors)
+- [New operator in JavaScript](/en-US/docs/Web/JavaScript/Reference/Operators/new)

--- a/files/en-us/glossary/constructor/index.md
+++ b/files/en-us/glossary/constructor/index.md
@@ -31,6 +31,6 @@ const defaultReference = new Default();
 
 ## See also
 
-- [Constructor](https://en.wikipedia.org/wiki/Constructor_%28object-oriented_programming%29) on Wikipedia
 - [The constructor in object oriented programming for JavaScript](/en-US/docs/Learn/JavaScript/Objects/Classes_in_JavaScript#classes_and_constructors)
-- [New operator in JavaScript](/en-US/docs/Web/JavaScript/Reference/Operators/new)
+- [`new` operator in JavaScript](/en-US/docs/Web/JavaScript/Reference/Operators/new)
+- [Constructor](https://en.wikipedia.org/wiki/Constructor_%28object-oriented_programming%29) on Wikipedia

--- a/files/en-us/glossary/constructor/index.md
+++ b/files/en-us/glossary/constructor/index.md
@@ -31,6 +31,6 @@ const defaultReference = new Default();
 
 ## See also
 
-- [The constructor in object oriented programming for JavaScript](/en-US/docs/Learn/JavaScript/Objects/Classes_in_JavaScript#classes_and_constructors)
+- [Classes and constructors in JavaScript](/en-US/docs/Learn/JavaScript/Objects/Classes_in_JavaScript#classes_and_constructors)
 - [`new` operator in JavaScript](/en-US/docs/Web/JavaScript/Reference/Operators/new)
 - [Constructor](https://en.wikipedia.org/wiki/Constructor_%28object-oriented_programming%29) on Wikipedia

--- a/files/en-us/glossary/continuous_media/index.md
+++ b/files/en-us/glossary/continuous_media/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Continuous Media** is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.
+**Continuous media** is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.
 
 CSS can be used in a variety of contexts, including print media. And some CSS, particularly those that are used for layout, behave differently depending on the context they are in.
 

--- a/files/en-us/glossary/continuous_media/index.md
+++ b/files/en-us/glossary/continuous_media/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Continuous media is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.
+**Continuous Media** is data where there is a timing relationship between source and destination. The most common examples of continuous media are audio and motion video. Continuous media can be real-time (interactive), where there is a "tight" timing relationship between source and sink, or streaming (playback), where the relationship is less strict.
 
 CSS can be used in a variety of contexts, including print media. And some CSS, particularly those that are used for layout, behave differently depending on the context they are in.
 

--- a/files/en-us/glossary/control_flow/index.md
+++ b/files/en-us/glossary/control_flow/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The _control flow_ is the order in which the computer executes statements in a script.
+**Control flow** is the order in which the computer executes statements in a script.
 
 Code is run in order from the first line in the file to the last line, unless the computer runs across the (extremely frequent) structures that change the control flow, such as conditionals and loops.
 
@@ -29,5 +29,5 @@ Control flow means that when you read a script, you must not only read from star
 ## See also
 
 - [Control flow](https://en.wikipedia.org/wiki/Control_flow) on Wikipedia
-- [JavaScript Reference - Control flow](/en-US/docs/Web/JavaScript/Reference#control_flow) on MDN
-- [Statements (Control flow)](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling) on MDN
+- [JavaScript Reference - Control flow](/en-US/docs/Web/JavaScript/Reference#control_flow)
+- [Statements (Control flow)](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)

--- a/files/en-us/glossary/control_flow/index.md
+++ b/files/en-us/glossary/control_flow/index.md
@@ -28,6 +28,6 @@ Control flow means that when you read a script, you must not only read from star
 
 ## See also
 
-- [Control flow](https://en.wikipedia.org/wiki/Control_flow) on Wikipedia
 - [JavaScript Reference - Control flow](/en-US/docs/Web/JavaScript/Reference#control_flow)
 - [Statements (Control flow)](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)
+- [Control flow](https://en.wikipedia.org/wiki/Control_flow) on Wikipedia

--- a/files/en-us/glossary/control_flow/index.md
+++ b/files/en-us/glossary/control_flow/index.md
@@ -29,5 +29,5 @@ Control flow means that when you read a script, you must not only read from star
 ## See also
 
 - [JavaScript Reference - Control flow](/en-US/docs/Web/JavaScript/Reference#control_flow)
-- [Statements (Control flow)](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)
+- [Control flow and error handling](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)
 - [Control flow](https://en.wikipedia.org/wiki/Control_flow) on Wikipedia

--- a/files/en-us/glossary/cookie/index.md
+++ b/files/en-us/glossary/cookie/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A cookie is a small piece of information left on a visitor's computer by a website, via a web browser.
+A **cookie** is a small piece of information left on a visitor's computer by a website, via a web browser.
 
 Cookies are used to personalize a user's web experience with a website. It may contain the user's preferences or inputs when accessing that website. A user can customize their web browser to accept, reject, or delete cookies.
 

--- a/files/en-us/glossary/copyleft/index.md
+++ b/files/en-us/glossary/copyleft/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Copyleft is a term, usually referring to a license, used to indicate that such license requires that redistribution of said work is subject to the same license as the original. Examples of copyleft licenses are the GNU {{Glossary("GPL")}} (for software) and the Creative Commons SA (Share Alike) licenses (for works of art).
+**Copyleft** is a term, usually referring to a license, used to indicate that such license requires that redistribution of said work is subject to the same license as the original. Examples of copyleft licenses are the GNU {{Glossary("GPL")}} (for software) and the Creative Commons SA (Share Alike) licenses (for works of art).
 
 ## See also
 

--- a/files/en-us/glossary/cors-safelisted_request_header/index.md
+++ b/files/en-us/glossary/cors-safelisted_request_header/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A [CORS-safelisted request header](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) is one of the following [HTTP headers](/en-US/docs/Web/HTTP/Headers):
+A [**CORS-safelisted request header**](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) is one of the following [HTTP headers](/en-US/docs/Web/HTTP/Headers):
 
 - {{HTTPHeader("Accept")}},
 - {{HTTPHeader("Accept-Language")}},

--- a/files/en-us/glossary/cors-safelisted_response_header/index.md
+++ b/files/en-us/glossary/cors-safelisted_response_header/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A _CORS-safelisted response header_ is an [HTTP header](/en-US/docs/Web/HTTP/Headers) in a [CORS](/en-US/docs/Web/HTTP/CORS) response that it is considered _safe_ to expose to client scripts. Only safelisted response headers are made available to web pages.
+A **CORS-safelisted response header** is an [HTTP header](/en-US/docs/Web/HTTP/Headers) in a [CORS](/en-US/docs/Web/HTTP/CORS) response that it is considered _safe_ to expose to client scripts. Only safelisted response headers are made available to web pages.
 
 By default, the safelist includes the following response headers:
 

--- a/files/en-us/glossary/cors/index.md
+++ b/files/en-us/glossary/cors/index.md
@@ -35,6 +35,6 @@ The [same-origin security policy](/en-US/docs/Web/Security/Same-origin_policy) f
 
 ## See also
 
-- [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS) on MDN
+- [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
 - [Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) on Wikipedia
 - [Fetch specification](https://fetch.spec.whatwg.org)

--- a/files/en-us/glossary/crawler/index.md
+++ b/files/en-us/glossary/crawler/index.md
@@ -6,9 +6,9 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A web crawler is a program, often called a bot or robot, which systematically browses the {{glossary("World Wide Web","Web")}} to collect data from webpages. Typically search engines (e.g. Google, Bing, etc.) use crawlers to build indexes.
+A **web crawler** is a program, often called a bot or robot, which systematically browses the {{glossary("World Wide Web","Web")}} to collect data from webpages. Typically search engines (e.g. Google, Bing, etc.) use crawlers to build indexes.
 
 ## See also
 
+- {{Glossary("Search engine")}}
 - [Web crawler](https://en.wikipedia.org/wiki/Web_crawler) on Wikipedia
-- {{Glossary("Search engine")}} (Glossary)

--- a/files/en-us/glossary/crlf/index.md
+++ b/files/en-us/glossary/crlf/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-CR and LF are [control characters](https://en.wikipedia.org/wiki/Control_character) or [bytecode](https://en.wikipedia.org/wiki/Bytecode) that can be used to mark a line break in a text file.
+**CR and LF** are [control characters](https://en.wikipedia.org/wiki/Control_character) or [bytecode](https://en.wikipedia.org/wiki/Bytecode) that can be used to mark a line break in a text file.
 
 - CR = **Carriage Return** (`\r`, `0x0D` in hexadecimal, 13 in decimal) — moves the cursor to the beginning of the line without advancing to the next line.
 - LF = **Line Feed** (`\n`, `0x0A` in hexadecimal, 10 in decimal) — moves the cursor down to the next line without returning to the beginning of the line.

--- a/files/en-us/glossary/cross-site_scripting/index.md
+++ b/files/en-us/glossary/cross-site_scripting/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Cross-site scripting (XSS) is a security exploit which allows an attacker to inject into a website malicious client-side code. This code is executed by the victims and lets the attackers bypass access controls and impersonate users. According to the Open Web Application Security Project, XSS was the [seventh most common Web app vulnerability](<https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A7-Cross-Site_Scripting_(XSS)>) in 2017.
+**Cross-site scripting** (XSS) is a security exploit which allows an attacker to inject into a website malicious client-side code. This code is executed by the victims and lets the attackers bypass access controls and impersonate users. According to the Open Web Application Security Project, XSS was the [seventh most common Web app vulnerability](<https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A7-Cross-Site_Scripting_(XSS)>) in 2017.
 
 These attacks succeed if the Web app does not employ enough validation or encoding. The user's browser cannot detect the malicious script is untrustworthy, and so gives it access to any cookies, session tokens, or other sensitive site-specific information, or lets the malicious script rewrite the {{glossary("HTML")}} content.
 

--- a/files/en-us/glossary/cross_axis/index.md
+++ b/files/en-us/glossary/cross_axis/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The cross axis in {{glossary("flexbox")}} runs perpendicular to the {{glossary("main axis")}}, therefore if your {{cssxref("flex-direction")}} is either `row` or `row-reverse` then the cross axis runs down the columns.
+The **cross axis** in {{glossary("flexbox")}} runs perpendicular to the {{glossary("main axis")}}, therefore if your {{cssxref("flex-direction")}} is either `row` or `row-reverse` then the cross axis runs down the columns.
 
 ![The cross axis runs down the column](basics3.png)
 

--- a/files/en-us/glossary/cryptographic_hash_function/index.md
+++ b/files/en-us/glossary/cryptographic_hash_function/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A cryptographic hash function, also sometimes called a _digest function_, is a {{glossary("cryptography", "cryptographic")}} primitive transforming a message of arbitrary size into a message of fixed size, called a {{glossary("digest")}}. Cryptographic hash functions are used for authentication, {{Glossary("digital signature", "digital signatures")}}, and {{Glossary("HMAC", "message authentication codes")}}.
+A **cryptographic hash function**, also sometimes called a _digest function_, is a {{glossary("cryptography", "cryptographic")}} primitive transforming a message of arbitrary size into a message of fixed size, called a {{glossary("digest")}}. Cryptographic hash functions are used for authentication, {{Glossary("digital signature", "digital signatures")}}, and {{Glossary("HMAC", "message authentication codes")}}.
 
 To be used for cryptography, a hash function must have these qualities:
 
@@ -20,6 +20,6 @@ Cryptographic hash functions such as MD5 and SHA-1 are considered broken, as att
 ## See also
 
 - [Cryptographic hash function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) on Wikipedia
-- [MDN Web Docs Glossary](/en-US/docs/Glossary)
+- [Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("Symmetric-key cryptography")}}

--- a/files/en-us/glossary/csp/index.md
+++ b/files/en-us/glossary/csp/index.md
@@ -6,11 +6,11 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A CSP ([Content Security Policy](/en-US/docs/Web/HTTP/CSP)) is used to detect and mitigate certain types of website related attacks like {{Glossary("Cross-site_scripting")}}, [clickjacking](/en-US/docs/Glossary/Clickjacking) and data injections.
+A **CSP** ([Content Security Policy](/en-US/docs/Web/HTTP/CSP)) is used to detect and mitigate certain types of website related attacks like {{Glossary("Cross-site_scripting")}}, [clickjacking](/en-US/docs/Glossary/Clickjacking) and data injections.
 
 The implementation is based on an {{Glossary("HTTP")}} header called {{HTTPHeader("Content-Security-Policy")}}.
 
 ## See also
 
+- [Content Security Policy documentation](/en-US/docs/Web/HTTP/CSP)
 - [Content Security Policy on Wikipedia](https://en.wikipedia.org/wiki/Content_Security_Policy)
-- [Content Security Policy documentation on MDN](/en-US/docs/Web/HTTP/CSP)

--- a/files/en-us/glossary/css/index.md
+++ b/files/en-us/glossary/css/index.md
@@ -30,6 +30,6 @@ p {
 ## See also
 
 - [Learn CSS](/en-US/docs/Learn/CSS)
+- [The CSS documentation](/en-US/docs/Web/CSS)
 - [CSS](https://en.wikipedia.org/wiki/CSS) on Wikipedia
-- [The CSS documentation on MDN](/en-US/docs/Web/CSS)
 - [The CSS Working Group current work](https://www.w3.org/Style/CSS/current-work)

--- a/files/en-us/glossary/database/index.md
+++ b/files/en-us/glossary/database/index.md
@@ -17,7 +17,7 @@ Browsers also have their own database system called {{glossary("IndexedDB")}}.
 ## See also
 
 - [Database](https://en.wikipedia.org/wiki/Database) on Wikipedia
-- Glossary
+- [Glossary](/en-US/docs/glossary)
 
   - {{Glossary("IndexedDB")}}
   - {{Glossary("SQL")}}

--- a/files/en-us/glossary/decryption/index.md
+++ b/files/en-us/glossary/decryption/index.md
@@ -17,6 +17,6 @@ Decryption is the reverse of {{glossary("encryption")}} and if the key stays sec
 ## See also
 
 - [Encryption and Decryption](/en-US/docs/Encryption_and_Decryption)
-- {{glossary("encryption", "Encryption")}}
-- {{glossary("cipher", "Cipher")}}
-- {{glossary("cryptography", "Cryptography")}}
+- {{glossary("Encryption")}}
+- {{glossary("Cipher")}}
+- {{glossary("Cryptography")}}

--- a/files/en-us/glossary/decryption/index.md
+++ b/files/en-us/glossary/decryption/index.md
@@ -17,3 +17,6 @@ Decryption is the reverse of {{glossary("encryption")}} and if the key stays sec
 ## See also
 
 - [Encryption and Decryption](/en-US/docs/Encryption_and_Decryption)
+- {{glossary("encryption", "Encryption")}}
+- {{glossary("cipher", "Cipher")}}
+- {{glossary("cryptography", "Cryptography")}}

--- a/files/en-us/glossary/deep_copy/index.md
+++ b/files/en-us/glossary/deep_copy/index.md
@@ -52,5 +52,5 @@ The web API [`structuredClone()`](/en-US/docs/Web/API/structuredClone) also crea
 
 ## See also
 
-- {{glossary("shallow_copy", "Shallow copy")}}
+- {{glossary("Shallow copy")}}
 - [`window.structuredClone()`](/en-US/docs/Web/API/structuredClone)

--- a/files/en-us/glossary/deep_copy/index.md
+++ b/files/en-us/glossary/deep_copy/index.md
@@ -52,5 +52,5 @@ The web API [`structuredClone()`](/en-US/docs/Web/API/structuredClone) also crea
 
 ## See also
 
-- [Shallow copy](/en-US/docs/Glossary/Shallow_copy)
+- {{glossary("shallow_copy", "Shallow copy")}}
 - [`window.structuredClone()`](/en-US/docs/Web/API/structuredClone)

--- a/files/en-us/glossary/denial_of_service/index.md
+++ b/files/en-us/glossary/denial_of_service/index.md
@@ -8,4 +8,4 @@ page-type: glossary-definition
 
 **DoS** (Denial of Service) is a category of network attack that consumes available server resources, typically by flooding the server with requests. The server is then sluggish or unavailable for legitimate users.
 
-See {{glossary("DOS_attack", "DoS attack")}} for more information.
+See {{glossary("DOS attack")}} for more information.

--- a/files/en-us/glossary/denial_of_service/index.md
+++ b/files/en-us/glossary/denial_of_service/index.md
@@ -6,6 +6,6 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-DoS (Denial of Service) is a category of network attack that consumes available server resources, typically by flooding the server with requests. The server is then sluggish or unavailable for legitimate users.
+**DoS** (Denial of Service) is a category of network attack that consumes available server resources, typically by flooding the server with requests. The server is then sluggish or unavailable for legitimate users.
 
 See [DoS attack](/en-US/docs/Glossary/DOS_attack) for more information.

--- a/files/en-us/glossary/denial_of_service/index.md
+++ b/files/en-us/glossary/denial_of_service/index.md
@@ -8,4 +8,4 @@ page-type: glossary-definition
 
 **DoS** (Denial of Service) is a category of network attack that consumes available server resources, typically by flooding the server with requests. The server is then sluggish or unavailable for legitimate users.
 
-See [DoS attack](/en-US/docs/Glossary/DOS_attack) for more information.
+See {{glossary("DOS_attack", "DoS attack")}} for more information.

--- a/files/en-us/glossary/deno/index.md
+++ b/files/en-us/glossary/deno/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Deno is a runtime environment for {{Glossary("JavaScript")}}, {{Glossary("TypeScript")}}, and {{glossary("WebAssembly")}}.
+**Deno** is a runtime environment for {{Glossary("JavaScript")}}, {{Glossary("TypeScript")}}, and {{glossary("WebAssembly")}}.
 
 Like {{glossary("Node.js")}}, Deno is based on the V8 JavaScript engine and enables developers to run JavaScript outside browsers. However, there are some notable differences between Node and Deno. In particular, Deno:
 

--- a/files/en-us/glossary/deserialization/index.md
+++ b/files/en-us/glossary/deserialization/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-The process whereby a lower-level format (e.g. that has been transferred over a network, or stored in a data store) is translated into a readable object or other data structure.
+**Deserialization** is the process whereby a lower-level format (e.g. that has been transferred over a network, or stored in a data store) being translated into a readable object or other data structure.
 
 In {{Glossary("JavaScript")}}, for example, you can deserialize a {{Glossary("JSON")}} {{Glossary("string")}} to an object by calling the {{Glossary("function")}} {{jsxref("JSON.parse()")}}.
 

--- a/files/en-us/glossary/deserialization/index.md
+++ b/files/en-us/glossary/deserialization/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Deserialization** is the process whereby a lower-level format (e.g. that has been transferred over a network, or stored in a data store) being translated into a readable object or other data structure.
+**Deserialization** is the process whereby a lower-level format (e.g. that has been transferred over a network, or stored in a data store) is translated into a readable object or other data structure.
 
 In {{Glossary("JavaScript")}}, for example, you can deserialize a {{Glossary("JSON")}} {{Glossary("string")}} to an object by calling the {{Glossary("function")}} {{jsxref("JSON.parse()")}}.
 

--- a/files/en-us/glossary/developer_tools/index.md
+++ b/files/en-us/glossary/developer_tools/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-Developer tools (or "development tools" or short "DevTools") are programs that allow a developer to create, test and debug software.
+**Developer tools** (or "development tools" or short "DevTools") are programs that allow a developer to create, test and debug software.
 
 Current browsers provide integrated developer tools, which allow to inspect a website. They let users inspect and debug the page's {{Glossary("HTML")}}, {{Glossary("CSS")}}, and {{Glossary("JavaScript")}}, allow to inspect the network traffic it causes, make it possible to measure it's performance, and much more.
 

--- a/files/en-us/glossary/digital_certificate/index.md
+++ b/files/en-us/glossary/digital_certificate/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A digital certificate is a data file that binds a publicly known {{Glossary("Key", "cryptographic key")}} to an organization.
+A **digital certificate** is a data file that binds a publicly known {{Glossary("Key", "cryptographic key")}} to an organization.
 
 A digital certificate contains information about an organization, such as the common name (e.g., mozilla.org), the organization unit (e.g., Mozilla Corporation), and the location (e.g., Mountain View). Digital certificates are most commonly signed by a {{Glossary("certificate authority")}}, attesting to the certificate's authenticity.
 

--- a/files/en-us/glossary/distributed_denial_of_service/index.md
+++ b/files/en-us/glossary/distributed_denial_of_service/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A Distributed Denial-of-Service (DDoS) is an attack in which many compromised systems are made to attack a single target, in order to swamp server resources and block legitimate users.
+A **Distributed Denial-of-Service** (DDoS) is an attack in which many compromised systems are made to attack a single target, in order to swamp server resources and block legitimate users.
 
 Normally many persons, using many bots, attack high-profile Web {{glossary("server","servers")}} like banks or credit-card payment gateways. DDoS concerns computer networks and CPU resource management.
 

--- a/files/en-us/glossary/doctype/index.md
+++ b/files/en-us/glossary/doctype/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In {{Glossary("HTML")}}, the doctype is the required "`<!DOCTYPE html>`" preamble found at the top of all documents. Its sole purpose is to prevent a {{Glossary("browser")}} from switching into so-called ["quirks mode"](/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode) when rendering a document; that is, the "`<!DOCTYPE html>`" doctype ensures that the browser makes a best-effort attempt at following the relevant specifications, rather than using a different rendering mode that is incompatible with some specifications.
+In {{Glossary("HTML")}}, the **doctype** is the required "`<!DOCTYPE html>`" preamble found at the top of all documents. Its sole purpose is to prevent a {{Glossary("browser")}} from switching into so-called ["quirks mode"](/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode) when rendering a document; that is, the "`<!DOCTYPE html>`" doctype ensures that the browser makes a best-effort attempt at following the relevant specifications, rather than using a different rendering mode that is incompatible with some specifications.
 
 ## See also
 

--- a/files/en-us/glossary/document_directive/index.md
+++ b/files/en-us/glossary/document_directive/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**{{Glossary("CSP")}} document directives** are used in a {{HTTPHeader("Content-Security-Policy")}} header and govern the properties of a document or [worker](/en-US/docs/Web/API/Web_Workers_API) environment to which a policy applies.
+In {{Glossary("CSP")}}, **document directives** are used in a {{HTTPHeader("Content-Security-Policy")}} header and govern the properties of a document or [worker](/en-US/docs/Web/API/Web_Workers_API) environment to which a policy applies.
 
 Document directives don't fall back to the {{CSP("default-src")}} directive.
 

--- a/files/en-us/glossary/document_environment/index.md
+++ b/files/en-us/glossary/document_environment/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-When the JavaScript global environment is a window or an iframe, it is called a _document environment_. A global environment is an environment that doesn't have an outer environment.
+When the JavaScript global environment is a window or an iframe, it is called a **document environment**. A global environment is an environment that doesn't have an outer environment.
 
 ## See also
 

--- a/files/en-us/glossary/domain/index.md
+++ b/files/en-us/glossary/domain/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-A domain is an authority within the internet that controls its own resources. Its "domain name" is a way to address this authority as part of the hierarchy in a {{Glossary("URL")}} - usually the most memorable part of it, for instance a brand name.
+A **domain** is an authority within the internet that controls its own resources. Its "domain name" is a way to address this authority as part of the hierarchy in a {{Glossary("URL")}} - usually the most memorable part of it, for instance a brand name.
 
 A fully qualified domain name (FQDN) contains all necessary parts to look up this authority by name unambiguously using the {{Glossary("DNS")}} system of the internet.
 

--- a/files/en-us/glossary/dominator/index.md
+++ b/files/en-us/glossary/dominator/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In graph theory, node A dominates node B if every path from the root node to B passes through A.
+In graph theory, node A **dominates** node B if every path from the root node to B passes through A.
 
 This concept is important for {{Glossary("garbage collection")}} because it means that B is only reachable through A. So if the garbage collector found A to be unreachable and eligible for reclaiming, than B would also be unreachable and eligible for reclaiming. So objects that A dominates contribute to the retained size of A: that is, the total amount of memory that could be freed if A itself were freed.
 

--- a/files/en-us/glossary/dos_attack/index.md
+++ b/files/en-us/glossary/dos_attack/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**DoS** (Denial of Service) is a network attack that prevents legitimate use of {{glossary("server")}} resources by flooding the server with requests.
+**Denial of Service (DoS)** is a network attack that prevents legitimate use of {{glossary("server")}} resources by flooding the server with requests.
 
 Computers have limited resources, for example computation power or memory. When these are exhausted, the program can freeze or crash, making it unavailable. A DoS attack consists of various techniques to exhaust these resources and make a server or a network unavailable to legitimate users, or at least make the server perform sluggishly.
 

--- a/files/en-us/glossary/dos_attack/index.md
+++ b/files/en-us/glossary/dos_attack/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-DoS (Denial of Service) is a network attack that prevents legitimate use of {{glossary("server")}} resources by flooding the server with requests.
+**DoS** (Denial of Service) is a network attack that prevents legitimate use of {{glossary("server")}} resources by flooding the server with requests.
 
 Computers have limited resources, for example computation power or memory. When these are exhausted, the program can freeze or crash, making it unavailable. A DoS attack consists of various techniques to exhaust these resources and make a server or a network unavailable to legitimate users, or at least make the server perform sluggishly.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

improvements includes:

- normalize `see also` url name
- add styles for the first occurence (the definition) of the glossary
- remove `crypto system` glossary macro link, as it's not existed in glossary list

### Motivation

inconsistent glossary definition stylings make it harder to understand (e.g. why some labled `on MDN` links, while some dont' have are also mdn docs?)

### Additional details

### Related issues and pull requests


