### PR TITLE
Fix `@supports` Documentation

### DIFF
--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -42,7 +42,7 @@ The following sections describe the use of each type of supports condition.
 
 The declaration syntax checks if a browser supports the specified `<property>: <value>` declaration.
 The declaration must be surrounded by parentheses.
-The following example returns true and applies the CSS style if the browser supports the expression `transform-origin: 5% 5%`:
+The following example returns true if the browser supports the expression `transform-origin: 5% 5%`:
 
 ```css
 @supports (transform-origin: 5% 5%) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I removed a few inaccurate words from the documentation for `@supports`: it doesn't actually apply the style, it just tests for it, at least in Chrome.

A short example:

```html
<span>text</span>
<style>
  span {
    @supports (color: blue) {
      color: blue;
    }
  }
</style>
```

Comment out the second `color: blue`, and the styles don't apply.

### Motivation

I wrote some CSS that assumed that this applied it, which caused a major production bug (in a very tiny project[^1]  😉).

[^1]: And it's my fault for forgetting that Fresh doesn't support CSS hot reloading so that it slipped in, but it still might confuse some beginners. There's no reason not to fix docs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Below, the example manually applies the style, which further validates that this is documentation issue, not a Chrome bug.

I don't know why'd you need to look at my code, but here's the diff that broke my code, and the one that fixed it if you need the source.
https://github.com/PHS-TSA/webmaster-23-24/compare/c32dd35967aa5242bca5801ccb47a45257f4854f..025b5539b07bcf668d3c3dd7376ba7aa5ba48d1e
https://github.com/PHS-TSA/webmaster-23-24/commit/b62fefc6436e9c2b0d23454c846402663b9cf6b2

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
