### PR TITLE
Fix up event names in “Element: mouseenter event” doc (again)

### DIFF
--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -92,7 +92,7 @@ One `mouseenter` event is sent to each element of the hierarchy when entering th
 ![Mouseover behavior diagram](mouseover.png)
 A single `mouseover` event is sent to the deepest element of the DOM tree, then it bubbles up the hierarchy until it is canceled by a handler or reaches the root.
 
-With deep hierarchies, the number of `mouseover` events sent can be quite huge and cause significant performance problems. In such cases, it is better to listen for `mouseenter` events.
+With deep hierarchies, the number of `mouseenter` events sent can be quite huge and cause significant performance problems. In such cases, it is better to listen for `mouseover` events.
 
 Combined with the corresponding `mouseleave` (which is fired at the element when the mouse exits its content area), the `mouseenter` event acts in a very similar way to the CSS {{cssxref(':hover')}} pseudo-class.
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This change reverts an older change that was based on a misunderstanding.
When hovering a deeply nested element, `mouseenter` events are sent to all ancestors (not bubbling) while only a single `mouseover` event is sent to the deepest element (bubbling).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The documentation as it is currently worded is incorrect. A change to the docs was made because of [this issue](https://github.com/mdn/content/issues/7185) that I raised. This was based on a misunderstanding on my part though because I mistook event bubbling as having multiple events. Maybe the documentation could be clearer to prevent such a misunderstanding but in any case it should be corrected.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The reasoning for the initial issue and an illustration why it is actually wrong is included in https://github.com/mdn/content/issues/7185.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Reverts #7289

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
