### PR TITLE
fix(css): Organize sections as per template guidelines

### DIFF
--- a/files/en-us/web/css/hue/index.md
+++ b/files/en-us/web/css/hue/index.md
@@ -15,6 +15,21 @@ spec-urls: https://drafts.csswg.org/css-color/#typedef-hue
 The **`<hue>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents the hue angle of a color.
 It is used in the color functions that accept hue expressed as a single value, specifically [`hsl()`](/en-US/docs/Web/CSS/color_value/hsl), [`hwb()`](/en-US/docs/Web/CSS/color_value/hwb), [`lch()`](/en-US/docs/Web/CSS/color_value/lch), and [`oklch()`](/en-US/docs/Web/CSS/color_value/oklch) functional notations.
 
+## Syntax
+
+A `<hue>` can be either an `<angle>` or a `<number>`.
+
+### Values
+
+- {{CSSXref("&lt;angle&gt;")}}
+  - : An angle expressed in degrees, gradians, radians, or turns using the `deg`, `grad`, `rad`, or `turn`, respectively.
+- `<number>`
+  - : A real number, representing degrees of the hue angle.
+
+As an `<angle>` is periodic, `<hue>` is normalized to the range `[0deg, 360deg)`. It implicitly wraps around such that `480deg` is the same as `120deg`, `-120deg` is the same as `240deg`, `-1turn` is the same as `1turn`, and so on.
+
+## Description
+
 ![An sRGB color wheel](color_wheel.svg)
 
 The color wheel above shows hues at all angles in the [sRGB](https://en.wikipedia.org/wiki/SRGB) {{glossary("color space")}}. In particular, _red_ is at `0deg`, _yellow_ is at `60deg`, _lime_ is at `120deg`, _cyan_ is at `180deg`, _blue_ is at `240deg`, and _magenta_ is at `300deg`.
@@ -106,24 +121,11 @@ The following table lists typical colors at various angles in the sRGB (used by 
   </tbody>
 </table>
 
-## Syntax
-
-A `<hue>` can be either an `<angle>` or a `<number>`.
-
-### Values
-
-- {{CSSXref("&lt;angle&gt;")}}
-  - : An angle expressed in degrees, gradians, radians, or turns using the `deg`, `grad`, `rad`, or `turn`, respectively.
-- `<number>`
-  - : A real number, representing degrees of the hue angle.
-
-As an `<angle>` is periodic, `<hue>` is normalized to the range `[0deg, 360deg)`. It implicitly wraps around such that `480deg` is the same as `120deg`, `-120deg` is the same as `240deg`, `-1turn` is the same as `1turn`, and so on.
-
-### Interpolation
+## Interpolation of `<hue>` values
 
 `<hue>` values are interpolated as {{CSSXref("&lt;angle&gt;")}} values, and the default interpolation algorithm is [`shorter`](/en-US/docs/Web/CSS/hue-interpolation-method#values). In some color-related CSS functions, this can be overridden by the {{CSSXref("&lt;hue-interpolation-method&gt;")}} component.
 
-### Formal syntax
+## Formal syntax
 
 {{csssyntax}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR:
- Changes "Formal syntax" from H3 to H2. 
- Moves the content before the "Syntax" section into a new "Description" section.

### Motivation

Make the page compliant with the general order in our [CSS property page](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template) template.
