### PR TITLE
FF126Relnote: Element.currentCSSZoom supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -53,7 +53,7 @@ This article provides information about the changes in Firefox 126 that affect d
 
   ([Firefox bug 1322186](https://bugzil.la/1322186)).
 
-- The {{domxref("Element.currentCSSZoom")}} read only property can now be used for getting the effective CSS [zoom](/en-US/docs/Web/CSS/zoom) of an element ([Firefox bug 1880189](https://bugzil.la/1880189)).
+- The {{domxref("Element.currentCSSZoom")}} read only property is now supported for getting the effective CSS [zoom](/en-US/docs/Web/CSS/zoom) of an element ([Firefox bug 1880189](https://bugzil.la/1880189)).
 
 #### DOM
 

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 126 that affect d
 
   ([Firefox bug 1322186](https://bugzil.la/1322186)).
 
+- The {{domxref("Element.currentCSSZoom")}} read only property can now be used for getting the effective CSS [zoom](/en-US/docs/Web/CSS/zoom) of an element ([Firefox bug 1880189](https://bugzil.la/1880189)).
+
 #### DOM
 
 - The ability to define states for custom elements and match them using CSS selectors is now available by default.


### PR DESCRIPTION
FF126 adds support for `Element.currentCSSZoom` in https://bugzilla.mozilla.org/show_bug.cgi?id=1880189 . This adds release note. Docs are being added in #33427

Rest of the work can be tracked in #33241