### PR TITLE
Document that class and ID selector values must be valid CSS identifiers

### DIFF
--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -33,15 +33,30 @@ li.spacious.elegant {
 .class_name { style properties }
 ```
 
-Note that this is equivalent to the following {{Cssxref("Attribute_selectors", "attribute selector")}}:
+Note that this is equivalent to the following [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors):
 
 ```css
 [class~=class_name] { style properties }
 ```
 
+The `class_name` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident).
+
 ## Examples
 
-### CSS
+### Valid class selectors
+
+#### HTML
+
+```html
+<p class="red">This paragraph has red text.</p>
+<p class="red yellow-bg">
+  This paragraph has red text and a yellow background.
+</p>
+<p class="red fancy">This paragraph has red text and "fancy" styling.</p>
+<p>This is just a regular paragraph.</p>
+```
+
+#### CSS
 
 ```css
 .red {
@@ -58,20 +73,23 @@ Note that this is equivalent to the following {{Cssxref("Attribute_selectors", "
 }
 ```
 
-### HTML
-
-```html
-<p class="red">This paragraph has red text.</p>
-<p class="red yellow-bg">
-  This paragraph has red text and a yellow background.
-</p>
-<p class="red fancy">This paragraph has red text and "fancy" styling.</p>
-<p>This is just a regular paragraph.</p>
-```
-
-### Result
+#### Result
 
 {{EmbedLiveSample('Examples')}}
+
+### Invalid class selectors
+
+Class selectors must be valid CSS identifiers.
+
+```css example-bad
+.item?one {
+  background-color: green;
+}
+
+.123item {
+  background-color: green;
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -39,7 +39,7 @@ Note that this is equivalent to the following [attribute selector](/en-US/docs/W
 [class~=class_name] { style properties }
 ```
 
-The `class_name` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident).
+The `class_name` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident). HTML `class` attributes which are not valid CSS identifiers must be [escaped](/en-US/docs/Web/CSS/ident#escaping_characters) before they can be used in class selectors.
 
 ## Examples
 
@@ -99,7 +99,7 @@ that contain characters which must be escaped in CSS -->
 
 ### Invalid class selectors
 
-Class selectors must be valid CSS identifiers.
+The class selectors in the following rules are not valid CSS identifiers, and will be ignored.
 
 ```css example-bad
 .item?one {

--- a/files/en-us/web/css/class_selectors/index.md
+++ b/files/en-us/web/css/class_selectors/index.md
@@ -56,6 +56,14 @@ The `class_name` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/iden
 <p>This is just a regular paragraph.</p>
 ```
 
+```html
+<!-- The next two paragraphs have class attributes
+that contain characters which must be escaped in CSS -->
+
+<p class="item?one">This paragraph has a pink background.</p>
+<p class="123item">This paragraph has a yellow background.</p>
+```
+
 #### CSS
 
 ```css
@@ -73,9 +81,21 @@ The `class_name` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/iden
 }
 ```
 
+```css
+/* In the next two rules, the class attributes must be escaped */
+
+.item\?one {
+  background-color: pink;
+}
+
+.\00003123item {
+  background-color: yellow;
+}
+```
+
 #### Result
 
-{{EmbedLiveSample('Examples')}}
+{{EmbedLiveSample('Examples', "", 300)}}
 
 ### Invalid class selectors
 

--- a/files/en-us/web/css/id_selectors/index.md
+++ b/files/en-us/web/css/id_selectors/index.md
@@ -22,15 +22,26 @@ The CSS **ID selector** matches an element based on the value of the element's [
 #id_value { style properties }
 ```
 
-Note that syntactically (but not specificity-wise), this is equivalent to the following {{Cssxref("Attribute_selectors", "attribute selector")}}:
+Note that syntactically (but not specificity-wise), this is equivalent to the following [attribute selector](/en-US/docs/Web/CSS/Attribute_selectors):
 
 ```css
 [id=id_value] { style properties }
 ```
 
+The `id_value` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident).
+
 ## Examples
 
-### CSS
+### Valid ID selectors
+
+#### HTML
+
+```html
+<div id="identified">This div has a special ID on it!</div>
+<div>This is just a regular div.</div>
+```
+
+#### CSS
 
 ```css
 #identified {
@@ -38,16 +49,23 @@ Note that syntactically (but not specificity-wise), this is equivalent to the fo
 }
 ```
 
-### HTML
-
-```html
-<div id="identified">This div has a special ID on it!</div>
-<div>This is just a regular div.</div>
-```
-
-### Result
+#### Result
 
 {{EmbedLiveSample("Examples", '100%', 50)}}
+
+### Invalid ID selectors
+
+ID selectors must be valid CSS identifiers.
+
+```css example-bad
+#item?one {
+  background-color: green;
+}
+
+#123item {
+  background-color: green;
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/id_selectors/index.md
+++ b/files/en-us/web/css/id_selectors/index.md
@@ -28,7 +28,7 @@ Note that syntactically (but not specificity-wise), this is equivalent to the fo
 [id=id_value] { style properties }
 ```
 
-The `id_value` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident).
+The `id_value` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident). HTML `id` attributes which are not valid CSS identifiers must be [escaped](/en-US/docs/Web/CSS/ident#escaping_characters) before they can be used in class selectors.
 
 ## Examples
 
@@ -37,25 +37,45 @@ The `id_value` value must be a valid [CSS identifier](/en-US/docs/Web/CSS/ident)
 #### HTML
 
 ```html
-<div id="identified">This div has a special ID on it!</div>
-<div>This is just a regular div.</div>
+<p id="blue">This paragraph has a blue background.</p>
+<p>This is just a regular paragraph.</p>
+```
+
+```html
+<!-- The next two paragraphs have id attributes
+that contain characters which must be escaped in CSS -->
+
+<p id="item?one">This paragraph has a pink background.</p>
+<p id="123item">This paragraph has a yellow background.</p>
 ```
 
 #### CSS
 
 ```css
-#identified {
+#blue {
   background-color: skyblue;
+}
+```
+
+```css
+/* In the next two rules, the id attributes must be escaped */
+
+#item\?one {
+  background-color: pink;
+}
+
+#\00003123item {
+  background-color: yellow;
 }
 ```
 
 #### Result
 
-{{EmbedLiveSample("Examples", '100%', 50)}}
+{{EmbedLiveSample("Examples", '100%', 200)}}
 
 ### Invalid ID selectors
 
-ID selectors must be valid CSS identifiers.
+The ID selectors in the following rules are not valid CSS identifiers, and will be ignored.
 
 ```css example-bad
 #item?one {


### PR DESCRIPTION
This is part 2 of the fix for https://github.com/mdn/content/issues/28752, as described in https://github.com/mdn/content/issues/28752#issuecomment-1707035191.

It follows on from https://github.com/mdn/content/pull/34340, and says that the values used for class and ID selectors must be valid CSS identifiers.