### PR TITLE
Explain deprecation of permissions.revoke()

### DIFF
--- a/files/en-us/web/api/permissions/index.md
+++ b/files/en-us/web/api/permissions/index.md
@@ -13,10 +13,6 @@ The **`Permissions`** interface of the [Permissions API](/en-US/docs/Web/API/Per
 
 - {{domxref("Permissions.query","Permissions.query()")}}
   - : Returns the user permission status for a given API.
-- {{domxref("Permissions.request","Permissions.request()")}} {{Experimental_Inline}}
-  - : Requests permission to use a given API. This is not currently supported in any browser.
-- {{domxref("Permissions.requestAll","Permissions.requestAll()")}} {{Experimental_Inline}} {{Non-standard_Inline}}
-  - : Requests permission to use a given set of APIs. This is not currently supported in any browser.
 - {{domxref("Permissions.revoke","Permissions.revoke()")}} {{Deprecated_Inline}}
   - : Revokes the permission currently set on a given API.
 

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -16,6 +16,8 @@ default state, which is usually `prompt`.
 This method is called on the global {{domxref("Permissions")}} object
 {{domxref("navigator.permissions")}}.
 
+This method is removed from the main permissions API specification because its use case is unclear. Permissions are managed by the browser and the current permission model does not involve the site developer being able to imperatively request or revoke permissions. Browsers have shipped this API behind preferences but it's unlikely to reach the standards track. For more context, see the [original discussion to remove `permissions.revoke()`](https://github.com/w3c/permissions/issues/46).
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -20,10 +20,7 @@ The [Permissions API](/en-US/docs/Web/API/Permissions_API) provides a consistent
 Specifically, developers can use {{domxref("Permissions.query()")}} to check whether permission to use a particular API in the current context is granted, denied, or requires specific user permission via a prompt.
 Querying permissions in the main thread is [broadly supported](/en-US/docs/Web/API/Permissions_API#api.navigator.permissions), and also in [Workers](/en-US/docs/Web/API/Permissions_API#api.workernavigator.permissions) (with a notable exception).
 
-Many APIs now enable permission querying, such as the [Clipboard API](/en-US/docs/Web/API/Clipboard_API), [Notifications API](/en-US/docs/Web/API/Notifications_API)
-
-- [Push API](/en-US/docs/Web/API/Push_API), [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API).
-  A list of many permission enabled APIs is provided in the [API Overview](/en-US/docs/Web/API/Permissions_API#permission-aware_apis), and you can get a sense of browser support in the [compatibility table here](/en-US/docs/Web/API/Permissions_API#api.permissions).
+Many APIs now enable permission querying, such as the [Clipboard API](/en-US/docs/Web/API/Clipboard_API), [Notifications API](/en-US/docs/Web/API/Notifications_API), [Push API](/en-US/docs/Web/API/Push_API), and [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API). A list of many permission enabled APIs is provided in the [API Overview](/en-US/docs/Web/API/Permissions_API#permission-aware_apis), and you can get a sense of browser support in the [compatibility table here](/en-US/docs/Web/API/Permissions_API#api.permissions).
 
 {{domxref("Permissions")}} has other methods to specifically request permission to use an API, and to revoke permission, but these are deprecated (non-standard, and/or not broadly supported).
 
@@ -85,30 +82,6 @@ handlePermission();
 
 The {{domxref("Permissions.query()")}} method takes a `PermissionDescriptor` dictionary as a parameter — this contains the name of the API you are interested in. Some APIs have more complex `PermissionDescriptor`s containing additional information, which inherit from the default `PermissionDescriptor`. For example, the `PushPermissionDescriptor` should also contain a Boolean that specifies if [`userVisibleOnly`](/en-US/docs/Web/API/PushManager/subscribe#parameters) is `true` or `false`.
 
-### Revoking permissions
-
-Starting in Firefox 47, you can now revoke existing permissions, using the {{domxref("Permissions.revoke()")}} method. This works in exactly the same way as the {{domxref("Permissions.query()")}} method, except that it causes an existing permission to be reverted back to its default state when the promise successfully resolves (which is usually `prompt`). See the following code in our demo:
-
-```js
-const revokeBtn = document.querySelector(".revoke");
-
-// ...
-
-revokeBtn.onclick = () => {
-  revokePermission();
-};
-
-// ...
-
-function revokePermission() {
-  navigator.permissions.revoke({ name: "geolocation" }).then((result) => {
-    report(result.state);
-  });
-}
-```
-
-> **Note:** The `revoke()` function has been disabled by default starting in Firefox 51, since its design has been brought into question in the [Web Applications Security Working Group](https://www.w3.org/2011/webappsec/). It can be re-enabled by setting the preference `dom.permissions.revoke.enable` to `true`.
-
 ### Responding to permission state changes
 
 You'll notice that we're listening to the {{domxref("PermissionStatus.change_event", "change")}} event in the code above, attached to the {{domxref("PermissionStatus")}} object — this allows us to respond to any changes in the permission status for the API we are interested in. At the moment we are just reporting the change in state.
@@ -120,4 +93,4 @@ At the moment this doesn't offer much more than what we had already. If we choos
 - **Firefox**: _Tools > Page Info > Permissions > Access Your Location_. Select _Always Ask_.
 - **Chrome**: _Hamburger Menu > Settings > Show advanced settings_. In the _Privacy_ section, click _Content Settings_. In the resulting dialog, find the _Location_ section and select _Ask when a site tries to…_. Finally, click _Manage Exceptions_ and remove the permissions you granted to the sites you are interested in.
 
-However, future additions to browser functionality should provide the `request()` method, which will allow us to programmatically request permissions, any time we like. These should hopefully be available soon.
+There are proposals to add the ability for sites to imperatively [request](https://github.com/WICG/permissions-request) and [revoke](https://github.com/WICG/permissions-revoke) permissions, but there has not been much progress as the use case is unclear and they have faced opposition from browser vendors. See the discussions to [remove `permissions.request()`](https://github.com/w3c/permissions/issues/83) and [remove `permissions.revoke()`](https://github.com/w3c/permissions/issues/46) from the main specification.


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/26557