### PR TITLE
Make chunks definition linkable; link to it

### DIFF
--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
@@ -9,8 +9,7 @@ browser-compat: api.ReadableStreamDefaultController.enqueue
 {{APIRef("Streams")}}{{AvailableInWorkers}}
 
 The **`enqueue()`** method of the
-{{domxref("ReadableStreamDefaultController")}} interface enqueues a given chunk in the
-associated stream.
+{{domxref("ReadableStreamDefaultController")}} interface enqueues a given [chunk](/en-US/docs/Web/API/Streams_API/Concepts#chunks) in the associated stream.
 
 ## Syntax
 

--- a/files/en-us/web/api/streams_api/concepts/index.md
+++ b/files/en-us/web/api/streams_api/concepts/index.md
@@ -17,17 +17,25 @@ There are two types of underlying sources:
 - **Push sources** constantly push data at you when you've accessed them, and it is up to you to start, pause, or cancel access to the stream. Examples include video streams and TCP/[Web sockets](/en-US/docs/Web/API/WebSockets_API).
 - **Pull sources** require you to explicitly request data from them once connected to. Examples include a file access operation via a {{domxref("fetch()")}} request.
 
+### Chunks
+
 The data is read sequentially in small pieces called **chunks**. A chunk can be a single byte, or it can be something larger such as a [typed array](/en-US/docs/Web/JavaScript/Guide/Typed_arrays) of a certain size. A single stream can contain chunks of different sizes and types.
 
 ![Readable streams data flow](readable_streams.png)
 
 The chunks placed in a stream are said to be **enqueued** — this means they are waiting in a queue ready to be read. An **internal queue** keeps track of the chunks that have not yet been read (see the Internal queues and queuing strategies section below).
 
+### Readers, consumers, and controllers
+
 The chunks inside the stream are read by a **reader** — this processes the data one chunk at a time, allowing you to do whatever kind of operation you want to do on it. The reader plus the other processing code that goes along with it is called a **consumer**.
 
 There is also a construct you'll use called a **controller** — each reader has an associated controller that allows you to control the stream (for example, to close it if wished).
 
+### Locking
+
 Only one reader can read a stream at a time; when a reader is created and starts reading a stream (an **active reader**), we say it is **locked** to it. If you want another reader to start reading your stream, you typically need to cancel the first reader before you do anything else (although you can **tee** streams, see the Teeing section below)
+
+### Readable streams and byte streams
 
 Note that there are two different types of readable stream. As well as the conventional readable stream there is a type called a byte stream — this is an extended version of a conventional stream for reading underlying byte sources. Compared with the conventional readable stream, byte streams are allowed to be read by BYOB readers (BYOB, "bring your own buffer"). This kind of reader allows streams to be read straight into a buffer supplied by the developer, minimizing the copying required. Which underlying stream (and by extension, reader and controller) your code will use depends on how the stream was created in the first place (see the {{domxref("ReadableStream.ReadableStream","ReadableStream()")}} constructor page).
 


### PR DESCRIPTION
This PR is intended to supersede https://github.com/mdn/content/pull/33562, implementing option 4 of https://github.com/mdn/content/pull/33562#pullrequestreview-2081339338.

I'm not entirely sure it's needed, or even the best option. There must be loads of places we refer to chunks in the streams API docs, do we really need to link it every time? Also, I wasn't sure what to do with the last paragraph in the section:

> You can make use of ready-made readable streams via mechanisms like a [Response.body](https://developer.mozilla.org/en-US/docs/Web/API/Response/body) from a fetch request, or roll your own streams using the [ReadableStream()](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/ReadableStream) constructor.

...it doesn't really fit under its heading. I tried putting it nearer the start of the section but it seemed to interrupt the flow there too.

But I thought it was worth a look. If it's no good, I think we should just close https://github.com/mdn/content/pull/33562.