### PR TITLE
fix: correct the hex value of decimal value `32`

### DIFF
--- a/files/en-us/web/javascript/guide/typed_arrays/index.md
+++ b/files/en-us/web/javascript/guide/typed_arrays/index.md
@@ -205,7 +205,7 @@ In other words, the two arrays are indeed viewed on the same data buffer, treati
 ```plain
 Int16Array  |  32  |  0   |   2  |  0   |   4  |  0   |   6  |  0   |
 Int32Array  |     32      |      2      |      4      |      6      |
-ArrayBuffer | 00 02 00 00 | 02 00 00 00 | 04 00 00 00 | 06 00 00 00 |
+ArrayBuffer | 20 00 00 00 | 02 00 00 00 | 04 00 00 00 | 06 00 00 00 |
 ```
 
 You can do this with any view type, although if you set an integer and then read it as a floating-point number, you will probably get a strange result because the bits are interpreted differently.


### PR DESCRIPTION
### Description

correct the hex value of decimal value `32`.

### Additional details

test code snippet:

```js
// create buffer
const arr = new ArrayBuffer(4);

// create view and set value
const int16View = new Int16Array(arr);
int16View[0] = 32;

// check the underlying buffer
const uint8View = new Uint8Array(arr);
console.log([...uint8View].map(x => x.toString(16))); // ['20', '0', '0', '0']

// check the int32view
const int32View = new Int32Array(arr);
console.log(int32View[0]); // 32
```

### Related issues and pull requests

This issue is reported in mdn/translated-content#20723
