### PR TITLE
CSS zoom is standard

### DIFF
--- a/files/en-us/web/css/zoom/index.md
+++ b/files/en-us/web/css/zoom/index.md
@@ -2,14 +2,12 @@
 title: zoom
 slug: Web/CSS/zoom
 page-type: css-property
-status:
-  - non-standard
 browser-compat: css.properties.zoom
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}
 
-The non-standard **`zoom`** [CSS](/en-US/docs/Web/CSS) property can be used to control the magnification level of an element. {{cssxref("transform-function/scale", "transform: scale()")}} should be used instead of this property, if possible. However, unlike CSS Transforms, `zoom` affects the layout size of the element.
+The **`zoom`** [CSS](/en-US/docs/Web/CSS) property can be used to control the magnification level of an element. {{cssxref("transform-function/scale", "transform: scale()")}} should be used instead of this property, if possible. However, unlike CSS Transforms, `zoom` affects the layout size of the element.
 
 ## Syntax
 
@@ -140,7 +138,7 @@ div#c {
 
 ## Specifications
 
-Not part of any standard. Apple has [a description in the Safari CSS Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-SW15). Rossen Atanassov of Microsoft has [an unofficial draft specification proposal on GitHub](https://github.com/atanassov/css-zoom).
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
This marks the CSS zoom class as standard, as the auto-update does not appear to have caught the change. Also updates the specifications section.

This is related to work I am doing for https://github.com/mdn/content/issues/33241

FYI @dletorey - I see you updated the BCD recently - notifying in case you were planning on touching this. Note, this was was just minimal work to update status and get specifications added. I haven't checked against the spec.