### PR TITLE
Resolve #32605 browser support for display:content

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/relationship_of_flexbox_to_other_layout_methods/index.md
@@ -102,4 +102,4 @@ Also, having removed the box you cannot then use it to — for example — add a
 
 {{EmbedGHLiveSample("css-examples/flexbox/relationship/display-contents.html", '100%', 650)}}
 
-Browser support for `display:contents` is limited and required for this demo to work. Firefox supports `display: contents` already, and the value is being implemented in Chrome. Once there is better browser support this feature will be very useful in circumstances where you need the markup for semantic reasons but do not want to display the box that it would generate by default.
+All major browser have support for `display:contents`. The feature is useful in circumstances where you need the markup for semantic reasons but do not want to display the box that it would generate by default.


### PR DESCRIPTION
### Description
This PR updates the incorrect statement that current browsers have limited support for `display: contents`. 

### Motivation

They help readers get the correct information on browser support for this feature.

### Additional details

[Caniuse](https://caniuse.com/css-display-contents)

### Related issues and pull requests

Fixes #32605 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
