### PR TITLE
FF128 Request.bytes(), Response.bytes()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -46,6 +46,7 @@ This article provides information about the changes in Firefox 128 that affect d
 ### APIs
 
 - {{domxref('RTCRtpReceiver.getParameters()')}} and {{domxref('RTCRtpSender.getParameters()')}} are now supported, returning an object that describes the current codecs used for the encoding and transmission of media on the receiver and sender tracks, respectively. ([Firefox bug 1534687](https://bugzil.la/1534687)).
+- {{domxref("Request.bytes()")}} and {{domxref("Response.bytes()")}} are now supported as a convenient way to get a {{jsxref("Uint8Array")}} from a {{domxref("Request")}} and {{domxref("Response")}}, respectively. ([Firefox bug 1896475](https://bugzil.la/1896475)).
 - {{domxref("PushMessageData.bytes()")}} is now supported for returning the data from a push message as an array of bytes in a {{jsxref("Uint8Array")}} object. ([Firefox bug 1897871](https://bugzil.la/1897871)).
 - {{domxref('Blob.bytes()')}} is supported for returning the data from a {{domxref('Blob')}} as an array of bytes in a {{jsxref("Uint8Array")}} object. ([Firefox bug 1896509](https://bugzil.la/1896509)).
 - {{domxref('MediaKeys.getStatusForPolicy()')}} is now supported for checking whether the CDM module, which is used to decrypt DRM protected content, would allow the presentation of encrypted media data for a "hypothetical" key based on specified policy requirements such as the [High-bandwidth Digital Content Protection (HDCP)](https://en.wikipedia.org/wiki/High-bandwidth_Digital_Content_Protection) version supported by the system.

--- a/files/en-us/web/api/request/bytes/index.md
+++ b/files/en-us/web/api/request/bytes/index.md
@@ -1,0 +1,52 @@
+---
+title: "Request: bytes() method"
+short-title: bytes()
+slug: Web/API/Request/bytes
+page-type: web-api-instance-method
+browser-compat: api.Request.bytes
+---
+
+{{APIRef("Fetch API")}}
+
+The **`bytes()`** method of the {{domxref("Request")}} interface reads the request body and returns it as a promise that resolves with an {{jsxref("Uint8Array")}}.
+
+## Syntax
+
+```js-nolint
+bytes()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A promise that resolves with an {{jsxref("Uint8Array")}}.
+
+## Examples
+
+```js
+const myArray = new Uint8Array(10);
+
+const request = new Request("/myEndpoint", {
+  method: "POST",
+  body: myArray,
+});
+
+request.bytes().then((buffer) => {
+  // do something with the buffer sent in the request
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Response.arrayBuffer()")}}

--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -53,6 +53,8 @@ You can create a new `Request` object using the {{domxref("Request.Request","Req
   - : Returns a promise that resolves with an {{jsxref("ArrayBuffer")}} representation of the request body.
 - {{domxref("Request.blob()")}}
   - : Returns a promise that resolves with a {{domxref("Blob")}} representation of the request body.
+- {{domxref("Request.bytes()")}}
+  - : Returns a promise that resolves with a {{jsxref("Uint8Array")}} representation of the request body.
 - {{domxref("Request.clone()")}}
   - : Creates a copy of the current `Request` object.
 - {{domxref("Request.formData()")}}

--- a/files/en-us/web/api/response/bytes/index.md
+++ b/files/en-us/web/api/response/bytes/index.md
@@ -1,0 +1,61 @@
+---
+title: "Response: bytes() method"
+short-title: bytes()
+slug: Web/API/Response/bytes
+page-type: web-api-instance-method
+browser-compat: api.Response.bytes
+---
+
+{{APIRef("Fetch API")}}
+
+The **`bytes()`** method of the {{domxref("Response")}} interface takes a {{domxref("Response")}} stream and reads it to completion.
+It returns a promise that resolves with a {{jsxref("Uint8Array")}}.
+
+## Syntax
+
+```js-nolint
+bytes()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A promise that resolves with an {{jsxref("Uint8Array")}}.
+
+### Exceptions
+
+- `TypeError`
+  - : The response body has already been read from, or the associated stream is locked or has been cancelled.
+- `RangeError`
+  - : There is a problem creating the associated `ArrayBuffer`.
+    For example, if the data size is more than [`Number.MAX_SAFE_INTEGER`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
+
+## Examples
+
+### Fetching and decoding a file
+
+The code below shows how you might fetch a text file, return the body as a {{jsxref("Uint8Array")}}, and then decode this into a string.
+
+```js
+const response = await fetch("https://www.example.com/textfile.txt");
+const textFile = await response.bytes();
+const string = new TextDecoder().decode(textFile);
+console.log(string);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API)
+- [HTTP access control (CORS)](/en-US/docs/Web/HTTP/CORS)
+- [HTTP](/en-US/docs/Web/HTTP)

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -52,6 +52,8 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
   - : Returns a promise that resolves with an {{jsxref("ArrayBuffer")}} representation of the response body.
 - {{domxref("Response.blob()")}}
   - : Returns a promise that resolves with a {{domxref("Blob")}} representation of the response body.
+- {{domxref("Response.bytes()")}}
+  - : Returns a promise that resolves with a {{jsxref("Uint8Array")}} representation of the response body.
 - {{domxref("Response.clone()")}}
   - : Creates a clone of a `Response` object.
 - {{domxref("Response.formData()")}}


### PR DESCRIPTION
FF128 adds support for `Requests.bytes()` and `Response.bytes()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1896475

This contains docs for the two methods and a release note.

related docs can be tracked in #33984