### PR TITLE
Document `vlinkColor` property fix no Specifications

### DIFF
--- a/files/en-us/web/api/document/vlinkcolor/index.md
+++ b/files/en-us/web/api/document/vlinkcolor/index.md
@@ -25,6 +25,10 @@ A string representing the color as a word (e.g., `"red"`) or hexadecimal value (
 - The recommended alternative is to get/set the color of the CSS {{Cssxref(":visited")}} pseudo-class on HTML {{HtmlElement("a")}} elements (e.g., `a:visited {color:red;}`).
 - Another alternative is `document.body.vLink`, although this is [deprecated in HTML 4.01](https://www.w3.org/TR/html401/struct/global.html#adef-vlink) in favor of the CSS alternative.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
<!-- Do not make changes below this line -->
<details>
<summary>Page report details</summary>

* Folder: `en-us/web/api/document/visibilitystate`
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/document/visibilitystate/index.md
* Last commit: https://github.com/mdn/content/commit/14a752ccdcaa736e8e368156c48bca61a3c1e5ed
* Document last modified: 2024-05-08T16:25:11.000Z

</details>