### PR TITLE
Update Firefox 127 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -67,11 +67,11 @@ No notable changes.
 
 #### WebDriver BiDi
 
-- Added the `contexts` argument to the `network.addIntercept` command to limit the interception of network requests to particular top-level browsing contexts ([Firefox bug 1884935](https://bugzil.la/1882260)).
-- Both the commands `session.subscribe` and `session.unsubscribe` now raise an `invalid argument` error when the value of the arguments `events` or `contexts` are empty arrays ([Firefox bug 1884935](https://bugzil.la/1887871)).
-- Updated the implementation of the `storage.getCookies` command to align with the Gecko default cookie behaviour. This allows the removal of the user value for the preference `network.cookie.cookieBehavior`, which was only expected to be set for our CDP implementation ([Firefox bug 1884935](https://bugzil.la/1879503)).
-- Removed the `ownership` and `sandbox` arguments for the `browsingContext.locateNodes` command because they are no longer necessary ([Firefox bug 1884935](https://bugzil.la/1838152)).
-- Improved error message for the `session.new` command when no capabilities are specified ([Firefox bug 1885495](https://bugzil.la/1838152)).
+- Added the `contexts` argument to the `network.addIntercept` command to limit the interception of network requests to particular top-level browsing contexts ([Firefox bug 1882260](https://bugzil.la/1882260)).
+- Both the commands `session.subscribe` and `session.unsubscribe` now raise an `invalid argument` error when the value of the arguments `events` or `contexts` are empty arrays ([Firefox bug 1887871](https://bugzil.la/1887871)).
+- Updated the implementation of the `storage.getCookies` command to align with the Gecko default cookie behaviour. This allows the removal of the user value for the preference `network.cookie.cookieBehavior`, which was only expected to be set for our CDP implementation ([Firefox bug 1879503](https://bugzil.la/1879503)).
+- Removed the `ownership` and `sandbox` arguments for the `browsingContext.locateNodes` command because they are no longer necessary ([Firefox bug 1884935](https://bugzil.la/1884935)).
+- Improved error message for the `session.new` command when no capabilities are specified ([Firefox bug 1838152](https://bugzil.la/1838152)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -72,7 +72,7 @@ This article provides information about the changes in Firefox 127 that affect d
 
 #### WebDriver BiDi
 
-- Added the `permissions.setPermission` command which allows to update browser permissions (such as `geolocation`). The permissions module is an extension to the WebDriver BiDi specification [defined in the permissions specification](https://www.w3.org/TR/permissions/#webdriver-bidi-module-permissions) ([Firefox bug 1875065](https://bugzil.la/1875065)).
+- Added the `permissions.setPermission` command which allows to update browser permissions (such as `geolocation`). The permissions module is an extension to the WebDriver BiDi specification [defined in the Permissions specification](https://www.w3.org/TR/permissions/#webdriver-bidi-module-permissions) ([Firefox bug 1875065](https://bugzil.la/1875065)).
 - Added support for a11y attributes `name` and `role` as locators for the `browsingContext.locateNodes` command ([Firefox bug 1885577](https://bugzil.la/1885577)).
 - Added support for the `devicePixelRatio` argument to `browsingContext.setViewport` which allows to emulate the behavior of the screens with different device pixel ratio ([Firefox bug 1857961](https://bugzil.la/1857961)).
 - Improved `browsingContext.navigate` to avoid race conditions leading to wait unnecessarily before resolving the command ([Firefox bug 1894305](https://bugzil.la/1894305)).
@@ -80,8 +80,8 @@ This article provides information about the changes in Firefox 127 that affect d
 #### Marionette
 
 - Fixed `WebDriver:ElementClear` for elements located in a disabled fieldset ([Firefox bug 1863266](https://bugzil.la/1863266)).
-- Fixed a bug in `WebDriver:SwitchToFrame` which could fail if the tab was in the middle of a navigation ([Firefox bug 1817820](https://bugzil.la/1817820)).
 - Fixed a bug where `WebDriver:GetElementText` failed to correctly capitalize text containing an underscore ([Firefox bug 1888004](https://bugzil.la/1888004)).
+- Fixed a bug in `WebDriver:SwitchToFrame` which could fail if the tab was in the middle of a navigation ([Firefox bug 1817820](https://bugzil.la/1817820)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -83,7 +83,6 @@ This article provides information about the changes in Firefox 127 that affect d
 - Fixed a bug in `WebDriver:SwitchToFrame` which could fail if the tab was in the middle of a navigation ([Firefox bug 1817820](https://bugzil.la/1817820)).
 - Fixed a bug where `WebDriver:GetElementText` failed to correctly capitalize text containing an underscore ([Firefox bug 1888004](https://bugzil.la/1888004)).
 
-
 ## Changes for add-on developers
 
 - {{WebExtAPIRef("management.ExtensionInfo")}} now returns the `install_type` of `"admin"` when an add-on is installed using an enterprise policy ([Firefox bug 1895341](https://bugzil.la/1895341)).

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -68,9 +68,18 @@ This article provides information about the changes in Firefox 127 that affect d
 
 #### General
 
+- Fixed support for `wheel` actions in both WebDriver classic and BiDi to correctly handle modifiers such as `ctrl`, `shift`, etc. ([Firefox bug 1885542](https://bugzil.la/1885542)).
+
 #### WebDriver BiDi
 
+- Added support for a11y attributes `name` and `role` as locators for the `browsingContext.locateNodes` command ([Firefox bug 1885577](https://bugzil.la/1885577)).
+- Added support for the `devicePixelRatio` argument to `browsingContext.setViewport` which allows to emulate the behavior of the screens with different device pixel ratio ([Firefox bug 1857961](https://bugzil.la/1857961)).
+- Improved `browsingContext.navigate` to avoid race conditions leading to wait unnecessarily before resolving the command ([Firefox bug 1894305](https://bugzil.la/1894305)).
+
 #### Marionette
+
+- Fixed `WebDriver:ElementClear` for elements located in a disabled fieldset ([Firefox bug 1863266](https://bugzil.la/1863266)).
+- Fixed a bug in `WebDriver:SwitchToFrame` which could fail if the tab was in the middle of a navigation ([Firefox bug 1817820](https://bugzil.la/1817820)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -72,6 +72,7 @@ This article provides information about the changes in Firefox 127 that affect d
 
 #### WebDriver BiDi
 
+- Added the `permissions.setPermission` command which allows to update browser permissions (such as `geolocation`). The permissions module is an extension to the WebDriver BiDi specification [defined in the permissions specification](https://www.w3.org/TR/permissions/#webdriver-bidi-module-permissions) ([Firefox bug 1875065](https://bugzil.la/1875065)).
 - Added support for a11y attributes `name` and `role` as locators for the `browsingContext.locateNodes` command ([Firefox bug 1885577](https://bugzil.la/1885577)).
 - Added support for the `devicePixelRatio` argument to `browsingContext.setViewport` which allows to emulate the behavior of the screens with different device pixel ratio ([Firefox bug 1857961](https://bugzil.la/1857961)).
 - Improved `browsingContext.navigate` to avoid race conditions leading to wait unnecessarily before resolving the command ([Firefox bug 1894305](https://bugzil.la/1894305)).
@@ -80,6 +81,8 @@ This article provides information about the changes in Firefox 127 that affect d
 
 - Fixed `WebDriver:ElementClear` for elements located in a disabled fieldset ([Firefox bug 1863266](https://bugzil.la/1863266)).
 - Fixed a bug in `WebDriver:SwitchToFrame` which could fail if the tab was in the middle of a navigation ([Firefox bug 1817820](https://bugzil.la/1817820)).
+- Fixed a bug where `WebDriver:GetElementText` failed to correctly capitalize text containing an underscore ([Firefox bug 1888004](https://bugzil.la/1888004)).
+
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
This updates the WebDriver section of the Firefox 127 release notes for all the [note-worthy WebDriver changes in this release](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox126&query_format=advanced&o1=equals&f1=cf_status_firefox127&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed).