### PR TITLE
Adjust examples to match the formal syntax definition

### DIFF
--- a/files/en-us/web/css/color-scheme/index.md
+++ b/files/en-us/web/css/color-scheme/index.md
@@ -20,7 +20,7 @@ color-scheme: normal;
 color-scheme: light;
 color-scheme: dark;
 color-scheme: light dark;
-color-scheme: only light;
+color-scheme: light only;
 
 /* Global values */
 color-scheme: inherit;
@@ -44,7 +44,7 @@ The `color-scheme` property's value must be one of the following keywords.
 
   - : Forbids the user agent from overriding the color scheme for the element.
 
-    Can be used to turn off color overrides caused by Chrome's [Auto Dark Theme](https://developer.chrome.com/blog/auto-dark-theme/#per-element-opt-out), by applying `color-scheme: only light;` on a specific element or `:root`.
+    Can be used to turn off color overrides caused by Chrome's [Auto Dark Theme](https://developer.chrome.com/blog/auto-dark-theme/#per-element-opt-out), by applying `color-scheme: light only;` on a specific element or `:root`.
 
 ## Formal definition
 
@@ -70,13 +70,13 @@ To opt in specific elements to the user's color scheme preferences, declare `col
 
 ```css
 header {
-  color-scheme: only light;
+  color-scheme: light only;
 }
 main {
   color-scheme: light dark;
 }
 footer {
-  color-scheme: only dark;
+  color-scheme: dark only;
 }
 ```
 


### PR DESCRIPTION
### Description

Adjust the examples to use `<color> only` instead of `only <color>` to match the formal syntax definition of the document.

### Motivation

Prevent confusion between the formal syntax definition and the code examples.