### PR TITLE
Fix the `blocking` attribute of the `<link>` element example

### DIFF
--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -386,12 +386,7 @@ You can include `render` token inside a `blocking` attribute;
 the rendering of the page will be blocked till the resource is fetched. For example:
 
 ```html
-<link
-  blocking="render"
-  rel="preload"
-  href="critical-font.woff2"
-  as="font"
-  crossorigin />
+<link blocking="render" rel="stylesheet" href="example.css" crossorigin />
 ```
 
 ## Technical summary


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

see https://html.spec.whatwg.org/multipage/semantics.html#attr-link-blocking and https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet, https://html.spec.whatwg.org/multipage/links.html#link-type-expect

the `blocking` attribute of the `<link>` element can only used when `rel` attribute containing `expect` or `stylesheet` keywords

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
