### PR TITLE
Link AudioListener position* properties param types

### DIFF
--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioListener.positionX
 
 The `positionX` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) otherwise.
+> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioListener.positionX
 
 The `positionX` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
+> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioListener.positionY
 
 The `positionY` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) otherwise.
+> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioListener.positionY
 
 The `positionY` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
+> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioListener.positionZ
 
 The `positionZ` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) otherwise.
+> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioListener.positionZ
 
 The `positionZ` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
+> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#audioparam_types) otherwise.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Linked the terms `a-rate` and `k-rate` to a MDN page that explains them.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Haven't worked with the web audio API in a while and when I wanted to fix some deprecated method usages in an old page I came across the page for `positionX` and did not know what `a-rate` and `k-rate` meant.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
