### PR TITLE
 Clarify arrow function brace requirements in documentation #34006

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -106,7 +106,7 @@ const b = 2;
 () => a + b + 100;
 ```
 
-The braces can only be omitted if the function directly returns an expression. If the body contains anything other than a single `return` statement, the braces are required — and so is the `return` keyword. Arrow functions cannot guess what or when you want to return.
+The braces can only be omitted if the function directly returns an expression. If the body has statements, the braces are required — and so is the `return` keyword. Arrow functions cannot guess what or when you want to return.
 
 ```js
 // Traditional anonymous function

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -106,7 +106,7 @@ const b = 2;
 () => a + b + 100;
 ```
 
-The braces can only be omitted if the function directly returns an expression. If the body has additional lines of processing, the braces are required — and so is the `return` keyword. Arrow functions cannot guess what or when you want to return.
+The braces can only be omitted if the function directly returns an expression. If the body contains statements, the braces are required — and so is the `return` keyword. Arrow functions cannot guess what or when you want to return.
 
 ```js
 // Traditional anonymous function

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -106,7 +106,7 @@ const b = 2;
 () => a + b + 100;
 ```
 
-The braces can only be omitted if the function directly returns an expression. If the body contains statements, the braces are required — and so is the `return` keyword. Arrow functions cannot guess what or when you want to return.
+The braces can only be omitted if the function directly returns an expression. If the body contains anything other than a single `return` statement, the braces are required — and so is the `return` keyword. Arrow functions cannot guess what or when you want to return.
 
 ```js
 // Traditional anonymous function


### PR DESCRIPTION
### Description

Updated the documentation to accurately describe when braces are required in arrow functions. The previous explanation used the term "lines of processing," which was misleading. Replaced it with a clearer explanation about the inclusion of statements.

### Motivation

The term "lines of processing" was misleading because arrow functions can have multiple expressions on separate lines and still return a value directly. The requirement for braces is based on the inclusion of statements, not the number of lines.

### Additional Details

For more information on arrow functions, refer to the [MDN Web Docs on Arrow Functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).

### Related Issues and Pull Requests

Fixes #34006

---

After submitting, go to the "Checks" tab of your PR for the build status.