### PR TITLE
Fix typo in IndexedDB openKeyCursor() example

### DIFF
--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
@@ -478,7 +478,7 @@ index.openCursor().onsuccess = (event) => {
 index.openKeyCursor().onsuccess = (event) => {
   const cursor = event.target.result;
   if (cursor) {
-    // cursor.key is a name, like "Bill", and cursor.value is the SSN.
+    // cursor.key is a name, like "Bill", and cursor.primaryKey is the SSN.
     // No way to directly get the rest of the stored object.
     console.log(`Name: ${cursor.key}, SSN: ${cursor.primaryKey}`);
     cursor.continue();


### PR DESCRIPTION
### Description

The `openKeyCursor()` example appears to erroneously refer to `cursor.value` in the code comment, when it should probably refer to `cursor.primaryKey`. The code just below the comment uses `cursor.primaryKey` not `cursor.value`.

### Motivation

I was a bit confused reading this API documentation for the first time. The explanations right above the code example refer to `cursor.primaryKey`, but the code comment references `code.value`. This inconsistency could confuse future readers, though it should be easy to discern that it's just a typo.

