### PR TITLE
FF127Relnote- data: and javascript: URLS forbidden in base HREF

### DIFF
--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -14,6 +14,8 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ### HTML
 
+- `data:` and `javascript:` URLs are now forbidden in the [`href`](/en-US/docs/Web/HTML/Element/base#href) attribute of the `<base>` element ([Firefox bug 1850967](https://bugzil.la/1850967)).
+
 #### Removals
 
 ### CSS


### PR DESCRIPTION
FF127 forbids `<base>` element href being a `data:` or `javascript:` URL in https://bugzilla.mozilla.org/show_bug.cgi?id=1850967. This just adds a release note.

Related docs can be tracked in #33566