### PR TITLE
remove duplicate chapter

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -43,6 +43,10 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 - [`devtools.panels.onThemeChanged`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged)
   - : Fired when the devtools theme changes.
 
+## Example extensions
+
+{{WebExtExamples("h2")}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -51,8 +51,6 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 
 {{Compat}}
 
-{{WebExtExamples("h2")}}
-
 > **Note:** This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
 
 <!--

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -43,10 +43,6 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 - [`devtools.panels.onThemeChanged`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged)
   - : Fired when the devtools theme changes.
 
-## Example extensions
-
-- [devtools-panels](https://github.com/mdn/webextensions-examples/tree/main/devtools-panels)
-
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -43,8 +43,6 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 - [`devtools.panels.onThemeChanged`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/onThemeChanged)
   - : Fired when the devtools theme changes.
 
-## Example extensions
-
 {{WebExtExamples("h2")}}
 
 ## Browser compatibility


### PR DESCRIPTION
## Related MDN page

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels

## Summary

remove `example extension` cuz it duplicates with what is in the h2 macro.

<img width="417" alt="image" src="https://github.com/mdn/content/assets/146603607/9e92cb71-1859-458f-a07f-fbacf4a9fa36">
