### PR TITLE
Use more salient name for imported Wasm module

### DIFF
--- a/files/en-us/webassembly/javascript_interface/compilestreaming_static/index.md
+++ b/files/en-us/webassembly/javascript_interface/compilestreaming_static/index.md
@@ -42,7 +42,9 @@ A `Promise` that resolves to a [`WebAssembly.Module`](/en-US/docs/WebAssembly/Ja
 The following example (see our [compile-streaming.html](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/compile-streaming.html) demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/compile-streaming.html) also) directly streams a Wasm module from an underlying source then compiles it to a [`WebAssembly.Module`](/en-US/docs/WebAssembly/JavaScript_interface/Module) object. Because the `compileStreaming()` function accepts a promise for a [`Response`](/en-US/docs/Web/API/Response) object, you can directly pass it a `Promise` from calling [`fetch()`](/en-US/docs/Web/API/fetch), without waiting for the promise to fulfill.
 
 ```js
-const importObject = { imports: { imported_func: (arg) => console.log(arg) } };
+const importObject = {
+  my_namespace: { imported_func: (arg) => console.log(arg) },
+};
 
 WebAssembly.compileStreaming(fetch("simple.wasm"))
   .then((module) => WebAssembly.instantiate(module, importObject))

--- a/files/en-us/webassembly/javascript_interface/index.md
+++ b/files/en-us/webassembly/javascript_interface/index.md
@@ -62,7 +62,9 @@ The primary uses for the `WebAssembly` object are:
 The following example (see our [instantiate-streaming.html](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/instantiate-streaming.html) demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/instantiate-streaming.html) also) directly streams a Wasm module from an underlying source then compiles and instantiates it, the promise fulfilling with a `ResultObject`. Because the `instantiateStreaming()` function accepts a promise for a [`Response`](/en-US/docs/Web/API/Response) object, you can directly pass it a [`fetch()`](/en-US/docs/Web/API/fetch) call, and it will pass the response into the function when it fulfills.
 
 ```js
-const importObject = { imports: { imported_func: (arg) => console.log(arg) } };
+const importObject = {
+  my_namespace: { imported_func: (arg) => console.log(arg) },
+};
 
 WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
   (obj) => obj.instance.exports.exported_func(),

--- a/files/en-us/webassembly/javascript_interface/instance/exports/index.md
+++ b/files/en-us/webassembly/javascript_interface/instance/exports/index.md
@@ -23,7 +23,7 @@ that is exported by the `Instance`.
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/javascript_interface/instance/index.md
+++ b/files/en-us/webassembly/javascript_interface/instance/index.md
@@ -27,7 +27,7 @@ The `WebAssembly.Instance()` constructor function can be called to synchronously
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },
@@ -47,7 +47,7 @@ The preferred way to get an `Instance` is asynchronously, for example using the 
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/javascript_interface/instance/instance/index.md
+++ b/files/en-us/webassembly/javascript_interface/instance/instance/index.md
@@ -51,7 +51,7 @@ synchronously instantiate a given [`WebAssembly.Module`](/en-US/docs/WebAssembly
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },
@@ -72,7 +72,7 @@ However, the preferred way to get an `Instance` is through the asynchronous
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/javascript_interface/instantiate_static/index.md
+++ b/files/en-us/webassembly/javascript_interface/instantiate_static/index.md
@@ -102,7 +102,7 @@ that is exported by the `Instance`.
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },
@@ -143,7 +143,7 @@ exported function from inside it.
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/javascript_interface/instantiatestreaming_static/index.md
+++ b/files/en-us/webassembly/javascript_interface/instantiatestreaming_static/index.md
@@ -66,7 +66,9 @@ object, you can directly pass it a [`fetch()`](/en-US/docs/Web/API/fetch)
 call, and it will pass the response into the function when it fulfills.
 
 ```js
-const importObject = { imports: { imported_func: (arg) => console.log(arg) } };
+const importObject = {
+  my_namespace: { imported_func: (arg) => console.log(arg) },
+};
 
 WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject).then(
   (obj) => obj.instance.exports.exported_func(),

--- a/files/en-us/webassembly/javascript_interface/module/exports_static/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/exports_static/index.md
@@ -58,7 +58,7 @@ available exports on a module using `WebAssembly.Module.exports`.
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/javascript_interface/module/imports_static/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/imports_static/index.md
@@ -49,7 +49,7 @@ WebAssembly.compileStreaming(fetch("simple.wasm")).then((mod) => {
 The console log displays the following description for the imported module:
 
 ```js
-{ module: "imports", name: "imported_func", kind: "function" }
+{ module: "my_namespace", name: "imported_func", kind: "function" }
 ```
 
 ## Specifications

--- a/files/en-us/webassembly/javascript_interface/module/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/index.md
@@ -45,7 +45,7 @@ The worker function [`wasm_worker.js`](https://github.com/mdn/webassembly-exampl
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/javascript_interface/module/module/index.md
+++ b/files/en-us/webassembly/javascript_interface/module/module/index.md
@@ -50,7 +50,7 @@ new WebAssembly.Module(bufferSource)
 
 ```js
 const importObject = {
-  imports: {
+  my_namespace: {
     imported_func(arg) {
       console.log(arg);
     },

--- a/files/en-us/webassembly/text_format_to_wasm/index.md
+++ b/files/en-us/webassembly/text_format_to_wasm/index.md
@@ -12,11 +12,11 @@ WebAssembly has an S-expression-based textual representation, an intermediate fo
 
 ## A first look at the text format
 
-Let's look at a simple example of this — the following program imports a function called `imported_func` from a module called `imports`, and exports a function called `exported_func`:
+Let's look at a simple example of this — the following program imports a function called `imported_func` from a module called `my_namespace`, and exports a function called `exported_func`:
 
 ```wasm
 (module
-  (func $i (import "imports" "imported_func") (param i32))
+  (func $i (import "my_namespace" "imported_func") (param i32))
   (func (export "exported_func")
     i32.const 42
     call $i

--- a/files/en-us/webassembly/using_the_javascript_api/index.md
+++ b/files/en-us/webassembly/using_the_javascript_api/index.md
@@ -24,17 +24,17 @@ Let's run through some examples that explain how to use the WebAssembly JavaScri
 
    ```wasm
    (module
-     (func $i (import "imports" "imported_func") (param i32))
+     (func $i (import "my_namespace" "imported_func") (param i32))
      (func (export "exported_func")
        i32.const 42
        call $i))
    ```
 
-4. In the second line, you will see that the import has a two-level namespace — the internal function `$i` is imported from `imports.imported_func`. We need to reflect this two-level namespace in JavaScript when writing the object to be imported into the Wasm module. Create a `<script></script>` element in your HTML file, and add the following code to it:
+4. In the second line, you will see that the import has a two-level namespace — the internal function `$i` is imported from `my_namespace.imported_func`. We need to reflect this two-level namespace in JavaScript when writing the object to be imported into the Wasm module. Create a `<script></script>` element in your HTML file, and add the following code to it:
 
    ```js
    const importObject = {
-     imports: { imported_func: (arg) => console.log(arg) },
+     my_namespace: { imported_func: (arg) => console.log(arg) },
    };
    ```
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/26785. Whoever is reviewing this PR please review https://github.com/mdn/webassembly-examples/pull/38 too so the content can be in sync, especially the naming.