### PR TITLE
Text `wholeText` property fix wrong variable name

### DIFF
--- a/files/en-us/web/api/text/wholetext/index.md
+++ b/files/en-us/web/api/text/wholetext/index.md
@@ -37,7 +37,7 @@ You decide you don't like the middle sentence, so you remove it:
 
 ```js
 const paragraph = document.querySelector("p"); // Reads the paragraph
-paragraph.removeChild(para.childNodes[1]); // Delete the strong element
+paragraph.removeChild(paragraph.childNodes[1]); // Delete the strong element
 ```
 
 Now you end up with _"Through-hiking is great! However, casting a ballot is tricky."_, with two nodes before the hyperlink:
@@ -45,7 +45,7 @@ Now you end up with _"Through-hiking is great! However, casting a ballot is tric
 1. A {{domxref("Text")}} containing the string `"Through-hiking is great!"`
 2. A second `Text` node containing the string `" However, "`
 
-To get those two nodes at once, you would call `para.childNodes[0].wholeText`:
+To get those two nodes at once, you would call `paragraph.childNodes[0].wholeText`:
 
 ```js
 console.log(`'${paragraph.childNodes[0].wholeText}'`); // 'Through-hiking is great!   However, '


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
<!-- Do not make changes below this line -->
<details>
<summary>Page report details</summary>

* Folder: `en-us/web/api/text/wholetext`
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/Text/wholeText
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/text/wholetext/index.md
* Last commit: https://github.com/mdn/content/commit/0c8a320b035cf625c1df67713a94ead2e7f3aec6
* Document last modified: 2023-04-08T06:16:25.000Z

</details>