### PR TITLE
Fix issue 33723: remove nonsensical emphasis character

### DIFF
--- a/files/en-us/web/css/text-emphasis-style/index.md
+++ b/files/en-us/web/css/text-emphasis-style/index.md
@@ -19,10 +19,8 @@ text-emphasis-style: none; /* No emphasis marks */
 
 /* <string> values */
 text-emphasis-style: "x";
-text-emphasis-style: "点";
 text-emphasis-style: "\25B2";
 text-emphasis-style: "*";
-text-emphasis-style: "foo"; /* Should NOT be used. It may be computed to or rendered as 'f' only */
 
 /* Keyword values */
 text-emphasis-style: filled;


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/33723.

This is just the simplest fix, of removing the example. If anyone has a suggestion for something to use instead, we can add that in this PR or a follow-up.

I also removed the `text-emphasis-style: "foo";` example, because I don't think "Syntax" should list things that people should not use.