### PR TITLE
fix: remove quotes from links

### DIFF
--- a/files/en-us/web/html/element/template/index.md
+++ b/files/en-us/web/html/element/template/index.md
@@ -380,7 +380,7 @@ Since `firstClone` is a `DocumentFragment`, only its children are added to `cont
 - {{HTMLElement("slot")}} HTML element
 - {{CSSXref(":host")}}, {{CSSXref(":host_function", ":host()")}}, and {{CSSXref(":host-context", ":host-context()")}} CSS pseudo-classes
 - {{CSSXref("::part")}} and {{CSSXref("::slotted")}} CSS pseudo-elements
-- [`ShadowRoot`]("/en-US/docs/Web/API/ShadowRoot) interface
+- [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot) interface
 - [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
 - [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module
 - [Declarative Shadow DOM (with html)](/en-US/docs/Web/API/Web_components/Using_shadow_DOM#declaratively_with_html) in _Using Shadow DOM_

--- a/files/en-us/web/html/global_attributes/exportparts/index.md
+++ b/files/en-us/web/html/global_attributes/exportparts/index.md
@@ -331,7 +331,7 @@ In targetting the parts of the `<card-component>` from within the `<card-wrapper
 - {{HTMLElement("template")}} and {{HTMLElement("slot")}} HTML elements
 - {{CSSXref("::part")}} and {{CSSXref("::slotted")}} pseudo-elements
 - {{CSSXref(":host")}} pseudo-class
-- [`ShadowRoot`]("/en-US/docs/Web/API/ShadowRoot) interface
+- [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot) interface
 - {{DOMxRef("Element.part")}} property
 - [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
 - [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module

--- a/files/en-us/web/html/global_attributes/part/index.md
+++ b/files/en-us/web/html/global_attributes/part/index.md
@@ -24,7 +24,7 @@ See the [`exportparts` attribute](/en-US/docs/Web/HTML/Global_attributes/exportp
 - [`exportparts`](/en-US/docs/Web/HTML/Global_attributes/exportparts) HTML attribute
 - {{HTMLElement("template")}} and {{HTMLElement("slot")}} HTML elements
 - {{CSSXref("::part")}} and {{CSSXref("::slotted")}} CSS pseudo-elements
-- [`ShadowRoot`]("/en-US/docs/Web/API/ShadowRoot) interface
+- [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot) interface
 - {{DOMxRef("Element.part")}} property
 - [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots)
 - [CSS scoping](/en-US/docs/Web/CSS/CSS_scoping) module


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes incorrect links to the [ShadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot) that contain a quote character and therefore lead to a 404.

### Motivation

We want users to get to the right page, rather than experiencing a 404.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://mozilla-hub.atlassian.net/browse/MP-1096 (Mozilla-internal).
