### PR TITLE
feat: add backticks to property in basic-shapes

### DIFF
--- a/files/en-us/web/css/css_shapes/basic_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/basic_shapes/index.md
@@ -23,7 +23,7 @@ The arguments which are accepted vary depending on the shape that you are creati
 
 Understanding the reference box used by CSS Shapes is important when using basic shapes, as it defines each shape's coordinate system. You have already met the reference box in [the guide on creating shapes from Box Values](/en-US/docs/Web/CSS/CSS_shapes/From_box_values), which directly uses the reference box to create the shape.
 
-The Firefox Shapes Inspector helpfully shows the reference box in use when you inspect a shape. In the screenshot below I have created a circle, using `shape-outside: circle(50%)`. The floated element has 20 pixels of padding, border and margin applied, and the Shapes Inspector highlights these reference boxes. When using a basic shape, the reference box used by default is the margin-box. You can see in the screenshot that the shape is being defined with reference to that part of the Box Model.
+The Firefox Shapes Inspector helpfully shows the reference box in use when you inspect a shape. In the screenshot below I have created a circle, using `shape-outside: circle(50%)`. The floated element has 20 pixels of padding, border and margin applied, and the Shapes Inspector highlights these reference boxes. When using a basic shape, the reference box used by default is the `margin-box`. You can see in the screenshot that the shape is being defined with reference to that part of the Box Model.
 
 ![An imaged clipped into a circle floated left, with a paragraph of text. The left edge of the text is circular abutting the clipped shape on the outside of the margin with the margin following the shape clipping.](shapes-reference-box.png)
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I found a small issue in the recently working on translation in another repo.
The margin-box property was not enclosed in backticks, which could make it less clear to readers. To maintain consistency with the existing documentation style, I have added backticks around margin-box.

this to 
![Screenshot 2024-05-30 at 11 21 24 AM](https://github.com/mdn/content/assets/89691274/2313e7b9-9988-4ad7-b906-9535619dbbba)
this 

<img width="783" alt="Screenshot 2024-05-30 at 11 21 42 AM" src="https://github.com/mdn/content/assets/89691274/8137c661-3bf3-42ce-b543-184fbfc29301">

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
