### PR TITLE
Clarify BFC creation in example to prevent margin collapsing #34306

### DIFF
--- a/files/en-us/web/css/css_display/block_formatting_context/index.md
+++ b/files/en-us/web/css/css_display/block_formatting_context/index.md
@@ -192,7 +192,7 @@ In this example we have two adjacent {{HTMLElement("div")}} elements, which each
 
 #### Preventing margin collapsing
 
-In this example we wrap the second `<div>` in an outer one, to create a new BFC and prevent margin collapsing.
+In this example, we wrap the second `<div>` in an outer `<div>`, and create a new Block Formatting Context (BFC) by using `overflow: hidden` on the outer `<div>`. This new BFC prevents the margins of the nested `<div>` from collapsing with those of the outer `<div>`.
 
 ```html
 <div class="blue"></div>
@@ -217,7 +217,7 @@ In this example we wrap the second `<div>` in an outer one, to create a new BFC 
 }
 
 .outer {
-  overflow: hidden;
+  overflow: hidden; 
   background: transparent;
 }
 ```

--- a/files/en-us/web/css/css_display/block_formatting_context/index.md
+++ b/files/en-us/web/css/css_display/block_formatting_context/index.md
@@ -217,7 +217,7 @@ In this example, we wrap the second `<div>` in an outer `<div>`, and create a ne
 }
 
 .outer {
-  overflow: hidden; 
+  overflow: hidden;
   background: transparent;
 }
 ```

--- a/files/en-us/web/css/css_display/block_formatting_context/index.md
+++ b/files/en-us/web/css/css_display/block_formatting_context/index.md
@@ -192,7 +192,7 @@ In this example we have two adjacent {{HTMLElement("div")}} elements, which each
 
 #### Preventing margin collapsing
 
-In this example, we wrap the second `<div>` in an outer `<div>`, and create a new Block Formatting Context (BFC) by using `overflow: hidden` on the outer `<div>`. This new BFC prevents the margins of the nested `<div>` from collapsing with those of the outer `<div>`.
+In this example, we wrap the second `<div>` in an outer `<div>`, and create a new BFC by using `overflow: hidden` on the outer `<div>`. This new BFC prevents the margins of the nested `<div>` from collapsing with those of the outer `<div>`.
 
 ```html
 <div class="blue"></div>


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Clarified the creation of Block Formatting Context (BFC) in the example to prevent margin collapsing by explicitly mentioning the use of `overflow: hidden`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The original documentation suggested that wrapping a `<div>` inside another automatically creates a BFC, which is incorrect. This update provides a precise explanation, helping readers understand that a BFC is created using specific CSS properties, in this case, `overflow: hidden`. This prevents any confusion and ensures proper implementation in their projects.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

For more details on how a Block Formatting Context (BFC) is created, refer to the [MDN Web Docs on Block Formatting Context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Block_formatting_context#:~:text=Block%20elements%20where%20overflow%20has%20a%20value%20other%20than%20visible%20and%20clip).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

Fixes #34306
