### PR TITLE
fix: remove duplicate note that

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -29,8 +29,6 @@ The `mixed` value is not supported on [`radio`](/en-US/docs/Web/Accessibility/AR
 <label id="chk15-label">Subscribe to the newsletter</label>
 ```
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
-
 The `tabindex` attribute is required to enable focus. JavaScript is required to toggle the `aria-checked` state. And, if this checkbox is part of a submittable form, more JavaScript is required to set a name and a value.
 
 The above could have been written as:


### PR DESCRIPTION
remove duplicate `note that`, which is same with line 14.https://github.com/mdn/content/blob/8373c7f5ba4d3b32381b4fb57002c6bfe634d140/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md?plain=1#L14

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
