### PR TITLE
Update misspelled word in en-US version of this page. #34005 

### DIFF
--- a/files/en-us/web/api/htmlelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlelement/autofocus/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLElement.autofocus
 
 The **`autofocus`** property of the {{domxref("HTMLElement")}} interface represents a boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Element/select#autofocus) HTML global attribute, which indicates whether the control should be focused when the page loads, or when dialog or popover become shown if specified in an element inside {{htmlelement("dialog")}} elements or elements whose popover attribute is set.
 
-Only one form-associated element inside a document, or a {{htmlelement("dialog")}} element, or an element whose `popover` attribute is set, can have this attribute specified. If there are several, the first element with the attribute set inserted, usually the first such element on the page, get the initial focus.
+Only one form-associated element inside a document, or a {{htmlelement("dialog")}} element, or an element whose `popover` attribute is set, can have this attribute specified. If there are several, the first element with the attribute set inserted, usually the first such element on the page, gets the initial focus.
 
 > **Note:** Setting this property doesn't set the focus to the associated element: it merely tells the browser to focus to it when _the element is inserted_ in the document. Setting it after the insertion, that is most of the time after the document load, has no visible effect.
 


### PR DESCRIPTION
Changed 'get' to 'gets'

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Making the change discussed in  #34005. The word 'get' should be 'gets' referring to a single object.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Its a spelling mistake. It will prevent confusion and increase readability 
### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
https://github.com/mdn/content/issues/34005
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
