### PR TITLE
Glossary: Character reference and link Entity

### DIFF
--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -22,11 +22,11 @@ There are three types of character references:
 - **Decimal numeric character references**
 
   - : These references start with `&#`, followed by one or more ASCII digits representing the base-ten integer that corresponds to the character's Unicode code point, and ending with `;`.
-    For example, the decimal character reference for `<` is `&#60;`, where the unicode code point for the symbol is `U+0003C`, and `3C` hexadecimal is 60 in decimal.
+    For example, the decimal character reference for `<` is `&#60;`, because the Unicode code point for the symbol is `U+0003C`, and `3C` hexadecimal is 60 in decimal.
 
 - **Hexadecimal numeric character reference**
   - : These references start with `&#x` or `&#X`, followed by one or more ASCII hex digits, representing the hexadecimal integer that corresponds to the character's Unicode code point, and ending with `;`.
-    For example, the decimal character reference for `<` is `&#x3C;` or `&#x3C;`, where the unicode code point for the symbol is `U+0003C`.
+    For example, the hexadecimal character reference for `<` is `&#x3C;` or `&#x3C;`, because the Unicode code point for the symbol is `U+0003C`.
 
 A very small subset of useful named character references along with their unicode code points are listed below.
 

--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -9,7 +9,7 @@ page-type: glossary-definition
 An {{glossary("HTML")}} **character reference** is a formatted pattern of characters that is used to represent another character in the rendered web page.
 
 Character references are used as replacements for characters that are reserved in HTML, such as the less-than (`<`) and greater-than (`>`) symbols used by the HTML parser to identify element {{Glossary('tag','tags')}}.
-They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, and control characthers like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.
+They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, control characters like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.
 
 There are three types of character references:
 

--- a/files/en-us/glossary/character_reference/index.md
+++ b/files/en-us/glossary/character_reference/index.md
@@ -1,0 +1,51 @@
+---
+title: Character reference
+slug: Glossary/Character_reference
+page-type: glossary-definition
+---
+
+{{GlossarySidebar}}
+
+An {{glossary("HTML")}} **character reference** is a formatted pattern of characters that is used to represent another character in the rendered web page.
+
+Character references are used as replacements for characters that are reserved in HTML, such as the less-than (`<`) and greater-than (`>`) symbols used by the HTML parser to identify element {{Glossary('tag','tags')}}.
+They can also be used for invisible characters that would otherwise be impossible to type, including non-breaking spaces, and control characthers like left-to-right and right-to-left marks, and for characters that are hard to type on a standard keyboard.
+
+There are three types of character references:
+
+- **Named character references**
+
+  - : These use a name string between an ampersand (`&`) and a semicolon (`;`) to refer to the corresponding character.
+    For example, `&lt;` is used for the less-than (`<`) symbol, and `&copy;` for the copyright symbol (`©`).
+    The string used for the reference is often a {{glossary("Camel case","camel-cased")}} initialization or contraction of the character name.
+
+- **Decimal numeric character references**
+
+  - : These references start with `&#`, followed by one or more ASCII digits representing the base-ten integer that corresponds to the character's Unicode code point, and ending with `;`.
+    For example, the decimal character reference for `<` is `&#60;`, where the unicode code point for the symbol is `U+0003C`, and `3C` hexadecimal is 60 in decimal.
+
+- **Hexadecimal numeric character reference**
+  - : These references start with `&#x` or `&#X`, followed by one or more ASCII hex digits, representing the hexadecimal integer that corresponds to the character's Unicode code point, and ending with `;`.
+    For example, the decimal character reference for `<` is `&#x3C;` or `&#x3C;`, where the unicode code point for the symbol is `U+0003C`.
+
+A very small subset of useful named character references along with their unicode code points are listed below.
+
+| Character | Named reference | Unicode code-point |
+| --------- | --------------- | ------------------ |
+| &         | `&amp;`         | U+00026            |
+| <         | `&lt;`          | U+0003C            |
+| >         | `&gt;`          | U+0003E            |
+| "         | `&quot;`        | U+00022            |
+|           | `&nbsp;`        | U+000A0            |
+| –         | `&ndash;`       | U+02013            |
+| —         | `&mdash;`       | U+02014            |
+| ©        | `&copy;`        | U+000A9            |
+| ®        | `&reg;`         | U+000AE            |
+| ™        | `&trade;`       | U+02122            |
+| ≈         | `&asymp;`       | U+02248            |
+| ≠         | `&ne;`          | U+02260            |
+| £         | `&pound;`       | U+000A3            |
+| €         | `&euro;`        | U+020AC            |
+| °         | `&deg;`         | U+000B0            |
+
+The full list of HTML named character references [can found in the HTML specification here](https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references).

--- a/files/en-us/glossary/entity/index.md
+++ b/files/en-us/glossary/entity/index.md
@@ -6,34 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An {{glossary("HTML")}} **entity** is a piece of text ("string") that begins with an ampersand (`&`) and ends with a semicolon (`;`). HTML entities are frequently used to display reserved characters (which would otherwise be interpreted as HTML code), and invisible characters (like non-breaking spaces). You can also use HTML character entities in place of other characters that are difficult to type with a standard keyboard.
+Entity is a term from the Standard Generalized Markup Language (SGML), which refers to a reference to information that can be defined once and used throughout a document.
 
-> **Note:** Many characters have memorable entities. For example, the entity for the copyright symbol (`©`) is `&copy;`. For less memorable characters, such as `&#8212;` or `&#x2014;`, you can use a [reference chart](https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references) or [decoder tool](https://mothereff.in/html-entities).
-
-## Reserved characters
-
-Some special characters are reserved for use in HTML, meaning that your browser will parse them as HTML code. For example, if you use the less-than (`<`) sign, the browser interprets any text that follows as a {{Glossary('tag')}}.
-
-To display these characters as text, replace them with their corresponding character entities, as shown in the following table.
-
-| Character | Entity    | Note                                                                          |
-| --------- | --------- | ----------------------------------------------------------------------------- |
-| &         | `&amp;`   | Interpreted as the beginning of an entity or character reference.             |
-| <         | `&lt;`    | Interpreted as the beginning of a {{Glossary('tag')}}                         |
-| >         | `&gt;`    | Interpreted as the ending of a {{Glossary('tag')}}                            |
-| "         | `&quot;`  | Interpreted as the beginning and end of an {{Glossary('attribute')}}'s value. |
-|           | `&nbsp;`  | Interpreted as the non breaking space.                                        |
-| –         | `&ndash;` | Interpreted as the en dash (half the width of an em unit).                    |
-| —         | `&mdash;` | Interpreted as the em dash (equal to width of an "m" character).              |
-| ©        | `&copy;`  | Interpreted as the copyright sign.                                            |
-| ®        | `&reg;`   | Interpreted as the registered sign.                                           |
-| ™        | `&trade;` | Interpreted as the trademark sign.                                            |
-| ≈         | `&asymp;` | Interpreted as almost equal to sign.                                          |
-| ≠         | `&ne;`    | Interpreted as not equal to sign.                                             |
-| £         | `&pound;` | Interpreted as the pound symbol.                                              |
-| €         | `&euro;`  | Interpreted as the euro symbol.                                               |
-| °         | `&deg;`   | Interpreted as the degree symbol.                                             |
-
-## See also
-
-- [Official list of character entities](https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references)
+The term "HTML Entity" is used as a synonym for a {{glossary("character reference")}} — a pattern of characters that can represent another character in the HTML.
+For example, `&lt;` is used to represent the less-than symbol (`<`) in HTML content.


### PR DESCRIPTION
This adds a glossary entry for "character reference", which is the specification term for what you might think of as an HTML entity reference  like  `&lt;` for the `<` character.

The term character reference is much more clearly defined and is useful because you can use it to differentiate the named, decimal numeric and hex numeric forms.

The existing reference for Entity had some problem with the English. I've made it clear that this is effectively a synonym for character reference and linked.

This fell out of my investigation into the WebVTT API. I want to refer to character references meaning all kinds of reference, not just the named references that were described in the Entity glossary.

This is part of doing #33589