### PR TITLE
Remove reference to unmaintained p2p networking library

### DIFF
--- a/files/en-us/games/techniques/webrtc_data_channels/index.md
+++ b/files/en-us/games/techniques/webrtc_data_channels/index.md
@@ -18,12 +18,6 @@ A WebRTC data channel lets you send text or binary data over an active connectio
 
 We have [documentation for using WebRTC](/en-US/docs/Web/API/WebRTC_API). This article, however, will take advantage of some libraries that can help trivialize the work, and will demonstrate ways to use abstraction to work around implementation differences between browsers. Hopefully, of course, those differences will fade away in time.
 
-## Using the p2p library
-
-One library you can use is the [p2p](https://github.com/js-platform/p2p) library. This library provides a simple API for creating peer connections and setting up streams and data channels. There's also a broker server component and a hosted broker you can use instead of having to set one up for yourself.
-
-> **Note:** We will continue to add content here soon; there are some organizational issues to sort out.
-
 ## Original Document Information
 
 - Author(s): Alan Kligman


### PR DESCRIPTION
### Description

Remove reference to a defunct library p2p so it doesn't mislead readers. The library hasn't worked for years, and is not being maintained.

### Motivation

I was reading the article and tried to use this library, but according to the issues it is no longer being maintained and does not work as of 2018.

### Additional details

Issue that mentions it does not work and is not being maintained:

https://github.com/js-platform/p2p/issues/24
