### PR TITLE
chore: fix set-timeout max-delay section

### DIFF
--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -387,7 +387,7 @@ Browsers store the delay as a 32-bit signed integer internally. This causes an i
 overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So for example,
 
 ```js
-setTimeout(() => console.log("hi!"),  2**32 - 5000);
+setTimeout(() => console.log("hi!"), 2 ** 32 - 5000);
 ```
 
 results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -390,15 +390,16 @@ overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So fo
 setTimeout(() => console.log("hi!"), 2 ** 32 - 5000);
 ```
 
-results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while
+…results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number).
+…while the following example:
 
 ```js
 setTimeout(() => console.log("hi!"), 2 ** 32 + 5000);
 ```
 
-results in the timeout being executed after approximately 5 seconds.
+…results in the timeout being executed after approximately 5 seconds.
 
-**Note**: this doesn't match `setTimeout` behavior in `node`, where any timeout larger than 2,147,483,647 ms
+**Note**: this doesn't match `setTimeout` behavior in Node.js, where any timeout larger than 2,147,483,647 ms
 results in an immediate execution.
 
 ## Examples

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -384,7 +384,7 @@ API instead.
 ### Maximum delay value
 
 Browsers store the delay as a 32-bit signed integer internally. This causes an integer
-overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So for example,
+overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So for example, this code:
 
 ```js
 setTimeout(() => console.log("hi!"), 2 ** 32 - 5000);

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -393,7 +393,7 @@ setTimeout(() => console.log("hi!"), 2 ** 32 - 5000);
 results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while
 
 ```js
-setTimeout(() => console.log("hi!"),  2**32 + 5000);
+setTimeout(() => console.log("hi!"), 2 ** 32 + 5000);
 ```
 
 results in the timeout being executed after approximately 5 seconds.

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -390,7 +390,7 @@ overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So fo
 setTimeout(() => console.log("hi!"), 2 ** 32 - 5000);
 ```
 
-…results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while the following example:
+…results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while the following code:
 
 ```js
 setTimeout(() => console.log("hi!"), 2 ** 32 + 5000);

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -398,7 +398,7 @@ setTimeout(() => console.log("hi!"), 2 ** 32 + 5000);
 
 …results in the timeout being executed after approximately 5 seconds.
 
-**Note**: this doesn't match `setTimeout` behavior in Node.js, where any timeout larger than 2,147,483,647 ms
+**Note**: That doesn't match `setTimeout` behavior in Node.js, where any timeout larger than 2,147,483,647 ms
 results in an immediate execution.
 
 ## Examples

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -390,8 +390,7 @@ overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So fo
 setTimeout(() => console.log("hi!"), 2 ** 32 - 5000);
 ```
 
-…results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number).
-…while the following example:
+…results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while the following example:
 
 ```js
 setTimeout(() => console.log("hi!"), 2 ** 32 + 5000);

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -384,8 +384,22 @@ API instead.
 ### Maximum delay value
 
 Browsers store the delay as a 32-bit signed integer internally. This causes an integer
-overflow when using delays larger than 2,147,483,647 ms (about 24.8 days), resulting in
-the timeout being executed immediately.
+overflow when using delays larger than 2,147,483,647 ms (about 24.8 days). So for example,
+
+```js
+setTimeout(() => console.log("hi!"),  2**32 - 5000);
+```
+
+results in the timeout being executed immediately (since `2**32 - 5000` overflows to a negative number), while
+
+```js
+setTimeout(() => console.log("hi!"),  2**32 + 5000);
+```
+
+results in the timeout being executed after approximately 5 seconds.
+
+**Note**: this doesn't match `setTimeout` behavior in `node`, where any timeout larger than 2,147,483,647 ms
+results in an immediate execution.
 
 ## Examples
 


### PR DESCRIPTION
### Description

The description for what happens when you call `setTimeout` with a value greater than `2**31-1` was not right. This fixes it.



