### PR TITLE
fix(css): add missing values of -moz-osx-font-smoothing

### DIFF
--- a/files/en-us/web/css/font-smooth/index.md
+++ b/files/en-us/web/css/font-smooth/index.md
@@ -41,6 +41,8 @@ font-smooth: unset;
 >
 > - `auto` - Allow the browser to select an optimization for font smoothing, typically `grayscale`.
 > - `grayscale` - Render text with grayscale anti-aliasing, as opposed to the subpixel. Switching from subpixel rendering to anti-aliasing for light text on dark backgrounds makes it look lighter.
+> - `inherit` - Inherits value of this property from its parent element.
+> - `unset` - Resets the property to its inherited value.
 
 ## Formal definition
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/25138

As requested, the PR adds additional values `inherit` and `unset` that are mentioned on https://caniuse.com/font-smooth page.