### PR TITLE
Clarify `chrome.runtime.getPlatformInfo()` usage in different extension contexts #33890

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -7,7 +7,7 @@ browser-compat: webextensions.api.runtime.getPlatformInfo
 
 {{AddonSidebar}}
 
-Returns information about the current platform. This can only be called in the background script context.
+Returns information about the current platform. This can be called in the background script context as well as in popups, options pages, and content scripts.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Clarified the usage of `chrome.runtime.getPlatformInfo()` in the documentation to indicate that it can be called from various extension contexts, including background scripts, popups, options pages, and content scripts.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The current documentation suggests that `chrome.runtime.getPlatformInfo()` can only be called from the background script context. However, testing has shown that this API can be used in other contexts as well. Updating the documentation will help developers better understand the versatility of this API and avoid potential confusion.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->



### Related issues and pull requests

Fixes #33874
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
