### PR TITLE
Remove references to group role in list role

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.md
@@ -19,7 +19,7 @@ The ARIA `list` role can be used to identify a list of items. It is normally use
 
 ## Description
 
-Any content that consists of an outer container with a list of elements inside it can be identified to assistive technologies using the `list` and `listitem` containers respectively. A `list` must have one or more `listitem` children.
+Any content that consists of an outer container with a list of elements inside can be identified to assistive technologies using the `list` and `listitem` containers, respectively. A `list` can only contain zero or more `listitem` children.
 
 There are no hard and fast rules about which elements you should use to mark up the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.
 

--- a/files/en-us/web/accessibility/aria/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.md
@@ -28,7 +28,7 @@ There are no hard and fast rules about which elements you should use to mark up 
 ### Associated WAI-ARIA Roles, States, and Properties
 
 - [`listitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role) role
-  - : A single item in a list or directory. Elements with role listitem can only be found in an element with the role `list`.
+  - : A single item in a list or directory. Elements with role `listitem` can only be found in an element with the role `list`.
 
 ## Best practices
 

--- a/files/en-us/web/accessibility/aria/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.md
@@ -28,7 +28,7 @@ There are no hard and fast rules about which elements you should use to mark up 
 ### Associated WAI-ARIA Roles, States, and Properties
 
 - [`listitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role) role
-  - : A single item in a list or directory. Elements with role `listitem` can only be found in an element with the role `list`.
+  - : A single item in a list. Elements with role `listitem` can only be found in an element with the role `list`.
 
 ## Best practices
 

--- a/files/en-us/web/accessibility/aria/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.md
@@ -19,7 +19,7 @@ The ARIA `list` role can be used to identify a list of items. It is normally use
 
 ## Description
 
-Any content that consists of an outer container with a list of elements inside it can be identified to assistive technologies using the `list` and `listitem` containers respectively. A `list` must have one or more `listitem` children, or, alternatively, have one or more `group`s as children, with each `group` having one or more `listitem`s as children.
+Any content that consists of an outer container with a list of elements inside it can be identified to assistive technologies using the `list` and `listitem` containers respectively. A `list` must have one or more `listitem` children.
 
 There are no hard and fast rules about which elements you should use to mark up the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.
 
@@ -28,9 +28,7 @@ There are no hard and fast rules about which elements you should use to mark up 
 ### Associated WAI-ARIA Roles, States, and Properties
 
 - [`listitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role) role
-  - : A single item in a list or directory. Elements with role listitem can only be found in an element with the role `list` or `group`.
-- [`group`](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) role
-  - : A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a page's table of contents.
+  - : A single item in a list or directory. Elements with role listitem can only be found in an element with the role `list`.
 
 ## Best practices
 
@@ -72,7 +70,6 @@ As an aside, note that if you are using the semantic HTML elements of `<ol>` or 
 - The {{HTMLElement("ol")}} element
 - The {{HTMLElement("li")}} element
 - [ARIA: listitem role](/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role)
-- [ARIA: group role](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role)
 - [ARIA Lists examples](https://www.scottohara.me/blog/2018/05/26/aria-lists.html) — by Scott O'Hara
 - [Accessibility Object Model](https://wicg.github.io/aom/spec/)
 - [ARIA in HTML](https://w3c.github.io/html-aria/)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove all references to `group` role in the `list` role page.

### Motivation

According to the [ARIA spec](https://w3c.github.io/aria/#list), only `listitem` role elements are valid children of `list` role elements. This PR removes the incorrect descriptions of `group` role elements being valid children of `list`.

### Additional details

https://w3c.github.io/aria/#list
https://github.com/w3c/aria/issues/1478 - in particular, [this comment shows that list > group > listitem doesn't work in screenreaders](https://github.com/w3c/aria/issues/1478#issuecomment-830868245)

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
