### PR TITLE
Update support for installing non-PWA sites 

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -110,8 +110,8 @@ Support for PWA installation promotion from the web varies by browser and by pla
 
 On desktop:
 
-- Firefox and Safari do not support installing PWAs on any desktop operating systems. See [Installing sites as apps](#installing_sites_as_apps), below.
-- Chrome and Edge support installing PWAs on Linux, Windows, macOS, and Chromebooks.
+- Chrome, Edge & Safari support installing PWAs on all supported desktop operating systems.
+- Firefox only supports installing PWAs on desktop with an [unofficial extension](https://addons.mozilla.org/en-US/firefox/addon/pwas-for-firefox/).
 
 On mobile:
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -110,8 +110,8 @@ Support for PWA installation promotion from the web varies by browser and by pla
 
 On desktop:
 
-- Chrome, Edge & Safari support installing PWAs on all supported desktop operating systems.
-- Firefox only supports installing PWAs on desktop with an [unofficial extension](https://addons.mozilla.org/en-US/firefox/addon/pwas-for-firefox/).
+- Chromium browsers support installing PWAs that have a manifest file on all supported desktop operating systems.
+- Firefox and Safari do not support installing PWAs using a manifest file.
 
 On mobile:
 
@@ -121,7 +121,8 @@ On mobile:
 
 ### Installing sites as apps
 
-Chrome for desktop and Android, Safari for desktop, and Edge for desktop also support installing any website as an app. However, this is not specific to PWA because the site doesn't need to meet the installability criteria described in this guide, and because the browser doesn't proactively promote the site for installation.
+Chrome for desktop and Android, Safari for desktop, and Edge for desktop also support users installing any website as an app, whether or not it has a manifest file, and without regard to the installability criteria for the manifest file.
+The benefit of using a manifest file is that the browser will actively promote the site for installation when it is visited, and developers can customize installation behavior.
 
 ### Triggering the install prompt
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -121,7 +121,7 @@ On mobile:
 
 ### Installing sites as apps
 
-Chrome, Safari, all iOS browsers since iOS 16.4, and Edge for desktop also support installing any website as an app. However, this is not specific to PWA because the site doesn't need to meet the installability criteria described in this guide, and because the browser doesn't proactively promote the site for installation.
+Chrome for desktop and Android, Safari for desktop, and Edge for desktop also support installing any website as an app. However, this is not specific to PWA because the site doesn't need to meet the installability criteria described in this guide, and because the browser doesn't proactively promote the site for installation.
 
 ### Triggering the install prompt
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -121,7 +121,7 @@ On mobile:
 
 ### Installing sites as apps
 
-Safari for desktop and mobile, and Edge for desktop also support installing any website as an app. However, this is not specific to PWA because the site doesn't need to meet the installability criteria described in this guide, and because the browser doesn't proactively promote the site for installation.
+Chrome, Safari, all iOS browsers since iOS 16.4, and Edge for desktop also support installing any website as an app. However, this is not specific to PWA because the site doesn't need to meet the installability criteria described in this guide, and because the browser doesn't proactively promote the site for installation.
 
 ### Triggering the install prompt
 


### PR DESCRIPTION
As of [124](https://developer.chrome.com/release-notes/124), Chrome now supports installing any site as an app. See [here](https://x.com/Leopeva64/status/1765698342191780066) as well. 

In my testing this works on both desktop and mobile. On desktop the wording is "install site as app" rather than "install [site name in manifest]", but otherwise works the same. On mobile the install pop-up has a more generic "install app" title and UI rather than the rich install UI of a PWA (which can be with/without screenshots), but it still creates a webAPK that functions like a PWA.
![Screenshot_20240621-235441](https://github.com/mdn/content/assets/36278229/04f35f2c-ea06-4a3c-a6b0-fb5b489be161)
![Screenshot_20240621-235459](https://github.com/mdn/content/assets/36278229/c1f46300-1fa6-4d1d-85ba-70a991b473f8)

Interestingly unlike a PWA it has a Chrome bar at the top a bit like if it were in an-app browser, but other than that it seems to act the same.
![Screenshot_20240621-235427](https://github.com/mdn/content/assets/36278229/95bd960c-92da-4869-b810-27050d9d804b)

I tested in Edge to double check, but trying to add a non-PWA site to the homescreen just creates a bookmark that launches the site in Edge, which was the old behaviour of Chrome before they made this change.

<strike>I've also updated the text for iOS browsers as I believe that all iOS browsers support installing sites as apps given it's part of the system share menu and a feature of WKWebView which they all use. Certainly all the ones I've tried (Firefox, Chrome, Edge, possibly more) do.</strike>