### PR TITLE
Update description of GPUColorWrite constants in WebGPU 

### DIFF
--- a/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
+++ b/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
@@ -203,7 +203,7 @@ The `fragment` object contains an array of objects, each of which can contain th
         Note that multiple flags can be specified by separating values with pipe symbols, for example:
 
         ```js
-        writeMask: GPUColorWrite.RED | GPUColorWrite.ALPHA
+        writeMask: GPUColorWrite.RED | GPUColorWrite.ALPHA;
         ```
 
 ### `multisample` object structure

--- a/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
+++ b/files/en-us/web/api/gpudevice/createrenderpipeline/index.md
@@ -192,18 +192,18 @@ The `fragment` object contains an array of objects, each of which can contain th
 
       - : One or more {{glossary("bitwise flags")}} defining the write mask to apply to the color target state. Possible flag values are:
 
-        - `GPUFlagsConstant.RED`
-        - `GPUFlagsConstant.GREEN`
-        - `GPUFlagsConstant.BLUE`
-        - `GPUFlagsConstant.ALPHA`
-        - `GPUFlagsConstant.ALL`
+        - `GPUColorWrite.RED`
+        - `GPUColorWrite.GREEN`
+        - `GPUColorWrite.BLUE`
+        - `GPUColorWrite.ALPHA`
+        - `GPUColorWrite.ALL`
 
-        If omitted, `writeMask` defaults to `GPUFlagsConstant.ALL`.
+        If omitted, `writeMask` defaults to `GPUColorWrite.ALL`.
 
         Note that multiple flags can be specified by separating values with pipe symbols, for example:
 
         ```js
-        writeMask: GPUFlagsConstant.RED | GPUFlagsConstant.ALPHA;
+        writeMask: GPUColorWrite.RED | GPUColorWrite.ALPHA
         ```
 
 ### `multisample` object structure


### PR DESCRIPTION
### Description

The WebGPU createRenderPipeline call takes bitwise flags as parameters but I think they were mislabeled on the docs. I've updated them to the correct name. 

### Motivation

Following the way in which the flags were originally described on the docs, you would get a JavaScript ReferenceError saying 'GPUFlagsConstant is not defined'. 

### Additional details

WebGPU documentation for GPUColorWrite: https://www.w3.org/TR/webgpu/#namespacedef-gpucolorwrite 

