### PR TITLE
the blocking attribute is no longer valid on preload link elements

### DIFF
--- a/files/en-us/web/api/performanceresourcetiming/renderblockingstatus/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/renderblockingstatus/index.md
@@ -22,12 +22,7 @@ Render-blocking resources are static files, such as fonts, CSS, and JavaScript t
 In addition to the automatic render-blocking mechanism, `blocking="render"` can be provided as an attribute and value to {{HTMLElement("script")}}, {{HTMLElement("style")}} or {{HTMLElement("link")}} elements to specify explicit render-blocking. For example:
 
 ```html
-<link
-  blocking="render"
-  rel="preload"
-  href="critical-font.woff2"
-  as="font"
-  crossorigin />
+<script blocking="render" src="important.js" defer></script>
 ```
 
 ## Value


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I replaced an invalid example of `blocking=render`

### Motivation

At one point in time the blocking attribute worked for `preload` links. That is no longer the case. I updated the example to use the blocking attribute on a `<script>`.

### Additional details

[Issue in the HTML spec](https://github.com/whatwg/html/issues/7896) which made the blocking attribute invalid for preload links. 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
