### PR TITLE
CSS caption-side: Remove unsupported values

### DIFF
--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -34,7 +34,6 @@ The `caption-side` property is specified as one of the keyword values listed bel
   - : The caption box should be positioned at the block start side of the table.
 - `bottom`
   - : The caption box should be positioned at the block end side of the table.
- 
 > ![Note]
 > The [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module defines two logical values, `inline-start` and `inline-end`, to position the caption box at the inline start edge and inline end edge of the table, respectively. These values are not supported in any browsers.
 

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -34,7 +34,8 @@ The `caption-side` property is specified as one of the keyword values listed bel
   - : The caption box should be positioned at the block start side of the table.
 - `bottom`
   - : The caption box should be positioned at the block end side of the table.
-> [!Note]
+
+> [!NOTE]
 > The [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module defines two logical values, `inline-start` and `inline-end`, to position the caption box at the inline start edge and inline end edge of the table, respectively. These values are not supported in any browsers.
 
 ## Formal definition

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.caption-side
 
 {{CSSRef}}
 
-The **`caption-side`** [CSS](/en-US/docs/Web/CSS) property puts the content of a table's {{HTMLElement("caption")}} on the specified side. The values are relative to the {{cssxref('writing-mode')}} of the table.
+The **`caption-side`** [CSS](/en-US/docs/Web/CSS) property puts the content of a table's {{HTMLElement("caption")}} on the specified side. The values are relative to the {{cssxref("writing-mode")}} of the table.
 
 {{EmbedInteractiveExample("pages/css/caption-side.html")}}
 
@@ -36,7 +36,7 @@ The `caption-side` property is specified as one of the keyword values listed bel
   - : The caption box should be positioned at the block end side of the table.
  
 > ![Note]
-> The [CSS logical properties and values] module defines two logical values, `inline-start` and `inline-end`, to position the caption box at the inline start edge and inline end edge of the table, respectively. These values are not supported in any browsers.
+> The [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module defines two logical values, `inline-start` and `inline-end`, to position the caption box at the inline start edge and inline end edge of the table, respectively. These values are not supported in any browsers.
 
 ## Formal definition
 
@@ -110,5 +110,6 @@ td {
 
 ## See also
 
+- {{HTMLelement("caption")}}
 - [CSS table](/en-US/docs/Web/CSS/CSS_table) module
 - [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -18,10 +18,6 @@ The **`caption-side`** [CSS](/en-US/docs/Web/CSS) property puts the content of a
 caption-side: top;
 caption-side: bottom;
 
-/* Logical values */
-caption-side: inline-start;
-caption-side: inline-end;
-
 /* Global values */
 caption-side: inherit;
 caption-side: initial;
@@ -38,10 +34,9 @@ The `caption-side` property is specified as one of the keyword values listed bel
   - : The caption box should be positioned at the block start side of the table.
 - `bottom`
   - : The caption box should be positioned at the block end side of the table.
-- `inline-start`
-  - : The caption box should be positioned at the inline start edge of the table.
-- `inline-end`
-  - : The caption box should be positioned at the inline end edge of the table.
+ 
+> ![Note]
+> The [CSS logical properties and values] module defines two logical values, `inline-start` and `inline-end`, to position the caption box at the inline start edge and inline end edge of the table, respectively. These values are not supported in any browsers.
 
 ## Formal definition
 

--- a/files/en-us/web/css/caption-side/index.md
+++ b/files/en-us/web/css/caption-side/index.md
@@ -34,7 +34,7 @@ The `caption-side` property is specified as one of the keyword values listed bel
   - : The caption box should be positioned at the block start side of the table.
 - `bottom`
   - : The caption box should be positioned at the block end side of the table.
-> ![Note]
+> [!Note]
 > The [CSS logical properties and values](/en-US/docs/Web/CSS/CSS_logical_properties_and_values) module defines two logical values, `inline-start` and `inline-end`, to position the caption box at the inline start edge and inline end edge of the table, respectively. These values are not supported in any browsers.
 
 ## Formal definition


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/issues/23245

no browser supports `inline-start` or `inline-end`, they aren't listed in the formal syntax, and they are not tracked in BCD.