### PR TITLE
Standardize examples in `URLSearchParams: has()`

### DIFF
--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -38,59 +38,45 @@ A boolean value.
 
 This example shows how to check if the query string has any parameters with a particular name.
 
-```html hidden
-<pre id="log"></pre>
-```
-
-```js hidden
-const logElement = document.getElementById("log");
-function log(text) {
-  logElement.innerText += `${text}\n`;
-}
-```
-
 ```js
 const url = new URL("https://example.com?foo=1&bar=2&foo=3");
 const params = new URLSearchParams(url.search);
 
 // has() returns true if the parameter is in the query string
-log(`bar?:\t${params.has("bar")}`);
-log(`bark?:\t${params.has("bark")}`);
-log(`foo?:\t${params.has("foo")}`);
+console.log(`bar?:\t${params.has("bar")}`);
+console.log(`bark?:\t${params.has("bark")}`);
+console.log(`foo?:\t${params.has("foo")}`);
 ```
 
 The log below shows whether the parameters `bar`, `bark`, and `foo`, are present in the query string.
 
-{{EmbedLiveSample('Check for parameter with specified name', '100%', '80')}}
+```plain
+bar?:  true
+bark?: false
+foo?:  true
+```
 
 ### Check for parameter with specified name and value
 
 This example shows how to check whether the query string has a parameter that matches both a particular name and value.
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```js hidden
-const logElement = document.getElementById("log");
-function log(text) {
-  logElement.innerText += `${text}\n`;
-}
-```
 
 ```js
 const url = new URL("https://example.com?foo=1&bar=2&foo=3");
 const params = new URLSearchParams(url.search);
 
 // has() returns true if a parameter with the matching name and value is in the query string
-log(`bar=1?:\t${params.has("bar", "1")}`);
-log(`bar=2?:\t${params.has("bar", "2")}`);
-log(`foo=4?:\t${params.has("foo", "4")}`);
+console.log(`bar=1?:\t${params.has("bar", "1")}`);
+console.log(`bar=2?:\t${params.has("bar", "2")}`);
+console.log(`foo=4?:\t${params.has("foo", "4")}`);
 ```
 
 Only the second value above should be `true`, as only the parameter name `bar` with value `2` is matched.
 
-{{EmbedLiveSample('Check for parameter with specified name and value', '100%', '80')}}
+```plain
+bar=1?: false
+bar=2?: true
+foo=4?: false
+```
 
 If your browser does not support the `value` option the method will match on the name, and all the results should be `true`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Replaces LiveSample with console.log in the examples for URLSearchParams: has()

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Inspired by my recent PR: https://github.com/mdn/content/pull/34489. It looks like `has()` is the last method using LiveSample for its examples.
