### PR TITLE
FF128 Relnote: HTMLMediaElement.seekToNextFrame() removed

### DIFF
--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -55,7 +55,7 @@ This article provides information about the changes in Firefox 128 that affect d
 
 #### Removals
 
-- The non-standard {{domxref('HTMLMediaElement.seekToNextFrame()')}} method has been removed, and is now not present on any platform. ([Firefox bug 1336404](https://bugzil.la/1336404)).
+- The non-standard {{domxref('HTMLMediaElement.seekToNextFrame()')}} method has been removed, and is now not supported by any browser. ([Firefox bug 1336404](https://bugzil.la/1336404)).
 
 ### WebAssembly
 

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -55,6 +55,8 @@ This article provides information about the changes in Firefox 128 that affect d
 
 #### Removals
 
+- The non-standard {{domxref('HTMLMediaElement.seekToNextFrame()')}} method has been removed, and is not present on any platform. ([Firefox bug 1336404](https://bugzil.la/1336404)).
+
 ### WebAssembly
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -55,7 +55,7 @@ This article provides information about the changes in Firefox 128 that affect d
 
 #### Removals
 
-- The non-standard {{domxref('HTMLMediaElement.seekToNextFrame()')}} method has been removed, and is not present on any platform. ([Firefox bug 1336404](https://bugzil.la/1336404)).
+- The non-standard {{domxref('HTMLMediaElement.seekToNextFrame()')}} method has been removed, and is now not present on any platform. ([Firefox bug 1336404](https://bugzil.la/1336404)).
 
 ### WebAssembly
 


### PR DESCRIPTION
Release note for removal of [`HTMLMediaElement.seekToNextFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekToNextFrame) in https://bugzilla.mozilla.org/show_bug.cgi?id=1336404

Related docs work can be tracked in #33986