### PR TITLE
Change incorrect href

### DIFF
--- a/files/en-us/learn/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.md
@@ -375,7 +375,7 @@ Many of the elements used to define form controls have some of their own specifi
     </tr>
     <tr>
       <td>
-        <code><a href="/en-US/docs/Web/HTML/Element/form">form</a></code>
+        <code><a href="/en-US/docs/Web/HTML/Element/input#form">form</a></code>
       </td>
       <td></td>
       <td>

--- a/files/en-us/learn/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.md
@@ -352,9 +352,8 @@ Many of the elements used to define form controls have some of their own specifi
       </td>
       <td>false</td>
       <td>
-        This Boolean attribute lets you specify that the element should
-        automatically have input focus when the page loads. Only one
-        form-associated element in a document can have this attribute specified.
+        This Boolean attribute lets you specify that the element should automatically have input focus when the page loads.
+        Only one form-associated element in a document can have this attribute specified.
       </td>
     </tr>
     <tr>
@@ -365,12 +364,9 @@ Many of the elements used to define form controls have some of their own specifi
       </td>
       <td>false</td>
       <td>
-        This Boolean attribute indicates that the user cannot interact with the
-        element. If this attribute is not specified, the element inherits its
-        setting from the containing element, for example,
-        {{HTMLElement("fieldset")}}; if there is no containing element
-        with the <code>disabled</code> attribute set, then the element is
-        enabled.
+        This Boolean attribute indicates that the user cannot interact with the element.
+        If this attribute is not specified, the element inherits its setting from the containing element, for example, {{HTMLElement("fieldset")}};
+        if there is no containing element with the <code>disabled</code> attribute set, then the element is enabled.
       </td>
     </tr>
     <tr>
@@ -379,12 +375,9 @@ Many of the elements used to define form controls have some of their own specifi
       </td>
       <td></td>
       <td>
-        The <code>&#x3C;form></code> element that the widget is associated with,
-        used if it is not nested within that form. The value of the attribute
-        must be the <code>id</code> attribute of a
-        {{HTMLElement("form")}} element in the same document. This lets
-        you associate a form control with a form it is outside of, even if it is
-        inside a different form element.
+        The <code>&#x3C;form></code> element that the widget is associated with, used if it is not nested within that form.
+        The value of the attribute must be the <code>id</code> attribute of a {{HTMLElement("form")}} element in the same document.
+        This lets you associate a form control with a form it is outside of, even if it is inside a different form element.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Right now link for common attribute "form" points to incorrect page (Element/Form).

It expected to be linked with input page, and #form section inside it, that is describing this attribute.

For now, auto-scrolling to section doesn't work in for some reason for Chrome (Version 125.0.6422.60)

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#form

But I believe commited link is correct

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
