### PR TITLE
Add ARIA note to PWA tutorial for improved accessibility

### DIFF
--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -297,9 +297,9 @@ For examples of transitioning the `display` property, see the [`@starting-style`
 
 Using a `display` value of `none` on an element will remove it from the [accessibility tree](/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis). This will cause the element and all its descendant elements to no longer be announced by screen reading technology.
 
-If you want to visually hide the element, a more accessible alternative is to use [a combination of properties](https://gomakethings.com/hidden-content-for-better-a11y/#hiding-the-link) to remove it visually from the screen but keep it parsable by assistive technology such as screen readers.
+If you want to visually hide the element, a more accessible alternative is to use [a combination of properties](https://webaim.org/techniques/css/invisiblecontent/) to remove it visually from the screen but still make it available to assistive technology such as screen readers.
 
-> **Note:** While `display: none` hides content from the accessibility tree, this behavior can be overridden using ARIA attributes. For example, elements that are hidden but still need to be referenced for accessibility purposes can be addressed using `aria-describedby` or `aria-labelledby`.
+While `display: none` hides content from the accessibility tree, elements that are hidden but are referenced from visible elements' `aria-describedby` or `aria-labelledby` attributes are exposed to assistive technologies.
 
 ### display: contents
 

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -299,6 +299,8 @@ Using a `display` value of `none` on an element will remove it from the [accessi
 
 If you want to visually hide the element, a more accessible alternative is to use [a combination of properties](https://gomakethings.com/hidden-content-for-better-a11y/#hiding-the-link) to remove it visually from the screen but keep it parsable by assistive technology such as screen readers.
 
+> **Note:** While `display: none` hides content from the accessibility tree, this behavior can be overridden using ARIA attributes. For example, elements that are hidden but still need to be referenced for accessibility purposes can be addressed using `aria-describedby` or `aria-labelledby`.
+
 ### display: contents
 
 Current implementations in some browsers will remove from the [accessibility tree](/en-US/docs/Learn/Accessibility/What_is_accessibility#accessibility_apis) any element with a `display` value of `contents` (but descendants will remain). This will cause the element itself to no longer be announced by screen reading technology. This is incorrect behavior according to the [CSS specification](https://drafts.csswg.org/css-display/#valdef-display-contents).


### PR DESCRIPTION
#### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Added a note to the PWA tutorial about using ARIA attributes to override the `display: none` behavior, ensuring hidden elements remain accessible to assistive technologies.

#### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
These changes help readers understand how to maintain accessibility when hiding elements, ensuring that important content is still accessible to users relying on assistive technologies.

#### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
For more details on current ARIA practices, see [MDN Web Docs on ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA).

#### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #34115 