### PR TITLE
Release notes for Firefox 126 for WebDriver conformance changes.

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -71,11 +71,13 @@ This article provides information about the changes in Firefox 126 that affect d
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-#### General
-
 #### WebDriver BiDi
 
-#### Marionette
+- Added the `contexts` argument to the `network.addIntercept` command to limit the interception of network requests to particular top-level browsing contexts ([Firefox bug 1884935](https://bugzil.la/1882260)).
+- Both the commands `session.subscribe` and `session.unsubscribe` now raise an `invalid argument` error when the value of the arguments `events` or `contexts`  are empty arrays ([Firefox bug 1884935](https://bugzil.la/1887871)).
+- Updated the implementation of the `storage.getCookies` command to align with the Gecko default cookie behaviour. This allows the removal of the user value for the preference `network.cookie.cookieBehavior`, which was only expected to be set for our CDP implementation ([Firefox bug 1884935](https://bugzil.la/1879503)).
+- Removed the `ownership` and `sandbox` arguments for the `browsingContext.locateNodes` command because they are no longer necessary ([Firefox bug 1884935](https://bugzil.la/1838152)).
+- Improved error message for the `session.new` command when no capabilities are specified ([Firefox bug 1885495](https://bugzil.la/1838152)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -74,7 +74,7 @@ This article provides information about the changes in Firefox 126 that affect d
 #### WebDriver BiDi
 
 - Added the `contexts` argument to the `network.addIntercept` command to limit the interception of network requests to particular top-level browsing contexts ([Firefox bug 1884935](https://bugzil.la/1882260)).
-- Both the commands `session.subscribe` and `session.unsubscribe` now raise an `invalid argument` error when the value of the arguments `events` or `contexts`  are empty arrays ([Firefox bug 1884935](https://bugzil.la/1887871)).
+- Both the commands `session.subscribe` and `session.unsubscribe` now raise an `invalid argument` error when the value of the arguments `events` or `contexts` are empty arrays ([Firefox bug 1884935](https://bugzil.la/1887871)).
 - Updated the implementation of the `storage.getCookies` command to align with the Gecko default cookie behaviour. This allows the removal of the user value for the preference `network.cookie.cookieBehavior`, which was only expected to be set for our CDP implementation ([Firefox bug 1884935](https://bugzil.la/1879503)).
 - Removed the `ownership` and `sandbox` arguments for the `browsingContext.locateNodes` command because they are no longer necessary ([Firefox bug 1884935](https://bugzil.la/1838152)).
 - Improved error message for the `session.new` command when no capabilities are specified ([Firefox bug 1885495](https://bugzil.la/1838152)).


### PR DESCRIPTION
Based on the [release notes list on Bugzilla](https://bugzilla.mozilla.org/buglist.cgi?component=Agent&component=Marionette&component=WebDriver%20BiDi&v1=fixed&columnlist=component%2Cresolution%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&resolution=FIXED&v2=%5Bwptsync%20downstream%5D&query_format=advanced&o1=equals&product=Remote%20Protocol&f2=status_whiteboard&o2=notsubstring&f1=cf_status_firefox126&list_id=17022072).

@juliandescottes and @lutien can you please review? Thanks