### PR TITLE
Fix isSameEntry example

### DIFF
--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -30,12 +30,16 @@ A Promise that fulfills with a {{jsxref('Boolean')}}.
 ## Examples
 
 The following function compares a single entry with an array of entries, and returns a
-new array with any matching entries removed.
+Promise that fullfills with a new array with any matching entries removed.
 
 ```js
-function removeMatches(fileEntry, entriesArr) {
-  let newArr = entriesArr.filter((entry) => !fileEntry.isSameEntry(entry));
-
+async function removeMatches(fileEntry, entriesArr) {
+  const newArr = [];
+  for (let entry of entriesArr) {
+    if (!(await fileEntry.isSameEntry(entry))) {
+      newArr.push(entry);
+    }
+  }
   return newArr;
 }
 ```

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -30,7 +30,7 @@ A Promise that fulfills with a {{jsxref('Boolean')}}.
 ## Examples
 
 The following function compares a single entry with an array of entries, and returns a
-Promise that fullfills with a new array with any matching entries removed.
+{{jsxref("Promise")}} that fulfils with a new array with any matching entries removed.
 
 ```js
 async function removeMatches(fileEntry, entriesArr) {

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -35,7 +35,7 @@ The following function compares a single entry with an array of entries, and ret
 ```js
 async function removeMatches(fileEntry, entriesArr) {
   const newArr = [];
-  for (let entry of entriesArr) {
+  for (const entry of entriesArr) {
     if (!(await fileEntry.isSameEntry(entry))) {
       newArr.push(entry);
     }


### PR DESCRIPTION
The previous example was incorrect, as FileSystemHandle.isSameEntry returns a promise.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replaces example for FileSystemHandle.isSameEntry with an async version.

### Motivation

The previous example was incorrect.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
