### PR TITLE
Standardize examples in `URLSearchParams: delete()`

### DIFF
--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -68,8 +68,8 @@ console.log(`Query string (after):\t ${params}`);
 All parameters that match both the parameter `name` and `value` should be deleted (there is no reason to specify two parameters with the same name and value as shown above).
 
 ```plain
-Query string (before):	 foo=1&bar=2&foo=3&foo=1
-Query string (after):	 bar=2&foo=3
+Query string (before):   foo=1&bar=2&foo=3&foo=1
+Query string (after):   bar=2&foo=3
 ```
 
 If your browser supports the `value` option, the "after" string should be `bar=2&foo=3`.

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -38,55 +38,39 @@ None ({{jsxref("undefined")}}).
 
 This example shows how to delete all query parameters (and values) that have a particular name.
 
-```html hidden
-<pre id="log"></pre>
-```
-
-```js hidden
-const logElement = document.getElementById("log");
-function log(text) {
-  logElement.innerText += `${text}\n`;
-}
-```
-
 ```js
 const url = new URL("https://example.com?foo=1&bar=2&foo=3");
 const params = new URLSearchParams(url.search);
-log(`Query string (before):\t ${params}`);
+console.log(`Query string (before):\t ${params}`);
 params.delete("foo");
-log(`Query string (after):\t ${params}`);
+console.log(`Query string (after):\t ${params}`);
 ```
 
 The log below shows that all parameters that have the name of `foo` are deleted.
 
-{{EmbedLiveSample('Delete all parameters with specified name', '100%', '50')}}
+```plain
+Query string (before):	 foo=1&bar=2&foo=3
+Query string (after):	 bar=2
+```
 
 ### Delete parameters with specified name and value
 
 This example shows how to delete query parameters that match a particular name and value.
 
-```html hidden
-<pre id="log"></pre>
-```
-
-```js hidden
-const logElement = document.getElementById("log");
-function log(text) {
-  logElement.innerText += `${text}\n`;
-}
-```
-
 ```js
 const url = new URL("https://example.com?foo=1&bar=2&foo=3&foo=1");
 const params = new URLSearchParams(url.search);
-log(`Query string (before):\t ${params}`);
+console.log(`Query string (before):\t ${params}`);
 params.delete("foo", "1");
-log(`Query string (after):\t ${params}`);
+console.log(`Query string (after):\t ${params}`);
 ```
 
 All parameters that match both the parameter `name` and `value` should be deleted (there is no reason to specify two parameters with the same name and value as shown above).
 
-{{EmbedLiveSample('Delete parameters with specified name and value', '100%', '50')}}
+```plain
+Query string (before):	 foo=1&bar=2&foo=3&foo=1
+Query string (after):	 bar=2&foo=3
+```
 
 If your browser supports the `value` option, the "after" string should be `bar=2&foo=3`.
 Otherwise the result will be the same as in the previous example (`bar=2`).

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -49,8 +49,8 @@ console.log(`Query string (after):\t ${params}`);
 The log below shows that all parameters that have the name of `foo` are deleted.
 
 ```plain
-Query string (before):	 foo=1&bar=2&foo=3
-Query string (after):	 bar=2
+Query string (before):   foo=1&bar=2&foo=3
+Query string (after):   bar=2
 ```
 
 ### Delete parameters with specified name and value

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -49,7 +49,7 @@ console.log(`Query string (after):\t ${params}`);
 The log below shows that all parameters that have the name of `foo` are deleted.
 
 ```plain
-Query string (before):   foo=1&bar=2&foo=3
+Query string (before):  foo=1&bar=2&foo=3
 Query string (after):   bar=2
 ```
 
@@ -68,7 +68,7 @@ console.log(`Query string (after):\t ${params}`);
 All parameters that match both the parameter `name` and `value` should be deleted (there is no reason to specify two parameters with the same name and value as shown above).
 
 ```plain
-Query string (before):   foo=1&bar=2&foo=3&foo=1
+Query string (before):  foo=1&bar=2&foo=3&foo=1
 Query string (after):   bar=2&foo=3
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Replaces LiveSample with console.log in the examples for URLSearchParams: delete()

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I blindly copy-pasted the first example into my terminal and was surprised when I got back `Uncaught ReferenceError: log is not defined`. It wasn't until after I checked the source of the page that I realized it was utilizing a custom `log` function that didn't lend itself to copy/pasting outside of the LiveSample.

The rest of the URLSearchParams method examples use `console.log`, so I think it makes sense to do the same thing here. Look at [forEach](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/forEach#examples) as an example.

