### PR TITLE
docs(Fx127): color interpolation methods are supported in gradient functions

### DIFF
--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -20,6 +20,8 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ### CSS
 
+- Using a [`<color-interpolation-method>`](/en-US/docs/Web/CSS/color-interpolation-method) is now supported in gradients created with [`conic-gradient()`](/en-US/docs/Web/CSS/gradient/conic-gradient), [`linear-gradient()`](/en-US/docs/Web/CSS/gradient/linear-gradient), and [`radial-gradient()`](/en-US/docs/Web/CSS/gradient/radial-gradient) functions and the [`repeating-conic-gradient()`](/en-US/docs/Web/CSS/gradient/repeating-conic-gradient), [`repeating-linear-gradient()`](/en-US/docs/Web/CSS/gradient/repeating-linear-gradient), and [`repeating-radial-gradient()`](/en-US/docs/Web/CSS/gradient/repeating-radial-gradient) functions for repeating gradients ([Firefox bug 1861363](https://bugzil.la/1861363)).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
### Description

Relnote for changes in CSS gradient functions, you may now specify a color interpolation method.

__Bugzilla:__

- [bugzilla.mozilla.org/show_bug.cgi?id=1861363](https://bugzilla.mozilla.org/show_bug.cgi?id=1861363)

__Related issues and pull requests:__

- [x] Parent issue https://github.com/mdn/content/issues/33520
- [x] Examples: https://github.com/mdn/content/pull/34035
- [x] BCD: https://github.com/mdn/browser-compat-data/pull/23246

