### PR TITLE
Remove Sapper mention

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
@@ -68,8 +68,6 @@ Nevertheless, Svelte is particularly appropriate to tackle the following situati
 
 The Svelte team launched [SvelteKit](https://kit.svelte.dev), a framework for building web applications using Svelte. It contains features found in modern web frameworks, such as filesystem-based routing, server-side rendering (SSR), page-specific rendering modes, offline support, and more. For more information about SvelteKit, see the [official tutorial](https://learn.svelte.dev) and [documentation](https://kit.svelte.dev/docs).
 
-> **Note:** SvelteKit is designed to replace [Sapper](https://sapper.svelte.dev/) as the recommended Svelte framework for building web applications.
-
 Svelte is also available for mobile development via [Svelte Native](https://svelte-native.technology).
 
 ## How does Svelte work?


### PR DESCRIPTION
### Description

Remove mention of Sapper in Svelte docs

### Motivation

Sapper has been deprecated for a while now and Sveltekit is at version 2, so removing the mention here
