### PR TITLE
CustomStateSet doc: Add feature detection for :state pseudo-class and browser compatibility warning

### DIFF
--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -140,7 +140,22 @@ class LabeledCheckbox extends HTMLElement {
     // Toggle the 'checked' property when the element is clicked
     this.checked = !this.checked;
   }
+
+  static isStateSyntaxSupported() {
+    return CSS.supports("selector(:state(checked))");
+  }
 }
+
+customElements.define("labeled-checkbox", LabeledCheckbox);
+
+document.addEventListener("DOMContentLoaded", () => {
+  if (!LabeledCheckbox.isStateSyntaxSupported()) {
+    const warning = document.createElement("div");
+    warning.style.color = "red";
+    warning.textContent = "This feature is not supported by your browser.";
+    document.body.insertBefore(warning, document.body.firstChild);
+  }
+});
 ```
 
 In the `LabeledCheckbox` class:
@@ -199,6 +214,7 @@ class LabeledCheckbox extends HTMLElement {
     super();
     this._boundOnClick = this._onClick.bind(this);
     this.addEventListener("click", this._boundOnClick);
+
     // Attach an ElementInternals to get states property
     this._internals = this.attachInternals();
   }
@@ -235,9 +251,22 @@ class LabeledCheckbox extends HTMLElement {
     // Toggle the 'checked' property when the element is clicked
     this.checked = !this.checked;
   }
+
+  static isStateSyntaxSupported() {
+    return CSS.supports("selector(:state(checked))");
+  }
 }
 
 customElements.define("labeled-checkbox", LabeledCheckbox);
+
+document.addEventListener("DOMContentLoaded", () => {
+  if (!LabeledCheckbox.isStateSyntaxSupported()) {
+    const warning = document.createElement("div");
+    warning.style.color = "red";
+    warning.textContent = "This feature is not supported by your browser.";
+    document.body.insertBefore(warning, document.body.firstChild);
+  }
+});
 ```
 
 First, we define the custom element class `QuestionBox`, which extends `HTMLElement`.

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -151,9 +151,9 @@ customElements.define("labeled-checkbox", LabeledCheckbox);
 // Display a warning to unsupported browsers
 document.addEventListener("DOMContentLoaded", () => {
   if (!LabeledCheckbox.isStateSyntaxSupported()) {
-    if (!document.getElementById('state-warning')) {
+    if (!document.getElementById("state-warning")) {
       const warning = document.createElement("div");
-      warning.id = 'state-warning';
+      warning.id = "state-warning";
       warning.style.color = "red";
       warning.textContent = "This feature is not supported by your browser.";
       document.body.insertBefore(warning, document.body.firstChild);
@@ -265,9 +265,9 @@ customElements.define("labeled-checkbox", LabeledCheckbox);
 
 document.addEventListener("DOMContentLoaded", () => {
   if (!LabeledCheckbox.isStateSyntaxSupported()) {
-    if (!document.getElementById('state-warning')) {
+    if (!document.getElementById("state-warning")) {
       const warning = document.createElement("div");
-      warning.id = 'state-warning';
+      warning.id = "state-warning";
       warning.style.color = "red";
       warning.textContent = "This feature is not supported by your browser.";
       document.body.insertBefore(warning, document.body.firstChild);
@@ -424,9 +424,9 @@ customElements.define("many-state-element", ManyStateElement);
 
 document.addEventListener("DOMContentLoaded", () => {
   if (!LabeledCheckbox.isStateSyntaxSupported()) {
-    if (!document.getElementById('state-warning')) {
+    if (!document.getElementById("state-warning")) {
       const warning = document.createElement("div");
-      warning.id = 'state-warning';
+      warning.id = "state-warning";
       warning.style.color = "red";
       warning.textContent = "This feature is not supported by your browser.";
       document.body.insertBefore(warning, document.body.firstChild);

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -148,12 +148,16 @@ class LabeledCheckbox extends HTMLElement {
 
 customElements.define("labeled-checkbox", LabeledCheckbox);
 
+// Display a warning to unsupported browsers
 document.addEventListener("DOMContentLoaded", () => {
   if (!LabeledCheckbox.isStateSyntaxSupported()) {
-    const warning = document.createElement("div");
-    warning.style.color = "red";
-    warning.textContent = "This feature is not supported by your browser.";
-    document.body.insertBefore(warning, document.body.firstChild);
+    if (!document.getElementById('state-warning')) {
+      const warning = document.createElement("div");
+      warning.id = 'state-warning';
+      warning.style.color = "red";
+      warning.textContent = "This feature is not supported by your browser.";
+      document.body.insertBefore(warning, document.body.firstChild);
+    }
   }
 });
 ```
@@ -261,10 +265,13 @@ customElements.define("labeled-checkbox", LabeledCheckbox);
 
 document.addEventListener("DOMContentLoaded", () => {
   if (!LabeledCheckbox.isStateSyntaxSupported()) {
-    const warning = document.createElement("div");
-    warning.style.color = "red";
-    warning.textContent = "This feature is not supported by your browser.";
-    document.body.insertBefore(warning, document.body.firstChild);
+    if (!document.getElementById('state-warning')) {
+      const warning = document.createElement("div");
+      warning.id = 'state-warning';
+      warning.style.color = "red";
+      warning.textContent = "This feature is not supported by your browser.";
+      document.body.insertBefore(warning, document.body.firstChild);
+    }
   }
 });
 ```
@@ -416,11 +423,14 @@ class ManyStateElement extends HTMLElement {
 customElements.define("many-state-element", ManyStateElement);
 
 document.addEventListener("DOMContentLoaded", () => {
-  if (!ManyStateElement.isStateSyntaxSupported()) {
-    const warning = document.createElement("div");
-    warning.style.color = "red";
-    warning.textContent = "This feature is not supported by your browser.";
-    document.body.insertBefore(warning, document.body.firstChild);
+  if (!LabeledCheckbox.isStateSyntaxSupported()) {
+    if (!document.getElementById('state-warning')) {
+      const warning = document.createElement("div");
+      warning.id = 'state-warning';
+      warning.style.color = "red";
+      warning.textContent = "This feature is not supported by your browser.";
+      document.body.insertBefore(warning, document.body.firstChild);
+    }
   }
 });
 ```

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -379,17 +379,17 @@ class ManyStateElement extends HTMLElement {
   set state(stateName) {
     // Set internal state to passed value
     // Add identifier matching state and delete others
-    if (stateName == "loading") {
+    if (stateName === "loading") {
       this._state = "loading";
       this._internals.states.add("loading");
       this._internals.states.delete("interactive");
       this._internals.states.delete("complete");
-    } else if (stateName == "interactive") {
+    } else if (stateName === "interactive") {
       this._state = "interactive";
       this._internals.states.delete("loading");
       this._internals.states.add("interactive");
       this._internals.states.delete("complete");
-    } else if (stateName == "complete") {
+    } else if (stateName === "complete") {
       this._state = "complete";
       this._internals.states.delete("loading");
       this._internals.states.delete("interactive");
@@ -407,9 +407,22 @@ class ManyStateElement extends HTMLElement {
       this.state = "loading";
     }
   }
+
+  static isStateSyntaxSupported() {
+    return CSS.supports("selector(:state(loading))");
+  }
 }
 
 customElements.define("many-state-element", ManyStateElement);
+
+document.addEventListener("DOMContentLoaded", () => {
+  if (!ManyStateElement.isStateSyntaxSupported()) {
+    const warning = document.createElement("div");
+    warning.style.color = "red";
+    warning.textContent = "This feature is not supported by your browser.";
+    document.body.insertBefore(warning, document.body.firstChild);
+  }
+});
 ```
 
 #### HTML


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added feature detection for the :state CSS pseudo-class and provided a warning message if the browser does not support this syntax.

### Motivation

The current syntax isn't supported in Chrome browsers yet, and although Chrome 125 is adding support, there will be a transition period where I suspect the majority of readers will be using an incompatible browser.

### Additional details

Per @hamishwillee's [comment in 33636](https://github.com/mdn/content/issues/33636#issuecomment-2116367013):

> Closing this, but if you wanted we'd accept a PR that modifies the examples to check for support of the new state syntax and put a "not supported by this browser warning" when the examples don't work.

### Related issues and pull requests

- #33636
- https://github.com/mdn/browser-compat-data/pull/23072

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
