### PR TITLE
fix(jsxref): make $3 a number for all invocations

### DIFF
--- a/files/en-us/mozilla/firefox/releases/65/index.md
+++ b/files/en-us/mozilla/firefox/releases/65/index.md
@@ -78,7 +78,7 @@ _No changes._
 ### JavaScript
 
 - {{jsxref("Intl/RelativeTimeFormat", "Intl.RelativeTimeFormat")}} is now supported ([Firefox bug 1504334](https://bugzil.la/1504334)).
-- Strings now have a maximum {{jsxref("String/length","length","","1")}} of `2**30 - 2` (\~1GB) instead of `2**28 - 1` (\~256MB) ([Firefox bug 1509542](https://bugzil.la/1509542)).
+- Strings now have a maximum {{jsxref("String/length","length","", 1)}} of `2**30 - 2` (\~1GB) instead of `2**28 - 1` (\~256MB) ([Firefox bug 1509542](https://bugzil.la/1509542)).
 - The {{jsxref("globalThis")}} property, which always refers to the top-level global object, has been implemented ([Firefox bug 1317422](https://bugzil.la/1317422)).
 
 ### APIs

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -126,7 +126,7 @@ In addition, `get()` can be used in nested browsing contexts loaded from the sam
 `get()` and `create()` can be used in nested browsing contexts loaded from the different origins to the top-most document (i.e. in cross-origin `<iframes>`), if allowed by the [`publickey-credentials-get`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) and [`publickey-credentials-create`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) `Permission-Policy` directives, respectively.
 For cross-origin `create()` calls, where the permission was granted by [`allow=` on an iframe](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes), the frame must also have {{glossary("Transient activation")}}.
 
-> **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises", "", "nocode")}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
+> **Note:** Where a policy forbids use of these methods, the {{jsxref("Promise", "promises", "", 1)}} returned by them will reject with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ### Basic access control
 

--- a/files/en-us/web/api/xmlhttprequest_api/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/index.md
@@ -10,7 +10,7 @@ spec-urls: https://xhr.spec.whatwg.org/
 
 The **XMLHttpRequest API** enables web apps to make HTTP requests to web servers and receive the responses programmatically using JavaScript. This in turn enables a website to update just part of a page with data from the server, rather than having to navigate to a whole new page. This practice is also sometimes known as {{glossary("Ajax")}}.
 
-The [Fetch API](/en-US/docs/Web/API/Fetch_API) is the more flexible and powerful replacement for the XMLHttpRequest API. The Fetch API uses {{jsxref("Promise", "promises", "", "nocode")}} instead of events to handle asynchronous responses, integrates well with [service workers](/en-US/docs/Web/API/Service_Worker_API), and supports advanced aspects of HTTP such as [CORS](/en-US/docs/Web/HTTP/CORS). For these reasons, the Fetch API is usually used in modern web apps instead of {{domxref("XMLHttpRequest")}}.
+The [Fetch API](/en-US/docs/Web/API/Fetch_API) is the more flexible and powerful replacement for the XMLHttpRequest API. The Fetch API uses {{jsxref("Promise", "promises", "", 1)}} instead of events to handle asynchronous responses, integrates well with [service workers](/en-US/docs/Web/API/Service_Worker_API), and supports advanced aspects of HTTP such as [CORS](/en-US/docs/Web/HTTP/CORS). For these reasons, the Fetch API is usually used in modern web apps instead of {{domxref("XMLHttpRequest")}}.
 
 ## Concepts and usage
 

--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -34,7 +34,7 @@ Additional examples are available on the {{jsxref("Proxy")}} reference page.
 
 The following terms are used when talking about the functionality of proxies.
 
-- {{jsxref("Proxy/Proxy", "handler", "", "true")}}
+- {{jsxref("Proxy/Proxy", "handler", "", 1)}}
   - : Placeholder object which contains traps.
 - traps
   - : The methods that provide property access. (This is analogous to the concept of _traps_ in operating systems.)

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -58,7 +58,7 @@ console.log(total); // 4
 
 ### Merging two arrays
 
-This example uses {{jsxref("Operators/Spread_syntax", "spread syntax", "", "1")}} to push all elements from a
+This example uses {{jsxref("Operators/Spread_syntax", "spread syntax", "", 1)}} to push all elements from a
 second array into the first one.
 
 ```js

--- a/files/en-us/web/javascript/reference/operators/class/index.md
+++ b/files/en-us/web/javascript/reference/operators/class/index.md
@@ -77,4 +77,4 @@ Foo.name; // "NamedFoo"
 ## See also
 
 - {{jsxref("Statements/class", "class")}}
-- {{jsxref("Classes", "Classes", "", "true")}}
+- {{jsxref("Classes", "Classes", "", 1)}}

--- a/files/en-us/web/javascript/reference/statements/index.md
+++ b/files/en-us/web/javascript/reference/statements/index.md
@@ -61,7 +61,7 @@ For an alphabetical listing see the sidebar on the left.
 - {{jsxref("Statements/for...in", "for...in")}}
   - : Iterates over the enumerable properties of an object, in arbitrary order. For each distinct property, statements can be executed.
 - {{jsxref("Statements/for...of", "for...of")}}
-  - : Iterates over iterable objects (including {{jsxref("Array", "arrays", "", "true")}}, array-like objects, [iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators)), invoking a custom iteration hook with statements to be executed for the value of each distinct property.
+  - : Iterates over iterable objects (including {{jsxref("Array", "arrays", "", 1)}}, array-like objects, [iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators)), invoking a custom iteration hook with statements to be executed for the value of each distinct property.
 - {{jsxref("Statements/for-await...of", "for await...of")}}
   - : Iterates over async iterable objects, array-like objects, [iterators and generators](/en-US/docs/Web/JavaScript/Guide/Iterators_and_generators), invoking a custom iteration hook with statements to be executed for the value of each distinct property.
 - {{jsxref("Statements/while", "while")}}


### PR DESCRIPTION
### Description

Unify the last argument ($3 / do not wrap in code tags) of the jsxref macro. This is a preparation to be more strict regarding arguments. I would have opted for a boolean but it seems like the majority of invocations use 1. 