### PR TITLE
Update link to date and time picker

### DIFF
--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -363,5 +363,5 @@ input:valid + span::after {
 - [`<input type="month">`](/en-US/docs/Web/HTML/Element/input/month)
 - The generic {{HTMLElement("input")}} element and the interface used to manipulate it, {{domxref("HTMLInputElement")}}
 - [Date and time formats used in HTML](/en-US/docs/Web/HTML/Date_and_time_formats)
-- [Date and Time picker tutorial](/en-US/docs/Learn/Forms/Basic_native_form_controls#date_and_time_picker)
+- [Date and Time picker tutorial](/en-US/docs/Learn/Forms/HTML5_input_types#date_and_time_pickers)
 - [Compatibility of CSS properties](/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls)


### PR DESCRIPTION
The old link is to a portion of a page that has been moved.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The old link was to the "#date_and_time_picker" section that no longer exists on https://developer.mozilla.org/en-US/docs/Learn/Forms/Basic_native_form_controls

Replacing to a section on date and time pickers found on a different page.

### Motivation

Help people locate the information.

### Additional details



### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
