### PR TITLE
Revert "=== Symbol("foo")"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -24,7 +24,7 @@ const sym3 = Symbol("foo");
 The above code creates three new Symbols. Note that `Symbol("foo")` does not coerce the string `"foo"` into a Symbol. It creates a new Symbol each time:
 
 ```js
-Symbol("foo") === "foo"; // false
+Symbol("foo") === Symbol("foo"); // false
 ```
 
 The following syntax with the {{jsxref("Operators/new", "new")}} operator will throw a {{jsxref("TypeError")}}:


### PR DESCRIPTION
I merged an error.  this reverts it.

per: https://github.com/mdn/content/pull/33765#issuecomment-2133124813

fixes #33765