### PR TITLE
Fix typos in the `CSSNumericValue.sub()` method example

### DIFF
--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -36,9 +36,9 @@ A {{domxref('CSSMathSum')}}
 
 ```js
 let mathSum = CSS.px("23")
-  .sum(CSS.percent("4"))
-  .sum(CSS.cm("3"))
-  .sum(CSS.in("9"));
+  .sub(CSS.percent("4"))
+  .sub(CSS.cm("3"))
+  .sub(CSS.in("9"));
 // Prints "calc(23px - 4% - 3cm - 9in)"
 console.log(mathSum.toString());
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/CSSNumericValue/sub

### Description

The example code snippet for the [CSSNumericValue.sub()](https://developer.mozilla.org/en-US/docs/Web/API/CSSNumericValue/sub) method currently shows:
```js
let mathSum = CSS.px("23")
  .sum(CSS.percent("4"))
  .sum(CSS.cm("3"))
  .sum(CSS.in("9"));
```
When the method name is actually `sub`.

This PR replaces these instances of `sum` with `sub`.


### Related issues and pull requests

I was unable to find any existing issues or PRs. Please let me know if one already exists.

Thanks!


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
