### PR TITLE
Update the description regarding Apple's support for PWA

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/installing/index.md
@@ -68,7 +68,7 @@ Installation is supported on all modern desktop and mobile devices. Whether the 
 
 Firefox requires a [PWA extension](https://addons.mozilla.org/en-US/firefox/addon/pwas-for-firefox/).
 
-Before macOS 14 (Sonoma), PWAs can be installed on macOS from any browser **except** Safari. The opposite is true for iOS versions before 16.4, where PWAs could **only** be installed in Safari. PWAs can be installed on macOS 14.0 or later and iOS/iPadOS 16.4 or later from any supporting browser.
+Before macOS 14 (Sonoma), PWAs could be installed on macOS from any browser **except** Safari. The opposite is true for iOS versions before 16.4, where PWAs could **only** be installed in Safari. PWAs can be installed on macOS 14.0 or later and iOS/iPadOS 16.4 or later from any supporting browser.
 
 When an installed PWA is launched, it can be displayed in its own standalone window (without the full browser UI) but it still effectively runs in a browser window, even if the usual browser UI elements, such as the address bar or back button, aren't visible. The application will be found where the OS saves other applications, within a folder specific to the browser.
 

--- a/files/en-us/web/progressive_web_apps/guides/installing/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/installing/index.md
@@ -68,7 +68,7 @@ Installation is supported on all modern desktop and mobile devices. Whether the 
 
 Firefox requires a [PWA extension](https://addons.mozilla.org/en-US/firefox/addon/pwas-for-firefox/).
 
-Apple is unique when it comes to PWAs: PWAs can be installed on macOS from any browser **except** Safari. The opposite is true for iOS versions before 16.4, where PWAs could **only** be installed in Safari. PWAs can be installed on iOS/iPadOS 16.4 or later from any supporting browser.
+Before macOS 14 (Sonoma), PWAs can be installed on macOS from any browser **except** Safari. The opposite is true for iOS versions before 16.4, where PWAs could **only** be installed in Safari. PWAs can be installed on macOS 14.0 or later and iOS/iPadOS 16.4 or later from any supporting browser.
 
 When an installed PWA is launched, it can be displayed in its own standalone window (without the full browser UI) but it still effectively runs in a browser window, even if the usual browser UI elements, such as the address bar or back button, aren't visible. The application will be found where the OS saves other applications, within a folder specific to the browser.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Slightly changed the description on Apple's support for PWA by adding information about macOS 14's support for PWA. Also removed the 'unique' claim as it does little to help better understanding.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Apple added partial support for PWAs from Safari on macOS 14. The existing information is somewhat outdated, hence this pull request is made.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

[Apple support site for Safari PWAs](https://support.apple.com/en-us/104996).



<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
