### PR TITLE
docs(manifest): Improve `display` member page

### DIFF
--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -7,77 +7,79 @@ browser-compat: html.manifest.display
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>String</code></td>
-    </tr>
-  </tbody>
-</table>
+The `display` manifest member is a string used to specify your preferred display mode for the web application. The display mode determines how much of the browser UI is shown to the user when the app is launched within the context of an operating system. You can choose to show the full browser interface or hide it to provide a more app-like experience.
 
-The `display` member is a string that determines the developers' preferred display mode for the website. The display mode changes how much of browser UI is shown to the user and can range from `browser` (when the full browser window is shown) to `fullscreen` (when the app is fullscreened).
-
-> **Note:** The browser follows a pre-defined fallback chain if it does not support a given mode: `fullscreen` → `standalone` → `minimal-ui` → `browser`, with `browser` being the default value if the `display` member is not specified.
-
-> **Note:** You can selectively apply CSS to your app based on the display mode, using the {{cssxref("@media/display-mode", "display-mode")}} media feature. This can be used to provide a consistent user experience between launching a site from a URL and launching it from a desktop icon.
-
-## Values
-
-The possible values are:
-
-<table class="fullwidth-table standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Display Mode</th>
-      <th scope="col">Description</th>
-      <th scope="col">Fallback Display Mode</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>fullscreen</code></td>
-      <td>
-        All of the available display area is used and no user agent
-        {{Glossary("chrome")}} is shown.
-      </td>
-      <td><code>standalone</code></td>
-    </tr>
-    <tr>
-      <td><code>standalone</code></td>
-      <td>
-        The application will look and feel like a standalone application. This
-        can include the application having a different window, its own icon in
-        the application launcher, etc. In this mode, the user agent will exclude
-        UI elements for controlling navigation, but can include other UI
-        elements such as a status bar.
-      </td>
-      <td><code>minimal-ui</code></td>
-    </tr>
-    <tr>
-      <td><code>minimal-ui</code></td>
-      <td>
-        The application will look and feel like a standalone application, but
-        will have a minimal set of UI elements for controlling navigation. The
-        elements will vary by browser.
-      </td>
-      <td><code>browser</code></td>
-    </tr>
-    <tr>
-      <td><code>browser</code></td>
-      <td>
-        The application opens in a conventional browser tab or new window,
-        depending on the browser and platform. This is the default.
-      </td>
-      <td>(None)</td>
-    </tr>
-  </tbody>
-</table>
-
-## Example
+## Syntax
 
 ```json
 "display": "standalone"
+```
+
+### Values
+
+The possible values include `fullscreen`, `standalone`, `minimal-ui`, and `browser`. If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`. If `display` is not specified, the default value `browser` is used.
+
+- `fullscreen`
+
+  - : Opens the app with browser UI elements hidden and uses the entirety of the available display area. Use this value for apps where fullscreen engagement is crucial and desired. For example, use it for a game app that can take up the entire screen without any browser controls visible, providing a fully immersive gaming experience.
+
+    **Note:** The `fullscreen` value of the manifest's `display` member works separately from the [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API). The `fullscreen` display mode changes the state of the entire browser window to full screen, while the Fullscreen API only makes a specific element within the window go full screen. Therefore, a web app can be in `fullscreen` display mode while {{DOMxRef("Document.fullscreenElement")}} is `null` and {{DOMxRef("Document.fullscreenEnabled")}} is `false`.
+
+- `standalone`
+
+  - : Opens the app to look and feel like a standalone native app. This can include the app having a different window and its own icon in the app launcher. The browser will exclude UI elements such as a URL bar but can still include other UI elements such as the status bar. For example, use it for a task manager app that opens in its own window without the browser's URL bar, while still displaying the device's status bar for battery and notifications, thereby providing an integrated experience.
+
+- `minimal-ui`
+
+  - : Opens the app to look and feel like a standalone app but with a minimal set of UI elements for navigation. The specific elements can vary by browser but typically include navigation controls like back, forward, reload, and possibly a way to view the app's URL. Additionally, the browser may include platform-specific UI elements that provide functionality for sharing and printing content. Use this value for apps where displaying a minimal browser interface is beneficial. For example, use it for a news reading or other general reading apps that show only the essential browser controls like back and reload buttons, providing a cleaner and less distracting interface.
+
+- `browser`
+  - : Opens the app in a conventional browser tab or new window, using the platform-specific convention for opening hyperlinks. Use this value for apps that are designed to be used within a browser context, where full browser functionality is needed. This is the default value if no `display` mode is specified.
+
+## Description
+
+After a browser applies a `display` mode to an {{Glossary("application context")}}, it becomes the default display mode for the top-level browsing context. The browser may override this display mode for security reasons or provide users with a means for switching to another `display` mode.
+
+Use the {{cssxref("@media/display-mode", "display-mode")}} media feature to determine the current `display` mode applied by the browser, which is useful for ensuring your app behaves as expected in different display contexts. Additionally, the `display-mode` media feature allows you to adjust your app's styles based on the `display` mode currently being used. This can help provide a consistent user experience regardless of whether the website is launched from a URL or from a desktop icon.
+
+**Note:** The value of the `display-mode` media feature reflects the actual `display` mode being used, which might differ from the one requested in the manifest's `display`, because the browser might not support the requested mode.
+
+As shown in the code below, you can adjust an app's style depending on the `display-mode` used.
+
+```css
+@media (display-mode: standalone) {
+  body {
+    background-color: #f0f0f0; /* Light grey background for standalone mode */
+  }
+}
+
+@media (display-mode: fullscreen) {
+  body {
+    background-color: #000000; /* Black background for fullscreen mode */
+  }
+}
+```
+
+## Examples
+
+The following example manifest file for the web app named "HackerWeb" defines how the app should appear and behave when installed on a user's device. The `display` member is set to `standalone`, which specifies that the app should open in a separate window without the typical browser UI elements like the URL bar.
+
+```json
+{
+  "name": "HackerWeb",
+  "short_name": "HackerWeb",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "A readable Hacker News app",
+  "icons": [
+    {
+      "src": "images/icons/homescreen192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -7,7 +7,7 @@ browser-compat: html.manifest.display
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `display` manifest member is a string used to specify your preferred display mode for the web application. The display mode determines how much of the browser UI is shown to the user when the app is launched within the context of an operating system. You can choose to show the full browser interface or hide it to provide a more app-like experience.
+The `display` manifest member is used to specify your preferred display mode for the web application. The display mode determines how much of the browser UI is shown to the user when the app is launched within the context of an operating system. You can choose to show the full browser interface or hide it to provide a more app-like experience.
 
 ## Syntax
 
@@ -17,7 +17,7 @@ The `display` manifest member is a string used to specify your preferred display
 
 ### Values
 
-The possible values include `fullscreen`, `standalone`, `minimal-ui`, and `browser`. If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`. If `display` is not specified, the default value `browser` is used.
+The values of the `display` member is a string. The possible values include `fullscreen`, `standalone`, `minimal-ui`, and `browser`. If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`. If `display` is not specified, the default value `browser` is used.
 
 - `fullscreen`
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -17,7 +17,7 @@ The `display` manifest member is used to specify your preferred display mode for
 
 ### Values
 
-The values of the `display` member is a string. The possible values include `fullscreen`, `standalone`, `minimal-ui`, and `browser`. If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`. If `display` is not specified, the default value `browser` is used.
+The value of the `display` member is a string. The possible values include `fullscreen`, `standalone`, `minimal-ui`, and `browser`. If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`. If `display` is not specified, the default value `browser` is used.
 
 - `fullscreen`
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -34,7 +34,7 @@ The value of the `display` member is a string. The possible values include `full
   - : Opens the app to look and feel like a standalone app but with a minimal set of UI elements for navigation. The specific elements can vary by browser but typically include navigation controls like back, forward, reload, and possibly a way to view the app's URL. Additionally, the browser may include platform-specific UI elements that provide functionality for sharing and printing content. Use this value for apps where displaying a minimal browser interface is beneficial. For example, use it for a news reading or other general reading apps that show only the essential browser controls like back and reload buttons, providing a cleaner and less distracting interface.
 
 - `browser`
-  - : Opens the app in a conventional browser tab or new window, using the platform-specific convention for opening hyperlinks. Use this value for apps that are designed to be used within a browser context, where full browser functionality is needed. This is the default value if no `display` mode is specified.
+  - : Opens the app in a conventional browser tab or new window, using the platform-specific convention for opening links. Use this value for apps that are designed to be used within a browser context, where full browser functionality is needed. This is the default value if no `display` mode is specified.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This work is part of improving the web/manifest docs. This PR focuses on the [`display`](https://developer.mozilla.org/en-US/docs/Web/Manifest/display) member page.

A few notable changes done in this PR:
- Formatting/layout changes:
  - Removed the "Type" table from the top of the page. The type can be covered in the Syntax section and does not need a table. (On some other pages like [file_handlers](https://developer.mozilla.org/en-US/docs/Web/Manifest/file_handlers), this Type table overcrowds with technology status banners.)
  - Created a "Syntax" section with a "Values" subsection. Removed the table describing the values, instead added a definition list format for explaining the values.
  - Created a "Description" section to include additional info about the member instead of using "Notes".

- Content improvements:
  - For each value, added an example scenario where the value might be used
  - Removed the two notes at the top of the page and moved them into the "Values" and "Description" sections, respectively.
  - Added two missing caveats from the spec:
     - One about `fullscreen` vs `Fullscreen API`
     - The other about `display-mode` media feature vs `display` manifest member
  - Added a more complete example to show the `display` member in context with other members of the manifest file.

### Motivation

To add more usage examples, update information from spec, make the page compliant with our page templates

### Additional details

- https://w3c.github.io/manifest/#display-member
- https://w3c.github.io/manifest/#display-modes

### Related issues and pull requests

https://github.com/mdn/mdn/issues/560
