### PR TITLE
Fix description of device-cmyk

### DIFF
--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -202,7 +202,7 @@ The {{CSSxRef("color_value","&lt;color&gt;")}} CSS [data type](/en-US/docs/Web/C
 - {{CSSxRef("color_value/color-contrast", "color-contrast()")}} {{Experimental_Inline}}
   - : Selects the highest color contrast from a list of colors, compare to a base color value.
 - {{CSSxRef("color_value/device-cmyk", "device-cmyk()")}} {{Experimental_Inline}}
-  - : Defines CMYK colors in a device-independent way.
+  - : Defines CMYK colors in a device-dependent way.
 - {{CSSXref("color_value/light-dark", "light-dark()")}} {{Experimental_Inline}}
   - : Returns one of two provided colors based on the current color scheme.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Minor fix. Function `device-cmyk` is device dependent, not *in*dependent, as described here: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/device-cmyk
