### PR TITLE
Add a note for light-dark to "Styling console output" section

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -216,9 +216,9 @@ The properties usable along with the `%c` syntax are as follows (at least, in Fi
 - {{cssxref("word-spacing")}} and {{cssxref("word-break")}}
 - {{cssxref("writing-mode")}}
 
-> **Note:** The console message behaves like an inline element by default. To see the effects of `padding`, `margin`, etc. you should set it to for example `display: inline-block`.
+> **Note:** Each console message behaves like an inline element by default. If you want to properties such as `padding`, `margin`, and so to have any effect, you can set the `display` property to `display: inline-block`.
 
-> **Note:** In order to support both light and dark color schemes, {{cssxref("color_value/light-dark")}} can be used when specifying color. e.g. `color: light-dark(#D00000, #FF4040);`
+> **Note:** In order to support both light and dark color schemes, {{cssxref("color_value/light-dark")}} can be used when specifying colors; for example: `color: light-dark(#D00000, #FF4040);`
 
 ### Using groups in the console
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -218,7 +218,7 @@ The properties usable along with the `%c` syntax are as follows (at least, in Fi
 
 > **Note:** The console message behaves like an inline element by default. To see the effects of `padding`, `margin`, etc. you should set it to for example `display: inline-block`.
 
-> **Note:** In order to support both light and dark color schemes, {{cssxref("light-dark")}} can be used when specifying color. e.g. `color: light-dark(#D00000, #FF4040);`
+> **Note:** In order to support both light and dark color schemes, {{cssxref("color_value/light-dark")}} can be used when specifying color. e.g. `color: light-dark(#D00000, #FF4040);`
 
 ### Using groups in the console
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -216,7 +216,7 @@ The properties usable along with the `%c` syntax are as follows (at least, in Fi
 - {{cssxref("word-spacing")}} and {{cssxref("word-break")}}
 - {{cssxref("writing-mode")}}
 
-> **Note:** Each console message behaves like an inline element by default. If you want to properties such as `padding`, `margin`, and so to have any effect, you can set the `display` property to `display: inline-block`.
+> **Note:** Each console message behaves like an inline element by default. If you want properties such as `padding`, `margin`, and so on to have any effect, you can set the `display` property to `display: inline-block`.
 
 > **Note:** In order to support both light and dark color schemes, {{cssxref("color_value/light-dark")}} can be used when specifying colors; for example: `color: light-dark(#D00000, #FF4040);`
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -218,6 +218,8 @@ The properties usable along with the `%c` syntax are as follows (at least, in Fi
 
 > **Note:** The console message behaves like an inline element by default. To see the effects of `padding`, `margin`, etc. you should set it to for example `display: inline-block`.
 
+> **Note:** In order to support both light and dark color schemes, {{cssxref("light-dark")}} can be used when specifying color. e.g. `color: light-dark(#D00000, #FF4040);`
+
 ### Using groups in the console
 
 You can use nested groups to help organize your output by visually combining related material. To create a new nested block, call `console.group()`. The `console.groupCollapsed()` method is similar but creates the new block collapsed, requiring the use of a disclosure button to open it for reading.


### PR DESCRIPTION
### Description

Add a note for [light-dark](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) to the `console.log`'s "Styling console output" section.

### Motivation

In most browsers, the console can be configured to reflect the system color scheme, or its own color scheme, either light or dark.
Specifying single color may not work well for either light or dark color scheme, for example it may be too light for light background color and and it becomes almost invisible, or too vivid for dark background color, etc.
Explaining the `light-dark()` functionality there will help people generate console logs with color which work nicely both with light and dark color schemes.

### Additional details

As mentioned in https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark , `light-dark` works on the latest version of major browsers.

### Related issues and pull requests

none