### PR TITLE
Correct the example of rel=me

### DIFF
--- a/files/en-us/web/html/attributes/rel/me/index.md
+++ b/files/en-us/web/html/attributes/rel/me/index.md
@@ -10,7 +10,7 @@ browser-compat: html.elements.link.rel.me
 The **`me`** keyword for the [`rel`](/en-US/docs/Web/HTML/Element/link#rel) attribute of the {{HTMLElement("link")}} and {{HTMLElement("a")}} elements indicates that the current resource is represented by the linked party. The `me` value was introduced in the [XHTML Friends Network (XFN) specification](https://gmpg.org/xfn/).
 
 ```html
-<link rel="me" value="example.com" />
+<link rel="me" href="example.com" />
 ```
 
 The `rel="me"` attribute is used in [RelMeAuth](https://microformats.org/wiki/RelMeAuth) and [Web sign in](https://microformats.org/wiki/web-sign-in) specifications as a way to enable a person to identify themselves to a web service using their domain name or a particular URL.


### PR DESCRIPTION
According to W3C standard <https://www.w3.org/TR/2011/WD-html5-author-20110809/the-link-element.html>, there's no `value` attribute. Instead, use the proper `href` attribute in the example.
