### PR TITLE
Fix broken code example in “Managing screen orientation”

### DIFF
--- a/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
@@ -143,7 +143,7 @@ The Screen Orientation API is made to prevent or handle such a change.
 
 ### Listening to orientation changes
 
-The {{domxref("Window.orientationchange_event", "orientationchange")}} event is triggered each time the device change the orientation of the screen and the orientation itself can be read with the {{domxref("Screen.orientation")}} property.
+Each time the orientation of the screen changes, the {{domxref("Window.orientationchange_event", "orientationchange")}} event is triggered:
 
 ```js
 screen.orientation.addEventListener("change", () => {

--- a/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
@@ -146,7 +146,7 @@ The Screen Orientation API is made to prevent or handle such a change.
 The {{domxref("Window.orientationchange_event", "orientationchange")}} event is triggered each time the device change the orientation of the screen and the orientation itself can be read with the {{domxref("Screen.orientation")}} property.
 
 ```js
-screen.addEventListener("orientationchange", () => {
+screen.orientation.addEventListener("change", () => {
   console.log(`The orientation of the screen is: ${screen.orientation}`);
 });
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

An example given in the api shows:

screen.addEventListener("orientationchange", () => { console.log(The orientation of the screen is: ${screen.orientation}); });

The correct version should be:

screen.orientation.addEventListener("orientationchange", () => { console.log(The orientation of the screen is: ${screen.orientation}); });

<!-- ❓ Why are you making these changes and how do they help readers? -->

the previous information was slight wrong 
event type ("change") for listening to orientation changes on the screen.orientation object and accesses the type property of screen.orientation to log the orientation information accurate

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #33721 " -->
<!-- 👉 Highlight related pull requests using "Relates to #33721" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #33721" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
