### PR TITLE
fix: '/en-US/observatory/' -> '/en-US/observatory'

### DIFF
--- a/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn/server-side/apache_configuration_htaccess/index.md
@@ -494,7 +494,7 @@ To prevent referrer leakage entirely, specify the `no-referrer` value instead. N
 
 Use services like the ones below to check your `Referrer-Policy`:
 
-- [HTTP Observatory](/en-US/observatory/)
+- [HTTP Observatory](/en-US/observatory)
 - [securityheaders.com](https://securityheaders.com/)
 
 ```apacheconf

--- a/files/en-us/web/http/headers/x-content-type-options/index.md
+++ b/files/en-us/web/http/headers/x-content-type-options/index.md
@@ -72,7 +72,7 @@ X-Content-Type-Options: nosniff
 
 - {{HTTPHeader("Content-Type")}}
 - The [original definition](https://docs.microsoft.com/archive/blogs/ie/ie8-security-part-vi-beta-2-update) of X-Content-Type-Options by Microsoft.
-- Use [HTTP Observatory](/en-US/observatory/) to test the security configuration of websites (including this header).
+- Use [HTTP Observatory](/en-US/observatory) to test the security configuration of websites (including this header).
 - [Mitigating MIME Confusion Attacks in Firefox](https://blog.mozilla.org/security/2016/08/26/mitigating-mime-confusion-attacks-in-firefox/)
 - [Cross-Origin Read Blocking (CORB)](https://fetch.spec.whatwg.org/#corb)
 - [Google Docs CORB explainer](https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md)

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -53,7 +53,7 @@ Helpful tools and resources for understanding and debugging HTTP.
 
 - [Firefox Developer Tools](https://firefox-source-docs.mozilla.org/devtools-user/index.html)
   - : [Network monitor](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
-- [HTTP Observatory](/en-US/observatory/)
+- [HTTP Observatory](/en-US/observatory)
   - : A project designed to help developers, system administrators, and security professionals configure their sites safely and securely.
 - [RedBot](https://redbot.org/)
   - : Tools to check your cache-related headers.

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -163,7 +163,7 @@ The following features can help guard against clickjacking:
 
 To get comprehensive instructions for implementing security features effectively on websites and to ensure you're following best practices, see our set of [Practical security implementation guides](/en-US/docs/Web/Security/Practical_implementation_guides).
 
-Some of these guides are directly related to the [HTTP Observatory](/en-US/observatory/) tool. Observatory performs security audits on a website and provides a grade and score along with recommendations for fixing the security issues it finds. These guides explain how to resolve issues surfaced by the MDN Observatory tests: the tool links to the relevant guide for each issue, helping guide you towards an effective resolution. Interestingly, Mozilla's internal developer teams use this guidance when implementing websites to ensure that security best practices are applied.
+Some of these guides are directly related to the [HTTP Observatory](/en-US/observatory) tool. Observatory performs security audits on a website and provides a grade and score along with recommendations for fixing the security issues it finds. These guides explain how to resolve issues surfaced by the MDN Observatory tests: the tool links to the relevant guide for each issue, helping guide you towards an effective resolution. Interestingly, Mozilla's internal developer teams use this guidance when implementing websites to ensure that security best practices are applied.
 
 ## See also
 

--- a/files/en-us/web/security/practical_implementation_guides/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/index.md
@@ -12,7 +12,7 @@ This page lists guides that detail the best practices for implementing security 
 
 ## Content security fundamentals
 
-Most of these guides are directly related to the [HTTP Observatory](/en-US/observatory/) tool. Observatory performs security audits on a website and provides a grade and score along with recommendations for fixing the security issues it finds. These guides explain how to resolve issues surfaced by the HTTP Observatory tests: the tool links to the relevant guide for each issue, helping guide you towards an effective resolution. Interestingly, Mozilla's internal developer teams use this guidance when implementing websites to ensure that security best practices are applied.
+Most of these guides are directly related to the [HTTP Observatory](/en-US/observatory) tool. Observatory performs security audits on a website and provides a grade and score along with recommendations for fixing the security issues it finds. These guides explain how to resolve issues surfaced by the HTTP Observatory tests: the tool links to the relevant guide for each issue, helping guide you towards an effective resolution. Interestingly, Mozilla's internal developer teams use this guidance when implementing websites to ensure that security best practices are applied.
 
 The guides in the table below are listed in the order that we recommend implementing the security features they describe. This order is based on a combination of each feature's security impact and the ease of its implementation from both operational and developmental perspectives. The table provides information about each feature's impact, difficulty of implementation, whether or not it is required, and a brief description.
 

--- a/files/en-us/web/security/transport_layer_security/index.md
+++ b/files/en-us/web/security/transport_layer_security/index.md
@@ -97,6 +97,6 @@ If the TLS handshake starts to become slow or unresponsive for some reason, the 
 
 - The [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org) and [Cipherlist.eu](https://cipherlist.eu/) can help you generate configuration files for your server to secure your site.
 - The Mozilla Operations Security (OpSec) team maintains a wiki page with [reference TLS configurations](https://wiki.mozilla.org/Security/Server_Side_TLS).
-- Use [HTTP Observatory](/en-US/observatory/) and [SSL Labs](https://www.ssllabs.com/ssltest/) to test how secure a site's HTTP/TLS configuration is.
+- Use [HTTP Observatory](/en-US/observatory) and [SSL Labs](https://www.ssllabs.com/ssltest/) to test how secure a site's HTTP/TLS configuration is.
 - [Secure Contexts](/en-US/docs/Web/Security/Secure_Contexts)
 - [Strict-Transport-Security](/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) HTTP header


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove the trailing slash from all HTTP Observatory links.

### Motivation

The HTTP Observatory landing page URL doesn't have a trailing slash.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
