### PR TITLE
Updated preference for "Toggle password display"

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -94,7 +94,7 @@ HTML password input elements ([`<input type="password">`](/en-US/docs/Web/HTML/E
     </tr>
     <tr>
       <th>Preference name</th>
-      <td colspan="2"><code>layout.forms.input-type-show-password-button.enabled</code></td>
+      <td colspan="2"><code>layout.forms.reveal-password-button.enabled</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
### Description

`layout.forms.input-type-show-password-button.enabled` has been replaced with `layout.forms.reveal-password-button.enabled`.

### Related issues and pull requests

https://bugzilla.mozilla.org/show_bug.cgi?id=1743046#c3

Note: `layout.forms.reveal-password-context-menu.enabled` is set to `true` by default now.