### PR TITLE
Cache-Control: max-stale - fix description

### DIFF
--- a/files/en-us/web/http/headers/cache-control/index.md
+++ b/files/en-us/web/http/headers/cache-control/index.md
@@ -303,12 +303,13 @@ In other words, for any `max-age` value that isn't an integer or isn't non-negat
 #### `max-stale`
 
 The `max-stale=N` request directive indicates that the client allows a stored response that is [stale](/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) within _N_ seconds.
+If no _N_ value is specified, the client will accept a stale response of any age.
 
 ```http
 Cache-Control: max-stale=3600
 ```
 
-In the case above, if the response with `Cache-Control: max-age=604800` was generated more than 3 hours ago (calculated from `max-age` and the `Age` header), the cache couldn't reuse that response.
+For example, a request with the header above indicates that the browser will accept a stale response from the cache that has expired within the last hour.
 
 Clients can use this header when the origin server is down or too slow and can accept cached responses from caches even if they are a bit old.
 


### PR DESCRIPTION
Fixes #34221

The `Cache-Control: max-stale` description was very confusing because it refers to the max-age and Age examples above and these times don't match the description. The fundamental problem though is that the expiry time is irrelevant for the description - this is much simpler if you just say that the browser will still accept values even if they have expired/are stale.