### PR TITLE
fix error is not defined issue

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -370,7 +370,7 @@ promise
   .then((data) => {
     console.log(data[0].name);
   })
-  .catch(() => {
+  .catch((error) => {
     console.error(`Could not get products: ${error}`);
   });
 ```


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The catch missed the error parameter, so I add the missed parameter in the catch function.



### Motivation

If we set up the fetch url to
"bad-scheme://mdn.github.io/learning-area/javascript/apis/fetching-data/can-store/products.json".   
The catch will throw "error is not defined", instead of log "Could not get products: TypeError: Failed to fetch".

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
#### Before
![image](https://github.com/mdn/content/assets/148249900/98beaca0-a4a8-404c-9bc4-88237d4f898a)
#### After
![image](https://github.com/mdn/content/assets/148249900/a8b01a9b-b1f1-4f92-bb94-ab25cd19f870)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
