### PR TITLE
fix(html): update positioning and scaling section

### DIFF
--- a/files/en-us/web/css/object-fit/index.md
+++ b/files/en-us/web/css/object-fit/index.md
@@ -10,7 +10,7 @@ browser-compat: css.properties.object-fit
 The **`object-fit`** [CSS](/en-US/docs/Web/CSS) property sets how the content of a [replaced element](/en-US/docs/Web/CSS/Replaced_element), such as an {{HTMLElement("img")}} or {{HTMLElement("video")}}, should be resized to fit its container.
 
 > [!NOTE]
-> The `object-fit` has no effect on {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("fencedframe")}} elements.
+> The `object-fit` property has no effect on {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("fencedframe")}} elements.
 
 You can alter the alignment of the replaced element's content object within the element's box using the {{cssxref("object-position")}} property.
 

--- a/files/en-us/web/css/object-fit/index.md
+++ b/files/en-us/web/css/object-fit/index.md
@@ -9,6 +9,9 @@ browser-compat: css.properties.object-fit
 
 The **`object-fit`** [CSS](/en-US/docs/Web/CSS) property sets how the content of a [replaced element](/en-US/docs/Web/CSS/Replaced_element), such as an {{HTMLElement("img")}} or {{HTMLElement("video")}}, should be resized to fit its container.
 
+> [!NOTE]
+> The `object-fit` has no effect on {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("fencedframe")}} elements.
+
 You can alter the alignment of the replaced element's content object within the element's box using the {{cssxref("object-position")}} property.
 
 {{EmbedInteractiveExample("pages/css/object-fit.html")}}

--- a/files/en-us/web/css/replaced_element/index.md
+++ b/files/en-us/web/css/replaced_element/index.md
@@ -44,7 +44,7 @@ Note that some replaced elements, but not all, have intrinsic dimensions or a de
 Certain CSS properties can be used to specify how the object contained within the replaced element should be positioned within the element's box area. These are defined by the [CSS Images](https://drafts.csswg.org/css-images/) specification:
 
 - {{cssxref("object-fit")}}
-  - : Specifies how the replaced element's content object should be fitted to the containing element's box. The `object-fit` has no effect on {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("fencedframe")}} elements.
+  - : Specifies how the replaced element's content object should be fitted to the containing element's box. The `object-fit` property has no effect on {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("fencedframe")}} elements.
 - {{cssxref("object-position")}}
   - : Specifies the alignment of the replaced element's content object within the element's box.
 

--- a/files/en-us/web/css/replaced_element/index.md
+++ b/files/en-us/web/css/replaced_element/index.md
@@ -16,10 +16,11 @@ The only other impact CSS can have on a replaced element is that there are prope
 
 Typical replaced elements are:
 
-- {{HTMLElement("iframe")}}
-- {{HTMLElement("video")}}
-- {{HTMLElement("embed")}}
 - {{HTMLElement("img")}}
+- {{HTMLElement("video")}}
+- {{HTMLElement("iframe")}}
+- {{HTMLElement("embed")}}
+- {{HTMLElement("fencedframe")}}
 
 Some elements are treated as replaced elements only in specific cases:
 
@@ -43,7 +44,7 @@ Note that some replaced elements, but not all, have intrinsic dimensions or a de
 Certain CSS properties can be used to specify how the object contained within the replaced element should be positioned within the element's box area. These are defined by the [CSS Images](https://drafts.csswg.org/css-images/) specification:
 
 - {{cssxref("object-fit")}}
-  - : Specifies how the replaced element's content object should be fitted to the containing element's box.
+  - : Specifies how the replaced element's content object should be fitted to the containing element's box. The `object-fit` has no effect on {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTMLElement("fencedframe")}} elements.
 - {{cssxref("object-position")}}
   - : Specifies the alignment of the replaced element's content object within the element's box.
 

--- a/files/en-us/web/html/element/embed/index.md
+++ b/files/en-us/web/html/element/embed/index.md
@@ -33,7 +33,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 You can use the {{cssxref("object-position")}} property to adjust the positioning of the embedded object within the element's frame.
 
 > [!NOTE]
-> The {{cssxref("object-fit")}} doesn't work on `<embed>` element.
+> The {{cssxref("object-fit")}} has no effect on `<embed>` elements.
 
 ## Accessibility
 

--- a/files/en-us/web/html/element/embed/index.md
+++ b/files/en-us/web/html/element/embed/index.md
@@ -30,7 +30,10 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ## Usage notes
 
-You can use the {{cssxref("object-position")}} property to adjust the positioning of the embedded object within the element's frame, and the {{cssxref("object-fit")}} property to control how the object's size is adjusted to fit within the frame.
+You can use the {{cssxref("object-position")}} property to adjust the positioning of the embedded object within the element's frame.
+
+> [!NOTE]
+> The {{cssxref("object-fit")}} doesn't work on `<embed>` element.
 
 ## Accessibility
 

--- a/files/en-us/web/html/element/embed/index.md
+++ b/files/en-us/web/html/element/embed/index.md
@@ -33,7 +33,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 You can use the {{cssxref("object-position")}} property to adjust the positioning of the embedded object within the element's frame.
 
 > [!NOTE]
-> The {{cssxref("object-fit")}} has no effect on `<embed>` elements.
+> The {{cssxref("object-fit")}} property has no effect on `<embed>` elements.
 
 ## Accessibility
 

--- a/files/en-us/web/html/element/fencedframe/index.md
+++ b/files/en-us/web/html/element/fencedframe/index.md
@@ -60,7 +60,7 @@ However, trying to traverse the boundary via an API call such as {{domxref("HTML
 
 ## Positioning and scaling
 
-As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position of the embedded document within the `<iframe>` element's box can be adjusted with the {{cssxref("object-position")}}.
+Being a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the `<fencedframe>` allows the position of the embedded document within its box to be adjusted using the {{cssxref("object-position")}} property.
 
 > [!NOTE]
 > The {{cssxref("object-fit")}} has no effect on `<fencedframe>` elements.

--- a/files/en-us/web/html/element/fencedframe/index.md
+++ b/files/en-us/web/html/element/fencedframe/index.md
@@ -63,7 +63,7 @@ However, trying to traverse the boundary via an API call such as {{domxref("HTML
 Being a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the `<fencedframe>` allows the position of the embedded document within its box to be adjusted using the {{cssxref("object-position")}} property.
 
 > [!NOTE]
-> The {{cssxref("object-fit")}} has no effect on `<fencedframe>` elements.
+> The {{cssxref("object-fit")}} property has no effect on `<fencedframe>` elements.
 
 The size of the embedded content may be set by internal `contentWidth` and `contentHeight` properties of the `<fencedframe>`'s {{domxref("HTMLFencedFrameElement.config", "config")}} object. In such cases, changing the `width` or `height` of the `<fencedframe>` will change the size of the embedded container on the page, but the document inside the container will be visually scaled to fit. The reported width and height of the embedded document (i.e. {{domxref("Window.innerWidth")}} and {{domxref("Window.innerHeight")}}) will be unchanged.
 

--- a/files/en-us/web/html/element/fencedframe/index.md
+++ b/files/en-us/web/html/element/fencedframe/index.md
@@ -63,7 +63,7 @@ However, trying to traverse the boundary via an API call such as {{domxref("HTML
 As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position of the embedded document within the `<iframe>` element's box can be adjusted with the {{cssxref("object-position")}}.
 
 > [!NOTE]
-> The {{cssxref("object-fit")}} doesn't work on `<fencedframe>` element.
+> The {{cssxref("object-fit")}} has no effect on `<fencedframe>` elements.
 
 The size of the embedded content may be set by internal `contentWidth` and `contentHeight` properties of the `<fencedframe>`'s {{domxref("HTMLFencedFrameElement.config", "config")}} object. In such cases, changing the `width` or `height` of the `<fencedframe>` will change the size of the embedded container on the page, but the document inside the container will be visually scaled to fit. The reported width and height of the embedded document (i.e. {{domxref("Window.innerWidth")}} and {{domxref("Window.innerHeight")}}) will be unchanged.
 

--- a/files/en-us/web/html/element/fencedframe/index.md
+++ b/files/en-us/web/html/element/fencedframe/index.md
@@ -60,7 +60,10 @@ However, trying to traverse the boundary via an API call such as {{domxref("HTML
 
 ## Positioning and scaling
 
-As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position, alignment, and scaling of the embedded document within the `<iframe>` element's box, can be adjusted with the {{cssxref("object-position")}} and {{cssxref("object-fit")}} properties.
+As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position of the embedded document within the `<iframe>` element's box can be adjusted with the {{cssxref("object-position")}}.
+
+> [!NOTE]
+> The {{cssxref("object-fit")}} doesn't work on `<fencedframe>` element.
 
 The size of the embedded content may be set by internal `contentWidth` and `contentHeight` properties of the `<fencedframe>`'s {{domxref("HTMLFencedFrameElement.config", "config")}} object. In such cases, changing the `width` or `height` of the `<fencedframe>` will change the size of the embedded container on the page, but the document inside the container will be visually scaled to fit. The reported width and height of the embedded document (i.e. {{domxref("Window.innerWidth")}} and {{domxref("Window.innerHeight")}}) will be unchanged.
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -181,9 +181,12 @@ From the inside of a frame, a script can get a reference to its parent window wi
 
 Script access to a frame's content is subject to the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy). Scripts cannot access most properties in other `window` objects if the script was loaded from a different origin, including scripts inside a frame accessing the frame's parent. Cross-origin communication can be achieved using {{domxref("Window.postMessage()")}}.
 
-## Positioning
+## Positioning and scaling
 
 As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position of the embedded document within the `<iframe>` element's box can be adjusted with the {{cssxref("object-position")}} property.
+
+> [!NOTE]
+> The {{cssxref("object-fit")}} doesn't work on `<iframe>` element.
 
 ## `error` and `load` event behavior
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -98,7 +98,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `allow-downloads`
       - : Allows downloading files through an {{HTMLElement("a")}} or {{HTMLElement("area")}} element with the [download](/en-US/docs/Web/HTML/Element/a#download) attribute, as well as through the navigation that leads to a download of a file. This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction.
     - `allow-forms`
-      - : Allows the page to submit forms. If this keyword is not used, a form will be displayed as normal, but submitting it will not trigger input validation, sending data to a web server or closing a dialog.
+      - : Allows the page to submit forms. If this keyword is not used, a form will be displayed as normal, but submitting it will not trigger input validation, send data to a web server, or close a dialog.
     - `allow-modals`
       - : Allows the page to open modal windows by {{domxref("Window.alert()")}}, {{domxref("Window.confirm()")}}, {{domxref("Window.print()")}} and {{domxref("Window.prompt()")}}, while opening a {{HTMLElement("dialog")}} is allowed regardless of this keyword. It also allows the page to receive {{domxref("BeforeUnloadEvent")}} event.
     - `allow-orientation-lock`
@@ -183,10 +183,10 @@ Script access to a frame's content is subject to the [same-origin policy](/en-US
 
 ## Positioning and scaling
 
-As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position of the embedded document within the `<iframe>` element's box can be adjusted with the {{cssxref("object-position")}} property.
+Being a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the `<iframe>` allows the position of the embedded document within its box to be adjusted using the {{cssxref("object-position")}} property.
 
 > [!NOTE]
-> The {{cssxref("object-fit")}} doesn't work on `<iframe>` element.
+> The {{cssxref("object-fit")}} has no effect on `<iframe>` elements.
 
 ## `error` and `load` event behavior
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -98,7 +98,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `allow-downloads`
       - : Allows downloading files through an {{HTMLElement("a")}} or {{HTMLElement("area")}} element with the [download](/en-US/docs/Web/HTML/Element/a#download) attribute, as well as through the navigation that leads to a download of a file. This works regardless of whether the user clicked on the link, or JS code initiated it without user interaction.
     - `allow-forms`
-      - : Allows the page to submit forms. If this keyword is not used, form will be displayed as normal, but submitting it will not trigger input validation, sending data to a web server or closing a dialog.
+      - : Allows the page to submit forms. If this keyword is not used, a form will be displayed as normal, but submitting it will not trigger input validation, sending data to a web server or closing a dialog.
     - `allow-modals`
       - : Allows the page to open modal windows by {{domxref("Window.alert()")}}, {{domxref("Window.confirm()")}}, {{domxref("Window.print()")}} and {{domxref("Window.prompt()")}}, while opening a {{HTMLElement("dialog")}} is allowed regardless of this keyword. It also allows the page to receive {{domxref("BeforeUnloadEvent")}} event.
     - `allow-orientation-lock`
@@ -181,9 +181,9 @@ From the inside of a frame, a script can get a reference to its parent window wi
 
 Script access to a frame's content is subject to the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy). Scripts cannot access most properties in other `window` objects if the script was loaded from a different origin, including scripts inside a frame accessing the frame's parent. Cross-origin communication can be achieved using {{domxref("Window.postMessage()")}}.
 
-## Positioning and scaling
+## Positioning
 
-As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position, alignment, and scaling of the embedded document within the `<iframe>` element's box, can be adjusted with the {{cssxref("object-position")}} and {{cssxref("object-fit")}} properties.
+As a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the position of the embedded document within the `<iframe>` element's box can be adjusted with the {{cssxref("object-position")}} property.
 
 ## `error` and `load` event behavior
 
@@ -287,7 +287,7 @@ Here's how to write escape sequences when using `srcdoc`:
     </tr>
     <tr>
       <th scope="row">Tag omission</th>
-      <td>None, both the starting and ending tag are mandatory.</td>
+      <td>None, both the starting and ending tags are mandatory.</td>
     </tr>
     <tr>
       <th scope="row">Permitted parents</th>

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -186,7 +186,7 @@ Script access to a frame's content is subject to the [same-origin policy](/en-US
 Being a [replaced element](/en-US/docs/Web/CSS/Replaced_element), the `<iframe>` allows the position of the embedded document within its box to be adjusted using the {{cssxref("object-position")}} property.
 
 > [!NOTE]
-> The {{cssxref("object-fit")}} has no effect on `<iframe>` elements.
+> The {{cssxref("object-fit")}} property has no effect on `<iframe>` elements.
 
 ## `error` and `load` event behavior
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/32474

The `object-fit` doesn't work at all in any browser. And `object-position` works only in Firefox.

In the OWD meeting, it was decided to remove `object-fit` from the section. And [update BCD of `object-position`](https://github.com/mdn/browser-compat-data/issues/23586) to show that, for iframe, it's supported only in Firefox.