### PR TITLE
chore: remove the references to `Accept-CH-Lifetime`

### DIFF
--- a/files/en-us/web/http/content_negotiation/index.md
+++ b/files/en-us/web/http/content_negotiation/index.md
@@ -57,12 +57,6 @@ The experimental {{HTTPHeader("Accept-CH")}} lists configuration data that the s
 | `Viewport-Width` | Indicates the layout viewport width in CSS pixels.                                                                                                                                                                 |
 | `Width`          | Indicates the resource width in physical pixels (in other words the intrinsic size of an image).                                                                                                                   |
 
-### The `Accept-CH-Lifetime` header
-
-> **Note:** This is part of an **experimental** technology called _Client Hints_ and is only available in Chrome 61 or later.
-
-The {{HTTPHeader("Accept-CH-Lifetime")}} header is used with the `Device-Memory` value of the `Accept-CH` header and indicates the amount of time the device should opt in to sharing the device memory with the server. The value is given in milliseconds and it's optional.
-
 ### The `Accept-Encoding` header
 
 The {{HTTPHeader("Accept-Encoding")}} header defines the acceptable content encoding (supported compressions). The value is a q-factor list (e.g., `br, gzip;q=0.8`) that indicates the priority of the encoding values. The default value `identity` is at the lowest priority (unless otherwise noted).

--- a/files/en-us/web/http/headers/accept-ch/index.md
+++ b/files/en-us/web/http/headers/accept-ch/index.md
@@ -7,9 +7,7 @@ browser-compat: http.headers.Accept-CH
 
 {{HTTPSidebar}}{{securecontext_header}}
 
-The **`Accept-CH`** header may be set by a server to specify
-which [client hints](/en-US/docs/Web/HTTP/Client_hints) headers a client
-should include in subsequent requests.
+The **`Accept-CH`** header may be set by a server to specify which [client hints](/en-US/docs/Web/HTTP/Client_hints) headers a client should include in subsequent requests.
 
 <table class="properties">
   <tbody>
@@ -30,8 +28,7 @@ should include in subsequent requests.
   </tbody>
 </table>
 
-> **Note:** Client hints are accessible only on secure origins (via TLS).
-> `Accept-CH` (and `Accept-CH-Lifetime`) headers should be persisted for all secure requests to ensure client hints are sent reliably.
+> **Note:** Client hints are accessible only on secure origins (via TLS). The `Accept-CH` header should be persisted for all secure requests to ensure client hints are sent reliably.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

emove the references to `Accept-CH-Lifetime`

### Motivation

We've removed the documentation of `Accept-CH-Lifetime` in #34313.
