### PR TITLE
Fix error in the code snippet for Symbol

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -24,7 +24,7 @@ const sym3 = Symbol("foo");
 The above code creates three new Symbols. Note that `Symbol("foo")` does not coerce the string `"foo"` into a Symbol. It creates a new Symbol each time:
 
 ```js
-Symbol("foo") === Symbol("foo"); // false
+Symbol("foo") === "foo"; // false
 ```
 
 The following syntax with the {{jsxref("Operators/new", "new")}} operator will throw a {{jsxref("TypeError")}}:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Correct the code snippet for demonstrating how a string won't get coerced into a symbol.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

In [the reference doc for Symbol, under description section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#description), the explanation above one of the snippet says:
> Note that Symbol("foo") does not coerce the string "foo" into a Symbol.

However, the code snippet says:
```javascript
Symbol("foo") === Symbol("foo"); // false
```

<img width="1373" alt="MDN JavaScript Symbol doc error" src="https://github.com/mdn/content/assets/5660356/f3b6bc23-c36d-4abd-9ec7-f38d485a0211">


Executing this statement in the Firefox dev console yields `true` not `false` as the code snippet states:
```javascript
>> Symbol.for("foo") === Symbol.for("foo")
true 
```

I'm guessing that the code snippet was intended to be:
```javascript
Symbol("foo") === "foo"; // false
```

Testing this new statement in the dev console:
```javascript
>> Symbol.for("foo") === "foo"
false 
```

<img width="757" alt="Testing on Dev console" src="https://github.com/mdn/content/assets/5660356/1362bb65-55d8-47d0-99c1-79c8eb1c6d6e">


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
