### PR TITLE
Add example of selecting by xml:id

### DIFF
--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -95,6 +95,8 @@ if not, it is the same object as the one passed as the `result` parameter.
 
 ## Examples
 
+### Finding all H2 headings by XPath
+
 ```js
 const headings = document.evaluate(
   "/html/body//h2",
@@ -137,6 +139,22 @@ query would start from the root node (`html`) which would be more
 wasteful.)
 
 See [Introduction to using XPath in JavaScript](/en-US/docs/Web/XPath/Introduction_to_using_XPath_in_JavaScript) for more information.
+
+### Getting element by xml:id
+
+This function is a replacement for {{domxref("Document.getElementById()")}} for when you need to search by `xml:id` instead.
+
+```js
+function getElementByIdWrapper(xmldoc, id) {
+  return xmldoc.evaluate(
+    `//*[@xml:id="${id}"]`,
+    xmldoc,
+    () => "http://www.w3.org/XML/1998/namespace",
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null,
+  ).singleNodeValue;
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/document/getelementbyid/index.md
+++ b/files/en-us/web/api/document/getelementbyid/index.md
@@ -115,4 +115,4 @@ In non-HTML documents, the DOM implementation must have information on which att
 
 - {{domxref("Document")}} reference for other methods and properties you can use to get references to elements in the document.
 - {{domxref("Document.querySelector()")}} for selectors via queries like `'div.myclass'`
-- [xml:id](https://www.w3.org/TR/xml-id/) - has a utility method for allowing `getElementById()` to obtain 'xml:id' in {{glossary("XML")}} documents
+- {{domxref("Document.evaluate()")}} - has a utility method for selecting by `xml:id` in {{glossary("XML")}} documents


### PR DESCRIPTION
Not sure how useful it is, but at least someone wants it (fixes https://github.com/mdn/content/issues/9777) and it works across browsers.