### PR TITLE
fix(css-syntax): change language to plain

### DIFF
--- a/files/en-us/web/css/_colon_lang/index.md
+++ b/files/en-us/web/css/_colon_lang/index.md
@@ -17,7 +17,7 @@ The **`:lang()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/
 
 ### Formal syntax
 
-```css-nolint
+```plain
 :lang(<language-code> [,<language-code> ]*)
   /* ... */
 }

--- a/files/en-us/web/css/transform-function/translate/index.md
+++ b/files/en-us/web/css/transform-function/translate/index.md
@@ -126,7 +126,7 @@ transform: translate(30%, 50%);
 
 ### Formal syntax
 
-```css
+```plain
 translate({{cssxref("&lt;length-percentage&gt;")}}, {{cssxref("&lt;length-percentage&gt;")}}?)
 ```
 

--- a/files/en-us/web/css/transform-function/translatex/index.md
+++ b/files/en-us/web/css/transform-function/translatex/index.md
@@ -114,7 +114,7 @@ transform: translateX(50%);
 
 ### Formal syntax
 
-```css
+```plain
 translateX({{cssxref("&lt;length-percentage&gt;")}})
 ```
 

--- a/files/en-us/web/css/transform-function/translatey/index.md
+++ b/files/en-us/web/css/transform-function/translatey/index.md
@@ -128,7 +128,7 @@ transform: translateY(50%);
 
 ### Formal syntax
 
-```css
+```plain
 translateY({{cssxref("&lt;length-percentage&gt;")}})
 ```
 

--- a/files/en-us/web/css/url/index.md
+++ b/files/en-us/web/css/url/index.md
@@ -84,7 +84,7 @@ The **`url()`** function can be included as a value for
 
 ### Formal syntax
 
-```css
+```plain
 url( <string> <url-modifier>* )
 ```
 


### PR DESCRIPTION
### Description

We should always use plain for CSS syntax.

### Motivation

Consistency. There were only 5 occurrences.