### PR TITLE
Fix the Syntax for `FileSystemDirectoryHandle.keys()`

### DIFF
--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -16,7 +16,7 @@ on which this method is called.
 ## Syntax
 
 ```js-nolint
-FileSystemDirectoryHandle.keys()
+keys()
 ```
 
 ### Parameters


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

relates to https://github.com/mdn/translated-content/issues/19988 and https://github.com/mdn/translated-content/pull/20167

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
