### PR TITLE
fixed typo ('as' to 'if')

### DIFF
--- a/files/en-us/web/html/attributes/rel/index.md
+++ b/files/en-us/web/html/attributes/rel/index.md
@@ -206,7 +206,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 
 - `stylesheet`
 
-  - : Valid for the {{htmlelement('link')}} element, it imports an external resource to be used as a stylesheet. The [`type`](/en-US/docs/Web/HTML/Element/link#type) attribute is not needed as it's a `text/css` stylesheet, as that is the default value. If it's not a stylesheet of type `text/css` it is best to declare the type.
+  - : Valid for the {{htmlelement('link')}} element, it imports an external resource to be used as a stylesheet. The [`type`](/en-US/docs/Web/HTML/Element/link#type) attribute is not needed if it's a `text/css` stylesheet, as that is the default value. If it's not a stylesheet of type `text/css` it is best to declare the type.
 
     While this attribute defines the link as being a stylesheet, the interaction with other attributes and other key terms within the rel value impact whether the stylesheet is downloaded and/or used.
 


### PR DESCRIPTION
fixed typo 

Changed 

> The `type` attribute is not needed as 👈 it's a `text/css` stylesheet, as that is the default value. If it's not a stylesheet of type `text/css` it is best to declare the type.

to 

> The `type` attribute is not needed if 👈 it's a `text/css` stylesheet, as that is the default value. If it's not a stylesheet of type `text/css` it is best to declare the type.