### PR TITLE
FF128 Accept Header values string changed

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2459,7 +2459,7 @@ The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP respo
 
 ### Accept header with MIME type image/jxl
 
-The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be configured via a preference to indicate support for the `image/jxl` MIME type. If enabled, this appears after `image/avif`.
+The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be configured via a preference to indicate support for the `image/jxl` MIME type.
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2459,7 +2459,7 @@ The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP respo
 
 ### Accept header with MIME type image/jxl
 
-The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header for [default and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be customized via preferences to indicate support for the `image/jxl` MIME type. If enabled, this appears after `image/avif`.
+The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be configured via a preference to indicate support for the `image/jxl` MIME type. If enabled, this appears after `image/avif`.
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -2457,6 +2457,48 @@ The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP respo
 
 ## HTTP
 
+### Accept header with MIME type image/jxl
+
+The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header for [default and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be customized via preferences to indicate support for the `image/jxl` MIME type. If enabled, this appears after `image/avif`.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>128</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>128</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>128</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>128</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2">
+        <code>image.jxl.enabled</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### SameSite=Lax by default
 
 [`SameSite` cookies](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) have a default value of `Lax`.

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -75,8 +75,6 @@ This article provides information about the changes in Firefox 128 that affect d
 
 These features are newly shipped in Firefox 128 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
-Symmetrical spacing with CSS letter-spacing: layout.css.letter-spacing.model. The CSS letter-spacing property now splits the specified letter spacing evenly on both sides of each character. This is unlike the current behavior where spacing is added primarily to one side (Firefox bug 1891446).
-
 - **`image/jxl` MIME type in Accept header for default and image requests:** `image.jxl.enabled`.
 
   The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be configured to indicate support for the `image/jxl` MIME type. ([Firefox bug 1711622](https://bugzil.la/1711622)).

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -32,6 +32,8 @@ This article provides information about the changes in Firefox 128 that affect d
 
 ### HTTP
 
+- The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) now includes the `image/svg+xml` MIME type ([Firefox bug 1711622](https://bugzil.la/1711622)).
+
 #### Removals
 
 ### Security
@@ -72,6 +74,12 @@ This article provides information about the changes in Firefox 128 that affect d
 ## Experimental web features
 
 These features are newly shipped in Firefox 128 but are disabled by default. To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`. You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+Symmetrical spacing with CSS letter-spacing: layout.css.letter-spacing.model. The CSS letter-spacing property now splits the specified letter spacing evenly on both sides of each character. This is unlike the current behavior where spacing is added primarily to one side (Firefox bug 1891446).
+
+- **`image/jxl` MIME type in Accept header for default and image requests:** `image.jxl.enabled`.
+
+  The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) can be configured to indicate support for the `image/jxl` MIME type. ([Firefox bug 1711622](https://bugzil.la/1711622)).
 
 ## Older versions
 

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -14,19 +14,22 @@ These are the values sent when the context doesn't give better information. Note
 
 | User Agent                 | Value                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Firefox 92 and later [1]   | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                             |
-| Firefox 72 to 91 [1]       | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                        |
-| Firefox 66 to 71 [1]       | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
-| Firefox 65 [1]             | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                        |
-| Firefox 64 and earlier [1] | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
+| Firefox 128 and later [1]  | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8`                     |
+| Firefox 92 to 127 [2]      | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                             |
+| Firefox 72 to 91 [2]       | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                        |
+| Firefox 66 to 71 [2]       | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
+| Firefox 65 [2]             | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                        |
+| Firefox 64 and earlier [2] | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
 | Safari, Chrome             | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8`                                             |
-| Safari 5 [2]               | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
+| Safari 5 [3]               | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
 | Edge                       | `text/html, application/xhtml+xml, image/jxr, */*`                                                                                  |
 | Opera                      | `text/html, application/xml;q=0.9, application/xhtml+xml, image/png, image/webp, image/jpeg, image/gif, image/x-xbitmap, */*;q=0.1` |
 
-\[1] This value can be modified using the [`network.http.accept.default`](https://kb.mozillazine.org/Network.http.accept.default) parameter.
+\[1] The [`image.avif.enabled`](https://searchfox.org/mozilla-central/search?q=image.avif.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) and [`image.jxl.enabled`](https://searchfox.org/mozilla-central/search?q=image.jxl.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) preferences can be enabled/disabled in `about:config` to add/remove `image/avif` and `image/jxl` in the accept header, respectively. `image.avif.enabled` is currently enabled by default. If both are enabled, they appear in the order: `image/avif`, `image/jxl`(, `image/webp`, ...).
 
-\[2] This is an improvement over earlier `Accept` headers as it no longer ranks `image/png` above `text/html`.
+\[2] This value can be modified using the [`network.http.accept.default`](https://kb.mozillazine.org/Network.http.accept.default) parameter.
+
+\[3] This is an improvement over earlier `Accept` headers as it no longer ranks `image/png` above `text/html`.
 
 ## Values for an image
 
@@ -34,7 +37,8 @@ When requesting an image, like through an HTML {{HTMLElement("img")}} element, u
 
 | User Agent                     | Value                                                                      |
 | ------------------------------ | -------------------------------------------------------------------------- |
-| Firefox 92 and later [1]       | `image/avif,image/webp,*/*`                                                |
+| Firefox 128 and later [1] [2]  | `image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`    |
+| Firefox 92 to 127 [1]          | `image/avif,image/webp,*/*`                                                |
 | Firefox 65 to 91 [1]           | `image/webp,*/*`                                                           |
 | Firefox 47 to 63 [1]           | `*/*`                                                                      |
 | Firefox prior to 47 [1]        | `image/png,image/*;q=0.8,*/*;q=0.5`                                        |
@@ -42,7 +46,9 @@ When requesting an image, like through an HTML {{HTMLElement("img")}} element, u
 | Safari (before Mac OS Big Sur) | `image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5`            |
 | Chrome and Edge 121 and later  | `image/avif,image/webp,image/apng,image/*,*/*;q=0.8`                       |
 
-\[1] This value can be modified using the `image.http.accept` parameter (_[source](https://searchfox.org/mozilla-central/search?q=image.http.accept)_).
+\[1] This value can be set to an arbitrary string using the `image.http.accept` parameter (_[source](https://searchfox.org/mozilla-central/search?q=image.http.accept)_). This overrides specific settings as per \[2].
+
+\[2] The [`image.avif.enabled`](https://searchfox.org/mozilla-central/search?q=image.avif.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) and [`image.jxl.enabled`](https://searchfox.org/mozilla-central/search?q=image.jxl.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) preferences can be enabled/disabled in `about:config` to add/remove `image/avif` and `image/jxl` in the accept header, respectively. `image.avif.enabled` is currently enabled by default. If both are enabled, they appear in the order: `image/avif`, `image/jxl`(, `image/webp`, ...).
 
 ## Values for a video
 

--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -10,12 +10,14 @@ This article documents the default values for the HTTP [`Accept`](/en-US/docs/We
 
 ## Default values
 
-These are the values sent when the context doesn't give better information. Note that all browsers add the `*/*` MIME Type to cover all cases. This is typically used for requests initiated via the address bar of a browser, or via an HTML {{HTMLElement("a")}} element.
+These are the values sent when the context doesn't give better information.
+Note that all browsers add the `*/*` MIME Type to cover all cases.
+This is typically used for requests initiated via the address bar of a browser, or via an HTML {{HTMLElement("a")}} element.
 
 | User Agent                 | Value                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Firefox 128 and later [1]  | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8`                     |
-| Firefox 92 to 127 [2]      | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                             |
+| Firefox 92 to 127 [1]      | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                             |
 | Firefox 72 to 91 [2]       | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                        |
 | Firefox 66 to 71 [2]       | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                   |
 | Firefox 65 [2]             | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                        |
@@ -25,9 +27,9 @@ These are the values sent when the context doesn't give better information. Note
 | Edge                       | `text/html, application/xhtml+xml, image/jxr, */*`                                                                                  |
 | Opera                      | `text/html, application/xml;q=0.9, application/xhtml+xml, image/png, image/webp, image/jpeg, image/gif, image/x-xbitmap, */*;q=0.1` |
 
-\[1] The [`image.avif.enabled`](https://searchfox.org/mozilla-central/search?q=image.avif.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) and [`image.jxl.enabled`](https://searchfox.org/mozilla-central/search?q=image.jxl.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) preferences can be enabled/disabled in `about:config` to add/remove `image/avif` and `image/jxl` in the accept header, respectively. `image.avif.enabled` is currently enabled by default. If both are enabled, they appear in the order: `image/avif`, `image/jxl`(, `image/webp`, ...).
+\[1] The value can be set to an arbitrary string using the `network.http.accept` preference (`about:config`).
 
-\[2] This value can be modified using the [`network.http.accept.default`](https://kb.mozillazine.org/Network.http.accept.default) parameter.
+\[2] The value can be set to an arbitrary string using the [`network.http.accept.default`](https://kb.mozillazine.org/Network.http.accept.default) preference (`about:config`).
 
 \[3] This is an improvement over earlier `Accept` headers as it no longer ranks `image/png` above `text/html`.
 
@@ -37,7 +39,7 @@ When requesting an image, like through an HTML {{HTMLElement("img")}} element, u
 
 | User Agent                     | Value                                                                      |
 | ------------------------------ | -------------------------------------------------------------------------- |
-| Firefox 128 and later [1] [2]  | `image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`    |
+| Firefox 128 and later [1]      | `image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`    |
 | Firefox 92 to 127 [1]          | `image/avif,image/webp,*/*`                                                |
 | Firefox 65 to 91 [1]           | `image/webp,*/*`                                                           |
 | Firefox 47 to 63 [1]           | `*/*`                                                                      |
@@ -46,9 +48,7 @@ When requesting an image, like through an HTML {{HTMLElement("img")}} element, u
 | Safari (before Mac OS Big Sur) | `image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5`            |
 | Chrome and Edge 121 and later  | `image/avif,image/webp,image/apng,image/*,*/*;q=0.8`                       |
 
-\[1] This value can be set to an arbitrary string using the `image.http.accept` parameter (_[source](https://searchfox.org/mozilla-central/search?q=image.http.accept)_). This overrides specific settings as per \[2].
-
-\[2] The [`image.avif.enabled`](https://searchfox.org/mozilla-central/search?q=image.avif.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) and [`image.jxl.enabled`](https://searchfox.org/mozilla-central/search?q=image.jxl.enabled&path=modules%2Flibpref%2Finit%2FStaticPrefList.yaml&case=false&regexp=false) preferences can be enabled/disabled in `about:config` to add/remove `image/avif` and `image/jxl` in the accept header, respectively. `image.avif.enabled` is currently enabled by default. If both are enabled, they appear in the order: `image/avif`, `image/jxl`(, `image/webp`, ...).
+\[1] The value can be set to an arbitrary string using the `image.http.accept` parameter (_[source](https://searchfox.org/mozilla-central/search?q=image.http.accept)_).
 
 ## Values for a video
 


### PR DESCRIPTION
FF128 This updates the accept header string to match changes in https://bugzilla.mozilla.org/show_bug.cgi?id=1711622

This is addition of  `image/svg+xml` and `image/png` to the `Accept` header in image/default requests.
The is also a preference to add `image/jxl` to the string which is disabled by default (another preference exists for enabling avif, but that is enabled by default and predates this, so not recorded).

I've added release note and experimental features updates too.

Related docs work can be tracked in #34047