### PR TITLE
chore(GroupData): remove mozPresentationDeviceInfo

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1224,8 +1224,7 @@
       ],
       "methods": [],
       "properties": [
-        "Navigator.presentation",
-        "Navigator.mozPresentationDeviceInfo"
+        "Navigator.presentation"
       ],
       "events": []
     },

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1223,9 +1223,7 @@
         "PresentationSessionConnectEvent"
       ],
       "methods": [],
-      "properties": [
-        "Navigator.presentation"
-      ],
+      "properties": ["Navigator.presentation"],
       "events": []
     },
     "Prioritized Task Scheduling API": {


### PR DESCRIPTION
### Description

Removes `mozPresentationDeviceInfo` from the Presentation API.

### Motivation

This is no longer referenced in MDN or [in Firefox source code](https://searchfox.org/mozilla-central/search?q=mozPresentationDeviceInfo&path=&case=false&regexp=false).

### Additional details

Noticed when running `yarn build --locale en-us --quiet` in yari.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
