### PR TITLE
replace link to yari-demos.prod.mdn.mozit.cloud with LiveSampleLink macro

### DIFF
--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -66,7 +66,7 @@ window.onresize = reportWindowSize;
 
 > **Note:** The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
 >
-> The effect is easier to see if you {{LiveSampleLink('Window_size_logger', "view the example in its own window")}}.
+> The effect is easier to see if you {{LiveSampleLink("Window_size_logger", "view the example in its own window")}}.
 
 ### addEventListener equivalent
 

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -66,7 +66,7 @@ window.onresize = reportWindowSize;
 
 > **Note:** The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
 >
-> The effect is easier to see if you [view the example in its own window](https://yari-demos.prod.mdn.mozit.cloud/en-US/docs/Web/API/Window/resize_event/_sample_.window_size_logger.html).
+> The effect is easier to see if you [view the example in its own window]({{LiveSampleLink('Window_size_logger', 'Live sample demo link')}}).
 
 ### addEventListener equivalent
 

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -66,7 +66,7 @@ window.onresize = reportWindowSize;
 
 > **Note:** The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
 >
-> The effect is easier to see if you [view the example in its own window]({{LiveSampleLink('Window_size_logger', 'Live sample demo link')}}).
+> The effect is easier to see if you [view the example in its own window]({{LiveSampleLink('Window_size_logger', "Live sample demo link")}}).
 
 ### addEventListener equivalent
 

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -66,7 +66,7 @@ window.onresize = reportWindowSize;
 
 > **Note:** The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
 >
-> The effect is easier to see if you {{LiveSampleLink("Window_size_logger", "view the example in its own window")}}.
+> The effect is easier to see if you {{LiveSampleLink('Window_size_logger', "view the example in its own window")}}.
 
 ### addEventListener equivalent
 

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -66,7 +66,7 @@ window.onresize = reportWindowSize;
 
 > **Note:** The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
 >
-> The effect is easier to see if you [view the example in its own window]({{LiveSampleLink('Window_size_logger', "Live sample demo link")}}).
+> The effect is easier to see if you {{LiveSampleLink("Window_size_logger", "view the example in its own window")}}.
 
 ### addEventListener equivalent
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

The window size logger link should be replaced with the LiveSampleLink macro

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #34326 " -->
<!-- 👉 Highlight related pull requests using "Relates to #34326 " -->


https://github.com/mdn/content/issues/34326
