### PR TITLE
requeststorageaccessfor: Fix claim about gestures

### DIFF
--- a/files/en-us/web/api/document/requeststorageaccessfor/index.md
+++ b/files/en-us/web/api/document/requeststorageaccessfor/index.md
@@ -27,7 +27,7 @@ requestStorageAccessFor(requestedOrigin)
 
 A {{jsxref("Promise")}} that fulfills with `undefined` if the access to third-party cookies was granted and rejects if access was denied.
 
-`requestStorageAccessFor()` requests are automatically denied unless the embedded content is currently processing a user gesture such as a tap or click ({{Glossary("transient activation")}}), or unless permission was already granted previously. If permission was not previously granted, they must run inside a user gesture-based event handler. The user gesture behavior depends on the state of the promise:
+`requestStorageAccessFor()` requests are automatically denied unless the top-level content is currently processing a user gesture such as a tap or click ({{Glossary("transient activation")}}), or unless permission was already granted previously. If permission was not previously granted, they must run inside a user gesture-based event handler. The user gesture behavior depends on the state of the promise:
 
 - If the promise resolves (i.e., permission was granted), then the user gesture has not been consumed, so the script can subsequently call APIs requiring a user gesture.
 - If the promise is rejected (i.e., permission was not granted), then the user gesture has been consumed, so the script can't do anything that requires a gesture. This prevents scripts from calling `requestStorageAccessFor()` again if permission is denied.


### PR DESCRIPTION
It is the top-level content, not the embedded content, that needs to be processing a user gesture. 
See https://privacycg.github.io/requestStorageAccessFor/#dom-document-requeststorageaccessfor step 12 (but also common sense, the goal of requestStorageAccessFor is to allow storage access in requests which cannot execute Javascript, like an AJAX request or invisible pixel, and those do not have a concept of user gestures either.)