### PR TITLE
try...catch: clarify not-all-`break`s-trigger-finally

### DIFF
--- a/files/en-us/web/javascript/reference/statements/try...catch/index.md
+++ b/files/en-us/web/javascript/reference/statements/try...catch/index.md
@@ -113,7 +113,7 @@ The `finally` block contains statements to execute after the `try` block and `ca
 
 - Immediately after the `try` block finishes execution normally (and no exceptions were thrown);
 - Immediately after the `catch` block finishes execution normally;
-- Immediately before a control-flow statement (`return`, `throw`, `break`, `continue`) is executed in the `try` block or `catch` block.
+- Immediately before the execution of a control-flow statement (`return`, `throw`, `break`, `continue`) in the `try` block or `catch` block that would exit the block.
 
 If an exception is thrown from the `try` block, even when there's no `catch` block to handle the exception, the `finally` block still executes, in which case the exception is still thrown immediately after the `finally` block finishes executing.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Tweaks the phrasing of the only paragraph that mentions the interaction between `break`/`continue` and `finally` so that it does not erroneously imply that **any** `break`/`continue` statements are affected, only those which would exit the block.

I don't think this really needs example code in-document; no one should be surprised by this.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It seemed pretty clear to me when I read the paragraph that the modified wording should be correct, and that a `break` within a loop entirely contained within a `try` block should be unaffected by it; the alternative is pretty horrible. Due to the current wording, though, I bothered to write myself a code snippet to be super sure.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Confirming that the behavior works in general (when i is 2, the finally block is executed before the break, as it exits the try block):

```js
/*
0
finally
1
finally
2
finally
done!
*/
function a() {
  for (let i = 0; i < 10; i++) {
    try {
      console.log(i);
      if (i === 2) {
        break;
      }
    } finally {
      console.log('finally');
    }
  }
  console.log('done!');
}
a();
```

Confirming that the behavior only applies when exiting (no weird control flow shenanigans when the broken loop is entirely within the `try`):

```js
/*
0
1
2
done!
finally
*/
function b() {
  try {
    for (let i = 0; i < 10; i++) {
      console.log(i);
      if (i === 2) {
        break;
      }
    }
    console.log('done!');
  } finally {
    console.log('finally');
  }
}
b();
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

n/a


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
