### PR TITLE
feat: add 'packageManager' field for Corepack users

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
   },
   "devDependencies": {
     "jest": "^29.7.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/33630

In order to make it work with [Corepack](https://nodejs.org/api/corepack.html) we need to have [`packageManager` field](https://nodejs.org/api/packages.html#packagemanager) in the package.json.

It doesn't affect other users.