### PR TITLE
AudioListener: Add bugzilla link

### DIFF
--- a/files/en-us/web/api/audiolistener/index.md
+++ b/files/en-us/web/api/audiolistener/index.md
@@ -43,7 +43,7 @@ It is important to note that there is only one listener per context and that it 
 - {{domxref("AudioListener.setPosition()")}} {{deprecated_inline}}
   - : Sets the position of the listener.
 
-> **Note:** Although these methods are deprecated they are currently the only way to set the orientation and position in Firefox.
+> **Note:** Although these methods are deprecated they are currently the only way to set the orientation and position in Firefox (see [Firefox bug 1283029](https://bugzilla.mozilla.org/show_bug.cgi?id=1283029)).
 
 ## Deprecated features
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `AudioListener` [MDN page](https://developer.mozilla.org/en-US/docs/Web/API/AudioListener#instance_methods) states:
> Although these methods are deprecated they are currently the only way to set the orientation and position in Firefox.

I added a link to the relevant bugzilla ticket.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
When going through some old code I saw some deprecation warnings. I assumed I can fix this but unfortunately using deprecated method is the only way to do this stuff in Firefox at the moment. I think it makes sense to link to the bug ticket so its easier for people interested in this to track the progress.

