### PR TITLE
Remove `digits` value of `text-combine-upright` CSS property

### DIFF
--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -34,6 +34,9 @@ text-combine-upright: unset;
   - : There is no special processing.
 - `all`
   - : Attempts to typeset all consecutive characters within the box horizontally, such that they take up the space of a single character within the vertical line of the box.
+  
+ > ![NOTE]
+ > The [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes) module defines a `digits <integer>` value for the `text-combine-upright` property to display two to four consecutive {{Glossary("ASCII")}} digits (U+0030–U+0039) such that it takes up the space of a single character within the vertical line box, however, this is not supported in any browsers.
 
 ## Formal definition
 

--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -20,10 +20,6 @@ This is used to produce an effect that is known as tate-chū-yoko <q lang="ja">�
 text-combine-upright: none;
 text-combine-upright: all;
 
-/* Digits values */
-text-combine-upright: digits; /* fits 2 consecutive digits horizontally inside vertical text */
-text-combine-upright: digits 4; /* fits up to 4 consecutive digits horizontally inside vertical text */
-
 /* Global values */
 text-combine-upright: inherit;
 text-combine-upright: initial;
@@ -38,8 +34,6 @@ text-combine-upright: unset;
   - : There is no special processing.
 - `all`
   - : Attempts to typeset all consecutive characters within the box horizontally, such that they take up the space of a single character within the vertical line of the box.
-- `digits <integer>?`
-  - : Attempts to display a sequence of consecutive {{Glossary("ASCII")}} digits (U+0030–U+0039) that has as many or fewer characters than the specified integer, such that it takes up the space of a single character within the vertical line box. If the integer is omitted, it computes to 2. Integers outside the range of 2-4 are invalid.
 
 ## Formal definition
 

--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -34,9 +34,9 @@ text-combine-upright: unset;
   - : There is no special processing.
 - `all`
   - : Attempts to typeset all consecutive characters within the box horizontally, such that they take up the space of a single character within the vertical line of the box.
-  
- > ![NOTE]
- > The [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes) module defines a `digits <integer>` value for the `text-combine-upright` property to display two to four consecutive {{Glossary("ASCII")}} digits (U+0030–U+0039) such that it takes up the space of a single character within the vertical line box, however, this is not supported in any browsers.
+
+> ![NOTE]
+> The [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes) module defines a `digits <integer>` value for the `text-combine-upright` property to display two to four consecutive {{Glossary("ASCII")}} digits (U+0030–U+0039) such that it takes up the space of a single character within the vertical line box, however, this is not supported in any browsers.
 
 ## Formal definition
 


### PR DESCRIPTION
This PR removes mention of the `digits` value of the `text-combine-upright` CSS property.  This value was only supported under a Microsoft alias, and only in IE.  This value is being removed from BCD, see https://github.com/mdn/browser-compat-data/pull/23577.