### PR TITLE
Greatly shorten the Getting data into and out of an event listener section

### DIFF
--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -357,7 +357,9 @@ const myButton = document.getElementById("my-button-id");
 let someString = "Data";
 
 myButton.addEventListener("click", () => {
-  console.log(someString); // Expected Value: 'Data' on first click, 'Data Again' on second click
+  console.log(someString);
+  // 'Data' on first click,
+  // 'Data Again' on second click
 
   someString = "Data Again";
 });

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -350,7 +350,7 @@ an {{domxref("Event")}} or a subclass of `Event`,
 which is automatically passed to the listener, and the return value is ignored.
 Therefore, to get data into and out of an event listener, instead of passing the data through parameters and return values, you need to create [closures](/en-US/docs/Web/JavaScript/Closures) instead.
 
-The functions passed as event listeners have access to all variables declared in the outer scopes that contain the function. Read [the function guide](/en-US/docs/Web/JavaScript/Guide/Functions#function_scope) for more information about function scopes. Therefore, you can access any data from outside of an event listener is to make it accessible to the scope in which the event listener is declared.
+The functions passed as event listeners have access to all variables declared in the outer scopes that contain the function.
 
 ```js
 const myButton = document.getElementById("my-button-id");
@@ -364,6 +364,8 @@ myButton.addEventListener("click", () => {
 
 console.log(someString); // Expected Value: 'Data' (will never output 'Data Again')
 ```
+
+Read [the function guide](/en-US/docs/Web/JavaScript/Guide/Functions#function_scope) for more information about function scopes.
 
 ### Memory issues
 

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -346,7 +346,7 @@ myObject.register();
 ### Getting data into and out of an event listener
 
 Event listeners only take one argument,
-the [Event Object](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_objects),
+an {{domxref("Event")}} or a subclass of `Event`,
 which is automatically passed to the listener, and the return value is ignored.
 Therefore, to get data into and out of an event listener, instead of passing the data through parameters and return values, you need to create [closures](/en-US/docs/Web/JavaScript/Closures) instead.
 

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -345,118 +345,25 @@ myObject.register();
 
 ### Getting data into and out of an event listener
 
-It may seem that event listeners are like islands, and that it is extremely difficult
-to pass them any data, much less to get any data back from them after they execute.
 Event listeners only take one argument,
 the [Event Object](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_objects),
 which is automatically passed to the listener, and the return value is ignored.
-So how can we get data in and back out of them? There are a number of
-good methods for doing this.
+Therefore, to get data into and out of an event listener, instead of passing the data through parameters and return values, you need to create [closures](/en-US/docs/Web/JavaScript/Closures) instead.
 
-#### Getting data into an event listener using "this"
-
-As mentioned [above](#specifying_this_using_bind), you can use
-`Function.prototype.bind()` to pass a value to an event listener via the
-`this` reference variable.
-
-```js
-const myButton = document.getElementById("my-button-id");
-const someString = "Data";
-
-myButton.addEventListener("click", passIntoEvtListener.bind(someString));
-
-//function declaration for event listener
-function passIntoEvtListener(e) {
-  console.log("Expected Value:", this); // Expected Value: 'Data'
-  console.log("current target:", e.currentTarget.id); // current target: my-button-id
-}
-```
-
-This method is suitable when you don't need to know which HTML element the event
-listener fired on programmatically from within the event listener. The primary benefit
-to doing this is that the event listener receives the data in much the same way that it
-would if you were to actually pass it through its argument list.
-
-#### Getting data into an event listener using the outer scope property
-
-When an outer scope contains a variable declaration (with `const`,
-`let`), all the inner functions declared in that scope have access to that
-variable (look [here](/en-US/docs/Glossary/Function#different_types_of_functions) for
-information on outer/inner functions, and [here](/en-US/docs/Web/JavaScript/Reference/Statements/var#implicit_globals_and_outer_function_scope)
-for information on variable scope). Therefore, one of the simplest ways to access data
-from outside of an event listener is to make it accessible to the scope in which the
-event listener is declared.
+The functions passed as event listeners have access to all variables declared in the outer scopes that contain the function. Read [the function guide](/en-US/docs/Web/JavaScript/Guide/Functions#function_scope) for more information about function scopes. Therefore, you can access any data from outside of an event listener is to make it accessible to the scope in which the event listener is declared.
 
 ```js
 const myButton = document.getElementById("my-button-id");
 let someString = "Data";
 
 myButton.addEventListener("click", () => {
-  console.log(someString); // Expected Value: 'Data'
+  console.log(someString); // Expected Value: 'Data' on first click, 'Data Again' on second click
 
   someString = "Data Again";
 });
 
 console.log(someString); // Expected Value: 'Data' (will never output 'Data Again')
 ```
-
-> **Note:** Although inner scopes have access to `const`,
-> `let` variables from outer scopes, you cannot expect any changes to these
-> variables to be accessible after the event listener definition, within the same outer
-> scope. Why? Because by the time the event listener would execute, the scope in which
-> it was defined would have already finished executing.
-
-#### Getting data into and out of an event listener using objects
-
-Unlike most functions in JavaScript, objects are retained in memory as long as a
-variable referencing them exists in memory. This, and the fact that objects can have
-properties, and that they can be passed around by reference, makes them likely
-candidates for sharing data among scopes. Let's explore this.
-
-> **Note:** Functions in JavaScript are actually objects. (Hence they too
-> can have properties, and will be retained in memory even after they finish executing
-> if assigned to a variable that persists in memory.)
-
-Because object properties can be used to store data in memory as long as a variable
-referencing the object exists in memory, you can actually use them to get data into an
-event listener, and any changes to the data back out after an event handler executes.
-Consider this example.
-
-```js
-const myButton = document.getElementById("my-button-id");
-const someObject = { aProperty: "Data" };
-
-myButton.addEventListener("click", () => {
-  console.log(someObject.aProperty); // Expected Value: 'Data'
-
-  someObject.aProperty = "Data Again"; // Change the value
-});
-
-setInterval(() => {
-  if (someObject.aProperty === "Data Again") {
-    console.log("Data Again: True");
-    someObject.aProperty = "Data"; // Reset value to wait for next event execution
-  }
-}, 5000);
-```
-
-In this example, even though the scope in which both the event listener and the
-interval function are defined would have finished executing before the original value of
-`someObject.aProperty` would have changed, because `someObject`
-persists in memory (by _reference_) in both the event listener and interval
-function, both have access to the same data (i.e. when one changes the data, the other
-can respond to the change).
-
-> **Note:** Objects are stored in variables by reference, meaning only the
-> memory location of the actual data is stored in the variable. Among other things, this
-> means variables that "store" objects can actually affect other variables that get
-> assigned ("store") the same object reference. When two variables reference the same
-> object (e.g., `let a = b = {aProperty: 'Yeah'};`), changing the data in
-> either variable will affect the other.
-
-> **Note:** Because objects are stored in variables by reference, you can
-> return an object from a function to keep it alive (preserve it in memory so you don't
-> lose the data) after that function stops executing.
 
 ### Memory issues
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/23253

Maybe it was an issue when there was no `const`/`let`, but it no longer is. All this text just seems like bloat.