### PR TITLE
docs(Array): clarify slice() return value for edge cases #34419

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -28,13 +28,13 @@ slice(start, end)
   - : Zero-based index at which to start extraction, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion).
     - Negative index counts back from the end of the array — if `-array.length <= start < 0`, `start + array.length` is used.
     - If `start < -array.length` or `start` is omitted, `0` is used.
-    - If `start >= array.length`, nothing is extracted.
+    - If `start >= array.length`, an empty array is returned.
 - `end` {{optional_inline}}
   - : Zero-based index at which to end extraction, [converted to an integer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion). `slice()` extracts up to but not including `end`.
     - Negative index counts back from the end of the array — if `-array.length <= end < 0`, `end + array.length` is used.
     - If `end < -array.length`, `0` is used.
     - If `end >= array.length` or `end` is omitted, `array.length` is used, causing all elements until the end to be extracted.
-    - If `end` implies a position before or at the position that `start` implies, nothing is extracted.
+    - If `end` implies a position before or at the position that `start` implies, an empty array is returned.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
Clarify the return value of Array.prototype.slice() for edge cases where an empty array is returned.

### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
These changes address user feedback about unclear documentation. By explicitly stating that an empty array is returned in certain edge cases, we improve the clarity and completeness of the slice() method documentation.

### Additional details
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
This change aligns with the ECMAScript specification for Array.prototype.slice(), which states that an empty array should be returned in these cases.

### Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
Fixes #34419

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->