### PR TITLE
Fix syntax section structure of various references

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
@@ -15,7 +15,7 @@ To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
-### Syntax
+## Syntax
 
 ```js-nolint
 await browser.scripting.updateContentScripts(

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -48,18 +48,18 @@ Creates a new `DirectoryReaderSync` to read entries from this directory.
 
 #### Syntax
 
-```js
-createReader();
+```js-nolint
+createReader()
 ```
 
-##### Returns
+##### Parameters
+
+None
+
+##### Return value
 
 - [`DirectoryReaderSync`](/en-US/docs/Web/API/DirectoryReaderSync)
   - : Represents a directory in a file system.
-
-##### Parameter
-
-None
 
 ##### Exceptions
 
@@ -81,7 +81,7 @@ getFile(path)
 getFile(path, options)
 ```
 
-##### Parameter
+##### Parameters
 
 - `path`
   - : Either an absolute path or a relative path from the directory to the file to be looked up or created. You cannot create a file whose immediate parent does not exist. Create the parent directory first.
@@ -131,7 +131,7 @@ getFile(path, options)
   </tbody>
 </table>
 
-##### Returns
+##### Return value
 
 - [`FileEntrySync`](/en-US/docs/Web/API/FileEntrySync)
   - : Represents a file in a file system.
@@ -161,7 +161,7 @@ getDirectory(path)
 getDirectory(path, options)
 ```
 
-##### Parameter
+##### Parameters
 
 - `path`
   - : Either an absolute path or a relative path from the directory to the file to be looked up or created. You cannot create a file whose immediate parent does not exist. Create the parent directory first.
@@ -213,7 +213,7 @@ getDirectory(path, options)
   </tbody>
 </table>
 
-##### Returns
+##### Return value
 
 - [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryReaderSync)
   - : Represents a directory in a file system.
@@ -244,11 +244,11 @@ If you delete a directory that contains a file that cannot be removed or if an e
 removeRecursively()
 ```
 
-##### Parameter
+##### Parameters
 
 None
 
-##### Returns
+##### Return value
 
 {{jsxref('undefined')}}
 

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -106,13 +106,13 @@ Returns a list of entries from a specific directory. Call this method until an e
 readEntries()
 ```
 
+##### Parameters
+
+None.
+
 ##### Return value
 
-Array containing [`FileEntrySync`](/en-US/docs/Web/API/FileEntrySync) and [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync)
-
-##### Parameter
-
-None
+Array containing [`FileEntrySync`](/en-US/docs/Web/API/FileEntrySync) and [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync).
 
 ##### Exceptions
 

--- a/files/en-us/web/api/domtokenlist/supports/index.md
+++ b/files/en-us/web/api/domtokenlist/supports/index.md
@@ -23,7 +23,7 @@ supports(token)
 - `token`
   - : A string containing the token to query for.
 
-### Returns
+### Return value
 
 A boolean value indicating whether the token was found.
 

--- a/files/en-us/web/api/element/clientwidth/index.md
+++ b/files/en-us/web/api/element/clientwidth/index.md
@@ -32,10 +32,6 @@ A number.
 
 {{Specifications}}
 
-### Notes
-
-`clientWidth` was first introduced in the MS IE DHTML object model.
-
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/element/getclientrects/index.md
+++ b/files/en-us/web/api/element/getclientrects/index.md
@@ -259,10 +259,6 @@ function addClientRectsOverlay(elt) {
 
 {{Specifications}}
 
-### Notes
-
-`getClientRects()` was first introduced in the MS IE DHTML object model.
-
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -29,7 +29,7 @@ handlers are called and return before `dispatchEvent()` returns.
 dispatchEvent(event)
 ```
 
-### Parameter
+### Parameters
 
 - `event`
   - : The {{domxref("Event")}} object to dispatch. Its {{domxref("Event.target")}} property will be set to the current {{domxref("EventTarget")}}.

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
@@ -19,7 +19,7 @@ method of the {{DOMxRef("FeaturePolicy")}} interface enables querying of the all
 getAllowlistForFeature(feature)
 ```
 
-### Parameter
+### Parameters
 
 - `feature`
   - : The specific feature name to get its allowlist.

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -44,15 +44,15 @@ To write content to file, create a FileWriter object by calling [`createWriter()
 
 Creates a new `FileWriter` associated with the file that the `FileEntry` represents.
 
-```webidl
-void createWriter();
+```js-nolint
+createWriter()
 ```
 
-#### Parameter
+#### Parameters
 
 None.
 
-#### Returns
+#### Return value
 
 A `FileWriterSync` object.
 
@@ -69,15 +69,15 @@ This method can raise a [DOMException](/en-US/docs/Web/API/DOMException) with th
 
 Returns a File that represents the current state of the file that this `FileEntry` represents.
 
-```webidl
-void file();
+```js-nolint
+file()
 ```
 
-#### Parameter
+#### Parameters
 
 None.
 
-#### Returns
+#### Return value
 
 A `File` object.
 

--- a/files/en-us/web/api/htmlelement/offsetheight/index.md
+++ b/files/en-us/web/api/htmlelement/offsetheight/index.md
@@ -44,12 +44,6 @@ scrollable container.
 
 {{Specifications}}
 
-### Notes
-
-`offsetHeight` is a property of the DHTML object model which was first
-introduced by MSIE. It is sometimes referred to as an element's physical/graphical
-dimensions, or an element's border-box height.
-
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/htmlelement/offsetwidth/index.md
+++ b/files/en-us/web/api/htmlelement/offsetwidth/index.md
@@ -35,12 +35,6 @@ An integer corresponding to the `offsetWidth` pixel value of the element. The `o
 
 {{Specifications}}
 
-### Notes
-
-`offsetWidth` is a property of the DHTML object model which was first
-introduced by MSIE. It is sometimes referred to as an element's physical/graphical
-dimensions, or an element's border-box width.
-
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/inputdevicecapabilities/firestouchevents/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities/firestouchevents/index.md
@@ -23,7 +23,7 @@ touch events on mobile browsers.
 const boolean = InputDeviceCapabilities.firesTouchEvents
 ```
 
-### Returns
+### Return value
 
 A {{jsxref('Boolean')}}
 

--- a/files/en-us/web/api/inputdevicecapabilities/inputdevicecapabilities/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities/inputdevicecapabilities/index.md
@@ -21,10 +21,6 @@ new InputDeviceCapabilities()
 new InputDeviceCapabilities(InputDeviceCapabilitiesInit)
 ```
 
-### Returns
-
-An instance of the {{domxref("InputDeviceCapabilities")}} interface.
-
 ### Parameters
 
 - `InputDeviceCapabilitiesInit` {{optional_inline}}
@@ -34,6 +30,10 @@ An instance of the {{domxref("InputDeviceCapabilities")}} interface.
 
     - `fireTouchEvents`: A boolean value that indicates
       whether the device dispatches touch events.
+
+### Return value
+
+An instance of the {{domxref("InputDeviceCapabilities")}} interface.
 
 ## Specifications
 

--- a/files/en-us/web/api/storagemanager/persisted/index.md
+++ b/files/en-us/web/api/storagemanager/persisted/index.md
@@ -20,7 +20,7 @@ persisted()
 
 None.
 
-### Returns
+### Return value
 
 A {{jsxref('Promise')}} that resolves to a {{jsxref('Boolean')}}.
 

--- a/files/en-us/web/css/acos/index.md
+++ b/files/en-us/web/css/acos/index.md
@@ -21,7 +21,7 @@ transform: rotate(acos(pi / 5));
 transform: rotate(acos(e / 3));
 ```
 
-### Parameter
+### Parameters
 
 The `acos(number)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/asin/index.md
+++ b/files/en-us/web/css/asin/index.md
@@ -21,7 +21,7 @@ transform: rotate(asin(pi / 5));
 transform: rotate(asin(e / 3));
 ```
 
-### Parameter
+### Parameters
 
 The `asin(number)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/atan/index.md
+++ b/files/en-us/web/css/atan/index.md
@@ -21,7 +21,7 @@ transform: rotate(atan(pi / 2));
 transform: rotate(atan(e * 3));
 ```
 
-### Parameter
+### Parameters
 
 The `atan(number)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/cos/index.md
+++ b/files/en-us/web/css/cos/index.md
@@ -26,7 +26,7 @@ width: calc(100px * cos(pi));
 width: calc(100px * cos(e / 2));
 ```
 
-### Parameter
+### Parameters
 
 The `cos(angle)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/css_media_queries/using_media_queries_for_accessibility/index.md
+++ b/files/en-us/web/css/css_media_queries/using_media_queries_for_accessibility/index.md
@@ -10,11 +10,9 @@ page-type: guide
 
 ## Reduced Motion
 
-Blinking and flashing animation can be problematic for people with cognitive concerns such as Attention Deficit Hyperactivity Disorder (ADHD). Additionally, certain kinds of motion can be a trigger for Vestibular disorders, epilepsy, and migraine and Scotopic sensitivity. The [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query enables providing an experience with fewer animations and transitions to users who have set their operating system's accessibility preferences to reduce motion.
+Blinking and flashing animation can be problematic for people with cognitive concerns such as Attention Deficit Hyperactivity Disorder (ADHD). Additionally, certain kinds of motion can be a trigger for Vestibular disorders, epilepsy, and migraine and Scotopic sensitivity. Reducing animations or switching animation off completely based on the user's preference can also benefit users with low battery or low-end devices.
 
-Reducing animations or switching animation off completely based on the user's preference can also benefit users with low battery or low-end devices.
-
-### Syntax
+The [`prefers-reduced-motion`](/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query enables providing an experience with fewer animations and transitions to users who have set their operating system's accessibility preferences to reduce motion. It has two possible values:
 
 - `no-preference`
   - : Indicates that the user has made no preference known to the system.

--- a/files/en-us/web/css/exp/index.md
+++ b/files/en-us/web/css/exp/index.md
@@ -22,7 +22,7 @@ width: calc(100px * exp(0)); /* 100px * 1 = 100px */
 width: calc(100px * exp(1)); /* 100px * 2.718281828459045 = 217px */
 ```
 
-### Parameter
+### Parameters
 
 The `exp(number)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/mod/index.md
+++ b/files/en-us/web/css/mod/index.md
@@ -38,7 +38,7 @@ rotate: mod(10turn, 18turn / 3); /* 4turn */
 transition-duration: mod(20s / 2, 3000ms * 2); /* 4s */
 ```
 
-### Parameter
+### Parameters
 
 The `mod(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or {{cssxref("percentage")}}, for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
 

--- a/files/en-us/web/css/rem/index.md
+++ b/files/en-us/web/css/rem/index.md
@@ -38,7 +38,7 @@ rotate: rem(10turn, 18turn / 3); /* 4turn */
 transition-duration: rem(20s / 2, 3000ms * 2); /* 4s */
 ```
 
-### Parameter
+### Parameters
 
 The `rem(dividend, divisor)` function accepts two comma-separated values as its parameters. Both parameters must have the same type, [number](/en-US/docs/Web/CSS/number), [dimension](/en-US/docs/Web/CSS/dimension), or {{cssxref("percentage")}}, for the function to be valid. While the units in the two parameters don't need to be the same, they do need of the same dimension type, such as {{cssxref("length")}}, {{cssxref("angle")}}, {{cssxref("time")}}, or {{cssxref("frequency")}} to be valid.
 

--- a/files/en-us/web/css/round/index.md
+++ b/files/en-us/web/css/round/index.md
@@ -20,7 +20,7 @@ width: round(down, var(--height), var(--interval));
 margin: round(to-zero, -105px, 10px);
 ```
 
-### Parameter
+### Parameters
 
 The `round(<rounding-strategy>, valueToRound, roundingInterval)` function specifies an optional rounding strategy, a value (or mathematical expression) to be rounded and a rounding interval (or mathematical expression).
 The `valueToRound` is rounded according to the rounding strategy, to the nearest integer multiple of `roundingInterval`.

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -26,7 +26,7 @@ width: calc(100px * sin(pi / 2));
 width: calc(100px * sin(e / 4));
 ```
 
-### Parameter
+### Parameters
 
 The `sin(angle)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/css/tan/index.md
+++ b/files/en-us/web/css/tan/index.md
@@ -26,7 +26,7 @@ width: calc(100px * tan(pi / 3));
 width: calc(100px * tan(e));
 ```
 
-### Parameter
+### Parameters
 
 The `tan(angle)` function accepts only one value as its parameter.
 

--- a/files/en-us/web/exslt/exsl/node-set/index.md
+++ b/files/en-us/web/exslt/exsl/node-set/index.md
@@ -21,7 +21,7 @@ exsl:node-set(object)
 - `object`
   - : The object for which to return the corresponding node-set.
 
-### Returns
+### Return value
 
 The node-set corresponding to the specified `object`.
 

--- a/files/en-us/web/exslt/exsl/object-type/index.md
+++ b/files/en-us/web/exslt/exsl/object-type/index.md
@@ -21,7 +21,7 @@ exsl:object-type(object)
 - `object`
   - : The object whose type is to be returned.
 
-### Returns
+### Return value
 
 The object's type, which will be one of the following:
 

--- a/files/en-us/web/exslt/math/highest/index.md
+++ b/files/en-us/web/exslt/math/highest/index.md
@@ -21,7 +21,7 @@ math:highest(nodeSet)
 - `nodeSet`
   - : The node-set whose highest value is to be returned.
 
-### Returns
+### Return value
 
 A result tree fragment consisting of copies of the nodes returned by [`math:max()`](/en-US/docs/Web/EXSLT/math/max).
 

--- a/files/en-us/web/exslt/math/lowest/index.md
+++ b/files/en-us/web/exslt/math/lowest/index.md
@@ -21,7 +21,7 @@ math:lowest(nodeSet)
 - `nodeSet`
   - : The node-set whose lowest value is to be returned.
 
-### Returns
+### Return value
 
 A result tree fragment consisting of copies of the nodes returned by [`math:min()`](/en-US/docs/Web/EXSLT/math/min).
 

--- a/files/en-us/web/exslt/math/max/index.md
+++ b/files/en-us/web/exslt/math/max/index.md
@@ -21,7 +21,7 @@ math:max(nodeSet)
 - `nodeSet`
   - : The node-set whose highest value is to be returned.
 
-### Returns
+### Return value
 
 A result tree fragment representing the highest valued node's numeric value as a string.
 

--- a/files/en-us/web/exslt/math/min/index.md
+++ b/files/en-us/web/exslt/math/min/index.md
@@ -21,7 +21,7 @@ math:min(nodeSet)
 - `nodeSet`
   - : The node-set whose lowest value is to be returned.
 
-### Returns
+### Return value
 
 A result tree fragment representing the lowest valued node's numeric value as a string.
 

--- a/files/en-us/web/exslt/regexp/match/index.md
+++ b/files/en-us/web/exslt/regexp/match/index.md
@@ -30,7 +30,7 @@ The character flags are:
 - `i`
   - : Case insensitive match. If this flag is specified, the match is performed in a case insensitive fashion.
 
-### Returns
+### Return value
 
 A node set of `match` elements, each of which has the string value equal to a portion of the first parameter string as captured by the regular expression. If the match isn't a global one, the first match element has the value of the portion of the string matched by the entire regular expression.
 

--- a/files/en-us/web/exslt/regexp/replace/index.md
+++ b/files/en-us/web/exslt/regexp/replace/index.md
@@ -32,7 +32,7 @@ The character flags are:
 - `i` - Case insensitive match
   - : If this flag is specified, the match is performed in a case insensitive fashion.
 
-### Returns
+### Return value
 
 The revised version of the string.
 

--- a/files/en-us/web/exslt/regexp/test/index.md
+++ b/files/en-us/web/exslt/regexp/test/index.md
@@ -30,7 +30,7 @@ The character flags are:
 - `i`
   - : Case insensitive match<. If this flag is specified, the match is performed in a case insensitive fashion.
 
-### Returns
+### Return value
 
 `true` if the specified regexp matches the test string.
 

--- a/files/en-us/web/exslt/set/difference/index.md
+++ b/files/en-us/web/exslt/set/difference/index.md
@@ -23,7 +23,7 @@ set:difference(nodeSet1, nodeSet2)
 - `nodeSet2`
   - : The set of nodes to subtract from `nodeSet1`.
 
-### Returns
+### Return value
 
 A node-set containing the nodes that are in `nodeSet1` but not in `nodeSet2`.
 

--- a/files/en-us/web/exslt/set/distinct/index.md
+++ b/files/en-us/web/exslt/set/distinct/index.md
@@ -19,7 +19,7 @@ set:distinct(nodeSet)
 - `nodeSet`
   - : The node-set in which to find unique nodes.
 
-### Returns
+### Return value
 
 A node-set containing the nodes that have unique string values.
 

--- a/files/en-us/web/exslt/set/has-same-node/index.md
+++ b/files/en-us/web/exslt/set/has-same-node/index.md
@@ -21,7 +21,7 @@ set:has-same-node(nodeSet1, nodeSet2)
 - `nodeSet2`
   - : The second node set to check.
 
-### Returns
+### Return value
 
 `true` if the two node-sets have any nodes in common; otherwise `false`.
 

--- a/files/en-us/web/exslt/set/intersection/index.md
+++ b/files/en-us/web/exslt/set/intersection/index.md
@@ -14,14 +14,14 @@ page-type: exslt-function
 set:intersection(nodeSet1, nodeSet2)
 ```
 
-### Arguments
+### Parameters
 
 - `nodeSet1`
   - : The first node-set.
 - `nodeSet2`
   - : The second node-set.
 
-### Returns
+### Return value
 
 A node-set containing the nodes that existed in both `nodeSet1` and in `nodeSet2`.
 

--- a/files/en-us/web/exslt/set/leading/index.md
+++ b/files/en-us/web/exslt/set/leading/index.md
@@ -21,7 +21,7 @@ set:leading(nodeSet1, nodeSet2)
 - `nodeSet2`
   - : The node set to compare against.
 
-### Returns
+### Return value
 
 A node-set containing the nodes from `nodeSet1` whose values precede the first node in `nodeSet2`.
 

--- a/files/en-us/web/exslt/set/trailing/index.md
+++ b/files/en-us/web/exslt/set/trailing/index.md
@@ -21,7 +21,7 @@ set:trailing(nodeSet1, nodeSet2)
 - `nodeSet2`
   - : The node set to compare against.
 
-### Returns
+### Return value
 
 A node-set containing the nodes from `nodeSet1` whose values follow the first node in `nodeSet2`.
 

--- a/files/en-us/web/exslt/str/concat/index.md
+++ b/files/en-us/web/exslt/str/concat/index.md
@@ -19,7 +19,7 @@ str:concat(nodeSet)
 - `nodeSet`
   - : The node-set whose nodes' string values should be concatenated into one string.
 
-### Returns
+### Return value
 
 A string whose value is all the string values of the nodes in `nodeSet` concatenated together. If `nodeSet` is empty, an empty string is returned.
 

--- a/files/en-us/web/exslt/str/split/index.md
+++ b/files/en-us/web/exslt/str/split/index.md
@@ -21,7 +21,7 @@ str:split(string, pattern)
 - `pattern`
   - : The pattern indicating where to split the string.
 
-### Returns
+### Return value
 
 A node-set of `token` elements, each containing one token from the `string`.
 

--- a/files/en-us/web/exslt/str/tokenize/index.md
+++ b/files/en-us/web/exslt/str/tokenize/index.md
@@ -21,7 +21,7 @@ str:tokenize(string, delimiters)
 - `delimiters`
   - : Each character in this string is used as a word separator while tokenizing.
 
-### Returns
+### Return value
 
 A node-set of `token` elements, each containing one token from the `string`.
 

--- a/files/en-us/web/html/attributes/max/index.md
+++ b/files/en-us/web/html/attributes/max/index.md
@@ -16,7 +16,7 @@ Valid for the numeric input types, including the {{HTMLElement("input/date", "da
 
 If the value exceeds the max value allowed, the {{domxref('validityState.rangeOverflow')}} will be true, and the control will be matched by the {{cssxref(':out-of-range')}} and {{cssxref(':invalid')}} pseudo-classes.
 
-### Syntax
+## Syntax
 
 <table class="no-markdown">
   <caption>

--- a/files/en-us/web/html/attributes/min/index.md
+++ b/files/en-us/web/html/attributes/min/index.md
@@ -15,7 +15,7 @@ Some input types have a default minimum. If the input has no default minimum and
 
 It is valid for the input types including: {{HTMLElement("input/date", "date")}}, {{HTMLElement("input/month", "month")}}, {{HTMLElement("input/week", "week")}}, {{HTMLElement("input/time", "time")}}, {{HTMLElement("input/datetime-local", "datetime-local")}}, {{HTMLElement("input/number", "number")}} and {{HTMLElement("input/range", "range")}} types, and the {{htmlelement('meter')}} element.
 
-### Syntax
+## Syntax
 
 <table class="no-markdown">
   <caption>


### PR DESCRIPTION
Following up from https://github.com/mdn/content/pull/34331, I've identified a few other pages whose syntax sections are a bit off. This aligns them with the convention.