### PR TITLE
Add Function.length example including destructuring patterns

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.md
@@ -19,7 +19,7 @@ A number.
 
 ## Description
 
-A {{jsxref("Function")}} object's `length` property indicates how many arguments the function expects, i.e. the number of formal parameters. This number excludes the {{jsxref("Functions/rest_parameters", "rest parameter", "", 1)}} and only includes parameters before the first one with a default value. By contrast, {{jsxref("Functions/arguments/length", "arguments.length")}} is local to a function and provides the number of arguments actually passed to the function.
+A {{jsxref("Function")}} object's `length` property indicates how many arguments the function expects, i.e. the number of formal parameters. This number excludes the {{jsxref("Functions/rest_parameters", "rest parameter", "", 1)}} and only includes parameters before the first one with a default value. Additionally, a {{jsxref("Operators/Destructuring_assignment", "destructuring pattern")}} will count as a single parameter. By contrast, {{jsxref("Functions/arguments/length", "arguments.length")}} is local to a function and provides the number of arguments actually passed to the function.
 
 The {{jsxref("Function")}} constructor is itself a `Function` object. Its `length` data property has a value of `1`.
 

--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.md
@@ -42,6 +42,10 @@ console.log(((...args) => {}).length);
 console.log(((a, b = 1, c) => {}).length);
 // 1, only parameters before the first one with
 // a default value are counted
+
+console.log((({a, b}, [c, d]) => {}).length);
+// 2, destructuring patterns each count as 
+// a single parameter
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.md
@@ -43,8 +43,8 @@ console.log(((a, b = 1, c) => {}).length);
 // 1, only parameters before the first one with
 // a default value are counted
 
-console.log((({a, b}, [c, d]) => {}).length);
-// 2, destructuring patterns each count as 
+console.log((({ a, b }, [c, d]) => {}).length);
+// 2, destructuring patterns each count as
 // a single parameter
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/function/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/length/index.md
@@ -19,7 +19,13 @@ A number.
 
 ## Description
 
-A {{jsxref("Function")}} object's `length` property indicates how many arguments the function expects, i.e. the number of formal parameters. This number excludes the {{jsxref("Functions/rest_parameters", "rest parameter", "", 1)}} and only includes parameters before the first one with a default value. Additionally, a {{jsxref("Operators/Destructuring_assignment", "destructuring pattern")}} will count as a single parameter. By contrast, {{jsxref("Functions/arguments/length", "arguments.length")}} is local to a function and provides the number of arguments actually passed to the function.
+A {{jsxref("Function")}} object's `length` property indicates how many arguments the function expects, i.e. the number of formal parameters:
+
+- Only parameters before the first one with a [default value](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) are counted.
+- A [destructuring pattern](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) counts as a single parameter.
+- The [rest parameter](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) is excluded.
+
+By contrast, {{jsxref("Functions/arguments/length", "arguments.length")}} is local to a function and provides the number of arguments actually passed to the function.
 
 The {{jsxref("Function")}} constructor is itself a `Function` object. Its `length` data property has a value of `1`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

As with rest and default parameters, destructuring patterns in parameter lists can be a little misleading when it comes to function length. Each pattern counts as a single parameter rather than the count including each identifier within the destructuring pattern. This example shows how length is affected by such patterns.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Additional example to better understand behavior.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
