### PR TITLE
'data Ls' -> 'data URLs'

### DIFF
--- a/files/en-us/mozilla/firefox/releases/6/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/updating_add-ons/index.md
@@ -42,7 +42,7 @@ The {{ domxref("window.top") }} property is now read only. This will affect your
 
 `javascript:` and `data:` URLs entered into the location bar no longer inherit the principal of the currently loaded page. This probably won't affect many add-ons but if you run code that uses these URLs you may want to double check that everything is working as expected.
 
-[Firefox bug 658949](https://bugzil.la/658949) changed how the hash (#) symbol is treated in data Ls which may break CSS stylesheets which contain such symbol if it is not escaped.
+[Firefox bug 658949](https://bugzil.la/658949) changed how the hash (#) symbol is treated in data URLs which may break CSS stylesheets which contain such symbol if it is not escaped.
 
 ## Interfaces
 

--- a/files/en-us/web/svg/svg_as_an_image/index.md
+++ b/files/en-us/web/svg/svg_as_an_image/index.md
@@ -22,7 +22,7 @@ SVG images can be used as an image format, in a number of contexts. Browsers sup
 For security purposes, Gecko places some restrictions on SVG content when it's being used as an image:
 
 - [JavaScript](/en-US/docs/Web/JavaScript) is disabled.
-- External resources (e.g. images, stylesheets) cannot be loaded, though they can be used if inlined through data: Ls.
+- External resources (e.g. images, stylesheets) cannot be loaded, though they can be used if inlined through data: URLs.
 - {{cssxref(":visited")}}-link styles aren't rendered.
 - Platform-native widget styling (based on OS theme) is disabled.
 


### PR DESCRIPTION
### Description

Changed two instances of `data Ls` to `data URLs`. 

### Motivation

(this section intentionally left blank)

### Additional details

These were introduced in c70661931c1dfa8c788f783b84310309a6958c7d when trying to convert `data URIs` to `data URLs`

### Related issues and pull requests

Relates to #16094
