### PR TITLE
Fix broken link to `mxr.mozilla.org`

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/updating_extensions/index.md
@@ -122,7 +122,7 @@ Firefox 3.5 closes a security hole that made it possible to use remote chrome. T
 
 Previously, it was possible to get a load context from a request by querying various docShell APIs. In particular, it was a common practice to use `notificationCallbacks.getInterface(nsIDOMWindow)` to get the window object associated with the load. While the older approach may work in some circumstances, it is not recommended to use it anymore ([details](https://bugzil.la/457153#c16)).
 
-This correct and reliable way to do this is to use an `nsILoadContext` (see the [interface definition](https://mxr.mozilla.org/mozilla-central/source/docshell/base/nsILoadContext.idl) on mxr).
+This correct and reliable way to do this is to use an `nsILoadContext` (see the [interface definition](https://hg.mozilla.org/mozilla-central/file/tip/docshell/base/nsILoadContext.idl)).
 
 From JavaScript, you do it like this:
 


### PR DESCRIPTION
### Description

This PR replaces broken link to https://mxr.mozilla.org/mozilla-central/source/docshell/base/nsILoadContext.idl with https://hg.mozilla.org/mozilla-central/file/tip/docshell/base/nsILoadContext.idl
