### PR TITLE
FF128 Relnote: RFC 9218: Extensible Prioritization Scheme for HTTP

### DIFF
--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -36,7 +36,7 @@ This article provides information about the changes in Firefox 128 that affect d
 ### HTTP
 
 - The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) now includes the `image/svg+xml` MIME type ([Firefox bug 1711622](https://bugzil.la/1711622)).
-- The {{rfc("9218", "Extensible Prioritization Scheme for HTTP ")}} is now supported, including the HTTP [`Priority`](/en-US/docs/Web/HTTP/Headers/Priority) request and response header, which allows clients to hint at the expected relative priority for resources sent over a connection, and the HTTP/2 and HTTP/3 `PRIORITY_UPDATE` frames that allow the priority to be subsequently changed after the header has been sent ([Firefox bug 1865040](https://bugzil.la/1865040)).
+- The {{rfc("9218", "Extensible Prioritization Scheme for HTTP")}} is now supported, including the HTTP [`Priority`](/en-US/docs/Web/HTTP/Headers/Priority) request and response header, which allows clients to hint at the expected relative priority for resources sent over a connection, and the HTTP/2 and HTTP/3 `PRIORITY_UPDATE` frames that allow the priority to be subsequently changed after the header has been sent ([Firefox bug 1865040](https://bugzil.la/1865040)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -36,6 +36,7 @@ This article provides information about the changes in Firefox 128 that affect d
 ### HTTP
 
 - The HTTP [`Accept`](/en-US/docs/Web/HTTP/Headers/Accept) header in [default requests and image requests](/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) now includes the `image/svg+xml` MIME type ([Firefox bug 1711622](https://bugzil.la/1711622)).
+- The {{rfc("9218", "Extensible Prioritization Scheme for HTTP ")}} is now supported, including the HTTP [`Priority`](/en-US/docs/Web/HTTP/Headers/Priority) request and response header, which allows clients to hint at the expected relative priority for resources sent over a connection, and the HTTP/2 and HTTP/3 `PRIORITY_UPDATE` frames that allow the priority to be subsequently changed after the header has been sent ([Firefox bug 1865040](https://bugzil.la/1865040)).
 
 #### Removals
 


### PR DESCRIPTION
FF128 supports RFC 9218: Extensible Prioritization Scheme for HTTP in https://bugzilla.mozilla.org/show_bug.cgi?id=1865040

This adds a release note.
Note that the only bit of HTTP we formally document in MDN is the HTTP headers - in this case `Priority`. I have mentioned the other main parts of this spec - which are HTTP/2 & 3 frames but not "documented them", and hence not linked.

Related docs work can be tracked in #33847

