### PR TITLE
fix: correct a subtitle

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -373,7 +373,7 @@ Another option that is becoming popular for people who want to use modern JavaSc
 
 A common transpiler is [Babel.js](https://babeljs.io/) but there are others.
 
-### Don't browser sniff
+### Using bad browser sniffing code
 
 Historically developers used _browser sniffing code_ to detect which browser the user was using, and give them appropriate code to work on that browser.
 


### PR DESCRIPTION
This subtitle was supposed to be modified without doing more research in https://github.com/mdn/content/pull/26350

https://github.com/mdn/content/blob/e6fcda9d35359bbfec32ddb42086468701f57ee5/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md?plain=1#L222-L229

However, the subtitle have correspondence in line 228. The map between the problem list and the subtitles will be broken with the subtitle be modified