### PR TITLE
Mention DataTransfer usage in other APIs, clarify it can be null

### DIFF
--- a/files/en-us/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboarddata/index.md
@@ -19,6 +19,8 @@ See the {{domxref("Element/cut_event", "cut")}}, {{domxref("Element/copy_event",
 
 A {{domxref("DataTransfer")}} object.
 
+The property can be `null` when the event is created using the constructor. It is never `null` when dispatched by the browser.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -7,9 +7,9 @@ browser-compat: api.DataTransfer
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer`** object is used to hold the data that is being dragged during a drag and drop operation. It may hold one or more data items, each of one or more data types. For more information about drag and drop, see [HTML Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API).
+The **`DataTransfer`** object is used to hold any data transferred between contexts, such as a drag and drop operation, or clipboard read/write. It may hold one or more data items, each of one or more data types.
 
-This object is available from the {{domxref("DragEvent.dataTransfer","dataTransfer")}} property of all {{domxref("DragEvent","drag events")}}.
+`DataTransfer` was primarily designed for the [HTML Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API), as the {{domxref("DragEvent.dataTransfer")}} property, and is still specified in the HTML drag-and-drop section, but it is now also used by other APIs, such as {{domxref("ClipboardEvent.clipboardData")}} and {{domxref("InputEvent.dataTransfer")}}. However, other APIs only use certain parts of its interface, ignoring properties such as `dropEffect`. Documentation of `DataTransfer` will primarily discuss its usage in drag-and-drop operations, and you should refer to the other APIs' documentation for usage of `DataTransfer` in those contexts.
 
 ## Constructor
 
@@ -17,8 +17,6 @@ This object is available from the {{domxref("DragEvent.dataTransfer","dataTransf
   - : Creates and returns a new `DataTransfer` object.
 
 ## Instance properties
-
-### Standard properties
 
 - {{domxref("DataTransfer.dropEffect")}}
   - : Gets the type of drag-and-drop operation currently selected or sets the operation to a new type. The value must be `none`, `copy`, `link` or `move`.
@@ -31,13 +29,7 @@ This object is available from the {{domxref("DragEvent.dataTransfer","dataTransf
 - {{domxref("DataTransfer.types")}} {{ReadOnlyInline}}
   - : An array of strings giving the formats that were set in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event.
 
-### Gecko properties
-
-{{SeeCompatTable}}
-
 ## Instance methods
-
-### Standard methods
 
 - {{domxref("DataTransfer.clearData()")}}
   - : Remove the data associated with a given type. The type argument is optional. If the type is empty or not specified, the data associated with all types is removed. If data for the specified type does not exist, or the data transfer contains no data, this method will have no effect.
@@ -47,10 +39,6 @@ This object is available from the {{domxref("DragEvent.dataTransfer","dataTransf
   - : Set the data for a given type. If data for the type does not exist, it is added at the end, such that the last item in the types list will be the new format. If data for the type already exists, the existing data is replaced in the same position.
 - {{domxref("DataTransfer.setDragImage()")}}
   - : Set the image to be used for dragging if a custom one is desired.
-
-### Gecko methods
-
-{{Non-standard_Header}}
 
 ## Examples
 

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -8,12 +8,11 @@ browser-compat: api.DataTransfer.types
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.types`** read-only property returns the available types
-that exist in the {{domxref("DataTransfer.items","items")}}.
+The **`DataTransfer.types`** read-only property returns the available types that exist in the {{domxref("DataTransfer.items","items")}}.
 
 ## Value
 
-An array of the data formats used in the drag operation. Each format is a string
+An array of the data formats. Each format is a string
 which is generally a MIME type such as `text/plain` or `text/html`. If the drag
 operation included no data, this list will be empty. If any files are included in
 the drag operation, then one of the types will be the string `Files`.

--- a/files/en-us/web/api/datatransferitem/index.md
+++ b/files/en-us/web/api/datatransferitem/index.md
@@ -9,6 +9,8 @@ browser-compat: api.DataTransferItem
 
 The **`DataTransferItem`** object represents one drag data item. During a _drag operation_, each {{domxref("DragEvent","drag event")}} has a {{domxref("DragEvent.dataTransfer","dataTransfer")}} property which contains a {{domxref("DataTransferItemList","list")}} of drag data items. Each item in the list is a `DataTransferItem` object.
 
+`DataTransferItem` was primarily designed for the [HTML Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API), and is still specified in the HTML drag-and-drop section, but it is now also used by other APIs, such as {{domxref("ClipboardEvent.clipboardData")}} and {{domxref("InputEvent.dataTransfer")}}. Documentation of `DataTransferItem` will primarily discuss its usage in drag-and-drop operations, and you should refer to the other APIs' documentation for usage of `DataTransferItem` in those contexts.
+
 This interface has no constructor.
 
 ## Instance properties

--- a/files/en-us/web/api/datatransferitemlist/index.md
+++ b/files/en-us/web/api/datatransferitemlist/index.md
@@ -11,6 +11,8 @@ The **`DataTransferItemList`** object is a list of {{domxref("DataTransferItem")
 
 The individual items can be accessed using the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation) `[]`.
 
+`DataTransferItemList` was primarily designed for the [HTML Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API), and is still specified in the HTML drag-and-drop section, but it is now also used by other APIs, such as {{domxref("ClipboardEvent.clipboardData")}} and {{domxref("InputEvent.dataTransfer")}}. Documentation of `DataTransferItemList` will primarily discuss its usage in drag-and-drop operations, and you should refer to the other APIs' documentation for usage of `DataTransferItemList` in those contexts.
+
 This interface has no constructor.
 
 ## Instance properties
@@ -26,8 +28,6 @@ This interface has no constructor.
   - : Removes the drag item from the list at the given index.
 - {{domxref("DataTransferItemList.clear()")}}
   - : Removes all of the drag items from the list.
-- {{domxref("DataTransferItemList.operator[]")}}
-  - : Getter that returns a {{domxref("DataTransferItem")}} at the given index.
 
 ## Example
 

--- a/files/en-us/web/api/dragevent/datatransfer/index.md
+++ b/files/en-us/web/api/dragevent/datatransfer/index.md
@@ -13,7 +13,9 @@ operation's data (as a {{domxref("DataTransfer")}} object).
 
 ## Value
 
-A {{domxref("DataTransfer")}} object which contains the {{domxref("DragEvent","drag event's data")}}.
+A {{domxref("DataTransfer")}} object which contains the {{domxref("DragEvent","drag event's data", "", 1)}}.
+
+The property can be `null` when the event is created using the constructor. It is never `null` when dispatched by the browser.
 
 ## Examples
 

--- a/files/en-us/web/api/inputevent/data/index.md
+++ b/files/en-us/web/api/inputevent/data/index.md
@@ -15,7 +15,7 @@ characters are deleted.
 
 ## Value
 
-A string.
+A string or `null`. The spec has an [overview](https://w3c.github.io/input-events/#overview) of its value in various cases.
 
 ## Examples
 

--- a/files/en-us/web/api/inputevent/datatransfer/index.md
+++ b/files/en-us/web/api/inputevent/datatransfer/index.md
@@ -15,7 +15,7 @@ editable content.
 
 ## Value
 
-A {{domxref("DataTransfer")}} object.
+A {{domxref("DataTransfer")}} object or `null`. The spec has an [overview](https://w3c.github.io/input-events/#overview) of its value in various cases.
 
 ## Examples
 


### PR DESCRIPTION
- Fix https://github.com/mdn/content/issues/29696
- Fix https://github.com/mdn/content/issues/11670

A more ambitious fix would be to rewrite the whole `DataTransfer` docs to be drag-and-drop agnostic, but I'm not sure if that's beneficial since it's associated with the DnD sidebar, specified in DnD, and part of the interface only makes sense for DnD. As such I only added a mention on each landing page.