### PR TITLE
Add operators adjustment removal to Firefox 126 release

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -18,6 +18,12 @@ This article provides information about the changes in Firefox 126 that affect d
 
 No notable changes.
 
+### MathML
+
+#### Removals
+
+- The automatic adjustment for vertically centered operators (+, =, <, etc.) has been disabled by default. This behavior is not defined in MathML Core and was only necessary as a workaround for non-math fonts. It can still be enabled by setting the `mathml.centered_operators.disabled` config to `false`. ([Firefox bug 1890531](https://bugzil.la/1890531)).
+
 ### CSS
 
 - The {{cssxref("zoom")}} property is now supported. It can be used to increase or decrease the size of an element and its contents ([Firefox bug 390936](https://bugzil.la/390936)).


### PR DESCRIPTION
### Description

- Adds operators adjustment removal to Firefox 126 release

### Motivation

Firefox 126 release project

### Additional details

- [Bugzilla: Remove automatic adjustment for "centered operators"](https://bugzilla.mozilla.org/show_bug.cgi?id=1890531)

### Related issues and pull requests

- https://github.com/mdn/content/issues/33083