### PR TITLE
Remove CompositionStart shortcut

### DIFF
--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -55,10 +55,6 @@ inputElement.addEventListener("compositionstart", (event) => {
 <div class="control">
   <label for="example">
     Focus the text-input control, then open your IME and begin typing.
-    <ul>
-      <li>on macOS type <kbd>Command ⌘</kbd> + <kbd>`</kbd></li>
-      <li>on Windows type <kbd>windows</kbd> + <kbd>.</kbd></li>
-    </ul>
   </label>
   <input type="text" id="example" name="example" />
 </div>

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -54,7 +54,7 @@ inputElement.addEventListener("compositionstart", (event) => {
 ```html
 <div class="control">
   <label for="example">
-    First select textbox, then to open IME:
+    Focus the text-input control, then open your IME and begin typing.
     <ul>
       <li>on macOS type <kbd>Command ⌘</kbd> + <kbd>`</kbd></li>
       <li>on Windows type <kbd>windows</kbd> + <kbd>.</kbd></li>

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -56,7 +56,7 @@ inputElement.addEventListener("compositionstart", (event) => {
   <label for="example">
     First select textbox, then to open IME:
     <ul>
-      <li>on macOS type <kbd>option</kbd> + <kbd>`</kbd></li>
+      <li>on macOS type <kbd>Command ⌘</kbd> + <kbd>`</kbd></li>
       <li>on Windows type <kbd>windows</kbd> + <kbd>.</kbd></li>
     </ul>
   </label>


### PR DESCRIPTION
On macOS, <kbd>cmd</kbd>+<kbd>\`</kbd> start fires a compositionStart, not <kbd>option</kbd>+<kbd>\`</kbd>

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
