### PR TITLE
Region is not mandatory part of locale string

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/basename/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/basename/index.md
@@ -7,13 +7,13 @@ browser-compat: javascript.builtins.Intl.Locale.baseName
 
 {{JSRef}}
 
-The **`baseName`** accessor property of {{jsxref("Intl.Locale")}} instances returns a substring of this locale's string representation, containing core information about this locale.
+The **`baseName`** accessor property of {{jsxref("Intl.Locale")}} instances returns a substring of this locale's string representation, containing core information about this locale, including the language, and the script and region if available.
 
 ## Description
 
-An {{jsxref("Intl.Locale")}} object represents a parsed local and options for that locale. The `baseName` property returns basic, core information about the Locale in the form of a substring of the complete data string. Specifically, the property returns the substring containing the language, and the script and region if available.
+`baseName` returns the `language ["-" script] ["-" region] *("-" variant)` subsequence of the [unicode_language_id grammar](https://www.unicode.org/reports/tr35/#Identifiers). It only includes information explicitly specified in the constructor, either through the locale identifier string or the options object.
 
-`baseName` returns the `language ["-" script] ["-" region] *("-" variant)` subsequence of the [unicode_language_id grammar](https://www.unicode.org/reports/tr35/#Identifiers).
+The set accessor of `baseName` is `undefined`. You cannot change this property directly.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
@@ -11,11 +11,15 @@ The **`language`** accessor property of {{jsxref("Intl.Locale")}} instances retu
 
 ## Description
 
-Language is one of the core features of a locale. The Unicode specification treats the language identifier of a locale as the language and the region together (to make a distinction between dialects and variations, e.g. British English vs. American English). The `language` property of a {{jsxref("Intl.Locale")}} returns strictly the locale's language subtag.
+Language is one of the core attributes of a locale. The Unicode specification treats the language identifier of a locale as the language and the region together (to make a distinction between dialects and variations, e.g. British English vs. American English). The `language` property of a {{jsxref("Intl.Locale")}} returns strictly the locale's language subtag. The `language` property's value is set at construction time, either through the `language` subtag (first part) of the locale identifier or through the `language` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present.
+
+The set accessor of `language` is `undefined`. You cannot change this property directly.
 
 ## Examples
 
-### Setting the language in the locale identifier string argument
+Like other locale subtags, the language can be added to the {{jsxref("Intl.Locale")}} object via the locale string, or a configuration object argument to the constructor.
+
+### Setting the language via the locale string
 
 In order to be a valid Unicode locale identifier, a string must start with the language subtag. The main argument to the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor must be a valid Unicode locale identifier, so whenever the constructor is used, it must be passed an identifier with a language subtag.
 
@@ -24,9 +28,9 @@ const locale = new Intl.Locale("en-Latn-US");
 console.log(locale.language); // Prints "en"
 ```
 
-### Overriding language via the configuration object
+### Overriding language via the configuration object argument
 
-While the language subtag must be specified, the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a configuration object, which can override the language subtag.
+While the language subtag must be specified, the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can override the language subtag.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US", { language: "es" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -11,22 +11,26 @@ The **`region`** accessor property of {{jsxref("Intl.Locale")}} instances return
 
 ## Description
 
-Using a region indicates a region- or country- specific preference for a locale identifier, allowing selection for differences between the same locale in, say, different countries. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world.
+Region is one of the core attributes of a locale. It allows selection for differences between the same language in, say, different countries. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world. The `region` property's value is set at construction time, either through the `region` subtag (third part) of the locale identifier or through the `region` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
+
+The set accessor of `region` is `undefined`. You cannot change this property directly.
 
 ## Examples
 
-### Setting the region in the locale identifier string argument
+Like other locale subtags, the region can be added to the {{jsxref("Intl.Locale")}} object via the locale string, or a configuration object argument to the constructor.
 
-The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor.
+### Adding a region via the locale string
+
+The region is the third part of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");
 console.log(locale.region); // Prints "US"
 ```
 
-### Setting the region via the configuration object
+### Adding a region via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a configuration object, which can be used to set the region subtag and property.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument. Set the `region` property of the configuration object to your desired region, and then pass it into the constructor.
 
 ```js
 const locale = new Intl.Locale("fr-Latn", { region: "FR" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -11,7 +11,7 @@ The **`region`** accessor property of {{jsxref("Intl.Locale")}} instances return
 
 ## Description
 
-The region is an essential part of the locale identifier, as it places the locale in a specific area of the world. Knowing the locale's region is vital to identifying differences between locales. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world.
+Using a region indicates a region- or country- specific preference for a locale identifier, allowing selection for differences between the same locale in, say, different countries. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -11,7 +11,7 @@ The **`region`** accessor property of {{jsxref("Intl.Locale")}} instances return
 
 ## Description
 
-Region is one of the core attributes of a locale. It allows selection for differences between the same language in, say, different countries. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world. The `region` property's value is set at construction time, either through the `region` subtag (third part) of the locale identifier or through the `region` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
+Region is one of the core attributes of a locale. It allows selection for differences between the same language in, say, different countries. For example, English is spoken in the United Kingdom and the United States of America, but there are differences in spelling and other language conventions between those two countries. Knowing the locale's region helps JavaScript programmers make sure that the content from their sites and applications is correctly displayed when viewed from different areas of the world. The `region` property's value is set at construction time, either through the `region` subtag (third part if `script` is present, second part otherwise) of the locale identifier or through the `region` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
 
 The set accessor of `region` is `undefined`. You cannot change this property directly.
 
@@ -21,7 +21,7 @@ Like other locale subtags, the region can be added to the {{jsxref("Intl.Locale"
 
 ### Adding a region via the locale string
 
-The region is the third part of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
+The region, if present, is the third part (if `script` is present, second part otherwise) of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -17,7 +17,7 @@ The region is an essential part of the locale identifier, as it places the local
 
 ### Setting the region in the locale identifier string argument
 
-The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The region is a mandatory part of a
+The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -21,7 +21,7 @@ Like other locale subtags, the region can be added to the {{jsxref("Intl.Locale"
 
 ### Adding a region via the locale string
 
-The region, if present, is the third part (if `script` is present, second part otherwise) of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
+The region, if present, is the third part (if `script` is present, second part otherwise) of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the region is not a required part of a locale identifier.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
@@ -11,7 +11,7 @@ The **`script`** accessor property of {{jsxref("Intl.Locale")}} instances return
 
 ## Description
 
-Script, sometimes called writing system, is one of the core attributes of a locale. It indicates the set of symbols, or glyphs, that are used to write a particular language. For instance, the script associated with English is Latin, whereas the script typically associated with Korean is Hangul. In many cases, denoting a script is not strictly necessary, since the language (which is necessary) is only written in a single script. There are exceptions to this rule, however, and it is important to indicate the script when multiple scripts are applicable. The `script` property's value is set at construction time, either through the `script` subtag (second part) of the locale identifier or through the `script` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
+Script, sometimes called writing system, is one of the core attributes of a locale. It indicates the set of symbols, or glyphs, that are used to write a particular language. For instance, the script associated with English is Latin, whereas the script typically associated with Korean is Hangul. In many cases, denoting a script is not strictly necessary, since the language (which is necessary) is only written in a single script. There are exceptions to this rule, however, and it is important to indicate the script when multiple scripts are applicable. The `script` property's value is set at construction time, either through the `script` subtag (second part, if present) of the locale identifier or through the `script` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
 
 The set accessor of `script` is `undefined`. You cannot change this property directly.
 
@@ -21,7 +21,7 @@ Like other locale subtags, the script can be added to the {{jsxref("Intl.Locale"
 
 ### Adding a script via the locale string
 
-The script is the second part of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
+The script, if present, is the second part of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
@@ -11,22 +11,26 @@ The **`script`** accessor property of {{jsxref("Intl.Locale")}} instances return
 
 ## Description
 
-A script, sometimes called writing system, is one of the core attributes of a locale. It indicates the set of symbols, or glyphs, that are used to write a particular language. For instance, the script associated with English is Latin, whereas the script typically associated with Korean is Hangul. In many cases, denoting a script is not strictly necessary, since the language (which is necessary) is only written in a single script. There are exceptions to this rule, however, and it is important to indicate the script whenever possible, in order to have a complete Unicode language identifier.
+Script, sometimes called writing system, is one of the core attributes of a locale. It indicates the set of symbols, or glyphs, that are used to write a particular language. For instance, the script associated with English is Latin, whereas the script typically associated with Korean is Hangul. In many cases, denoting a script is not strictly necessary, since the language (which is necessary) is only written in a single script. There are exceptions to this rule, however, and it is important to indicate the script when multiple scripts are applicable. The `script` property's value is set at construction time, either through the `script` subtag (second part) of the locale identifier or through the `script` option of the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The latter takes priority if they are both present; and if neither is present, the property has value `undefined`.
+
+The set accessor of `script` is `undefined`. You cannot change this property directly.
 
 ## Examples
 
-### Setting the script in the locale identifier string argument
+Like other locale subtags, the script can be added to the {{jsxref("Intl.Locale")}} object via the locale string, or a configuration object argument to the constructor.
 
-The script is the second part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
+### Adding a script via the locale string
+
+The script is the second part of a valid Unicode language identifier string, and can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
 
 ```js
 const locale = new Intl.Locale("en-Latn-US");
 console.log(locale.script); // Prints "Latn"
 ```
 
-### Setting the script via the configuration object
+### Adding a script via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a configuration object, which can be used to set the script subtag and property.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument. Set the `script` property of the configuration object to your desired script, and then pass it into the constructor.
 
 ```js
 const locale = new Intl.Locale("fr-FR", { script: "Latn" });


### PR DESCRIPTION
Fixes #33685

As noted in the linked issue, the region part of the locale identifier string is not mandatory. IMO this is just a left over when the page was created.

FWIW I think this page  could do with more work @Josh-Cena . In particular the description is really over the top and enthusiastic in an unhelpful way. Specifically

> The region is an essential part of the locale identifier, as it places the locale in a specific area of the world. Knowing the locale's region is vital to identifying differences between locales. 

Essential does imply mandatory, which it is not. Vital implies mandatory and super important. Region is IMO just another important part of a language string that you can choose to refine your locale specificity.

We might perhaps do something like:

> Using a region indicates a region-specific preference for a locale variant, allowing selection for differences between the same language in, say, different countries.