### PR TITLE
fix(redirects): redirect scroll -> animation-timeline/scroll

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -801,7 +801,7 @@
 /en-US/docs/CSS/resolution	/en-US/docs/Web/CSS/resolution
 /en-US/docs/CSS/rgb	/en-US/docs/Web/CSS/color_value/rgb
 /en-US/docs/CSS/right	/en-US/docs/Web/CSS/right
-/en-US/docs/CSS/scroll	/en-US/docs/Web/CSS/overflow
+/en-US/docs/CSS/scroll	/en-US/docs/Web/CSS/animation-timeline/scroll
 /en-US/docs/CSS/shape	/en-US/docs/Web/CSS/shape
 /en-US/docs/CSS/shape-rendering	/en-US/docs/Web/SVG/Attribute/shape-rendering
 /en-US/docs/CSS/specified_value	/en-US/docs/Web/CSS/specified_value
@@ -1079,7 +1079,7 @@
 /en-US/docs/CSS:position	/en-US/docs/Web/CSS/position
 /en-US/docs/CSS:quotes	/en-US/docs/Web/CSS/quotes
 /en-US/docs/CSS:right	/en-US/docs/Web/CSS/right
-/en-US/docs/CSS:scroll	/en-US/docs/Web/CSS/overflow
+/en-US/docs/CSS:scroll	/en-US/docs/Web/CSS/animation-timeline/scroll
 /en-US/docs/CSS:shape	/en-US/docs/Web/CSS/shape
 /en-US/docs/CSS:static	/en-US/docs/Web/CSS/position
 /en-US/docs/CSS:string	/en-US/docs/Web/CSS/string
@@ -11695,7 +11695,7 @@
 /en-US/docs/Web/CSS/repeating-radial-gradient	/en-US/docs/Web/CSS/gradient/repeating-radial-gradient
 /en-US/docs/Web/CSS/repeating-radial-gradient()	/en-US/docs/Web/CSS/gradient/repeating-radial-gradient
 /en-US/docs/Web/CSS/rgb	/en-US/docs/Web/CSS/color_value/rgb
-/en-US/docs/Web/CSS/scroll	/en-US/docs/Web/CSS/overflow
+/en-US/docs/Web/CSS/scroll	/en-US/docs/Web/CSS/animation-timeline/scroll
 /en-US/docs/Web/CSS/scrollbar-track-color	/en-US/docs/Web/CSS/scrollbar-color
 /en-US/docs/Web/CSS/shape-box	/en-US/docs/Web/CSS/shape-outside
 /en-US/docs/Web/CSS/shape-rendering	/en-US/docs/Web/SVG/Attribute/shape-rendering


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrects the redirect for CSS/scroll.

### Motivation

It redirected to [CSS/overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow), although [CSS/animation-timeline/scroll](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline/scroll) exists.

### Additional details

Noticed when running `yarn build --locale en-us --quiet` in yari:

```
...
In CSS_Ref the smartLink to /en-US/docs/Web/CSS/scroll is broken! (redirects to /en-US/docs/Web/CSS/overflow)
```

### Related issues and pull requests

See also: https://github.com/mdn/data/pull/739