### PR TITLE
FF128Relnote: MediaKeys.getStatusForPolicy()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -41,6 +41,8 @@ This article provides information about the changes in Firefox 128 that affect d
 ### APIs
 
 - {{domxref('RTCRtpReceiver.getParameters()')}} and {{domxref('RTCRtpSender.getParameters()')}} are now supported, returning an object that describes the current codecs used for the encoding and transmission of media on the receiver and sender tracks, respectively. ([Firefox bug 1534687](https://bugzil.la/1534687)).
+- {{domxref('MediaKeys.getStatusForPolicy()')}} is now supported for checking whether the CDM module, which is used to decrypt DRM protected content, would allow the presentation of encrypted media data for a "hypothetical" key based on specified policy requirements such as the HDCP version supported by the system.
+  This provides an application with a simple mechanism to know in advance whether playback at the optimal resolution will be allowed, without having to create a media key session or fetch a real license. ([Firefox bug 1878714](https://bugzil.la/1878714)).
 
 #### DOM
 


### PR DESCRIPTION
FF128 supports `MediaKeys.getStatusForPolicy()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1878714.
This adds a release note.

Note that the actual docs are done in https://github.com/mdn/content/pull/34236

Related docs work can be tracked in #33980