### PR TITLE
css nesting: fix spelling

### DIFF
--- a/files/en-us/web/css/css_nesting/using_css_nesting/index.md
+++ b/files/en-us/web/css/css_nesting/using_css_nesting/index.md
@@ -19,7 +19,7 @@ You can use CSS nesting to create child selectors of a parent, which in turn can
 There are certain instances where using the `&` nesting selector can be necessary or helpful:
 
 - When joining selectors together, such as using [compound selectors](#compound_selectors) or [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes).
-- For backwards compatability.
+- For backwards compatibility.
 - As a visual indicator to aid with readability, when seeing the `&` nesting selector you know that CSS nesting is being used.
 
 ```css


### PR DESCRIPTION
Fix spelling of "compatibility".

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the "Using CSS nesting" section, replaced "compatability" with the correct spelling "compatibility".