### PR TITLE
Move and rename "Accessibility concerns" section in HTML element page template

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -105,7 +105,7 @@ Include a table of the events fired on this type of element, if any.
 
 ## Accessibility
 
-Optionally, warn of any potential accessibility concerns that exist with using this element, and how to work around them. Remove this section if there are none to list.
+Warn of any potential accessibility concerns that exist with using this element, and how to work around them. Remove this section if there are none to list.
 
 ## Examples
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -103,6 +103,10 @@ Include a table of the events fired on this type of element, if any.
 | event 2    | Explain briefly when it is fired |
 | etc.       |                                  |
 
+## Accessibility
+
+Optionally, warn of any potential accessibility concerns that exist with using this element, and how to work around them. Remove this section if there are none to list.
+
 ## Examples
 
 Note that we use the plural "Examples" even if the page only contains one example.
@@ -140,10 +144,6 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 >
 > For examples of this API, see [the page on fetch()](https://example.org).
 > ```
-
-## Accessibility concerns
-
-Optionally, warn of any potential accessibility concerns that exist with using this element, and how to work around them. Remove this section if there are none to list.
 
 ## Technical summary
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Renames "Accessibility concerns" to "Accessibility" and moves it above "Examples". In line with this discussion: https://github.com/orgs/mdn/discussions/430#discussioncomment-6633135 

I also removed the word "Optionally" from the start of the section, as it's already clear that the section should be removed if no guidance is needed.

### Motivation

Make accessibility guidance more prominent.

### Additional details

Full discussion: https://github.com/orgs/mdn/discussions/430

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
