### PR TITLE
CSS Selector bug

### DIFF
--- a/files/en-us/web/css/css_selectors/selectors_and_combinators/index.md
+++ b/files/en-us/web/css/css_selectors/selectors_and_combinators/index.md
@@ -101,7 +101,7 @@ h2 + p + p {
 #myId > .myClass {
   outline: 3px dashed red;
 }
-> p {
+p {
   font-size: 1.1rem;
 }
 ```
@@ -157,7 +157,7 @@ h2 {
     outline: 3px dashed red;
   }
 }
-> p {
+p {
   font-size: 1.1rem;
 }
 ```


### PR DESCRIPTION
### Description
  Fixes the issue #34230.
  Removed the CSS selector `>` before `p` tag as it was a code error. 