### PR TITLE
fix(css): Sync text with inheritance diagram

### DIFF
--- a/files/en-us/web/api/cssconditionrule/index.md
+++ b/files/en-us/web/api/cssconditionrule/index.md
@@ -15,14 +15,14 @@ Three objects derive from `CSSConditionRule`: {{domxref("CSSMediaRule")}}, {{dom
 
 ## Instance properties
 
-_Inherits properties from its ancestors {{domxref("CSSRule")}} and {{domxref("CSSGroupingRule")}}._
+_Inherits properties from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 - {{domxref("CSSConditionRule.conditionText")}} {{ReadOnlyInline}}
   - : Represents the text of the condition of the rule.
 
 ## Instance methods
 
-No specific methods; inherits methods from its ancestors {{domxref("CSSRule")}} and {{domxref("CSSGroupingRule")}}.
+_Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/csslayerblockrule/index.md
+++ b/files/en-us/web/api/csslayerblockrule/index.md
@@ -7,20 +7,20 @@ browser-compat: api.CSSLayerBlockRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSLayerBlockRule`** represents a {{cssxref("@layer")}} block rule. It is a grouping at-rule meaning that it can contain other rules, and is associated to a given cascade layer, identified by its _name_.
+The **`CSSLayerBlockRule`** represents a {{cssxref("@layer")}} block rule.
 
 {{InheritanceDiagram}}
 
 ## Instance properties
 
-_Also inherits properties from its parent interface, {{DOMxRef("CSSGroupingRule")}}._
+_Inherits properties from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 - {{DOMxRef("CSSLayerBlockRule.name")}} {{ReadOnlyInline}}
   - A string containing the name of the associated cascade layer.
 
 ## Instance methods
 
-_Inherits methods from its parent interface, {{DOMxRef("CSSGroupingRule")}}._
+_Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/csspagerule/index.md
+++ b/files/en-us/web/api/csspagerule/index.md
@@ -13,7 +13,7 @@ browser-compat: api.CSSPageRule
 
 ## Instance properties
 
-_Inherits properties from its ancestor {{domxref("CSSRule")}}._
+_Inherits properties from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 - {{domxref("CSSPageRule.selectorText")}}
   - : Represents the text of the page selector associated with the at-rule.
@@ -22,7 +22,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 ## Instance methods
 
-_Inherits methods from its ancestor {{domxref("CSSRule")}}._
+_Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssscoperule/index.md
+++ b/files/en-us/web/api/cssscoperule/index.md
@@ -13,7 +13,7 @@ The **`CSSScopeRule`** interface of the [CSS Object Model](/en-US/docs/Web/API/C
 
 ## Instance properties
 
-_This interface inherits properties from its parent, {{domxref("CSSGroupingRule")}}._
+_Inherits properties from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 - {{domxref("CSSScopeRule.end", "end")}}
   - : Returns a string containing the value of the `@scope` at-rule's scope limit.
@@ -22,7 +22,7 @@ _This interface inherits properties from its parent, {{domxref("CSSGroupingRule"
 
 ## Instance methods
 
-_This interface inherits methods from its parent, {{domxref("CSSGroupingRule")}}._
+_Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssstartingstylerule/index.md
+++ b/files/en-us/web/api/cssstartingstylerule/index.md
@@ -13,11 +13,11 @@ The **`CSSStartingStyleRule`** interface of the [CSS Object Model](/en-US/docs/W
 
 ## Instance properties
 
-_This interface inherits properties from its parent, {{domxref("CSSGroupingRule")}}._
+_Inherits properties from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Instance methods
 
-_This interface inherits methods from its parent, {{domxref("CSSGroupingRule")}}._
+_Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/cssstylerule/index.md
+++ b/files/en-us/web/api/cssstylerule/index.md
@@ -13,7 +13,7 @@ The **`CSSStyleRule`** interface represents a single CSS style rule.
 
 ## Instance properties
 
-_Inherits properties from its ancestor {{domxref("CSSRule")}}._
+_Inherits properties from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 - {{domxref("CSSStyleRule.selectorText")}}
   - : Returns the textual representation of the selector for this rule, e.g. `"h1, h2"`.
@@ -24,7 +24,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 ## Instance methods
 
-_No specific methods; inherits methods from its ancestor {{domxref("CSSRule")}}._
+_Inherits methods from its ancestors {{domxref("CSSGroupingRule")}} and {{domxref("CSSRule")}}._
 
 ## Examples
 


### PR DESCRIPTION
### Description

Syncs the ancestors from the inheritance diagram to the text under the headings for `CSSGroupingRule` subclasses. 

### Motivation

I was lost for a long time looking for `CSSStyleRule.cssRules`. The text mislead that CSSStyleRule still directly subclassed `CSSRule`, so I couldn't find `CSSGroupingRule.cssRules`.

### Related issues and pull requests

* Finishes what #28853 wanted to do