### PR TITLE
Link to additional examples in console.time/timeLog/timeEnd()

### DIFF
--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -38,8 +38,7 @@ None ({{jsxref("undefined")}}).
 
 ## See also
 
-- {{domxref("console/timeEnd_static", "console.timeEnd()")}}
-- {{domxref("console/timeLog_static", "console.timeLog()")}}
+- See {{domxref("console/timelog_static", "console.timeLog()")}} and {{domxref("console/timeend_static", "console.timeEnd()")}} for examples
 - [Microsoft Edge's documentation for `console.time()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#time)
 - [Node.JS documentation for `console.time()`](https://nodejs.org/docs/latest/api/console.html#consoletimelabel)
 - [Google Chrome's documentation for `console.time()`](https://developer.chrome.com/docs/devtools/console/api/#time)

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -55,8 +55,8 @@ longer tracking time.
 
 ## See also
 
+- See {{domxref("console/timelog_static", "console.timeLog()")}} for additional examples
 - {{domxref("console/time_static", "console.time()")}}
-- {{domxref("console/timeLog_static", "console.timeLog()")}}
 - [Microsoft Edge's documentation for `console.timeEnd()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/console/api#timeend)
 - [Node.JS documentation for `console.timeEnd()`](https://nodejs.org/docs/latest/api/console.html#consoletimeendlabel)
 - [Google Chrome's documentation for `console.timeEnd()`](https://developer.chrome.com/docs/devtools/console/api/#timeend)

--- a/files/en-us/web/api/console/timelog_static/index.md
+++ b/files/en-us/web/api/console/timelog_static/index.md
@@ -106,5 +106,5 @@ Notice that the timer's name is displayed when the timer value is logged using `
 ## See also
 
 - {{domxref("console/time_static", "console.time()")}}
-- {{domxref("console/timeEnd_static", "console.timeEnd()")}}
+- See {{domxref("console/timeend_static", "console.timeEnd()")}} for additional examples
 - [Node.JS documentation for `console.timeLog()`](https://nodejs.org/docs/latest/api/console.html#consoletimeloglabel-data)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

1. `console.time()` does not provide any examples of its own, so in the "See more" section, I stated where examples could be found. 
1. `console.timeLog()`/`console.timeEnd()` have their own examples, so in the "See more" section, I stated where additional examples could be found. 

### Motivation

Whenever I relearn how `console.time/timeLog/timeEnd()` work, if I visit `console.time()` first, I don't see any examples so I look elsewhere for them, sometimes on an external site. These examples do exist on MDN, so I made that fact more explicit by adding some description to the "See more" section.  

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
