### PR TITLE
fix(CookieStoreManager): params of unsubscribe method desc wrong

### DIFF
--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
@@ -20,7 +20,7 @@ unsubscribe(subscriptions)
 
 - `subscriptions`
 
-  - : An object containing:
+  - : An object list, each object containing:
 
     - `name`
       - : A string with the name of a cookie.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
CookieStoreManager unsubscribe method params desc wrong.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fix wrong desc.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
None.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Relates #33583

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
