### PR TITLE
Fix "methods" with "properties" in a description of properties

### DIFF
--- a/files/en-us/web/api/paintworkletglobalscope/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/index.md
@@ -20,7 +20,7 @@ To avoid leaking visited links, this feature is currently disabled in Chrome-bas
 
 ## Instance properties
 
-_This interface inherits methods from {{domxref('WorkletGlobalScope')}}._
+_This interface inherits properties from {{domxref('WorkletGlobalScope')}}._
 
 - {{domxref('PaintWorkletGlobalScope.devicePixelRatio')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the current device's ratio of physical pixels to logical pixels.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix "methods" with "properties" in a description of properties.

### Motivation

This sentence should say about properties rather than methods in the "Instance properties" section.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
