### PR TITLE
Fix `ByteLengthQueuingStrategy` constructor syntax should match guidelines

### DIFF
--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -25,6 +25,7 @@ new ByteLengthQueuingStrategy(options)
   - : An object with the following property:
 
     - `highWaterMark`
+
       - : The total number of bytes that can be contained in the internal queue before backpressure is applied.
 
         Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where `highWaterMark` specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, `highWaterMark` specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -21,7 +21,9 @@ new ByteLengthQueuingStrategy(options)
 ### Parameters
 
 - `options`
-  - : An object with the following property: 
+
+  - : An object with the following property:
+
     - `highWaterMark`
       - : The total number of bytes that can be contained in the internal queue before backpressure is applied.
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -27,7 +27,7 @@ new ByteLengthQueuingStrategy(options)
     - `highWaterMark`
       - : The total number of bytes that can be contained in the internal queue before backpressure is applied.
 
-    Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` parameter specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
+        Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where `highWaterMark` specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, `highWaterMark` specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
 
 ### Return value
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -15,16 +15,15 @@ instance.
 ## Syntax
 
 ```js-nolint
-new ByteLengthQueuingStrategy(highWaterMark)
+new ByteLengthQueuingStrategy(options)
 ```
 
 ### Parameters
 
-An object with the following property:
-
-- `highWaterMark`
-
-  - : The total number of bytes that can be contained in the internal queue before backpressure is applied.
+- `options`
+  - : An object with the following property: 
+    - `highWaterMark`
+      - : The total number of bytes that can be contained in the internal queue before backpressure is applied.
 
     Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` parameter specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
 

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
@@ -18,6 +18,7 @@ new CountQueuingStrategy(options)
 ```
 
 ### Parameters
+
 - `options`
   - : An object with the following property:
     - `highWaterMark`

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
@@ -14,16 +14,15 @@ creates and returns a `CountQueuingStrategy` object instance.
 ## Syntax
 
 ```js-nolint
-new CountQueuingStrategy(highWaterMark)
+new CountQueuingStrategy(options)
 ```
 
 ### Parameters
-
-An object with the following property:
-
-- `highWaterMark`
-  - : The total number of chunks that can be contained in the internal
-    queue before backpressure is applied.
+- `options`
+  - : An object with the following property:
+    - `highWaterMark`
+      - : The total number of chunks that can be contained in the internal
+        queue before backpressure is applied.
 
 ### Return value
 


### PR DESCRIPTION
### Description
fixes #34282 by changing the contructor syntax as per the guidelines