### PR TITLE
Createimagebitmap fix

### DIFF
--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -51,12 +51,12 @@ createImageBitmap(image, sx, sy, sw, sh, options)
 
       - : Specifies how the bitmap image should be oriented.
 
-        - `none`
-          - : Image oriented according to image encoding, ignoring any metadata about the orientation (such as EXIF metadata, that might be added to an image to indicate that the camera was turned sideways to capture the image in portrait mode).
         - `from-image`
-          - : Image oriented according to EXIF orientation metadata, if present. This is the default.
+          - : Image oriented according to EXIF orientation metadata, if present (default).
         - `flipY`
           - : Image oriented according to EXIF orientation metadata, if present, and then flipped vertically.
+        - `none`
+          - : Image oriented according to image encoding, ignoring any metadata about the orientation (such as EXIF metadata, that might be added to an image to indicate that the camera was turned sideways to capture the image in portrait mode).
 
     - `premultiplyAlpha`
       - : Specifies whether the bitmap's color channels should be premultiplied by the alpha channel.

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -49,12 +49,14 @@ createImageBitmap(image, sx, sy, sw, sh, options)
 
     - `imageOrientation`
 
-      - : Specifies how the image should be emplaced.
+      - : Specifies how the bitmap image should be oriented.
 
+        - `none`
+          - : Image oriented according to image encoding, ignoring any metadata about the orientation (such as EXIF metadata, that might be added to an image to indicate that the camera was turned sideways to capture the image in portrait mode).
         - `from-image`
-          - : Default value. The image is presented as it is.
+          - : Image oriented according to EXIF orientation metadata, if present. This is the default.
         - `flipY`
-          - : The image is flipped vertically.
+          - : Image oriented according to EXIF orientation metadata, if present, and then flipped vertically.
 
     - `premultiplyAlpha`
       - : Specifies whether the bitmap's color channels should be premultiplied by the alpha channel.

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -8,11 +8,9 @@ browser-compat: api.createImageBitmap
 
 {{APIRef("Canvas API")}}{{AvailableInWorkers}}
 
-The **`createImageBitmap()`** method creates a bitmap from a
-given source, optionally cropped to contain only a portion of that source. The method
-exists on the global scope in both windows and workers. It accepts a variety of
-different image sources, and returns a {{jsxref("Promise")}} which resolves to an
-{{domxref("ImageBitmap")}}.
+The **`createImageBitmap()`** global method creates a bitmap from a given source, optionally cropped to contain only a portion of that source.
+The method exists on the global scope in both windows and workers.
+It accepts a variety of different image sources, and returns a {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}}.
 
 ## Syntax
 
@@ -36,20 +34,18 @@ createImageBitmap(image, sx, sy, sw, sh, options)
     - {{domxref("ImageBitmap")}}
     - {{domxref("OffscreenCanvas")}}
 - `sx`
-  - : The x coordinate of the reference point of the rectangle from which the
-    `ImageBitmap` will be extracted.
+  - : The x coordinate of the reference point of the rectangle from which the `ImageBitmap` will be extracted.
 - `sy`
-  - : The y coordinate of the reference point of the rectangle from which the
-    `ImageBitmap` will be extracted.
+  - : The y coordinate of the reference point of the rectangle from which the `ImageBitmap` will be extracted.
 - `sw`
-  - : The width of the rectangle from which the `ImageBitmap` will be
-    extracted. This value can be negative.
+  - : The width of the rectangle from which the `ImageBitmap` will be extracted.
+    This value can be negative.
 - `sh`
-  - : The height of the rectangle from which the `ImageBitmap` will be
-    extracted. This value can be negative.
+  - : The height of the rectangle from which the `ImageBitmap` will be extracted. This value can be negative.
 - `options` {{optional_inline}}
 
-  - : An object that sets options for the image's extraction. The available options are:
+  - : An object that sets options for the image's extraction.
+    The available options are:
 
     - `imageOrientation`
 
@@ -61,27 +57,23 @@ createImageBitmap(image, sx, sy, sw, sh, options)
           - : The image is flipped vertically.
 
     - `premultiplyAlpha`
-      - : Specifies whether the bitmap's color channels
-        should be premultiplied by the alpha channel. One of `none`,
-        `premultiply`, or `default` (default).
+      - : Specifies whether the bitmap's color channels should be premultiplied by the alpha channel.
+        One of `none`, `premultiply`, or `default` (default).
     - `colorSpaceConversion`
-      - : Specifies whether the image should be decoded
-        using color space conversion. Either `none` or `default`
-        (default). The value `default` indicates that implementation-specific
-        behavior is used.
+      - : Specifies whether the image should be decoded using color space conversion.
+        Either `none` or `default` (default).
+        The value `default` indicates that implementation-specific behavior is used.
     - `resizeWidth`
       - : A long integer that indicates the output width.
     - `resizeHeight`
       - : A long integer that indicates the output height.
     - `resizeQuality`
-      - : Specifies the algorithm to be used for resizing the
-        input to match the output dimensions. One of `pixelated`,
-        `low` (default), `medium`, or `high`.
+      - : Specifies the algorithm to be used for resizing the input to match the output dimensions.
+        One of `pixelated`, `low` (default), `medium`, or `high`.
 
 ### Return value
 
-A {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}} object
-containing bitmap data from the given rectangle.
+A {{jsxref("Promise")}} which resolves to an {{domxref("ImageBitmap")}} object containing bitmap data from the given rectangle.
 
 ## Examples
 


### PR DESCRIPTION
The [`createImageBitmap()`](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap) method, `imageOrientation` parameter is going through a bit of a messy change, and work is being done to hide this from end users.

Previously it had two options `none` and `flipY`, where `none` respected the EXIF orientation data you might get in the image if the camera was turned sideways to take a portrait shot. However this contradicted the definition of CSS [`image-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation) where `none` means "use the raw encoded data" and `from-image` means "use the EXIF data".

Research shows little use of `none` so what the spec authors have done is renamed  `none`  to `from-image`. They _plan_ to also bring back `none`, matching the meaning of the CSS equivalent. This is not yet in spec, but is done by `deno`.
It's all a bit of a mess, but I am following the lead of the spec authors here and documenting AS though `none` never existed. 

Note that the spec says that `flipY` for this method not based on EXIF data. According to https://github.com/whatwg/html/issues/8085#issuecomment-2204696312 this is a spec bug, as all the browser vendors have agreed that it does.

Fixes #24857

Related docs work can be tracked in #23564

