### PR TITLE
fix(css): mention 'auto' value in outline-color as unsupported in any browser

### DIFF
--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -34,6 +34,8 @@ The `outline-color` property is specified as any one of the values listed below.
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the outline, specified as a `<color>`.
 
+The specification also lists an additional value, `auto`, which is not currently supported in any browsers. When implemented, `auto` will compute to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) unless [`outline-style`](/en-US/docs/Web/CSS/outline-style) is set to `auto` then it will compute to the [accent color](/en-US/docs/Web/CSS/accent-color).
+
 ## Description
 
 An outline is a line that is drawn around an element, outside the {{cssxref("border")}}. Unlike the element's border, the outline is drawn outside the element's frame, and may overlap other content. The border, on the other hand, will actually alter the page's layout to ensure that it fits without overlapping anything else (unless you explicitly set it to overlap).

--- a/files/en-us/web/css/outline-color/index.md
+++ b/files/en-us/web/css/outline-color/index.md
@@ -19,9 +19,6 @@ outline-color: #f92525;
 outline-color: rgb(30 222 121);
 outline-color: blue;
 
-/* Keyword value */
-outline-color: auto;
-
 /* Global values */
 outline-color: inherit;
 outline-color: initial;
@@ -36,8 +33,6 @@ The `outline-color` property is specified as any one of the values listed below.
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the outline, specified as a `<color>`.
-- `auto`
-  - : Computes to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) unless [`outline-style`](/en-US/docs/Web/CSS/outline-style) is set to `auto` then it computes to the [accent color](/en-US/docs/Web/CSS/accent-color).
 
 ## Description
 


### PR DESCRIPTION
### Description

Remove auto keyword from outline-color possible values

### Motivation

outline-color is not supported in any browser and [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color) does not show it in compatibility table making an impression it is well supported.

### Related issues and pull requests

Reverts https://github.com/mdn/content/pull/29798

See https://github.com/mdn/browser-compat-data/pull/23538#issuecomment-2202277555