### PR TITLE
CSS flexbox module: add links to two guides

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -69,6 +69,7 @@ In the following example a container has been set to `display: flex`, which mean
 - [Typical use cases of flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox)
 
   - : Common design patterns that are typical Flexbox use cases.
+
 - [CSS layout: flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
 
   - : Learn how to use flexbox layout to create web layouts.

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -73,7 +73,6 @@ In the following example a container has been set to `display: flex`, which mean
 - [CSS layout: flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
 
   - : Learn how to use flexbox layout to create web layouts.
- 
 - [Box alignment in flexbox](/en-US/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox)
 
   - : Details features of [CSS box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) which are specific to flexbox.

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -72,6 +72,7 @@ In the following example a container has been set to `display: flex`, which mean
 - [CSS layout: flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
 
   - : Learn how to use flexbox layout to create web layouts.
+
 - [Box alignment in flexbox](/en-US/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox)
 
   - : Details features of [CSS box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) which are specific to flexbox.

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -69,7 +69,6 @@ In the following example a container has been set to `display: flex`, which mean
 - [Typical use cases of flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox)
 
   - : Common design patterns that are typical Flexbox use cases.
- 
 - [CSS layout: flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
 
   - : Learn how to use flexbox layout to create web layouts.

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -69,6 +69,14 @@ In the following example a container has been set to `display: flex`, which mean
 - [Typical use cases of flexbox](/en-US/docs/Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox)
 
   - : Common design patterns that are typical Flexbox use cases.
+ 
+- [CSS layout: flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
+
+  - : Learn how to use flexbox layout to create web layouts.
+ 
+- [Box alignment in flexbox](/en-US/docs/Web/CSS/CSS_box_alignment/Box_alignment_in_flexbox)
+
+  - : Details features of [CSS box alignment](/en-US/docs/Web/CSS/CSS_box_alignment) which are specific to flexbox.
 
 ## Related concepts
 


### PR DESCRIPTION
they were missing