### PR TITLE
Link to a summary of hr-time #115

### DIFF
--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -60,7 +60,7 @@ The specification (Level 2) requires that `performance.now()` should tick during
 - Firefox ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1709767))
 - Safari/WebKit ([bug](https://bugs.webkit.org/show_bug.cgi?id=225610))
 
-More details can also be found in the specification issue [hr-time#115](https://github.com/w3c/hr-time/issues/115).
+More details can also be found in the specification issue [hr-time#115](https://github.com/w3c/hr-time/issues/115#issuecomment-1172985601).
 
 ## Examples
 


### PR DESCRIPTION
A comment at the end of [hr-time #115](https://github.com/w3c/hr-time/issues/115) summarized the issue well so I thought it might be more helpful to link directly to it. 

The top of the issue has more to do with getting others on the same page re: the exact details of this issue.

Ref: https://github.com/w3c/hr-time/issues/115
Ref: https://github.com/mdn/content/issues/33760
