### PR TITLE
One-line typo fix in service workers section of PWA tutorial

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/service_workers/index.md
@@ -87,7 +87,7 @@ const APP_STATIC_RESOURCES = [
   "/index.html",
   "/style.css",
   "/app.js",
-  "/cycletrack.json",
+  "/cycletracker.json",
   "/icons/wheel.svg",
 ];
 ```


### PR DESCRIPTION
cycletrack.json -> cycletracker.json

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The file `cycletracker.json` was incorrectly referred to as `cycletrack.json`. I fixed it :)

