### PR TITLE
Add support for lh/rlh in SVG to Firefox 127 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -36,7 +36,7 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ### SVG
 
-- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units, first supported in CSS [in Firefox 120](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/120#css), are now supported in SVG as well. They can be used both as CSS properties `stroke-width: 0.5lh` and SVG attributes `stroke-width="0.5lh"`. ([Firefox bug 1892089](https://bugzil.la/1892089)).
+- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units, first supported in CSS [in Firefox 120](/en-US/docs/Mozilla/Firefox/Releases/120#css), are now supported in SVG as well. They can be used both as CSS properties `stroke-width: 0.5lh` and SVG attributes `stroke-width="0.5lh"`. ([Firefox bug 1892089](https://bugzil.la/1892089)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -36,7 +36,7 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ### SVG
 
-- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units, first supported in CSS [in Firefox 120](/en-US/docs/Mozilla/Firefox/Releases/120#css), are now supported in SVG as well. They can be used both as CSS properties `stroke-width: 0.5lh` and SVG attributes `stroke-width="0.5lh"`. ([Firefox bug 1892089](https://bugzil.la/1892089)).
+- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units, first supported in CSS [in Firefox 120](/en-US/docs/Mozilla/Firefox/Releases/120#css), are now supported in SVG as well. They can be used both in CSS property values `stroke-width: 0.5lh` and SVG attributes values `stroke-width="0.5lh"`. ([Firefox bug 1892089](https://bugzil.la/1892089)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -36,6 +36,8 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ### SVG
 
+- The [`lh` and `rlh`](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#line_height_units) line height units, first supported in CSS [in Firefox 120](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/120#css), are now supported in SVG as well. They can be used both as CSS properties `stroke-width: 0.5lh` and SVG attributes `stroke-width="0.5lh"`. ([Firefox bug 1892089](https://bugzil.la/1892089)).
+
 #### Removals
 
 ### HTTP


### PR DESCRIPTION
### Description

- Adds support for lh/rlh in SVG to Firefox 127 release notes

### Motivation

Firefox 127 release project

### Additional details

- [Bugzilla: Support CSS font-relative line-height units in SVG: lh, rlh](https://bugzilla.mozilla.org/show_bug.cgi?id=1892089)

### Related issues and pull requests

- https://github.com/mdn/content/issues/33522