### PR TITLE
Fix broken links to no more existing HTML element

### DIFF
--- a/files/en-us/mozilla/firefox/releases/22/index.md
+++ b/files/en-us/mozilla/firefox/releases/22/index.md
@@ -32,7 +32,7 @@ page-type: firefox-release-notes
 - `Node.setUserData` and `Node.getUserData` has been removed for web content and are deprecated for chrome content ([Firefox bug 842372](https://bugzil.la/842372)).
 - The {{domxref("Element.attributes")}} property has been moved there from {{domxref("Node")}} as required by the spec ([Firefox bug 844134](https://bugzil.la/844134)).
 - The Mac OS X backend for **Ambient Light Events** has been implemented.
-- Elements in the HTML namespace with local names `<bgsound>`, {{HTMLElement("multicol")}}, and {{HTMLElement("image")}} no longer implement the {{domxref("HTMLSpanElement")}} interface. `<bgsound>` implements {{domxref("HTMLUnknownElement")}} and {{HTMLElement("image")}} implements {{domxref("HTMLElement")}}.
+- Elements in the HTML namespace with local names `<bgsound>`, `<multicol>`, and `<image>` no longer implement the {{domxref("HTMLSpanElement")}} interface. `<bgsound>` implements {{domxref("HTMLUnknownElement")}} and `<image>` implements {{domxref("HTMLElement")}}.
 - The {{ domxref("NodeIterator.detach") }} method has been changed to do nothing ([Firefox bug 823549](https://bugzil.la/823549)).
 - The {{domxref("BlobEvent")}} interface has been implemented ([Firefox bug 834165](https://bugzil.la/834165)).
 - The properties `HTMLMediaElement.crossorigin` and `HTMLInputElement.inputmode` has been removed to match the spec in {{domxref("HTMLMediaElement.crossOrigin")}} and `HTMLInputElement.inputMode`, respectively ([Firefox bug 847370](https://bugzil.la/847370) and [Firefox bug 850346](https://bugzil.la/850346)).


### PR DESCRIPTION
These elements have been removed later and don't have their own page (and won't).