### PR TITLE
Add example of code in pre

### DIFF
--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -15,6 +15,8 @@ By default, `<pre>` is a [block-level](/en-US/docs/Glossary/Block-level_content)
 
 If you have to display reserved characters such as `<`, `>`, `&`, and `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](/en-US/docs/Glossary/Entity).
 
+Can be used to wrap {{HTMLElement("code")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}.
+
 ## Attributes
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -66,11 +66,11 @@ A combination of the {{HTMLElement("figure")}} and {{HTMLElement("figcaption")}}
 
 ```html
 <p>Using CSS to change the font color is easy.</p>
-<pre>
+<pre><code>
 body {
   color: red;
 }
-</pre>
+</code></pre>
 ```
 
 #### Result
@@ -82,12 +82,12 @@ body {
 #### HTML
 
 ```html
-<pre>
+<pre><code>
 let i = 5;
 
 if (i &lt; 10 &amp;&amp; i &gt; 0)
   return &quot;Single Digit Number&quot;
-</pre>
+</code></pre>
 ```
 
 #### Result

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -15,7 +15,7 @@ By default, `<pre>` is a [block-level](/en-US/docs/Glossary/Block-level_content)
 
 If you have to display reserved characters such as `<`, `>`, `&`, and `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](/en-US/docs/Glossary/Entity).
 
-Can be used to wrap {{HTMLElement("code")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}.
+`<pre>` elements commonly contain {{HTMLElement("code")}}, {{HTMLElement("samp")}}, and {{HTMLElement("kbd")}} elements, to represent computer code, computer output, and user input, respectively.
 
 ## Attributes
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -166,4 +166,4 @@ if (i &lt; 10 &amp;&amp; i &gt; 0)
 
 - CSS: {{Cssxref('white-space')}}, {{Cssxref('word-break')}}
 - [HTML Entity](/en-US/docs/Glossary/Entity)
-- Related element: {{HTMLElement("code")}}
+- Related element: {{HTMLElement("code")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}


### PR DESCRIPTION
Updated the HTML snippets used to demonstrate the `<pre>` tags functionality. Since the snippets show code, it would be appropriate to include the `<code>` tag, as specified in the [Mdn Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added the `<code>` tag on HTML snippets that represent code.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
Mdn docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #34056
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
