### PR TITLE
Add info about presentation attributes to css cascade

### DIFF
--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -189,9 +189,9 @@ margin-left: 3px;
 
 > **Note:** The declaration defined in the user CSS, while it may have greater specificity, is not chosen as the cascade algorithm's _origin and importance_ is applied before the _specificity_ algorithm. The declaration defined in a cascade layer, though it may come later in the code, will not have precedence either as normal styles in cascade layers have less precedence than normal unlayered styles. _Order of appearance_ only matters when both origin, importance, and specificity are equal.
 
-## Author styles: inline styles, layers, and precedence
+## Author styles: inline styles, layers, presentational  attributes, and precedence
 
-The [table in Cascading order](#cascading_order) provided a precedence order overview. The table summarized the user-agent, user, and author origin type styles in two lines each with "origin type - normal" and "origin type - !important". The precedence within each origin type is more nuanced. Styles can be contained within layers within their origin type, and, with author styles, there is also the issue of where inline styles land in the cascade order.
+The [table in Cascading order](#cascading_order) provided a precedence order overview. The table summarized the user-agent, user, and author origin type styles in two lines each with "origin type - normal" and "origin type - !important". The precedence within each origin type is more nuanced. Styles can be contained within layers within their origin type, and, with author styles, there is also the issue of where inline styles and presentation attribuets land in the cascade order.
 
 The order in which layers are declared is important in determining precedence. Normal styles in a layer take precedence over styles declared in prior layers; with normal styles declared outside of any layer taking precedence over normal layered styles regardless of specificity.
 
@@ -217,23 +217,32 @@ and then in the body of the document we have inline styles:
 <p style="line-height: 1.6em; text-decoration: overline !important;">Hello</p>
 ```
 
-In the CSS code block above, three cascade layers named "A", "B", and "C", were created, in that order. Three stylesheets were imported directly into layers and two were imported without creating or being assigned to a layer.
-The "All unlayered styles" in the list below (normal author style precedence - order 4) includes styles from these two stylesheets and the additional unlayered CSS style blocks. In addition, there are two inline styles, a normal `line-height` declaration and an important `text-decoration` declaration:
+and presentation attributes:
 
-| Order (low to high) | Author style         | Importance   |
-| ------------------- | -------------------- | ------------ |
-| 1                   | A - first layer      | normal       |
-| 2                   | B - second layer     | normal       |
-| 3                   | C - last layer       | normal       |
-| 4                   | All unlayered styles | normal       |
-| 5                   | inline `style`       | normal       |
-| 6                   | animations           |              |
-| 7                   | All unlayered styles | `!important` |
-| 8                   | C - last layer       | `!important` |
-| 9                   | B - second layer     | `!important` |
-| 10                  | A - first layer      | `!important` |
-| 11                  | inline `style`       | `!important` |
-| 12                  | transitions          |              |
+```html
+<svg>
+  <rect width="100" height="100" fill="red"/>
+</svg>
+```
+
+In the CSS code block above, three cascade layers named "A", "B", and "C", were created, in that order. Three stylesheets were imported directly into layers and two were imported without creating or being assigned to a layer.
+The "All unlayered styles" in the list below (normal author style precedence - order 4) includes styles from these two stylesheets and the additional unlayered CSS style blocks. There are two inline styles, a normal `line-height` declaration and an important `text-decoration` declaration. And there are three presentation attributes, `width`, `height`, and `fill`.
+
+| Order (low to high) | Author style            | Importance   |
+| ------------------- | ----------------------- | ------------ |
+| 1                   | presentation attributes |              |
+| 2                   | A - first layer         | normal       |
+| 3                   | B - second layer        | normal       |
+| 4                   | C - last layer          | normal       |
+| 5                   | All unlayered styles    | normal       |
+| 6                   | inline `style`          | normal       |
+| 7                   | animations              |              |
+| 8                   | All unlayered styles    | `!important` |
+| 9                   | C - last layer          | `!important` |
+| 10                  | B - second layer        | `!important` |
+| 11                  | A - first layer         | `!important` |
+| 12                  | inline `style`          | `!important` |
+| 13                  | transitions             |              |
 
 In all origin types, the non important styles contained in layers have the lowest precedence. In our example, the normal styles associated with the first declared layer (A) have lower precedence than normal styles in the second declared layer (B), which have lower precedence than normal styles in the third declared layer (C). These layered styles have lower precedence than all normal unlayered styles, which includes normal styles from `unlayeredStyles.css`, `moreUnlayeredStyles.css`, and the `color` of `p` in the `<style>` itself.
 
@@ -243,11 +252,17 @@ The layer order of precedence is inverted for styles declared as `!important`. I
 
 ### Inline styles
 
-Only relevant to author styles are inline styles, declared with the `style` attribute. Normal inline styles take precedence over any other normal author styles, no matter the specificity of the selector. If `line-height: 2;` were declared in a `:root body p` selector block in any of the five imported stylesheets, the line height would still be `1.6`.
+Inline styles are styles declared within the `style` attribute. They are considered to be part of the author styles. Normal inline styles take precedence over any other normal author styles, no matter the specificity of the selector. If `line-height: 2;` were declared in a `:root body p` selector block in any of the five imported stylesheets, the line height would still be `1.6`.
 
 Normal inline styles take precedence over any other normal author styles unless the property is being altered by a CSS animation.
 
 All important inline styles take precedence over all author styles, important and not, inline and not, layered and not. Important styles also take precedence over animated properties, but not transitioning properties. Three things can override an important inline style: 1) an important user style, 2) an important user agent style, or 3) a property value being transitioned.
+
+### Presentational attributes
+
+Presentational attributes are other attributes in the source document that can affect styling. For example, `align` in HTML or `fill` in SVG. They are considered to be part of the author styles. Presentational attributes have the least precedence. Layered, unlayered, and inline styles all take precedence over presentational attributes.
+
+Presentational attributes cannot be declared `!important`.
 
 ### Importance and layers
 
@@ -302,7 +317,8 @@ Now that we have a better understanding of origin type and cascade layer precede
   <tr><td rowspan="3">2</td><td>user - first declared layer</td><td rowspan="3">normal</td></tr>
   <tr><td>user - last declared layer</td></tr>
   <tr><td>user - unlayered styles</td></tr>
-  <tr><td rowspan="4">3</td><td>author - first declared layer</td><td rowspan="4">normal</td></tr>
+  <tr><td rowspan="5">3</td><td>presentational attributes</td><td rowspan="5">normal</td></tr>
+  <td>author - first declared layer</td>
   <tr><td>author - last declared layer</td></tr>
   <tr><td>author - unlayered styles</td></tr>
   <tr><td>inline <code>style</code></td></tr>

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -189,7 +189,7 @@ margin-left: 3px;
 
 > **Note:** The declaration defined in the user CSS, while it may have greater specificity, is not chosen as the cascade algorithm's _origin and importance_ is applied before the _specificity_ algorithm. The declaration defined in a cascade layer, though it may come later in the code, will not have precedence either as normal styles in cascade layers have less precedence than normal unlayered styles. _Order of appearance_ only matters when both origin, importance, and specificity are equal.
 
-## Author styles: inline styles, layers, presentational  attributes, and precedence
+## Author styles: inline styles, layers, presentational attributes, and precedence
 
 The [table in Cascading order](#cascading_order) provided a precedence order overview. The table summarized the user-agent, user, and author origin type styles in two lines each with "origin type - normal" and "origin type - !important". The precedence within each origin type is more nuanced. Styles can be contained within layers within their origin type, and, with author styles, there is also the issue of where inline styles and presentation attribuets land in the cascade order.
 
@@ -221,7 +221,7 @@ and presentation attributes:
 
 ```html
 <svg>
-  <rect width="100" height="100" fill="red"/>
+  <rect width="100" height="100" fill="red" />
 </svg>
 ```
 

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -189,9 +189,9 @@ margin-left: 3px;
 
 > **Note:** The declaration defined in the user CSS, while it may have greater specificity, is not chosen as the cascade algorithm's _origin and importance_ is applied before the _specificity_ algorithm. The declaration defined in a cascade layer, though it may come later in the code, will not have precedence either as normal styles in cascade layers have less precedence than normal unlayered styles. _Order of appearance_ only matters when both origin, importance, and specificity are equal.
 
-## Author styles: inline styles, layers, presentational  attributes, and precedence
+## Author styles: inline styles, layers, and precedence
 
-The [table in Cascading order](#cascading_order) provided a precedence order overview. The table summarized the user-agent, user, and author origin type styles in two lines each with "origin type - normal" and "origin type - !important". The precedence within each origin type is more nuanced. Styles can be contained within layers within their origin type, and, with author styles, there is also the issue of where inline styles and presentation attribuets land in the cascade order.
+The [table in Cascading order](#cascading_order) provided a precedence order overview. The table summarized the user-agent, user, and author origin type styles in two lines each with "origin type - normal" and "origin type - !important". The precedence within each origin type is more nuanced. Styles can be contained within layers within their origin type, and, with author styles, there is also the issue of where inline styles land in the cascade order.
 
 The order in which layers are declared is important in determining precedence. Normal styles in a layer take precedence over styles declared in prior layers; with normal styles declared outside of any layer taking precedence over normal layered styles regardless of specificity.
 
@@ -217,32 +217,23 @@ and then in the body of the document we have inline styles:
 <p style="line-height: 1.6em; text-decoration: overline !important;">Hello</p>
 ```
 
-and presentation attributes:
-
-```html
-<svg>
-  <rect width="100" height="100" fill="red"/>
-</svg>
-```
-
 In the CSS code block above, three cascade layers named "A", "B", and "C", were created, in that order. Three stylesheets were imported directly into layers and two were imported without creating or being assigned to a layer.
-The "All unlayered styles" in the list below (normal author style precedence - order 4) includes styles from these two stylesheets and the additional unlayered CSS style blocks. There are two inline styles, a normal `line-height` declaration and an important `text-decoration` declaration. And there are three presentation attributes, `width`, `height`, and `fill`.
+The "All unlayered styles" in the list below (normal author style precedence - order 4) includes styles from these two stylesheets and the additional unlayered CSS style blocks. In addition, there are two inline styles, a normal `line-height` declaration and an important `text-decoration` declaration:
 
-| Order (low to high) | Author style            | Importance   |
-| ------------------- | ----------------------- | ------------ |
-| 1                   | presentation attributes |              |
-| 2                   | A - first layer         | normal       |
-| 3                   | B - second layer        | normal       |
-| 4                   | C - last layer          | normal       |
-| 5                   | All unlayered styles    | normal       |
-| 6                   | inline `style`          | normal       |
-| 7                   | animations              |              |
-| 8                   | All unlayered styles    | `!important` |
-| 9                   | C - last layer          | `!important` |
-| 10                  | B - second layer        | `!important` |
-| 11                  | A - first layer         | `!important` |
-| 12                  | inline `style`          | `!important` |
-| 13                  | transitions             |              |
+| Order (low to high) | Author style         | Importance   |
+| ------------------- | -------------------- | ------------ |
+| 1                   | A - first layer      | normal       |
+| 2                   | B - second layer     | normal       |
+| 3                   | C - last layer       | normal       |
+| 4                   | All unlayered styles | normal       |
+| 5                   | inline `style`       | normal       |
+| 6                   | animations           |              |
+| 7                   | All unlayered styles | `!important` |
+| 8                   | C - last layer       | `!important` |
+| 9                   | B - second layer     | `!important` |
+| 10                  | A - first layer      | `!important` |
+| 11                  | inline `style`       | `!important` |
+| 12                  | transitions          |              |
 
 In all origin types, the non important styles contained in layers have the lowest precedence. In our example, the normal styles associated with the first declared layer (A) have lower precedence than normal styles in the second declared layer (B), which have lower precedence than normal styles in the third declared layer (C). These layered styles have lower precedence than all normal unlayered styles, which includes normal styles from `unlayeredStyles.css`, `moreUnlayeredStyles.css`, and the `color` of `p` in the `<style>` itself.
 
@@ -252,17 +243,11 @@ The layer order of precedence is inverted for styles declared as `!important`. I
 
 ### Inline styles
 
-Inline styles are styles declared within the `style` attribute. They are considered to be part of the author styles. Normal inline styles take precedence over any other normal author styles, no matter the specificity of the selector. If `line-height: 2;` were declared in a `:root body p` selector block in any of the five imported stylesheets, the line height would still be `1.6`.
+Only relevant to author styles are inline styles, declared with the `style` attribute. Normal inline styles take precedence over any other normal author styles, no matter the specificity of the selector. If `line-height: 2;` were declared in a `:root body p` selector block in any of the five imported stylesheets, the line height would still be `1.6`.
 
 Normal inline styles take precedence over any other normal author styles unless the property is being altered by a CSS animation.
 
 All important inline styles take precedence over all author styles, important and not, inline and not, layered and not. Important styles also take precedence over animated properties, but not transitioning properties. Three things can override an important inline style: 1) an important user style, 2) an important user agent style, or 3) a property value being transitioned.
-
-### Presentational attributes
-
-Presentational attributes are other attributes in the source document that can affect styling. For example, `align` in HTML or `fill` in SVG. They are considered to be part of the author styles. Presentational attributes have the least precedence. Layered, unlayered, and inline styles all take precedence over presentational attributes.
-
-Presentational attributes cannot be declared `!important`.
 
 ### Importance and layers
 
@@ -317,8 +302,7 @@ Now that we have a better understanding of origin type and cascade layer precede
   <tr><td rowspan="3">2</td><td>user - first declared layer</td><td rowspan="3">normal</td></tr>
   <tr><td>user - last declared layer</td></tr>
   <tr><td>user - unlayered styles</td></tr>
-  <tr><td rowspan="5">3</td><td>presentational attributes</td><td rowspan="5">normal</td></tr>
-  <td>author - first declared layer</td>
+  <tr><td rowspan="4">3</td><td>author - first declared layer</td><td rowspan="4">normal</td></tr>
   <tr><td>author - last declared layer</td></tr>
   <tr><td>author - unlayered styles</td></tr>
   <tr><td>inline <code>style</code></td></tr>

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -323,7 +323,11 @@ Now that we have a better understanding of origin type and cascade layer precede
 
 ## Which CSS entities participate in the cascade
 
-Only CSS property/value pair declarations participate in the cascade. This means that [at-rules](/en-US/docs/Web/CSS/At-rule) containing entities other than declarations, such as a {{ cssxref("@font-face")}} rule containing _descriptors_, don't participate in the cascade.
+Only CSS property/value pair declarations participate in the cascade.
+
+### At-rules
+
+This means that [at-rules](/en-US/docs/Web/CSS/At-rule) containing entities other than declarations, such as a {{ cssxref("@font-face")}} rule containing _descriptors_, don't participate in the cascade.
 
 For the most part, the properties and descriptors defined in at-rules don't participate in the cascade. Only at-rules as a whole participate in the cascade. For example, within a `@font-face` rule, font names are identified by [`font-family`](/en-US/docs/Web/CSS/@font-face/font-family) descriptors. If several `@font-face` rules with the same descriptor are defined, only the most appropriate `@font-face`, as a whole, is considered. If more than one are identically appropriate, the entire `@font-face` declarations are compared using steps 1, 2, and 4 of the algorithm (there is no specificity when it comes to at-rules).
 
@@ -334,6 +338,15 @@ Declarations in {{cssxref("@keyframes")}} don't participate in the cascade. As w
 When it comes to {{cssxref("@import")}}, the `@import` doesn't participate itself in the cascade, but all of the imported styles do participate. If the `@import` defines a [named or anonymous layer](/en-US/docs/Web/CSS/@layer), the contents of the imported stylesheet are placed into the specified layer. All other CSS imported with `@import` is treated as the last declared layer. This was discussed above.
 
 Finally, {{cssxref("@charset")}} obeys specific algorithms and isn't affected by the cascade algorithm.
+
+### Presentational attributes
+
+Presentational attributes are other attributes in the source document that can affect styling. For example, `align` in HTML or `fill` in SVG. They are considered to be part of the author styles. Presentational attributes do not participate in the cascade.
+
+If they are respected by the user agent, these attributes are translated to the corresponding CSS rules with specificity equal to 0, and are treated as if they were inserted at the start of the author style sheet. Their interaction with
+layers is undefined.
+
+Presentational attributes cannot be declared `!important`.
 
 ## CSS animations and the cascade
 

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -323,11 +323,11 @@ Now that we have a better understanding of origin type and cascade layer precede
 
 ## Which CSS entities participate in the cascade
 
-Only CSS property/value pair declarations participate in the cascade.
+Only CSS property/value pair declarations participate in the cascade. CSS at-rule descriptors don't participate in the cascade and HTML presentational attributes are not part of the cascade.
 
 ### At-rules
 
-This means that [at-rules](/en-US/docs/Web/CSS/At-rule) containing entities other than declarations, such as a {{ cssxref("@font-face")}} rule containing _descriptors_, don't participate in the cascade.
+CSS [at-rules](/en-US/docs/Web/CSS/At-rule) containing entities other than declarations, such as a {{ cssxref("@font-face")}} rule containing _descriptors_, don't participate in the cascade.
 
 For the most part, the properties and descriptors defined in at-rules don't participate in the cascade. Only at-rules as a whole participate in the cascade. For example, within a `@font-face` rule, font names are identified by [`font-family`](/en-US/docs/Web/CSS/@font-face/font-family) descriptors. If several `@font-face` rules with the same descriptor are defined, only the most appropriate `@font-face`, as a whole, is considered. If more than one are identically appropriate, the entire `@font-face` declarations are compared using steps 1, 2, and 4 of the algorithm (there is no specificity when it comes to at-rules).
 
@@ -341,10 +341,9 @@ Finally, {{cssxref("@charset")}} obeys specific algorithms and isn't affected by
 
 ### Presentational attributes
 
-Presentational attributes are other attributes in the source document that can affect styling. For example, `align` in HTML or `fill` in SVG. They are considered to be part of the author styles. Presentational attributes do not participate in the cascade.
+Presentational attributes are attributes in the source document that can affect styling. For example, when included, the deprecated `align` attribute sets the alignment on several HTML elements and the `fill` attribute defines the color used to paint SVG shapes and text and defines the final state for SVG animations. While they are author styles, presentational attributes do not participate in the cascade.
 
-If they are respected by the user agent, these attributes are translated to the corresponding CSS rules with specificity equal to 0, and are treated as if they were inserted at the start of the author style sheet. Their interaction with
-layers is undefined.
+If the HTML presentation attribute is supported by the user agent, valid presentational attributes included in HTML are translated to the corresponding CSS rules, such as the {{cssxref("align")}} or `fill` property (all SVG presentation attributes can be used as a CSS property) inserted in the author stylesheet prior to any other styles with a specificity equal to `0`.
 
 Presentational attributes cannot be declared `!important`.
 

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -189,7 +189,7 @@ margin-left: 3px;
 
 > **Note:** The declaration defined in the user CSS, while it may have greater specificity, is not chosen as the cascade algorithm's _origin and importance_ is applied before the _specificity_ algorithm. The declaration defined in a cascade layer, though it may come later in the code, will not have precedence either as normal styles in cascade layers have less precedence than normal unlayered styles. _Order of appearance_ only matters when both origin, importance, and specificity are equal.
 
-## Author styles: inline styles, layers, presentational attributes, and precedence
+## Author styles: inline styles, layers, presentational  attributes, and precedence
 
 The [table in Cascading order](#cascading_order) provided a precedence order overview. The table summarized the user-agent, user, and author origin type styles in two lines each with "origin type - normal" and "origin type - !important". The precedence within each origin type is more nuanced. Styles can be contained within layers within their origin type, and, with author styles, there is also the issue of where inline styles and presentation attribuets land in the cascade order.
 
@@ -221,7 +221,7 @@ and presentation attributes:
 
 ```html
 <svg>
-  <rect width="100" height="100" fill="red" />
+  <rect width="100" height="100" fill="red"/>
 </svg>
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Adds information about presentational attributes to the CSS Cascade docs. Updated throughout the "Author styles" section.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Presentational attributes seem very similar to inline styles, but they have a very different precedence. This keeps people from thinking they're the same and running into unexpected behaviors.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Manually tested that this information is correct, since the CSS spec doesn't specify how presentational attributes interact with CSS layers.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes https://github.com/mdn/content/issues/33402

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
