### PR TITLE
Add Intl.DateTimeFormat.resolvedOptions dateStyle, timeStyle

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -148,9 +148,9 @@ The default value for each date-time component option is {{jsxref("undefined")}}
 #### Style shortcuts
 
 - `dateStyle`
-  - : The date formatting style to use when calling `format()`. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`.
+  - : The [date formatting style](https://cldr.unicode.org/translation/date-time/date-time-patterns#h.aa5zjyepm6vh) to use. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`. It resolves to styles for `weekday`, `day`, `month`, `year`, and `era`, with the exact combination of values depending on the locale.
 - `timeStyle`
-  - : The time formatting style to use when calling `format()`. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`.
+  - : The [time formatting style](https://cldr.unicode.org/translation/date-time/date-time-patterns#h.588vo3awdscu) to use. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`. It resolves to styles for `hour`, `minute`, `second`, and `timeZoneName`, with the exact combination of values depending on the locale.
 
 > **Note:** `dateStyle` and `timeStyle` can be used with each other, but not with other date-time component options (e.g. `weekday`, `hour`, `month`, etc.).
 
@@ -206,6 +206,8 @@ console.log(new Intl.DateTimeFormat().format(date));
 
 ### Using timeStyle and dateStyle
 
+`dateStyle` and `timeStyle` provide a shortcut for setting multiple date-time component options at once. For example, for `en-US`, `dateStyle: "short"` is equivalent to setting `year: "2-digit", month: "numeric", day: "numeric"`, and `timeStyle: "short"` is equivalent to setting `hour: "numeric", minute: "numeric"`.
+
 ```js
 const shortTime = new Intl.DateTimeFormat("en", {
   timeStyle: "short",
@@ -215,13 +217,19 @@ console.log(shortTime.format(Date.now())); // "1:31 PM"
 const shortDate = new Intl.DateTimeFormat("en", {
   dateStyle: "short",
 });
-console.log(shortDate.format(Date.now())); // "07/07/20"
+console.log(shortDate.format(Date.now())); // "7/7/20"
 
 const mediumTime = new Intl.DateTimeFormat("en", {
   timeStyle: "medium",
   dateStyle: "short",
 });
-console.log(mediumTime.format(Date.now())); // "07/07/20, 1:31:55 PM"
+console.log(mediumTime.format(Date.now())); // "7/7/20, 1:31:55 PM"
+```
+
+However, the exact (locale dependent) component styles they resolve to are not included in the [resolved options](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions). This ensures the result of `resolvedOptions()` can be passed directly to the `Intl.DateTimeFormat()` constructor (because an `options` object with both `dateStyle` or `timeStyle` and individual date or time component styles is not valid).
+
+```js
+console.log(shortDate.resolvedOptions().year); // undefined
 ```
 
 ### Using dayPeriod

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -148,9 +148,9 @@ The default value for each date-time component option is {{jsxref("undefined")}}
 #### Style shortcuts
 
 - `dateStyle`
-  - : The [date formatting style](https://cldr.unicode.org/translation/date-time/date-time-patterns#h.aa5zjyepm6vh) to use. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`. It resolves to styles for `weekday`, `day`, `month`, `year`, and `era`, with the exact combination of values depending on the locale.
+  - : The [date formatting style](https://cldr.unicode.org/translation/date-time/date-time-patterns#h.aa5zjyepm6vh) to use. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`. It expands to styles for `weekday`, `day`, `month`, `year`, and `era`, with the exact combination of values depending on the locale.
 - `timeStyle`
-  - : The [time formatting style](https://cldr.unicode.org/translation/date-time/date-time-patterns#h.588vo3awdscu) to use. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`. It resolves to styles for `hour`, `minute`, `second`, and `timeZoneName`, with the exact combination of values depending on the locale.
+  - : The [time formatting style](https://cldr.unicode.org/translation/date-time/date-time-patterns#h.588vo3awdscu) to use. Possible values are `"full"`, `"long"`, `"medium"`, and `"short"`. It expands to styles for `hour`, `minute`, `second`, and `timeZoneName`, with the exact combination of values depending on the locale.
 
 > **Note:** `dateStyle` and `timeStyle` can be used with each other, but not with other date-time component options (e.g. `weekday`, `hour`, `month`, etc.).
 
@@ -209,17 +209,17 @@ console.log(new Intl.DateTimeFormat().format(date));
 `dateStyle` and `timeStyle` provide a shortcut for setting multiple date-time component options at once. For example, for `en-US`, `dateStyle: "short"` is equivalent to setting `year: "2-digit", month: "numeric", day: "numeric"`, and `timeStyle: "short"` is equivalent to setting `hour: "numeric", minute: "numeric"`.
 
 ```js
-const shortTime = new Intl.DateTimeFormat("en", {
+const shortTime = new Intl.DateTimeFormat("en-US", {
   timeStyle: "short",
 });
 console.log(shortTime.format(Date.now())); // "1:31 PM"
 
-const shortDate = new Intl.DateTimeFormat("en", {
+const shortDate = new Intl.DateTimeFormat("en-US", {
   dateStyle: "short",
 });
 console.log(shortDate.format(Date.now())); // "7/7/20"
 
-const mediumTime = new Intl.DateTimeFormat("en", {
+const mediumTime = new Intl.DateTimeFormat("en-US", {
   timeStyle: "medium",
   dateStyle: "short",
 });

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -63,10 +63,10 @@ usedOptions.month; // "numeric"
 
 ### Getting the user's time zone and locale preferences
 
-The `Intl.DateTimeFormat` constructor without any options uses the current system settings. You can use `resolvedOptions()` to get the user's current time zone and locale's preferred calendar and numbering system:
+You can use `resolvedOptions()` to get the user's current time zone and locale's preferred calendar and numbering system:
 
 ```js
-const systemOptions = new Intl.DateTimeFormat().resolvedOptions();
+const systemOptions = new Intl.DateTimeFormat(navigator.languages).resolvedOptions();
 systemOptions.timeZone; // e.g., "Europe/Brussels" or "Asia/Riyadh"
 systemOptions.calendar; // e.g., "gregory" or "islamic-umalqura"
 systemOptions.numberingSystem; // e.g., "latn" or "arab"

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -63,10 +63,12 @@ usedOptions.month; // "numeric"
 
 ### Getting the user's time zone and locale preferences
 
-You can use `resolvedOptions()` to get the user's current time zone and locale's preferred calendar and numbering system:
+The `Intl.DateTimeFormat` constructor without any options uses the current
+system settings. You can use `resolvedOptions()` to get the user's current
+time zone and locale's preferred calendar and numbering system:
 
 ```js
-const systemOptions = new Intl.DateTimeFormat(navigator.languages).resolvedOptions();
+const systemOptions = new Intl.DateTimeFormat().resolvedOptions();
 systemOptions.timeZone; // e.g., "Europe/Brussels" or "Asia/Riyadh"
 systemOptions.calendar; // e.g., "gregory" or "islamic-umalqura"
 systemOptions.numberingSystem; // e.g., "latn" or "arab"

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -23,51 +23,28 @@ None.
 
 ### Return value
 
-A new object with properties reflecting the locale and date and time formatting options
-computed during the initialization of the given {{jsxref("Intl.DateTimeFormat")}} object.
-
-## Description
-
-The resulting object has the following properties:
+A new object with properties reflecting the options computed during the initialization of the given {{jsxref("Intl.DateTimeFormat")}} object. The object has the following properties, in the order they are listed:
 
 - `locale`
-  - : The BCP 47 language tag for the locale actually used. If any Unicode extension
-    values were requested in the input BCP 47 language tag that led to this locale,
-    the key-value pairs that were requested and are supported for this locale are
-    included in `locale`.
+  - : The BCP 47 language tag for the locale actually used. Only the `ca`, `hc`, and `nu` Unicode extension keys may be included in the output.
 - `calendar`
-  - : The calendar system actually used. From the value provided for this property
-    in the `options` argument, a specific calendar requested using the Unicode
-    extension key `ca` in the `locales` argument, or the default calendar system
-    for the resolved `locale`. E.g. "gregory", "hebrew".
+  - : One of the [supported calendar types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars#supported_calendar_types), reflecting the value provided for this property in the `options` argument or the `ca` Unicode extension key. The default is locale dependent.
 - `numberingSystem`
-  - : The numbering system actually used. From the value provided for this property
-    in the `options` argument, a specific numbering system requested using
-    the Unicode extension key `nu` in the `locales` argument, or the default
-    numbering system for the resolved `calendar` and `locale`.
+  - : One of the [supported numbering system types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems#supported_numbering_system_types), reflecting the value provided for this property in the `options` argument or the `nu` Unicode extension key. The default is locale dependent.
 - `timeZone`
-  - : The value provided for this property in the `options` argument;
-    defaults to the runtime's default time zone. Should never be `undefined`.
-- `hour12`, `hourCycle`
-  - : The values provided for these properties in the `options` argument, or
-    the locale's preferred representation for hours if not specified. (These
-    properties are only present if the `options` argument included `hour`
-    or `timeStyle`.)
-- `weekday`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`, `timeZoneName`
-  - : The values resulting from format matching between the corresponding properties in
-    the `options` argument and the available combinations and
-    representations for date-time formatting in the selected locale. Some of these
-    properties may not be present, indicating that the corresponding components will
-    not be represented in formatted output. (If the `dateStyle` or `timeStyle` shortcuts
-    were used in `options`, these individual component properties will never be present.)
+  - : One of the [IANA time zone names](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZoneNames), reflecting the value provided for this property in the `options` argument. The default is the runtime's default time zone; should never be `undefined`.
+- `hourCycle`
+  - : The value provided for this property in the `options` argument, or provided in the Unicode extension key `"hc"`, with default filled in as needed. Only present if the `options` argument included `hour` or `timeStyle`.
+- `hour12`
+  - : The value provided for this property in the `options` argument, or computed from the `hourCycle` property. Only present if the `options` argument included `hour` or `timeStyle`.
+- `weekday`, `era`, `year`, `month`, `day`, `dayPeriod`, `hour`, `minute`, `second`, `fractionalSecondDigits`, `timeZoneName`
+  - : The values resulting from format matching between the corresponding properties in the `options` argument and the available combinations and representations for date-time formatting in the selected locale. Some of these properties may not be present, indicating that the corresponding components will not be represented in formatted output. If the `dateStyle` or `timeStyle` shortcuts were used in `options`, these individual component properties will never be present.
 - `dateStyle`, `timeStyle`
   - : The values provided for these properties in the `options` argument, if any.
 
-Although `dateStyle` and `timeStyle` are shortcuts for individual date and time component
-styles, the exact (locale dependent) component styles they resolve to are not
-included in the resolved options. This ensures the result of `resolvedOptions()` can
-be passed directly to the `Intl.DateTimeFormat()` constructor (because an `options` object
-with both `dateStyle` or `timeStyle` and individual date or time component styles is not valid).
+## Description
+
+Although `dateStyle` and `timeStyle` are shortcuts for individual date and time component styles, the exact (locale dependent) component styles they resolve to are not included in the resolved options. This ensures the result of `resolvedOptions()` can be passed directly to the `Intl.DateTimeFormat()` constructor (because an `options` object with both `dateStyle` or `timeStyle` and individual date or time component styles is not valid).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -54,7 +54,7 @@ The resulting object has the following properties:
     not be represented in formatted output.
 - `dateStyle`, `timeStyle`
   - : The values provided for these properties in the `options` argument, if any.
-    (The `dateStyle` and `timeStyle` shortcuts are *not* resolved to individual
+    (The `dateStyle` and `timeStyle` shortcuts are _not_ resolved to individual
     date-time format properties like `year` or `hour`.)
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -52,6 +52,10 @@ The resulting object has the following properties:
     representations for date-time formatting in the selected locale. Some of these
     properties may not be present, indicating that the corresponding components will
     not be represented in formatted output.
+- `dateStyle`, `timeStyle`
+  - : The values provided for these properties in the `options` argument, if any.
+    (The `dateStyle` and `timeStyle` shortcuts are *not* resolved to individual
+    date-time format properties like `year` or `hour`.)
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -64,9 +64,9 @@ The resulting object has the following properties:
   - : The values provided for these properties in the `options` argument, if any.
 
 Although `dateStyle` and `timeStyle` are shortcuts for individual date and time component
-styles, the exact (locale dependent) component styles they resolve to are not 
-included in the resolved options. This ensures the result of `resolvedOptions()` can 
-be passed directly to the `Intl.DateTimeFormat()` constructor (because an `options` object 
+styles, the exact (locale dependent) component styles they resolve to are not
+included in the resolved options. This ensures the result of `resolvedOptions()` can
+be passed directly to the `Intl.DateTimeFormat()` constructor (because an `options` object
 with both `dateStyle` or `timeStyle` and individual date or time component styles is not valid).
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -63,9 +63,7 @@ usedOptions.month; // "numeric"
 
 ### Getting the user's time zone and locale preferences
 
-The `Intl.DateTimeFormat` constructor without any options uses the current
-system settings. You can use `resolvedOptions()` to get the user's current
-time zone and locale's preferred calendar and numbering system:
+The `Intl.DateTimeFormat` constructor without any options uses the current system settings. You can use `resolvedOptions()` to get the user's current time zone and locale's preferred calendar and numbering system:
 
 ```js
 const systemOptions = new Intl.DateTimeFormat().resolvedOptions();

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -36,26 +36,38 @@ The resulting object has the following properties:
     the key-value pairs that were requested and are supported for this locale are
     included in `locale`.
 - `calendar`
-  - : E.g. "gregory"
+  - : The calendar system actually used. From the value provided for this property
+    in the `options` argument, a specific calendar requested using the Unicode
+    extension key `ca` in the `locales` argument, or the default calendar system
+    for the resolved `locale`. E.g. "gregory", "hebrew".
 - `numberingSystem`
-  - : The values requested using the Unicode extension keys `"ca"` and
-    `"nu"` or filled in as default values.
+  - : The numbering system actually used. From the value provided for this property
+    in the `options` argument, a specific numbering system requested using
+    the Unicode extension key `nu` in the `locales` argument, or the default
+    numbering system for the resolved `calendar` and `locale`.
 - `timeZone`
   - : The value provided for this property in the `options` argument;
     defaults to the runtime's default time zone. Should never be `undefined`.
-- `hour12`
-  - : The value provided for this property in the `options` argument or
-    filled in as a default.
+- `hour12`, `hourCycle`
+  - : The values provided for these properties in the `options` argument, or
+    the locale's preferred representation for hours if not specified. (These
+    properties are only present if the `options` argument included `hour`
+    or `timeStyle`.)
 - `weekday`, `era`, `year`, `month`, `day`, `hour`, `minute`, `second`, `timeZoneName`
   - : The values resulting from format matching between the corresponding properties in
     the `options` argument and the available combinations and
     representations for date-time formatting in the selected locale. Some of these
     properties may not be present, indicating that the corresponding components will
-    not be represented in formatted output.
+    not be represented in formatted output. (If the `dateStyle` or `timeStyle` shortcuts
+    were used in `options`, these individual component properties will never be present.)
 - `dateStyle`, `timeStyle`
   - : The values provided for these properties in the `options` argument, if any.
-    (The `dateStyle` and `timeStyle` shortcuts are _not_ resolved to individual
-    date-time format properties like `year` or `hour`.)
+
+Although `dateStyle` and `timeStyle` are shortcuts for individual date and time component
+styles, the exact (locale dependent) component styles they resolve to are not 
+included in the resolved options. This ensures the result of `resolvedOptions()` can 
+be passed directly to the `Intl.DateTimeFormat()` constructor (because an `options` object 
+with both `dateStyle` or `timeStyle` and individual date or time component styles is not valid).
 
 ## Examples
 
@@ -65,11 +77,25 @@ The resulting object has the following properties:
 const germanFakeRegion = new Intl.DateTimeFormat("de-XX", { timeZone: "UTC" });
 const usedOptions = germanFakeRegion.resolvedOptions();
 
-usedOptions.locale; // "de"
+usedOptions.locale; // "de" (because "de-XX" does not exist)
 usedOptions.calendar; // "gregory"
 usedOptions.numberingSystem; // "latn"
 usedOptions.timeZone; // "UTC"
 usedOptions.month; // "numeric"
+```
+
+### Getting the user's time zone and locale preferences
+
+The `Intl.DateTimeFormat` constructor without any options uses the current
+system settings. You can use `resolvedOptions()` to get the user's current
+time zone and locale's preferred calendar and numbering system:
+
+```js
+const systemOptions = new Intl.DateTimeFormat().resolvedOptions();
+systemOptions.timeZone; // e.g., "Europe/Brussels" or "Asia/Riyadh"
+systemOptions.calendar; // e.g., "gregory" or "islamic-umalqura"
+systemOptions.numberingSystem; // e.g., "latn" or "arab"
+systemOptions.locale; // e.g., "nl-BE" or "ar-SA"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Document `dateStyle` and `timeStyle` for [`Intl.DateTimeFormat.resolvedOptions()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#description) return value.

### Motivation

These properties were added in https://github.com/tc39/ecma402/pull/457, but are not covered by the current documentation.

### Additional details

See current https://tc39.es/ecma402/#table-datetimeformat-resolvedoptions-properties


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
