### PR TITLE
Correction to Iterator.prototype.flatMap()'s callback return type

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/iterator/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/flatmap/index.md
@@ -20,7 +20,7 @@ flatMap(callbackFn)
 ### Parameters
 
 - `callbackFn`
-  - : A function to execute for each element produced by the iterator. It should return an iterator or iterable that yields elements to be yielded by `flatMap()`, or a single non-iterator/iterable value to be yielded. The function is called with the following arguments:
+  - : A function to execute for each element produced by the iterator. It should return an iterator or iterable that yields elements to be yielded by `flatMap()`. Note that unlike `Array.prototype.flatMap()`, you cannot return single non-iterator/iterable values. The function is called with the following arguments:
     - `element`
       - : The current element being processed in the array.
     - `index`

--- a/files/en-us/web/javascript/reference/global_objects/iterator/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/iterator/flatmap/index.md
@@ -20,7 +20,7 @@ flatMap(callbackFn)
 ### Parameters
 
 - `callbackFn`
-  - : A function to execute for each element produced by the iterator. It should return an iterator or iterable that yields elements to be yielded by `flatMap()`. Note that unlike `Array.prototype.flatMap()`, you cannot return single non-iterator/iterable values. The function is called with the following arguments:
+  - : A function to execute for each element produced by the iterator. It should return an iterator or iterable that yields elements to be yielded by `flatMap()`. Note that unlike {{jsxref("Array.prototype.flatMap()")}}, you cannot return single non-iterator/iterable values. The function is called with the following arguments:
     - `element`
       - : The current element being processed in the array.
     - `index`


### PR DESCRIPTION


### Description

Correction to `Iterator.prototype.flatMap()`'s callback return type, which always needs to be an iterator. E.g this does not work (check in Chrome or using a polyfill):

```js
[1, 2, 3].values().flatMap(num => num === 2 ? [2, 2] : 1).toArray()
```

### Motivation

motivated by https://github.com/tc39/proposal-iterator-helpers/issues/275#issuecomment-2098790245

