### PR TITLE
Remove unnecessary change event in dialog return value example

### DIFF
--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -166,11 +166,6 @@ showButton.addEventListener("click", () => {
   favDialog.showModal();
 });
 
-// "Favorite animal" input sets the value of the submit button
-selectEl.addEventListener("change", (e) => {
-  confirmBtn.value = selectEl.value;
-});
-
 // "Cancel" button closes the dialog without submitting because of [formmethod="dialog"], triggering a close event.
 favDialog.addEventListener("close", (e) => {
   outputBox.value =


### PR DESCRIPTION
### Description

The dialog return value example was setting the value on the button but it didn't need to because it never read that value. 

### Motivation

Removing this event handler streamlines the example and makes it clearer to the reader which code is actually making the return value available.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#handling_the_return_value_from_the_dialog

### Related issues and pull requests

Fixes #32242
