### PR TITLE
Update ToggleEvent page to show that it's now also used for details.

### DIFF
--- a/files/en-us/web/api/toggleevent/index.md
+++ b/files/en-us/web/api/toggleevent/index.md
@@ -7,13 +7,12 @@ browser-compat: api.ToggleEvent
 
 {{APIRef("Popover API")}}
 
-The **`ToggleEvent`** interface represents an event notifying the user when a [popover element](/en-US/docs/Web/API/Popover_API)'s state toggles between showing and hidden.
+The **`ToggleEvent`** interface represents an event notifying the user an Element's state has changed.
 
 It is the event object for the `HTMLElement` {{domxref("HTMLElement.beforetoggle_event", "beforetoggle")}} and {{domxref("HTMLElement.toggle_event", "toggle")}} events, which fire on popovers when they transition between showing and hidden (before and after, respectively).
+It is also the event object for the `HTMLDetailsElement` {{domxref("HTMLDetailsElement.toggle_event", "toggle")}} event, which fires when a `<details>` element is toggled between open and closed.
 
 {{InheritanceDiagram}}
-
-> **Note:** `ToggleEvent` is unrelated to the `HTMLDetailsElement` {{domxref("HTMLDetailsElement.toggle_event", "toggle")}} event, which fires on a {{htmlelement("details")}} element when its `open`/`closed` state is toggled. Its event object is a generic {{domxref("Event")}}.
 
 ## Constructor
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The ToggleEvent page currently says that details' "toggle" event is a generic Event type. This is no longer true. This PR corrects that content.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

It's misleading in its current form, and is also inconsistent as the details Toggle event page correctly lists the type as ToggleEvent.

### Additional details

HTML change at https://github.com/whatwg/html/pull/8893

This is implemented in the latest version of Chromium, Firefox and Safari.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
