### PR TITLE
fix: replace the link to the harmful website

### DIFF
--- a/files/en-us/learn/performance/multimedia/index.md
+++ b/files/en-us/learn/performance/multimedia/index.md
@@ -80,7 +80,7 @@ Other formats improve on JPEG's capabilities regarding compression, but are not 
 
   > **Note:** Despite Apple [announcing support for WebP in Safari 14](https://developer.apple.com/videos/play/wwdc2020/10663/?time=1174), Safari versions earlier than 16.0 don't display `.webp` images successfully on macOS desktop versions earlier than 11/Big Sur. Safari for iOS 14 _does_ display `.webp` images successfully.
 
-- [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif_image) — Good choice for both images and animated images due to high performance and royalty-free image format (even more efficient than WebP, but not as widely supported). It is now supported on Chrome, Edge, Opera, and Firefox. See also [an online tool to convert previous image formats to AVIF](https://avif.io/).
+- [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif_image) — Good choice for both images and animated images due to high performance and royalty-free image format (even more efficient than WebP, but not as widely supported). It is now supported on Chrome, Edge, Opera, and Firefox. [Squoosh](https://squoosh.app) is a good online tool for converting previous image formats to AVIF.
 - **JPEG2000** — once to be the successor to JPEG but only supported in Safari. Doesn't support progressive display either.
 
 Given the narrow support for JPEG-XR and JPEG2000, and also taking decode costs into the equation, the only serious contender for JPEG is WebP. Which is why you could offer your images in that flavor too. This can be done via the `<picture>` element with the help of a `<source>` element equipped with a [type attribute](/en-US/docs/Web/HTML/Element/picture#the_type_attribute).


### PR DESCRIPTION
### Description

replace the link to the harmful website, as `https://avif.io/` is now redirect to a gambling website.

The replaced link - [Squoosh](https://squoosh.app) - has already been listed in this article, and the website operator is associated with Google: <https://github.com/GoogleChromeLabs/squoosh>.

### Related issues and pull requests

Reported in mdn/translated-content#21319
