### PR TITLE
add correct property to JavaScript example

### DIFF
--- a/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/sectionrowindex/index.md
@@ -59,7 +59,7 @@ const rows = document.querySelectorAll("tbody tr");
 
 rows.forEach((row) => {
   const z = document.createElement("td");
-  z.textContent = `(row #${row.rowIndex})`;
+  z.textContent = `(row #${row.sectionRowIndex})`;
   row.appendChild(z);
 });
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Add `sectionRowIndex` property instead of `rowIndex` in JavaScript example

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

This should also change the "Result" section:

`rowIndex`
![24139010559](https://github.com/mdn/content/assets/8797432/6d219103-8c59-461f-94a4-6bf60c2112e2)

`sectionRowIndex`
![24139010547](https://github.com/mdn/content/assets/8797432/1d52b927-188c-4e41-b957-b0fb9611ab66)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
