### PR TITLE
set `handle` value

### DIFF
--- a/files/en-us/web/api/dedicatedworkerglobalscope/requestanimationframe/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/requestanimationframe/index.md
@@ -66,19 +66,20 @@ When receiving the `"start"` message, the worker starts the animation, moving th
 ```js
 let ctx;
 let pos = 0;
+let handle;
 
 function draw(dt) {
   ctx.clearRect(0, 0, 100, 100);
   ctx.fillRect(pos, 0, 10, 10);
   pos += 10 * dt;
-  self.requestAnimationFrame(draw);
+  handle = self.requestAnimationFrame(draw);
 }
 
 self.addEventListener("message", (e) => {
   if (e.data.type === "start") {
     const transferredCanvas = e.data.canvas;
     ctx = transferredCanvas.getContext("2d");
-    self.requestAnimationFrame(draw);
+    handle = self.requestAnimationFrame(draw);
   }
   if (e.data.type === "stop") {
     self.cancelAnimationFrame(handle);


### PR DESCRIPTION
`handle` is passed to `self.cancelAnimationFrame`, but it was never declared nor set to anything.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

set `handle` to cancellation token

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

existing code is buggy

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
