### PR TITLE
fix(learn/css): remove prose regarding IE

### DIFF
--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -428,7 +428,7 @@ input[type="checkbox"]:checked + aside {
 
 The selector is pretty complex here — we are selecting the `<aside>` element adjacent to the `<input>` element, but only when it is checked (note the use of the {{cssxref(":checked")}} pseudo-class to achieve this). When this is the case, we are setting the {{cssxref("right")}} property of the `<aside>` to `0px`, which causes the panel to appear on the screen again (smoothly due to the transition). Clicking the label again unchecks the checkbox, which hides the panel again.
 
-So there you have it — a rather clever JavaScript-free way to create a toggling button effect. This will work in IE9 and above (the smooth transition will work in IE10 and above.) This effect does have some concerns — this is a bit of an abuse of form elements, as they weren't intended for this purpose. In addition, the effect is not great in terms of accessibility; the label is not focusable by default, and the non-semantic use of the form elements could cause issues with screen readers. JavaScript and a link or button might be more appropriate, but it is still fun to experiment with.
+So there you have it — a rather clever JavaScript-free way to create a toggling button effect. This effect does have some concerns — this is a bit of an abuse of form elements, as they weren't intended for this purpose. In addition, the effect is not great in terms of accessibility; the label is not focusable by default, and the non-semantic use of the form elements could cause issues with screen readers. JavaScript and a link or button might be more appropriate, but it is still fun to experiment with.
 
 ## Summary
 


### PR DESCRIPTION
We are getting rid of Internet Explorer(IE) mentions. The statement could be removed.