### PR TITLE
FF111 Relnote - imageOrientation value renamed from none to from-image

### DIFF
--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -43,6 +43,8 @@ No notable changes.
   See [Firefox bug 1785123](https://bugzil.la/1785123) for more details.
 - The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) header is removed from [`fetch()`](/en-US/docs/Web/API/fetch) and [`XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) requests that are redirected cross-origin (`fetch()` headers may be added by developers using the [`option.headers`](/en-US/docs/Web/API/fetch#headers) argument).
   See [Firefox bug 1802086](https://bugzil.la/1802086) for more details.
+- The `none` value of the `options.imageOrientation` parameter passed to [`createImageBitmap()`](/en-US/docs/Web/API/createImageBitmap) has been renamed to [`from-image`](/en-US/docs/Web/API/createImageBitmap#from-image).
+  This is to better match the meaning of the equivalent CSS [`image-orientation`](/en-US/docs/Web/CSS/image-orientation) property. ([Firefox bug 1809740](https://bugzil.la/1809740)).
 
 #### DOM
 


### PR DESCRIPTION
FF111 renamed the `options.imageOrientation` parameter value passed to [`createImageBitmap()`](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap) from `none` to `from-image`. This just adds a release note.
Related docs work can be tracked in #23564