### PR TITLE
#34027 fix: add flex: initial to #flex-initial in CSS

### DIFF
--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -221,6 +221,7 @@ This example shows how a flex item with `flex: auto` grows to absorb any free sp
 }
 
 #flex-initial {
+  flex: initial;
   border: 1px solid #000;
 }
 ```
@@ -230,6 +231,7 @@ This example shows how a flex item with `flex: auto` grows to absorb any free sp
 ```js
 const flexAuto = document.getElementById("flex-auto");
 const flexInitial = document.getElementById("flex-initial");
+
 flexAuto.addEventListener("click", () => {
   flexInitial.style.display =
     flexInitial.style.display === "none" ? "block" : "none";

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -222,6 +222,7 @@ This example shows how a flex item with `flex: auto` grows to absorb any free sp
 
 #flex-initial {
   flex: initial;
+  flex: 0 1 auto;
   border: 1px solid #000;
 }
 ```
@@ -231,7 +232,6 @@ This example shows how a flex item with `flex: auto` grows to absorb any free sp
 ```js
 const flexAuto = document.getElementById("flex-auto");
 const flexInitial = document.getElementById("flex-initial");
-
 flexAuto.addEventListener("click", () => {
   flexInitial.style.display =
     flexInitial.style.display === "none" ? "block" : "none";


### PR DESCRIPTION
Sure, here's how you can fill out the PR template based on the issue and the fix you provided:

---

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added `flex: initial` to the `#flex-initial` CSS rule to ensure consistency between the CSS code and the example description.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The example description indicated that the `#flex-initial` element had `flex: initial`, but this was not reflected in the CSS code. This change corrects that discrepancy, ensuring the example works as described and helps readers understand the proper use of `flex: initial`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
For context, see the [CSS Flexible Box Layout documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/flex) which explains the use of the `flex` property.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
#34027
