### PR TITLE
fix: remove Edge bug tracker URL

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/introduction/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/introduction/index.md
@@ -157,7 +157,6 @@ Once a fix has been made, you'll want to repeat your testing process to make sur
 Just to reiterate on what was said above, if you discover bugs in browsers, you should report them:
 
 - [Firefox Bugzilla](https://bugzilla.mozilla.org/)
-- [EdgeHTML issue tracker](https://developer.microsoft.com/en-us/microsoft-edge/)
 - [Safari](https://bugs.webkit.org/)
 - [Chrome](https://bugs.chromium.org/p/chromium/issues/list)
 - [Opera](https://opera.atlassian.net/servicedesk/customer/portal/9)


### PR DESCRIPTION
### Description

The bug tracker for Edge seems to be permanently redirecting to support forums. In this case, I'm removing the URL instead of replacing it. Alternatively, we can use:

```md
- [Microsoft Edge forum](https://answers.microsoft.com/en-us/microsoftedge/)
```

It's harder to track issues in the forum, and the audience seems to be end users instead of developers.

### Related issues and pull requests

Fixes #33982