### PR TITLE
Relected that HTTP was updated again in 2022 with RFC 9110

### DIFF
--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -142,7 +142,7 @@ HTTP/1.1 was first published as {{rfc(2068)}} in January 1997.
 
 ## More than 15 years of extensions
 
-The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years.
+The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two major revisions, RFC 2616 published in June 1999, and RFC 7230-RFC 7235 published in June 2014, it remained extremely stable for more than 15 years. HTTP was further updated in 2022 with RFC 9110.
 
 ### Using HTTP for secure transmissions
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updated the documentation to reflect that HTTP was updated in 2022 with RFC 9110.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The previous documentation did not include the most recent update to HTTP, which occurred in 2022 with RFC 9110. This update is important for providing readers with the most current information regarding the HTTP protocol.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- [RFC 9110 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html)
- [HTTP/1.1 Overview](https://httpwg.org/specs/rfc9110.html)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
#34374
