### PR TITLE
Update definition of the dfn element.

### DIFF
--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.dfn
 
 {{HTMLSidebar}}
 
-The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element indicates a term to be defined. The `<dfn>` element should be used in a complete definition statement, where the ancestor {{HTMLElement("p")}} element, the {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing, or the nearest {{HTMLElement("section")}} ancestor of the `<dfn>` element, is considered to be the full definition of the term.
+The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element indicates a term to be defined. The `<dfn>` element should be used in a complete definition statement, where the ancestor paragraph such as the {{HTMLElement("p")}} element, the {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing, or the nearest [section](/en-US/docs/Web/HTML/Content_categories#sectioning_content) ancestor of the `<dfn>` element, is considered to be the full definition of the term.
 
 {{EmbedInteractiveExample("pages/tabbed/dfn.html", "tabbed-shorter")}}
 
@@ -130,7 +130,8 @@ Note the `<abbr>` element nested inside the `<dfn>`. The former establishes that
       </th>
       <td>
         <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>,
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>, palpable content.
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>,
+        <a href="/en-US/docs/Web/HTML/Content_categories#palpable_content">palpable content</a>.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.dfn
 
 {{HTMLSidebar}}
 
-The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element indicates a term to be defined. The `<dfn>` element should be used in a complete definition statement, where the ancestor paragraph such as the {{HTMLElement("p")}} element, the {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing, or the nearest [section](/en-US/docs/Web/HTML/Content_categories#sectioning_content) ancestor of the `<dfn>` element, is considered to be the full definition of the term.
+The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element indicates a term to be defined. The `<dfn>` element should be used in a complete definition statement, where the ancestor paragraph (a block of text, sometimes marked by a {{HTMLElement("p")}} element), the {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing, or the nearest [section](/en-US/docs/Web/HTML/Content_categories#sectioning_content) ancestor of the `<dfn>` element, is considered to be the full definition of the term.
 
 {{EmbedInteractiveExample("pages/tabbed/dfn.html", "tabbed-shorter")}}
 

--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -7,7 +7,11 @@ browser-compat: html.elements.dfn
 
 {{HTMLSidebar}}
 
-The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element indicates a term to be defined. The `<dfn>` element should be used in a complete definition statement, where the ancestor paragraph (a block of text, sometimes marked by a {{HTMLElement("p")}} element), the {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing, or the nearest [section](/en-US/docs/Web/HTML/Content_categories#sectioning_content) ancestor of the `<dfn>` element, is considered to be the full definition of the term.
+The **`<dfn>`** [HTML](/en-US/docs/Web/HTML) element indicates a term to be defined. The `<dfn>` element should be used in a complete definition statement, where the full definition of the term can be one of the following:
+
+- The ancestor paragraph (a block of text, sometimes marked by a {{HTMLElement("p")}} element)
+- The {{HTMLElement("dt")}}/{{HTMLElement("dd")}} pairing
+- The nearest [section](/en-US/docs/Web/HTML/Content_categories#sectioning_content) ancestor of the `<dfn>` element,
 
 {{EmbedInteractiveExample("pages/tabbed/dfn.html", "tabbed-shorter")}}
 


### PR DESCRIPTION
Update the definition of the dfn element, and fixes a missing link to the palpable content on the Content categories page.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updated the `<dfn>` element definition to comply to the [official definition}(https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element). Added a missing link to the [palpaple content paragraph](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#palpable_content).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #34195
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
