### PR TITLE
fix(macro): update GroupData.json to fix sidebar macro flaws

### DIFF
--- a/files/en-us/web/api/htmlmetaelement/index.md
+++ b/files/en-us/web/api/htmlmetaelement/index.md
@@ -16,7 +16,7 @@ This interface inherits all of the properties and methods described in the {{dom
 
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
-- {{domxref("HTMLMetaElement.charset")}}
+- {{HTMLElement("meta#charset")}}
   - : The character encoding for a HTML document.
 - {{domxref("HTMLMetaElement.content")}}
   - : The 'value' part of the name-value pairs of the document metadata.

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -31,11 +31,11 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
     > **Note:** The exact processing details for these attributes are complex, involving many different aspects of HTML, and therefore are scattered throughout the specification. [These algorithms](https://html.spec.whatwg.org/multipage/scripting.html) describe the core ideas, but they rely on the parsing rules for {{HTMLElement("script")}} [start](https://html.spec.whatwg.org/multipage/syntax.html#start-tags) and [end](https://html.spec.whatwg.org/multipage/syntax.html#end-tags) tags in HTML, [in foreign content](https://html.spec.whatwg.org/multipage/syntax.html#foreign-elements), and [in XML](https://html.spec.whatwg.org/multipage/xhtml.html); the rules for the [`document.write()`](/en-US/docs/Web/API/Document/write) method; the handling of [scripting](https://html.spec.whatwg.org/multipage/webappapis.html); and so on.
 
-- {{domxref("HTMLScriptElement.charset")}} {{deprecated_inline}}
+- `HTMLScriptElement.charset` {{deprecated_inline}}
   - : A string representing the character encoding of an external script. It reflects the [`charset`](/en-US/docs/Web/HTML/Element/script#charset) attribute.
 - {{domxref("HTMLScriptElement.crossOrigin")}}
   - : A string reflecting the [CORS setting](/en-US/docs/Web/HTML/Attributes/crossorigin) for the script element. For classic scripts from other [origins](/en-US/docs/Glossary/Origin), this controls if error information will be exposed.
-- {{domxref("HTMLScriptElement.event")}} {{deprecated_inline}}
+- `HTMLScriptElement.event` {{deprecated_inline}}
   - : A string; an obsolete way of registering event handlers on elements in an HTML document.
 - {{domxref("HTMLScriptElement.fetchPriority")}}
   - : An optional string representing a hint given to the browser on how it should prioritize fetching of an external script relative to other external scripts. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default). It reflects the `fetchpriority` attribute of the {{HTMLElement("script")}} element.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -183,7 +183,7 @@
       "overview": ["CSS Custom Highlight API"],
       "interfaces": ["Highlight", "HighlightRegistry"],
       "methods": [],
-      "properties": ["CSS.highlights"],
+      "properties": ["CSS.highlights_static"],
       "events": []
     },
     "Console API": {
@@ -247,7 +247,7 @@
         "PaintRenderingContext2D",
         "PaintSize"
       ],
-      "methods": ["CSS.paintWorklet"],
+      "methods": ["CSS.paintWorklet_static"],
       "properties": [],
       "events": []
     },
@@ -255,7 +255,7 @@
       "overview": ["CSS Properties and Values API"],
       "guides": ["/docs/Web/API/CSS_Properties_and_Values_API/guide"],
       "interfaces": ["CSSPropertyRule"],
-      "methods": ["CSS.registerProperty"],
+      "methods": ["CSS.registerProperty_static"],
       "properties": [],
       "events": []
     },
@@ -566,8 +566,8 @@
       "methods": [],
       "properties": [
         "MouseEvent.webkitForce",
-        "MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN",
-        "MouseEvent.WEBKIT_FORCE_AT_MOUSE_DOWN"
+        "MouseEvent.WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN_static",
+        "MouseEvent.WEBKIT_FORCE_AT_MOUSE_DOWN_static"
       ],
       "events": [
         "Element: webkitmouseforcewillbegin",
@@ -657,7 +657,7 @@
         "StylePropertyMap",
         "Worklet"
       ],
-      "methods": ["CSS.registerProperty", "Worklet.addModule"],
+      "methods": ["CSS.registerProperty_static", "Worklet.addModule"],
       "properties": [],
       "events": []
     },


### PR DESCRIPTION
1. The `HTMLMetaElement.charset` document doesn't exist and redirects to `<meta>` page.
2. In GroupData.json `_static` is required because sidebars do `.replace('.', '/')` [to form the URLs](https://github.com/mdn/yari/blob/344ec8c1e4a0bd120b8ea1ef6d9cd187446fc33c/kumascript/macros/APIRef.ejs#L218).


/cc @wbamberg 