### PR TITLE
Add CloseWatcher reference pages

### DIFF
--- a/files/en-us/web/api/closewatcher/cancel_event/index.md
+++ b/files/en-us/web/api/closewatcher/cancel_event/index.md
@@ -3,9 +3,9 @@ title: "CloseWatcher: cancel event"
 short-title: cancel
 slug: Web/API/CloseWatcher/cancel_event
 page-type: web-api-event
-browser-compat: api.CloseWatcher.cancel_event
 status:
   - experimental
+browser-compat: api.CloseWatcher.cancel_event
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/en-us/web/api/closewatcher/cancel_event/index.md
+++ b/files/en-us/web/api/closewatcher/cancel_event/index.md
@@ -1,0 +1,55 @@
+---
+title: "CloseWatcher: cancel event"
+short-title: cancel
+slug: Web/API/CloseWatcher/cancel_event
+page-type: web-api-event
+browser-compat: api.CloseWatcher.cancel_event
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+A `cancel` event is fired at a {{domxref("CloseWatcher")}} object before the `close` event, so that `close` can be prevented from firing, if necessary.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js-nolint
+addEventListener("cancel", (event) => { })
+
+oncancel = (event) => { }
+```
+
+## Event type
+
+An {{domxref("Event")}}.
+
+## Examples
+
+### Using the `cancel` event
+
+The `cancel` event can be used to interrupt the close request. The `cancel` event is triggered by the `requestClose()` method.
+
+```js
+// Use the cancel event to interrupt the close request
+watcher.addEventListener("cancel", (e) => {
+  e.preventDefault();
+  // Close if some condition is met
+  if (condition) {
+    watcher.close();
+  }
+};
+
+// Trigger a close request manually
+watcher.requestClose();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/closewatcher/cancel_event/index.md
+++ b/files/en-us/web/api/closewatcher/cancel_event/index.md
@@ -30,7 +30,7 @@ An {{domxref("Event")}}.
 
 ### Using the `cancel` event
 
-The `cancel` event can be used to catch close request. The `cancel` event is triggered by all close signals and the {{domxref("CloseWatcher.requestClose()")}} method.
+In this example, we ask the user to confirm that they really want to close the component, and if they don't, we cancel the event using {{domxref("Event.preventDefault()")}}, which prevents the `close` event from being fired.
 
 ```js
 watcher.addEventListener("cancel", (e) => {

--- a/files/en-us/web/api/closewatcher/cancel_event/index.md
+++ b/files/en-us/web/api/closewatcher/cancel_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CloseWatcher.cancel_event
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-A `cancel` event is fired at a {{domxref("CloseWatcher")}} object before the `close` event, so that `close` can be prevented from firing, if necessary.
+A `cancel` event is fired at a {{domxref("CloseWatcher")}} object before the `close` event, so that `close` can be prevented from firing, if necessary. It is triggered by all close signals (e.g. the <kbd>Esc</kbd> key) as well as {{domxref("CloseWatcher.requestClose()")}}.
 
 ## Syntax
 
@@ -30,15 +30,15 @@ An {{domxref("Event")}}.
 
 ### Using the `cancel` event
 
-The `cancel` event can be used to interrupt the close request. The `cancel` event is triggered by the `requestClose()` method.
+The `cancel` event can be used to catch close request. The `cancel` event is triggered by all close signals and the {{domxref("CloseWatcher.requestClose()")}} method.
 
 ```js
-// Use the cancel event to interrupt the close request
 watcher.addEventListener("cancel", (e) => {
-  e.preventDefault();
-  // Close if some condition is met
-  if (condition) {
-    watcher.close();
+  if (e.cancelable && hasUnsavedData) {
+    const userReallyWantsToClose = confirm("Are you sure you want to close?");
+    if (!userReallyWantsToClose) {
+      e.preventDefault();
+    }
   }
 };
 

--- a/files/en-us/web/api/closewatcher/close/index.md
+++ b/files/en-us/web/api/closewatcher/close/index.md
@@ -3,9 +3,9 @@ title: "CloseWatcher: close() method"
 short-title: close()
 slug: Web/API/CloseWatcher/close
 page-type: web-api-instance-method
-browser-compat: api.CloseWatcher.close
 status:
   - experimental
+browser-compat: api.CloseWatcher.close
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/en-us/web/api/closewatcher/close/index.md
+++ b/files/en-us/web/api/closewatcher/close/index.md
@@ -1,0 +1,52 @@
+---
+title: "CloseWatcher: close() method"
+short-title: close()
+slug: Web/API/CloseWatcher/close
+page-type: web-api-instance-method
+browser-compat: api.CloseWatcher.close
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+The **`close()`** method of the {{domxref("CloseWatcher")}} interface immediately fires the `close` event and deactivates the close watcher as if `destroy()` was called. It skips any logic in the `cancel` event handler.
+
+## Syntax
+
+```js-nolint
+close()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+### Using the `close()` method
+
+Use the `close()` method to deactivate the close watcher and destroy it.
+
+```js
+watcher.addEventListener("cancel", (e) => {
+  e.preventDefault();
+  // Decide to close if some condition is met
+  if (condition) {
+    watcher.close();
+  }
+};
+watcher.requestClose();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/closewatcher/close/index.md
+++ b/files/en-us/web/api/closewatcher/close/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CloseWatcher.close
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-The **`close()`** method of the {{domxref("CloseWatcher")}} interface immediately fires the `close` event and deactivates the close watcher as if `destroy()` was called. It skips any logic in the `cancel` event handler.
+The **`close()`** method of the {{domxref("CloseWatcher")}} interface lets you skip any logic in the `cancel` event handler and immediately fire the `close` event. It then deactivates the close watcher as if `destroy()` was called.
 
 ## Syntax
 
@@ -33,14 +33,7 @@ None ({{jsxref("undefined")}}).
 Use the `close()` method to deactivate the close watcher and destroy it.
 
 ```js
-watcher.addEventListener("cancel", (e) => {
-  e.preventDefault();
-  // Decide to close if some condition is met
-  if (condition) {
-    watcher.close();
-  }
-};
-watcher.requestClose();
+watcher.close();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/closewatcher/close_event/index.md
+++ b/files/en-us/web/api/closewatcher/close_event/index.md
@@ -3,9 +3,9 @@ title: "CloseWatcher: close event"
 short-title: close
 slug: Web/API/CloseWatcher/close_event
 page-type: web-api-event
-browser-compat: api.CloseWatcher.close_event
 status:
   - experimental
+browser-compat: api.CloseWatcher.close_event
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/en-us/web/api/closewatcher/close_event/index.md
+++ b/files/en-us/web/api/closewatcher/close_event/index.md
@@ -1,0 +1,50 @@
+---
+title: "CloseWatcher: close event"
+short-title: close
+slug: Web/API/CloseWatcher/close_event
+page-type: web-api-event
+browser-compat: api.CloseWatcher.close_event
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+A `close` event is fired at a {{domxref("CloseWatcher")}} object when a close request was received.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js-nolint
+addEventListener("close", (event) => { })
+
+onclose = (event) => { }
+```
+
+## Event type
+
+An {{domxref("Event")}}.
+
+## Examples
+
+### Using the `close` event
+
+Use the `close` to listen for close requests.
+
+```js
+watcher.addEventListener("close", () => {
+  // Close your UI component
+  sidebar.hide();
+  // Dispose the watcher instance
+  watcher.destroy();
+};
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/closewatcher/close_event/index.md
+++ b/files/en-us/web/api/closewatcher/close_event/index.md
@@ -12,6 +12,8 @@ browser-compat: api.CloseWatcher.close_event
 
 A `close` event is fired at a {{domxref("CloseWatcher")}} object when a close request was received and only fired if the {{domxref("CloseWatcher.cancel_event", "cancel")}} event that preceded the `close` one was not canceled.
 
+The `close` event handler is where the code to close the UI component should be called: this ensures that the component will be closed properly either from the platform-specific close signal or from a call to {{domxref("CloseWatcher.requestClose()")}}.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.

--- a/files/en-us/web/api/closewatcher/close_event/index.md
+++ b/files/en-us/web/api/closewatcher/close_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CloseWatcher.close_event
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-A `close` event is fired at a {{domxref("CloseWatcher")}} object when a close request was received.
+A `close` event is fired at a {{domxref("CloseWatcher")}} object when a close request was received and only fired if the {{domxref("CloseWatcher.cancel_event", "cancel")}} event that preceded the `close` one was not canceled.
 
 ## Syntax
 
@@ -36,8 +36,6 @@ Use the `close` to listen for close requests.
 watcher.addEventListener("close", () => {
   // Close your UI component
   sidebar.hide();
-  // Dispose the watcher instance
-  watcher.destroy();
 };
 ```
 

--- a/files/en-us/web/api/closewatcher/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/closewatcher/index.md
@@ -1,0 +1,58 @@
+---
+title: "CloseWatcher: CloseWatcher() constructor"
+short-title: CloseWatcher()
+slug: Web/API/CloseWatcher/CloseWatcher
+page-type: web-api-constructor
+browser-compat: api.CloseWatcher.CloseWatcher
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+The **`CloseWatcher()`** constructor creates a new {{domxref("CloseWatcher")}} object.
+
+## Syntax
+
+```js-nolint
+new CloseWatcher()
+new CloseWatcher(options)
+```
+
+### Parameters
+
+- `options` {{optional_inline}}
+  - : An object that has the following properties:
+    - `signal`
+      - : An {{domxref("AbortSignal")}} that, if provided, the watcher can be destroyed by.
+
+## Return value
+
+A new {{domxref("CloseEvent")}} object.
+
+## Examples
+
+### Creating new `CloseWatcher` instances
+
+Optionally, the `CloseWatcher` constructor accepts a `signal` option which is an {{domxref("AbortSignal")}}.
+
+```js
+// Create a new close watcher
+let watcher = new CloseWatcher();
+
+// Create a new CloseWatcher with an AbortSignal that controls destroying the watcher
+let controller = new AbortController();
+let signalWatcher = new CloseWatcher({ signal: controller.signal };
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("CloseWatcher")}}, the interface of the objects it constructs.

--- a/files/en-us/web/api/closewatcher/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/closewatcher/index.md
@@ -3,9 +3,9 @@ title: "CloseWatcher: CloseWatcher() constructor"
 short-title: CloseWatcher()
 slug: Web/API/CloseWatcher/CloseWatcher
 page-type: web-api-constructor
-browser-compat: api.CloseWatcher.CloseWatcher
 status:
   - experimental
+browser-compat: api.CloseWatcher.CloseWatcher
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/en-us/web/api/closewatcher/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/closewatcher/index.md
@@ -12,6 +12,8 @@ browser-compat: api.CloseWatcher.CloseWatcher
 
 The **`CloseWatcher()`** constructor creates a new {{domxref("CloseWatcher")}} object.
 
+You can create `CloseWatcher` instances without [user activation](/en-US/docs/Web/Security/User_activation), and this can be useful to implement cases like session inactivity timeout dialogs. However, if you create more than one `CloseWatcher` without user activation, then the newly-created one will be grouped together with the last one, so a single close request will close them both. This means that it is important to call {{domxref("CloseWatcher.destroy()", "destroy()")}}, {{domxref("CloseWatcher.close()", "close()")}}, and {{domxref("CloseWatcher.requestClose()", "requestClose()")}} properly.
+
 ## Syntax
 
 ```js-nolint
@@ -24,7 +26,7 @@ new CloseWatcher(options)
 - `options` {{optional_inline}}
   - : An object that has the following properties:
     - `signal`
-      - : If a `signal`, is provided then the watcher can be destroyed (as if by `watcher.destroy()`) by aborting the given {{domxref("AbortSignal")}}.
+      - : An {{domxref("AbortSignal")}}. If this is provided, then the watcher can be destroyed (as if by calling {{domxref("CloseWatcher.destroy()")}}) by calling {{domxref("AbortController.abort()")}} on the corresponding {{domxref("AbortController")}}.
 
 ## Return value
 
@@ -34,7 +36,7 @@ A new {{domxref("CloseWatcher")}} object.
 
 ### Creating new `CloseWatcher` instances
 
-Create a new close watcher.
+Create a new `CloseWatcher`.
 
 ```js
 const watcher = new CloseWatcher();

--- a/files/en-us/web/api/closewatcher/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/closewatcher/index.md
@@ -24,25 +24,27 @@ new CloseWatcher(options)
 - `options` {{optional_inline}}
   - : An object that has the following properties:
     - `signal`
-      - : An {{domxref("AbortSignal")}} that, if provided, the watcher can be destroyed by.
+      - : If a `signal`, is provided then the watcher can be destroyed (as if by `watcher.destroy()`) by aborting the given {{domxref("AbortSignal")}}.
 
 ## Return value
 
-A new {{domxref("CloseEvent")}} object.
+A new {{domxref("CloseWatcher")}} object.
 
 ## Examples
 
 ### Creating new `CloseWatcher` instances
 
-Optionally, the `CloseWatcher` constructor accepts a `signal` option which is an {{domxref("AbortSignal")}}.
+Create a new close watcher.
 
 ```js
-// Create a new close watcher
-let watcher = new CloseWatcher();
+const watcher = new CloseWatcher();
+```
 
-// Create a new CloseWatcher with an AbortSignal that controls destroying the watcher
-let controller = new AbortController();
-let signalWatcher = new CloseWatcher({ signal: controller.signal };
+Create a new `CloseWatcher` with an {{domxref("AbortSignal")}} that controls destroying the watcher.
+
+```js
+const controller = new AbortController();
+const signalWatcher = new CloseWatcher({ signal: controller.signal };
 ```
 
 ## Specifications
@@ -52,7 +54,3 @@ let signalWatcher = new CloseWatcher({ signal: controller.signal };
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- {{domxref("CloseWatcher")}}, the interface of the objects it constructs.

--- a/files/en-us/web/api/closewatcher/destroy/index.md
+++ b/files/en-us/web/api/closewatcher/destroy/index.md
@@ -5,6 +5,7 @@ slug: Web/API/CloseWatcher/destroy
 page-type: web-api-instance-method
 status:
   - experimental
+browser-compat: api.CloseWatcher.destroy
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/en-us/web/api/closewatcher/destroy/index.md
+++ b/files/en-us/web/api/closewatcher/destroy/index.md
@@ -1,0 +1,51 @@
+---
+title: "CloseWatcher: destroy() method"
+short-title: destroy()
+slug: Web/API/CloseWatcher/destroy
+page-type: web-api-instance-method
+browser-compat: api.CloseWatcher.destroy
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+The **`destroy()`** method of the {{domxref("CloseWatcher")}} interface deactivates the close watcher so that it will no longer receive `close` events.
+
+## Syntax
+
+```js-nolint
+destroy()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+### Using the `destroy()` method
+
+Use the `destory()` method to dispose the watcher instance
+
+```js
+// Listen for close requests
+watcher.addEventListener("close", () => {
+  // Close your UI component
+  sidebar.hide();
+  // Dispose the watcher instance
+  watcher.destroy();
+};
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/closewatcher/destroy/index.md
+++ b/files/en-us/web/api/closewatcher/destroy/index.md
@@ -3,7 +3,6 @@ title: "CloseWatcher: destroy() method"
 short-title: destroy()
 slug: Web/API/CloseWatcher/destroy
 page-type: web-api-instance-method
-browser-compat: api.CloseWatcher.destroy
 status:
   - experimental
 ---

--- a/files/en-us/web/api/closewatcher/destroy/index.md
+++ b/files/en-us/web/api/closewatcher/destroy/index.md
@@ -10,7 +10,9 @@ browser-compat: api.CloseWatcher.destroy
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-The **`destroy()`** method of the {{domxref("CloseWatcher")}} interface deactivates the close watcher so that it will no longer receive `cancel` or `close` events. This method is useful when a close watcher is associated with a component that gets removed from the DOM before being closed. Similar to how you clean up event listeners with {{domxref("EventTarget.removeEventListener", "removeEventListener()")}}.
+The **`destroy()`** method of the {{domxref("CloseWatcher")}} interface deactivates the close watcher. This is intended to be called if the relevant UI element is torn down in some other way than being closed.
+
+After being deactivated, this `CloseWatcher` will no longer receive `cancel` or `close` events, and it will be possible to create new independent `CloseWatcher` instances.
 
 ## Syntax
 

--- a/files/en-us/web/api/closewatcher/destroy/index.md
+++ b/files/en-us/web/api/closewatcher/destroy/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CloseWatcher.destroy
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-The **`destroy()`** method of the {{domxref("CloseWatcher")}} interface deactivates the close watcher so that it will no longer receive `close` events.
+The **`destroy()`** method of the {{domxref("CloseWatcher")}} interface deactivates the close watcher so that it will no longer receive `cancel` or `close` events. This method is useful when a close watcher is associated with a component that gets removed from the DOM before being closed. Similar to how you clean up event listeners with {{domxref("EventTarget.removeEventListener", "removeEventListener()")}}.
 
 ## Syntax
 
@@ -30,16 +30,10 @@ None ({{jsxref("undefined")}}).
 
 ### Using the `destroy()` method
 
-Use the `destory()` method to dispose the watcher instance
+Use the `destroy()` method to dispose of the watcher instance for cleanup.
 
 ```js
-// Listen for close requests
-watcher.addEventListener("close", () => {
-  // Close your UI component
-  sidebar.hide();
-  // Dispose the watcher instance
-  watcher.destroy();
-};
+watcher.destroy();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/index.md
@@ -2,9 +2,9 @@
 title: CloseWatcher
 slug: Web/API/CloseWatcher
 page-type: web-api-interface
-browser-compat: api.CloseWatcher
 status:
   - experimental
+browser-compat: api.CloseWatcher
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
@@ -47,7 +47,7 @@ _This interface also inherits methods from its parent, {{domxref("EventTarget")}
 The following code example gives an overview how use use the `CloseWatcher` methods and events.
 
 ```js
-// Create a new close watcher 
+// Create a new close watcher
 const watcher = new CloseWatcher();
 
 // Listen for close requests

--- a/files/en-us/web/api/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/index.md
@@ -1,0 +1,87 @@
+---
+title: CloseWatcher
+slug: Web/API/CloseWatcher
+page-type: web-api-interface
+browser-compat: api.CloseWatcher
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+The `CloseWatcher` API listens and responds to close requests. A close request can be for anything that the user wants to close, like a [popover](/en-US/docs/Web/API/Popover_API), a sidebar, a [dialog](/en-US/docs/Web/HTML/Element/dialog), or any UI that has an open/close interaction.
+
+The user usually sends close requests using the <kbd>Esc</kbd> key, the back button on Android, the "z" gesture on iOS VoiceOver, and similar actions on other platforms.
+
+{{InheritanceDiagram}}
+
+The `CloseWatcher` interface inherits from {{domxref("EventTarget")}}.
+
+## Constructor
+
+- {{domxref("CloseWatcher.CloseWatcher", "CloseWatcher()")}} {{Experimental_Inline}}
+  - : Creates a new `CloseWatcher` instance.
+
+## Instance methods
+
+_This interface also inherits methods from its parent, {{domxref("EventTarget")}}._
+
+- {{domxref("CloseWatcher.requestClose()")}} {{Experimental_Inline}}
+  - : Fires a `cancel` event and if that event is not canceled with {{domxref("Event.preventDefault()")}}, proceeds to fire a `close` event, and then finally deactivates the close watcher as if `destroy()` was called.
+- {{domxref("CloseWatcher.close()")}} {{Experimental_Inline}}
+  - : Immediately fires the `close` event and deactivates the close watcher as if `destroy()` was called. Skips any logic in the `cancel` event handler.
+- {{domxref("CloseWatcher.destroy()")}} {{Experimental_Inline}}
+  - : Deactivates the close watcher so that it will no longer receive `close` events.
+
+## Events
+
+- {{domxref("CloseWatcher.cancel_event", "cancel")}} {{Experimental_Inline}}
+  - : An event fired before the `close` event, so that `close` can be prevented from firing.
+- {{domxref("CloseWatcher.close_event", "close")}} {{Experimental_Inline}}
+  - : An event fired when a close request was received.
+
+## Examples
+
+### Using the `CloseWatcher` API
+
+The following code example gives an overview how use use the `CloseWatcher` methods and events.
+
+```js
+// Create a new close watcher 
+const watcher = new CloseWatcher();
+
+// Listen for close requests
+watcher.addEventListener("close", () => {
+  // Close your UI component
+  sidebar.hide();
+  // Dispose the watcher instance
+  watcher.destroy();
+};
+
+// Use the cancel event to interrupt the close request
+watcher.addEventListener("cancel", (e) => {
+  e.preventDefault();
+  // Close if some condition is met
+  if (condition) {
+    watcher.close();
+  }
+};
+
+// Trigger a close request manually
+watcher.requestClose();
+
+// Trigger the close handler, bypassing the cancel handler
+watcher.close();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLDialogElement.close_event", "close")}} event on {{domxref("HTMLDialogElement")}}

--- a/files/en-us/web/api/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/index.md
@@ -9,9 +9,7 @@ browser-compat: api.CloseWatcher
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-The `CloseWatcher` API listens and responds to close requests. A close request can be for anything that the user wants to close, like a [popover](/en-US/docs/Web/API/Popover_API), a sidebar, a [dialog](/en-US/docs/Web/HTML/Element/dialog), or any UI that has an open/close interaction.
-
-The user usually sends close requests using the <kbd>Esc</kbd> key, the back button on Android, the "z" gesture on iOS VoiceOver, and similar actions on other platforms.
+The `CloseWatcher` interface listens and responds to close requests. The user usually sends close requests using the <kbd>Esc</kbd> key, the back button on Android, the "z" gesture on iOS VoiceOver, and similar actions on other platforms. Custom UI components don't respond to these close requests like built-in components ([popover](/en-US/docs/Web/API/Popover_API) or [dialog](/en-US/docs/Web/HTML/Element/dialog)) do. The `CloseWatcher` API abstracts device-specific close methods and delivers a `close` event that custom UI components can use to deliver a device-integrated close behaviour.
 
 {{InheritanceDiagram}}
 
@@ -29,7 +27,7 @@ _This interface also inherits methods from its parent, {{domxref("EventTarget")}
 - {{domxref("CloseWatcher.requestClose()")}} {{Experimental_Inline}}
   - : Fires a `cancel` event and if that event is not canceled with {{domxref("Event.preventDefault()")}}, proceeds to fire a `close` event, and then finally deactivates the close watcher as if `destroy()` was called.
 - {{domxref("CloseWatcher.close()")}} {{Experimental_Inline}}
-  - : Immediately fires the `close` event and deactivates the close watcher as if `destroy()` was called. Skips any logic in the `cancel` event handler.
+  - : Immediately fires the `close` event, without firing `cancel` first, and deactivates the close watcher as if `destroy()` was called.
 - {{domxref("CloseWatcher.destroy()")}} {{Experimental_Inline}}
   - : Deactivates the close watcher so that it will no longer receive `close` events.
 
@@ -42,36 +40,25 @@ _This interface also inherits methods from its parent, {{domxref("EventTarget")}
 
 ## Examples
 
-### Using the `CloseWatcher` API
+### Processing close requests
 
-The following code example gives an overview how use use the `CloseWatcher` methods and events.
+In this example, you have your own UI component (a picker) and you want to support both, the platform's default close method (e.g. the <kbd>Esc</kbd> key) and your custom close method (a close button).
+
+You create a `CloseWatcher` to handle all `close` events.
+
+The `onclick` handler of your UI component can call `requestClose` to request a close and to route your close request through the same `onclose` handler the platform close method uses.
 
 ```js
-// Create a new close watcher
 const watcher = new CloseWatcher();
+const picker = setUpAndShowPickerDOMElement();
+let chosenValue = null;
 
-// Listen for close requests
-watcher.addEventListener("close", () => {
-  // Close your UI component
-  sidebar.hide();
-  // Dispose the watcher instance
-  watcher.destroy();
+watcher.onclose = () => {
+  chosenValue = picker.querySelector("input").value;
+  picker.remove();
 };
 
-// Use the cancel event to interrupt the close request
-watcher.addEventListener("cancel", (e) => {
-  e.preventDefault();
-  // Close if some condition is met
-  if (condition) {
-    watcher.close();
-  }
-};
-
-// Trigger a close request manually
-watcher.requestClose();
-
-// Trigger the close handler, bypassing the cancel handler
-watcher.close();
+picker.querySelector(".close-button").onclick = () => watcher.requestClose();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/closewatcher/index.md
+++ b/files/en-us/web/api/closewatcher/index.md
@@ -9,7 +9,11 @@ browser-compat: api.CloseWatcher
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}
 
-The `CloseWatcher` interface listens and responds to close requests. The user usually sends close requests using the <kbd>Esc</kbd> key, the back button on Android, the "z" gesture on iOS VoiceOver, and similar actions on other platforms. Custom UI components don't respond to these close requests like built-in components ([popover](/en-US/docs/Web/API/Popover_API) or [dialog](/en-US/docs/Web/HTML/Element/dialog)) do. The `CloseWatcher` API abstracts device-specific close methods and delivers a `close` event that custom UI components can use to deliver a device-integrated close behaviour.
+The `CloseWatcher` interface listens and responds to close requests.
+
+Some UI components have "close behavior", meaning that the component appears, and the user can close it when they are finished with it. For example: sidebars, popups, dialogs, or notifications.
+
+Users generally expect to be able to use a particular mechanism to close these elements, and the mechanism tends to be device-specific. For example, on a device with a keyboard it might be the <kbd>Esc</kbd> key, but Android might use the back button. For built-in components, such as [popover](/en-US/docs/Web/API/Popover_API) or {{htmlelement("dialog")}} elements, the browser takes care of these differences, closing the element when the user performs the close action appropriate for the device. However, when a web developer implements their own closable UI component (for example, a sidebar), it is hard to implement this kind of device-specific close behavior. The `CloseWatcher` interface solves this problem by delivering a `close` event to the when the user executes the close action for the device.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/closewatcher/requestclose/index.md
+++ b/files/en-us/web/api/closewatcher/requestclose/index.md
@@ -3,9 +3,9 @@ title: "CloseWatcher: requestClose() method"
 short-title: requestClose()
 slug: Web/API/CloseWatcher/requestClose
 page-type: web-api-instance-method
-browser-compat: api.CloseWatcher.requestClose
 status:
   - experimental
+browser-compat: api.CloseWatcher.requestClose
 ---
 
 {{APIRef("HTML DOM")}} {{SeeCompatTable}}

--- a/files/en-us/web/api/closewatcher/requestclose/index.md
+++ b/files/en-us/web/api/closewatcher/requestclose/index.md
@@ -1,0 +1,55 @@
+---
+title: "CloseWatcher: requestClose() method"
+short-title: requestClose()
+slug: Web/API/CloseWatcher/requestClose
+page-type: web-api-instance-method
+browser-compat: api.CloseWatcher.requestClose
+status:
+  - experimental
+---
+
+{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+
+The **`requestClose()`** method of the {{domxref("CloseWatcher")}} interface fires a `cancel` event and if that event is not canceled with {{domxref("Event.preventDefault()")}}, proceeds to fire a `close` event, and then finally deactivates the close watcher as if `destroy()` was called.
+
+## Syntax
+
+```js-nolint
+requestClose()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+### Using the `requestClose()` method
+
+Use the `requestClose()` method to go through the `cancel` event handler first if there is one.
+
+```js
+// Use the cancel event to interrupt the close request
+watcher.addEventListener("cancel", (e) => {
+  e.preventDefault();
+  // Close if some condition is met
+  if (condition) {
+    watcher.close();
+  }
+};
+
+// Trigger a close request manually
+watcher.requestClose();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/closewatcher/requestclose/index.md
+++ b/files/en-us/web/api/closewatcher/requestclose/index.md
@@ -30,20 +30,21 @@ None ({{jsxref("undefined")}}).
 
 ### Using the `requestClose()` method
 
-Use the `requestClose()` method to go through the `cancel` event handler first if there is one.
+In this example, you have your own UI component (a picker) and you want to support both, the platform's default close method (e.g. the <kbd>Esc</kbd> key) and your custom close method (a close button).
+
+The `onclick` handler of your UI component can call `requestClose` to request a close and to route your close request through the same `onclose` handler the platform close method uses.
 
 ```js
-// Use the cancel event to interrupt the close request
-watcher.addEventListener("cancel", (e) => {
-  e.preventDefault();
-  // Close if some condition is met
-  if (condition) {
-    watcher.close();
-  }
+const watcher = new CloseWatcher();
+const picker = setUpAndShowPickerDOMElement();
+let chosenValue = null;
+
+watcher.onclose = () => {
+  chosenValue = picker.querySelector("input").value;
+  picker.remove();
 };
 
-// Trigger a close request manually
-watcher.requestClose();
+picker.querySelector(".close-button").onclick = () => watcher.requestClose();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/closewatcher/requestclose/index.md
+++ b/files/en-us/web/api/closewatcher/requestclose/index.md
@@ -30,7 +30,7 @@ None ({{jsxref("undefined")}}).
 
 ### Using the `requestClose()` method
 
-In this example, you have your own UI component (a picker) and you want to support both, the platform's default close method (e.g. the <kbd>Esc</kbd> key) and your custom close method (a close button).
+In this example, you have your own UI component (a picker), and you want to support both the platform's default close method (e.g. the <kbd>Esc</kbd> key) and your custom close method (a close button).
 
 The `onclick` handler of your UI component can call `requestClose` to request a close and to route your close request through the same `onclose` handler the platform close method uses.
 


### PR DESCRIPTION
### Description

Adds references pages for `CloseWatcher`. 

I reckon that my work here is quite minimal. Would be cool to write a bit more about this either in this PR or as a follow-up. 

### Motivation

This API is new and ships in Chromium based browsers in M126.
Fixes https://github.com/mdn/content/issues/34184

### Additional details

Link to spec: https://html.spec.whatwg.org/multipage/interaction.html#the-closewatcher-interface

### Related issues and pull requests

BCD: https://github.com/mdn/browser-compat-data/pull/23207