### PR TITLE
added exprimental note about from keyword

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -233,6 +233,47 @@ Note:
 - The {{domxref("Element.checkVisibility()")}} `options` object parameter now takes the property `contentVisibilityAuto`, which can be set `true` to test if the element has `content-visibility: auto` set and is currently skipping rendering its content (the `options` object also takes new values `opacityProperty` and `visibilityProperty` but these are not related to `content-visibility`).
   (See [Firefox bug 1859852](https://bugzil.la/1859852) for more details).
 
+### from keyword for relative colors
+
+The `from` keyword is now parsed by firefox, behind a flag, this allows the work for [relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) to proceed.
+Currently this has no effect, but with out this the relative colors work can not proceed. (See [Firefox bug 1889133](https://bugzil.la/1889133) for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>126</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>126</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>126</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>126</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.relative-color-syntax.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Single numbers as aspect ratio in media queries
 
 Support for using a single {{cssxref("number")}} as a {{cssxref("ratio")}} when specifying the aspect ratio for a [media query](/en-US/docs/Web/CSS/CSS_media_queries). (See [Firefox bug 1565562](https://bugzil.la/1565562) for more details.)


### PR DESCRIPTION
### Description

Added experimental note for `from` keyword for relative colors

### Motivation

Working on [https://github.com/mdn/content/issues/33082](https://github.com/mdn/content/issues/33082)

### Related issues and pull requests

[https://bugzilla.mozilla.org/show_bug.cgi?id=1889133](https://bugzilla.mozilla.org/show_bug.cgi?id=1889133)