### PR TITLE
fix typos

### DIFF
--- a/files/en-us/web/performance/index.md
+++ b/files/en-us/web/performance/index.md
@@ -29,7 +29,7 @@ The MDN [Web Performance Learning Area](/en-US/docs/Learn/Performance) contains 
 - [Web performance basics](/en-US/docs/Learn/Performance/Web_Performance_Basics)
   - : In addition to the front end components of HTML, CSS, JavaScript, and media files, there are features that can make applications slower and features that can make applications subjectively and objectively faster. There are many APIs, developer tools, best practices, and bad practices relating to web performance. Here we'll introduce many of these features ad the basic level and provide links to deeper dives to improve performance for each topic.
 - [HTML performance features](/en-US/docs/Learn/Performance/HTML)
-  - : Some attributes and the source order of your markup can impact the performance or your website. By minimizing the number of DOM nodes, making sure the best order and attributes are used for including content such as styles, scripts, media, and third-party scripts, you can drastically improve the user experience. This article looks in detail at how HTML can be used to ensure maximum performance.
+  - : Some attributes and the source order of your markup can impact the performance of your website. By minimizing the number of DOM nodes, making sure the best order and attributes are used for including content such as styles, scripts, media, and third-party scripts, you can drastically improve the user experience. This article looks in detail at how HTML can be used to ensure maximum performance.
 - [Multimedia: images and video](/en-US/docs/Learn/Performance/Multimedia)
   - : The lowest hanging fruit of web performance is often media optimization. Serving different media files based on each user agent's capability, size, and pixel density is possible. Additional tips like removing audio tracks from background videos can improve performance even further. In this article we discuss the impact video, audio, and image content has on performance, and the methods to ensure that impact is as minimal as possible.
 - [CSS performance features](/en-US/docs/Learn/Performance/CSS)
@@ -144,7 +144,7 @@ APIs
 - [Navigator.deviceMemory](/en-US/docs/Web/API/Navigator/deviceMemory)
 - [Intersection Observer](/en-US/docs/Web/API/Intersection_Observer_API)
 - [Using the User Timing API](/en-US/docs/Web/API/Performance_API/User_timing)
-- [High Resolution Timing API](/en-US/docs/Web/API/DOMHighResTimeStamp) ([https://w3c.github.io/hr-time/)](https://w3c.github.io/hr-time/)
+- [High Resolution Timing API](/en-US/docs/Web/API/DOMHighResTimeStamp) (<https://w3c.github.io/hr-time/>)
 - [Resource Timing API](/en-US/docs/Web/API/Performance_API/Resource_timing)
 - [Page Visibility](/en-US/docs/Web/API/Page_Visibility_API)
 - [Cooperative Scheduling of Background Tasks API](/en-US/docs/Web/API/Background_Tasks_API)
@@ -152,7 +152,7 @@ APIs
   - [requestIdleCallback()](/en-US/docs/Web/API/Window/requestIdleCallback)
 
 - [Beacon API](/en-US/docs/Web/API/Beacon_API)
-- Resource Hints - [dns-prefetch](/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control), preconnect, [prefetch](/en-US/docs/Glossary/Prefetch), and prerender
+- Resource Hints - [dns-prefetch](/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control), [preconnect](/en-US/docs/Web/HTML/Attributes/rel/preconnect), [prefetch](/en-US/docs/Glossary/Prefetch), and prerender
 - [FetchEvent.preloadResponse](/en-US/docs/Web/API/FetchEvent/preloadResponse)
 - [Performance Server Timing API](/en-US/docs/Web/API/PerformanceServerTiming)
 


### PR DESCRIPTION
### Description

- fix typos:
  - "or" => "of"
  - move the bracket out of the link text
- add the link to `rel=preconnect`
