### PR TITLE
Replaces HTML entity glossary links/mentions with char reference

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -13,21 +13,13 @@ In this article, we cover the absolute basics of HTML. To get you started, this 
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        <a
-          href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software"
-          >Basic software installed</a
-        >, and basic knowledge of
-        <a
-          href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files"
-          >working with files</a
-        >.
+        <a href="/en-US/docs/Learn/Getting_started_with_the_web/Installing_basic_software">Basic software installed</a>, and basic knowledge of <a href="/en-US/docs/Learn/Getting_started_with_the_web/Dealing_with_files">working with files</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        To gain basic familiarity with HTML, and practice writing a few HTML
-        elements.
+        To gain basic familiarity with HTML, and practice writing a few HTML elements.
       </td>
     </tr>
   </tbody>
@@ -700,11 +692,11 @@ console.log(whitespace);
 //        silly."
 ```
 
-## Entity references: Including special characters in HTML
+## Character references: including special characters in HTML
 
 In HTML, the characters `<`, `>`,`"`,`'`, and `&` are special characters. They are parts of the HTML syntax itself. So how do you include one of these special characters in your text? For example, if you want to use an ampersand or less-than sign, and not have it interpreted as code.
 
-You do this with character references. These are special codes that represent characters, to be used in these exact circumstances. Each character reference starts with an ampersand (&), and ends with a semicolon (;).
+You do this with {{glossary("character reference", "character references")}}. These are special codes that represent characters, to be used in these exact circumstances. Each character reference starts with an ampersand (&), and ends with a semicolon (;).
 
 | Literal character | Character reference equivalent |
 | ----------------- | ------------------------------ |

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -452,7 +452,8 @@ However, if you use one type of quote, you can include the other type of quote _
 </a>
 ```
 
-To use quote marks inside other quote marks of the same type (single quote or double quote), use [HTML entities](#entity_references_including_special_characters_in_html). For example, this will break:
+To use quote marks inside other quote marks of the same type (single quote or double quote), use {{glossary("character reference", "character references")}}.
+For example, this will break:
 
 ```html-nolint example-bad
 <a href="https://www.example.com" title="An "interesting" reference">A link to my example.</a>

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -114,9 +114,9 @@ Use semantic class/ID names, and separate multiple words with hyphens ({{Glossar
 <p class="bigRedBox">Blah blah blah</p>
 ```
 
-## Entity references
+## Character references
 
-Don't use entity references unnecessarily — use the literal character wherever possible (you'll still need to escape characters like angle brackets and quote marks).
+Don't use {{glossary("character reference", "character references")}} unnecessarily — use the literal character wherever possible (you'll still need to escape characters like angle brackets and quote marks).
 
 As an example, you could just write:
 

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -60,7 +60,7 @@ For example, you can erase the entire contents of a document by clearing the con
 document.body.innerHTML = "";
 ```
 
-This example fetches the document's current HTML markup and replaces the `"<"` characters with the HTML entity `"&lt;"`, thereby essentially converting the HTML into raw text.
+This example fetches the document's current HTML markup and replaces the `"<"` characters with the {{glossary("character reference")}} `"&lt;"`, thereby essentially converting the HTML into raw text.
 This is then wrapped in a {{HTMLElement("pre")}} element.
 Then the value of `innerHTML` is changed to this new string.
 As a result, the document contents are replaced with a display of the page's entire source code.

--- a/files/en-us/web/css/string/index.md
+++ b/files/en-us/web/css/string/index.md
@@ -21,7 +21,7 @@ To output new lines, you must escape them with a line feed character such as `\A
 
 However, to get new lines, you must also set the {{cssxref("white-space")}} property to appropriate value.
 
-> **Note:** [HTML entities](/en-US/docs/Glossary/Entity) (such as `&nbsp;` or `&#8212;`) cannot be used in a CSS `<string>`.
+> **Note:** {{glossary("character reference", "Character references")}} (such as `&nbsp;` or `&#8212;`) cannot be used in a CSS `<string>`.
 
 ## Examples
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -13,7 +13,7 @@ By default, `<pre>` is a [block-level](/en-US/docs/Glossary/Block-level_content)
 
 {{EmbedInteractiveExample("pages/tabbed/pre.html", "tabbed-standard")}}
 
-If you have to display reserved characters such as `<`, `>`, `&`, and `"` within the `<pre>` tag, the characters must be escaped using their respective [HTML entity](/en-US/docs/Glossary/Entity).
+If you have to display reserved characters such as `<`, `>`, `&`, and `"` within the `<pre>` tag, the characters must be escaped using their respective {{glossary("character reference", "character references")}}.
 
 `<pre>` elements commonly contain {{HTMLElement("code")}}, {{HTMLElement("samp")}}, and {{HTMLElement("kbd")}} elements, to represent computer code, computer output, and user input, respectively.
 
@@ -165,5 +165,5 @@ if (i &lt; 10 &amp;&amp; i &gt; 0)
 ## See also
 
 - CSS: {{Cssxref('white-space')}}, {{Cssxref('word-break')}}
-- [HTML Entity](/en-US/docs/Glossary/Entity)
+- {{glossary("Character reference")}}
 - Related element: {{HTMLElement("code")}}, {{HTMLElement("samp")}}, {{HTMLElement("kbd")}}

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -41,7 +41,7 @@ A new string representing the provided `uriComponent` encoded as a URI component
 A–Z a–z 0–9 - _ . ! ~ * ' ( )
 ```
 
-Compared to {{jsxref("encodeURI()")}}, `encodeURIComponent()` escapes a larger set of characters. Use `encodeURIComponent()` on user-entered fields from forms {{HTTPMethod("POST")}}'d to the server — this will encode `&` symbols that may inadvertently be generated during data entry for special HTML entities or other characters that require encoding/decoding. For example, if a user writes `Jack & Jill`, without `encodeURIComponent()`, the ampersand could be interpreted on the server as the start of a new field and jeopardize the integrity of the data.
+Compared to {{jsxref("encodeURI()")}}, `encodeURIComponent()` escapes a larger set of characters. Use `encodeURIComponent()` on user-entered fields from forms {{HTTPMethod("POST")}}'d to the server — this will encode `&` symbols that may inadvertently be generated during data entry for {{glossary("character reference", "character references")}} or other characters that require encoding/decoding. For example, if a user writes `Jack & Jill`, without `encodeURIComponent()`, the ampersand could be interpreted on the server as the start of a new field and jeopardize the integrity of the data.
 
 For [`application/x-www-form-urlencoded`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#application/x-www-form-urlencoded-encoding-algorithm), spaces are to be replaced by `+`, so one may wish to follow a `encodeURIComponent()` replacement with an additional replacement of `%20` with `+`.
 

--- a/files/en-us/web/xml/xml_introduction/index.md
+++ b/files/en-us/web/xml/xml_introduction/index.md
@@ -73,7 +73,7 @@ Most browsers offer a debugger that can identify poorly-formed XML documents.
 
 ## Character references
 
-Like HTML, XML offers methods (called {{glossary("character reference", "character references")}}) for referring to some special reserved characters (such as a greater than sign which is used for tags). There are five of these characters that you should know:
+Like HTML, XML offers {{glossary("character reference", "character references")}} for referring to some special reserved characters (such as a greater than sign which is used for tags). There are five of these characters that you should know:
 
 | Entity     | Character | Description                               |
 | ---------- | --------- | ----------------------------------------- |

--- a/files/en-us/web/xml/xml_introduction/index.md
+++ b/files/en-us/web/xml/xml_introduction/index.md
@@ -83,7 +83,7 @@ Like HTML, XML offers methods (called {{glossary("character reference", "charact
 | &amp;quot; | "         | One double-quotation mark                 |
 | &amp;apos; | '         | One apostrophe (or single-quotation mark) |
 
-Even though there are only 5 declared references, more can be added using the document's [Document Type Definition](/en-US/docs/Glossary/Doctype). For example, to create a new `&warning;` entity, you can do this:
+Even though there are only 5 declared character references, or entities, more can be added using the document's [Document Type Definition](/en-US/docs/Glossary/Doctype). For example, to create a new `&warning;` entity, you can do this:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/files/en-us/web/xml/xml_introduction/index.md
+++ b/files/en-us/web/xml/xml_introduction/index.md
@@ -71,9 +71,9 @@ A document that contains an undefined tag is invalid. For example, if we never d
 
 Most browsers offer a debugger that can identify poorly-formed XML documents.
 
-## Entities
+## Character references
 
-Like HTML, XML offers methods (called entities) for referring to some special reserved characters (such as a greater than sign which is used for tags). There are five of these characters that you should know:
+Like HTML, XML offers methods (called {{glossary("character reference", "character references")}}) for referring to some special reserved characters (such as a greater than sign which is used for tags). There are five of these characters that you should know:
 
 | Entity     | Character | Description                               |
 | ---------- | --------- | ----------------------------------------- |
@@ -83,7 +83,7 @@ Like HTML, XML offers methods (called entities) for referring to some special re
 | &amp;quot; | "         | One double-quotation mark                 |
 | &amp;apos; | '         | One apostrophe (or single-quotation mark) |
 
-Even though there are only 5 declared entities, more can be added using the document's [Document Type Definition](/en-US/docs/Glossary/Doctype). For example, to create a new `&warning;` entity, you can do this:
+Even though there are only 5 declared references, more can be added using the document's [Document Type Definition](/en-US/docs/Glossary/Doctype). For example, to create a new `&warning;` entity, you can do this:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This replaces the term "HTML Entity" with "Character reference" in places where that makes sense (in most cases, this is what people mean).

Fixes #34383