### PR TITLE
Update PWA required manifest members

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -66,7 +66,7 @@ Chromium-based browsers, including Google Chrome, Samsung Internet, and Microsof
 - [`icons`](/en-US/docs/Web/Manifest/icons) - must contain a 192px and a 512px icon
 - [`start_url`](/en-US/docs/Web/Manifest/start_url)
 - [`display`](/en-US/docs/Web/Manifest/display) and/or [`display_override`](/en-US/docs/Web/Manifest/display_override)
-- [`prefer-related-application`](/en-US/docs/Web/Manifest/prefer_related_applications) must be false or not present
+- [`prefer-related-application`](/en-US/docs/Web/Manifest/prefer_related_applications) - must be false or not present
 
 For a full description of every member, see the [web app manifest reference documentation](/en-US/docs/Web/Manifest).
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -62,10 +62,11 @@ The manifest contains a single JSON object containing a collection of members, e
 
 Chromium-based browsers, including Google Chrome, Samsung Internet, and Microsoft Edge, require that the manifest includes the following members:
 
-- [`name`](/en-US/docs/Web/Manifest/name)
-- [`icons`](/en-US/docs/Web/Manifest/icons)
+- [`name`](/en-US/docs/Web/Manifest/name) or [`short_name`](/en-US/docs/Web/Manifest/short_name)
+- [`icons`](/en-US/docs/Web/Manifest/icons) - must contain a 192px and a 512px icon
 - [`start_url`](/en-US/docs/Web/Manifest/start_url)
 - [`display`](/en-US/docs/Web/Manifest/display) and/or [`display_override`](/en-US/docs/Web/Manifest/display_override)
+- [`prefer-related-application`](/en-US/docs/Web/Manifest/prefer_related_applications) must be false or not present
 
 For a full description of every member, see the [web app manifest reference documentation](/en-US/docs/Web/Manifest).
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -63,10 +63,10 @@ The manifest contains a single JSON object containing a collection of members, e
 Chromium-based browsers, including Google Chrome, Samsung Internet, and Microsoft Edge, require that the manifest includes the following members:
 
 - [`name`](/en-US/docs/Web/Manifest/name) or [`short_name`](/en-US/docs/Web/Manifest/short_name)
-- [`icons`](/en-US/docs/Web/Manifest/icons) - must contain a 192px and a 512px icon
+- [`icons`](/en-US/docs/Web/Manifest/icons) must contain a 192px and a 512px icon
 - [`start_url`](/en-US/docs/Web/Manifest/start_url)
 - [`display`](/en-US/docs/Web/Manifest/display) and/or [`display_override`](/en-US/docs/Web/Manifest/display_override)
-- [`prefer-related-application`](/en-US/docs/Web/Manifest/prefer_related_applications) - must be false or not present
+- [`prefer-related-application`](/en-US/docs/Web/Manifest/prefer_related_applications) must be `false` or not present
 
 For a full description of every member, see the [web app manifest reference documentation](/en-US/docs/Web/Manifest).
 


### PR DESCRIPTION
The PWA installability [required manifest](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability) section for Chromium-based browsers was missing a few things that are mentioned on the [web.dev article](https://web.dev/articles/install-criteria) and do seem to be needed in my testing