### PR TITLE
Remove all line number references to inline code examples

### DIFF
--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -334,7 +334,7 @@ This is a lot of code — phew! Let's go through each section and explain what i
   - Now we've chained another test onto the end of the last one using an `else if (){ }` structure. This one checks whether this turn is the user's last turn. If it is, the program does the same thing as in the previous block, except with a game over message instead of a congratulations message.
   - The final block chained onto the end of this code (the `else { }`) contains code that is only run if neither of the other two tests returns true (i.e. the player didn't guess right, but they have more guesses left). In this case we tell them they are wrong, then we perform another conditional test to check whether the guess was higher or lower than the answer, displaying a further message as appropriate to tell them higher or lower.
 
-- The last three lines in the function (lines 26–28 above) get us ready for the next guess to be submitted. We add 1 to the `guessCount` variable so the player uses up their turn (`++` is an incrementation operation — increment by 1), and empty the value out of the form text field and focus it again, ready for the next guess to be entered.
+- The last three lines in the function get us ready for the next guess to be submitted. We add 1 to the `guessCount` variable so the player uses up their turn (`++` is an incrementation operation — increment by 1), and empty the value out of the form text field and focus it again, ready for the next guess to be entered.
 
 ### Events
 

--- a/files/en-us/learn/javascript/first_steps/strings/index.md
+++ b/files/en-us/learn/javascript/first_steps/strings/index.md
@@ -252,7 +252,7 @@ If you have a numeric variable that you want to convert to a string or a string 
   // string
   ```
 
-These constructs can be really useful in some situations. For example, if a user enters a number into a form's text field, it's a string. However, if you want to add this number to something, you'll need it to be a number, so you could pass it through `Number()` to handle this. We did exactly this in our [Number Guessing Game, in line 59](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game.html#L59).
+These constructs can be really useful in some situations. For example, if a user enters a number into a form's text field, it's a string. However, if you want to add this number to something, you'll need it to be a number, so you could pass it through `Number()` to handle this. We did exactly this in our [Number Guessing Game](https://github.com/mdn/learning-area/blob/main/javascript/introduction-to-js-1/first-splash/number-guessing-game.html), in the `checkGuess` function.
 
 ## Conclusion
 

--- a/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
+++ b/files/en-us/learn/javascript/first_steps/what_is_javascript/index.md
@@ -159,7 +159,7 @@ function updateName() {
 }
 ```
 
-Here we are selecting a button (line 1), then attaching an event listener to it (line 3) so that when the button is clicked, the `updateName()` code block (lines 5–8) is run. The `updateName()` code block (these types of reusable code blocks are called "functions") asks the user for a new name, and then inserts that name into the button text to update the display.
+Here we first select a button using `document.querySelector`, then attaching an event listener to it using `addEventListener` so that when the button is clicked, the `updateName()` code block (lines 5–8) is run. The `updateName()` code block (these types of reusable code blocks are called "functions") asks the user for a new name, and then inserts that name into the button text to update the display.
 
 If you swapped the order of the first two lines of code, it would no longer work — instead, you'd get an error returned in the [browser developer console](/en-US/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools) — `Uncaught ReferenceError: Cannot access 'button' before initialization`.
 This means that the `button` object has not been initialized yet, so we can't add an event listener to it.

--- a/files/en-us/learn/performance/javascript/index.md
+++ b/files/en-us/learn/performance/javascript/index.md
@@ -310,7 +310,7 @@ There are several general best practices that will make your code run more effic
     }
     ```
 
-  - Do work that is only needed once outside the loop. This may sound a bit obvious, but it is easy to overlook. Take the following snippet, which fetches a JSON object containing data to be processed in some way. In this case the {{domxref("fetch()")}} operation is being done on every iteration of the loop, which is a waste of computing power. Lines 3 and 4 could be moved outside the loop, so the network fetch is only being done once.
+  - Do work that is only needed once outside the loop. This may sound a bit obvious, but it is easy to overlook. Take the following snippet, which fetches a JSON object containing data to be processed in some way. In this case the {{domxref("fetch()")}} operation is being done on every iteration of the loop, which is a waste of computing power. The fetching, which does not depend on `i`, could be moved outside the loop, so it is only done once.
 
     ```js
     async function returnResults(number) {

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
@@ -295,7 +295,7 @@ When compiling the app, Svelte changes our `h1` styles definition to `h1.svelte-
 ## Making a couple of changes
 
 Now that we have a general idea of how it all fits together, we can start making a few changes.
-At this point you can try updating your `App.svelte` component — for example change the `<h1>` element on line 6 of `App.svelte` so that it reads like this:
+At this point you can try updating your `App.svelte` component — for example change the `<h1>` element in `App.svelte` so that it reads like this:
 
 ```html
 <h1>Hello {name} from MDN!</h1>
@@ -357,7 +357,7 @@ const app = new App({
 export default app;
 ```
 
-`main.js` starts by importing the Svelte component that we are going to use. Then in line 3 it instantiates it, passing an option object with the following properties:
+`main.js` starts by importing the Svelte component that we are going to use. Then it gets instantiated with `new App`, passing an option object with the following properties:
 
 - `target`: The DOM element inside which we want the component to be rendered, in this case the `<body>` element.
 - `props`: the values to assign to each prop of the `App` component.

--- a/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
+++ b/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
@@ -107,8 +107,6 @@ When content visibility is changed (i.e., an element is hidden or shown), develo
 
 Here is an example of a tooltip that uses **`aria-hidden`** to control the visibility of the tooltip. The example shows a simple web form with tooltips containing instructions associated with the entry fields.
 
-In this example, the HTML for the tooltip has the form shown. Line 9 sets the **`aria-hidden`** state to `true`.
-
 ```html
 <div class="text">
   <label id="tp1-label" for="first">First Name:</label>
@@ -126,7 +124,7 @@ In this example, the HTML for the tooltip has the form shown. Line 9 sets the **
 </div>
 ```
 
-The CSS for this markup is shown in the following code. Note that there is no custom classname used, only the status of the **`aria-hidden`** attribute on line 1.
+The CSS for this markup is shown in the following code. Note that there is no custom classname used, only the status of the **`aria-hidden`** attribute.
 
 ```css
 div.tooltip[aria-hidden="true"] {
@@ -134,7 +132,7 @@ div.tooltip[aria-hidden="true"] {
 }
 ```
 
-The JavaScript to update the **`aria-hidden`** property has the form shown in the following code. Note that the script only updates the **`aria-hidden`** attribute (line 2); it does not need to also add or remove a custom classname.
+The JavaScript to update the **`aria-hidden`** property has the form shown in the following code. Note that the script only updates the **`aria-hidden`** attribute; it does not need to also add or remove a custom classname.
 
 ```js
 function showTip(el) {

--- a/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -146,15 +146,15 @@ When this routine is called, the video element is displaying the most recent fra
 
 ![A single frame of the video element. There is a person wearing a black t-shirt. The background-color is yellow.](video.png)
 
-In line 2, that frame of video is copied into the graphics context `ctx1` of the first canvas, specifying as the height and width the values we previously saved to draw the frame at half size. Note that you can pass the video element into the context's `drawImage()` method to draw the current video frame into the context. The result is:
+That frame of video is copied into the graphics context `ctx1` of the first canvas, specifying as the height and width the values we previously saved to draw the frame at half size. Note that you can pass the video element into the context's `drawImage()` method to draw the current video frame into the context. The result is:
 
 ![A single frame of the video element. There is a person wearing a black t-shirt. The background-color is yellow. This is a smaller version of the picture above.](sourcectx.png)
 
-Line 3 fetches a copy of the raw graphics data for the current frame of video by calling the `getImageData()` method on the first context. This provides raw 32-bit pixel image data we can then manipulate. Line 4 computes the number of pixels in the image by dividing the total size of the frame's image data by four.
+Calling the `getImageData()` method on the first context fetches a copy of the raw graphics data for the current frame of video. This provides raw 32-bit pixel image data we can then manipulate. We then compute the number of pixels in the image by dividing the total size of the frame's image data by four.
 
-The `for` loop that begins on line 6 scans through the frame's pixels, pulling out the red, green, and blue values for each pixel, and compares the values against predetermined numbers that are used to detect the green screen that will be replaced with the still background image imported from `foo.png`.
+The `for` loop scans through the frame's pixels, pulling out the red, green, and blue values for each pixel, and compares the values against predetermined numbers that are used to detect the green screen that will be replaced with the still background image imported from `foo.png`.
 
-Every pixel in the frame's image data that is found that is within the parameters that are considered to be part of the green screen has its alpha value replaced with a zero, indicating that the pixel is entirely transparent. As a result, the final image has the entire green screen area 100% transparent, so that when it's drawn into the destination context in line 13, the result is an overlay onto the static backdrop.
+Every pixel in the frame's image data that is found that is within the parameters that are considered to be part of the green screen has its alpha value replaced with a zero, indicating that the pixel is entirely transparent. As a result, the final image has the entire green screen area 100% transparent, so that when it's drawn into the destination context using `ctx2.putImageData`, the result is an overlay onto the static backdrop.
 
 The resulting image looks like this:
 

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -67,7 +67,7 @@ In [browsers that support `computedStyleMap()`](/en-US/docs/Web/API/Element/comp
 
 {{EmbedLiveSample("Getting_all_the_properties_and_values", 120, 300)}}
 
-Did you realize how many default CSS properties a link had? Update the JavaScript on line 2 to select the {{htmlelement("p")}} rather than the {{htmlelement("a")}}. You'll notice a difference in the [`margin-top`](/en-US/docs/Web/CSS/margin-top) and [`margin-bottom`](/en-US/docs/Web/CSS/margin-bottom) default computed values.
+Did you realize how many default CSS properties a link had? Update the first `document.querySelector` call to select the {{htmlelement("p")}} rather than the {{htmlelement("a")}}. You'll notice a difference in the [`margin-top`](/en-US/docs/Web/CSS/margin-top) and [`margin-bottom`](/en-US/docs/Web/CSS/margin-bottom) default computed values.
 
 ### .get() method / custom properties
 

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.md
@@ -70,15 +70,15 @@ function makeDocument() {
 }
 ```
 
-The code in lines 4–12 handle creating the new HTML document and inserting some content
-into it. Line 4 uses `createHTMLDocument()` to construct a new HTML document
-whose {{ HTMLElement("title") }} is `"New Document"`. Lines 5 and 6 create a
-new paragraph element with some simple content, and then lines 8–12 handle inserting the
-new paragraph into the new document.
+The code handles creating the new HTML document and inserting some content
+into it. `createHTMLDocument()` constructs a new HTML document
+whose {{ HTMLElement("title") }} is `"New Document"`. Then we create a
+new paragraph element with some simple content, and then the new paragraph gets inserted
+into the new document.
 
-Line 16 pulls the `contentDocument` of the frame; this is the document into
+`destDocument` stores the `contentDocument` of the frame; this is the document into
 which we'll be injecting the new content. The next two lines handle importing the
-contents of our new document into the new document's context. Finally, line 20 actually
+contents of our new document into the new document's context. Finally, `destDocument.replaceChild` actually
 replaces the contents of the frame with the new document's contents.
 
 [View Live Examples](https://mdn.dev/archives/media/samples/domref/createHTMLDocument.html)

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -400,7 +400,7 @@ function sendFiles() {
 }
 ```
 
-Line 2 fetches a {{DOMxRef("NodeList")}}, called `imgs`, of all the elements in the document with the CSS class `obj`. In our case, these will be all of the image thumbnails. Once we have that list, it's trivial to go through it and create a new `FileUpload` instance for each. Each of these handles uploading the corresponding file.
+`document.querySelectorAll` fetches a {{DOMxRef("NodeList")}} of all the elements in the document with the CSS class `obj`. In our case, these will be all of the image thumbnails. Once we have that list, it's trivial to go through it and create a new `FileUpload` instance for each. Each of these handles uploading the corresponding file.
 
 ### Handling the upload process for a file
 

--- a/files/en-us/web/api/htmltableelement/rows/index.md
+++ b/files/en-us/web/api/htmltableelement/rows/index.md
@@ -32,8 +32,8 @@ firstRow = mytable.rows[0];
 lastRow = mytable.rows.item(mytable.rows.length - 1);
 ```
 
-This demonstrates how you can use both array syntax (line 2) and the
-{{domxref("HTMLCollection.item()")}} method (line 3) to obtain individual rows in the
+This demonstrates how you can use both indexed access and the
+{{domxref("HTMLCollection.item()")}} method to obtain individual rows in the
 table.
 
 ## Specifications

--- a/files/en-us/web/api/mediarecorder/mimetype/index.md
+++ b/files/en-us/web/api/mediarecorder/mimetype/index.md
@@ -55,11 +55,7 @@ if (navigator.mediaDevices) {
 }
 ```
 
-Changing line 14 to the following causes `MediaRecorder` to try to use AVC Constrained Baseline Profile Level 4 for video and AAC-LC (Low Complexity) for audio, which is good for mobile and other possible resource-constrained situations.
-
-```js
-mimeType: 'video/mp4; codecs="avc1.424028, mp4a.40.2"';
-```
+Changing the `mimeType` in `options` to `'video/mp4; codecs="avc1.424028, mp4a.40.2"'` causes `MediaRecorder` to try to use AVC Constrained Baseline Profile Level 4 for video and AAC-LC (Low Complexity) for audio, which is good for mobile and other possible resource-constrained situations.
 
 Assuming this configuration is acceptable to the user agent, the value returned later
 by `m.mimeType` would then be

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -173,20 +173,13 @@ function startRecording(stream, lengthInMS) {
 
 `startRecording()` takes two input parameters: a {{domxref("MediaStream")}} to record from and the length in milliseconds of the recording to make. We always record no more than the specified number of milliseconds of media, although if the media stops before that time is reached, {{domxref("MediaRecorder")}} automatically stops recording as well.
 
-- Line 2
-  - : Creates the `MediaRecorder` that will handle recording the input `stream`.
-- Line 3
-  - : Creates an empty array, `data`, which will be used to hold the {{domxref("Blob")}}s of media data provided to our {{domxref("MediaRecorder.dataavailable_event", "ondataavailable")}} event handler.
-- Line 5
-  - : Sets up the handler for the {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event. The received event's `data` property is a {{domxref("Blob")}} that contains the media data. The event handler pushes the `Blob` onto the `data` array.
-- Lines 6-7
-  - : Starts the recording process by calling {{domxref("MediaRecorder.start", "recorder.start()")}}, and outputs a message to the log with the updated state of the recorder and the number of seconds it will be recording.
-- Lines 9-12
-  - : Creates a new {{jsxref("Promise")}}, named `stopped`, which is resolved when the `MediaRecorder`'s {{domxref("MediaRecorder.stop_event", "onstop")}} event handler is called, and is rejected if its {{domxref("MediaRecorder.error_event", "onerror")}} event handler is called. The rejection handler receives as input the name of the error that occurred.
-- Lines 14-16
-  - : Creates a new `Promise`, named `recorded`, which is resolved when the specified number of milliseconds have elapsed. Upon resolution, it stops the `MediaRecorder` if it's recording.
-- Lines 18-22
-  - : These lines create a new `Promise` which is fulfilled when both of the two `Promise`s (`stopped` and `recorded`) have resolved. Once that resolves, the array data is returned by `startRecording()` to its caller.
+- We first create the `MediaRecorder` that will handle recording the input `stream`.
+- `data` is an array, initially empty, that holds the {{domxref("Blob")}}s of media data provided to our {{domxref("MediaRecorder.dataavailable_event", "ondataavailable")}} event handler.
+- The `ondataavailable` assignment sets up the handler for the {{domxref("MediaRecorder.dataavailable_event", "dataavailable")}} event. The received event's `data` property is a {{domxref("Blob")}} that contains the media data. The event handler pushes the `Blob` onto the `data` array.
+- We start the recording process by calling {{domxref("MediaRecorder.start", "recorder.start()")}}, and output a message to the log with the updated state of the recorder and the number of seconds it will be recording.
+- We create a new {{jsxref("Promise")}}, named `stopped`, which is resolved when the `MediaRecorder`'s {{domxref("MediaRecorder.stop_event", "onstop")}} event handler is called, and is rejected if its {{domxref("MediaRecorder.error_event", "onerror")}} event handler is called. The rejection handler receives as input the name of the error that occurred.
+- We creates another new `Promise`, named `recorded`, which is resolved when the specified number of milliseconds have elapsed. Upon resolution, it stops the `MediaRecorder` if it's recording.
+- Finally, we use {{jsxref("Promise.all")}} to create a new `Promise` which is fulfilled when both of the two `Promise`s (`stopped` and `recorded`) have resolved. Once that resolves, the array data is returned by `startRecording()` to its caller.
 
 ### Stopping the input stream
 
@@ -245,22 +238,15 @@ startButton.addEventListener(
 
 When a {{domxref("Element/click_event", "click")}} event occurs, here's what happens:
 
-- Lines 2-4
-  - : {{domxref("MediaDevices.getUserMedia")}} is called to request a new {{domxref("MediaStream")}} that has both video and audio tracks. This is the stream we'll record.
-- Lines 5-9
-  - : When the Promise returned by `getUserMedia()` is resolved, the preview {{HTMLElement("video")}} element's {{domxref("HTMLMediaElement.srcObject","srcObject")}} property is set to be the input stream, which causes the video being captured by the user's camera to be displayed in the preview box. Since the `<video>` element is muted, the audio won't play. The "Download" button's link is then set to refer to the stream as well. Then, in line 8, we arrange for `preview.captureStream()` to call `preview.mozCaptureStream()` so that our code will work on Firefox, on which the {{domxref("HTMLMediaElement.captureStream()")}} method is prefixed. Then a new {{jsxref("Promise")}} which resolves when the preview video starts to play is created and returned.
-- Line 10
-  - : When the preview video begins to play, we know there's media to record, so we respond by calling the [`startRecording()`](#starting_media_recording) function we created earlier, passing in the preview video stream (as the source media to be recorded) and `recordingTimeMS` as the number of milliseconds of media to record. As mentioned before, `startRecording()` returns a {{jsxref("Promise")}} whose resolution handler is called (receiving as input an array of {{domxref("Blob")}} objects containing the chunks of recorded media data) once recording has completed.
-- Lines 11-15
+- {{domxref("MediaDevices.getUserMedia")}} is called to request a new {{domxref("MediaStream")}} that has both video and audio tracks. This is the stream we'll record.
+- When the Promise returned by `getUserMedia()` is resolved, the preview {{HTMLElement("video")}} element's {{domxref("HTMLMediaElement.srcObject","srcObject")}} property is set to be the input stream, which causes the video being captured by the user's camera to be displayed in the preview box. Since the `<video>` element is muted, the audio won't play. The "Download" button's link is then set to refer to the stream as well. Then, we arrange for `preview.captureStream()` to call `preview.mozCaptureStream()` so that our code will work on Firefox, on which the {{domxref("HTMLMediaElement.captureStream()")}} method is prefixed. Then a new {{jsxref("Promise")}} which resolves when the preview video starts to play is created and returned.
+- When the preview video begins to play, we know there's media to record, so we respond by calling the [`startRecording()`](#starting_media_recording) function we created earlier, passing in the preview video stream (as the source media to be recorded) and `recordingTimeMS` as the number of milliseconds of media to record. As mentioned before, `startRecording()` returns a {{jsxref("Promise")}} whose resolution handler is called (receiving as input an array of {{domxref("Blob")}} objects containing the chunks of recorded media data) once recording has completed.
+- The recording process's resolution handler receives as input an array of media data `Blob`s locally known as `recordedChunks`. The first thing we do is merge the chunks into a single {{domxref("Blob")}} whose MIME type is `"video/webm"` by taking advantage of the fact that the {{domxref("Blob.Blob", "Blob()")}} constructor concatenates arrays of objects into one object. Then {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}} is used to create a URL that references the blob; this is then made the value of the recorded video playback element's [`src`](/en-US/docs/Web/HTML/Element/video#src) attribute (so that you can play the video from the blob) as well as the target of the download button's link.
 
-  - : The recording process's resolution handler receives as input an array of media data `Blob`s locally known as `recordedChunks`. The first thing we do is merge the chunks into a single {{domxref("Blob")}} whose MIME type is `"video/webm"` by taking advantage of the fact that the {{domxref("Blob.Blob", "Blob()")}} constructor concatenates arrays of objects into one object. Then {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}} is used to create a URL that references the blob; this is then made the value of the recorded video playback element's [`src`](/en-US/docs/Web/HTML/Element/video#src) attribute (so that you can play the video from the blob) as well as the target of the download button's link.
+  Then the download button's [`download`](/en-US/docs/Web/HTML/Element/a#download) attribute is set. While the `download` attribute can be a Boolean, you can also set it to a string to use as the name for the downloaded file. So by setting the download link's `download` attribute to "RecordedVideo.webm", we tell the browser that clicking the button should download a file named `"RecordedVideo.webm"` whose contents are the recorded video.
 
-    Then the download button's [`download`](/en-US/docs/Web/HTML/Element/a#download) attribute is set. While the `download` attribute can be a Boolean, you can also set it to a string to use as the name for the downloaded file. So by setting the download link's `download` attribute to "RecordedVideo.webm", we tell the browser that clicking the button should download a file named `"RecordedVideo.webm"` whose contents are the recorded video.
-
-- Lines 17-18
-  - : The size and type of the recorded media are output to the log area below the two videos and the download button.
-- Line 20
-  - : The `catch()` for all the `Promise`s outputs the error to the logging area by calling our `log()` function.
+- The size and type of the recorded media are output to the log area below the two videos and the download button.
+- The `catch()` for all the `Promise`s outputs the error to the logging area by calling our `log()` function.
 
 ### Handling the stop button
 

--- a/files/en-us/web/api/mutationobserver/takerecords/index.md
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.md
@@ -66,7 +66,7 @@ if (mutations.length > 0) {
 }
 ```
 
-The code in lines 12–17 fetches any unprocessed mutation records, then invokes the
+The code fetches any unprocessed mutation records, then invokes the
 callback with the records so that they can be processed. This is done immediately prior
 to calling {{domxref("MutationObserver.disconnect", "disconnect()")}} to stop observing
 the DOM.

--- a/files/en-us/web/api/rtcdatachannel/message_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/message_event/index.md
@@ -63,7 +63,7 @@ dc.addEventListener(
 );
 ```
 
-Lines 2-4 create the new paragraph element and add the message data to it as a new text node. Line 6 appends the new paragraph to the end of the document's body.
+We first create the new paragraph element and add the message data to it as a new text node. Then we append the new paragraph to the end of the document's body.
 
 You can also use an `RTCDataChannel` object's {{domxref("RTCDataChannel.message_event", "onmessage")}} event handler property to set the event handler:
 

--- a/files/en-us/web/api/sourcebuffer/abort/index.md
+++ b/files/en-us/web/api/sourcebuffer/abort/index.md
@@ -58,15 +58,6 @@ this case you would want to manually call `abort()` on the source buffer to
 stop the decoding of the current buffer, then fetch and append the newly requested
 segment that relates to the current new position of the video.
 
-You can see something similar in action in Nick Desaulnier's [bufferWhenNeeded demo](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferWhenNeeded.html) — in [line 48, an event listener is added to the playing video](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferWhenNeeded.html#L48) so a function called
-`seek()` is run when the `seeking` event fires. In [lines 92-101, the seek() function is defined](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferWhenNeeded.html#L92-L101) — note that `abort()` is called
-if {{domxref("MediaSource.readyState")}} is set to `open`, which means that
-it is ready to receive new source buffers — at this point it is worth aborting the
-current segment and just getting the one for the new seek position (see
-[`checkBuffer()`](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferWhenNeeded.html#L78-L90)
-and
-[`getCurrentSegment()`](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferWhenNeeded.html#L103-L105).)
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/speechgrammar/index.md
+++ b/files/en-us/web/api/speechgrammar/index.md
@@ -36,7 +36,7 @@ speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
 console.log(speechRecognitionList[0].src); // should return the same as the contents of the grammar variable
-console.log(speechRecognitionList[0].weight); // should return 1 - the same as the weight set in line 4.
+console.log(speechRecognitionList[0].weight); // should return 1 - the same as the weight set in addFromString.
 ```
 
 ## Specifications

--- a/files/en-us/web/api/speechgrammar/src/index.md
+++ b/files/en-us/web/api/speechgrammar/src/index.md
@@ -29,7 +29,7 @@ speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
 console.log(speechRecognitionList[0].src); // should return the same as the contents of the grammar variable
-console.log(speechRecognitionList[0].weight); // should return 1 - the same as the weight set in line 4.
+console.log(speechRecognitionList[0].weight); // should return 1 - the same as the weight set in addFromString.
 ```
 
 ## Specifications

--- a/files/en-us/web/api/speechgrammar/weight/index.md
+++ b/files/en-us/web/api/speechgrammar/weight/index.md
@@ -29,7 +29,7 @@ speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
 console.log(speechRecognitionList[0].src); // should return the same as the contents of the grammar variable
-console.log(speechRecognitionList[0].weight); // should return 1 - the same as the weight set in line 4.
+console.log(speechRecognitionList[0].weight); // should return 1 - the same as the weight set in addFromString.
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
@@ -62,7 +62,7 @@ In this article we'll set up the server for our phone app. The server file will 
    console.log(`Listening on: ${port}`);
    ```
 
-5. You should be able to connect to your app via `localhost` (in our `server.js` we're using port 8000 (defined on line 7) but you may be using another port number). Run `yarn start` (where `start` refers to the script you declared in `package.json` on the previous page) in your terminal. Visit `localhost:8000` in your browser and you should see a page that looks like this:
+5. You should be able to connect to your app via `localhost` (in our `server.js` we're using port 8000 but you may be using another port number). Run `yarn start` (where `start` refers to the script you declared in `package.json` on the previous page) in your terminal. Visit `localhost:8000` in your browser and you should see a page that looks like this:
 
    ![A cream background with the words 'phone a friend' in bold, dark green font as the heading. 'Connecting...' is immediately below that and 'please use headphones!' below that. Following on, a big dark green button with 'Call' written in the same cream color of the background. ](connecting_screen.png)
 

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -108,9 +108,13 @@ You can find the full code in our [Simple writer example](https://mdn.github.io/
 Because of how [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is supported in the API, its implementation in code may be less than obvious.
 To see how backpressure is implemented look for three things:
 
-- The `highWaterMark` property, which is set when creating the counting strategy (line 35), sets the maximum amount of data that the `WritableStream` instance will handle in a single `write()` operation. In this example, it's the maximum amount of data that can be sent to `defaultWriter.write()` (line 11).
-- The `defaultWriter.ready` property returns a promise that resolves when the sink (the first property of the `WritableStream` constructor) is done writing data. The data source can either write more data (line 9) or call `close()` (line 24). Calling close() too early can prevent data from being written. This is why the example calls `defaultWriter.ready` twice (lines 9 and 22).
-- The {{jsxref("Promise")}} returned by the sink's `write()` method (line 40) tells the `WritableStream` and its writer when to resolve `defaultWriter.ready`.
+- The `highWaterMark` property, which is set when creating the counting strategy using `new CountQueuingStrategy`, sets the maximum amount of data that the `WritableStream` instance will handle in a single `write()` operation.
+  In this example, it's the maximum amount of data that can be sent to `defaultWriter.write()`, in the `sendMessage` function.
+- The `defaultWriter.ready` property returns a promise that resolves when the sink (the first property of the `WritableStream` constructor) is done writing data.
+  The data source can either write more data using `defaultWriter.write()` or call `defaultWriter.close()`, as demonstrated in the example above.
+  Calling `close()` too early can prevent data from being written.
+  This is why the example calls `defaultWriter.ready` twice.
+- The {{jsxref("Promise")}} returned by the sink's `write()` method tells the `WritableStream` and its writer when to resolve `defaultWriter.ready`.
 
 ## Specifications
 

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -140,13 +140,13 @@ You can find the full code in our [Simple writer example](https://mdn.github.io/
 Because of how backpressure is supported in the API, its implementation in code may be less than obvious.
 To see how backpressure is implemented look for three things.
 
-- The `highWaterMark` property, which is set when creating the counting strategy (line 35), sets the maximum amount of data that the `WritableStream` instance will handle in a single `write()` operation.
-  In this example, it's the maximum amount of data that can be sent to `defaultWriter.write()` (line 11).
+- The `highWaterMark` property, which is set when creating the counting strategy using `new CountQueuingStrategy`, sets the maximum amount of data that the `WritableStream` instance will handle in a single `write()` operation.
+  In this example, it's the maximum amount of data that can be sent to `defaultWriter.write()`, in the `sendMessage` function.
 - The `defaultWriter.ready` property returns a promise that resolves when the sink (the first property of the `WritableStream` constructor) is done writing data.
-  The data source can either write more data (line 11) or call `close()` (line 24).
+  The data source can either write more data using `defaultWriter.write()` or call `defaultWriter.close()`, as demonstrated in the example above.
   Calling `close()` too early can prevent data from being written.
-  This is why the example calls `defaultWriter.ready` twice (lines 9 and 22).
-- The {{jsxref("Promise")}} returned by the sink's `write()` method (line 40\) tells the `WritableStream` and its writer when to resolve `defaultWriter.ready`.
+  This is why the example calls `defaultWriter.ready` twice.
+- The {{jsxref("Promise")}} returned by the sink's `write()` method tells the `WritableStream` and its writer when to resolve `defaultWriter.ready`.
 
 ## Specifications
 

--- a/files/en-us/web/api/xmlhttprequest_api/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/sending_and_receiving_binary_data/index.md
@@ -59,7 +59,7 @@ function loadBinaryResource(url) {
 }
 ```
 
-The magic happens in line 5, which overrides the MIME type, forcing the browser to treat it as plain text, using a user-defined character set. This tells the browser not to parse it, and to let the bytes pass through unprocessed.
+The magic happens in the `overrideMimeType` function, which forces the browser to treat it as plain text, using a user-defined character set. This tells the browser not to parse it, and to let the bytes pass through unprocessed.
 
 ```js
 const filestream = loadBinaryResource(url);

--- a/files/en-us/web/api/xmlhttprequest_api/synchronous_and_asynchronous_requests/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/synchronous_and_asynchronous_requests/index.md
@@ -36,11 +36,11 @@ xhr.onerror = (e) => {
 xhr.send(null);
 ```
 
-Line 2 specifies `true` for its third parameter to indicate that the request should be handled asynchronously.
+The `xhr.open` line specifies `true` for its third parameter to indicate that the request should be handled asynchronously.
 
-Line 3 creates an event handler function object and assigns it to the request's `onload` attribute. This handler looks at the request's `readyState` to see if the transaction is complete in line 4; if it is, and the HTTP status is 200, the handler dumps the received content. If an error occurred, an error message is displayed.
+We then creates an event handler function object and assigns it to the request's `onload` attribute. This handler looks at the request's `readyState` to see if the transaction is complete; if it is, and the HTTP status is 200, the handler dumps the received content. If an error occurred, an error message is displayed.
 
-Line 15 actually initiates the request. The callback routine is called whenever the state of the request changes.
+The `xhr.send` call actually initiates the request. The callback routine is called whenever the state of the request changes.
 
 ### Example: writing a function to read an external file
 
@@ -78,17 +78,13 @@ loadFile("message.txt", showMessage, "New message!\n\n");
 
 The signature of the utility function **_loadFile_** declares (i) a target URL to read (via an HTTP GET request), (ii) a function to execute on successful completion of the XHR operation, and (iii) an arbitrary list of additional arguments that are passed through the XHR object (via the `arguments` property) to the success callback function.
 
-Line 1 declares a function invoked when the XHR operation completes successfully. It, in turn, invokes the callback function specified in the invocation of the `loadFile` function (in this case, the function `showMessage`) which has been assigned to a property of the XHR object (Line 11). The additional arguments (if any) supplied to the invocation of function loadFile are "applied" to the running of the callback function.
+We first declare a function `xhrSuccess` invoked when the XHR operation completes successfully. It, in turn, invokes the callback function specified in the invocation of the `loadFile` function (in this case, the function `showMessage`) which has been assigned to a property of the XHR object. The additional arguments (if any) supplied to the invocation of function loadFile are "applied" to the running of the callback function. The `xhrError` function is invoked when the XHR operation fails to complete successfully.
 
-Line 5 declares a function invoked when the XHR operation fails to complete successfully.
+We stores the success callback given as the second argument to `loadFile` in the XHR object's `callback` property. Starting with the third argument, all remaining arguments of `loadFile` are collected (using the [rest parameter](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) syntax), assigned to the `arguments` property of the variable `xhr`, passed to the success callback function `xhrSuccess`, and ultimately supplied to the callback function (in this case, `showMessage`) which is invoked by function `xhrSuccess`.
 
-Line 11 stores the success callback given as the second argument to `loadFile` in the XHR object's `callback` property.
+The `xhr.open` call specifies `true` for its third parameter to indicate that the request should be handled asynchronously.
 
-Line 12 slices the arguments array given to the invocation of `loadFile`. Starting with the third argument, all remaining arguments are collected, assigned to the arguments property of the variable `xhr`, passed to the success callback function `xhrSuccess`., and ultimately supplied to the callback function (in this case, `showMessage`) which is invoked by function `xhrSuccess`.
-
-Line 15 specifies _true_ for its third parameter to indicate that the request should be handled asynchronously.
-
-Line 16 actually initiates the request.
+Finally, `xhr.send` actually initiates the request.
 
 ### Example: using a timeout
 
@@ -149,9 +145,9 @@ if (request.status === 200) {
 }
 ```
 
-Line 3 sends the request. The `null` parameter indicates that no body content is needed for the `GET` request.
+The `request.send` call sends the request. The `null` parameter indicates that no body content is needed for the `GET` request.
 
-Line 5 checks the status code after the transaction is completed. If the result is 200 — HTTP's "OK" result — the document's text content is output to the console.
+The `if` statement checks the status code after the transaction is completed. If the result is 200 — HTTP's "OK" result — the document's text content is output to the console.
 
 ### Example: Synchronous HTTP request from a Worker
 

--- a/files/en-us/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -135,7 +135,7 @@ function transferCanceled(evt) {
 }
 ```
 
-Lines 3-6 add event listeners for the various events that are sent while performing a data transfer using `XMLHttpRequest`.
+We add event listeners for the various events that are sent while performing a data transfer using `XMLHttpRequest`.
 
 > **Note:** You need to add the event listeners before calling `open()` on the request. Otherwise the `progress` events will not fire.
 

--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -74,7 +74,7 @@ The cascade is in ascending order, meaning animations have precedence of normal 
 >
 > Property values being set in a {{cssxref('transition')}} take precedence over all other values set, even those marked with `!important`.
 
-The cascade algorithm is applied _before_ the specificity algorithm, meaning if `:root p { color: red;}` is declared in the user stylesheet (line 2) and a less specific `p {color: blue;}` is in the author stylesheet (line 3), the paragraphs will be blue.
+The cascade algorithm is applied _before_ the specificity algorithm, meaning if `:root p { color: red;}` is declared in the user stylesheet (row 2) and a less specific `p {color: blue;}` is in the author stylesheet (row 3), the paragraphs will be blue.
 
 ## Basic example
 

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -194,7 +194,7 @@ Keep-Alive: timeout=2, max=100
 Connection: Keep-Alive
 ```
 
-Lines 1 - 10 above represent the preflight request with the {{HTTPMethod("OPTIONS")}} method. The browser determines that it needs to send this based on the request parameters that the JavaScript code snippet above was using, so that the server can respond whether it is acceptable to send the request with the actual request parameters. OPTIONS is an HTTP/1.1 method that is used to determine further information from servers, and is a {{Glossary("Safe/HTTP", "safe")}} method, meaning that it can't be used to change the resource. Note that along with the OPTIONS request, two other request headers are sent (lines 9 and 10 respectively):
+The first block above represents the preflight request with the {{HTTPMethod("OPTIONS")}} method. The browser determines that it needs to send this based on the request parameters that the JavaScript code snippet above was using, so that the server can respond whether it is acceptable to send the request with the actual request parameters. OPTIONS is an HTTP/1.1 method that is used to determine further information from servers, and is a {{Glossary("Safe/HTTP", "safe")}} method, meaning that it can't be used to change the resource. Note that along with the OPTIONS request, two other request headers are sent:
 
 ```http
 Access-Control-Request-Method: POST
@@ -203,7 +203,7 @@ Access-Control-Request-Headers: content-type,x-pingother
 
 The {{HTTPHeader("Access-Control-Request-Method")}} header notifies the server as part of a preflight request that when the actual request is sent, it will do so with a `POST` request method. The {{HTTPHeader("Access-Control-Request-Headers")}} header notifies the server that when the actual request is sent, it will do so with `X-PINGOTHER` and `Content-Type` custom headers. Now the server has an opportunity to determine whether it can accept a request under these conditions.
 
-Lines 12 - 21 above are the response that the server returns, which indicate that the request method (`POST`) and request headers (`X-PINGOTHER`) are acceptable. Let's have a closer look at lines 15-18:
+The second block above is the response that the server returns, which indicate that the request method (`POST`) and request headers (`X-PINGOTHER`) are acceptable. Let's have a closer look at the following lines:
 
 ```http
 Access-Control-Allow-Origin: https://foo.example
@@ -330,7 +330,7 @@ Content-Type: text/plain
 [text/plain payload]
 ```
 
-Although line 10 contains the Cookie destined for the content on `https://bar.other`, if bar.other did not respond with an {{HTTPHeader("Access-Control-Allow-Credentials")}}`: true` (line 16), the response would be ignored and not made available to the web content.
+Although the request's `Cookie` header contains the cookie destined for the content on `https://bar.other`, if bar.other did not respond with an {{HTTPHeader("Access-Control-Allow-Credentials")}} with value `true`, as demonstrated in this example, the response would be ignored and not made available to the web content.
 
 #### Preflight requests and credentials
 
@@ -360,9 +360,9 @@ Also note that any `Set-Cookie` response header in a response would not set a co
 
 #### Third-party cookies
 
-Note that cookies set in CORS responses are subject to normal third-party cookie policies. In the example above, the page is loaded from `foo.example` but the cookie on line 19 is sent by `bar.other`, and would thus not be saved if the user's browser is configured to reject all third-party cookies.
+Note that cookies set in CORS responses are subject to normal third-party cookie policies. In the example above, the page is loaded from `foo.example` but the `Cookie` header in the response is sent by `bar.other`, and would thus not be saved if the user's browser is configured to reject all third-party cookies.
 
-Cookie in the request (line 10) may also be suppressed in normal third-party cookie policies. The enforced cookie policy may therefore nullify the capability described in this chapter, effectively preventing you from making credentialed requests whatsoever.
+Cookie in the request may also be suppressed in normal third-party cookie policies. The enforced cookie policy may therefore nullify the capability described in this chapter, effectively preventing you from making credentialed requests whatsoever.
 
 Cookie policy around the [SameSite](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) attribute would apply.
 

--- a/files/en-us/web/javascript/reference/errors/getter_only/index.md
+++ b/files/en-us/web/javascript/reference/errors/getter_only/index.md
@@ -57,7 +57,7 @@ arc.temperature = 30;
 // TypeError: setting getter-only property "temperature"
 ```
 
-To fix this error, you will either need to remove line 16, where there is an attempt to
+To fix this error, you will either need to remove the `arc.temperature = 30` line, which attempts to
 set the temperature property, or you will need to implement a [setter](/en-US/docs/Web/JavaScript/Reference/Functions/set) for it, for
 example like this:
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/33122.

Since Yari doesn't render line numbers in code examples, these line number references are actually useless and it's better to explain the code conceptually step-by-step rather than line-by-line, so it's also resilient to formatting.