### PR TITLE
Remove `balance-all` value of `column-fill` CSS property

### DIFF
--- a/files/en-us/web/css/column-fill/index.md
+++ b/files/en-us/web/css/column-fill/index.md
@@ -17,7 +17,6 @@ The **`column-fill`** [CSS](/en-US/docs/Web/CSS) property controls how an elemen
 /* Keyword values */
 column-fill: auto;
 column-fill: balance;
-column-fill: balance-all;
 
 /* Global values */
 column-fill: inherit;
@@ -35,8 +34,6 @@ The `column-fill` property is specified as one of the keyword values listed belo
   - : Columns are filled sequentially. Content takes up only the room it needs, possibly resulting in some columns remaining empty.
 - `balance`
   - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.
-- `balance-all`
-  - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/CSS_paged_media), all fragments are balanced.
 
 ## Formal definition
 


### PR DESCRIPTION
This PR removes the mention of the `balance-all` value from the `column-fill` CSS property.  This value had not been implemented in any browser, and as such is being removed from BCD.  See https://github.com/mdn/browser-compat-data/pull/23578.