### PR TITLE
fix: improvements on Glossary/Delta

### DIFF
--- a/files/en-us/glossary/delta/index.md
+++ b/files/en-us/glossary/delta/index.md
@@ -26,6 +26,4 @@ More commonly, you receive the delta and use it to update a saved previous condi
 let newX = oldX + deltaX;
 ```
 
-## See also
-
-- Mouse wheel events ({{domxref("WheelEvent")}} offer the amount the wheel moved since the last event in its {{domxref("WheelEvent.deltaX", "deltaX")}}, {{domxref("WheelEvent.deltaY", "deltaY")}}, and {{domxref("WheelEvent.deltaZ", "deltaZ")}} properties, for example.
+For example, mouse wheel events {{domxref("WheelEvent")}} offer the amount the wheel moved since the last event in its {{domxref("WheelEvent.deltaX", "deltaX")}}, {{domxref("WheelEvent.deltaY", "deltaY")}}, and {{domxref("WheelEvent.deltaZ", "deltaZ")}} properties.


### PR DESCRIPTION
### Motivation

#### Modifications

the description in see-also section is an example, but not external links for further information references like the other pages have.

plus, an unclosed parentness is deleted.