### PR TITLE
Remove unsupported values for -moz-user-input CSS property

### DIFF
--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.-moz-user-input
 
 In Mozilla applications, **`-moz-user-input`** determines if an element will accept user input.
 
-For elements that normally take user input, such as a {{HTMLElement("textarea")}}, the initial value of `-moz-user-input` is `enabled`.
+As of Firefox 60, this property may no longer be used to grant an element to accept user input if it normally does not. It may only be used to disable user input.
 
 > **Note:** `-moz-user-input` was one of the proposals leading to the proposed CSS 3 {{cssxref("user-input")}} property, which has not yet reached Candidate Recommendation (call for implementations). A similar property, `user-focus`, was proposed in [early drafts of a predecessor of the User Interface for CSS3 specification](https://www.w3.org/TR/2000/WD-css3-userint-20000216), but was rejected by the working group.
 
@@ -20,9 +20,8 @@ For elements that normally take user input, such as a {{HTMLElement("textarea")}
 
 ```css
 /* Keyword values */
+-moz-user-input: auto;
 -moz-user-input: none;
--moz-user-input: enabled;
--moz-user-input: disabled;
 
 /* Global values */
 -moz-user-input: inherit;
@@ -32,12 +31,10 @@ For elements that normally take user input, such as a {{HTMLElement("textarea")}
 
 ### Values
 
+- `auto`
+  - : The element will respond to user input if it normally takes user input, such as a {{HTMLElement("textarea")}}.
 - `none`
   - : The element does not respond to user input, and it does not become {{CSSxRef(":active")}}.
-- `enabled`
-  - : The element accepts user input. For textboxes, this is the default behavior. **Please note that this value is no longer supported in Firefox 60 onwards ([Firefox bug 1405087](https://bugzil.la/1405087)).**
-- `disabled`
-  - : The element does not accept user input. However, this is not the same as setting `disabled` to true, in that the element is drawn normally. **Please note that this value is no longer supported in Firefox 60 onwards ([Firefox bug 1405087](https://bugzil.la/1405087)).**
 
 ## Formal definition
 
@@ -47,7 +44,7 @@ For elements that normally take user input, such as a {{HTMLElement("textarea")}
 
 ```plain
 -moz-user-input =
-  auto | none | enabled | disabled
+  auto | none
 ```
 
 ## Examples
@@ -57,7 +54,7 @@ For elements that normally take user input, such as a {{HTMLElement("textarea")}
 ```css
 input.example {
   /* The user will be able to select the text, but not change it. */
-  -moz-user-input: disabled;
+  -moz-user-input: none;
 }
 ```
 

--- a/files/en-us/web/css/-moz-user-input/index.md
+++ b/files/en-us/web/css/-moz-user-input/index.md
@@ -12,7 +12,7 @@ browser-compat: css.properties.-moz-user-input
 
 In Mozilla applications, **`-moz-user-input`** determines if an element will accept user input.
 
-As of Firefox 60, this property may no longer be used to grant an element to accept user input if it normally does not. It may only be used to disable user input.
+As of Firefox 60, this property can no longer grant an element the ability to accept user input if it normally does not. It may only be used to disable user input.
 
 > **Note:** `-moz-user-input` was one of the proposals leading to the proposed CSS 3 {{cssxref("user-input")}} property, which has not yet reached Candidate Recommendation (call for implementations). A similar property, `user-focus`, was proposed in [early drafts of a predecessor of the User Interface for CSS3 specification](https://www.w3.org/TR/2000/WD-css3-userint-20000216), but was rejected by the working group.
 


### PR DESCRIPTION
This PR removes mention of the unsupported values of the `-moz-user-input` CSS property.  These will be removed in BCD, see https://github.com/mdn/browser-compat-data/pull/23567.