### PR TITLE
fix: remove duplicates

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getavailablestaticrulecount/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getavailablestaticrulecount/index.md
@@ -23,8 +23,6 @@ This function takes no parameters.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with a number that indicates how many static rules can enable before the global static rule limit is reached. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getdynamicrules/index.md
@@ -27,8 +27,6 @@ let gettingDynamicRules = browser.declarativeNetRequest.getDynamicRules();
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) is fulfilled with an array of {{WebExtAPIRef("declarativeNetRequest.Rule")}} objects. Each of these represents a rule that belongs to the extension. If no rules are active, the array is empty. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getenabledrulesets/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getenabledrulesets/index.md
@@ -23,8 +23,6 @@ This function takes no parameters.
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with an array of string containing static rulesets IDs. If no rules are active, the array is empty. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
@@ -40,8 +40,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If no rules are matched, the object is empty. If the request fail, the promise is rejected with an error message
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getsessionrules/index.md
@@ -27,8 +27,6 @@ let sessionRules = await browser.declarativeNetRequest.getSessionRules();
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with an array of {{WebExtAPIRef("declarativeNetRequest.Rule")}} objects. If no rules are active, the object is empty. If the request fails, the promise is rejected with an error message
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/isregexsupported/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/isregexsupported/index.md
@@ -40,8 +40,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/setextensionactionoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/setextensionactionoptions/index.md
@@ -40,8 +40,6 @@ let count = browser.declarativeNetRequest.setExtensionActionOptions(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that fulfills with no arguments. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/testmatchoutcome/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/testmatchoutcome/index.md
@@ -49,8 +49,6 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If no rules match, the `matchedRules` array is empty. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatedynamicrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatedynamicrules/index.md
@@ -36,8 +36,6 @@ let updatedRules = browser.declarativeNetRequest.updateDynamicRules(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) If the request was successful, the promise is fulfilled with no arguments. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updateenabledrulesets/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updateenabledrulesets/index.md
@@ -31,8 +31,6 @@ let updatedRulesets = browser.declarativeNetRequest.updateEnabledRulesets(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) If the request was successful, the promise is fulfilled with no arguments. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatesessionrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/updatesessionrules/index.md
@@ -35,8 +35,6 @@ let updatedRuleset = browser.declarativeNetRequest.updateSessionRules(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) If the request was successful, the promise is fulfilled with no arguments. If the request fails, the promise is rejected with an error message.
 
-## Examples
-
 {{WebExtExamples}}
 
 ## Browser compatibility


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
## Related MDN page

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getSessionRules

## Summary

Remove `## examples` due to the possible duplicated chapter title you may see in the picture below, which is `getSession Rules()`. 

<img width="679" alt="image" src="https://github.com/mdn/content/assets/146603607/e8159443-b71b-4393-93ef-54f84103a962">