### PR TITLE
Correct offsetParent condition

### DIFF
--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -12,9 +12,10 @@ The **`HTMLElement.offsetParent`** read-only property returns a
 reference to the element which is the closest (nearest in the containment hierarchy)
 positioned ancestor element.
 
-A positioned ancestor is either:
+A positioned ancestor might be:
 
-- an element with a non-static position, or
+- a [containing block](/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block) for absolutely-positioned elements
+- an element with a different effective [zoom](/en-US/docs/Web/CSS/zoom) value (that is, the product of all zoom scales of its parents) from this element
 - `td`, `th`, `table` in case the element itself is static positioned.
 
 If there is no positioned ancestor element, the `body` is returned.


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/28991. `offsetParent` includes non-static positioning, but also other things. Luckily we already have a good article on containing blocks.