### PR TITLE
Add context-stroke and context-fill example to SVG fill and stroke pages

### DIFF
--- a/files/en-us/web/svg/attribute/fill/index.md
+++ b/files/en-us/web/svg/attribute/fill/index.md
@@ -24,7 +24,9 @@ You can use this attribute with the following SVG elements:
 
 For animation, these elements are using this attribute: {{SVGElement('animate')}}, {{SVGElement('animateMotion')}}, {{SVGElement('animateTransform')}}, and {{SVGElement('set')}}.
 
-## Example
+## Examples
+
+### Basic color and gradient fills, and animation
 
 ```css hidden
 html,
@@ -65,7 +67,41 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", '100%', 200)}}
+{{EmbedLiveSample("Basic color and gradient fills, and animation", '100%', 200)}}
+
+### `context-fill` example
+
+In this example, we define three shapes using {{SVGElement('path')}} elements, each with a different [`stroke`](/en-US/docs/Web/SVG/Attribute/stroke) and `fill` color set on them. We also define a {{SVGElement('circle')}} element as a marker via the {{SVGElement('marker')}} element. Each shape has the marker applied via the `marker` CSS property.
+
+The {{SVGElement('circle')}} has `stroke="context-stroke"` and `fill="context-fill"` set on it. Because it is being set as a marker in the context of the shapes, these attributes cause it to inherit the `fill` and `stroke` set on the {{SVGElement('path')}} element in each case.
+
+```html-nolint
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 90">
+  <style>
+    path {
+      stroke-width: 2px;
+      marker: url(#circle);
+    }
+  </style>
+  <path d="M 10 44.64 L 30 10 L 70 10 L 90 44.64 L 70 79.28 L 30 79.28 Z"
+        stroke="red" fill="orange" />
+  <path d="M 100 44.64 L 80 10 L 120 10 L 140 44.64 L 120 79.28 L 80 79.28 Z"
+        stroke="green" fill="lightgreen" />
+  <path d="M 150 44.64 L 130 10 L 170 10 L 190 44.64 L 170 79.28 L 130 79.28 Z"
+        stroke="blue" fill="lightblue" />
+  <marker id="circle" markerWidth="12" markerHeight="12"
+          refX="6" refY="6" markerUnits="userSpaceOnUse">
+    <circle cx="6" cy="6" r="3" stroke-width="2"
+            stroke="context-stroke" fill="context-fill"  />
+  </marker>
+</svg>
+```
+
+The output is as follows:
+
+{{EmbedLiveSample("`context-stroke` example", '100%', 220)}}
+
+> **Note:** Elements can also use `context-stroke` and `context-fill` to inherit `stroke` and `fill` values when they are referenced by {{SVGElement('use')}} elements.
 
 ## animate
 

--- a/files/en-us/web/svg/attribute/stroke/index.md
+++ b/files/en-us/web/svg/attribute/stroke/index.md
@@ -25,7 +25,9 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement('tref')}}
 - {{SVGElement('tspan')}}
 
-## Example
+## Examples
+
+### Basic color and gradient stroke
 
 ```css hidden
 html,
@@ -52,7 +54,43 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", '100%', 200)}}
+The output is as follows:
+
+{{EmbedLiveSample("Basic color and gradient stroke", '100%', 200)}}
+
+### `context-stroke` example
+
+In this example, we define three shapes using {{SVGElement('path')}} elements, each with a different `stroke` and [`fill`](/en-US/docs/Web/SVG/Attribute/fill) color set on them. We also define a {{SVGElement('circle')}} element as a marker via the {{SVGElement('marker')}} element. Each shape has the marker applied via the `marker` CSS property.
+
+The {{SVGElement('circle')}} has `stroke="context-stroke"` and `fill="context-fill"` set on it. Because it is being set as a marker in the context of the shapes, these attributes cause it to inherit the `fill` and `stroke` set on the {{SVGElement('path')}} element in each case.
+
+```html-nolint
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 90">
+  <style>
+    path {
+      stroke-width: 2px;
+      marker: url(#circle);
+    }
+  </style>
+  <path d="M 10 44.64 L 30 10 L 70 10 L 90 44.64 L 70 79.28 L 30 79.28 Z"
+        stroke="red" fill="orange" />
+  <path d="M 100 44.64 L 80 10 L 120 10 L 140 44.64 L 120 79.28 L 80 79.28 Z"
+        stroke="green" fill="lightgreen" />
+  <path d="M 150 44.64 L 130 10 L 170 10 L 190 44.64 L 170 79.28 L 130 79.28 Z"
+        stroke="blue" fill="lightblue" />
+  <marker id="circle" markerWidth="12" markerHeight="12"
+          refX="6" refY="6" markerUnits="userSpaceOnUse">
+    <circle cx="6" cy="6" r="3" stroke-width="2"
+            stroke="context-stroke" fill="context-fill"  />
+  </marker>
+</svg>
+```
+
+The output is as follows:
+
+{{EmbedLiveSample("`context-stroke` example", '100%', 220)}}
+
+> **Note:** Elements can also use `context-stroke` and `context-fill` to inherit `stroke` and `fill` values when they are referenced by {{SVGElement('use')}} elements.
 
 ## Usage notes
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Chrome 124 supports the SVG `stroke="context-stroke"` and `fill="context-fill"` values ([see spec](https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint), [see ChromeStatus entry](https://chromestatus.com/feature/5146558556536832)).

This PR updates the `fill` and `stroke` reference pages to include an example that shows how these attribute values can be used.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
