### PR TITLE
Add additional values for `rectangular-color-space`

### DIFF
--- a/files/en-us/web/css/color-interpolation-method/index.md
+++ b/files/en-us/web/css/color-interpolation-method/index.md
@@ -33,7 +33,7 @@ in <polar-color-space>[ <hue-interpolation method>]
 
 - `<rectangular-color-space>`
 
-  - : One of the keywords `srgb`, `srgb-linear`, `lab`, `oklab`, `xyz`, `xyz-d50`, or `xyz-d65`.
+  - : One of the keywords `srgb`, `srgb-linear`, `display-p3`, `a98-rgb`, `prophoto-rgb`, `rec2020`, `lab`, `oklab`, `xyz`, `xyz-d50`, or `xyz-d65`.
 
 - `<polar-color-space>`
 


### PR DESCRIPTION
### Description

Add additional specced values for `rectangular-color-space`.

### Motivation

These have been in the [CSS color spec](https://drafts.csswg.org/css-color/#color-function) since at least 4 years and are also present in the "Format syntax" section. Ordering is the same as in that section.

### Additional details

Browser suppport [varies](https://jsfiddle.net/silverwind/abmr64Lj/), Firefox supports them all, Chrome and Safari support none.