### PR TITLE
Remove a few "browser support" sections

### DIFF
--- a/files/en-us/games/techniques/controls_gamepad_api/index.md
+++ b/files/en-us/games/techniques/controls_gamepad_api/index.md
@@ -12,10 +12,6 @@ This article looks at implementing an effective, cross-browser control system fo
 
 Historically playing games on a console connected to your TV was always a totally different experience to gaming on the PC, mostly because of the unique controls. Eventually, extra drivers and plugins allowed us to use console gamepads with desktop games — either native games or those running in the browser. Now we have the [Gamepad API](/en-US/docs/Web/API/Gamepad_API), which gives us the ability to play browser-based games using gamepad controllers without any plugins. The Gamepad API achieves this by providing an interface exposing button presses and axis changes that can be used inside JavaScript code to handle the input. These are good times for browser gaming.
 
-## API status and browser support
-
-The [Gamepad API](https://www.w3.org/TR/gamepad/) is still at the Working Draft stage in the W3C process, which means its implementation might still change, but saying that the [browser support](https://caniuse.com/gamepad) is already quite good. Firefox 29+ and Chrome 35+ support it out of the box. Opera supports the API in version 22+ (not surprising given that they now use Chrome's Blink engine.) And Microsoft implemented support for the API in Edge recently, which means four main browsers now supporting the Gamepad API.
-
 ## Which gamepads are best?
 
 The most popular gamepads right now are those from the Xbox 360, Xbox One, PS3 and PS4 — they have been heavily tested and work well with the Gamepad API implementation in browsers across Windows and macOS.

--- a/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
@@ -22,10 +22,6 @@ Note the retro cassette deck with a play button, and vol and pan sliders to allo
 
 [Check out the final demo here on Codepen](https://codepen.io/Rumyra/pen/qyMzqN/), or see the [source code on GitHub](https://github.com/mdn/webaudio-examples/tree/main/audio-basics).
 
-## Browser support
-
-Modern browsers have good support for most features of the Web Audio API. There are a lot of features of the API, so for more exact information, you'll have to check the browser compatibility tables at the bottom of each reference page.
-
 ## Audio graphs
 
 Everything within the Web Audio API is based around the concept of an audio graph, which is made up of nodes.

--- a/files/en-us/web/media/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
@@ -71,27 +71,11 @@ So `defaultPlaybackRate` allows us to set the playback rate _before_ playing the
 
 There is also an event available called `ratechange`, which fires every time the `playbackRate` changes.
 
-## Browser support
-
-- Chrome 20+ ✔
-- Firefox 20+ ✔
-- IE 9+ ✔
-- Safari 6+ ✔
-- Opera 15+ ✔
-- Mobile Chrome (Android) ✖
-- Mobile Firefox 24+ ✔
-- IE Mobile ✖
-- Mobile Safari 6+ (iOS) ✔
-- Opera Mobile ✖
-
 ### Notes
 
 - Most browsers stop playing audio outside `playbackRate` bounds of 0.5 and 4, leaving the video playing silently. For most applications, it's recommended that you limit the range to between 0.5 and 4.
 - The pitch of the audio track does not change when `playBackRate` is altered.
 - Negative values indicating the media should play in reverse is not currently supported by most browsers.
-- IE9+ switches to the default playback rate when an `ended` event is fired.
-- Firefox generates a `ratechange` event when the media source is substituted.
-- On iOS 7 you can only affect the `playbackRate` when the media is paused (not while it's playing).
 
 ## See also
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/9972.

These are guide pages and don't need browser support tables; their respective references have the necessary information.

I think this PR is sufficient to fix https://github.com/mdn/content/issues/9972, because the remaining pages are media pages (https://github.com/mdn/browser-compat-data/issues/6971) and one `keyCode` which needs more rewrite anyway (part of https://github.com/mdn/content/issues/22432?)