### PR TITLE
Fix release notes formatting

### DIFF
--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -43,7 +43,7 @@ This article provides information about the changes in Firefox 127 that affect d
 
 ### APIs
 
-- The async {{domxref('Clipboard API')}} is now fully supported. The {{domxref('ClipboardItem')}} interface, along with the [`read()`](/en-US/docs/Web/API/Clipboard/read) and [`write()`](/en-US/docs/Web/API/Clipboard/write) methods of the {{domxref('Clipboard')}} interface, have been enabled. ([Firefox bug 1887845](https://bugzil.la/1887845),[Firefox bug 1858788](https://bugzil.la/1858788)).
+- The async {{domxref('Clipboard API')}} is now fully supported. The {{domxref('ClipboardItem')}} interface, along with the [`read()`](/en-US/docs/Web/API/Clipboard/read) and [`write()`](/en-US/docs/Web/API/Clipboard/write) methods of the {{domxref('Clipboard')}} interface, have been enabled. ([Firefox bug 1887845](https://bugzil.la/1887845), [Firefox bug 1858788](https://bugzil.la/1858788)).
 - All {{glossary("character reference","HTML character references")}} are now supported in [Web Video Text Tracks Format (WebVTT)](/en-US/docs/Web/API/WebVTT_API) cues, title text, comments, annotations, and so on. ([Firefox bug 1395924](https://bugzil.la/1395924)).
 - {{domxref('WebGLRenderingContext.drawingBufferColorSpace')}} and [`WebGL2RenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGL2RenderingContext) are now supported. ([Firefox bug 1885491](https://bugzil.la/1885491)).
 
@@ -77,11 +77,11 @@ These features are newly shipped in Firefox 127 but are disabled by default. To 
 
 - **Symmetrical spacing with CSS `letter-spacing`:** `layout.css.letter-spacing.model`.
 
-  The CSS {{cssxref("letter-spacing")}} property now splits the specified letter spacing evenly on both sides of each character. This is unlike the current behavior where spacing is added primarily to one side [Firefox bug 1891446](https://bugzil.la/1891446).
+  The CSS {{cssxref("letter-spacing")}} property now splits the specified letter spacing evenly on both sides of each character. This is unlike the current behavior where spacing is added primarily to one side ([Firefox bug 1891446](https://bugzil.la/1891446)).
 
 - **`calc()` color channel support in relative colors:** `layout.css.relative-color-syntax.enabled`.
 
-  The CSS [`calc()`](/en-US/docs/Web/CSS/calc) function can now parse color channels in [relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors#using_math_functions) [Firefox bug 1889561](https://bugzil.la/1889561).
+  The CSS [`calc()`](/en-US/docs/Web/CSS/calc) function can now parse color channels in [relative colors](/en-US/docs/Web/CSS/CSS_colors/Relative_colors#using_math_functions) ([Firefox bug 1889561](https://bugzil.la/1889561)).
 
 ## Older versions
 


### PR DESCRIPTION
### Description

- Missed space before comma
- Missed colons around “Firefox bug” (makes it look like a part of the sentence)

<img width="792" alt="Screenshot 2024-06-13 at 12 04 19" src="https://github.com/mdn/content/assets/105274/bdc556f2-2c38-43af-9268-ddc0a72f9d8d">