### PR TITLE
Update WebM support in glossary page

### DIFF
--- a/files/en-us/glossary/webm/index.md
+++ b/files/en-us/glossary/webm/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**WebM** is royalty-free and is an open web video format natively supported in all modern browsers.
+**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is royalty-free and is an open web video format natively supported in all modern browsers.
 
 ## See also
 

--- a/files/en-us/glossary/webm/index.md
+++ b/files/en-us/glossary/webm/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is a royalty-free open web video format that is natively supported in all modern browsers.
+**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is a royalty-free, open web video format that is natively supported in all modern browsers.
 
 ## See also
 

--- a/files/en-us/glossary/webm/index.md
+++ b/files/en-us/glossary/webm/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**WebM** is royalty-free and is an open web video format natively supported in Mozilla Firefox.
+**WebM** is royalty-free and is an open web video format natively supported in all modern browsers.
 
 ## See also
 

--- a/files/en-us/glossary/webm/index.md
+++ b/files/en-us/glossary/webm/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is a royalty-free, open web video format that is natively supported in all modern browsers.
+**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is a royalty-free and open web video format, which is natively supported in all modern browsers.
 
 ## See also
 

--- a/files/en-us/glossary/webm/index.md
+++ b/files/en-us/glossary/webm/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is royalty-free and is an open web video format natively supported in all modern browsers.
+**[WebM](/en-US/docs/Web/Media/Formats/Containers#webm)** is a royalty-free open web video format that is natively supported in all modern browsers.
 
 ## See also
 


### PR DESCRIPTION
### Description

WebM is finally becoming a reality. Since recently, it gained supported in all modern browsers: see https://caniuse.com/webm.

This PR updates the glossary page describing WebM (https://developer.mozilla.org/en-US/docs/Glossary/WebM) accordingly.

### Motivation

Clarify that WebM is not some niche format specific to Firefox: it is a widely-supported open standard.

### Additional details

Not sure if there's other pages related to WebM/video formats in general that also need to be updated.

Also I'm not familiar with your translation process, will this change propagate to other Translations of the docs? 

### Related issues and pull requests

None that I found.

Thanks! ❤️