### PR TITLE
Add initial content for setHTMLUnsafe and parseHTMLUnsafe

### DIFF
--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -305,6 +305,14 @@ The `Document` interface for HTML documents inherit from the {{DOMxRef("HTMLDocu
 - {{DOMxRef("Document.writeln()")}}
   - : Writes a line of text in a document.
 
+## Static methods
+
+_This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventTarget")}} interfaces._
+
+- {{domxref("Document/parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}
+  - : Creates a new `Document` object from a string of HTML without performing sanitization.
+    The string may contain declarative shadow roots.
+
 ## Events
 
 Listen to these events using `addEventListener()` or by assigning an event listener to the `oneventname` property of this interface. In addition to the events listed below, many events can bubble from {{domxref("Node", "nodes", "", "nocode")}} contained in the document tree.

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -6,7 +6,7 @@ page-type: web-api-static-method
 browser-compat: api.Document.parseHTMLUnsafe_static
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`Document.parseHTMLUnsafe()`** static method is used to parse a string of HTML as a new document object.
 

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -14,8 +14,6 @@ The suffix "Unsafe" in the method name indicates that, while `<script>` elements
 
 The resulting `Document` will have a [content type](/en-US/docs/Web/API/Document/contentType) of "text/html", a [character set](/en-US/docs/Web/API/Document/characterSet) of UTF-8, and a URL of "about:blank"
 
-
-
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Document.parseHTMLUnsafe_static
 
 {{APIRef("DOM")}}{{SeeCompatTable}}
 
-The **`Document.parseHTMLUnsafe()`** static method is used to parse a string of HTML as a new document object.
+The **`Document.parseHTMLUnsafe()`** static method is used to parse a string of HTML to create a new {{domxref("Document")}} object.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -24,7 +24,7 @@ Document.parseHTMLUnsafe(input)
 
 ### Parameters
 
-- `input`
+- `html`
   - : A string of HTML to be parsed.
 
 ### Return value

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -6,20 +6,26 @@ page-type: web-api-static-method
 browser-compat: api.Document.parseHTMLUnsafe_static
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("DOM")}}
 
-The **`Document.parseHTMLUnsafe()`** static method is used to parse a string of HTML to create a new {{domxref("Document")}} object.
+The **`parseHTMLUnsafe()`** static method of the {{domxref("Document")}} object is used to parse a string of HTML, which may contain [declarative shadow roots](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom), in order to create a new {{domxref("Document")}} instance.
+
+The suffix "Unsafe" in the method name indicates that, while `<script>` elements are not evaluated during parsing, the method does not sanitize other potentially unsafe XSS-relevant input.
+
+The resulting `Document` will have a [content type](/en-US/docs/Web/API/Document/contentType) of "text/html", a [character set](/en-US/docs/Web/API/Document/characterSet) of UTF-8, and a URL of "about:blank"
+
+
 
 ## Syntax
 
 ```js-nolint
-const doc = Document.parseHTMLUnsafe(input)
+Document.parseHTMLUnsafe(input)
 ```
 
 ### Parameters
 
 - `input`
-  - : A string defining HTML to be parsed.
+  - : A string of HTML to be parsed.
 
 ### Return value
 
@@ -39,5 +45,5 @@ None.
 
 ## See also
 
-- Parsing HTML or XML into a DOM tree: {{domxref("DOMParser")}}
+- {{domxref("DOMParser.parseFromString()")}} for parsing HTML or XML into a DOM tree
 - {{domxref("Element.setHTMLUnsafe")}}

--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -1,0 +1,43 @@
+---
+title: "Document: parseHTMLUnsafe() static method"
+short-title: parseHTMLUnsafe()
+slug: Web/API/Document/parseHTMLUnsafe_static
+page-type: web-api-static-method
+browser-compat: api.Document.parseHTMLUnsafe_static
+---
+
+{{APIRef("DOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
+
+The **`Document.parseHTMLUnsafe()`** static method is used to parse a string of HTML as a new document object.
+
+## Syntax
+
+```js-nolint
+const doc = Document.parseHTMLUnsafe(input)
+```
+
+### Parameters
+
+- `input`
+  - : A string defining HTML to be parsed.
+
+### Return value
+
+A {{domxref("Document")}}.
+
+### Exceptions
+
+None.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Parsing HTML or XML into a DOM tree: {{domxref("DOMParser")}}
+- {{domxref("Element.setHTMLUnsafe")}}

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -10,6 +10,8 @@ browser-compat: api.DOMParser.parseFromString
 
 The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface parses a string containing either HTML or XML, returning an {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}.
 
+> **Note:** The [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) static method provides an ergonomic alternative for parsing HTML strings into a {{domxref("Document")}}.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -284,7 +284,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.setHTML()")}} {{SecureContext_Inline}} {{deprecated_inline}}
   - : Parses and [sanitizes](/en-US/docs/Web/API/HTML_Sanitizer_API) a string of HTML into a document fragment, which then replaces the element's original subtree in the DOM.
 - {{DOMxRef("Element.setHTMLUnsafe()")}}
-  - : Parses a string of HTML into a document fragment, without sanitization, which then replaces the element's original subtree in the DOM. The HTML string may include declarative shadow roots, which would be parsed as template elements if setting the HTML using [`Element.innerHTML`](#element.innerhtml).
+  - : Parses a string of HTML into a document fragment, without sanitization, which then replaces the element's original subtree in the DOM. The HTML string may include declarative shadow roots, which would be parsed as template elements if the HTML was set using [`Element.innerHTML`](#element.innerhtml).
 - {{DOMxRef("Element.setPointerCapture()")}}
   - : Designates a specific element as the capture target of future [pointer events](/en-US/docs/Web/API/Pointer_events).
 - {{DOMxRef("Element.toggleAttribute()")}}

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -282,7 +282,9 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.setCapture()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : Sets up mouse event capture, redirecting all mouse events to this element.
 - {{DOMxRef("Element.setHTML()")}} {{SecureContext_Inline}} {{deprecated_inline}}
-  - : Parses and [sanitizes](/en-US/docs/Web/API/HTML_Sanitizer_API) a string of HTML and inserts into the DOM as a subtree of the element.
+  - : Parses and [sanitizes](/en-US/docs/Web/API/HTML_Sanitizer_API) a string of HTML into a document fragment, which then replaces the element's original subtree in the DOM.
+- {{DOMxRef("Element.setHTMLUnsafe()")}}
+  - : Parses a string of HTML into a document fragment, without sanitization, which then replaces the element's original subtree in the DOM. The HTML string may include declarative shadow roots, which would be parsed as template elements if setting the HTML using [`Element.innerHTML`](#element.innerhtml).
 - {{DOMxRef("Element.setPointerCapture()")}}
   - : Designates a specific element as the capture target of future [pointer events](/en-US/docs/Web/API/Pointer_events).
 - {{DOMxRef("Element.toggleAttribute()")}}

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Element.setHTMLUnsafe
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the element.
 

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -1,0 +1,56 @@
+---
+title: "Element: setHTMLUnsafe() method"
+short-title: setHTMLUnsafe()
+slug: Web/API/Element/setHTMLUnsafe
+page-type: web-api-instance-method
+browser-compat: api.Element.setHTMLUnsafe
+---
+
+{{APIRef("DOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
+
+The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the element.
+
+## Syntax
+
+```js-nolint
+element.setHTMLUnsafe(input)
+```
+
+### Parameters
+
+- `input`
+  - : A string defining HTML to be parsed.
+
+### Return value
+
+None (`undefined`).
+
+### Exceptions
+
+None.
+
+## Examples
+
+The code below demonstrates how to parse a string of HTML and insert it into the `Element` with an id of `target`.
+
+```js
+const value = "<p>This is a string of text</p>"; // string of HTML
+
+// Get the Element with id "target" and set it with the string.
+document.getElementById("target").setHTMLUnsafe(value);
+
+// Result (as a string): "<p>This is a string of text</p>"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Element.innerHTML")}}
+- {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -6,19 +6,19 @@ page-type: web-api-instance-method
 browser-compat: api.Element.setHTMLUnsafe
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("DOM")}}
 
 The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the element.
 
 ## Syntax
 
 ```js-nolint
-element.setHTMLUnsafe(input)
+setHTMLUnsafe(html)
 ```
 
 ### Parameters
 
-- `input`
+- `html`
   - : A string defining HTML to be parsed.
 
 ### Return value

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -15,7 +15,7 @@ The suffix "Unsafe" in the method name indicates that the method does not saniti
 
 If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
 
-> **Note:** This method should be used instead of {{domxref("Element.innerHTML")}} when a string of untrusted HTML may contain declarative shadow roots.
+> **Note:** This method should be used instead of {{domxref("Element.innerHTML")}} when a string of HTML may contain declarative shadow roots.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -13,6 +13,8 @@ The input HTML may include [declarative shadow roots](/en-US/docs/Web/HTML/Eleme
 
 The suffix "Unsafe" in the method name indicates that the method does not sanitize or remove potentially unsafe XSS-relevant input, such as `<script>` elements, and script or event handler content attributes.
 
+If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
+
 > **Note:** This method should be used instead of {{domxref("Element.innerHTML")}} when a string of untrusted HTML may contain declarative shadow roots.
 
 ## Syntax

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -8,7 +8,12 @@ browser-compat: api.Element.setHTMLUnsafe
 
 {{APIRef("DOM")}}
 
-The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the element.
+The **`setHTMLUnsafe()`** method of the {{domxref("Element")}} interface is used to parse a string of HTML into a {{domxref("DocumentFragment")}}, which then replaces the element's subtree in the DOM.
+The input HTML may include [declarative shadow roots](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom).
+
+The suffix "Unsafe" in the method name indicates that the method does not sanitize or remove potentially unsafe XSS-relevant input, such as `<script>` elements, and script or event handler content attributes.
+
+> **Note:** This method should be used instead of {{domxref("Element.innerHTML")}} when a string of untrusted HTML may contain declarative shadow roots.
 
 ## Syntax
 
@@ -52,5 +57,6 @@ document.getElementById("target").setHTMLUnsafe(value);
 
 ## See also
 
+- {{domxref("ShadowRoot.setHTMLUnsafe()")}}
 - {{domxref("Element.innerHTML")}}
 - {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}

--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -57,6 +57,8 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
   - : Returns the topmost element at the specified coordinates.
 - {{domxref("ShadowRoot.elementsFromPoint()")}} {{Non-standard_Inline}}
   - : Returns an array of all elements at the specified coordinates.
+- {{DOMxRef("ShadowRoot.setHTMLUnsafe()")}}
+  - : Parses a string of HTML into a document fragment, without sanitization, which then replaces the shadowroot's original subtree. The HTML string may include declarative shadow roots, which would be parsed as template elements the HTML was set using [`ShadowRoot.innerHTML`](#shadowroot.innerhtml).
 
 ## Events
 

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -1,0 +1,43 @@
+---
+title: "ShadowRoot: setHTMLUnsafe() method"
+short-title: setHTMLUnsafe()
+slug: Web/API/ShadowRoot/setHTMLUnsafe
+page-type: web-api-instance-method
+browser-compat: api.ShadowRoot.setHTMLUnsafe
+---
+
+{{APIRef("DOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
+
+The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the shadow root.
+
+## Syntax
+
+```js-nolint
+shadowRoot.setHTMLUnsafe(input)
+```
+
+### Parameters
+
+- `input`
+  - : A string defining HTML to be parsed.
+
+### Return value
+
+None (`undefined`).
+
+### Exceptions
+
+None.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ShadowRoot.innerHTML")}}
+- {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -15,7 +15,7 @@ The suffix "Unsafe" in the method name indicates that the method does not saniti
 
 If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
 
-> **Note:** This method should be used instead of {{domxref("ShadowRoot.innerHTML")}} when a string of untrusted HTML may contain declarative shadow roots.
+> **Note:** This method should be used instead of {{domxref("ShadowRoot.innerHTML")}} when a string of HTML may contain declarative shadow roots.
 
 ## Syntax
 

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -8,7 +8,14 @@ browser-compat: api.ShadowRoot.setHTMLUnsafe
 
 {{APIRef("Shadow DOM")}}
 
-The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the shadow root.
+The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface is used to parse a string of HTML into a {{domxref("DocumentFragment")}}, which then replaces the element's subtree in the DOM.
+The input HTML may include [declarative shadow roots](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom).
+
+The suffix "Unsafe" in the method name indicates that the method does not sanitize or remove potentially unsafe XSS-relevant input, such as `<script>` elements, and script or event handler content attributes.
+
+If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
+
+> **Note:** This method should be used instead of {{domxref("ShadowRoot.innerHTML")}} when a string of untrusted HTML may contain declarative shadow roots.
 
 ## Syntax
 
@@ -39,5 +46,6 @@ None.
 
 ## See also
 
+- {{domxref("Element.setHTMLUnsafe()")}}
 - {{domxref("ShadowRoot.innerHTML")}}
 - {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.ShadowRoot.setHTMLUnsafe
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the shadow root.
 

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -6,19 +6,19 @@ page-type: web-api-instance-method
 browser-compat: api.ShadowRoot.setHTMLUnsafe
 ---
 
-{{APIRef("DOM")}}{{SeeCompatTable}}
+{{APIRef("Shadow DOM")}}
 
 The **`setHTMLUnsafe()`** method of the {{domxref("ShadowRoot")}} interface is used to parse a string of HTML and then insert it into the DOM as a subtree of the shadow root.
 
 ## Syntax
 
 ```js-nolint
-shadowRoot.setHTMLUnsafe(input)
+setHTMLUnsafe(html)
 ```
 
 ### Parameters
 
-- `input`
+- `html`
   - : A string defining HTML to be parsed.
 
 ### Return value


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds basic pages for setHTMLUnsafe and parseHTMLUnsafe.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

These functions are recently shipping across the board and there's no indication of their existence on MDN.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/32731

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
