### PR TITLE
Consistent reduced time precision sections

### DIFF
--- a/files/en-us/web/api/animation/currenttime/index.md
+++ b/files/en-us/web/api/animation/currenttime/index.md
@@ -34,12 +34,14 @@ animation.currentTime =
 
 ## Reduced time precision
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animation.currentTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 microseconds in Firefox 59; in 60 it will be 2 milliseconds.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animation.currentTime` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `animation.currentTime` will always be a multiple of 0.002, or a multiple of 0.1 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 animation.currentTime;
+// Might be:
 // 23.404
 // 24.192
 // 25.514
@@ -47,13 +49,12 @@ animation.currentTime;
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 animation.currentTime;
+// Might be:
 // 49.8
 // 50.6
 // 51.7
 // …
 ```
-
-In Firefox, you can also enabled `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/animation/starttime/index.md
+++ b/files/en-us/web/api/animation/starttime/index.md
@@ -50,12 +50,14 @@ function animateNewCatWithWAAPI() {
 
 ## Reduced time precision
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animation.startTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 µs in Firefox 59; in 60 it will be 2 ms.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animation.startTime` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `animation.startTime` will always be a multiple of 0.002, or a multiple of 0.1 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 animation.startTime;
+// Might be:
 // 23.404
 // 24.192
 // 25.514
@@ -63,13 +65,12 @@ animation.startTime;
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 animation.startTime;
+// Might be:
 // 49.8
 // 50.6
 // 51.7
 // …
 ```
-
-In Firefox, you can also enabled `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationplaybackevent/currenttime/index.md
+++ b/files/en-us/web/api/animationplaybackevent/currenttime/index.md
@@ -16,12 +16,14 @@ A number representing the current time in milliseconds, or `null`.
 
 ## Reduced time precision
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `playbackEvent.currentTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20 µs in Firefox 59; in 60, it will be 2 ms.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `platbackEvent.currentTime` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `platbackEvent.currentTime` will always be a multiple of 0.002, or a multiple of 0.1 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 playbackEvent.currentTime;
+// Might be:
 // 23.404
 // 24.192
 // 25.514
@@ -29,13 +31,12 @@ playbackEvent.currentTime;
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 playbackEvent.currentTime;
+// Might be:
 // 49.8
 // 50.6
 // 51.7
 // …
 ```
-
-In Firefox, you can also enabled `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/animationtimeline/currenttime/index.md
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.md
@@ -16,12 +16,14 @@ A number representing the timeline's current time in milliseconds, or `null` if 
 
 ## Reduced time precision
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animationTimeline.currentTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20us in Firefox 59; in 60 it will be 2ms.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `animationTimeline.currentTime` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `animationTimeline.currentTime` will always be a multiple of 0.002, or a multiple of 0.1 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 animationTimeline.currentTime;
+// Might be:
 // 23.404
 // 24.192
 // 25.514
@@ -29,13 +31,12 @@ animationTimeline.currentTime;
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 animationTimeline.currentTime;
+// Might be:
 // 49.8
 // 50.6
 // 51.7
 // …
 ```
-
-In Firefox, you can also enable `privacy.resistFingerprinting`; the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.md
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.md
@@ -29,14 +29,14 @@ console.log(audioCtx.currentTime);
 
 ## Reduced time precision
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of
-`audioCtx.currentTime` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by
-default and defaults to 20us in Firefox 59; in 60 it will be 2ms.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `audioCtx.currentTime` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `audioCtx.currentTime` will always be a multiple of 0.002, or a multiple of 0.1 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 audioCtx.currentTime;
+// Might be:
 // 23.404
 // 24.192
 // 25.514
@@ -44,16 +44,12 @@ audioCtx.currentTime;
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 audioCtx.currentTime;
+// Might be:
 // 49.8
 // 50.6
 // 51.7
 // …
 ```
-
-In Firefox, you can also enabled `privacy.resistFingerprinting`, the
-precision will be 100ms or the value of
-`privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever
-is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/event/timestamp/index.md
+++ b/files/en-us/web/api/event/timestamp/index.md
@@ -46,20 +46,27 @@ document.body.addEventListener("keypress", getTime);
 
 ## Reduced time precision
 
-To offer protection against timing attacks and fingerprinting, the precision of `Event.timeStamp` might get rounded depending on browser settings.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `event.timeStamp` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms.
+For example, with reduced time precision, the result of `event.timeStamp` will always be a multiple of 2, or a multiple of 100 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
-// reduced time precision in Firefox (default: 2ms)
+// reduced time precision (2ms) in Firefox 60
 event.timeStamp;
+// Might be:
 // 9934
 // 10362
 // 11670
 // …
-```
 
-In Firefox, if you also enable `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+// reduced time precision with `privacy.resistFingerprinting` enabled
+event.timeStamp;
+// Might be:
+// 53500
+// 58900
+// 64400
+// …
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/file/lastmodified/index.md
+++ b/files/en-us/web/api/file/lastmodified/index.md
@@ -80,14 +80,14 @@ console.log(fileWithoutDate.lastModified); // returns current time
 
 ## Reduced time precision
 
-To offer protection against timing attacks and {{glossary("fingerprinting")}}, the precision of
-`someFile.lastModified` might get rounded depending on browser settings.
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by
-default and defaults to 20us in Firefox 59; in 60 it will be 2ms.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `someFile.lastModified` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `someFile.lastModified` will always be a multiple of 2, or a multiple of 100 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 someFile.lastModified;
+// Might be:
 // 1519211809934
 // 1519211810362
 // 1519211811670
@@ -95,16 +95,12 @@ someFile.lastModified;
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 someFile.lastModified;
+// Might be:
 // 1519129853500
 // 1519129858900
 // 1519129864400
 // …
 ```
-
-In Firefox, if you enable `privacy.resistFingerprinting`, the
-precision will be 100ms or the value of
-`privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever
-is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/file/lastmodifieddate/index.md
+++ b/files/en-us/web/api/file/lastmodifieddate/index.md
@@ -32,13 +32,14 @@ for (const file of fileInput.files) {
 
 ## Reduced time precision
 
-To offer protection against timing attacks and {{glossary("fingerprinting")}}, the precision of `someFile.lastModifiedDate.getTime()` might get rounded depending on browser settings.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `someFile.lastModifiedDate` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
-In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 20us in Firefox 59; in 60 it will be 2ms.
+For example, with reduced time precision, the result of `someFile.lastModifiedDate.getTime()` will always be a multiple of 2, or a multiple of 100 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
 
 ```js
 // reduced time precision (2ms) in Firefox 60
 someFile.lastModifiedDate.getTime();
+// Might be:
 // 1519211809934
 // 1519211810362
 // 1519211811670
@@ -46,13 +47,12 @@ someFile.lastModifiedDate.getTime();
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 someFile.lastModifiedDate.getTime();
+// Might be:
 // 1519129853500
 // 1519129858900
 // 1519129864400
 // …
 ```
-
-In Firefox, you can also enable `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlmediaelement/currenttime/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currenttime/index.md
@@ -46,8 +46,27 @@ console.log(video.currentTime);
 
 ### Reduced time precision
 
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), browsers may round or
-otherwise adjust the value returned by `currentTime`.
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `video.currentTime` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `video.currentTime` will always be a multiple of 0.002, or a multiple of 0.1 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
+
+```js
+// reduced time precision (2ms) in Firefox 60
+video.currentTime;
+// Might be:
+// 23.404
+// 24.192
+// 25.514
+// …
+
+// reduced time precision with `privacy.resistFingerprinting` enabled
+video.currentTime;
+// Might be:
+// 49.8
+// 50.6
+// 51.7
+// …
+```
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -85,6 +85,32 @@ Calling `new Date()` (the `Date()` constructor) returns a [`Date`](/en-US/docs/W
 
 Calling the `Date()` function (without the `new` keyword) returns a string representation of the current date and time, exactly as `new Date().toString()` does. Any arguments given in a `Date()` function call (without the `new` keyword) are ignored; regardless of whether it's called with an invalid date string — or even called with any arbitrary object or other primitive as an argument — it always returns a string representation of the current date and time.
 
+## Description
+
+### Reduced time precision
+
+To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `new Date()` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
+
+For example, with reduced time precision, the result of `new Date().getTime()` will always be a multiple of 2, or a multiple of 100 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
+
+```js
+// reduced time precision (2ms) in Firefox 60
+new Date().getTime();
+// Might be:
+// 1519211809934
+// 1519211810362
+// 1519211811670
+// …
+
+// reduced time precision with `privacy.resistFingerprinting` enabled
+new Date().getTime();
+// Might be:
+// 1519129853500
+// 1519129858900
+// 1519129864400
+// …
+```
+
 ## Examples
 
 ### Several ways to create a Date object

--- a/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
@@ -29,26 +29,6 @@ A number representing the [timestamp](/en-US/docs/Web/JavaScript/Reference/Globa
 
 `Date` objects are fundamentally represented by a [timestamp](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date), and this method allows you to retrieve the timestamp. You can use this method to help assign a date and time to another {{jsxref("Date")}} object. This method is functionally equivalent to the {{jsxref("Date/valueof", "valueOf()")}} method.
 
-### Reduced time precision
-
-To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `new Date().getTime()` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
-
-```js
-// reduced time precision (2ms) in Firefox 60
-new Date().getTime();
-// 1519211809934
-// 1519211810362
-// 1519211811670
-// …
-
-// reduced time precision with `privacy.resistFingerprinting` enabled
-new Date().getTime();
-// 1519129853500
-// 1519129858900
-// 1519129864400
-// …
-```
-
 ## Examples
 
 ### Using getTime() for copying dates

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -31,9 +31,12 @@ A number representing the [timestamp](/en-US/docs/Web/JavaScript/Reference/Globa
 
 To offer protection against timing attacks and [fingerprinting](/en-US/docs/Glossary/Fingerprinting), the precision of `Date.now()` might get rounded depending on browser settings. In Firefox, the `privacy.reduceTimerPrecision` preference is enabled by default and defaults to 2ms. You can also enable `privacy.resistFingerprinting`, in which case the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.
 
+For example, with reduced time precision, the result of `Date.now()` will always be a multiple of 2, or a multiple of 100 (or `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`) with `privacy.resistFingerprinting` enabled.
+
 ```js
 // reduced time precision (2ms) in Firefox 60
 Date.now();
+// Might be:
 // 1519211809934
 // 1519211810362
 // 1519211811670
@@ -41,6 +44,7 @@ Date.now();
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 Date.now();
+// Might be:
 // 1519129853500
 // 1519129858900
 // 1519129864400


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/29634. Instead of demonstrating three calls, I just added "Might be", because the same format doesn't make sense for other things such as `currentTime`.