### PR TITLE
[css width property] remove vendor prefixes in examples

### DIFF
--- a/files/en-us/web/css/width/index.md
+++ b/files/en-us/web/css/width/index.md
@@ -135,9 +135,6 @@ p.goldie {
 ```css
 p.maxgreen {
   background: lightgreen;
-  width: intrinsic; /* Safari/WebKit uses a non-standard name */
-  width: -moz-max-content; /* Firefox/Gecko */
-  width: -webkit-max-content; /* Chrome */
   width: max-content;
 }
 ```
@@ -153,8 +150,6 @@ p.maxgreen {
 ```css
 p.minblue {
   background: lightblue;
-  width: -moz-min-content; /* Firefox */
-  width: -webkit-min-content; /* Chrome */
   width: min-content;
 }
 ```


### PR DESCRIPTION
### Description

Remove vendor prefixes in the examples for the `max-content` and `min-content` values of the `width` property.

### Motivation

Both values have global browser support of >95% (not prefixed) and prefixes are therefore not needed and should not be "suggested" to readers.

### Additional details

[Support for `width: max-content`](https://caniuse.com/?search=width%3A%20max-content)
[Support for `width: min-content`](https://caniuse.com/?search=width%3A%20min-content)


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
