### PR TITLE
Case Sensitivity: Correcting 'Document.documentElement' to 'document.documentElement'

### DIFF
--- a/files/en-us/web/api/document/documentelement/index.md
+++ b/files/en-us/web/api/document/documentelement/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Document.documentElement
 
 {{ApiRef("DOM")}}
 
-**`Document.documentElement`** returns the
+**`document.documentElement`** returns the
 {{domxref("Element")}} that is the root element of the {{domxref("document")}} (for
 example, the {{HTMLElement("html")}} element for HTML documents).
 

--- a/files/en-us/web/api/document/documentelement/index.md
+++ b/files/en-us/web/api/document/documentelement/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Document.documentElement
 
 {{ApiRef("DOM")}}
 
-**`document.documentElement`** returns the
+The **`documentElement`** read-only roperty of the {{domxref("Document")}} interface returns the
 {{domxref("Element")}} that is the root element of the {{domxref("document")}} (for
 example, the {{HTMLElement("html")}} element for HTML documents).
 

--- a/files/en-us/web/api/document/documentelement/index.md
+++ b/files/en-us/web/api/document/documentelement/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Document.documentElement
 
 {{ApiRef("DOM")}}
 
-The **`documentElement`** read-only roperty of the {{domxref("Document")}} interface returns the
+The **`documentElement`** read-only property of the {{domxref("Document")}} interface returns the
 {{domxref("Element")}} that is the root element of the {{domxref("document")}} (for
 example, the {{HTMLElement("html")}} element for HTML documents).
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
'Document' should be in lowercase because JavaScript is case-sensitive so 'Document.documentElement' doesn't work. It should have been 'document.documentElement'.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I learnt a lot from MDN and would like to contribute

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
