### PR TITLE
Update PWA installability requirements in js13kGames tutorial

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
@@ -21,7 +21,8 @@ To make our example application installable, the following things are needed:
 - A web application manifest, with the [correct members filled in](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest).
 - The website to be served from a secure (HTTPS) domain.
 - An icon to represent the app on the device.
-- A [service worker](/en-US/docs/Web/API/Service_Worker_API) registered, to allow the app to work offline.
+
+> **Note:** Previously, a service worker was required for installability in Chromium-based browsers, but this requirement has been removed. Safari and Firefox have never required a service worker for a PWA to be installable. You can find the current list of requirements [here](https://web.dev/articles/install-criteria).
 
 ### The web app manifest file
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updated the js13kGames tutorial to reflect current PWA installability requirements, removing the outdated requirement for service workers in Chromium-based browsers.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
These changes align the documentation with the current installability criteria for PWAs, ensuring readers have accurate and up-to-date information.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
For more details on the current install criteria, see the [web.dev article on install criteria](https://web.dev/articles/install-criteria).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #34124

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->