### PR TITLE
Remove mention of `contain` value of `user-select` CSS property

### DIFF
--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -18,7 +18,6 @@ The **`user-select`** [CSS](/en-US/docs/Web/CSS) property controls whether the u
 user-select: none;
 user-select: auto;
 user-select: text;
-user-select: contain;
 user-select: all;
 
 /* Global values */
@@ -49,11 +48,6 @@ user-select: unset;
   - : The text can be selected by the user.
 - `all`
   - : The content of the element shall be selected atomically: If a selection would contain part of the element, then the selection must contain the entire element including all its descendants. If a double-click or context-click occurred in sub-elements, the highest ancestor with this value will be selected.
-- `contain`
-
-  - : Enables selection to start within the element; however, the selection will be contained by the bounds of that element.
-
-    > **Note:** CSS UI 4 [renamed](https://github.com/w3c/csswg-drafts/commit/3f1d9db96fad8d9fc787d3ed66e2d5ad8cfadd05) the `element` value to `contain`.
 
 ## Formal definition
 
@@ -101,6 +95,5 @@ user-select: unset;
 
 ## See also
 
-- [Polyfill for `user-select: contain`](https://github.com/github/user-select-contain-polyfill)
 - {{Cssxref("::selection")}} pseudo-element
 - The JavaScript {{domxref("Selection")}} object

--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -48,6 +48,7 @@ user-select: unset;
   - : The text can be selected by the user.
 - `all`
   - : The content of the element shall be selected atomically: If a selection would contain part of the element, then the selection must contain the entire element including all its descendants. If a double-click or context-click occurred in sub-elements, the highest ancestor with this value will be selected.
+
 > [!NOTE]
 > The [CSS basic user interface](/en-US/docs/Web/CSS/CSS_basic_user_interface) module defines a `contain` value for the `user-select` property to enable selection to start within the element to be contained by the bounds of that element, however, this is not supported in any browsers.
 

--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -48,6 +48,8 @@ user-select: unset;
   - : The text can be selected by the user.
 - `all`
   - : The content of the element shall be selected atomically: If a selection would contain part of the element, then the selection must contain the entire element including all its descendants. If a double-click or context-click occurred in sub-elements, the highest ancestor with this value will be selected.
+> [!NOTE]
+> The [CSS basic user interface](/en-US/docs/Web/CSS/CSS_basic_user_interface) module defines a `contain` value for the `user-select` property to enable selection to start within the element to be contained by the bounds of that element, however, this is not supported in any browsers.
 
 ## Formal definition
 

--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -39,9 +39,8 @@ user-select: unset;
   - : The used value of `auto` is determined as follows:
 
     - On the `::before` and `::after` pseudo elements, the used value is `none`
-    - If the element is an editable element, the used value is `contain`
+    - If the used value of `user-select` on the parent of this element is `none`, the used value is `none`
     - Otherwise, if the used value of `user-select` on the parent of this element is `all`, the used value is `all`
-    - Otherwise, if the used value of `user-select` on the parent of this element is `none`, the used value is `none`
     - Otherwise, the used value is `text`
 
 - `text`


### PR DESCRIPTION
This PR removes the mention of the `contain` value of the `user-select` CSS property.  This was only ever supported in Microsoft browsers, and was removed in Edge 79 -- as such, it meets the irrelevance guidelines for BCD, see https://github.com/mdn/browser-compat-data/pull/23575.