### PR TITLE
Make async function error handling consistent with promise example

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -355,26 +355,27 @@ Instead, you'd need to do something like:
 
 ```js
 async function fetchProducts() {
-  try {
-    const response = await fetch(
-      "https://mdn.github.io/learning-area/javascript/apis/fetching-data/can-store/products.json",
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error: ${response.status}`);
-    }
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    console.error(`Could not get products: ${error}`);
-    throw error;
+  const response = await fetch(
+    "https://mdn.github.io/learning-area/javascript/apis/fetching-data/can-store/products.json",
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP error: ${response.status}`);
   }
+  const data = await response.json();
+  return data;
 }
 
 const promise = fetchProducts();
-promise.then((data) => {
-  console.log(data[0].name);
-});
+promise
+  .then((data) => {
+    console.log(data[0].name);
+  })
+  .catch(() => {
+    console.error(`Could not get products: ${error}`);
+  });
 ```
+
+Here, we moved the `try...catch` back to the `catch` handler on the returned promise. This means our `then` handler doesn't have to deal with the case where an  error got caught inside the `fetchProducts` function, causing `data` to be `undefined`. Handle errors as the last step of your promise chain.
 
 Also, note that you can only use `await` inside an `async` function, unless your code is in a [JavaScript module](/en-US/docs/Web/JavaScript/Guide/Modules). That means you can't do this in a normal script:
 
@@ -391,6 +392,7 @@ try {
   console.log(data[0].name);
 } catch (error) {
   console.error(`Could not get products: ${error}`);
+  throw error;
 }
 ```
 

--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -375,7 +375,7 @@ promise
   });
 ```
 
-Here, we moved the `try...catch` back to the `catch` handler on the returned promise. This means our `then` handler doesn't have to deal with the case where an  error got caught inside the `fetchProducts` function, causing `data` to be `undefined`. Handle errors as the last step of your promise chain.
+Here, we moved the `try...catch` back to the `catch` handler on the returned promise. This means our `then` handler doesn't have to deal with the case where an error got caught inside the `fetchProducts` function, causing `data` to be `undefined`. Handle errors as the last step of your promise chain.
 
 Also, note that you can only use `await` inside an `async` function, unless your code is in a [JavaScript module](/en-US/docs/Web/JavaScript/Guide/Modules). That means you can't do this in a normal script:
 

--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -366,14 +366,14 @@ async function fetchProducts() {
     return data;
   } catch (error) {
     console.error(`Could not get products: ${error}`);
+    throw error;
   }
 }
 
 const promise = fetchProducts();
 promise.then((data) => {
-    if(data){ 
-    console.log(data[0].name);
-    }})
+  console.log(data[0].name);
+});
 ```
 
 Also, note that you can only use `await` inside an `async` function, unless your code is in a [JavaScript module](/en-US/docs/Web/JavaScript/Guide/Modules). That means you can't do this in a normal script:

--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -370,7 +370,10 @@ async function fetchProducts() {
 }
 
 const promise = fetchProducts();
-promise.then((data) => console.log(data[0].name));
+promise.then((data) => {
+    if(data){ 
+    console.log(data[0].name);
+    }})
 ```
 
 Also, note that you can only use `await` inside an `async` function, unless your code is in a [JavaScript module](/en-US/docs/Web/JavaScript/Guide/Modules). That means you can't do this in a normal script:


### PR DESCRIPTION
The example fetchProduct():

Let handler work this way by ensuring data exists(returned) incase the async function throws an error.

```
const promise = fetchProducts();
promise.then((data) => {
    if(data){ 
    console.log(data[0].name);
    }})
```

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Check if  data object is returned by the async function fetchProduct() to  prevent TypeError in the line:

```
console.log(data[0].name);
```

I propose this change in the example,

```
const promise = fetchProducts();
promise.then((data) => {
    if(data){ 
    console.log(data[0].name);
    }})
```

### Motivation

To help future readers as I have benefited from contribution of others.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
