### PR TITLE
FF128 RelNote: <base> element, target attribute can have newline, tab, < char

### DIFF
--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -14,6 +14,8 @@ This article provides information about the changes in Firefox 128 that affect d
 
 ### HTML
 
+- The [`target`](/en-US/docs/Web/HTML/Element/base#target) attribute of the `<base>` element now disallows ASCII newlines, tabs, or the `<` character, changing the value to `_blank` if any are present. This prevents dangling markdown injection attacks that use an unclosed `target` attribute ([Firefox bug 1835157](https://bugzil.la/1835157)).
+
 #### Removals
 
 ### CSS

--- a/files/en-us/mozilla/firefox/releases/128/index.md
+++ b/files/en-us/mozilla/firefox/releases/128/index.md
@@ -14,7 +14,7 @@ This article provides information about the changes in Firefox 128 that affect d
 
 ### HTML
 
-- The [`target`](/en-US/docs/Web/HTML/Element/base#target) attribute of the `<base>` element now disallows ASCII newlines, tabs, or the `<` character, changing the value to `_blank` if any are present. This prevents dangling markdown injection attacks that use an unclosed `target` attribute ([Firefox bug 1835157](https://bugzil.la/1835157)).
+- The [`target`](/en-US/docs/Web/HTML/Element/base#target) attribute of the `<base>` element now disallows ASCII newlines, tabs, or the `<` character, changing the value to `_blank` if any are present. This prevents dangling markup injection attacks that use an unclosed `target` attribute ([Firefox bug 1835157](https://bugzil.la/1835157)).
 
 #### Removals
 


### PR DESCRIPTION
The `<base>` element [`target`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#target) attribute may not have a `\n`, `\t`, `<`. This is to prevent a dangling markdown attack using `target` as described here https://portswigger.net/research/evading-csp-with-dom-based-dangling-markup

This is supported in FF128. This PR adds a release note.

Related docs work can be tracked in #33995

