### PR TITLE
fix(css): elaborate specific `pointer-event: none` behaviour

### DIFF
--- a/files/en-us/web/css/pointer-events/index.md
+++ b/files/en-us/web/css/pointer-events/index.md
@@ -41,7 +41,10 @@ The `pointer-events` property is specified as a single keyword chosen from the l
 - `auto`
   - : The element behaves as it would if the `pointer-events` property were not specified. In SVG content, this value and the value `visiblePainted` have the same effect.
 - `none`
-  - : The element is never the [target](/en-US/docs/Web/API/Event/target) of pointer events; however, pointer events may target its descendant elements if those descendants have `pointer-events` set to some other value. In these circumstances, pointer events will trigger event listeners on this parent element as appropriate on their way to/from the descendant during the event capture/[bubble](/en-US/docs/Web/API/Event/bubbles) phases.
+
+  - : The element on its own is never the [target](/en-US/docs/Web/API/Event/target) of pointer events. However its subtree could be kept targettable by setting `pointer-events` to some other value. In these circumstances, pointer events will trigger event listeners on this parent element as appropriate on their way to/from the descendant during the event capture/[bubble](/en-US/docs/Web/API/Event/bubbles) phases.
+
+    > **Note:** The `pointerenter` and `pointerleave` events are fired when a pointing device is moved into an element or one of its descendants. So, even if `pointer-events: none` is set on the parent and not set on children, the events are triggered on the parent after pointer is moved in/out of a decendent.
 
 #### SVG only (experimental for HTML)
 

--- a/files/en-us/web/css/pointer-events/index.md
+++ b/files/en-us/web/css/pointer-events/index.md
@@ -42,9 +42,9 @@ The `pointer-events` property is specified as a single keyword chosen from the l
   - : The element behaves as it would if the `pointer-events` property were not specified. In SVG content, this value and the value `visiblePainted` have the same effect.
 - `none`
 
-  - : The element on its own is never the [target](/en-US/docs/Web/API/Event/target) of pointer events. However its subtree could be kept targettable by setting `pointer-events` to some other value. In these circumstances, pointer events will trigger event listeners on this parent element as appropriate on their way to/from the descendant during the event capture/[bubble](/en-US/docs/Web/API/Event/bubbles) phases.
+  - : The element on its own is never the [target](/en-US/docs/Web/API/Event/target) of pointer events. However its subtree could be kept targettable by setting `pointer-events` to some other value. In these circumstances, pointer events will trigger event listeners on this parent element as appropriate on their way to or from the descendant during the event capture and [bubble](/en-US/docs/Web/API/Event/bubbles) phases.
 
-    > **Note:** The `pointerenter` and `pointerleave` events are fired when a pointing device is moved into an element or one of its descendants. So, even if `pointer-events: none` is set on the parent and not set on children, the events are triggered on the parent after pointer is moved in/out of a decendent.
+    > **Note:** The `pointerenter` and `pointerleave` events are fired when a pointing device is moved into an element or one of its descendants. So, even if `pointer-events: none` is set on the parent and not set on children, the events are triggered on the parent after the pointer is moved in or out of a descendant.
 
 #### SVG only (experimental for HTML)
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/33633

The PR address following both the requests from the raised issue:
> Maybe the right tradeoff is to soften slightly not to use words like "never"? ... Or we could explicitly exclude enter and leave events from this definition.