### PR TITLE
feat(husky): run fix-redirects command in precommit

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,3 @@
+export default {
+  "files/en-us/_redirects.txt": (filenames) => `yarn content fix-redirects en-US`,
+}

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,6 @@
 export default {
-  "files/en-us/_redirects.txt": (filenames) => `yarn content fix-redirects en-US`,
-}
+  "files/en-us/_redirects.txt": (filenames) => [
+    `yarn content fix-redirects en-US`,
+    `yarn content validate-redirects en-us --strict`,
+  ],
+};


### PR DESCRIPTION
- related to https://github.com/mdn/content/pull/33291#issuecomment-2097456520

## Issue

Sometimes we have to manually edit the redirects file which may introduce errors. Command `yarn content validate-redirects en-us --strict` is run in GitHub PR checks. We have to wait for GitHub workflow to know about the error. Also, yari errors messages are not intuitive:
> error: _redirects.txt for en-us is causing issues: Error: Invalid redirect for /en-US/docs/AJAX/Community -> /en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data or /en-US/docs/AJAX -> /en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data

From the log message above it is not clear that this is a sorting issue. The issue is auto fixable and one shouldn't be bothered to fix it manually.

## Solution

 It would be good if we auto fix fixable errors in husky pre-commit hook itself by running `yarn content fix-redirects en-US` and do redirects check as well.\
:warning:  **Note:** The script suggested in this PR runs only when `_redirects.txt` is modified and _it doesn't run on all commits_.

In case of `.lintstagedrc.json`, all modified file paths are appended to the commands, this is not desirable for the `fix-redirects` command. It throws invalid locale error. In order to avoid appending file paths to commands `.lintstagedrc.js` file has been introduced to the repo.