### PR TITLE
Reflected that HTTP was updated again in 2022 with RFC 9110

### DIFF
--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -302,7 +302,7 @@ const person2 = {
 };
 ```
 
-In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case. 
+In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case.
 
 This isn't hugely useful when you are writing out object literals by hand, but it will be essential when we start using **constructors** to create more than one object from a single object definition, and that's the subject of the next section.
 

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -302,7 +302,6 @@ const person2 = {
 };
 ```
 
-
 In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case. This isn't hugely useful when you are writing out object literals by hand, but it will be essential when we start using **constructors** to create more than one object from a single object definition, and that's the subject of the next section.
 
 ## Introducing constructors

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -302,9 +302,8 @@ const person2 = {
 };
 ```
 
-In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case.
 
-This isn't hugely useful when you are writing out object literals by hand, but it will be essential when we start using **constructors** to create more than one object from a single object definition, and that's the subject of the next section.
+In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case. This isn't hugely useful when you are writing out object literals by hand, but it will be essential when we start using **constructors** to create more than one object from a single object definition, and that's the subject of the next section.
 
 ## Introducing constructors
 

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -302,7 +302,9 @@ const person2 = {
 };
 ```
 
-In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case. This isn't hugely useful when you are writing out object literals by hand, but it will be essential when we start using **constructors** to create more than one object from a single object definition, and that's the subject of the next section.
+In this case, `person1.introduceSelf()` outputs "Hi! I'm Chris."; `person2.introduceSelf()` on the other hand outputs "Hi! I'm Deepti.", even though the method's code is exactly the same in each case. 
+
+This isn't hugely useful when you are writing out object literals by hand, but it will be essential when we start using **constructors** to create more than one object from a single object definition, and that's the subject of the next section.
 
 ## Introducing constructors
 

--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -142,7 +142,7 @@ HTTP/1.1 was first published as {{rfc(2068)}} in January 1997.
 
 ## More than 15 years of extensions
 
-The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years.
+The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years. HTTP/1.1 was updated again in 2022 with {{RFC("9110")}}.
 
 ### Using HTTP for secure transmissions
 

--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -142,7 +142,7 @@ HTTP/1.1 was first published as {{rfc(2068)}} in January 1997.
 
 ## More than 15 years of extensions
 
-The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years. HTTP/1.1 was updated again in 2022 with {{RFC("9110")}}.
+The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years. Not only was HTTP/1.1 updated, but all of HTTP was revised and is now split into the following documents: semantics ({{RFC("9110")}}), caching ({{RFC("9111")}}) applying to all HTTP versions, and HTTP/1.1 ({{RFC("9112")}}), HTTP/2 ({{RFC("9113")}}), and HTTP/3 ({{RFC("9114")}}). In addition, the specification finally achieved the status of Internet Standard (STD 97), whereas before it was always a proposed/draft standard.
 
 ### Using HTTP for secure transmissions
 

--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -142,7 +142,7 @@ HTTP/1.1 was first published as {{rfc(2068)}} in January 1997.
 
 ## More than 15 years of extensions
 
-The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years. Not only was HTTP/1.1 updated, but all of HTTP was revised and is now split into the following documents: semantics ({{RFC("9110")}}), caching ({{RFC("9111")}}) applying to all HTTP versions, and HTTP/1.1 ({{RFC("9112")}}), HTTP/2 ({{RFC("9113")}}), and HTTP/3 ({{RFC("9114")}}). In addition, the specification finally achieved the status of Internet Standard (STD 97), whereas before it was always a proposed/draft standard.
+The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years. HTTP/1.1 was updated again in 2022 with {{RFC("9110")}}. Not only was HTTP/1.1 updated, but all of HTTP was revised and is now split into the following documents: semantics ({{RFC("9110")}}), caching ({{RFC("9111")}}) applying to all HTTP versions, and HTTP/1.1 ({{RFC("9112")}}), HTTP/2 ({{RFC("9113")}}), and HTTP/3 ({{RFC("9114")}}). In addition, the specification finally achieved the status of Internet Standard (STD 97), whereas before it was always a proposed/draft standard.
 
 ### Using HTTP for secure transmissions
 

--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -140,7 +140,7 @@ Server: Apache
 
 HTTP/1.1 was first published as {{rfc(2068)}} in January 1997.
 
-## More than 15 years of extensions
+## More than two decades of development
 
 The extensibility of HTTP made it easy to create new headers and methods. Even though the HTTP/1.1 protocol was refined over two revisions, {{RFC("2616")}} published in June 1999 and {{RFC("7230")}}-{{RFC("7235")}} published in June 2014 before the release of HTTP/2, it was extremely stable for more than 15 years. HTTP/1.1 was updated again in 2022 with {{RFC("9110")}}. Not only was HTTP/1.1 updated, but all of HTTP was revised and is now split into the following documents: semantics ({{RFC("9110")}}), caching ({{RFC("9111")}}) applying to all HTTP versions, and HTTP/1.1 ({{RFC("9112")}}), HTTP/2 ({{RFC("9113")}}), and HTTP/3 ({{RFC("9114")}}). In addition, the specification finally achieved the status of Internet Standard (STD 97), whereas before it was always a proposed/draft standard.
 


### PR DESCRIPTION
### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Updated the documentation to reflect that HTTP was updated in 2022 with RFC 9110.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The previous documentation did not include the most recent update to HTTP, which occurred in 2022 with RFC 9110. This update is important for providing readers with the most current information regarding the HTTP protocol.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
- [RFC 9110 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html)
- [HTTP/1.1 Overview](https://httpwg.org/specs/rfc9110.html)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #34374
