### PR TITLE
Note about CLDR having legacy TZ names

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -32,7 +32,11 @@ A new object with properties reflecting the options computed during the initiali
 - `numberingSystem`
   - : One of the [supported numbering system types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems#supported_numbering_system_types), reflecting the value provided for this property in the `options` argument or the `nu` Unicode extension key. The default is locale dependent.
 - `timeZone`
+
   - : One of the [IANA time zone names](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones), reflecting the value provided for this property in the `options` argument. The default is the runtime's default time zone; should never be `undefined`.
+
+    > **Note:** While the IANA database changes from time to time, the Unicode CLDR database (which browsers use) keeps old time zone names for stability purposes. All browsers canonicalize time zone names, but in different directions. For example, `new Intl.DateTimeFormat("en-US", { timeZone: "Europe/Kiev" }).resolvedOptions().timeZone` and `new Intl.DateTimeFormat("en-US", { timeZone: "Europe/Kyiv" }).resolvedOptions().timeZone` will return the same string in the same browser, but maybe different strings in different browsers. See {{jsxref("Intl/Locale/getTimeZones", "Intl.Locale.prototype.getTimeZones")}} for more information.
+
 - `hourCycle`
   - : The value provided for this property in the `options` argument, or provided in the Unicode extension key `"hc"`, with default filled in as needed. Only present if the `options` argument included `hour` or `timeStyle`.
 - `hour12`

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/gettimezones/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/gettimezones/index.md
@@ -25,6 +25,17 @@ None.
 
 An array of strings representing supported time zones for the associated `Locale`, where each value is an [IANA time zone canonical name](https://en.wikipedia.org/wiki/Daylight_saving_time#IANA_time_zone_database), sorted in alphabetical order. If the locale identifier does not contain a region subtag, the returned value is `undefined`.
 
+Note that while the IANA database changes from time to time, [the Unicode CLDR database (which browsers use) keeps old time zone names for stability purposes](https://unicode.org/reports/tr35/#Time_Zone_Identifiers). For example, here are a few notable name changes:
+
+| Current IANA name                | CDLR database          |
+| -------------------------------- | ---------------------- |
+| `America/Argentina/Buenos_Aires` | `America/Buenos_Aires` |
+| `Asia/Kolkata`                   | `Asia/Calcutta`        |
+| `Asia/Ho_Chi_Minh`               | `Asia/Saigon`          |
+| `Europe/Kyiv`                    | `Europe/Kiev`          |
+
+Some browsers (Firefox) override these legacy names, while others don't (Safari and Chrome). For more information, check the [CLDR database](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-bcp47/bcp47/timezone.json). (IANA names are marked with `"_iana"`, if different.) There is [an effort in TC39 to properly handle these canonical identifiers](https://github.com/tc39/proposal-canonical-tz), which also contains links to related CLDR issues.
+
 ## Examples
 
 ### Obtaining supported time zones

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -31,6 +31,8 @@ Intl.supportedValuesOf(key)
 
 A sorted array of unique string values indicating the values supported by the implementation for the given key.
 
+> **Note:** While the IANA database changes from time to time, the Unicode CLDR database (which browsers use) keeps old time zone names for stability purposes. Some browsers may use the legacy name, while others override it with the new name. See {{jsxref("Intl/Locale/getTimeZones", "Intl.Locale.prototype.getTimeZones")}} for more information.
+
 ### Exceptions
 
 - {{jsxref("RangeError")}}


### PR DESCRIPTION
The browsers' behavior turned out to be very interesting! Fixes https://github.com/mdn/content/issues/33691.

cc @jackdeguest 