### PR TITLE
fix: typo in Glossary/Gzip_compression

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -3582,7 +3582,7 @@
 /en-US/docs/Glossary/Empty_element	/en-US/docs/Glossary/Void_element
 /en-US/docs/Glossary/Error	/en-US/docs/Glossary/Exception
 /en-US/docs/Glossary/First_interactive	/en-US/docs/Glossary/First_CPU_idle
-/en-US/docs/Glossary/GZip	/en-US/docs/Glossary/GZip_compression
+/en-US/docs/Glossary/GZip	/en-US/docs/Glossary/gzip_compression
 /en-US/docs/Glossary/Global_attribute	/en-US/docs/Web/HTML/Global_attributes
 /en-US/docs/Glossary/Grid_Rows	/en-US/docs/Glossary/Grid_Row
 /en-US/docs/Glossary/Hash_function	/en-US/docs/Glossary/Cryptographic_hash_function

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -2464,16 +2464,6 @@
     "modified": "2019-09-05T00:37:41.703Z",
     "contributors": ["ran", "vtkrishn", "Kongklakker", "coder206", "klez"]
   },
-  "Glossary/GZip_compression": {
-    "modified": "2019-03-18T20:37:25.635Z",
-    "contributors": [
-      "RainSlide",
-      "ezrinjaz",
-      "mfuji09",
-      "ramsunvtech",
-      "chrisdavidmills"
-    ]
-  },
   "Glossary/Garbage_collection": {
     "modified": "2019-03-23T22:37:56.867Z",
     "contributors": ["klez", "teoli", "Sheppy"]
@@ -5584,6 +5574,16 @@
   "Glossary/gif": {
     "modified": "2019-01-16T20:56:47.872Z",
     "contributors": ["klez", "dsmatlak"]
+  },
+  "Glossary/gzip_compression": {
+    "modified": "2019-03-18T20:37:25.635Z",
+    "contributors": [
+      "RainSlide",
+      "ezrinjaz",
+      "mfuji09",
+      "ramsunvtech",
+      "chrisdavidmills"
+    ]
   },
   "Glossary/hash": {
     "modified": "2019-03-23T22:46:23.923Z",
@@ -11728,6 +11728,26 @@
       "nasifmdtanjim"
     ]
   },
+  "MDN/Writing_guidelines/Howto/Write_an_api_reference": {
+    "modified": "2019-05-03T10:17:00.872Z",
+    "contributors": [
+      "Sheppy",
+      "wbamberg",
+      "stephaniehobson",
+      "Jedipedia",
+      "jpmedley",
+      "chrisdavidmills",
+      "fscholz",
+      "Sebastianz",
+      "jswisher",
+      "essymo",
+      "maybe",
+      "ifilin",
+      "AFBarstow",
+      "teoli",
+      "ChrisL"
+    ]
+  },
   "MDN/Writing_guidelines/Howto/Write_an_api_reference/Information_contained_in_a_WebIDL_file": {
     "modified": "2019-10-01T06:57:46.015Z",
     "contributors": [
@@ -11752,26 +11772,6 @@
       "Sheppy",
       "wbamberg",
       "Thw0rted"
-    ]
-  },
-  "MDN/Writing_guidelines/Howto/Write_an_api_reference": {
-    "modified": "2019-05-03T10:17:00.872Z",
-    "contributors": [
-      "Sheppy",
-      "wbamberg",
-      "stephaniehobson",
-      "Jedipedia",
-      "jpmedley",
-      "chrisdavidmills",
-      "fscholz",
-      "Sebastianz",
-      "jswisher",
-      "essymo",
-      "maybe",
-      "ifilin",
-      "AFBarstow",
-      "teoli",
-      "ChrisL"
     ]
   },
   "MDN/Writing_guidelines/Page_structures": {
@@ -30091,6 +30091,25 @@
       "JesseW"
     ]
   },
+  "Web/API/Document_Object_Model/How_to_create_a_DOM_tree": {
+    "modified": "2019-03-24T00:17:33.140Z",
+    "contributors": [
+      "SphinxKnight",
+      "ajhsu",
+      "teoli",
+      "Jeremie",
+      "Jameshfisher",
+      "Sheppy",
+      "ziyunfei",
+      "fusionchess",
+      "kmaglione",
+      "Mgjbot",
+      "Carrie zhxj",
+      "electrolysis",
+      "Nickolay",
+      "ericjung"
+    ]
+  },
   "Web/API/Document_Object_Model/Introduction": {
     "modified": "2020-09-22T15:08:09.001Z",
     "contributors": [
@@ -30178,6 +30197,24 @@
       "Callek"
     ]
   },
+  "Web/API/Document_Object_Model/Locating_DOM_elements_using_selectors": {
+    "modified": "2020-12-06T22:57:45.352Z",
+    "contributors": [
+      "jordan-git",
+      "mfuji09",
+      "maibroadcast",
+      "Sheppy",
+      "n.lopin",
+      "alattalatta",
+      "vjanssens",
+      "teoli",
+      "Jeremie",
+      "ethertank",
+      "Philip Chee",
+      "mcsi",
+      "asadotzler"
+    ]
+  },
   "Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces": {
     "modified": "2020-08-22T02:28:27.619Z",
     "contributors": [
@@ -30219,69 +30256,6 @@
       "Ruby"
     ]
   },
-  "Web/API/Document_Object_Model/Whitespace": {
-    "modified": "2020-03-27T15:25:12.263Z",
-    "contributors": [
-      "mfuji09",
-      "dev-nicolaos",
-      "chrisdavidmills",
-      "violasong",
-      "mfluehr",
-      "teoli",
-      "michaelnetbiz",
-      "ishita",
-      "Brettz9",
-      "Jeremie",
-      "Sheppy",
-      "jswisher",
-      "hectorsan68",
-      "ethertank",
-      "VK",
-      "Mgjbot",
-      "BobChao",
-      "Ptak82",
-      "NickolayBot",
-      "Dria",
-      "JesseW"
-    ]
-  },
-  "Web/API/Document_Object_Model/How_to_create_a_DOM_tree": {
-    "modified": "2019-03-24T00:17:33.140Z",
-    "contributors": [
-      "SphinxKnight",
-      "ajhsu",
-      "teoli",
-      "Jeremie",
-      "Jameshfisher",
-      "Sheppy",
-      "ziyunfei",
-      "fusionchess",
-      "kmaglione",
-      "Mgjbot",
-      "Carrie zhxj",
-      "electrolysis",
-      "Nickolay",
-      "ericjung"
-    ]
-  },
-  "Web/API/Document_Object_Model/Locating_DOM_elements_using_selectors": {
-    "modified": "2020-12-06T22:57:45.352Z",
-    "contributors": [
-      "jordan-git",
-      "mfuji09",
-      "maibroadcast",
-      "Sheppy",
-      "n.lopin",
-      "alattalatta",
-      "vjanssens",
-      "teoli",
-      "Jeremie",
-      "ethertank",
-      "Philip Chee",
-      "mcsi",
-      "asadotzler"
-    ]
-  },
   "Web/API/Document_Object_Model/Using_the_Document_Object_Model": {
     "modified": "2020-12-09T01:05:18.504Z",
     "contributors": [
@@ -30317,6 +30291,32 @@
       "Andreas Wuest",
       "Nickolay",
       "Gor1"
+    ]
+  },
+  "Web/API/Document_Object_Model/Whitespace": {
+    "modified": "2020-03-27T15:25:12.263Z",
+    "contributors": [
+      "mfuji09",
+      "dev-nicolaos",
+      "chrisdavidmills",
+      "violasong",
+      "mfluehr",
+      "teoli",
+      "michaelnetbiz",
+      "ishita",
+      "Brettz9",
+      "Jeremie",
+      "Sheppy",
+      "jswisher",
+      "hectorsan68",
+      "ethertank",
+      "VK",
+      "Mgjbot",
+      "BobChao",
+      "Ptak82",
+      "NickolayBot",
+      "Dria",
+      "JesseW"
     ]
   },
   "Web/API/DragEvent": {
@@ -64838,6 +64838,10 @@
     "modified": "2020-12-10T13:45:22.546Z",
     "contributors": ["lolaodelola"]
   },
+  "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/End_a_call": {
+    "modified": "2020-12-10T13:59:26.911Z",
+    "contributors": ["lolaodelola"]
+  },
   "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission": {
     "modified": "2020-12-10T13:17:19.730Z",
     "contributors": ["lolaodelola"]
@@ -64968,10 +64972,6 @@
   "Web/API/WebRTC_API/Using_data_channels": {
     "modified": "2019-06-17T09:14:48.783Z",
     "contributors": ["Sheppy", "beaulac", "now-raymond", "chrisdavidmills"]
-  },
-  "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/End_a_call": {
-    "modified": "2020-12-10T13:59:26.911Z",
-    "contributors": ["lolaodelola"]
   },
   "Web/API/WebSocket": {
     "modified": "2020-12-07T20:03:00.345Z",
@@ -67096,6 +67096,23 @@
       "Jabez"
     ]
   },
+  "Web/API/Window/getDefaultComputedStyle": {
+    "modified": "2020-10-15T21:20:40.098Z",
+    "contributors": [
+      "mfluehr",
+      "teoli",
+      "lucian95",
+      "Sebastianz",
+      "phistuck",
+      "fscholz",
+      "cpigat",
+      "kscarfone",
+      "Sheppy",
+      "Krinkle",
+      "ethertank",
+      "Bzbarsky"
+    ]
+  },
   "Web/API/Window/getSelection": {
     "modified": "2020-10-15T21:11:02.940Z",
     "contributors": [
@@ -68219,6 +68236,98 @@
       "Callek",
       "Dria",
       "JesseW"
+    ]
+  },
+  "Web/API/Window/requestAnimationFrame": {
+    "modified": "2020-11-28T11:54:08.634Z",
+    "contributors": [
+      "bulk88",
+      "hamishwillee",
+      "smatric",
+      "dd-pardal",
+      "mfuji09",
+      "asmar",
+      "Sheppy",
+      "Andrew-Cottrell",
+      "bershanskiy",
+      "chrisdavidmills",
+      "Lonniebiz",
+      "sideshowbarker",
+      "Aarblon",
+      "leegee23",
+      "hemkaran",
+      "Kaiido",
+      "mauriciabad",
+      "Azin",
+      "mfluehr",
+      "ManyouRisms",
+      "lucian95",
+      "Sheikh1365",
+      "fvsch",
+      "pdkovacs",
+      "jstewart8053",
+      "frosas",
+      "beaucarnes",
+      "DearVikki",
+      "mgold",
+      "nmve",
+      "elmstfreddie",
+      "henryzhu",
+      "jellebrouwer",
+      "phistuck",
+      "jpmedley",
+      "teoli",
+      "fscholz",
+      "DomenicoDeFelice",
+      "Jeremie",
+      "stevekinney",
+      "foxbrush",
+      "Thomas-Brierley",
+      "while0pass",
+      "jscape",
+      "dviramontes",
+      "Nevraeka",
+      "Bzbarsky",
+      "Debloper",
+      "dbruant",
+      "emersonveenstra",
+      "jkff",
+      "Kubo2",
+      "ScottMichaud",
+      "kirbysayshi",
+      "silverwind",
+      "alistairmcmillan",
+      "michaeltherobot",
+      "riophae",
+      "erik.brannstrom",
+      "evilpie",
+      "mdrejhon",
+      "gbr",
+      "WGH",
+      "justin.self",
+      "inglor",
+      "ethertank",
+      "anton",
+      "ziyunfei",
+      "PixievoltNo1",
+      "MTonly",
+      "brianblakely",
+      "m_gol",
+      "fusionchess",
+      "Josiah",
+      "TitanNano",
+      "eikes",
+      "dgash",
+      "JaredWein",
+      "CutenessOverload",
+      "Krusty",
+      "ebidel",
+      "soswow",
+      "paul.irish",
+      "myakura",
+      "louisremi",
+      "Hsivonen",
+      "kathyw"
     ]
   },
   "Web/API/Window/requestFileSystem": {
@@ -71760,115 +71869,6 @@
       "BenoitL",
       "Dria",
       "JesseW"
-    ]
-  },
-  "Web/API/Window/getDefaultComputedStyle": {
-    "modified": "2020-10-15T21:20:40.098Z",
-    "contributors": [
-      "mfluehr",
-      "teoli",
-      "lucian95",
-      "Sebastianz",
-      "phistuck",
-      "fscholz",
-      "cpigat",
-      "kscarfone",
-      "Sheppy",
-      "Krinkle",
-      "ethertank",
-      "Bzbarsky"
-    ]
-  },
-  "Web/API/Window/requestAnimationFrame": {
-    "modified": "2020-11-28T11:54:08.634Z",
-    "contributors": [
-      "bulk88",
-      "hamishwillee",
-      "smatric",
-      "dd-pardal",
-      "mfuji09",
-      "asmar",
-      "Sheppy",
-      "Andrew-Cottrell",
-      "bershanskiy",
-      "chrisdavidmills",
-      "Lonniebiz",
-      "sideshowbarker",
-      "Aarblon",
-      "leegee23",
-      "hemkaran",
-      "Kaiido",
-      "mauriciabad",
-      "Azin",
-      "mfluehr",
-      "ManyouRisms",
-      "lucian95",
-      "Sheikh1365",
-      "fvsch",
-      "pdkovacs",
-      "jstewart8053",
-      "frosas",
-      "beaucarnes",
-      "DearVikki",
-      "mgold",
-      "nmve",
-      "elmstfreddie",
-      "henryzhu",
-      "jellebrouwer",
-      "phistuck",
-      "jpmedley",
-      "teoli",
-      "fscholz",
-      "DomenicoDeFelice",
-      "Jeremie",
-      "stevekinney",
-      "foxbrush",
-      "Thomas-Brierley",
-      "while0pass",
-      "jscape",
-      "dviramontes",
-      "Nevraeka",
-      "Bzbarsky",
-      "Debloper",
-      "dbruant",
-      "emersonveenstra",
-      "jkff",
-      "Kubo2",
-      "ScottMichaud",
-      "kirbysayshi",
-      "silverwind",
-      "alistairmcmillan",
-      "michaeltherobot",
-      "riophae",
-      "erik.brannstrom",
-      "evilpie",
-      "mdrejhon",
-      "gbr",
-      "WGH",
-      "justin.self",
-      "inglor",
-      "ethertank",
-      "anton",
-      "ziyunfei",
-      "PixievoltNo1",
-      "MTonly",
-      "brianblakely",
-      "m_gol",
-      "fusionchess",
-      "Josiah",
-      "TitanNano",
-      "eikes",
-      "dgash",
-      "JaredWein",
-      "CutenessOverload",
-      "Krusty",
-      "ebidel",
-      "soswow",
-      "paul.irish",
-      "myakura",
-      "louisremi",
-      "Hsivonen",
-      "kathyw"
     ]
   },
   "Web/Accessibility": {

--- a/files/en-us/glossary/gzip_compression/index.md
+++ b/files/en-us/glossary/gzip_compression/index.md
@@ -1,16 +1,19 @@
 ---
-title: GZip compression
-slug: Glossary/GZip_compression
+title: gzip compression
+slug: Glossary/gzip_compression
 page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}
 
-gzip is a file format used for file compression and decompression. It is based on [the Deflate algorithm](https://www.zlib.net/feldspar.html) which allows files to be made smaller in size, allowing for faster network transfers. gzip is commonly supported by web servers and modern browsers, meaning that servers can automatically compress files with gzip before sending them, and browsers can uncompress files upon receiving them.
+**gzip** is a file format used in file compression and decompression. It is based on [the Deflate algorithm](https://www.zlib.net/feldspar.html) which allows files to be made smaller, allowing for faster network transfers. gzip is commonly supported by web servers and modern browsers, meaning that servers can automatically compress files with gzip before sending them, and browsers can uncompress files upon receiving them.
 
 ## See also
 
-- {{glossary("Lossless compression")}}
-- {{glossary("Lossy compression")}}
+- [Glossary](/en-US/docs/Glossary)
+
+  - {{glossary("Lossless compression")}}
+  - {{glossary("Lossy compression")}}
+
 - [The gzip home page](https://www.gzip.org/)
 - [gzip on Wikipedia](https://en.wikipedia.org/wiki/Gzip)


### PR DESCRIPTION
### Details

#### Modifications

1. GZip => gzip, as gzip has no capitalization like `GZip` in anywhere else than mdn... (and [a question in stackoverflow](https://stackoverflow.com/questions/16691506/what-is-gzip-compression))
 
(https://github.com/mdn/translated-content/pull/20572#discussion_r1614438179)
