### PR TITLE
Update Installable_PWAs redirect

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11103,7 +11103,7 @@
 /en-US/docs/Web/Apps/Progressive/App_structure	/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/App_structure
 /en-US/docs/Web/Apps/Progressive/Discoverable	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Apps/Progressive/Installable	/en-US/docs/Web/Progressive_web_apps
-/en-US/docs/Web/Apps/Progressive/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability
+/en-US/docs/Web/Apps/Progressive/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable
 /en-US/docs/Web/Apps/Progressive/Introduction	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Apps/Progressive/Linkable	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Apps/Progressive/Loading	/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Loading
@@ -12808,7 +12808,7 @@
 /en-US/docs/Web/Progressive_web_apps/Discoverable	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Progressive_web_apps/Guides/Structural_overview	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Progressive_web_apps/Installable	/en-US/docs/Web/Progressive_web_apps
-/en-US/docs/Web/Progressive_web_apps/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability
+/en-US/docs/Web/Progressive_web_apps/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable
 /en-US/docs/Web/Progressive_web_apps/Installing	/en-US/docs/Web/Progressive_web_apps/Guides/Installing
 /en-US/docs/Web/Progressive_web_apps/Introduction	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Progressive_web_apps/Linkable	/en-US/docs/Web/Progressive_web_apps

--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11103,7 +11103,7 @@
 /en-US/docs/Web/Apps/Progressive/App_structure	/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/App_structure
 /en-US/docs/Web/Apps/Progressive/Discoverable	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Apps/Progressive/Installable	/en-US/docs/Web/Progressive_web_apps
-/en-US/docs/Web/Apps/Progressive/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs
+/en-US/docs/Web/Apps/Progressive/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability
 /en-US/docs/Web/Apps/Progressive/Introduction	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Apps/Progressive/Linkable	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Apps/Progressive/Loading	/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Loading
@@ -12808,7 +12808,7 @@
 /en-US/docs/Web/Progressive_web_apps/Discoverable	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Progressive_web_apps/Guides/Structural_overview	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Progressive_web_apps/Installable	/en-US/docs/Web/Progressive_web_apps
-/en-US/docs/Web/Progressive_web_apps/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Installable_PWAs
+/en-US/docs/Web/Progressive_web_apps/Installable_PWAs	/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability
 /en-US/docs/Web/Progressive_web_apps/Installing	/en-US/docs/Web/Progressive_web_apps/Guides/Installing
 /en-US/docs/Web/Progressive_web_apps/Introduction	/en-US/docs/Web/Progressive_web_apps
 /en-US/docs/Web/Progressive_web_apps/Linkable	/en-US/docs/Web/Progressive_web_apps


### PR DESCRIPTION
Related to a previous pull request and as mentioned in this [comment](https://github.com/mdn/content/pull/34127#issuecomment-2173955664), I think https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable is the best place to point people towards for information on making PWAs installable, rather than the js13kGames tutorial which is a bit outdated and specific to that example project. I came across this redirect on the Google web.dev [PWA install criteria](https://web.dev/articles/install-criteria) which links to it as the Firefox PWA install criteria.