### PR TITLE
fix(css): correct wording about margin size

### DIFF
--- a/files/en-us/learn/css/css_layout/normal_flow/index.md
+++ b/files/en-us/learn/css/css_layout/normal_flow/index.md
@@ -69,7 +69,7 @@ Let's look at a simple example that explains all of this:
 
 <p>
   We are separated by our margins. Because of margin collapsing, we are
-  separated by the width of one of our margins, not both.
+  separated by the size of one of our margins, not both.
 </p>
 
 <p>


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/34408

The [spec does use "width"](https://drafts.csswg.org/css-box/#margin-edge) but to avoid confusion we could use "size" as it's been used on the [MDN `margin` page](https://developer.mozilla.org/en-US/docs/Web/CSS/margin#values).