### PR TITLE
HTTPS Record Generator

### DIFF
--- a/files/en-us/glossary/https_rr/index.md
+++ b/files/en-us/glossary/https_rr/index.md
@@ -15,4 +15,5 @@ Further, the presence of an _HTTPS RR_ signals that all useful {{Glossary("HTTP"
 
 - [Service binding and parameter specification via the DNS (DNS SVCB and HTTPS RRs)](https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/00/) (Draft IETF specification: draft-ietf-dnsop-svcb-https-00)
 - [Strict Transport Security vs. HTTPS Resource Records: the showdown](https://emilymstark.com/2020/10/24/strict-transport-security-vs-https-resource-records-the-showdown.html) (Emily M. Stark blog)
+- [HTTPS Record Generator](https://earmaster.github.io/https-record-generator)
 - {{glossary("TLS")}}


### PR DESCRIPTION
Added a link to a HTTPS Record Generator hosted on Github Pages.

### Description

Added a link to a HTTPS Record Generator hosted on Github Pages.

### Motivation

I build this generator, because I love generators like the [https://report-uri.com/home/generate](CSP Policy Generator) and use them regularly. Generating a HTTPS Record is way easier, but I wanted to lower the threshold for everyone looking into using one and not knowing exactly how to use it.

### Additional details

https://earmaster.github.io/https-record-generator