### PR TITLE
Fixed WebGL compressed textures example

### DIFF
--- a/files/en-us/web/api/webgl_api/compressed_texture_formats/index.md
+++ b/files/en-us/web/api/webgl_api/compressed_texture_formats/index.md
@@ -52,7 +52,7 @@ async function getCompressedTextureIfAvailable(gl) {
       0, // border, always 0
       new DataView(dataArrayBuffer),
     );
-    gl.generateMipMap(); // create mipmap levels, like we would for a standard image
+    gl.generateMipMap(gl.TEXTURE_2D); // create mipmap levels, like we would for a standard image
     return texture;
   }
 }


### PR DESCRIPTION
### Description

Fixed the `generateMipMap` call as it was missing a parameter.

### Motivation

The code example otherwise has a bug.

### Additional details

[generateMipMap](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/generateMipmap) reference

