### PR TITLE
Correct syntax rules for <ident>

### DIFF
--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -2,7 +2,7 @@
 title: <ident>
 slug: Web/CSS/ident
 page-type: css-type
-spec-urls: https://drafts.csswg.org/css-values/#css-identifier
+spec-urls: https://drafts.csswg.org/css-values/#typedef-ident
 ---
 
 {{CSSRef}}
@@ -13,11 +13,11 @@ The **`<ident>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS
 
 A CSS identifier consists of one or more characters, which can be any of the following:
 
-- any ASCII character in the ranges `A-Z` and `a-z`
+- any {{glossary("ASCII")}} character in the ranges `A-Z` and `a-z`
 - any decimal digit (`0` to `9`)
 - a hyphen (`-`)
 - an underscore (`_`)
-- any other Unicode character `U+00A0` and higher (that is, any other non-ASCII Unicode character)
+- any other {{glossary("Unicode")}} character `U+00A0` and higher (that is, any other non-ASCII Unicode character)
 - an [escaped character](escaping_characters)
 
 Additionally, an identifier must not start with an unescaped digit, and must not start with an unescaped hyphen followed by an unescaped digit.
@@ -26,39 +26,39 @@ Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers because th
 
 ### Escaping characters
 
-You can escape a character by adding a backslash (\) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
+Escaping a character means representing it in a way that changes the way it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
 
 You can also escape any character with a backslash followed by the character's Unicode {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
 
-- a space or other whitespace character must be placed after the Unicode code point, or:
-- the Unicode code point must be given in full, with all six digits.
+- Place a space or other whitespace character after the Unicode code point.
+- Provide the full six-digit Unicode code point of the character being escaped.
 
-For example, the string `&123` can be escaped as `\26 123` (with a whitespace) or `\000026123` (with the six-digit Unicode code point of `&`) to ensure that `123` is not considered as part of the escape pattern.
+For example, the string `&123` can be escaped as `\26 123` (with a whitespace) or `\000026123` (with the six-digit Unicode code point for `&`) to ensure that `123` is not considered as part of the escape pattern.
 
 ## Examples
 
 ### Valid identifiers
 
 ```plain example-good
-nono79        A mix of alphanumeric characters and numbers
-ground-level  A mix of alphanumeric characters and a dash
+nono79        /* A mix of alphanumeric characters and numbers */
+ground-level  /* A mix of alphanumeric characters and a dash */
 -test         /* A hyphen followed by alphanumeric characters */
---toto        A custom-property like identifier
-_internal     An underscore followed by alphanumeric characters
-\22 toto      An escaped character followed by a sequence of alphanumeric characters
+--toto        /* A custom-property like identifier */
+_internal     /* An underscore followed by alphanumeric characters */
+\22 toto      /* An escaped character followed by alphanumeric characters */
 \000022toto   /* Same as the previous example */
-bili\.bob     A correctly escaped period
-🔥123         A non-ASCII character followed by numbers
+bili\.bob     /* A correctly escaped period */
+🔥123         /* A non-ASCII character followed by numbers */
 ```
 
 ### Invalid identifiers
 
 ```plain example-bad
 34rem     /* Must not start with a decimal digit */
--12rad    It must not start with a dash followed by a decimal digit.
-bili.bob  ASCII characters apart from alphanumerics must be escaped.
+-12rad    /* Must not start with a dash followed by a decimal digit */
+bili.bob  /* ASCII characters apart from alphanumerics must be escaped */
 'bilibob' /* Treated as a string */
-"bilibob" This would be a {{CSSxRef("&lt;string&gt;")}}.
+"bilibob" /* Treated as a string */
 ```
 
 ## Specifications

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -26,7 +26,7 @@ Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers because th
 
 ### Escaping characters
 
-Escaping a character means representing it in a way that changes the way it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
+Escaping a character means representing it in a way that changes how it is interpreted by a software system. In CSS, you can escape a character by adding a backslash (`\`) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
 
 You can also escape any character with a backslash followed by the character's Unicode {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
 

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -13,7 +13,7 @@ The **`<ident>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS
 
 A CSS identifier consists of one or more characters, where characters can be any of the following:
 
-- any ASCII character `A-Z` and `a-z`
+- any ASCII character in the ranges `A-Z` and `a-z`
 - any decimal digit (`0` to `9`)
 - a hyphen (`-`)
 - an underscore (`_`)

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -18,22 +18,22 @@ A CSS identifier consists of one or more characters, which can be any of the fol
 - a hyphen (`-`)
 - an underscore (`_`)
 - any other Unicode character `U+00A0` and higher (that is, any other non-ASCII Unicode character)
-- an [escaped character](escaping_characters).
+- an [escaped character](escaping_characters)
 
 Additionally, an identifier must not start with an unescaped digit, and must not start with an unescaped hyphen followed by an unescaped digit.
 
-Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers as they are [case-sensitive](https://en.wikipedia.org/wiki/Case_sensitivity). On the other hand, as there are several ways to escape a character, `toto\?` and `toto\3F` are the same identifiers.
+Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers because they are [case-sensitive](https://en.wikipedia.org/wiki/Case_sensitivity). On the other hand, since there are several ways to escape a character, `toto\?` and `toto\3F` are the same identifiers.
 
 ### Escaping characters
 
-Any character except a hexadecimal digit (`[0-9a-fA-F]`) can be escaped by placing a backslash in front of it. For example, `&` can be escaped as `\&`.
+You can escape a character by adding a backslash (\) in front of the character. Any character, except the hexadecimal digits `0-9`, `a-f`, and `A-F`, can be escaped in this way. For example, `&` can be escaped as `\&`.
 
-Any character can be escaped with a backslash followed by followed by one to six hexadecimal digits, representing the character's Unicode {{glossary("code point")}}. For example, `&` can be escaped as `\26`. In this situation, if the character following the escaped character is a hexadecimal digit, then either:
+You can also escape any character with a backslash followed by the character's Unicode {{glossary("code point")}} represented by one to six hexadecimal digits. For example, `&` can be escaped as `\26`. In this usage, if the escaped character is followed by a hexadecimal digit, do one of the following:
 
 - a space or other whitespace character must be placed after the Unicode code point, or:
 - the Unicode code point must be given in full, with all six digits.
 
-For example, the string `&123` could be escaped as `\26 123` or `\000026123`.
+For example, the string `&123` can be escaped as `\26 123` (with a whitespace) or `\000026123` (with the six-digit Unicode code point of `&`) to ensure that `123` is not considered as part of the escape pattern.
 
 ## Examples
 
@@ -42,11 +42,11 @@ For example, the string `&123` could be escaped as `\26 123` or `\000026123`.
 ```plain example-good
 nono79        A mix of alphanumeric characters and numbers
 ground-level  A mix of alphanumeric characters and a dash
--test         A dash followed by alphanumeric characters
+-test         /* A hyphen followed by alphanumeric characters */
 --toto        A custom-property like identifier
 _internal     An underscore followed by alphanumeric characters
 \22 toto      An escaped character followed by a sequence of alphanumeric characters
-\000022toto   The same as the previous example
+\000022toto   /* Same as the previous example */
 bili\.bob     A correctly escaped period
 🔥123         A non-ASCII character followed by numbers
 ```
@@ -54,10 +54,10 @@ bili\.bob     A correctly escaped period
 ### Invalid identifiers
 
 ```plain example-bad
-34rem     It must not start with a decimal digit.
+34rem     /* Must not start with a decimal digit */
 -12rad    It must not start with a dash followed by a decimal digit.
 bili.bob  ASCII characters apart from alphanumerics must be escaped.
-'bilibob' This would be a {{CSSxRef("&lt;string&gt;")}}.
+'bilibob' /* Treated as a string */
 "bilibob" This would be a {{CSSxRef("&lt;string&gt;")}}.
 ```
 

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -11,16 +11,29 @@ The **`<ident>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS
 
 ## Syntax
 
-The syntax of `<custom-ident>` is similar to CSS identifiers (such as property names), except that it is [case-sensitive](https://en.wikipedia.org/wiki/Case_sensitivity). It consists of one or more characters, where characters can be any of the following:
+A CSS identifier consists of one or more characters, where characters can be any of the following:
 
-- any alphabetical character (`A` to `Z`, or `a` to `z`),
-- any decimal digit (`0` to `9`),
-- a hyphen (`-`),
-- an underscore (`_`),
-- an escaped character (preceded by a backslash, `\`),
-- a [Unicode](https://en.wikipedia.org/wiki/Unicode) character (in the format of a backslash, `\`, followed by one to six hexadecimal digits, representing its Unicode code point)
+- any ASCII character `A-Z` and `a-z`
+- any decimal digit (`0` to `9`)
+- a hyphen (`-`)
+- an underscore (`_`)
+- any other Unicode character `U+00A0` and higher (that is, any other non-ASCII Unicode character)
+- an [escaped character](escaping_characters).
+
+Additionally, an identifier must not start with an unescaped digit, and must not start with an unescaped hyphen followed by an unescaped digit.
 
 Note that `id1`, `Id1`, `iD1` and `ID1` are all different identifiers as they are [case-sensitive](https://en.wikipedia.org/wiki/Case_sensitivity). On the other hand, as there are several ways to escape a character, `toto\?` and `toto\3F` are the same identifiers.
+
+### Escaping characters
+
+Any character except a hexadecimal digit (`[0-9a-fA-F]`) can be escaped by placing a backslash in front of it. For example, `&` can be escaped as `\&`.
+
+Any character can be escaped with a backslash followed by followed by one to six hexadecimal digits, representing the character's Unicode {{glossary("code point")}}. For example, `&` can be escaped as `\26`. In this situation, if the character following the escaped character is a hexadecimal digit, then either:
+
+- a space or other whitespace character must be placed after the Unicode code point, or:
+- the Unicode code point must be given in full, with all six digits.
+
+For example, the string `&123` could be escaped as `\26 123` or `\000026123`.
 
 ## Examples
 
@@ -32,8 +45,10 @@ ground-level  A mix of alphanumeric characters and a dash
 -test         A dash followed by alphanumeric characters
 --toto        A custom-property like identifier
 _internal     An underscore followed by alphanumeric characters
-\22 toto      A Unicode character followed by a sequence of alphanumeric characters
+\22 toto      An escaped character followed by a sequence of alphanumeric characters
+\000022toto   The same as the previous example
 bili\.bob     A correctly escaped period
+🔥123         A non-ASCII character followed by numbers
 ```
 
 ### Invalid identifiers
@@ -41,7 +56,7 @@ bili\.bob     A correctly escaped period
 ```plain example-bad
 34rem     It must not start with a decimal digit.
 -12rad    It must not start with a dash followed by a decimal digit.
-bili.bob  Only alphanumeric characters, _, and - needn't be escaped.
+bili.bob  ASCII characters apart from alphanumerics must be escaped.
 'bilibob' This would be a {{CSSxRef("&lt;string&gt;")}}.
 "bilibob" This would be a {{CSSxRef("&lt;string&gt;")}}.
 ```

--- a/files/en-us/web/css/ident/index.md
+++ b/files/en-us/web/css/ident/index.md
@@ -11,7 +11,7 @@ The **`<ident>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS
 
 ## Syntax
 
-A CSS identifier consists of one or more characters, where characters can be any of the following:
+A CSS identifier consists of one or more characters, which can be any of the following:
 
 - any ASCII character in the ranges `A-Z` and `a-z`
 - any decimal digit (`0` to `9`)


### PR DESCRIPTION
This is supposed to be the first bit of a fix for https://github.com/mdn/content/issues/28752. I want to have somewhere to document the rules for CSS identifiers, and I'm hoping https://developer.mozilla.org/en-US/docs/Web/CSS/ident is a reasonable place.

I _believe_ the description there is wrong, in particular that it says you can't have unescaped non-ASCII Unicode characters, which I think you can.

So this is basically part 1 of https://github.com/mdn/content/issues/28752#issuecomment-1707035191, and next steps would be parts 2, 3, and 4. But let's get the definition clear and in the right place first.

One thing I'm uncertain about - I follow the spec in saying that (for example) `&123` can be escaped like `\&123`, but actually, the string <strike>(and the output of `CSS.escape()`)</strike> is `\\&123` I guess because you have to escape the backslash itself in the string. We should probably say that because it's quite confusing.
