### PR TITLE
<details> toggle event improvements

### DIFF
--- a/files/en-us/web/api/htmldetailselement/toggle_event/index.md
+++ b/files/en-us/web/api/htmldetailselement/toggle_event/index.md
@@ -25,9 +25,7 @@ ontoggle = (event) => {};
 ```
 
 ```html example-bad
-<details ontoggle="console.log(this.open)" open>
-  ...
-</details>
+<details ontoggle="console.log(this.open)" open>...</details>
 ```
 
 > **Note:** In the example above the event listener will be called once without any user interaction because the `open` attribute is set. Using event handlers like this [is discouraged](/en-US/docs/Web/HTML/Attributes#event_handler_attributes).

--- a/files/en-us/web/api/htmldetailselement/toggle_event/index.md
+++ b/files/en-us/web/api/htmldetailselement/toggle_event/index.md
@@ -18,15 +18,25 @@ This event is not cancelable and does not bubble.
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
-```js
+```js example-good
 addEventListener("toggle", (event) => {});
 
 ontoggle = (event) => {};
 ```
 
+```html example-bad
+<details ontoggle="console.log(this.open)" open>
+  ...
+</details>
+```
+
+> **Note:** In the example above the event listener will be called once without any user interaction because the `open` attribute is set. Using event handlers like this [is discouraged](/en-US/docs/Web/HTML/Attributes#event_handler_attributes).
+
 ## Event type
 
-A generic {{domxref("Event")}}.
+A {{domxref("ToggleEvent")}}. Inherits from {{domxref("Event")}}.
+
+{{InheritanceDiagram("ToggleEvent")}}
 
 ## Examples
 


### PR DESCRIPTION
### Description

Fixed event type info (was `Event` but is actually `ToggleEvent`).
Added a bad example with an explainer note.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I recently had to work on a legacy application and the only way I could use the toggle event was with an attribute event handler. This is when I came across the surprising behavior when the `open` attribute is set initially. I thought it was worth mentioning here but I can remove that part if it is considered not helpful.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
