### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -74,7 +74,7 @@ function delayedValue(time, value) {
 
 async function* generate() {
   yield delayedValue(2000, 1);
-  yield delayedValue(100, 2);
+  yield delayedValue(1000, 2);
   yield delayedValue(500, 3);
   yield delayedValue(250, 4);
   yield delayedValue(125, 5);


### PR DESCRIPTION
In the first async generator iteration example with decreasing times, I think the second "yield delayedValue" should have a delay of 1000ms, not 100ms.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Minor change to one of the example codes. I'm sure it's just a typo, but I think the delay time for the second yield should be 1000ms, not 100ms.

<!-- ✍️ Summarize your changes in one or two sentences -->

Not going to change anyone's life drastically, but I shouldn't wait for someone else to suggest this fix -- albeit small.

<!-- ❓ Why are you making these changes and how do they help readers? -->

Just makes the example work exactly as described

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

None related.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
