### PR TITLE
Clarify family-name syntax

### DIFF
--- a/files/en-us/web/css/font-family/index.md
+++ b/files/en-us/web/css/font-family/index.md
@@ -60,7 +60,13 @@ font-family: "Gill Sans Extrabold", sans-serif;
 ### Values
 
 - `<family-name>`
-  - : The name of a font family. For example, "Times" and "Helvetica" are font families. Font family names containing whitespace should be quoted. For example: "Comic Sans MS".
+
+  - : The name of a font family. This must be either a single {{cssxref("string")}} value or a space-separated sequence of {{cssxref("custom-ident")}} values. String values must be quoted but may contain any Unicode character. Custom identifiers are not quoted, but certain characters must be escaped.
+
+    It is good practice to quote font family names that contain white space, digits, or punctuation characters other than hyphens.
+
+    See also [Valid family names](#valid_family_names).
+
 - `<generic-name>`
 
   - : Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. Generic family names are keywords and must not be quoted. A generic font family should be the last item in the list of font family names. The following keywords are defined:
@@ -111,38 +117,6 @@ font-family: "Gill Sans Extrabold", sans-serif;
       - : Fonts that are specifically designed to render emoji.
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.
-
-### Valid family names
-
-Font family names must either be given quoted as strings, or unquoted as a sequence of one or more identifiers. This means that punctuation characters and digits at the start of each token must be escaped in unquoted font family names.
-
-It is a **good practice** to quote font family names that contain white space, digits, or punctuation characters other than hyphens.
-
-For example, the following declarations are valid:
-
-```css example-good
-font-family: "Goudy Bookletter 1911", sans-serif;
-```
-
-The following declarations are **invalid**:
-
-```css-nolint example-bad
-font-family: Goudy Bookletter 1911, sans-serif;
-font-family: Red/Black, sans-serif;
-font-family: "Lucida" Grande, sans-serif;
-font-family: Ahem!, sans-serif;
-font-family: test@foo, sans-serif;
-font-family: #POUND, sans-serif;
-font-family: Hawaii 5-0, sans-serif;
-```
-
-The following example is technically **valid** but is not recommended:
-
-```css
-font-family:
-  Gill Sans Extrabold,
-  sans-serif;
-```
 
 ## Formal definition
 
@@ -209,6 +183,34 @@ font-family:
 ```
 
 {{EmbedLiveSample("Some_common_font_families", 600, 220)}}
+
+### Valid family names
+
+The following declarations are valid:
+
+```css example-good
+font-family: "Goudy Bookletter 1911", sans-serif;
+```
+
+The following declarations are invalid:
+
+```css-nolint example-bad
+font-family: Goudy Bookletter 1911, sans-serif;
+font-family: Red/Black, sans-serif;
+font-family: "Lucida" Grande, sans-serif;
+font-family: Ahem!, sans-serif;
+font-family: test@foo, sans-serif;
+font-family: #POUND, sans-serif;
+font-family: Hawaii 5-0, sans-serif;
+```
+
+The following example is technically valid but is not recommended:
+
+```css
+font-family:
+  Gill Sans Extrabold,
+  sans-serif;
+```
 
 ## Specifications
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/33024, more or less as suggested in https://github.com/mdn/content/issues/33024#issuecomment-2150570470.

I also moved "valid family names" to Examples, since that's what it is.