### PR TITLE
scripting.registerContentScripts() returns no arguments

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -30,7 +30,7 @@ await browser.scripting.registerContentScripts(
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that fulfills with an array of {{WebExtAPIRef("scripting.RegisteredContentScript")}}. If there are errors during script parsing and file validation, or if the IDs specified do not exist, no scripts are registered and the promise is rejected.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with no arguments or rejected when there are errors. Errors can occur during script parsing and file validation or if the IDs specified do not exist. When an error occurs, no scripts are registered.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Updates documentation as per resolution of [Bug 1896508](https://bugzilla.mozilla.org/show_bug.cgi?id=1896508) scripting.registerContentScripts() should return the registered scripts, according to MDN i.e. scripting.registerContentScripts() returns no argugents.


