### PR TITLE
Add info about <base> target attribute disallowed chars

### DIFF
--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -43,6 +43,11 @@ Links pointing to a fragment in the document — e.g. `<a href="#some-id">` — 
 
 For example, given `<base href="https://example.com/">` and this link: `<a href="#anchor">To anchor</a>`. The link points to `https://example.com/#anchor`.
 
+### target may not contain ASCII newline, tab, or <
+
+If the [`target`](#target) attribute contains an ASCII newline, tab or the `<` character the value is reset to `_blank`.
+This is to prevent dangling markup attacks, a form of scriptless injection where an unclosed `target` attribute is injected into the page so that any text that follows is captured (until the browser reaches a character that closes the attribute).
+
 ### Open Graph
 
 [Open Graph](https://ogp.me/) tags do not acknowledge `<base>`, and should always have full absolute URLs. For example:

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -46,7 +46,7 @@ For example, given `<base href="https://example.com/">` and this link: `<a href=
 ### target may not contain ASCII newline, tab, or <
 
 If the [`target`](#target) attribute contains an ASCII newline, tab or the `<` character the value is reset to `_blank`.
-This is to prevent dangling markup attacks, a form of scriptless injection where an unclosed `target` attribute is injected into the page so that any text that follows is captured (until the browser reaches a character that closes the attribute).
+This is to prevent dangling markup injection attacks, a form of scriptless injection where an unclosed `target` attribute is injected into the page so that any text that follows is captured (until the browser reaches a character that closes the attribute).
 
 ### Open Graph
 

--- a/files/en-us/web/html/element/base/index.md
+++ b/files/en-us/web/html/element/base/index.md
@@ -45,8 +45,8 @@ For example, given `<base href="https://example.com/">` and this link: `<a href=
 
 ### target may not contain ASCII newline, tab, or <
 
-If the [`target`](#target) attribute contains an ASCII newline, tab or the `<` character the value is reset to `_blank`.
-This is to prevent dangling markup injection attacks, a form of scriptless injection where an unclosed `target` attribute is injected into the page so that any text that follows is captured (until the browser reaches a character that closes the attribute).
+If the [`target`](#target) attribute contains an ASCII newline, tab, or the `<` character, the value is reset to `_blank`.
+This is to prevent dangling markup injection attacks, a script-less attack in which an unclosed `target` attribute is injected into the page so that any text that follows is captured until the browser reaches a character that closes the attribute.
 
 ### Open Graph
 


### PR DESCRIPTION
The `<base>` element [`target`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#target) attribute may not have a `\n`, `\t`, `<`. This is to prevent a dangling markdown attack using `target` as described here https://portswigger.net/research/evading-csp-with-dom-based-dangling-markup

This is present in Safari 16, Chrome 61, and now FF128.

What I have done is added this as a "Usage note" for the restriction (rather than putting this directly under `target`). You shouldn't be trying this normally, so I think having it as a usage note rather than in the attribute description is more helpful. There is also a BCD entry coming.

Related docs work can be tracked in #33995

