### PR TITLE
fix(*): The autoplay attribute has precedence over preload If autoplay is set to true

### DIFF
--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -81,7 +81,7 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 
     > **Note:**
     >
-    > - The `autoplay` attribute has precedence over `preload`. If `autoplay` is specified, the browser would obviously need to start downloading the video for playback.
+    > - The `autoplay` attribute has precedence over `preload`. If `autoplay` is set to `true`, the browser would obviously need to start downloading the video for playback.
     > - The specification does not force the browser to follow the value of this attribute; it is a mere hint.
 
 - `src`


### PR DESCRIPTION
### Description

Just a little correction for `HTMLVideoElement` preload docs

### Motivation

With current description it sounds like even if `autoplay=false` it will has precedence over `preload=none`
