### PR TITLE
Express: Pug variables evaluate as falsy and display as empty string

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/home_page/index.md
@@ -97,6 +97,9 @@ When all the queries complete, the promise returned by `all()` fulfills, continu
 We then call [`res.render()`](https://expressjs.com/en/4x/api.html#res.render), specifying a view (template) named '**index**' and objects mapping the results of the database queries to the view template.
 The data is supplied as key-value pairs, and can be accessed in the template using the key.
 
+> **Note:** If you use a key/variable in a Pug template that hasn't been passed in, then it will render as an empty string, and be evaluated as `false` in expressions.
+> Other template languages may require that you pass in values for all objects that you use.
+
 Note that the code is very simple because we can assume that the database queries succeed.
 If any of the database operations fail, the exception that is thrown will be caught by `asyncHandler()` and passed to the `next` middleware handler in the chain.
 

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/template_primer/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/template_primer/index.md
@@ -12,7 +12,7 @@ Express can be used with many different [template rendering engines](https://exp
 
 Different template languages use different approaches for defining layout and marking placeholders for data—some use HTML to define the layout while others use different markup formats that can be transpiled to HTML. Pug is of the second type; it uses a _representation_ of HTML where the first word in any line usually represents an HTML element, and indentation on subsequent lines is used to represent nesting. The result is a page definition that translates directly to HTML, but is more concise and arguably easier to read.
 
-> **Note:** The downside of using _Pug_ is that it is sensitive to indentation and whitespace (if you add an extra space in the wrong place you may get an unhelpful error code). Once you have your templates in place, however, they are very easy to read and maintain.
+> **Note:** A downside of using _Pug_ is that it is sensitive to indentation and whitespace (if you add an extra space in the wrong place you may get an unhelpful error code). Once you have your templates in place, however, they are very easy to read and maintain.
 
 ## Template configuration
 
@@ -92,6 +92,11 @@ If a tag is followed by the equals sign, the following text is treated as a Java
 h1= title
 p= 'Evaluated and <em>escaped expression</em>:' + title
 ```
+
+> **Note:** In Pug templates, a variable that is used but not passed in from your Express code (or defined locally) is "undefined".
+> If you used this template without passing in a `title` variable the tags would be created but would contain an empty string.
+> If you use undefined variables in conditional statements then they evaluate to `false`.
+> Other template languages may require that variables used in the template must be defined.
 
 If there is no equals symbol after the tag then the content is treated as plain text. Within the plain text you can insert escaped and unescaped data using the `#{}` and `!{}` syntax respectively, as shown below. You can also add raw HTML within the plain text.
 


### PR DESCRIPTION
This explains how pug variables evaluate if not passed in from express. Also makes it clear other templates might behave differently.

Fixes https://github.com/mdn/express-locallibrary-tutorial/issues/299