### PR TITLE
Fix `childList` docs for `MutationRecord.type`

### DIFF
--- a/files/en-us/web/api/mutationrecord/type/index.md
+++ b/files/en-us/web/api/mutationrecord/type/index.md
@@ -18,7 +18,7 @@ The property is set to the type of the mutation as a string. The value can be on
 
 - `characterData` if it was a mutation to a {{domxref("CharacterData")}} node.
 
-- `childList` if the mutation a mutation to the tree of nodes.
+- `childList` if the mutation was a mutation to the tree of nodes.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Fixing a minor grammar issue in the `childList` docs for `MutationRecord.type`.

### Motivation

Improves the docs by making it dramatically correct. I had to read it twice to understand what it does. 

### Additional details

Discovered while reviewing https://github.com/Automattic/wp-calypso/pull/90813

### Related issues and pull requests

None