### PR TITLE
Template engines link fix - list the main engines

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.md
@@ -478,7 +478,10 @@ For more information see [Database integration](https://expressjs.com/en/guide/d
 
 ### Rendering data (views)
 
-Template engines (also referred to as "view engines" in _Express_) allow you to specify the _structure_ of an output document in a template, using placeholders for data that will be filled in when a page is generated. Templates are often used to create HTML, but can also create other types of documents. Express has support for [a number of template engines](https://expressjs.com/en/resources/template-engines.html), each with its own strengths for addressing particular use cases (relative comparisons can easily be found via Internet search).
+Template engines (also referred to as "view engines" in _Express_) allow you to specify the _structure_ of an output document in a template, using placeholders for data that will be filled in when a page is generated. Templates are often used to create HTML, but can also create other types of documents.
+
+Express has support for a number of template engines, notably Pug (formerly "Jade"), Mustache, and EJS. Each has its own strengths for addressing particular use cases (relative comparisons can easily be found via Internet search).
+The Express application generator uses Jade as its default, but it also supports several others.
 
 In your application settings code you set the template engine to use and the location where Express should look for templates using the 'views' and 'view engine' settings, as shown below (you will also have to install the package containing your template library too!)
 


### PR DESCRIPTION
Express have no useful links anymore to template engines other than the main ones - Pug, EJS, Moustache. I've mirrored this by listing those main libraries and referring to them as "notable".

I'm relatively happy with this. The original doc assumed you might have a strong preference for a particular templating engine, but in fact most support fairly similar syntax and concepts. Three is more than enough to list and people can search if they want to find if their preferred engine is supported.

Fixes #34481