### PR TITLE
Document that saturate()/hue-rotate() are not in HSL space

### DIFF
--- a/files/en-us/web/css/filter-function/hue-rotate/index.md
+++ b/files/en-us/web/css/filter-function/hue-rotate/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.filter-function.hue-rotate
 
 The **`hue-rotate()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) rotates the [hue](https://en.wikipedia.org/wiki/Hue) of an element and its contents. Its result is a {{cssxref("&lt;filter-function&gt;")}}.
 
-> **Note:** `hue-rotate()` is specified as a matrix operation on the RGB color. It does not actually convert the color to the HSL model, which is a non-linear operation. Therefore, it may not preserve saturation or lightness of the original color perfectly, especially for saturated colors.
+> **Note:** `hue-rotate()` is specified as a matrix operation on the RGB color. It does not actually convert the color to the HSL model, which is a non-linear operation. Therefore, it may not preserve the saturation or lightness of the original color, especially for saturated colors.
 
 {{EmbedInteractiveExample("pages/css/function-hue-rotate.html")}}
 
@@ -178,15 +178,15 @@ This example shows three images: the image with a `hue-rotate()` filter function
 
 ### hue-rotate() does not preserve saturation or lightness
 
-The diagram below compares two color strips starting with red: one generated using `hue-rotate`, one using actual HSL color values. Note how the one using `hue-rotate` shows obvious differences in saturation and lightness in the middle.
+The diagram below compares two color gradients starting with red: the first is generated using `hue-rotate()`, and the second uses actual HSL color values. Note how the `hue-rotate()` gradient shows obvious differences in saturation and lightness in the middle.
 
 ```html
 <div>
-  <b>Using <code>hue-rotate()</code></b>
+  <p>Using <code>hue-rotate()</code></p>
   <div id="hue-rotate"></div>
 </div>
 <div>
-  <b>Using <code>hsl()</code></b>
+  <p>Using <code>hsl()</code></p>
   <div id="hsl"></div>
 </div>
 ```

--- a/files/en-us/web/css/filter-function/hue-rotate/index.md
+++ b/files/en-us/web/css/filter-function/hue-rotate/index.md
@@ -9,6 +9,8 @@ browser-compat: css.types.filter-function.hue-rotate
 
 The **`hue-rotate()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) rotates the [hue](https://en.wikipedia.org/wiki/Hue) of an element and its contents. Its result is a {{cssxref("&lt;filter-function&gt;")}}.
 
+> **Note:** `hue-rotate()` is specified as a matrix operation on the RGB color. It does not actually convert the color to the HSL model, which is a non-linear operation. Therefore, it may not preserve saturation or lightness of the original color perfectly, especially for saturated colors.
+
 {{EmbedInteractiveExample("pages/css/function-hue-rotate.html")}}
 
 ## Syntax
@@ -173,6 +175,53 @@ This example shows three images: the image with a `hue-rotate()` filter function
 ```
 
 {{EmbedLiveSample('With_url()_and_the_SVG_hue-rotate_filter','100%','280')}}
+
+### hue-rotate() does not preserve saturation or lightness
+
+The diagram below compares two color strips starting with red: one generated using `hue-rotate`, one using actual HSL color values. Note how the one using `hue-rotate` shows obvious differences in saturation and lightness in the middle.
+
+```html
+<div>
+  <b>Using <code>hue-rotate()</code></b>
+  <div id="hue-rotate"></div>
+</div>
+<div>
+  <b>Using <code>hsl()</code></b>
+  <div id="hsl"></div>
+</div>
+```
+
+```css hidden
+#hue-rotate,
+#hsl {
+  display: flex;
+  margin: 1em 0;
+}
+
+#hue-rotate div,
+#hsl div {
+  width: 2px;
+  height: 100px;
+}
+```
+
+```js
+const hueRotate = document.getElementById("hue-rotate");
+const hsl = document.getElementById("hsl");
+
+for (let i = 0; i < 360; i++) {
+  const div1 = document.createElement("div");
+  div1.style.backgroundColor = `hsl(${i}, 100%, 50%)`;
+  hsl.appendChild(div1);
+
+  const div2 = document.createElement("div");
+  div2.style.backgroundColor = "red";
+  div2.style.filter = `hue-rotate(${i}deg)`;
+  hueRotate.appendChild(div2);
+}
+```
+
+{{EmbedLiveSample('hue-rotate_does_not_preserve_saturation_or_lightness','100%','350')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/filter-function/saturate/index.md
+++ b/files/en-us/web/css/filter-function/saturate/index.md
@@ -9,7 +9,7 @@ browser-compat: css.types.filter-function.saturate
 
 The **`saturate()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) super-saturates or desaturates the input image. Its result is a {{cssxref("&lt;filter-function&gt;")}}.
 
-> **Note:** `saturate()` is specified as a matrix operation on the RGB color. It does not actually convert the color to the HSL model, which is a non-linear operation. Therefore, it may not preserve the hue or lightness of the original color perfectly.
+> **Note:** `saturate()` is specified as a matrix operation on the RGB color. It does not actually convert the color to the HSL model, which is a non-linear operation. Therefore, it may not preserve the hue or lightness of the original color.
 
 {{EmbedInteractiveExample("pages/css/function-saturate.html")}}
 
@@ -37,15 +37,15 @@ saturate(200%)  /* Double saturation */
 
 ### saturate() does not preserve hue or lightness
 
-The diagram below compares two color strips with `hsl(0, 50%, 50%)` as the mid-point: one generated using `saturate`, one using actual HSL color values. Note how the one using `saturate` shows obvious differences in hue and lightness towards the two ends.
+The diagram below compares two color gradients with `hsl(0, 50%, 50%)` as the mid-point: the first is generated using `saturate()`, and the second uses actual HSL color values. Note how the `saturate()` gradient shows differences in hue and lightness towards the two ends.
 
 ```html
 <div>
-  <b>Using <code>saturate()</code></b>
+  <p>Using <code>saturate()</code></p>
   <div id="saturate"></div>
 </div>
 <div>
-  <b>Using <code>hsl()</code></b>
+  <p>Using <code>hsl()</code></p>
   <div id="hsl"></div>
 </div>
 ```

--- a/files/en-us/web/css/filter-function/saturate/index.md
+++ b/files/en-us/web/css/filter-function/saturate/index.md
@@ -9,6 +9,8 @@ browser-compat: css.types.filter-function.saturate
 
 The **`saturate()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) super-saturates or desaturates the input image. Its result is a {{cssxref("&lt;filter-function&gt;")}}.
 
+> **Note:** `saturate()` is specified as a matrix operation on the RGB color. It does not actually convert the color to the HSL model, which is a non-linear operation. Therefore, it may not preserve the hue or lightness of the original color perfectly.
+
 {{EmbedInteractiveExample("pages/css/function-saturate.html")}}
 
 ## Syntax
@@ -32,6 +34,53 @@ saturate(.4)    /* 40% saturated */
 saturate(100%)  /* No effect */
 saturate(200%)  /* Double saturation */
 ```
+
+### saturate() does not preserve hue or lightness
+
+The diagram below compares two color strips with `hsl(0, 50%, 50%)` as the mid-point: one generated using `saturate`, one using actual HSL color values. Note how the one using `saturate` shows obvious differences in hue and lightness towards the two ends.
+
+```html
+<div>
+  <b>Using <code>saturate()</code></b>
+  <div id="saturate"></div>
+</div>
+<div>
+  <b>Using <code>hsl()</code></b>
+  <div id="hsl"></div>
+</div>
+```
+
+```css hidden
+#saturate,
+#hsl {
+  display: flex;
+  margin: 1em 0;
+}
+
+#saturate div,
+#hsl div {
+  width: 2px;
+  height: 100px;
+}
+```
+
+```js
+const saturate = document.getElementById("saturate");
+const hsl = document.getElementById("hsl");
+
+for (let i = 0; i <= 200; i++) {
+  const div1 = document.createElement("div");
+  div1.style.backgroundColor = `hsl(0, ${i / 2}%, 50%)`;
+  hsl.appendChild(div1);
+
+  const div2 = document.createElement("div");
+  div2.style.backgroundColor = "hsl(0, 50%, 50%)";
+  div2.style.filter = `saturate(${i}%)`;
+  saturate.appendChild(div2);
+}
+```
+
+{{EmbedLiveSample('saturate_does_not_preserve_hue_or_lightness','100%','350')}}
 
 ## Specifications
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/24839