### PR TITLE
Update link to Wikipedia in `Web/API/HTMLAnchorElement/hash`

### DIFF
--- a/files/en-us/web/api/htmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.md
@@ -8,13 +8,9 @@ browser-compat: api.HTMLAnchorElement.hash
 
 {{ APIRef("HTML DOM") }}
 
-The
-**`HTMLAnchorElement.hash`** property returns a
-string containing a `'#'` followed by the fragment
-identifier of the URL.
+The **`HTMLAnchorElement.hash`** property returns a string containing a `'#'` followed by the fragment identifier of the URL.
 
-The fragment is [URL encoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
-have a fragment identifier, this property contains an empty string, `""`.
+The fragment is [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value
 
@@ -27,14 +23,16 @@ A string.
 Given this HTML
 
 ```html
-<a id="myAnchor" href="/en-US/docs/HTMLAnchorElement#Examples">Examples</a>
+<a id="myAnchor" href="/en-US/docs/Web/API/HTMLAnchorElement/hash#examples">
+  Examples
+</a>
 ```
 
 you can get the hash of the anchor like this:
 
 ```js
 const anchor = document.getElementById("myAnchor");
-anchor.hash; // returns '#Examples'
+anchor.hash; // '#examples'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLAnchorElement.hash
 
 The **`HTMLAnchorElement.hash`** property returns a string containing a `'#'` followed by the fragment identifier of the URL.
 
-The fragment is [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
+The fragment is [percent-encoded](/en-US/docs/Glossary/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value
 


### PR DESCRIPTION
### Description

Ths PR updates link to Wikipedia in `Web/API/HTMLAnchorElement/hash`: https://en.wikipedia.org/wiki/URL_encoding was changed to https://en.wikipedia.org/wiki/Percent-encoding

### Additional details

Also updates formatting and improves example style. 

