### PR TITLE
fix(learn/css): restructure guides navigation

### DIFF
--- a/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
+++ b/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
@@ -341,4 +341,4 @@ If you do want to use such features in your production work, make sure to test a
 
 We hope this article was fun — playing with shiny toys generally is, and it is always interesting to see what kinds of advanced styling tools are becoming available in modern browsers.
 
-{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
+++ b/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
@@ -4,7 +4,7 @@ slug: Learn/CSS/Building_blocks/Advanced_styling_effects
 page-type: guide
 ---
 
-{{LearnSidebar}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
 
 This article acts as a box of tricks, providing an introduction to some interesting advanced styling features such as box shadows, blend modes, and filters.
 
@@ -340,3 +340,5 @@ If you do want to use such features in your production work, make sure to test a
 ## Summary
 
 We hope this article was fun — playing with shiny toys generally is, and it is always interesting to see what kinds of advanced styling tools are becoming available in modern browsers.
+
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/debugging_css/index.md
+++ b/files/en-us/learn/css/building_blocks/debugging_css/index.md
@@ -4,7 +4,7 @@ slug: Learn/CSS/Building_blocks/Debugging_CSS
 page-type: learn-module-chapter
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Advanced_styling_effects", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}
 
 Sometimes when writing CSS you will encounter an issue where your CSS doesn't seem to be doing what you expect. Perhaps you believe that a certain selector should match an element, but nothing happens, or a box is a different size than you expected. This article will give you guidance on how to go about debugging a CSS problem, and show you how the DevTools included in all modern browsers can help you to find out what is going on.
 
@@ -192,4 +192,4 @@ So there we have it: an introduction to debugging CSS, which should give you som
 
 In the last article of this module, we'll take a look at how to [organize your CSS](/en-US/docs/Learn/CSS/Building_blocks/Organizing).
 
-{{PreviousMenuNext("Learn/CSS/Building_blocks/Styling_tables", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Advanced_styling_effects", "Learn/CSS/Building_blocks/Organizing", "Learn/CSS/Building_blocks")}}

--- a/files/en-us/learn/css/building_blocks/index.md
+++ b/files/en-us/learn/css/building_blocks/index.md
@@ -58,6 +58,8 @@ This module contains the following articles, which cover the most essential part
   - : In this lesson we will take a look at how certain special elements are treated in CSS. Images, other media, and form elements behave a little differently in terms of your ability to style them with CSS than regular boxes. Understanding what is and isn't possible can save some frustration, and this lesson will highlight some of the main things that you need to know.
 - [Styling tables](/en-US/docs/Learn/CSS/Building_blocks/Styling_tables)
   - : Styling an HTML table isn't the most glamorous job in the world, but sometimes we all have to do it. This article provides a guide to making HTML tables look good, with some specific table styling techniques highlighted.
+- [Advanced styling effects](/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects)
+  - : This article acts as a box of tricks, providing an introduction to some interesting advanced styling features such as box shadows, blend modes, and filters.
 - [Debugging CSS](/en-US/docs/Learn/CSS/Building_blocks/Debugging_CSS)
   - : Sometimes when writing CSS you will encounter an issue where your CSS doesn't seem to be doing what you expect. This article will give you guidance on how to go about debugging a CSS problem, and show you how the DevTools included in all modern browsers can help you find out what is going on.
 - [Organizing your CSS](/en-US/docs/Learn/CSS/Building_blocks/Organizing)
@@ -73,8 +75,3 @@ The following assessments will test your understanding of the CSS covered in the
   - : If you want to make the right impression, writing a letter on nice letterheaded paper can be a really good start. In this assessment, we'll challenge you to create an online template to achieve such a look.
 - [A cool looking box](/en-US/docs/Learn/CSS/Building_blocks/A_cool_looking_box)
   - : Here you'll get some practice in using background and border styling to create an eye-catching box.
-
-## See also
-
-- [Advanced styling effects](/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects)
-  - : This article acts as a box of tricks, providing an introduction to some interesting advanced styling features such as box shadows, blend modes, and filters.

--- a/files/en-us/learn/css/building_blocks/styling_tables/index.md
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.md
@@ -4,7 +4,7 @@ slug: Learn/CSS/Building_blocks/Styling_tables
 page-type: learn-module-chapter
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Advanced_styling_effects", "Learn/CSS/Building_blocks")}}
 
 Styling an HTML table isn't the most glamorous job in the world, but sometimes we all have to do it. This article provides a guide to making HTML tables look good, with some specific table styling techniques highlighted.
 
@@ -307,4 +307,4 @@ You've reached the end of this article, but can you remember the most important 
 
 With styling tables now behind us, we need something else to occupy our time. The next article explores [debugging CSS](/en-US/docs/Learn/CSS/Building_blocks/Debugging_CSS) — how to solve problems such as layouts not looking like they should, or properties not applying when you think they should. This includes information on using browser DevTools to find solutions to your problems.
 
-{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Debugging_CSS", "Learn/CSS/Building_blocks")}}
+{{PreviousMenuNext("Learn/CSS/Building_blocks/Images_media_form_elements", "Learn/CSS/Building_blocks/Advanced_styling_effects", "Learn/CSS/Building_blocks")}}


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/14552

The PR implements following suggestion:
> If so then I think the right thing to do would be to:
>
> remove the "See also" section from [CSS Building blocks](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks#see_also), and move the [Advanced styling effects](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Advanced_styling_effects) link under [Guides](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks#guides) instead (perhaps just before "Debugging CSS"?)
update the other nav elements (e.g. the Next/Previous buttons) to splice in the "Advanced styling effects" article at that point.