### PR TITLE
fix: Number.MAX_VALUE should be 2 ** 1023 * (2 - 2 ** -52)

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_value/index.md
@@ -13,7 +13,7 @@ The **`Number.MAX_VALUE`** static data property represents the maximum numeric v
 
 ## Value
 
-2<sup>1024</sup> - 2<sup>971</sup>, or approximately `1.7976931348623157E+308`.
+2<sup>1023</sup> × (2 - 2<sup>-52</sup>), or approximately `1.7976931348623157E+308`.
 
 {{js_property_attributes(0, 0, 0)}}
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There was an incorrect `Number.MAX_VALUE` representation on [Number.MAX_VALUE page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE#value). This PR fixes it.

In JavaScript, the result of `2 ** 1024` is `Infinity`, so the same is `Infinity` of `2 ** 1024 - 2 ** 971`.

Therefore, `Number.MAX_VALUE`  should be `2 ** 1023 * (2 - 2 ** -52)` to prevent overflow.

**View Chrome browser result:**

<img width="1222" alt="image" src="https://github.com/mdn/content/assets/156683013/e7abaad8-3b62-447a-9aca-1bb195cdfb89">


