### PR TITLE
Fix redirected links to glossary

### DIFF
--- a/files/en-us/glossary/request_header/index.md
+++ b/files/en-us/glossary/request_header/index.md
@@ -10,7 +10,7 @@ A **request header** is an {{glossary("HTTP header")}} that can be used in an HT
 
 Not all headers that can appear in a request are referred to as _request headers_ by the specification. For example, the {{HTTPHeader("Content-Type")}} header is referred to as a {{glossary("representation header")}}.
 
-In addition, [CORS](/en-US/docs/Glossary/CORS) defines a subset of request headers as {{glossary('simple header', 'simple headers')}}, request headers that are always considered authorized and are not explicitly listed in responses to {{glossary("preflight request", "preflight")}} requests.
+In addition, [CORS](/en-US/docs/Glossary/CORS) defines a subset of request headers as {{glossary('CORS-safelisted request header', 'simple headers')}}, request headers that are always considered authorized and are not explicitly listed in responses to {{glossary("preflight request", "preflight")}} requests.
 
 The HTTP message below shows a few request headers after a {{HTTPMethod("GET")}} request:
 

--- a/files/en-us/web/api/fetch_api/basic_concepts/index.md
+++ b/files/en-us/web/api/fetch_api/basic_concepts/index.md
@@ -65,5 +65,5 @@ When a new {{domxref("Headers")}} object is created using the {{domxref("Headers
 A header's guard affects the {{domxref("Headers.set","set()")}}, {{domxref("Headers.delete","delete()")}}, and {{domxref("Headers.append","append()")}} methods which change the header's contents. A {{jsxref("TypeError")}} is thrown if you try to modify a {{domxref("Headers")}} object whose guard is `immutable`. However, the operation will work if
 
 - guard is `request` and the header _name_ isn't a {{Glossary("forbidden header name")}} .
-- guard is `request-no-cors` and the header _name_/_value_ is a {{Glossary("simple header")}} .
+- guard is `request-no-cors` and the header _name_/_value_ is a {{Glossary("CORS-safelisted request header", "simple header")}} .
 - guard is `response` and the header _name_ isn't a {{Glossary("forbidden response header name")}} .

--- a/files/en-us/web/http/headers/content-range/index.md
+++ b/files/en-us/web/http/headers/content-range/index.md
@@ -25,7 +25,7 @@ a full body message a partial message belongs.
     </tr>
     <tr>
       <th scope="row">
-        {{Glossary("Simple response header", "CORS-safelisted response-header")}}
+        {{Glossary("CORS-safelisted request header")}}
       </th>
       <td>no</td>
     </tr>


### PR DESCRIPTION
The page has been moved; this prevent three redirections (and 3 flaws)