### PR TITLE
Document: `characterSet` property fix menu content

### DIFF
--- a/files/en-us/web/api/document/characterset/index.md
+++ b/files/en-us/web/api/document/characterset/index.md
@@ -16,8 +16,7 @@ document that it's currently rendered with.
 > name of this property, it returns the _encoding_.
 
 Users can override the developer-specified encoding inside the [Content-Type](/en-US/docs/Web/HTTP/Headers/Content-Type) header or inline
-like `<meta charset="utf-8">`, such as with Firefox's <kbd>View → Text
-Encoding</kbd> menu. This override is provided to fix incorrect developer-specified
+like `<meta charset="utf-8">`, such as with Firefox's <kbd>View → Repair Text Encoding </kbd> menu. This override is provided to fix incorrect developer-specified
 encodings that result in [garbled text](https://en.wikipedia.org/wiki/Mojibake).
 
 > **Note:** The properties `document.charset` and `document.inputEncoding`

--- a/files/en-us/web/api/document/characterset/index.md
+++ b/files/en-us/web/api/document/characterset/index.md
@@ -15,13 +15,6 @@ document that it's currently rendered with.
 > **Note:** A "character set" and a "character encoding" are related, but different. Despite the
 > name of this property, it returns the _encoding_.
 
-Users can override the developer-specified encoding inside the [Content-Type](/en-US/docs/Web/HTTP/Headers/Content-Type) header or inline
-like `<meta charset="utf-8">`, such as with Firefox's <kbd>View → Repair Text Encoding </kbd> menu. This override is provided to fix incorrect developer-specified
-encodings that result in [garbled text](https://en.wikipedia.org/wiki/Mojibake).
-
-> **Note:** The properties `document.charset` and `document.inputEncoding`
-> are legacy aliases for `document.characterSet`. Do not use them any more.
-
 ## Value
 
 A string.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
https://support.mozilla.org/en-US/kb/text-encoding-no-longer-available-firefox-menu
<!-- ✍️ Summarize your changes in one or two sentences -->
![image](https://github.com/mdn/content/assets/71604450/2f568efa-a542-44e4-bceb-a5b418d8edf3)
i think update this content.
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
