### PR TITLE
Add toJSON to Geolocation objects

### DIFF
--- a/files/en-us/web/api/geolocationcoordinates/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/index.md
@@ -31,7 +31,10 @@ _The `GeolocationCoordinates` interface doesn't inherit any properties._
 
 ## Instance methods
 
-_The `GeolocationCoordinates` interface neither implements, nor inherits any method._
+_The `GeolocationCoordinates` interface doesn't inherit any methods._
+
+- {{domxref("GeolocationCoordinates.toJSON()")}} {{experimental_inline}}
+  - : Returns a JSON representation of the `GeolocationCoordinates` object and enables serialization with {{jsxref("JSON.stringify()")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/geolocationcoordinates/tojson/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/tojson/index.md
@@ -1,0 +1,67 @@
+---
+title: "GeolocationCoordinates: toJSON() method"
+short-title: toJSON()
+slug: Web/API/GeolocationCoordinates/toJSON
+page-type: web-api-instance-method
+status:
+  - experimental
+browser-compat: api.GeolocationCoordinates.toJSON
+---
+
+{{APIRef("Geolocation API")}}{{SeeCompatTable}}
+
+The **`toJSON()`** method of the {{domxref("GeolocationCoordinates")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("GeolocationCoordinates")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("GeolocationCoordinates")}} object.
+
+## Examples
+
+### Using the `toJSON()` method
+
+In this example, calling `position.coords.toJSON()` returns a JSON representation of the `GeolocationCoordinates` object.
+
+```js
+navigator.geolocation.getCurrentPosition(position => {
+  console.log(position.coords.toJSON());
+});
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "accuracy": 12.000,
+  "latitude": 53.0000000,
+  "longitude": 8.0000000,
+  "altitude": null,
+  "altitudeAccuracy": null,
+  "heading": null,
+  "speed": null
+}
+```
+
+To get a JSON string, you can use [`JSON.stringify(position.coords)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}

--- a/files/en-us/web/api/geolocationcoordinates/tojson/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/tojson/index.md
@@ -33,7 +33,7 @@ A {{jsxref("JSON")}} object that is the serialization of the {{domxref("Geolocat
 In this example, calling `position.coords.toJSON()` returns a JSON representation of the `GeolocationCoordinates` object.
 
 ```js
-navigator.geolocation.getCurrentPosition(position => {
+navigator.geolocation.getCurrentPosition((position) => {
   console.log(position.coords.toJSON());
 });
 ```
@@ -42,9 +42,9 @@ This would log a JSON object like so:
 
 ```json
 {
-  "accuracy": 12.000,
-  "latitude": 53.0000000,
-  "longitude": 8.0000000,
+  "accuracy": 12.0,
+  "latitude": 53.0,
+  "longitude": 8.0,
   "altitude": null,
   "altitudeAccuracy": null,
   "heading": null,

--- a/files/en-us/web/api/geolocationposition/index.md
+++ b/files/en-us/web/api/geolocationposition/index.md
@@ -20,7 +20,10 @@ _The `GeolocationPosition` interface doesn't inherit any properties._
 
 ## Instance methods
 
-_The `GeolocationPosition` interface neither implements, nor inherits any methods._
+_The `GeolocationPosition` interface doesn't inherit any methods._
+
+- {{domxref("GeolocationPosition.toJSON()")}} {{experimental_inline}}
+  - : Returns a JSON representation of the `GeolocationPosition` object and enables serialization with {{jsxref("JSON.stringify()")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/geolocationposition/tojson/index.md
+++ b/files/en-us/web/api/geolocationposition/tojson/index.md
@@ -33,7 +33,7 @@ A {{jsxref("JSON")}} object that is the serialization of the {{domxref("Geolocat
 In this example, calling `position.toJSON()` returns a JSON representation of the `GeolocationPosition` object.
 
 ```js
-navigator.geolocation.getCurrentPosition(position => {
+navigator.geolocation.getCurrentPosition((position) => {
   console.log(position.toJSON());
 });
 ```
@@ -44,9 +44,9 @@ This would log a JSON object like so:
 {
   "timestamp": 1717509611840,
   "coords": {
-    "accuracy": 13.000,
-    "latitude": 53.0000000,
-    "longitude": 8.0000000,
+    "accuracy": 13.0,
+    "latitude": 53.0,
+    "longitude": 8.0,
     "altitude": null,
     "altitudeAccuracy": null,
     "heading": null,

--- a/files/en-us/web/api/geolocationposition/tojson/index.md
+++ b/files/en-us/web/api/geolocationposition/tojson/index.md
@@ -1,0 +1,70 @@
+---
+title: "GeolocationPosition: toJSON() method"
+short-title: toJSON()
+slug: Web/API/GeolocationPosition/toJSON
+page-type: web-api-instance-method
+status:
+  - experimental
+browser-compat: api.GeolocationPosition.toJSON
+---
+
+{{APIRef("Geolocation API")}}{{SeeCompatTable}}
+
+The **`toJSON()`** method of the {{domxref("GeolocationPosition")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("GeolocationPosition")}} object.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("JSON")}} object that is the serialization of the {{domxref("GeolocationPosition")}} object.
+
+## Examples
+
+### Using the `toJSON()` method
+
+In this example, calling `position.toJSON()` returns a JSON representation of the `GeolocationPosition` object.
+
+```js
+navigator.geolocation.getCurrentPosition(position => {
+  console.log(position.toJSON());
+});
+```
+
+This would log a JSON object like so:
+
+```json
+{
+  "timestamp": 1717509611840,
+  "coords": {
+    "accuracy": 13.000,
+    "latitude": 53.0000000,
+    "longitude": 8.0000000,
+    "altitude": null,
+    "altitudeAccuracy": null,
+    "heading": null,
+    "speed": null
+  }
+}
+```
+
+To get a JSON string, you can use [`JSON.stringify(position)`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) directly; it will call `toJSON()` automatically.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("JSON")}}


### PR DESCRIPTION
### Description

`toJSON()` is now on `GeolocationCoordinates` + `GeolocationPosition`

### Motivation

Adding missing pages. Will be available in Chromiums starting in 126.

### Additional details

Spec: https://w3c.github.io/geolocation-api/#tojson-method and https://w3c.github.io/geolocation-api/#tojson-method-0

### Related issues and pull requests

BCD: https://github.com/mdn/browser-compat-data/pull/23207