### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/htmltablecellelement/abbr/index.md
+++ b/files/en-us/web/api/htmltablecellelement/abbr/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLTableCellElement.abbr
 The **`abbr`** property of the {{domxref("HTMLTableCellElement")}} interface
 indicates an abbreviation associated with the cell. If the cell does not represent a header cell {{HTMLElement("th")}}, it is ignored.
 
-It reflects the `abbr` attribute of the {{HTMLElement("tr")}} element.
+It reflects the `abbr` attribute of the {{HTMLElement("th")}} element.
 
 > **Note:** this property doesn't have a visual effect in browsers. It adds information to help assistive technology like screenreaders that can use this abbreviation
 


### PR DESCRIPTION
Only the `<th>` element has abbr="" attribute, not `<tr>`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Wrong element

### Motivation

So the docs are right

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
