### PR TITLE
fix(CookieStoreManager): params of `CookieStoreManager.subscribe` method desc wrong

### DIFF
--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.md
@@ -20,7 +20,7 @@ subscribe(subscriptions)
 
 - `subscriptions`
 
-  - : An object list, each object containing:
+  - : An array of objects, each of which has the following properties:
 
     - `name`
       - : A string with the name of a cookie.

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.md
@@ -20,7 +20,7 @@ subscribe(subscriptions)
 
 - `subscriptions`
 
-  - : An object containing:
+  - : An object list, each object containing:
 
     - `name`
       - : A string with the name of a cookie.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
CookieStoreManager subscribe method params desc wrong.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fix wrong desc.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/en-US/docs/Web/API/CookieStoreManager/subscribe#examples

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
None.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
