### PR TITLE
feat: add backticks to property

### DIFF
--- a/files/en-us/web/css/css_shapes/from_box_values/index.md
+++ b/files/en-us/web/css/css_shapes/from_box_values/index.md
@@ -55,7 +55,7 @@ The `content-box` value defines the shape enclosed by the outside content edge. 
 
 ## When to use box values
 
-Using box values is a simple way to create shapes; however, this is by nature only going to work with very simple shapes that can be defined using the well-supported `border-radius` property. The examples shown above show one such use case. You can create a circular shape using border-radius and then curve text around it.
+Using box values is a simple way to create shapes; however, this is by nature only going to work with very simple shapes that can be defined using the well-supported `border-radius` property. The examples shown above show one such use case. You can create a circular shape using `border-radius` and then curve text around it.
 
 With just this basic technique, you can create some interesting effects. In my final example of this section, I have floated two elements left and right, giving each a border radius of 100% in the direction closest to the text.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I found a small issue in the recently working on translation in another repo. 
The border-radius property was not enclosed in backticks, which could make it less clear to readers. To maintain consistency with the existing documentation style, I have added backticks around border-radius.
This part to 
![Screenshot 2024-05-29 at 9 58 43 AM](https://github.com/mdn/content/assets/89691274/de2e6b36-5f8b-4a24-bc58-83a56a2879e1)
this.
<img width="776" alt="Screenshot 2024-05-29 at 9 59 14 AM" src="https://github.com/mdn/content/assets/89691274/33513c6a-ebee-4267-8c2a-a28a5d33c58d">

Please let me know if this is unnecessary or if you have any feedback.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
