### PR TITLE
chore: update the heading to algin with the content

### DIFF
--- a/files/en-us/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/xml/parsing_and_serializing_xml/index.md
@@ -42,7 +42,7 @@ if (errorNode) {
 
 ### Parsing URL-addressable resources into DOM trees
 
-#### Using XMLHttpRequest
+#### Using fetch
 
 Here is sample code that reads and parses a URL-addressable XML file into a DOM tree:
 


### PR DESCRIPTION
### Description

update the heading to algin with the content, which is using `fetch()` only.
