### PR TITLE
Add display_override manifest member tabbed value

### DIFF
--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -69,7 +69,7 @@ Display override objects are display-mode strings, the possible values are:
     <tr>
       <td><code>tabbed</code></td>
       <td>
-        The application can contain multiple application contexts inside a single OS-level window. Supporting browsers can choose to handle the display of these contexts in whatever way they want, but a common approach is to provide a tab bar to switch between them.
+        The application can contain multiple application contexts inside a single OS-level window. Supporting browsers can choose how to display these contexts, but a common approach is to provide a tab bar to switch between them.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -51,8 +51,8 @@ Display override objects are display-mode strings, the possible values are:
     <tr>
       <td><code>minimal-ui</code></td>
       <td>
-        The application will look and feel like a standalone application, but
-        will have a minimal set of UI elements for controlling navigation. The
+        The application will look and feel like a standalone application with
+        a minimal set of UI elements for controlling navigation. The
         elements will vary by browser.
       </td>
     </tr>

--- a/files/en-us/web/manifest/display_override/index.md
+++ b/files/en-us/web/manifest/display_override/index.md
@@ -35,10 +35,25 @@ Display override objects are display-mode strings, the possible values are:
   </thead>
   <tbody>
     <tr>
+      <td><code>browser</code></td>
+      <td>
+        The application opens in a conventional browser tab or new window,
+        depending on the browser and platform. This is the default.
+      </td>
+    </tr>
+    <tr>
       <td><code>fullscreen</code></td>
       <td>
         All of the available display area is used and no user agent
         {{Glossary("chrome")}} is shown.
+      </td>
+    </tr>
+    <tr>
+      <td><code>minimal-ui</code></td>
+      <td>
+        The application will look and feel like a standalone application, but
+        will have a minimal set of UI elements for controlling navigation. The
+        elements will vary by browser.
       </td>
     </tr>
     <tr>
@@ -52,18 +67,9 @@ Display override objects are display-mode strings, the possible values are:
       </td>
     </tr>
     <tr>
-      <td><code>minimal-ui</code></td>
+      <td><code>tabbed</code></td>
       <td>
-        The application will look and feel like a standalone application, but
-        will have a minimal set of UI elements for controlling navigation. The
-        elements will vary by browser.
-      </td>
-    </tr>
-    <tr>
-      <td><code>browser</code></td>
-      <td>
-        The application opens in a conventional browser tab or new window,
-        depending on the browser and platform. This is the default.
+        The application can contain multiple application contexts inside a single OS-level window. Supporting browsers can choose to handle the display of these contexts in whatever way they want, but a common approach is to provide a tab bar to switch between them.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 126 supports the [`display_override`](https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override) manifest member's [`tabbed`](https://wicg.github.io/manifest-incubations/#dfn-tabbed) value (see the [ChromeStatus emtry](https://chromestatus.com/feature/5128143454076928)).

This PR adds information about it to the documentation.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
