### PR TITLE
added the experimental release note for relative color syntax in firefox

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -277,7 +277,7 @@ See [Firefox bug 1889133](https://bugzil.la/1889133) for more details.
 
 ### Relative color syntax
 
-The [relative color syntax](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) is now enabled by default in Nightly and when the `layout,css.relative-color-syntax.enabled` preference is set to `true` in other versions. This allows the creation of colors from other colors using the [`color()`](/en-US/docs/Web/CSS/color_value/color) functional notation and other [color spaces](/en-US/docs/Glossary/Color_space) such as [`lch()`](/en-US/docs/Web/CSS/color_value/lch), [`lab()`](/en-US/docs/Web/CSS/color_value/lab), etc. [Firefox bug 1701488](https://bugzil.la/1701488).
+[Relative color syntax](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) is now enabled by default in the Nightly release and via the `layout.css.relative-color-syntax.enabled` preference set to `true` in other release versions. Relative color syntax allows you to create a color value relative to an origin color, and can allow you to change a color in a different [color space](/en-US/docs/Glossary/Color_space) using [color functions](/en-US/docs/Web/CSS/CSS_colors#functions) ([Firefox bug 1701488](https://bugzil.la/1701488)).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -275,7 +275,7 @@ See [Firefox bug 1889133](https://bugzil.la/1889133) for more details.
   </tbody>
 </table>
 
-### Relative colors syntax
+### Relative color syntax
 
 The [relative color syntax](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) is now enabled by default in Nightly and when the `layout,css.relative-color-syntax.enabled` preference is set to `true` in other versions. This allows the creation of colors from other colors using the [`color()`](/en-US/docs/Web/CSS/color_value/color) functional notation and other [color spaces](/en-US/docs/Glossary/Color_space) such as [`lch()`](/en-US/docs/Web/CSS/color_value/lch), [`lab()`](/en-US/docs/Web/CSS/color_value/lab), etc. [Firefox bug 1701488](https://bugzil.la/1701488).
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -275,6 +275,46 @@ See [Firefox bug 1889133](https://bugzil.la/1889133) for more details.
   </tbody>
 </table>
 
+### Relative colors syntax
+
+The [relative color syntax](/en-US/docs/Web/CSS/CSS_colors/Relative_colors) is now enabled by default in Nightly and when the `layout,css.relative-color-syntax.enabled` preference is set to `true` in other versions. This allows the creation of colors from other colors using the [`color()`](/en-US/docs/Web/CSS/color_value/color) functional notation and other [color spaces](/en-US/docs/Glossary/Color_space) such as [`lch()`](/en-US/docs/Web/CSS/color_value/lch), [`lab()`](/en-US/docs/Web/CSS/color_value/lab), etc. [Firefox bug 1701488](https://bugzil.la/1701488).
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>128</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>127</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>127</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>127</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.relative-color-syntax.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ### Single numbers as aspect ratio in media queries
 
 Support for using a single {{cssxref("number")}} as a {{cssxref("ratio")}} when specifying the aspect ratio for a [media query](/en-US/docs/Web/CSS/CSS_media_queries). (See [Firefox bug 1565562](https://bugzil.la/1565562) for more details.)


### PR DESCRIPTION
### Description

Added the experimental release note for reative color syntax

### Motivation

Working on [Enable relative color syntax on nightly #33517](https://github.com/mdn/content/issues/33517)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/23340)