### PR TITLE
Box model guide incorrectly mentions flexbox

### DIFF
--- a/files/en-us/learn/css/building_blocks/the_box_model/index.md
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.md
@@ -321,7 +321,7 @@ It does not, however, break onto a new line, and will only become larger than it
 
 Where this can be useful is when you want to give a link a larger hit area by adding `padding`. `<a>` is an inline element like `<span>`; you can use `display: inline-block` to allow padding to be set on it, making it easier for a user to click the link.
 
-You see this fairly frequently in navigation bars. The navigation below is displayed in a row using flexbox and we have added padding to the `<a>` element as we want to be able to change the `background-color` when the `<a>` is hovered. The padding appears to overlap the border on the `<ul>` element. This is because the `<a>` is an inline element.
+You see this fairly frequently in navigation bars. The navigation below is displayed in a row and we have added padding to the `<a>` element as we want to be able to change the `background-color` when the `<a>` is hovered. The padding appears to overlap the border on the `<ul>` element. This is because the `<a>` is an inline element.
 
 **Add `display: inline-block` to the rule with the `.links-list a` selector, and you will see how it fixes this issue by causing the padding to be respected by other elements.**
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This guide says some navigation elements have been put in a row "using flexbox", but not only does the example not use flexbox, if it did then the issues about inline elements that it is attempting to illustrate wouldn't exist.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Fixing an error so future readers don't get confused about the behaviour of flexbox.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://developer.mozilla.org/en-US/docs/Web/CSS/display#flex ("The element behaves like a block-level element").

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
