### PR TITLE
fix glossary links "CSS pixel"

### DIFF
--- a/files/en-us/web/api/htmlimageelement/height/index.md
+++ b/files/en-us/web/api/htmlimageelement/height/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLImageElement.height
 
 The **`height`** property of the
 {{domxref("HTMLImageElement")}} interface indicates the height at which the image is
-drawn, in {{Glossary("CSS pixels")}} if the image is being drawn or rendered to any
+drawn, in {{Glossary("CSS pixel", "CSS pixels")}} if the image is being drawn or rendered to any
 visual medium such as the screen or a printer; otherwise, it's the natural, pixel
 density corrected height of the image.
 
@@ -20,7 +20,7 @@ An integer value indicating the height of the image. The terms in which the heig
 defined depends on whether the image is being rendered to a visual medium or not.
 
 - If the image is being rendered to a visual medium such as a screen or printer, the
-  height is expressed in {{Glossary("CSS pixels")}}.
+  height is expressed in {{Glossary("CSS pixel", "CSS pixels")}}.
 - Otherwise, the image's height is represented using its natural (intrinsic) height,
   adjusted for the display density as indicated by
   {{domxref("HTMLImageElement.naturalHeight", "naturalHeight")}}.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix glossary links "CSS pixels" should be linked to "CSS pixel" (without "s").

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
