### PR TITLE
Add click as possible type of MouseEvent

### DIFF
--- a/files/en-us/web/api/mouseevent/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.md
@@ -21,7 +21,7 @@ new MouseEvent(type, options)
 
 - `type`
   - : A string with the name of the event.
-    It is case-sensitive and browsers set it to `dblclick`, `mousedown`, `mouseenter`, `mouseleave`, `mousemove`, `mouseout`, `mouseover`, or `mouseup`.
+    It is case-sensitive and browsers set it to `click`, `dblclick`, `mousedown`, `mouseenter`, `mouseleave`, `mousemove`, `mouseout`, `mouseover`, or `mouseup`.
 - `options` {{optional_inline}}
 
   - : An object that, _in addition of the properties defined in {{domxref("UIEvent/UIEvent", "UIEvent()")}}_, can have the following properties:


### PR DESCRIPTION
Consistent with introductory description at https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent

### Description

Include `click` as a possible `type` of MouseEvent, which the documentation for MouseEvent indicates is common.

### Motivation

The text surrounding the existing list has some implications that it's an exhaustive list and it seems like it should be. 

### Additional details

The above seems to cover it.

### Related issues and pull requests

None found, example query [here](https://github.com/mdn/content/issues?q=mouseevent+click+type).
