### PR TITLE
Remove broken links and outdated note from `Web/API/HTMLAnchorElement`

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/index.md
+++ b/files/en-us/web/api/htmlanchorelement/index.md
@@ -58,19 +58,19 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 ### Obsolete properties
 
-- {{domxref("HTMLAnchorElement.charset")}} {{deprecated_inline}}
+- `HTMLAnchorElement.charset` {{deprecated_inline}}
   - : A string representing the character encoding of the linked resource.
-- {{domxref("HTMLAnchorElement.coords")}} {{deprecated_inline}}
+- `HTMLAnchorElement.coords` {{deprecated_inline}}
   - : A string representing a comma-separated list of coordinates.
-- {{domxref("HTMLAnchorElement.name")}} {{deprecated_inline}}
+- `HTMLAnchorElement.name` {{deprecated_inline}}
   - : A string representing the anchor name.
-- {{domxref("HTMLAnchorElement.rev")}} {{deprecated_inline}}
+- `HTMLAnchorElement.rev` {{deprecated_inline}}
 
   - : A string representing that the [`rev`](/en-US/docs/Web/HTML/Element/a#rev) HTML attribute, specifying the relationship of the link object to the target object.
 
     > **Note:** Currently the W3C HTML 5.2 spec states that `rev` is no longer obsolete, whereas the WHATWG living standard still has it labeled obsolete. Until this discrepancy is resolved, you should still assume it is obsolete.
 
-- {{domxref("HTMLAnchorElement.shape")}} {{deprecated_inline}}
+- `HTMLAnchorElement.shape` {{deprecated_inline}}
   - : A string representing the shape of the active area.
 
 ## Instance methods

--- a/files/en-us/web/api/htmlanchorelement/index.md
+++ b/files/en-us/web/api/htmlanchorelement/index.md
@@ -65,11 +65,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - `HTMLAnchorElement.name` {{deprecated_inline}}
   - : A string representing the anchor name.
 - `HTMLAnchorElement.rev` {{deprecated_inline}}
-
   - : A string representing that the [`rev`](/en-US/docs/Web/HTML/Element/a#rev) HTML attribute, specifying the relationship of the link object to the target object.
-
-    > **Note:** Currently the W3C HTML 5.2 spec states that `rev` is no longer obsolete, whereas the WHATWG living standard still has it labeled obsolete. Until this discrepancy is resolved, you should still assume it is obsolete.
-
 - `HTMLAnchorElement.shape` {{deprecated_inline}}
   - : A string representing the shape of the active area.
 


### PR DESCRIPTION
### Description

This PR removes broken links and outdated note from `Web/API/HTMLAnchorElement`.

https://www.w3.org/TR/html52/ now redirects to https://html.spec.whatwg.org/multipage/ so note about `W3C HTML 5.2 spec` is no longer relevant.

### Additional details

Before:
![Screenshot from 2024-05-22 00-55-44](https://github.com/mdn/content/assets/1682136/7b5e5a2f-161f-474f-85a3-2750f3957eaf)

After:
![Screenshot from 2024-05-22 01-21-57](https://github.com/mdn/content/assets/1682136/df7d5309-d5a0-496f-8e06-a3e8a83a94d6)
