### PR TITLE
Remove mention that requestPort is available in Workers

### DIFF
--- a/files/en-us/web/api/serial/requestport/index.md
+++ b/files/en-us/web/api/serial/requestport/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Serial.requestPort
 ---
 
-{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`Serial.requestPort()`** method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user or rejects if no device was selected.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
This removes the note in https://developer.mozilla.org/en-US/docs/Web/API/Serial/requestPort about this method being available in Workers.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This particular method is only available in Window contexts https://wicg.github.io/serial/#webidl-1469373565
> [[Exposed](https://webidl.spec.whatwg.org/#Exposed)=Window] [Promise](https://webidl.spec.whatwg.org/#idl-promise)<[SerialPort](https://wicg.github.io/serial/#dom-serialport)> [requestPort](https://wicg.github.io/serial/#dom-serial-requestport)(optional ...

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

Given that the rest of the API is indeed available in Workers too it might be a good idea to add a note to this effect, but looking at the various macros I didn't find how this should be worded exactly.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
