### PR TITLE
Mention that ended is not fired when calling MediaStreamTrack.stop

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/ended_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/ended_event/index.md
@@ -33,7 +33,10 @@ A generic {{domxref("Event")}}.
 - There is no more data left to send.
 - The user revoked the permissions needed for the data to be sent.
 - The hardware generating the source data has been removed or ejected.
-- A remote peer has permanently stopped sending data; pausing media _does not_ generate an `ended` event.
+- A remote peer has permanently stopped sending data.
+- The only case where the track ends but the `ended` event is not fired is when calling {{domxref("MediaStreamTrack.stop")}}.
+
+Pausing media _does not_ generate an `ended` event.
 
 ## Examples
 

--- a/files/en-us/web/api/mediastreamtrack/index.md
+++ b/files/en-us/web/api/mediastreamtrack/index.md
@@ -64,7 +64,7 @@ In addition to the properties listed below, `MediaStreamTrack` has constrainable
 Listen to these events using {{domxref("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface:
 
 - {{domxref("MediaStreamTrack/ended_event", "ended")}}
-  - : Sent when playback of the track ends (when the value {{domxref("MediaStreamTrack.readyState", "readyState")}} changes to `ended`).
+  - : Sent when playback of the track ends (when the value {{domxref("MediaStreamTrack.readyState", "readyState")}} changes to `ended`), except when the track is ended by calling {{domxref("MediaStreamTrack.stop")}}.
 - {{domxref("MediaStreamTrack/mute_event", "mute")}}
   - : Sent to the `MediaStreamTrack` when the value of the {{domxref("MediaStreamTrack.muted", "muted")}} property is changed to `true`, indicating that the track is unable to provide data temporarily (such as when the network is experiencing a service malfunction).
 - {{domxref("MediaStreamTrack/unmute_event", "unmute")}}


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/4939.