### PR TITLE
Remove `inter-character` value from `ruby-position` CSS property

### DIFF
--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.ruby-position
 
 {{CSSRef}}
 
-The **`ruby-position`** [CSS](/en-US/docs/Web/CSS) property defines the position of a ruby element relatives to its base element. It can be positioned over the element (`over`), under it (`under`), or between the characters on their right side (`inter-character`).
+The **`ruby-position`** [CSS](/en-US/docs/Web/CSS) property defines the position of a ruby element relative to its base element. It can be positioned over the element (`over`), under it (`under`), or between the characters on their right side (`inter-character`).
 
 {{EmbedInteractiveExample("pages/css/ruby-position.html")}}
 

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -131,5 +131,5 @@ ruby {
 
 ## See also
 
-- HTML Ruby elements: {{HTMLElement("ruby")}}, {{HTMLElement("rt")}}, {{HTMLElement("rp")}}, and {{HTMLElement("rtc")}}.
-- CSS Ruby properties: {{cssxref("ruby-align")}}, {{cssxref("ruby-merge")}}.
+- {{HTMLElement("ruby")}}, {{HTMLElement("rt")}}, {{HTMLElement("rp")}}, and {{HTMLElement("rtc")}} HTML elements
+- {{cssxref("ruby-align")}}

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -17,7 +17,6 @@ The **`ruby-position`** [CSS](/en-US/docs/Web/CSS) property defines the position
 /* Keyword values */
 ruby-position: over;
 ruby-position: under;
-ruby-position: inter-character;
 ruby-position: alternate;
 
 /* Global values */
@@ -36,8 +35,6 @@ ruby-position: unset;
 - `under`
   - : ![Under example](screen_shot_2015-03-04_at_13.02.07.png)
     Is a keyword indicating that the ruby has to be placed under the main text for horizontal scripts and left to it for vertical scripts.
-- `inter-character`
-  - : Is a keyword indicating that the ruby has to be placed between the different characters.
 - `alternate`
   - : Is a keyword indicating that the ruby alternates between over and under, when there are multiple levels of annotation.
 

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -38,6 +38,9 @@ ruby-position: unset;
 - `alternate`
   - : Is a keyword indicating that the ruby alternates between over and under, when there are multiple levels of annotation.
 
+> ![NOTE]
+> The specification also lists an additional value, `inter-character`, which is not currently supported in any browsers. When implemented, `inter-character` will behave as `over` in vertical writing modes. Otherwise, it indicates that the ruby has to be placed between the different characters, appearing on the right of the base in horizontal text and forcing the children of the ruby annotation container to have a `vertical-rl` writing mode.
+
 ## Formal definition
 
 {{cssinfo}}

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -38,7 +38,7 @@ ruby-position: unset;
 - `alternate`
   - : Is a keyword indicating that the ruby alternates between over and under, when there are multiple levels of annotation.
 
-> ![NOTE]
+> [!NOTE]
 > The specification also lists an additional value, `inter-character`, which is not currently supported in any browsers. When implemented, `inter-character` will behave as `over` in vertical writing modes. Otherwise, it indicates that the ruby has to be placed between the different characters, appearing on the right of the base in horizontal text and forcing the children of the ruby annotation container to have a `vertical-rl` writing mode.
 
 ## Formal definition


### PR DESCRIPTION
This PR removes the mention of the `inter-character` value from the `ruby-position` CSS property page.  This value was not implemented in any browsers, and will be removed from BCD, see https://github.com/mdn/browser-compat-data/pull/23582.