### PR TITLE
Remove DNT spec links, add deprecation reasoning

### DIFF
--- a/files/en-us/web/accessibility/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/seizure_disorders/index.md
@@ -528,10 +528,6 @@ The `update` media feature is used to query the ability of the output device to 
 
 ## Developmental & Experimental Features
 
-### MDN Navigator.doNotTrack
-
-[From the documentation](/en-US/docs/Web/API/Navigator/doNotTrack): _"Returns the user's do-not-track setting. This is "1" if the user has requested not to be tracked by websites, content, or advertising"_.
-
 ### Media Queries Level 5
 
 EnvironmentMQ (Planned in Media Queries Level 5)

--- a/files/en-us/web/api/navigator/donottrack/index.md
+++ b/files/en-us/web/api/navigator/donottrack/index.md
@@ -15,6 +15,10 @@ The **`Navigator.doNotTrack`** property returns the user's Do Not Track setting,
 
 The value of the property reflects that of the {{httpheader("DNT")}} HTTP header, i.e. values of `"1"`, `"0"`, or `null`.
 
+The whole DNT (Do Not Track) specification has been discontinued. The mechanism design was flawed, because it was a cooperative feature between users, websites, and browsers. The idea is that the user tells the _website_ to not track them, and the _website_ would comply. However, there is no strict enforcement of this policy, so advertisement websites ignored the DNT header and tracked users anyway. The feature is therefore useless. Moreover, it is harmful as it leaves more user [fingerprint](/en-US/docs/Glossary/Fingerprinting) in the header, which can be used to track users even more.
+
+Browsers are exploring other more enforceable privacy features, such as [global privacy control](/en-US/docs/Web/API/Navigator/globalPrivacyControl), restriction to third-party cookies, and more.
+
 ## Value
 
 A string or `null`.
@@ -28,7 +32,7 @@ console.log(navigator.doNotTrack);
 
 ## Specifications
 
-{{Specifications}}
+Part of the discontinued [Tracking Preference Expression (DNT)](https://www.w3.org/TR/tracking-dnt/#dom-navigator-donottrack) specification.
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/dnt/index.md
+++ b/files/en-us/web/http/headers/dnt/index.md
@@ -10,6 +10,8 @@ browser-compat: http.headers.DNT
 
 {{HTTPSidebar}}{{Deprecated_header}}{{non-standard_header}}
 
+> **Note:** The DNT (Do Not Track) specification has been discontinued. See {{domxref("Navigator.doNotTrack")}} for more information.
+
 The **`DNT`** (**D**o **N**ot
 **T**rack) request header indicates the user's tracking preference. It lets
 users indicate whether they would prefer privacy rather than personalized content.
@@ -59,7 +61,7 @@ navigator.doNotTrack; // "0", "1" or null
 
 ## Specifications
 
-{{Specifications}}
+Part of the discontinued [Tracking Preference Expression (DNT)](https://www.w3.org/TR/tracking-dnt/#dnt-header-field) specification.
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/tk/index.md
+++ b/files/en-us/web/http/headers/tk/index.md
@@ -10,6 +10,8 @@ browser-compat: http.headers.Tk
 
 {{HTTPSidebar}}{{Deprecated_header}}{{non-standard_header}}
 
+> **Note:** The DNT (Do Not Track) specification has been discontinued. See {{domxref("Navigator.doNotTrack")}} for more information.
+
 The **`Tk`** response header indicates the tracking status that
 applied to the corresponding request.
 
@@ -80,7 +82,7 @@ Tk: N
 
 ## Specifications
 
-{{Specifications}}
+Part of the discontinued [Tracking Preference Expression (DNT)](https://www.w3.org/TR/tracking-dnt/#response-header-field) specification.
 
 ## Browser compatibility
 


### PR DESCRIPTION
The spec links were removed in https://github.com/mdn/browser-compat-data/pull/20975, so the macros are broken.

This also fixes https://github.com/mdn/content/issues/12912 by rewording @teoli2003's comment.