### PR TITLE
Chrome 125 supports :state() - de-emphasize incompat

### DIFF
--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -77,8 +77,8 @@ CSS can also be used to match a custom state [within a custom element's shadow D
 
 Additionally, the `:state()` pseudo-class can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that are in a particular state.
 
-> **Warning:** Chrome supports a deprecated syntax that selects custom states using a CSS `<dashed-ident>` rather than the `:state()` function.
-> For information about how to support both approaches see the [Compatibility with `<dashed-ident>` syntax](compability_with_dashed-ident_syntax) section below.
+> **Warning:** Browsers that do not yet support [`:state()`](/en-US/docs/Web/CSS/:state) will use a CSS `<dashed-ident>` for selecting custom states, which is now deprecated.
+> For information about how to support both approaches see the [Compatibility with `<dashed-ident>` syntax](#compability_with_dashed-ident_syntax) section below.
 
 ## Examples
 
@@ -418,12 +418,12 @@ Click the element to see a different border being applied as the state changes.
 ## Compability with `<dashed-ident>` syntax
 
 Previously custom elements with custom states were selected using a `<dashed-ident>` instead of the [`:state()`](/en-US/docs/Web/CSS/:state) function.
-Browsers that don't support `:state()`, including versions of Chrome, will throw an error when supplied with an ident that is not prefixed with the double dash.
+Browser versions that don't support `:state()` will throw an error when supplied with an ident that is not prefixed with the double dash.
 If support for these browsers is required, either use a [try...catch](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block to support both syntaxes, or use a `<dashed-ident>` as the state's value and select it with both the `:--mystate` and `:state(--mystate)` CSS selector.
 
 ### Using a try...catch block
 
-Setting the state to a name without the two dashes will cause an error in some versions of Chrome, catching this error and providing the `<dashed-ident>` alternative allows both to be selected for in CSS.
+This code shows how you can use `try...catch` to attempt adding a state identifier that does not use a `<dashed-ident>`, and fall back to `<dashed-ident>` if an error is thrown.
 
 #### JavaScript
 


### PR DESCRIPTION
Chrome now supports `:state()` CSS selector for custom states in 125 - see https://github.com/mdn/browser-compat-data/pull/23072

This modifies the text which effectively said "chrome doesn't support the new format but instead uses dashed-ident" to "Browsers that don't support `:state()` might use the old format". That way people know to check `:state()` and as soon as the BCD goes in they will see they can use Chrome 125 and later.

FYI @rachelandrew 