### PR TITLE
fix(glossary): Correct link to color-mix function page

### DIFF
--- a/files/en-us/glossary/interpolation/index.md
+++ b/files/en-us/glossary/interpolation/index.md
@@ -21,7 +21,7 @@ In JavaScript, the term "[interpolation](/en-US/docs/Web/JavaScript/Reference/Te
 - {{CSSXref("color-interpolation")}} CSS property
 - {{CSSXref("color-interpolation-method")}} CSS data type
 - {{CSSXref("hue-interpolation-method")}} CSS data type
--  {{CSSXref("color_value/color-mix", "color-mix()")}} CSS function
+- {{CSSXref("color_value/color-mix", "color-mix()")}} CSS function
 - [Interpolating colors in CSS](/en-US/docs/Web/CSS/color_value#interpolation)
 - [Interpolation](https://en.wikipedia.org/wiki/Interpolation) on Wikipedia
 - [String interpolation](https://en.wikipedia.org/wiki/String_interpolation) on Wikipedia

--- a/files/en-us/glossary/interpolation/index.md
+++ b/files/en-us/glossary/interpolation/index.md
@@ -21,7 +21,7 @@ In JavaScript, the term "[interpolation](/en-US/docs/Web/JavaScript/Reference/Te
 - {{CSSXref("color-interpolation")}} CSS property
 - {{CSSXref("color-interpolation-method")}} CSS data type
 - {{CSSXref("hue-interpolation-method")}} CSS data type
-- {{CSSXref("color-mix")}} CSS function
+-  {{CSSXref("color_value/color-mix", "color-mix()")}} CSS function
 - [Interpolating colors in CSS](/en-US/docs/Web/CSS/color_value#interpolation)
 - [Interpolation](https://en.wikipedia.org/wiki/Interpolation) on Wikipedia
 - [String interpolation](https://en.wikipedia.org/wiki/String_interpolation) on Wikipedia


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR fixes the link to the [color-mix](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) function on the [Interpolation](https://developer.mozilla.org/en-US/docs/Glossary/Interpolation#see_also) glossary page

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Remove broken links
