### PR TITLE
Corrected attribute reference that was ambiguous due to bad formatting

### DIFF
--- a/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -76,6 +76,7 @@ Inside the `<map>` element, we need {{htmlelement('area')}} elements. An `<area>
 `<area>` elements are {{glossary("void element", "void elements")}}, but do require four attributes:
 
 - [`shape`](/en-US/docs/Web/HTML/Element/area#shape)
+
   - : `shape` takes one of four values: `circle`, `rect`, `poly`, and `default`. An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined. If there is any overlap between the defined areas, the source order determines which area takes preference. The shape you choose determines the coordinate information you'll need to provide in `coords`.
 
   [`coords`](/en-US/docs/Web/HTML/Element/area#coords)

--- a/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -76,8 +76,7 @@ Inside the `<map>` element, we need {{htmlelement('area')}} elements. An `<area>
 `<area>` elements are {{glossary("void element", "void elements")}}, but do require four attributes:
 
 - [`shape`](/en-US/docs/Web/HTML/Element/area#shape)
-
-  - : `shape` takes one of four values: `circle`, `rect`, `poly`, and `default`. An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined. If there is any overlap between the defined areas, the source order determines which area takes preference. The shape you choose determines the coordinate information you'll need to provide in `coords`.
+  - : The `shape` attribute takes one of four values: `circle`, `rect`, `poly`, and `default`. An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined. If there is any overlap between the defined areas, the source order determines which area takes preference. The shape you choose determines the coordinate information you'll need to provide in `coords`.
 
   [`coords`](/en-US/docs/Web/HTML/Element/area#coords)
 

--- a/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -14,22 +14,13 @@ Here we go over how to set up an image map, and some downsides to consider first
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        You should already know how to
-        <a href="/en-US/docs/Learn/Getting_started_with_the_web"
-          >create a basic HTML document</a
-        >
-        and how to
-        <a
-          href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML#how_do_we_put_an_image_on_a_webpage"
-          >add accessible images to a webpage.</a
-        >
+        You should already know how to <a href="/en-US/docs/Learn/Getting_started_with_the_web">create a basic HTML document</a> and how to <a href="/en-US/docs/Learn/HTML/Multimedia_and_embedding/Images_in_HTML#how_do_we_put_an_image_on_a_webpage">add accessible images to a webpage.</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        Learn how to make different regions of one image link to different
-        pages.
+        Learn how to make different regions of one image link to different pages.
       </td>
     </tr>
   </tbody>
@@ -76,9 +67,12 @@ Inside the `<map>` element, we need {{htmlelement('area')}} elements. An `<area>
 `<area>` elements are {{glossary("void element", "void elements")}}, but do require four attributes:
 
 - [`shape`](/en-US/docs/Web/HTML/Element/area#shape)
-  - : The `shape` attribute takes one of four values: `circle`, `rect`, `poly`, and `default`. An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined. If there is any overlap between the defined areas, the source order determines which area takes preference. The shape you choose determines the coordinate information you'll need to provide in `coords`.
 
-  [`coords`](/en-US/docs/Web/HTML/Element/area#coords)
+  - : The `shape` attribute takes one of four values: `circle`, `rect`, `poly`, and `default`. An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined.
+    If there is any overlap between the defined areas, the source order determines which area takes preference.
+    The shape you choose determines the coordinate information you'll need to provide in `coords`.
+
+- [`coords`](/en-US/docs/Web/HTML/Element/area#coords)
 
   - : Coordinates are given in CSS pixels, and its value is dependent on the `shape` selected.
 
@@ -87,6 +81,7 @@ Inside the `<map>` element, we need {{htmlelement('area')}} elements. An `<area>
     - For a polygon, to provide the x and y coordinates of each corner (so, at least six values).
 
 - [`href`](/en-US/docs/Web/HTML/Element/area#href)
+
   - : The URL of the resource you're linking to. You may leave this attribute blank if you _don't_ want the current area to link anywhere (say, if you're making a hollow circle.)
 
 - [`alt`](/en-US/docs/Web/HTML/Element/area#alt)

--- a/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
+++ b/files/en-us/learn/html/howto/add_a_hit_map_on_top_of_an_image/index.md
@@ -76,21 +76,19 @@ Inside the `<map>` element, we need {{htmlelement('area')}} elements. An `<area>
 `<area>` elements are {{glossary("void element", "void elements")}}, but do require four attributes:
 
 - [`shape`](/en-US/docs/Web/HTML/Element/area#shape)
+  - : `shape` takes one of four values: `circle`, `rect`, `poly`, and `default`. An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined. If there is any overlap between the defined areas, the source order determines which area takes preference. The shape you choose determines the coordinate information you'll need to provide in `coords`.
 
   [`coords`](/en-US/docs/Web/HTML/Element/area#coords)
 
-  - : `shape` takes one of four values: `circle`, `rect`, `poly`, and `default`. (An `<area>` whose `shape` is `default` occupies the entire image, minus any other hotspots you've defined.) The shape you choose determines the coordinate information you'll need to provide in `coords`.
+  - : Coordinates are given in CSS pixels, and its value is dependent on the `shape` selected.
 
     - For a circle, provide the center's x and y coordinates, followed by the length of the radius.
-    - For a rectangle, provide the x/y coordinates of the upper-left and bottom-right corners.
-    - For a polygon, to provide the x/y coordinates of each corner (so, at least six values).
-
-    Coordinates are given in CSS pixels.
-
-    In case of overlap, source order carries the day.
+    - For a rectangle, provide the x and y coordinates of the upper-left and bottom-right corners.
+    - For a polygon, to provide the x and y coordinates of each corner (so, at least six values).
 
 - [`href`](/en-US/docs/Web/HTML/Element/area#href)
   - : The URL of the resource you're linking to. You may leave this attribute blank if you _don't_ want the current area to link anywhere (say, if you're making a hollow circle.)
+
 - [`alt`](/en-US/docs/Web/HTML/Element/area#alt)
 
   - : A mandatory attribute, telling people where the link goes or what it does. `alt` text only displays when the image is unavailable. Please refer to our [guidelines for writing accessible link text.](/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks#writing_accessible_link_text)

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -240,7 +240,7 @@ The example includes the bare essentials needed to use an `<iframe>`:
 - [`border: none`](/en-US/docs/Web/CSS/border)
   - : If used, the `<iframe>` is displayed without a surrounding border. Otherwise, by default, browsers display the `<iframe>` with a surrounding border (which is generally undesirable).
 - [`allowfullscreen`](/en-US/docs/Web/HTML/Element/iframe#allowfullscreen)
-  - : If set, the `<iframe>` is able to be placed in fullscreen mode using the [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API) (somewhat beyond the scope of this article.)
+  - : If set, the `<iframe>` is able to be placed in fullscreen mode using the [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API) (somewhat beyond the scope of this article).
 - [`src`](/en-US/docs/Web/HTML/Element/iframe#src)
   - : This attribute, as with {{htmlelement("video")}}/{{htmlelement("img")}}, contains a path pointing to the URL of the document to be embedded.
 - [`width`](/en-US/docs/Web/HTML/Element/iframe#width) and [`height`](/en-US/docs/Web/HTML/Element/iframe#height)

--- a/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/video_and_audio_content/index.md
@@ -60,7 +60,7 @@ The {{htmlelement("video")}} element allows you to embed a video very easily. A 
 </video>
 ```
 
-The features of note are:
+The features to note are:
 
 - [`src`](/en-US/docs/Web/HTML/Element/video#src)
   - : In the same way as for the {{htmlelement("img")}} element, the `src` (source) attribute contains a path to the video you want to embed. It works in exactly the same way.


### PR DESCRIPTION
### Description

- Corrected attribute reference for `<area>` element on the page: [Add a hitmap on top of an image](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image#step_2_activate_your_hotspots).
- Fixed small grammatical/formatting mistakes

### Motivation

The description for the attributes `shape` and `coords` of the `<area>` element as described on the page: [Add a hitmap on top of an image](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image#step_2_activate_your_hotspots) was badly formatted which made it look as if the `shape` attribute had no description.

### Additional details

N/A

### Related issues and pull requests

N/A