### PR TITLE
fix(css): Fix the `display-mode` links in the `@media` feature

### DIFF
--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -82,7 +82,7 @@ Media feature expressions test for their presence or value, and are entirely opt
 - {{cssxref("@media/device-width", "device-width")}}
   - : Width of the rendering surface of the output device. Deprecated in Media Queries Level 4.
 - {{cssxref("@media/display-mode", "display-mode")}}
-  - : The mode in which an application is being displayed: for example [fullscreen](/en-US/docs/Web/API/Fullscreen_API) or [picture-in-picture](/en-US/docs/Web/API/Document_Picture-in-Picture_API) mode.
+  - : The mode in which an application is being displayed: for example, [fullscreen](/en-US/docs/Web/CSS/@media/display-mode#fullscreen) or [picture-in-picture](/en-US/docs/Web/CSS/@media/display-mode#picture-in-picture) mode.
     Added in Media Queries Level 5.
 - {{cssxref("@media/dynamic-range", "dynamic-range")}}
   - : Combination of brightness, contrast ratio, and color depth that are supported by the user agent and the output device. Added in Media Queries Level 5.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `fullscreen` and `picture-in-picture` values of the [`display-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/display-mode#syntax) media feature currently link to their respective API pages.

These links should be updated to point to the correct values of the `display-mode` media feature.

### Motivation

Update links to point to the correct information

### Related issues and pull requests

Related PR about the `display` manifest: https://github.com/mdn/content/pull/34386
