### PR TITLE
Explicitly say what Link header can be used for

### DIFF
--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -7,9 +7,9 @@ browser-compat: http.headers.Link
 
 {{HTTPSidebar}}
 
-The HTTP **`Link`** entity-header field provides a means for serializing one or more links in HTTP headers. In many cases, it has the same effect as the HTML {{HTMLElement("link")}} element.
+The HTTP **`Link`** [entity header](/en-US/docs/Glossary/Entity_header) field provides a means for serializing one or more links in HTTP headers. This header has the same semantics as the HTML {{HTMLElement("link")}} element. The benefit of using the `Link` header is that the browser can start preconnecting or preloading resources before the HTML itself is fetched and processed.
 
-> **Note:** Some browsers do not support the "icon" relation via HTTP ([FF#1185705](https://bugzilla.mozilla.org/show_bug.cgi?id=1185705)). Use HTML `<link rel="icon">` instead.
+In practice, most [link types](/en-US/docs/Web/HTML/Attributes/rel) don't have an effect in the HTTP header. For example, the `icon` relation only works in HTML, and `stylesheet` does not work reliably across browsers (only in Firefox). The only relations that work reliably are `preconnect` and `preload`, which can be combined with {{HTTPStatus(103, "103 Early Hints")}}.
 
 ## Syntax
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/27670. The `Link` header is not fully defined in the HTML spec and there are a few open discussions, so I've left the text slightly open-ended too.