### PR TITLE
XPath/XSLT: correct page structures

### DIFF
--- a/files/en-us/web/xpath/functions/boolean/index.md
+++ b/files/en-us/web/xpath/functions/boolean/index.md
@@ -14,23 +14,23 @@ The `boolean` function evaluates an expression and returns true or false.
 boolean( expression )
 ```
 
-## Arguments
+### Parameters
 
 - `expression`
   - : The expression to be evaluated. The expression can refer to numbers and node-sets as well as booleans.
 
-## Returns
+### Return value
 
 Boolean `true` or `false` after evaluating `expression`.
 
-## Notes
+## Description
 
 - A number evaluates to false if it is positive or negative zero or `NaN`. Otherwise, it evaluates true.
 - A node-set evaluates to true if it is non-empty.
 - A string evaluates to false if it an empty string. Otherwise, it evaluates to true.
 - An object of a type other than the four basic types is converted to a boolean in a way that is dependent on that type.
 
-## Defined
+## Specifications
 
 [XPath 1.0 4.3](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-boolean)
 

--- a/files/en-us/web/xpath/functions/ceiling/index.md
+++ b/files/en-us/web/xpath/functions/ceiling/index.md
@@ -8,18 +8,18 @@ page-type: xpath-function
 
 The `ceiling` function evaluates a decimal number and returns the smallest integer greater than or equal to the decimal number.
 
-### Syntax
+## Syntax
 
 ```plain
 ceiling( number )
 ```
 
-### Arguments
+### Parameters
 
 - `number`
   - : The number to be evaluated.
 
-### Returns
+### Return value
 
 The nearest integer greater than or equal to `number`.
 
@@ -29,10 +29,10 @@ for example:
 
 `ceiling (-5.2)` = _-5_
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.4](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-ceiling)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/choose/index.md
+++ b/files/en-us/web/xpath/functions/choose/index.md
@@ -10,13 +10,13 @@ The `choose` function returns one of the specified objects based on a boolean pa
 
 > **Note:** This method should be used instead of `if ()`, which has been deprecated.
 
-### Syntax
+## Syntax
 
 ```plain
 choose( boolean, object1, object2 )
 ```
 
-### Arguments
+### Parameters
 
 - `boolean`
   - : The boolean operation to use when determining which object to return.
@@ -25,16 +25,16 @@ choose( boolean, object1, object2 )
 - `object2`
   - : The second object to consider returning.
 
-### Returns
+### Return value
 
 If the boolean parameter is true, the first object is returned; otherwise, the second object is returned.
 
 > **Note:** All parameters are evaluated, even the one that's not returned.
 
-### Defined
+## Specifications
 
 [XForms 1.1](https://www.w3.org/TR/xforms11/#fn-choose)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/concat/index.md
+++ b/files/en-us/web/xpath/functions/concat/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `concat` function concatenates two or more strings and returns the resulting string.
 
-### Syntax
+## Syntax
 
 ```plain
 concat( string1, string2 [,stringn]* )
 ```
 
-### Arguments
+### Parameters
 
 - `stringn`
   - : This function accepts two or more arguments. Each of these arguments is a string.
 
-### Returns
+### Return value
 
 A single string that is the concatenation of all the strings passed to the function as arguments.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-concat)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/contains/index.md
+++ b/files/en-us/web/xpath/functions/contains/index.md
@@ -8,27 +8,27 @@ page-type: xpath-function
 
 The `contains` function determines whether the first argument string contains the second argument string and returns boolean true or false.
 
-### Syntax
+## Syntax
 
 ```plain
 contains(haystack, needle)
 ```
 
-### Arguments
+### Parameters
 
 - `haystack`
   - : The string to be searched
 - `needle`
   - : The string to look for as a substring of `haystack`
 
-### Returns
+### Return value
 
 `true` if `haystack` contains `needle`. Otherwise, `false`.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-contains)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/count/index.md
+++ b/files/en-us/web/xpath/functions/count/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `count` function counts the number of nodes in a node-set and returns an integer.
 
-### Syntax
+## Syntax
 
 ```plain
 count( node-set )
 ```
 
-### Arguments
+### Parameters
 
 - `node-set`
   - : The node set to be counted.
 
-### Returns
+### Return value
 
 An integer representing the number of nodes in a node-set.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-count)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/current/index.md
+++ b/files/en-us/web/xpath/functions/current/index.md
@@ -8,17 +8,17 @@ page-type: xpath-function
 
 The `current` function can be used to get the context node in an XSLT instruction.
 
-### Syntax
+## Syntax
 
 ```plain
 current()
 ```
 
-### Returns
+### Return value
 
 A node-set containing only the current node.
 
-### Notes
+## Description
 
 This function is an XSLT-specific addition to XPath. It is not a part of the core XPath function library.
 
@@ -62,10 +62,10 @@ But the `.` always relate to the narrowest context. Thus in
 
 the `.` returns the `bar` node, which may be different from the current node.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.4](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-current)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/document/index.md
+++ b/files/en-us/web/xpath/functions/document/index.md
@@ -8,24 +8,24 @@ page-type: xpath-function
 
 The `document` finds a node-set in an external document, or multiple external documents, and returns the resulting node-set.
 
-### Syntax
+## Syntax
 
 ```plain
 document( URI [,node-set] )
 ```
 
-### Arguments
+### Parameters
 
 - `URI`
   - : An absolute or relative URI of the document to be retrieved. The URI may also include a fragment identifier.
 - `node-set` (optional)
   - : An expression pointing to a node-set in the external document that should be returned.
 
-### Returns
+### Return value
 
 A node-set.
 
-### Notes
+## Description
 
 - If the URI contains a fragment identifier and that fragment can be identified in the external document, that fragment will be treated as the root in the `node-set` argument's expression. If the `node-set` argument is omitted, the entire fragment will be returned.
 - If the `URI` argument is a node-set, and the second argument is present, each node in the node-set will be evaluated as a separate URI, and the returned node-set will be as if the `document` function has been called multiple times (each time with the same second argument just as given in the function call) and the resulting node-sets had been concatenated into a single node-set.
@@ -34,10 +34,10 @@ A node-set.
 
 This function is an XSLT-specific addition to XPath. It is not a part of the core XPath function library.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.1](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-document)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/element-available/index.md
+++ b/files/en-us/web/xpath/functions/element-available/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `element-available` function determines if an element is available and returns true or false.
 
-### Syntax
+## Syntax
 
 ```plain
 element-available( QName )
 ```
 
-### Arguments
+### Parameters
 
 - `QName`
   - : Must evaluate to a valid QName. The QName is expanded into an expanded-name using the namespace declarations in scope for the expression.
 
-### Returns
+### Return value
 
 Returns true if and only if the expanded-name is the name of an instruction. If the expanded-name has a namespace URI equal to the XSLT namespace URI, then it refers to an element defined by XSLT. Otherwise, it refers to an extension element. If the expanded-name has a null namespace URI, the element-available function will return false.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 15](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-element-available)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/false/index.md
+++ b/files/en-us/web/xpath/functions/false/index.md
@@ -8,17 +8,17 @@ page-type: xpath-function
 
 The `false` function returns boolean false.
 
-### Syntax
+## Syntax
 
 ```plain
 false()
 ```
 
-### Returns
+### Return value
 
 Boolean `false`.
 
-### Notes
+## Description
 
 This function is useful part of a comparison:
 
@@ -28,10 +28,10 @@ This function is useful part of a comparison:
 </xsl:if>
 ```
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.3](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-false)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/floor/index.md
+++ b/files/en-us/web/xpath/functions/floor/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `floor` function evaluates a decimal number and returns the largest integer less than or equal to the decimal number.
 
-### Syntax
+## Syntax
 
 ```plain
 floor( number )
 ```
 
-### Arguments
+### Parameters
 
 - `number`
   - : The decimal number to be evaluated.
 
-### Returns
+### Return value
 
 The nearest integer less than or equal to `number`.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.4](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-floor)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/format-number/index.md
+++ b/files/en-us/web/xpath/functions/format-number/index.md
@@ -8,7 +8,7 @@ page-type: xpath-function
 
 The `format-number` function evaluates a number and returns a string representing the number in a given format.
 
-### Syntax
+## Syntax
 
 ```plain
 format-number(number, pattern)
@@ -28,14 +28,14 @@ format-number(number, pattern, decimalFormat)
 
 A string representing the number in the new format.
 
-### Notes
+## Description
 
 This function is an XSLT-specific addition to XPath. It is not a part of the core XPath function library.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.3](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-format-number)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/function-available/index.md
+++ b/files/en-us/web/xpath/functions/function-available/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `function-available` function determines if a given function is available and returns boolean true or false.
 
-### Syntax
+## Syntax
 
 ```plain
 function-available( name )
 ```
 
-### Arguments
+### Parameters
 
 - `name`
   - : The name of the function to test.
 
-### Returns
+### Return value
 
 Boolean `true` or `false`.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 15](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-function-available)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/generate-id/index.md
+++ b/files/en-us/web/xpath/functions/generate-id/index.md
@@ -8,32 +8,32 @@ page-type: xpath-function
 
 The `generate-id` function generates a unique id for the first node in a given node-set and returns a string containing that id.
 
-### Syntax
+## Syntax
 
 ```plain
 generate-id( [node-set] )
 ```
 
-### Arguments
+### Parameters
 
 - `node-set` (optional)
   - : An id will be generated for the first node in this node-set. If omitted, the current context node will be used.
 
-### Returns
+### Return value
 
 A string containing the generated id.
 
-### Notes
+## Description
 
 - The same id must be generated every time for the same node in the current document in the current transformation.
 - The generated id may not be the same in subsequent transformations.
 
 This function is an XSLT-specific addition to XPath. It is not a part of the core XPath function library.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.4](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-generate-id)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/id/index.md
+++ b/files/en-us/web/xpath/functions/id/index.md
@@ -8,30 +8,30 @@ page-type: xpath-function
 
 The `id` function finds nodes matching the given ids and returns a node-set containing the identified nodes.
 
-### Syntax
+## Syntax
 
 ```plain
 id( expression )
 ```
 
-### Arguments
+### Parameters
 
 - `expression`
   - : If `expression` is a node-set, then the string value of each node in the node-set is treated as an individual id. The returned node set is the nodes corresponding to those ids.
     If `expression` is a string, or anything other than a node-set, then `expression` is treated as a space-separated list of ids. The returned node set is the nodes corresponding to those ids.
 
-### Returns
+### Return value
 
 A node-set containing the node or nodes identified by the given id or ids.
 
-### Notes
+## Description
 
 - The DTD of the XML document determines what attribute is an ID. See [XPath 1.0 5.2.1](https://www.w3.org/TR/xpath/#unique-id)
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-id)
 
-### Gecko support
+## Gecko support
 
 Partially supported.

--- a/files/en-us/web/xpath/functions/key/index.md
+++ b/files/en-us/web/xpath/functions/key/index.md
@@ -8,33 +8,33 @@ page-type: xpath-function
 
 The `key` function returns a node-set of nodes that have the given value for the given key.
 
-### Syntax
+## Syntax
 
 ```plain
 key( keyname, value )
 ```
 
-### Arguments
+### Parameters
 
 - `keyname`
   - : A string containing the name of the [`xsl:key`](/en-US/docs/Web/XSLT/Element/key) element to be used.
 - `value`
   - : The returned node-set will contain every node that has this value for the given key.
 
-### Returns
+### Return value
 
 A node set.
 
-### Notes
+## Description
 
 - The [`xsl:key`](/en-US/docs/Web/XSLT/Element/key) element defines what attribute on what given elements will be used to match the key.
 
 This function is an XSLT-specific addition to XPath. It is not a part of the core XPath function library.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.2](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-key)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/lang/index.md
+++ b/files/en-us/web/xpath/functions/lang/index.md
@@ -8,22 +8,22 @@ page-type: xpath-function
 
 The `lang` function determines whether the context node matches the given language and returns boolean true or false.
 
-### Syntax
+## Syntax
 
 ```plain
 lang(string )
 ```
 
-### Arguments
+### Parameters
 
 - `string`
   - : The language code or localization (language and country) code to be matched.
 
-### Returns
+### Return value
 
 `true` if the context node matches the given languages. Otherwise, `false`.
 
-### Notes
+## Description
 
 - A node's language is determined by its `xml:lang` attribute. If the current node does not have an `xml:lang` attribute, then the value of the `xml:lang` attribute of the nearest ancestor that has an `xml:lang` attribute will determine the current node's language. If the language cannot be determined (no ancestor has an `xml:lang` attribute), this function will return false.
 
@@ -55,10 +55,10 @@ The output might be:
 0
 ```
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.3](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-lang)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/last/index.md
+++ b/files/en-us/web/xpath/functions/last/index.md
@@ -8,24 +8,24 @@ page-type: xpath-function
 
 The `last` function returns a number equal to the context size from the expression evaluation context.
 
-### Syntax
+## Syntax
 
 ```plain
 last()
 ```
 
-### Returns
+### Return value
 
 An integer equal to the context size from the expression evaluation context.
 
-### Notes
+## Description
 
 - This is often used with the [position()](/en-US/docs/Web/XPath/Functions/position) function to determine if a particular node is the last in a node-set.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-last)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/local-name/index.md
+++ b/files/en-us/web/xpath/functions/local-name/index.md
@@ -8,29 +8,29 @@ page-type: xpath-function
 
 The `local-name` function returns a string representing the local name of the first node in a given node-set.
 
-### Syntax
+## Syntax
 
 ```plain
 local-name( [node-set] )
 ```
 
-### Arguments
+### Parameters
 
 - `node-set` (optional)
   - : The local name of the first node in this node-set will be returned. If this argument is omitted, the current context node will be used.
 
-### Returns
+### Return value
 
 A string.
 
-### Notes
+## Description
 
 - The local name is the local part of an [expanded-name](https://www.w3.org/TR/xpath/#dt-expanded-name).
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-local-name)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/name/index.md
+++ b/files/en-us/web/xpath/functions/name/index.md
@@ -8,29 +8,29 @@ page-type: xpath-function
 
 The `name` function returns a string representing the QName of the first node in a given node-set.
 
-### Syntax
+## Syntax
 
 ```plain
 name( [node-set] )
 ```
 
-### Arguments
+### Parameters
 
 - `node-set` (optional)
   - : The QName of the first node in this node-set will be returned. If this argument is omitted, the current context node will be used.
 
-### Returns
+### Return value
 
 A string representing the QName of a node.
 
-### Notes
+## Description
 
 - The [QName](https://www.w3.org/TR/REC-xml-names/#NT-QName) is the node's qualified name, including its namespace prefix and its local name.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-local-name)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/namespace-uri/index.md
+++ b/files/en-us/web/xpath/functions/namespace-uri/index.md
@@ -8,30 +8,30 @@ page-type: xpath-function
 
 The `namespace-uri` function returns a string representing the namespace URI of the first node in a given node-set.
 
-### Syntax
+## Syntax
 
 ```plain
 namespace-uri( [node-set] )
 ```
 
-### Arguments
+### Parameters
 
 - `node-set` (optional)
   - : The namespace URI of the first node in this node-set will be returned. If this argument is omitted, the current context node will be used.
 
-### Returns
+### Return value
 
 A string representing URI of the namespace in which the given node resides.
 
-### Notes
+## Description
 
 - If the given node does not have a specified namespace, the returned string will be an empty string.
 - For nodes other than element and attribute nodes, the returned string will always be an empty string.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-local-name)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/normalize-space/index.md
+++ b/files/en-us/web/xpath/functions/normalize-space/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `normalize-space` function strips leading and trailing white-space from a string, replaces sequences of whitespace characters by a single space, and returns the resulting string.
 
-### Syntax
+## Syntax
 
 ```plain
 normalize-space( [string] )
 ```
 
-### Arguments
+### Parameters
 
 - `string` (optional)
   - : The string to be normalized. If omitted, string used will be the same as the context node converted to a string.
 
-### Returns
+### Return value
 
 The normalized string.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/not/index.md
+++ b/files/en-us/web/xpath/functions/not/index.md
@@ -8,22 +8,22 @@ page-type: xpath-function
 
 The `not` function evaluates a boolean expression and returns the opposite value.
 
-### Syntax
+## Syntax
 
 ```plain
 not( expression )
 ```
 
-### Arguments
+### Parameters
 
 - `expression`
   - : The expression is evaluated exactly as if it were passed as an argument to the [boolean()](/en-US/docs/Web/XPath/Functions/boolean) function.
 
-### Returns
+### Return value
 
 True for an expression that evaluates to false; false for an expression that evaluates to true.
 
-### Notes
+## Description
 
 - This function should behave similarly to the [boolean()](/en-US/docs/Web/XPath/Functions/boolean) function except that it returns the opposite value.
 - You can test if an element doesn't have some attribute.
@@ -36,10 +36,10 @@ True for an expression that evaluates to false; false for an expression that eva
   </xsl:template>
   ```
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.3](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-not)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/number/index.md
+++ b/files/en-us/web/xpath/functions/number/index.md
@@ -8,32 +8,32 @@ page-type: xpath-function
 
 The `number` function converts an object to a number and returns the number.
 
-### Syntax
+## Syntax
 
 ```plain
 number( [object] )
 ```
 
-### Arguments
+### Parameters
 
 - `object` (optional)
   - : The object to be converted to a number. If this argument is omitted, the current context node will be used.
 
-### Returns
+### Return value
 
 The resulting number after converting the object.
 
-### Notes
+## Description
 
 - Strings are converted to a number by stripping the leading whitespace in the string before the number and ignoring whitespace after the number. If the string does not match this pattern, then the string is converted to NaN.
 - Boolean true is converted to 1. False is converted to 0.
 - A node-set is first converted to a string as if by a call to the [string()](/en-US/docs/Web/XPath/Functions/string) function and then converted in the same way as a string argument.
 - An object of a type other than the four basic types is converted to a number in a way that is dependent on that type.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.4](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-number)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/position/index.md
+++ b/files/en-us/web/xpath/functions/position/index.md
@@ -8,17 +8,17 @@ page-type: xpath-function
 
 The `position` function returns a number equal to the context position from the expression evaluation context.
 
-### Syntax
+## Syntax
 
 ```plain
 position()
 ```
 
-### Returns
+### Return value
 
 An integer equal to the context position from the expression evaluation context.
 
-### Notes
+## Description
 
 - Note that a node's position in a context is not zero-based. The first node has a position of 1.
 
@@ -38,10 +38,10 @@ An integer equal to the context position from the expression evaluation context.
   </xsl:template>
   ```
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.1](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-position)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/round/index.md
+++ b/files/en-us/web/xpath/functions/round/index.md
@@ -8,29 +8,29 @@ page-type: xpath-function
 
 The `round` function returns a number that is the nearest integer to the given number.
 
-### Syntax
+## Syntax
 
 ```plain
 round( decimal )
 ```
 
-### Arguments
+### Parameters
 
 - `decimal`
   - : The decimal number to be rounded.
 
-### Returns
+### Return value
 
 The nearest integer less then, greater than, or equal to `decimal`.
 
-### Notes
+## Description
 
 - \-0.5 rounds to negative zero. 0.4 rounds to positive zero.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.4](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-round)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/starts-with/index.md
+++ b/files/en-us/web/xpath/functions/starts-with/index.md
@@ -8,27 +8,27 @@ page-type: xpath-function
 
 The `starts-with` checks whether the first string starts with the second string and returns true or false.
 
-### Syntax
+## Syntax
 
 ```plain
 starts-with(haystack, needle)
 ```
 
-### Arguments
+### Parameters
 
 - `haystack`
   - : The string to look in.
 - `needle`
   - : The string to look for.
 
-### Returns
+### Return value
 
 `true` if `haystack` starts with `needle`. Otherwise, `false`.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-starts-with)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/string-length/index.md
+++ b/files/en-us/web/xpath/functions/string-length/index.md
@@ -8,25 +8,25 @@ page-type: xpath-function
 
 The `string-length` function returns a number equal to the number of characters in a given string.
 
-### Syntax
+## Syntax
 
 ```plain
 string-length( [string] )
 ```
 
-### Arguments
+### Parameters
 
 - `string` (optional)
   - : The string to evaluate. If omitted, string used will be the same as the context node converted to a string.
 
-### Returns
+### Return value
 
 An integer equal to the number of characters in the string.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-string-length)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/string/index.md
+++ b/files/en-us/web/xpath/functions/string/index.md
@@ -8,22 +8,22 @@ page-type: xpath-function
 
 The `string` function converts the given argument to a string.
 
-### Syntax
+## Syntax
 
 ```plain
 string( [object] )
 ```
 
-### Arguments
+### Parameters
 
 - `object` (optional)
   - : The object to convert to a string. If omitted, the context node is used.
 
-### Returns
+### Return value
 
 A string
 
-### Notes
+## Description
 
 - If the object is a node-set, the string value of the first node in the set is returned.
 - A number is converted as follows:
@@ -37,10 +37,10 @@ A string
   - Boolean true is converted to the string true.
   - Boolean false is converted to the string false.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-string)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/substring-after/index.md
+++ b/files/en-us/web/xpath/functions/substring-after/index.md
@@ -8,20 +8,20 @@ page-type: xpath-function
 
 The `substring-after` function returns a string that is the rest of a given string after a given substring.
 
-### Syntax
+## Syntax
 
 ```plain
 substring-after( haystack, needle )
 ```
 
-### Arguments
+### Parameters
 
 - `haystack`
   - : The string to be evaluated. Part of this string will be returned.
 - `needle`
   - : The substring to search for. Everything after the first occurrence of `needle` in `haystack` will be returned.
 
-### Returns
+### Return value
 
 A string.
 
@@ -34,10 +34,10 @@ A string.
 | `substring-after('aa-bb','b')` | `b`            |
 | `substring-after('aa-bb','q')` | (empty string) |
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-substring-after)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/substring-before/index.md
+++ b/files/en-us/web/xpath/functions/substring-before/index.md
@@ -8,20 +8,20 @@ page-type: xpath-function
 
 The `substring-before` function returns a string that is the part of a given string before a given substring.
 
-### Syntax
+## Syntax
 
 ```plain
 substring-before( haystack, needle )
 ```
 
-### Arguments
+### Parameters
 
 - `haystack`
   - : The string to be evaluated. Part of this string will be returned.
 - `needle`
   - : The substring to search for. Everything before the first occurrence of `needle` in `haystack` will be returned.
 
-### Returns
+### Return value
 
 A string.
 
@@ -34,10 +34,10 @@ A string.
 | `substring-before('aa-bb','b')` | `aa-`            |
 | `substring-before('aa-bb','q')` | (empty string)   |
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-substring-before)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/substring/index.md
+++ b/files/en-us/web/xpath/functions/substring/index.md
@@ -8,14 +8,14 @@ page-type: xpath-function
 
 The `substring` function returns a part of a given string.
 
-### Syntax
+## Syntax
 
 ```plain
 substring(string, start)
 substring(string, start, length)
 ```
 
-### Arguments
+### Parameters
 
 - `string`
   - : The string to evaluate.
@@ -25,18 +25,18 @@ substring(string, start, length)
   - : The length of the substring.
     If omitted, the returned string will contain every character from the `start` position to the end of `string`.
 
-### Returns
+### Return value
 
 A string.
 
-### Notes
+## Description
 
 As in other XPath functions, the position is not zero-based. The first character in the string has a position of 1, not 0.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-substring)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/sum/index.md
+++ b/files/en-us/web/xpath/functions/sum/index.md
@@ -8,29 +8,29 @@ page-type: xpath-function
 
 The `sum` function returns a number that is the sum of the numeric values of each node in a given node-set.
 
-### Syntax
+## Syntax
 
 ```plain
 sum(node-set)
 ```
 
-### Arguments
+### Parameters
 
 - `node-set`
   - : The node-set to be evaluated. Each node in this node-set is evaluated as if it were passed to the [number()](/en-US/docs/Web/XPath/Functions/number) function, and a sum of the resulting numbers is returned.
 
-### Returns
+### Return value
 
 A number.
 
-### Notes
+## Description
 
 None.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.3](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-sum)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/system-property/index.md
+++ b/files/en-us/web/xpath/functions/system-property/index.md
@@ -8,31 +8,31 @@ page-type: xpath-function
 
 The `system-property` function returns an object representing the given system-property.
 
-### Syntax
+## Syntax
 
 ```plain
 system-property(name)
 ```
 
-### Arguments
+### Parameters
 
 - `name` (optional)
   - : The name of the system property. The argument must evaluate to a string that is a QName. The QName is expanded into a name using the namespace declarations in scope for the expression. The system-property function returns an object representing the value of the system property identified by the name. If there is no such system property, the empty string should be returned.
 
-### Returns
+### Return value
 
 An object representing the given system-property.
 
-### Notes
+## Description
 
 - xsl:version, a number giving the version of XSLT implemented by the processor; for XSLT processors implementing the version of XSLT specified by this document, this is the number 1.0
 - xsl:vendor, a string identifying the vendor of the XSLT processor
 - xsl:vendor-url, a string containing a URL identifying the vendor of the XSLT processor; typically this is the host page (home page) of the vendor's website.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.4](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-system-property)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/translate/index.md
+++ b/files/en-us/web/xpath/functions/translate/index.md
@@ -8,13 +8,13 @@ page-type: xpath-function
 
 The `translate` function evaluates a string and a set of characters to translate and returns the translated string.
 
-### Syntax
+## Syntax
 
 ```plain
 translate(string, abc, XYZ)
 ```
 
-### Arguments
+### Parameters
 
 - `string`
   - : The string to evaluate.
@@ -23,11 +23,11 @@ translate(string, abc, XYZ)
 - `XYZ`
   - : The string of characters used for replacement. The first character in `XYZ` will replace every occurrence of the first character in `abc` that appears in `string`.
 
-### Returns
+### Return value
 
 The translated string.
 
-### Notes
+## Description
 
 XPath notes that the translate function is not a sufficient solution for case conversion in all languages. A future version of XPath may provide additional functions for case conversion.
 
@@ -61,10 +61,10 @@ The quick red fdx.
 
 - If `XYZ` contains more characters than `abc`, the extra characters are ignored.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.2](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-translate)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/true/index.md
+++ b/files/en-us/web/xpath/functions/true/index.md
@@ -8,20 +8,20 @@ page-type: xpath-function
 
 The `true` function returns a boolean value of true.
 
-### Syntax
+## Syntax
 
 ```plain
 true()
 ```
 
-### Returns
+### Return value
 
 Boolean `true`.
 
-### Defined
+## Specifications
 
 [XPath 1.0 4.3](https://www.w3.org/TR/1999/REC-xpath-19991116/#function-true)
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xpath/functions/unparsed-entity-url/index.md
+++ b/files/en-us/web/xpath/functions/unparsed-entity-url/index.md
@@ -8,24 +8,24 @@ page-type: xpath-function
 
 The `unparsed-entity-url()` function returns the URI of the unparsed entity with the given name. This is non-XML data referenced in the DTD of the source document.
 
-### Syntax
+## Syntax
 
 ```plain
 string unparsed-entity-url(string)
 ```
 
-### Arguments
+### Parameters
 
 The name of the unparsed entity. If the argument is not a string, it is converted using the rules of the string() function. The name should be an XML Name.
 
-### Returns
+### Return value
 
 The URI of the unparsed entity retrieved from the DTD, if it exists. Otherwise an empty string.
 
-### Defined
+## Specifications
 
 [XSLT 1.0 12.4](https://www.w3.org/TR/1999/REC-xslt-19991116/#function-unparsed-entity-uri)
 
-### Gecko support
+## Gecko support
 
 Not supported.

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -70,7 +70,7 @@ And then pass `document.evaluate`, the `nsResolver` variable as the `namespaceRe
 
 Note: XPath defines QNames without a prefix to match only elements in the null namespace. There is no way in XPath to pick up the default namespace as applied to a regular element reference (e.g., `p[@id='_myid']` for `xmlns='http://www.w3.org/1999/xhtml'`). To match default elements in a non-null namespace, you either have to refer to a particular element using a form such as `['namespace-uri()='http://www.w3.org/1999/xhtml' and name()='p' and @id='_myid']` ([this approach](#using_xpath_functions_to_reference_elements_with_a_default_namespace) works well for dynamic XPath's where the namespaces might not be known) or use prefixed name tests, and create a namespace resolver mapping the prefix to the namespace. Read more on [how to create a user-defined namespace resolver](#implementing_a_user_defined_namespace_resolver), if you wish to take the latter approach.
 
-### Notes
+## Description
 
 Adapts any DOM node to resolve namespaces so that an [XPath](/en-US/docs/Web/XPath) expression can be easily evaluated relative to the context of the node where it appeared within the document. This adapter works like the DOM Level 3 method `lookupNamespaceURI` on nodes in resolving the `namespaceURI` from a given prefix using the current information available in the node's hierarchy at the time `lookupNamespaceURI` is called. Also correctly resolves the implicit `xml` prefix.
 

--- a/files/en-us/web/xslt/element/apply-imports/index.md
+++ b/files/en-us/web/xslt/element/apply-imports/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:apply-imports>` element is fairly arcane, used mostly in complex stylesheets. Import precedence requires that template rules in main stylesheets have higher precedence than template rules in imported stylesheets. Sometimes, however, it is useful to be able to force the processor to use a template rule from the (lower precedence) imported stylesheet rather than an equivalent rule in the main stylesheet.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:apply-imports/>
@@ -26,10 +26,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 5.6.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/apply-templates/index.md
+++ b/files/en-us/web/xslt/element/apply-templates/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:apply-templates>` element selects a set of nodes in the input tree and instructs the processor to apply the proper templates to them.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:apply-templates select=EXPRESSION mode=NAME>
@@ -32,10 +32,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT section 5.4.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/attribute-set/index.md
+++ b/files/en-us/web/xslt/element/attribute-set/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:attribute-set>` element creates a named set of attributes, which can then be applied as whole to the output document, in a manner similar to named styles in CSS.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:attribute-set name=NAME use-attribute-sets=LIST-OF-NAMES>
@@ -30,10 +30,10 @@ The `<xsl:attribute-set>` element creates a named set of attributes, which can t
 
 Top-level, must be the child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 7.1.4.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/attribute/index.md
+++ b/files/en-us/web/xslt/element/attribute/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:attribute>` element creates an attribute in the output document, using any values that can be accessed from the stylesheet. The element must be defined before any other output document element inside the output document element for which it establishes attribute values. But it may be after or inside elements that won't be part of the output (like `<xsl:choose>` or `<xsl:apply-templates>` etc.).
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:attribute name=NAME namespace=URI>
@@ -30,10 +30,10 @@ The `<xsl:attribute>` element creates an attribute in the output document, using
 
 Instruction, appears within a template or an `<xsl:attribute-set>` element.
 
-### Defined
+## Specifications
 
 XSLT, section 7.1.3.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/call-template/index.md
+++ b/files/en-us/web/xslt/element/call-template/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:call-template>` element invokes a named template.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:call-template name=NAME>
@@ -29,10 +29,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 6.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/choose/index.md
+++ b/files/en-us/web/xslt/element/choose/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:choose>` element defines a choice among a number of alternatives. It behaves like a switch statement in procedural languages.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:choose>
@@ -30,10 +30,10 @@ None.
 
 Instruction, appears with a template. It contains one or more `<xsl:when>` elements, and, optionally, a final `<xsl:otherwise>` element.
 
-### Defined
+## Specifications
 
 XSLT, section 9.2.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/comment/index.md
+++ b/files/en-us/web/xslt/element/comment/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:comment>` element writes a comment to the output document. It must include only text.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:comment>
@@ -28,10 +28,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.4.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/copy-of/index.md
+++ b/files/en-us/web/xslt/element/copy-of/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:copy-of>` element makes a deep copy (including descendant nodes) of whatever the select attribute specifies to the output document.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:copy-of select=EXPRESSION />
@@ -27,10 +27,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 11.3.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/copy/index.md
+++ b/files/en-us/web/xslt/element/copy/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:copy>` element transfers a shallow copy (the node and any associated namespace node) of the current node to the output document. It does not copy any children or attributes of the current node.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:copy use-attribute-sets=LIST-OF-NAMES>
@@ -29,10 +29,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.5.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/decimal-format/index.md
+++ b/files/en-us/web/xslt/element/decimal-format/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:decimal-format>` element defines the characters and symbols that are to be used in converting numbers into strings using the `format-number( )` function.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:decimal-format
@@ -58,10 +58,10 @@ None.
 
 Top-level, must be the child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 12.3.
 
-### Gecko support
+## Gecko support
 
 Supported as of 1.0 (Mozilla 1.0, Netscape 7.0).

--- a/files/en-us/web/xslt/element/element/index.md
+++ b/files/en-us/web/xslt/element/element/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:element>` element creates an element in the output document.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:element name=NAME namespace=URI use-attribute-sets=LIST-OF-NAMES >
@@ -32,10 +32,10 @@ The `<xsl:element>` element creates an element in the output document.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.1.2.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/fallback/index.md
+++ b/files/en-us/web/xslt/element/fallback/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:fallback>` element specifies what template to use if a given extension (or, eventually, newer version) element is not supported.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:fallback>
@@ -28,10 +28,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 15
 
-### Gecko support
+## Gecko support
 
 Not supported at this time.

--- a/files/en-us/web/xslt/element/for-each/index.md
+++ b/files/en-us/web/xslt/element/for-each/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:for-each>` element selects a set of nodes and processes each of them in the same way. It is often used to iterate through a set of nodes or to change the current node. If one or more `<xsl:sort>` elements appear as the children of this element, sorting occurs before processing. Otherwise, nodes are processed in document order.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:for-each select=EXPRESSION>
@@ -30,10 +30,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 8.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/if/index.md
+++ b/files/en-us/web/xslt/element/if/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:if>` element contains a test attribute and a template. If the test evaluates to true, the template is processed. In this it is similar to an if statement in other languages. To achieve the functionality of an if-then-else statement, however, use the `<xsl:choose>` element with one `<xsl:when>` and one `<xsl:otherwise>` children.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:if test=EXPRESSION>
@@ -29,10 +29,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSL section 9.1.
 
-### Gecko support
+## Gecko support
 
 Supported

--- a/files/en-us/web/xslt/element/import/index.md
+++ b/files/en-us/web/xslt/element/import/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:import>` element is a top-level element that serves to import the contents of one stylesheet into another stylesheet. Generally speaking, the contents of the imported stylesheet have a lower import precedence than that of the importing stylesheet. This is in contrast to `<xsl:include>` where the contents of the included stylesheet have exactly the same precedence as the contents of the including stylesheet.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:import href=URI />
@@ -27,10 +27,10 @@ None.
 
 Top-level, must appear before any other child of `<xsl:stylesheet>` or `<xsl:transform>` in the importing stylesheet.
 
-### Defined
+## Specifications
 
 XSLT, section 2.6.2.
 
-### Gecko support
+## Gecko support
 
 Mostly supported with a few issues with top level variables and parameters as of Mozilla 1.0.

--- a/files/en-us/web/xslt/element/include/index.md
+++ b/files/en-us/web/xslt/element/include/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:include>` element merges the contents of one stylesheet with another. Unlike the case of `<xsl:import>`, the contents of an included stylesheet have exactly the same precedence as the contents of the including stylesheet.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:include href=URI />
@@ -27,10 +27,10 @@ None.
 
 Top-level, may appear in any order as a child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 2.6.1.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/key/index.md
+++ b/files/en-us/web/xslt/element/key/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:key>` element declares a named key which can be used elsewhere in the stylesheet with the `key( )` function.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:key name=NAME match=EXPRESSION
@@ -32,10 +32,10 @@ None.
 
 Top-level, must be the child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 12.2.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/message/index.md
+++ b/files/en-us/web/xslt/element/message/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:message>` element outputs a message (to the JavaScript Console in NS) and optionally terminates execution of the stylesheet. It can be useful for debugging.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:message terminate="yes" | "no" >
@@ -29,10 +29,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 13.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/namespace-alias/index.md
+++ b/files/en-us/web/xslt/element/namespace-alias/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:namespace-alias>` element is a rarely used device that maps a namespace in the stylesheet to a different namespace in the output tree. The most common use for this element is in generating a stylesheet from another stylesheet. To prevent a normally `xsl:`-prefixed literal result element (which should be copied as-is to the result tree) from being misunderstood by the processor, it is assigned a temporary namespace which is appropriately re-converted back to the XSLT namespace in the output tree.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:namespace-alias stylesheet-prefix=NAME result-prefix=NAME />
@@ -29,10 +29,10 @@ None.
 
 Top-level, must be the child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 7.1.1
 
-### Gecko support
+## Gecko support
 
 Not supported at this time.

--- a/files/en-us/web/xslt/element/number/index.md
+++ b/files/en-us/web/xslt/element/number/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:number>` element counts things sequentially. It can also be used to quickly format a number.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:number
@@ -76,10 +76,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.7
 
-### Gecko support
+## Gecko support
 
 Partial support. See comments above.

--- a/files/en-us/web/xslt/element/otherwise/index.md
+++ b/files/en-us/web/xslt/element/otherwise/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:otherwise>` element is used to define the action that should be taken when none of the `<xsl:when>` conditions apply. It is similar to the `else` or `default` case in other programming languages.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:otherwise>
@@ -28,10 +28,10 @@ None.
 
 Subinstruction, must appear as the last child of an `<xsl:choose>` element, within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 9.2
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/output/index.md
+++ b/files/en-us/web/xslt/element/output/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:output>` element controls the characteristics of the output document. To function correctly in Netscape, this element, with the method attribute, must be used. As of 7.0, `method="text"` works as expected.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:output
@@ -55,10 +55,10 @@ None.
 
 Top-level, must be the child `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 16.
 
-### Gecko support
+## Gecko support
 
 Partial support. See comments above.

--- a/files/en-us/web/xslt/element/param/index.md
+++ b/files/en-us/web/xslt/element/param/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:param>` element establishes a parameter by name and, optionally, a default value for that parameter. When used as a top-level element, the parameter is global. When used inside an `<xsl:template>` element, the parameter is local to that template. In this case it must be the first child element of the template.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:param name=NAME select=EXPRESSION>
@@ -30,10 +30,10 @@ The `<xsl:param>` element establishes a parameter by name and, optionally, a def
 
 Instruction, can appear as a top-level element or within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 11.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/preserve-space/index.md
+++ b/files/en-us/web/xslt/element/preserve-space/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:preserve-space>` element defines the elements in the source document for which whitespace should be preserved. If there is more than one element, separate the names with a whitespace character. Preserving whitespace is the default setting, so this element only needs to be used to counteract an `<xsl:strip-space>` element.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:preserve-space elements=LIST-OF-ELEMENT-NAMES />
@@ -27,10 +27,10 @@ None.
 
 Top-level, must be a child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 3.4
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/processing-instruction/index.md
+++ b/files/en-us/web/xslt/element/processing-instruction/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:processing-instruction>` element writes a processing instruction to the output document.
 
-### Syntax
+## Syntax
 
 `<xsl:processing-instruction name=NAME> TEMPLATE </xsl:processing-instruction>`
 
@@ -25,10 +25,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.3
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/sort/index.md
+++ b/files/en-us/web/xslt/element/sort/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:sort>` element defines a sort key for nodes selected by `<xsl:apply-templates>` or `<xsl:for-each>` and determines the order in which they are processed.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:sort
@@ -40,10 +40,10 @@ None.
 
 Subinstruction, always appears as a child of \<xsl:for-each>, where it must appear before the template proper or of \<xsl:apply-templates>.
 
-### Defined
+## Specifications
 
 XSLT, section10.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/strip-space/index.md
+++ b/files/en-us/web/xslt/element/strip-space/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:strip-space>` element defines the elements in the source document for which whitespace should be removed.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:strip-space elements=LIST-OF-ELEMENT-NAMES />
@@ -27,10 +27,10 @@ None.
 
 Top-level, must be a child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 3.4
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/template/index.md
+++ b/files/en-us/web/xslt/element/template/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:template>` element defines an output producing template. This element must have either the match attribute or the name attribute set.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:template
@@ -40,10 +40,10 @@ None.
 
 Top-level, must be the child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
-### Defined
+## Specifications
 
 XSLT, section 5.3.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/text/index.md
+++ b/files/en-us/web/xslt/element/text/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:text>` element writes literal text to the output tree. It may contain `#PCDATA`, literal text, and entity references.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:text disable-output-escaping="yes" | "no">
@@ -29,10 +29,10 @@ None.
 
 Instruction, appears within a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.2
 
-### Gecko support
+## Gecko support
 
 Supported as noted.

--- a/files/en-us/web/xslt/element/transform/index.md
+++ b/files/en-us/web/xslt/element/transform/index.md
@@ -8,6 +8,6 @@ page-type: xslt-element
 
 The `<xsl:transform>` element is exactly equivalent to the [`<xsl:stylesheet>`](/en-US/docs/Web/XSLT/Element/stylesheet) element.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/value-of/index.md
+++ b/files/en-us/web/xslt/element/value-of/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:value-of>` element evaluates an XPath expression, converts it to a string, and writes that string to the result tree.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:value-of select=EXPRESSION disable-output-escaping="yes" | "no"  />
@@ -28,10 +28,10 @@ The `<xsl:value-of>` element evaluates an XPath expression, converts it to a str
 
 Instruction, appears with a template.
 
-### Defined
+## Specifications
 
 XSLT, section 7.6.1.
 
-### Gecko support
+## Gecko support
 
 Supported except as above.

--- a/files/en-us/web/xslt/element/variable/index.md
+++ b/files/en-us/web/xslt/element/variable/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:variable>` element declares a global or local variable in a stylesheet and gives it a value. Because XSLT permits no side-effects, once the value of the variable has been established, it remains the same until the variable goes out of scope
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:variable name=NAME select=EXPRESSION >
@@ -30,10 +30,10 @@ The `<xsl:variable>` element declares a global or local variable in a stylesheet
 
 Top-level or instruction. If it occurs as a top-level element, the variable is global in scope, and can be accessed throughout the document. If it occurs within a template, the variable is local in scope, accessible only within the template in which it appears.
 
-### Defined
+## Specifications
 
 XSLT, section 11.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/when/index.md
+++ b/files/en-us/web/xslt/element/when/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:when>` element always appears within an `<xsl:choose>` element, acting like a case statement.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:when test=EXPRESSION>
@@ -29,10 +29,10 @@ None.
 
 Subinstruction, always appears within an `<xsl:choose>` element.
 
-### Defined
+## Specifications
 
 XSLT, section 9.2.
 
-### Gecko support
+## Gecko support
 
 Supported.

--- a/files/en-us/web/xslt/element/with-param/index.md
+++ b/files/en-us/web/xslt/element/with-param/index.md
@@ -8,7 +8,7 @@ page-type: xslt-element
 
 The `<xsl:with-param>` element sets the value of a parameter to be passed into a template.
 
-### Syntax
+## Syntax
 
 ```xml
 <xsl:with-param name=NAME select=EXPRESSION>
@@ -30,10 +30,10 @@ The `<xsl:with-param>` element sets the value of a parameter to be passed into a
 
 Subinstruction, always appears within an `<xsl:apply-templates>` or an `<xsl:call-template>` element.
 
-### Defined
+## Specifications
 
 XSLT 11.6
 
-### Gecko support
+## Gecko support
 
 Supported.


### PR DESCRIPTION
We have one issue (https://github.com/mdn/content/issues/29823) concerning XPath, but fixing it requires first making the XPath/XSLT docs structure reasonable and familiar. This adopts the common convention:

- Syntax
  - Parameters (from "Arguments")
  - Return value (from "Returns")
- Description (from "Notes")
- Specifications (from "Defined")
- Gecko support (Should be "Browser compatibility" but we only have Gecko data)