### PR TITLE
fix: make doctype property's description consistent with other documents

### DIFF
--- a/files/en-us/web/api/document/doctype/index.md
+++ b/files/en-us/web/api/document/doctype/index.md
@@ -8,12 +8,7 @@ browser-compat: api.Document.doctype
 
 {{ApiRef("DOM")}}
 
-Returns the Document Type Declaration (DTD) associated with current document. The
-returned object implements the {{domxref("DocumentType")}} interface. Use
-{{domxref("DOMImplementation.createDocumentType()")}} to create a
-`DocumentType`.
-
-- `doctype` is a read-only property.
+The **`doctype`** read-only property of the {{domxref("Document")}} interface returns the Document Type Declaration (DTD) associated with current document. Use {{domxref("DOMImplementation.createDocumentType()")}} to create a `DocumentType`.
 
 ## Value
 

--- a/files/en-us/web/api/document/doctype/index.md
+++ b/files/en-us/web/api/document/doctype/index.md
@@ -8,7 +8,8 @@ browser-compat: api.Document.doctype
 
 {{ApiRef("DOM")}}
 
-The **`doctype`** read-only property of the {{domxref("Document")}} interface returns the Document Type Declaration (DTD) associated with current document. Use {{domxref("DOMImplementation.createDocumentType()")}} to create a `DocumentType`.
+The **`doctype`** read-only property of the {{domxref("Document")}} interface returns the Document Type Declaration (DTD) associated with current document. The
+returned object implements the {{domxref("DocumentType")}} interface. Use {{domxref("DOMImplementation.createDocumentType()")}} to create a `DocumentType`.
 
 ## Value
 

--- a/files/en-us/web/api/document/doctype/index.md
+++ b/files/en-us/web/api/document/doctype/index.md
@@ -8,8 +8,7 @@ browser-compat: api.Document.doctype
 
 {{ApiRef("DOM")}}
 
-The **`doctype`** read-only property of the {{domxref("Document")}} interface returns the Document Type Declaration (DTD) associated with current document. The
-returned object implements the {{domxref("DocumentType")}} interface. Use {{domxref("DOMImplementation.createDocumentType()")}} to create a `DocumentType`.
+The **`doctype`** read-only property of the {{domxref("Document")}} interface is a {{domxref("DocumentType")}} object representing the the {{glossary("Doctype", "Document Type Declaration (DTD)")}} associated with the current document.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It would be better if the first sentence can be organized into 'The xxx read-only property of the yyy interface ...', like other document does.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
