### PR TITLE
fix: `Reflect.construct()` docs erroneously referenced `Reflect.apply()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/construct/index.md
@@ -38,7 +38,7 @@ A new instance of `target` (or `newTarget`, if present), initialized by `target`
 
 ## Description
 
-`Reflect.apply()` provides the reflective semantic of a constructor call. That is, `Reflect.construct(target, argumentsList, newTarget)` is semantically equivalent to:
+`Reflect.construct()` provides the reflective semantic of a constructor call. That is, `Reflect.construct(target, argumentsList, newTarget)` is semantically equivalent to:
 
 ```js
 new target(...argumentsList);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

[The MDN page for `Reflect.construct()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct) erroneously refers to `Reflect.apply()` in this sentence:

> Reflect.apply() provides the reflective semantic of a constructor call. That is, Reflect.construct(target, argumentsList, newTarget) is semantically equivalent to [...]

This sentence is describing `Reflect.construct()`, not `Reflect.apply()`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change ensures accuracy and consistency across the Reflect docs. (I double-checked the other Reflect methods, and they're all correct. This is the only one I saw with a mistaken reference to `Reflect.apply()`.)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

No further details! If there's anything else y'all need, please let me know :+1: 

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
