### PR TITLE
Remove compat tables from HTTP status codes

### DIFF
--- a/files/en-us/web/http/status/100/index.md
+++ b/files/en-us/web/http/status/100/index.md
@@ -2,7 +2,7 @@
 title: 100 Continue
 slug: Web/HTTP/Status/100
 page-type: http-status-code
-browser-compat: http.status.100
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.100
 ---
 
 {{HTTPSidebar}}
@@ -24,10 +24,6 @@ and receive a `100 Continue` status code in response before sending the body.
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/200/index.md
+++ b/files/en-us/web/http/status/200/index.md
@@ -2,7 +2,7 @@
 title: 200 OK
 slug: Web/HTTP/Status/200
 page-type: http-status-code
-browser-compat: http.status.200
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.200
 ---
 
 {{HTTPSidebar}}
@@ -27,10 +27,6 @@ The successful result of a {{HTTPMethod("PUT")}} or a {{HTTPMethod("DELETE")}} i
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/201/index.md
+++ b/files/en-us/web/http/status/201/index.md
@@ -2,7 +2,7 @@
 title: 201 Created
 slug: Web/HTTP/Status/201
 page-type: http-status-code
-browser-compat: http.status.201
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.201
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/status/201/index.md
+++ b/files/en-us/web/http/status/201/index.md
@@ -26,10 +26,6 @@ request.
 
 {{Specifications}}
 
-## Browser compatibility
-
-{{Compat}}
-
 ## See also
 
 - [HTTP request methods](/en-US/docs/Web/HTTP/Methods)

--- a/files/en-us/web/http/status/204/index.md
+++ b/files/en-us/web/http/status/204/index.md
@@ -2,7 +2,7 @@
 title: 204 No Content
 slug: Web/HTTP/Status/204
 page-type: http-status-code
-browser-compat: http.status.204
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.204
 ---
 
 {{HTTPSidebar}}
@@ -26,10 +26,6 @@ A 204 response is cacheable by default (an {{HTTPHeader("ETag")}} header is incl
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ### Compatibility notes
 

--- a/files/en-us/web/http/status/206/index.md
+++ b/files/en-us/web/http/status/206/index.md
@@ -2,7 +2,7 @@
 title: 206 Partial Content
 slug: Web/HTTP/Status/206
 page-type: http-status-code
-browser-compat: http.status.206
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.206
 ---
 
 {{HTTPSidebar}}
@@ -64,10 +64,6 @@ Content-Range: bytes 4590-7999/8000
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/301/index.md
+++ b/files/en-us/web/http/status/301/index.md
@@ -2,7 +2,7 @@
 title: 301 Moved Permanently
 slug: Web/HTTP/Status/301
 page-type: http-status-code
-browser-compat: http.status.301
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.301
 ---
 
 {{HTTPSidebar}}
@@ -36,10 +36,6 @@ Location: http://www.example.org/index.asp
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/302/index.md
+++ b/files/en-us/web/http/status/302/index.md
@@ -2,7 +2,7 @@
 title: 302 Found
 slug: Web/HTTP/Status/302
 page-type: http-status-code
-browser-compat: http.status.302
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.302
 ---
 
 {{HTTPSidebar}}
@@ -34,10 +34,6 @@ confirmation message such as: 'you successfully uploaded XYZ'.
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/303/index.md
+++ b/files/en-us/web/http/status/303/index.md
@@ -2,7 +2,7 @@
 title: 303 See Other
 slug: Web/HTTP/Status/303
 page-type: http-status-code
-browser-compat: http.status.303
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.303
 ---
 
 {{HTTPSidebar}}
@@ -21,10 +21,6 @@ redirected page is always {{HTTPMethod("GET")}}.
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -2,7 +2,7 @@
 title: 304 Not Modified
 slug: Web/HTTP/Status/304
 page-type: http-status-code
-browser-compat: http.status.304
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.304
 ---
 
 {{HTTPSidebar}}
@@ -82,15 +82,9 @@ etag: "e27d81b845c3716cdb5d4220d78e2799"
 
 {{Specifications}}
 
-## Browser compatibility
+## Compatibility notes
 
-{{Compat}}
-
-### Compatibility notes
-
-- Browser behavior differs if this response erroneously includes a body on persistent
-  connections. See [204 No Content](/en-US/docs/Web/HTTP/Status/204) for more
-  detail.
+Browser behavior differs if this response erroneously includes a body on persistent connections. See [204 No Content](/en-US/docs/Web/HTTP/Status/204) for more details.
 
 ## See also
 

--- a/files/en-us/web/http/status/307/index.md
+++ b/files/en-us/web/http/status/307/index.md
@@ -2,7 +2,7 @@
 title: 307 Temporary Redirect
 slug: Web/HTTP/Status/307
 page-type: http-status-code
-browser-compat: http.status.307
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.307
 ---
 
 {{HTTPSidebar}}
@@ -34,10 +34,6 @@ identical.
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/401/index.md
+++ b/files/en-us/web/http/status/401/index.md
@@ -2,7 +2,7 @@
 title: 401 Unauthorized
 slug: Web/HTTP/Status/401
 page-type: http-status-code
-browser-compat: http.status.401
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.401
 ---
 
 {{HTTPSidebar}}
@@ -33,10 +33,6 @@ WWW-Authenticate: Basic realm="Access to staging site"
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/403/index.md
+++ b/files/en-us/web/http/status/403/index.md
@@ -2,7 +2,7 @@
 title: 403 Forbidden
 slug: Web/HTTP/Status/403
 page-type: http-status-code
-browser-compat: http.status.403
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.403
 ---
 
 {{HTTPSidebar}}
@@ -27,10 +27,6 @@ Date: Wed, 21 Oct 2015 07:28:00 GMT
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/404/index.md
+++ b/files/en-us/web/http/status/404/index.md
@@ -2,7 +2,7 @@
 title: 404 Not Found
 slug: Web/HTTP/Status/404
 page-type: http-status-code
-browser-compat: http.status.404
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.404
 ---
 
 {{HTTPSidebar}}
@@ -34,10 +34,6 @@ For an example of a custom 404 page, see this [404 page](https://konmari.com/404
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/406/index.md
+++ b/files/en-us/web/http/status/406/index.md
@@ -2,7 +2,7 @@
 title: 406 Not Acceptable
 slug: Web/HTTP/Status/406
 page-type: http-status-code
-browser-compat: http.status.406
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.406
 ---
 
 {{HTTPSidebar}}
@@ -31,10 +31,6 @@ among them.
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/407/index.md
+++ b/files/en-us/web/http/status/407/index.md
@@ -2,7 +2,7 @@
 title: 407 Proxy Authentication Required
 slug: Web/HTTP/Status/407
 page-type: http-status-code
-browser-compat: http.status.407
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.407
 ---
 
 {{HTTPSidebar}}
@@ -32,10 +32,6 @@ Proxy-Authenticate: Basic realm="Access to internal site"
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/409/index.md
+++ b/files/en-us/web/http/status/409/index.md
@@ -2,7 +2,7 @@
 title: 409 Conflict
 slug: Web/HTTP/Status/409
 page-type: http-status-code
-browser-compat: http.status.409
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.409
 ---
 
 {{HTTPSidebar}}
@@ -20,10 +20,6 @@ Conflicts are most likely to occur in response to a {{HTTPMethod("PUT")}} reques
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/410/index.md
+++ b/files/en-us/web/http/status/410/index.md
@@ -2,7 +2,7 @@
 title: 410 Gone
 slug: Web/HTTP/Status/410
 page-type: http-status-code
-browser-compat: http.status.410
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.410
 ---
 
 {{HTTPSidebar}}
@@ -22,10 +22,6 @@ If you don't know whether this condition is temporary or permanent, a {{HTTPStat
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/412/index.md
+++ b/files/en-us/web/http/status/412/index.md
@@ -2,7 +2,7 @@
 title: 412 Precondition Failed
 slug: Web/HTTP/Status/412
 page-type: http-status-code
-browser-compat: http.status.412
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.412
 ---
 
 {{HTTPSidebar}}
@@ -55,10 +55,6 @@ If the hashes don't match, it means that the document has been edited in-between
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/416/index.md
+++ b/files/en-us/web/http/status/416/index.md
@@ -2,7 +2,7 @@
 title: 416 Range Not Satisfiable
 slug: Web/HTTP/Status/416
 page-type: http-status-code
-browser-compat: http.status.416
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.416
 ---
 
 {{HTTPSidebar}}
@@ -22,10 +22,6 @@ Faced with this error, browsers usually either abort the operation (for example,
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/418/index.md
+++ b/files/en-us/web/http/status/418/index.md
@@ -2,7 +2,7 @@
 title: 418 I'm a teapot
 slug: Web/HTTP/Status/418
 page-type: http-status-code
-browser-compat: http.status.418
+spec-urls: https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2
 ---
 
 {{HTTPSidebar}}
@@ -20,10 +20,6 @@ Some websites use this response for requests they do not wish to handle, such as
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/451/index.md
+++ b/files/en-us/web/http/status/451/index.md
@@ -2,7 +2,7 @@
 title: 451 Unavailable For Legal Reasons
 slug: Web/HTTP/Status/451
 page-type: http-status-code
-browser-compat: http.status.451
+spec-urls: https://httpwg.org/specs/rfc7725.html#n-451-unavailable-for-legal-reasons
 ---
 
 {{HTTPSidebar}}
@@ -43,10 +43,6 @@ Content-Type: text/html
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/500/index.md
+++ b/files/en-us/web/http/status/500/index.md
@@ -2,7 +2,7 @@
 title: 500 Internal Server Error
 slug: Web/HTTP/Status/500
 page-type: http-status-code
-browser-compat: http.status.500
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.500
 ---
 
 {{HTTPSidebar}}
@@ -20,10 +20,6 @@ This error response is a generic "catch-all" response. Usually, this indicates t
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/501/index.md
+++ b/files/en-us/web/http/status/501/index.md
@@ -2,7 +2,7 @@
 title: 501 Not Implemented
 slug: Web/HTTP/Status/501
 page-type: http-status-code
-browser-compat: http.status.501
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.501
 ---
 
 {{HTTPSidebar}}
@@ -29,7 +29,3 @@ If the server _does_ recognize the method, but intentionally does not support it
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}

--- a/files/en-us/web/http/status/502/index.md
+++ b/files/en-us/web/http/status/502/index.md
@@ -2,7 +2,7 @@
 title: 502 Bad Gateway
 slug: Web/HTTP/Status/502
 page-type: http-status-code
-browser-compat: http.status.502
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.502
 ---
 
 {{HTTPSidebar}}
@@ -20,10 +20,6 @@ The HyperText Transfer Protocol (HTTP) **`502 Bad Gateway`** server error respon
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/503/index.md
+++ b/files/en-us/web/http/status/503/index.md
@@ -2,7 +2,7 @@
 title: 503 Service Unavailable
 slug: Web/HTTP/Status/503
 page-type: http-status-code
-browser-compat: http.status.503
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.503
 ---
 
 {{HTTPSidebar}}
@@ -24,10 +24,6 @@ Caching-related headers that are sent along with this response should be taken c
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/status/504/index.md
+++ b/files/en-us/web/http/status/504/index.md
@@ -2,7 +2,7 @@
 title: 504 Gateway Timeout
 slug: Web/HTTP/Status/504
 page-type: http-status-code
-browser-compat: http.status.504
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.504
 ---
 
 {{HTTPSidebar}}
@@ -20,10 +20,6 @@ The HyperText Transfer Protocol (HTTP) **`504 Gateway Timeout`** server error re
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
### Description

This PR makes the HTTP status code docs more consistent by removing the compat tables everywhere (except for three exceptional statuses). This was discussed in the weekly BCD call yesterday among Daniel, Ruth, Vadim and myself.

### Motivation

Most HTTP status codes don't really have a browser compatibility story to tell and while we could say that status codes are "supported" from the initial releases of browsers, it doesn't seem to make much sense. Many HTTP status code pages already omit the compat table and this PR proposes to do that for all of them.

### Additional details

I couldn't find docs for the `http-status-code` page type, but if there are page guidelines for this page type in the meta docs, I would update it to say the HTTP status code pages usually get no compat table.

There are 3 status codes where I think it makes sense to keep the compat table as there is something to say about browsers: 

- https://developer.mozilla.org/docs/Web/HTTP/Status/103
- https://developer.mozilla.org/docs/Web/HTTP/Status/308
- https://developer.mozilla.org/docs/Web/HTTP/Status/425

So I kept the tables there and the BCD will be kept, too.

### Related issues and pull requests

BCD PR: https://github.com/mdn/browser-compat-data/pull/23529

### Review

Scope: I'm only interested in a decision for whether or not to show compat tables for HTTP status codes. Out of scope for this PR are other changes to the HTTP status code docs.

Time: I have no time constraints. It would be good to get to a decision though as this is part of sorting out BCD features that can't be calculated for the baseline project.

Reviewer nomination: Would love for @bsmth to review this. Please let me know if you could take a look at this. TY!