### PR TITLE
alignment-baseline usable on <text>

### DIFF
--- a/files/en-us/web/svg/attribute/alignment-baseline/index.md
+++ b/files/en-us/web/svg/attribute/alignment-baseline/index.md
@@ -14,7 +14,7 @@ The **`alignment-baseline`** attribute specifies how an object is aligned with r
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("tspan")}}
-- {{SVGElement("tref")}}
+- {{SVGElement("text")}}
 - {{SVGElement("textPath")}}
 
 ## Usage notes


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/22260. I also removed `<tref>` since it's not supported in any browser anyway. This does not address https://github.com/mdn/browser-compat-data/issues/23921 and I don't plan to add a compatibility note in this PR.