### PR TITLE
Fixes for CHIPS and cookies with __Host_ prefix

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -68,10 +68,10 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     > **Note:** Some `<cookie-name>` have a specific semantic:
     >
-    > **`__Secure-` prefix**: Cookies with names starting with `__Secure-` (dash is part of the prefix)
-    > must be set with the `secure` flag from a secure page (HTTPS).
+    > **`__Secure-` prefix**: Cookies with names starting with `__Secure-` (dash is part of the prefix) must be set with the `secure` flag from a secure page (HTTPS).
     >
-    > **`__Host-` prefix**: Cookies with names starting with `__Host-` must be set with the `secure` flag, must be from a secure page (HTTPS), must not have a domain specified (and therefore, are not sent to subdomains), and the path must be `/`.
+    > **`__Host-` prefix**: Cookies with names starting with `__Host-` are sent only to the host subdomain or domain that set them, and not to any host.
+    > They must be set with the `secure` flag, must be from a secure page (HTTPS), must not have a domain specified, and the path must be `/`.
 
 - `Domain=<domain-value>` {{optional_inline}}
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -70,7 +70,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     >
     > **`__Secure-` prefix**: Cookies with names starting with `__Secure-` (dash is part of the prefix) must be set with the `secure` flag from a secure page (HTTPS).
     >
-    > **`__Host-` prefix**: Cookies with names starting with `__Host-` are sent only to the host subdomain or domain that set them, and not to any host.
+    > **`__Host-` prefix**: Cookies with names starting with `__Host-` are sent only to the host subdomain or domain that set them, and not to any other host.
     > They must be set with the `secure` flag, must be from a secure page (HTTPS), must not have a domain specified, and the path must be `/`.
 
 - `Domain=<domain-value>` {{optional_inline}}

--- a/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
@@ -32,7 +32,7 @@ Browsers with CHIPS support provide a new attribute for the {{httpheader("Set-Co
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure`. In addition, you could use the `__Host` prefix when setting partitioned cookies to bind them only to the current host (domain or subdomain) and not any other subdomains (though in this case there would not be much need for a partitioned cookie).
+> **Note:** Partitioned cookies must be set with `Secure`. In addition, you could use the `__Host` prefix when setting partitioned cookies to bind them only to the current host and not any other subdomains (or the domain if you were binding to a subdomain).
 
 With `Partitioned` set, third-party cookies are stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 

--- a/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
@@ -32,7 +32,7 @@ Browsers with CHIPS support provide a new attribute for the {{httpheader("Set-Co
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure`. In addition, you could use the `__Host` prefix when setting partitioned cookies to bind them only to the current host and not any other subdomains (or the domain if you were binding to a subdomain).
+> **Note:** Partitioned cookies must be set with `Secure`. In addition, you can use the `__Host` prefix when setting partitioned cookies to bind them only to the current domain or subdomain, and this is recommended if you don't need to share cookies between subdomains.
 
 With `Partitioned` set, third-party cookies are stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 

--- a/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
@@ -52,8 +52,6 @@ CHIPS still allows third-party content embedded across different subdomains of a
 2. The storage key for the cookie would be `{("https://shoppy.example"), ("3rd-party.example/chat")}`.
 3. The user visits various subdomains that also embed `https://3rd-party.example/chat`, including `https://support.shoppy.example` and `https://checkout.shoppy.example`. The new embedded instances are able to access the cookie because the partition key still matches.
 
-You can restrict the cookie to just a domain and a particular subdomain by setting the cookie with the `__Host` prefix.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
@@ -32,7 +32,7 @@ Browsers with CHIPS support provide a new attribute for the {{httpheader("Set-Co
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure`. In addition, you could use the `__Host` prefix when setting partitioned cookies to bind them to the current host domain only, and not any subdomains.
+> **Note:** Partitioned cookies must be set with `Secure`. In addition, you could use the `__Host` prefix when setting partitioned cookies to bind them only to the current host (domain or subdomain) and not any other subdomains (though in this case there would not be much need for a partitioned cookie).
 
 With `Partitioned` set, third-party cookies are stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 

--- a/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
@@ -13,7 +13,7 @@ browser-compat: http.headers.Set-Cookie.Partitioned
 
 Without cookie partitioning, third-party cookies can enable services to track users and associate their information across unrelated top-level sites. Cookies marked `Partitioned` are double-keyed: by the origin that sets them _and_ the origin of the top-level page.
 
-This means they can only be read within the context of the top-level site they were set on. This allows cross-site tracking to be blocked, while still enabling legitimate uses of third-party cookies such as persisting state of embedded maps or chat widgets across different sites, and persisting config information for subresource CDN load balancing and Headless CMS providers.
+This means they can only be read within the context of the top-level site they were set on. This allows cross-site tracking to be blocked, while still enabling legitimate uses of third-party cookies such as persisting state of embedded maps or chat widgets across a domain and its subdomains, and persisting config information for subresource CDN load balancing and Headless CMS providers.
 
 ## How does CHIPS work?
 
@@ -32,7 +32,7 @@ Browsers with CHIPS support provide a new attribute for the {{httpheader("Set-Co
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure`. In addition, it is recommended to use the `__Host` prefix when setting partitioned cookies to make them bound to the hostname and not the registrable domain.
+> **Note:** Partitioned cookies must be set with `Secure`. In addition, you could use the `__Host` prefix when setting partitioned cookies to bind them to the current host domain only, and not any subdomains.
 
 With `Partitioned` set, third-party cookies are stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 
@@ -51,6 +51,8 @@ CHIPS still allows third-party content embedded across different subdomains of a
 1. A user visits `https://shoppy.example`, which embeds a third-party chat service from `https://3rd-party.example/chat` to provide support for users that need help. `https://3rd-party.example/chat` sets a cookie on the user's device using `Partitioned`, to persist the state of the chat across different site subdomains.
 2. The storage key for the cookie would be `{("https://shoppy.example"), ("3rd-party.example/chat")}`.
 3. The user visits various subdomains that also embed `https://3rd-party.example/chat`, including `https://support.shoppy.example` and `https://checkout.shoppy.example`. The new embedded instances are able to access the cookie because the partition key still matches.
+
+You can restrict the cookie to just a domain and a particular subdomain by setting the cookie with the `__Host` prefix.
 
 ## Specifications
 


### PR DESCRIPTION
The partitioned cookies docs seemed to indicate that they allow cross-site access when they meant cross-subdomain-only access.

The __Host_ prefix was similarly confusing. See notes inline.

This is associated with docs for #33996