### PR TITLE
update: Korean Discussions and Current maintainers info

### DIFF
--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -40,8 +40,8 @@ If you need help or have any questions, feel free to get in touch with one of th
 
 ### Korean (`ko`)
 
-- Discussions: [Discord (`#korean`)](/discord), [Kakao Talk (`#MDN Korea`)](https://open.kakao.com/o/gdfG288c)
-- Current maintainers: [hochan222](https://github.com/hochan222), [yechoi42](https://github.com/yechoi42), [cos18](https://github.com/cos18), [pje1740](https://github.com/pje1740), [wisedog](https://github.com/wisedog), [swimjiy](https://github.com/swimjiy), [jho2301](https://github.com/jho2301), [sunhpark42](https://github.com/sunhpark42), [1ilsang](https://github.com/1ilsang)
+- Discussions: [Discord (`#korean`)](/discord), [Google Group (`yari-content-ko`)](https://groups.google.com/g/yari-content-ko)
+- Current maintainers: [hochan222](https://github.com/hochan222), [yechoi42](https://github.com/yechoi42), [wisedog](https://github.com/wisedog), [jho2301](https://github.com/jho2301), [sunhpark42](https://github.com/sunhpark42), [1ilsang](https://github.com/1ilsang)
 
 ### Russian (`ru`)
 


### PR DESCRIPTION
### Description

update: Korean Discussions and Current maintainers info. 

cc. @mdn/yari-content-ko

### Motivation

Team members and channel changes 

### Additional details

- https://github.com/yari-content-ko/meetings/blob/main/2024/05-26/minutes.md