### PR TITLE
Improve `Web/API/Document/images`

### DIFF
--- a/files/en-us/web/api/document/images/index.md
+++ b/files/en-us/web/api/document/images/index.md
@@ -12,11 +12,13 @@ The **`images`** read-only property of the {{domxref("Document")}} interface ret
 
 ## Value
 
-An {{domxref("HTMLCollection")}} providing a live list of all of the images contained in the current document. Each entry in the collection is an {{domxref("HTMLImageElement")}} representing a single image element.
+An {{domxref("HTMLCollection")}} providing a live list of all of the images contained in the current document.
+Each entry in the collection is an {{domxref("HTMLImageElement")}} representing a single image element.
 
 ## Usage notes
 
-You can use either JavaScript array notation or the {{domxref("HTMLCollection.item", "item()")}} method on the returned collection to access the items in the collection. The following are equivalent:
+You can use either JavaScript array notation or the {{domxref("HTMLCollection.item", "item()")}} method on the returned collection to access the items in the collection.
+The following are equivalent:
 
 ```js
 firstImage = imageCollection.item(0);

--- a/files/en-us/web/api/document/images/index.md
+++ b/files/en-us/web/api/document/images/index.md
@@ -8,19 +8,15 @@ browser-compat: api.Document.images
 
 {{APIRef("DOM")}}
 
-The **`images`** read-only property of
-the {{domxref("Document")}} interface returns a [collection](/en-US/docs/Web/API/HTMLCollection) of the [images](/en-US/docs/Web/API/HTMLImageElement/Image) in the current HTML document.
+The **`images`** read-only property of the {{domxref("Document")}} interface returns a [collection](/en-US/docs/Web/API/HTMLCollection) of the [images](/en-US/docs/Web/API/HTMLImageElement) in the current HTML document.
 
 ## Value
 
-An {{domxref("HTMLCollection")}} providing a live list of all of the images contained
-in the current document. Each entry in the collection is an
-{{domxref("HTMLImageElement")}} representing a single image element.
+An {{domxref("HTMLCollection")}} providing a live list of all of the images contained in the current document. Each entry in the collection is an {{domxref("HTMLImageElement")}} representing a single image element.
 
 ## Usage notes
 
-You can use either JavaScript array notation or the {{domxref("HTMLCollection.item", "item()")}} method on the returned collection to access the items in the collection.
-The following are equivalent:
+You can use either JavaScript array notation or the {{domxref("HTMLCollection.item", "item()")}} method on the returned collection to access the items in the collection. The following are equivalent:
 
 ```js
 firstImage = imageCollection.item(0);
@@ -30,8 +26,7 @@ firstImage = imageCollection[0];
 
 ## Examples
 
-This example looks through the list of images and finds one whose name is
-`"banner.gif"`.
+This example looks through the list of images and finds those named `"banner.gif"`.
 
 ```js
 for (const image of document.images) {


### PR DESCRIPTION
### Description

This PR updates `Web/API/Document/images`. List of changes:
- replace link to HTMLImageElement instead of constructor,
- improve example description,
- remove unnecesary line breaks.
