### PR TITLE
FF128Relnote-RTCRtpReceiver.getParameters(), RTCRtpSender.getParameters()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -38,6 +38,8 @@ This article provides information about the changes in Firefox 128 that affect d
 
 ### APIs
 
+- {{domxref('RTCRtpReceiver.getParameters()')}} and {{domxref('RTCRtpSender.getParameters()')}} are now supported, returning an object that describes the current codecs used for the encoding and transmission of media on the receiver and sender tracks, respectively. ([Firefox bug 1534687](https://bugzil.la/1534687)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF128 supports `RTCRtpReceiver.getParameters()` and `RTCRtpSender.getParameters()` returning a config object that includes the `codecs` object in https://bugzilla.mozilla.org/show_bug.cgi?id=1534687

This adds a release note.

Related docs work is tracked in #33988
