### PR TITLE
Add filter to getDynamicRules and getSessionRules

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
@@ -21,7 +21,7 @@ let gettingDynamicRules = browser.declarativeNetRequest.getDynamicRules();
 
   - : An object to filter the list of returned rules.
     - `ruleIds` {{optional_inline}}
-      - : An array of  `integer`. The IDs of rules to include in the response.
+      - : An array of `integer`. The IDs of the rules to return.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
@@ -17,7 +17,11 @@ let gettingDynamicRules = browser.declarativeNetRequest.getDynamicRules();
 
 ### Parameters
 
-This function takes no parameters.
+- `filter` {{optional_inline}}
+
+  - : An object to filter the list of returned rules.
+    - `ruleIds` {{optional_inline}}
+      - : An array of  `integer`. The IDs of rules to include in the response.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
@@ -21,7 +21,7 @@ let sessionRules = await browser.declarativeNetRequest.getSessionRules();
 
   - : An object to filter the list of returned rules.
     - `ruleIds` {{optional_inline}}
-      - : An array of  `integer`. The IDs of rules to include in the response.
+      - : An array of `integer`. The IDs of the rules to return.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
@@ -17,7 +17,11 @@ let sessionRules = await browser.declarativeNetRequest.getSessionRules();
 
 ### Parameters
 
-This function takes no parameters.
+- `filter` {{optional_inline}}
+
+  - : An object to filter the list of returned rules.
+    - `ruleIds` {{optional_inline}}
+      - : An array of  `integer`. The IDs of rules to include in the response.
 
 ### Return value
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -58,6 +58,8 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ## Changes for add-on developers
 
+- Addition of a `filter` parameter to {{WebExtAPIRef("declarativeNetRequest.getDynamicRules")}}  and {{WebExtAPIRef("declarativeNetRequest.getSessionRules")}}, which enables the list of returned rules to be filtered by ID ([Firefox bug 1820870](https://bugzil.la/1820870)).
+
 ### Removals
 
 ### Other

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -58,7 +58,7 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ## Changes for add-on developers
 
-- Addition of a `filter` parameter to {{WebExtAPIRef("declarativeNetRequest.getDynamicRules")}}  and {{WebExtAPIRef("declarativeNetRequest.getSessionRules")}}, which enables the list of returned rules to be filtered by ID ([Firefox bug 1820870](https://bugzil.la/1820870)).
+- Addition of a `filter` parameter to {{WebExtAPIRef("declarativeNetRequest.getDynamicRules")}} and {{WebExtAPIRef("declarativeNetRequest.getSessionRules")}}, which enables the list of returned rules to be filtered by ID ([Firefox bug 1820870](https://bugzil.la/1820870)).
 
 ### Removals
 


### PR DESCRIPTION
### Description

Addresses the documentation requirements for [Bug 1820870](https://bugzilla.mozilla.org/show_bug.cgi?id=1820870) [DNR] Add ruleIds filter to getDynamicRules and getSessionRules

### Related issues and pull requests

Related BCD changes: https://github.com/mdn/browser-compat-data/pull/23114
