### PR TITLE
fix a broken link flaw

### DIFF
--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -98,7 +98,7 @@ This could be for the following reasons:
 - The path to your service worker file is not written correctly — it needs to be written relative to the origin, not your app's root directory. In our example, the worker is at `https://bncb2v.csb.app/sw.js`, and the app's root is `https://bncb2v.csb.app/`. But the path needs to be written as `/sw.js`.
 - It is also not allowed to point to a service worker of a different origin than that of your app.
 - The service worker will only catch requests from clients under the service worker's scope.
-- The max scope for a service worker is the location of the worker (in other words if the script `sw.js` is located in `/js/sw.js`, it can only control URLs under `/js/` by default). A list of max scopes for that worker can be specified with the [`Service-Worker-Allowed`](/en-US/docs/Web/HTTP/Header/Service-Worker-Allowed) header.
+- The max scope for a service worker is the location of the worker (in other words if the script `sw.js` is located in `/js/sw.js`, it can only control URLs under `/js/` by default). A list of max scopes for that worker can be specified with the `Service-Worker-Allowed` header.
 - In Firefox, Service Worker APIs are hidden and cannot be used when the user is in [private browsing mode](https://bugzil.la/1320796), or when history is disabled, or if cookies are cleared when Firefox is closed.
 - In Chrome, registration fails when the "Block all cookies (not recommended)" option is enabled.
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -267,7 +267,7 @@ The following request headers are not _strictly_ "fetch metadata request headers
   - : Indicates how long the user agent should wait before making a follow-up request.
 - {{HTTPHeader("Server-Timing")}}
   - : Communicates one or more metrics and descriptions for the given request-response cycle.
-- {{HTTPHeader("Service-Worker-Allowed")}}
+- `Service-Worker-Allowed`
   - : Used to remove the [path restriction](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#why_is_my_service_worker_failing_to_register) by including this header [in the response of the Service Worker script](https://w3c.github.io/ServiceWorker/#service-worker-script-response).
 - {{HTTPHeader("SourceMap")}}
   - : Links generated code to a [source map](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html).


### PR DESCRIPTION
We should avoid preemptively creating links to future docs.