### PR TITLE
Use svg.elements.text.textLength for textLength compat data

### DIFF
--- a/files/en-us/web/svg/attribute/textlength/index.md
+++ b/files/en-us/web/svg/attribute/textlength/index.md
@@ -2,7 +2,7 @@
 title: textLength
 slug: Web/SVG/Attribute/textLength
 page-type: svg-attribute
-browser-compat: svg.global_attributes.textLength
+browser-compat: svg.elements.text.textLength
 ---
 
 {{SVGRef}}


### PR DESCRIPTION
This unblocks https://github.com/mdn/browser-compat-data/pull/23135.