### PR TITLE
Add mention of text selection prevention in `inert` attribute doc

### DIFF
--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -13,8 +13,8 @@ Specifically, `inert` does the following:
 
 - Prevents the {{domxref("Element/click_event", "click")}} event from being fired when the user clicks on the element.
 - Prevents the {{domxref("Element/focus_event", "focus")}} event from being raised by preventing the element from gaining focus.
-- Prevents any contents of the element from being found/matched during any use of the browser's find-in-page feature. 
-- Prevents users from selecting text within the element — akin to using the CSS property {{domxref("CSS/user-select", "user-select")}} to disable text selection.
+- Prevents any contents of the element from being found/matched during any use of the browser's find-in-page feature.
+- Prevents users from selecting text within the element — akin to using the CSS property {{domxref("CSS/user-select", "user-select")}} to disable text selection.
 - Prevents users from editing any contents of the element that are otherwise editable.
 - Hides the element and its content from assistive technologies by excluding them from the accessibility tree.
 

--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -13,7 +13,9 @@ Specifically, `inert` does the following:
 
 - Prevents the {{domxref("Element/click_event", "click")}} event from being fired when the user clicks on the element.
 - Prevents the {{domxref("Element/focus_event", "focus")}} event from being raised by preventing the element from gaining focus.
-- Prevents users from selecting text within the element, akin to using the CSS property {{domxref("CSS/user-select", "user-select")}} to disable text selection.
+- Prevents any contents of the element from being found/matched during any use of the browser's find-in-page feature. 
+- Prevents users from selecting text within the element — akin to using the CSS property {{domxref("CSS/user-select", "user-select")}} to disable text selection.
+- Prevents users from editing any contents of the element that are otherwise editable.
 - Hides the element and its content from assistive technologies by excluding them from the accessibility tree.
 
 ```html

--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -13,6 +13,7 @@ Specifically, `inert` does the following:
 
 - Prevents the {{domxref("Element/click_event", "click")}} event from being fired when the user clicks on the element.
 - Prevents the {{domxref("Element/focus_event", "focus")}} event from being raised by preventing the element from gaining focus.
+- Prevents users from selecting text within the element, akin to using the CSS property {{domxref("CSS/user-select", "user-select")}} to disable text selection.
 - Hides the element and its content from assistive technologies by excluding them from the accessibility tree.
 
 ```html


### PR DESCRIPTION
This commit adds information to the MDN documentation for the `inert` attribute, specifying that it prevents users from selecting text within the element. This behavior is described as similar to using the CSS property `user-select: none` to disable text selection. The commit includes a link to the documentation for the `user-select` CSS property for further reference. Fixes #33611.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added mention of text selection prevention to the documentation for the inert attribute, highlighting its similarity to using the user-select: none CSS property.

### Motivation

These changes aim to enhance the clarity and completeness of the documentation for the inert attribute by providing information about its effect on preventing text selection. This addition helps readers understand the full range of behaviors associated with using the inert attribute and how it relates to CSS properties like user-select: none, improving their ability to use this attribute effectively in web development.

### Additional details

The `inert` HTML element also prevents the users from selecting the text.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert

### Related issues and pull requests

Fixes #33611 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
