### PR TITLE
Fix typo in Web/Security/Practical_implementation_guides/Cookies

### DIFF
--- a/files/en-us/web/security/practical_implementation_guides/cookies/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/cookies/index.md
@@ -42,7 +42,7 @@ To minimize the scope for cookie vulnerabilities on your site, limit access to c
 
     Both of the above values are useful in protecting against [Clickjacking](/en-US/docs/Glossary/Clickjacking) attacks in cases that rely on the user being authenticated.
 
-    > **Note:** In theory, `SameSite=Strict` should be more useful than it is in practice. It often breaks navigations — for example, users clicking a link to a website on which they are already logged in (i.e. a valid session cokie is set) appear not to be logged in, because the browser has deliberately omitted the session cookie. The best middle ground is to use `SameSite=Strict` only on tokens where CSRF is a concern or use `SameSite=Strict` everywhere, but reload the page and do a cookie check in JavaScript if there's an indication that the user is logged in but required cookies are not being sent.
+    > **Note:** In theory, `SameSite=Strict` should be more useful than it is in practice. It often breaks navigations — for example, users clicking a link to a website on which they are already logged in (i.e. a valid session cookie is set) appear not to be logged in, because the browser has deliberately omitted the session cookie. The best middle ground is to use `SameSite=Strict` only on tokens where CSRF is a concern or use `SameSite=Strict` everywhere, but reload the page and do a cookie check in JavaScript if there's an indication that the user is logged in but required cookies are not being sent.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Fix a typo in the word cookie in a callout section
