### PR TITLE
CSS property update: align-items

### DIFF
--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -137,7 +137,7 @@ We style a the conainer and items in a manner that ensures we have two lines or 
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 50px);
+  grid-template-columns: repeat(auto-fill, 100px);
   background-color: #9f8c8c;
   border-color: slateblue;
 }

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.align-items
 
 {{CSSRef}}
 
-The [CSS](/en-US/docs/Web/CSS) **`align-items`** property sets the {{cssxref("align-self")}} value on all direct children as a group. In Flexbox, it controls the alignment of items on the {{glossary("Cross Axis")}}. In Grid Layout, it controls the alignment of items on the Block Axis within their {{glossary("Grid Areas", "grid area")}}.
+The [CSS](/en-US/docs/Web/CSS) **`align-items`** property sets the {{cssxref("align-self")}} value on all direct children as a group. In Flexbox, it controls the alignment of items on the {{glossary("cross axis")}}. In Grid Layout, it controls the alignment of items on the block axis within their {{glossary("grid area")}}.
 
 The interactive example below demonstrates some of the values for `align-items` using grid layout.
 
@@ -57,28 +57,49 @@ align-items: unset;
     - For grid items, this keyword leads to a behavior similar to the one of `stretch`, except for boxes with an {{glossary("aspect ratio")}} or an intrinsic sizes where it behaves like `start`.
     - The property doesn't apply to block-level boxes, and to table cells.
 
+- `center`
+
+  - : The flex items' margin boxes are centered within the line on the cross-axis. If the cross-size of an item is larger than the flex container, it will overflow equally in both directions.
+
+- `start`
+
+  - : The items are packed flush to each other toward the start edge of the alignment container in the appropriate axis.
+
+- `end`
+
+  - : The items are packed flush to each other toward the end edge of the alignment container in the appropriate axis.
+
+- `self-start`
+
+  - : The items are packed flush to the edge of the alignment container's start side of the item, in the appropriate axis.
+
+- `self-end`
+
+  - : The items are packed flush to the edge of the alignment container's end side of the item, in the appropriate axis.
+
+- `baseline`, `first baseline`, `last baseline`
+
+  - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
+
+- `stretch`
+
+  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
+
+- `safe`
+
+  - : Used alongside an alignment keyword. If the chosen keyword means that the item overflows the alignment container causing data loss, the item is instead aligned as if the alignment mode were `start`.
+
+- `unsafe`
+
+  - : Used alongside an alignment keyword. Regardless of the relative sizes of the item and alignment container and whether overflow which causes data loss might happen, the given alignment value is honored.
+    There are also two values that are only used with Flexbox:
+
 - `flex-start`
+
   - : Used in flex layout only, aligns the flex items flush against the flex container's main-start or cross-start side.
+
 - `flex-end`
   - : Used in flex layout only, aligns the flex items flush against the flex container's main-end or cross-end side.
-- `center`
-  - : The flex items' margin boxes are centered within the line on the cross-axis. If the cross-size of an item is larger than the flex container, it will overflow equally in both directions.
-- `start`
-  - : The items are packed flush to each other toward the start edge of the alignment container in the appropriate axis.
-- `end`
-  - : The items are packed flush to each other toward the end edge of the alignment container in the appropriate axis.
-- `self-start`
-  - : The items are packed flush to the edge of the alignment container's start side of the item, in the appropriate axis.
-- `self-end`
-  - : The items are packed flush to the edge of the alignment container's end side of the item, in the appropriate axis.
-- `baseline`, `first baseline`, `last baseline`
-  - : All flex items are aligned such that their [flex container baselines](https://drafts.csswg.org/css-flexbox-1/#flex-baselines) align. The item with the largest distance between its cross-start margin edge and its baseline is flushed with the cross-start edge of the line.
-- `stretch`
-  - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
-- `safe`
-  - : Used alongside an alignment keyword. If the chosen keyword means that the item overflows the alignment container causing data loss, the item is instead aligned as if the alignment mode were `start`.
-- `unsafe`
-  - : Used alongside an alignment keyword. Regardless of the relative sizes of the item and alignment container and whether overflow which causes data loss might happen, the given alignment value is honored.
 
 ## Formal definition
 
@@ -90,33 +111,33 @@ align-items: unset;
 
 ## Examples
 
+In this example we have a container with six children. A {{htmlelement("select")}} drop down menu enables toggling the {{cssxref("display")}} of the container between `grid` and `flex`. A second menu enables changing the value of the container's `align-items` property.
+
 ### CSS
 
+We style a the conainer and items in a manner that ensures we have two lines or rows or items. We defined `.flex` and `.grid` classes, which will be applied to the container with JavaScript. They set the {{cssxref("display")}} value of the container, and change its background and border colors providing an additional indicator that the layout has changed. The six flex items each have a different background color, with the 4th item being two lines long and the 6th item having an enlarged font.
+
 ```css
-#container {
+:where(#container) {
   height: 200px;
   width: 240px;
-  align-items: center; /* Can be changed in the live sample */
-  background-color: #8c8c8c;
+  align-items: initial; /* Change the value in the live sample */
+  border: solid 5px transparent;
+  gap: 3px;
 }
 
 .flex {
   display: flex;
   flex-wrap: wrap;
+  background-color: #8c8c9f;
+  border-color: magenta;
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, 50px);
-}
-
-div > div {
-  box-sizing: border-box;
-  border: 2px solid #8c8c8c;
-  width: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background-color: #9f8c8c;
+  border-color: slateblue;
 }
 
 #item1 {
@@ -149,7 +170,9 @@ div > div {
   min-height: 50px;
   font-size: 30px;
 }
+```
 
+```css hidden
 select {
   font-size: 16px;
 }
@@ -157,20 +180,33 @@ select {
 .row {
   margin-top: 10px;
 }
+
+div > div {
+  box-sizing: border-box;
+  border: 2px solid #fff;
+  width: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 ```
 
 ### HTML
+
+We include a container {{htmlelement("div")}} with six nested `<div>` children. The HTML for the form and the JavaScript that changes the container's class have been hidden for the sake of brevity.
 
 ```html
 <div id="container" class="flex">
   <div id="item1">1</div>
   <div id="item2">2</div>
   <div id="item3">3</div>
-  <div id="item4">4</div>
+  <div id="item4">4<br />4</div>
   <div id="item5">5</div>
   <div id="item6">6</div>
 </div>
+```
 
+```html hidden
 <div class="row">
   <label for="display">display: </label>
   <select id="display">
@@ -227,7 +263,7 @@ display.addEventListener("change", (evt) => {
 
 ### Result
 
-{{EmbedLiveSample("Examples", "260px", "290px")}}
+{{EmbedLiveSample("Examples", "260", "290")}}
 
 ## Specifications
 
@@ -239,8 +275,13 @@ display.addEventListener("change", (evt) => {
 
 ## See also
 
-- CSS Flexbox Guide: _[Basic Concepts of Flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)_
-- CSS Flexbox Guide: _[Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)_
-- CSS Grid Guide: _[Box alignment in CSS Grid layouts](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout)_
-- [CSS Box Alignment](/en-US/docs/Web/CSS/CSS_box_alignment)
-- The {{cssxref("align-self")}} property
+- {{cssxref("align-self")}}
+- {{cssxref("align-content")}}
+- {{cssxref("justify-items")}}
+- {{cssxref("place-items")}} shorthand
+- [Basic concepts of Flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
+- [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
+- [Box alignment in CSS Grid layouts](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout)
+- [CSS box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) module
+- [CSS flexible box layout](/en-US/docs/Web/CSS/CSS_flexible_box_layout) module
+- [CSS grid layout](/en-US/docs/Web/CSS/CSS_grid_layout) module

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -93,14 +93,14 @@ align-items: unset;
 
   - : Used alongside an alignment keyword. Regardless of the relative sizes of the item and alignment container and whether overflow which causes data loss might happen, the given alignment value is honored.
 
-There are also two values that are only used with flexbox, as they are base on [flex model axes](/en-US/docs/Learn/CSS/CSS_layout/Flexbox#the_flex_model) concepts:
+There are also two values that were defined for flexbox, as they are base on [flex model axes](/en-US/docs/Learn/CSS/CSS_layout/Flexbox#the_flex_model) concepts, that work in grid layouts as well:
 
 - `flex-start`
 
-  - : Used in flex layout only, aligns the flex items flush against the flex container's main-start or cross-start side.
+  - : Used in flex layout only, aligns the flex items flush against the flex container's main-start or cross-start side. When used outside of a flex formatting context, this value behaves as `start`.
 
 - `flex-end`
-  - : Used in flex layout only, aligns the flex items flush against the flex container's main-end or cross-end side.
+  - : Used in flex layout only, aligns the flex items flush against the flex container's main-end or cross-end side. When used outside of a flex formatting context, this value behaves as `end`.
 
 ## Formal definition
 
@@ -116,7 +116,7 @@ In this example we have a container with six children. A {{htmlelement("select")
 
 ### CSS
 
-We style a the conainer and items in a manner that ensures we have two lines or rows or items. We defined `.flex` and `.grid` classes, which will be applied to the container with JavaScript. They set the {{cssxref("display")}} value of the container, and change its background and border colors providing an additional indicator that the layout has changed. The six flex items each have a different background color, with the 4th item being two lines long and the 6th item having an enlarged font.
+We style a the container and items in a manner that ensures we have two lines or rows or items. We defined `.flex` and `.grid` classes, which will be applied to the container with JavaScript. They set the {{cssxref("display")}} value of the container, and change its background and border colors providing an additional indicator that the layout has changed. The six flex items each have a different background color, with the 4th item being two lines long and the 6th item having an enlarged font.
 
 ```css
 .flex,

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -7,11 +7,11 @@ browser-compat: css.properties.align-items
 
 {{CSSRef}}
 
-The [CSS](/en-US/docs/Web/CSS) **`align-items`** property sets the {{cssxref("align-self")}} value on all direct children as a group. In Flexbox, it controls the alignment of items on the {{glossary("cross axis")}}. In Grid Layout, it controls the alignment of items on the block axis within their {{glossary("grid area")}}.
-
-The interactive example below demonstrates some of the values for `align-items` using grid layout.
+The [CSS](/en-US/docs/Web/CSS) **`align-items`** property sets the {{cssxref("align-self")}} value on all direct children as a group. In flexbox, it controls the alignment of items on the {{glossary("cross axis")}}. In Grid Layout, it controls the alignment of items on the block axis within their {{glossary("grid area")}}.
 
 {{EmbedInteractiveExample("pages/css/align-items.html")}}
+
+The interactive example below demonstrates some of the values for `align-items` using grid and flex layout.
 
 ## Syntax
 
@@ -92,7 +92,8 @@ align-items: unset;
 - `unsafe`
 
   - : Used alongside an alignment keyword. Regardless of the relative sizes of the item and alignment container and whether overflow which causes data loss might happen, the given alignment value is honored.
-    There are also two values that are only used with Flexbox:
+
+There are also two values that are only used with flexbox, as they are base on [flex model axes](/en-US/docs/Learn/CSS/CSS_layout/Flexbox#the_flex_model) concepts:
 
 - `flex-start`
 
@@ -111,16 +112,17 @@ align-items: unset;
 
 ## Examples
 
-In this example we have a container with six children. A {{htmlelement("select")}} drop down menu enables toggling the {{cssxref("display")}} of the container between `grid` and `flex`. A second menu enables changing the value of the container's `align-items` property.
+In this example we have a container with six children. A {{htmlelement("select")}} dropdown menu enables toggling the {{cssxref("display")}} of the container between `grid` and `flex`. A second menu enables changing the value of the container's `align-items` property.
 
 ### CSS
 
 We style a the conainer and items in a manner that ensures we have two lines or rows or items. We defined `.flex` and `.grid` classes, which will be applied to the container with JavaScript. They set the {{cssxref("display")}} value of the container, and change its background and border colors providing an additional indicator that the layout has changed. The six flex items each have a different background color, with the 4th item being two lines long and the 6th item having an enlarged font.
 
 ```css
-:where(#container) {
+.flex,
+.grid {
   height: 200px;
-  width: 240px;
+  width: 500px;
   align-items: initial; /* Change the value in the live sample */
   border: solid 5px transparent;
   gap: 3px;
@@ -184,7 +186,7 @@ select {
 div > div {
   box-sizing: border-box;
   border: 2px solid #fff;
-  width: 50px;
+  width: 100px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -200,7 +202,7 @@ We include a container {{htmlelement("div")}} with six nested `<div>` children. 
   <div id="item1">1</div>
   <div id="item2">2</div>
   <div id="item3">3</div>
-  <div id="item4">4<br />4</div>
+  <div id="item4">4<br />line 2</div>
   <div id="item5">5</div>
   <div id="item6">6</div>
 </div>
@@ -279,7 +281,7 @@ display.addEventListener("change", (evt) => {
 - {{cssxref("align-content")}}
 - {{cssxref("justify-items")}}
 - {{cssxref("place-items")}} shorthand
-- [Basic concepts of Flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
+- [Basic concepts of flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
 - [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
 - [Box alignment in CSS Grid layouts](/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout)
 - [CSS box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) module

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.align-items
 
 {{CSSRef}}
 
-The [CSS](/en-US/docs/Web/CSS) **`align-items`** property sets the {{cssxref("align-self")}} value on all direct children as a group. In flexbox, it controls the alignment of items on the {{glossary("cross axis")}}. In Grid Layout, it controls the alignment of items on the block axis within their {{glossary("grid area")}}.
+The [CSS](/en-US/docs/Web/CSS) **`align-items`** property sets the {{cssxref("align-self")}} value on all direct children as a group. In flexbox, it controls the alignment of items on the {{glossary("cross axis")}}. In grid layout, it controls the alignment of items on the block axis within their {{glossary("grid areas")}}.
 
 {{EmbedInteractiveExample("pages/css/align-items.html")}}
 


### PR DESCRIPTION
Updates to CSS property align-items:

- text case and links to comply with MDN writing guidelines
- move flex only values to the end of the values list
- Add text around example to explain what is going on.
- hide code not relevant to the property being discussed.
- add colors to grid and flex so the user can see that the value has changed.

addressed as part of CSS baseline / interop https://github.com/openwebdocs/project/issues/189 - subcomponent https://github.com/openwebdocs/project/issues/202