### PR TITLE
More prominently add examples of shift key changing KeyboardEvent.key

### DIFF
--- a/files/en-us/web/api/keyboardevent/key/index.md
+++ b/files/en-us/web/api/keyboardevent/key/index.md
@@ -16,8 +16,7 @@ A string.
 
 Its value is determined as follows:
 
-- If the pressed key has a printed representation, the returned value is a non-empty Unicode character string containing the printable representation of the key.
-- If the pressed key is a <kbd>Space</kbd> key, the returned value is a single space.
+- If the pressed key has a printed representation, the returned value is a non-empty Unicode character string containing the printable representation of the key. For example: if the pressed key is the <kbd>Space</kbd> key, the returned value is a single space (`" "`). If the pressed key is the <kbd>B</kbd> key, the returned value is the string `"b"`. However, if the <kbd>Shift</kbd> key is pressed at the same time (so {{domxref("KeyboardEvent/shiftKey", "shiftKey")}} is `true`), the returned value is the string `"B"`.
 - If the pressed key is a control or special character, the returned value is one of the [pre-defined key values](/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values).
 - If the `KeyboardEvent` represents the press of a [dead key](https://en.wikipedia.org/wiki/Dead_key), the key value must be "`Dead`".
 - Some specialty keyboard keys (such as the extended keys for controlling media on multimedia keyboards) don't generate key codes on Windows; instead, they trigger `WM_APPCOMMAND` events. These events get mapped to DOM keyboard events, and are listed among the "Virtual key codes" for Windows, even though they aren't actually key codes.

--- a/files/en-us/web/api/keyboardevent/shiftkey/index.md
+++ b/files/en-us/web/api/keyboardevent/shiftkey/index.md
@@ -12,6 +12,8 @@ The **`KeyboardEvent.shiftKey`** read-only property is a
 boolean value that indicates if the <kbd>shift</kbd> key was pressed
 (`true`) or not (`false`) when the event occurred.
 
+The pressing of the shift key may change the {{domxref("KeyboardEvent/key", "key")}} of the event too. For example, pressing <kbd>B</kbd> generates `key: "b"`, while simultaneously pressing <kbd>Shift</kbd> generates `key: "B"`.
+
 ## Value
 
 A boolean value.


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/33451.

It was sort of implied but made it really clear. Also made clear that <kbd>Space</kbd> is also just an example and not a special case.