### PR TITLE
feat: improvements on glossary brotli_compression

### DIFF
--- a/files/en-us/glossary/brotli_compression/index.md
+++ b/files/en-us/glossary/brotli_compression/index.md
@@ -7,9 +7,9 @@ page-type: glossary-definition
 {{GlossarySidebar}}
 
 **Brotli** is a general-purpose lossless compression algorithm.
-It compresses data using a combination of a modern variant of the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) LZ77 algorithm, [Huffman coding](https://rosettacode.org/wiki/Huffman_coding), and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods.
+It compresses data using a combination of a modern variant of the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) LZ77 algorithm, [Huffman coding](https://rosettacode.org/wiki/Huffman_coding), and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods. The specific Brotli Compressed Data Format defined in [RFC 7932](https://tools.ietf.org/html/rfc7932).
 
-Brotli provides better compression ratios than {{glossary("GZip_compression", "gzip")}} and deflate speeds are comparable, but brotli compression is a slower process than Gzip compression, so gzip may be a better option for the compression of non-{{glossary("Cache", "cacheable")}} content.
+Brotli provides better compression ratios than {{glossary("GZip_compression", "gzip")}}, and the speeds of it are comparable with deflate. Though, brotli compression is a slower process than Gzip compression, so gzip may be a better option for the compression of non-{{glossary("Cache", "cacheable")}} content.
 
 Brotli is compatible with most modern browsers, but you may want to consider a fallback.
 
@@ -19,5 +19,6 @@ Brotli is compatible with most modern browsers, but you may want to consider a f
 - {{glossary("Lossy compression")}}
 - [brotli.org](https://brotli.org/)
 - [Brotli GitHub repository](https://github.com/google/brotli)
+- [RFC 7932](https://tools.ietf.org/html/rfc7932)
 - [Brotli](https://en.wikipedia.org/wiki/Brotli) on Wikipedia
 - [Brotli on Caniuse](https://caniuse.com/#feat=brotli)

--- a/files/en-us/glossary/brotli_compression/index.md
+++ b/files/en-us/glossary/brotli_compression/index.md
@@ -9,7 +9,8 @@ page-type: glossary-definition
 **Brotli** is a general-purpose lossless compression algorithm.
 It compresses data using a combination of a modern variant of the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) LZ77 algorithm, [Huffman coding](https://rosettacode.org/wiki/Huffman_coding), and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods.
 
-Brotli provides better compression ratios than {{glossary("GZip_compression", "gzip")}}, and the speeds of it are comparable with deflate. Though, brotli compression is a slower process than Gzip compression, so gzip may be a better option for the compression of non-{{glossary("Cache", "cacheable")}} content.
+Brotli provides better compression ratios than {{glossary("GZip_compression", "gzip")}}, and speeds that are comparable to [deflate](https://en.wikipedia.org/wiki/Deflate).
+However brotli compression is slower than Gzip compression, so gzip may be a better option when compressing {{glossary("Cache", "non-cacheable")}} content.
 
 Brotli is compatible with most modern browsers, but you may want to consider a fallback.
 

--- a/files/en-us/glossary/brotli_compression/index.md
+++ b/files/en-us/glossary/brotli_compression/index.md
@@ -7,7 +7,7 @@ page-type: glossary-definition
 {{GlossarySidebar}}
 
 **Brotli** is a general-purpose lossless compression algorithm.
-It compresses data using a combination of a modern variant of the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) LZ77 algorithm, [Huffman coding](https://rosettacode.org/wiki/Huffman_coding), and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods. The specific Brotli Compressed Data Format defined in [RFC 7932](https://tools.ietf.org/html/rfc7932).
+It compresses data using a combination of a modern variant of the [Lempel-Ziv coding](https://en.wikipedia.org/wiki/LZ77_and_LZ78#LZ77) LZ77 algorithm, [Huffman coding](https://rosettacode.org/wiki/Huffman_coding), and second-order context modeling, providing a compression ratio comparable to the best currently available general-purpose compression methods.
 
 Brotli provides better compression ratios than {{glossary("GZip_compression", "gzip")}}, and the speeds of it are comparable with deflate. Though, brotli compression is a slower process than Gzip compression, so gzip may be a better option for the compression of non-{{glossary("Cache", "cacheable")}} content.
 
@@ -19,6 +19,6 @@ Brotli is compatible with most modern browsers, but you may want to consider a f
 - {{glossary("Lossy compression")}}
 - [brotli.org](https://brotli.org/)
 - [Brotli GitHub repository](https://github.com/google/brotli)
-- [RFC 7932](https://tools.ietf.org/html/rfc7932)
+- [RFC 7932: Brotli Compressed Data Format](https://tools.ietf.org/html/rfc7932)
 - [Brotli](https://en.wikipedia.org/wiki/Brotli) on Wikipedia
 - [Brotli on Caniuse](https://caniuse.com/#feat=brotli)


### PR DESCRIPTION
### Description

#### Modification

- and deflate speeds are comparable => and the speeds of it are comparable with defalte
    - reference: as described in repository’s README: `It is similar in speed with deflate but offers more dense compression.`

#### Addition

- added link to RFC-7932, which define the brotli compressed data format
