### PR TITLE
Update non-dead link on resize event page

### DIFF
--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -16,7 +16,7 @@ In some earlier browsers it was possible to register `resize` event handlers on 
 
 While the `resize` event fires only for the window nowadays, you can get resize notifications for other elements using the [ResizeObserver](/en-US/docs/Web/API/ResizeObserver) API.
 
-If the resize event is triggered too many times for your application, see [Optimizing window.onresize](https://web.archive.org/web/20220714020647/https://bencentra.com/code/2015/02/27/optimizing-window-resize.html) to control the time after which the event fires.
+If the resize event is triggered too many times for your application, see [Optimizing window.onresize](https://bencentra.com/code/2015/02/27/optimizing-window-resize.html) to control the time after which the event fires.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
Update link in resize event page
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Link in resize event page about `window.onresize` optimization points to archive.org as at some point it was dead. Loading from archive.org takes time. Now link is alive again, so using that instead.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Link was changed as was dead 2 years ago in #18792

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
