### PR TITLE
Remove IDB output "example", preferring live example

### DIFF
--- a/files/en-us/web/api/idbcursor/direction/index.md
+++ b/files/en-us/web/api/idbcursor/direction/index.md
@@ -34,11 +34,7 @@ Possible values are:
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we
-log the direction of the cursor, something like this:
-
-```plain
-prev
-```
+log the direction of the cursor.
 
 > **Note:** we can't change the direction of travel of the cursor using
 > the `direction` property, as it is read-only. We specify the direction of

--- a/files/en-us/web/api/idbcursor/key/index.md
+++ b/files/en-us/web/api/idbcursor/key/index.md
@@ -21,8 +21,7 @@ A value of any type.
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we
-log the key of the cursor to the console, something like this (its the album title in
-each case, which is our key).
+log the key of the cursor to the console.
 
 The cursor does not require us to select the data based
 on a key; we can just grab all of it. Also note that in each iteration of the loop,

--- a/files/en-us/web/api/idbcursor/primarykey/index.md
+++ b/files/en-us/web/api/idbcursor/primarykey/index.md
@@ -21,12 +21,7 @@ A value of any data type.
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we
-log the primary key of the cursor to the console, something like this (its the album
-title in each case, which is our primarykey):
-
-```plain
-Hemispheres
-```
+log the primary key of the cursor to the console.
 
 The cursor does not require us to select the data based
 on a key; we can just grab all of it. Also note that in each iteration of the loop,

--- a/files/en-us/web/api/idbcursor/source/index.md
+++ b/files/en-us/web/api/idbcursor/source/index.md
@@ -24,11 +24,7 @@ iterating over.
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. Within each iteration we
 log the source of the cursor, which will log our {{domxref("IDBObjectStore")}} object to
-the console, something like this:
-
-```json
-IDBObjectStore {autoIncrement: false, transaction: IDBTransaction, indexNames: DOMStringList, keyPath: "albumTitle", name: "rushAlbumList"…}
-```
+the console.
 
 The cursor does not require us to select the data based
 on a key; we can just grab all of it. Also note that in each iteration of the loop,


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/23328. Since we have a live example, it's not necessary to have these inline examples. Furthermore they are actively confusing since there's no way for you to reproduce this result yourself anyway.