### PR TITLE
CSS(src): Fix invalid example @font-face def

### DIFF
--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -189,9 +189,9 @@ The example below shows how to define two font faces with the same font family. 
 @font-face {
   font-family: MainText;
   src:
-    local(Gill Sans Bold),
-    /* full font name */ local(GillSans-Bold),
-    /* postscript name */ url("GillSansBold.woff") format("woff"),
+    /* full font name */ local(Gill Sans Bold),
+    /* postscript name */ local(GillSans-Bold),
+    url("GillSansBold.woff") format("woff"),
     url("GillSansBold.otf") format("opentype"),
     url("GillSansBold.svg#MyFontBold"); /* Referencing an SVG font fragment by id */
   font-weight: bold;

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -179,27 +179,27 @@ The example below shows how to define two font faces with the same font family. 
 /* Defining a regular font face */
 @font-face {
   font-family: MainText;
-  src: local(Futura-Medium),
-    url('FuturaMedium.woff') format("woff"),
-    url('FuturaMedium.otf') format("opentype");
+  src:
+    local(Futura-Medium),
+    url("FuturaMedium.woff") format("woff"),
+    url("FuturaMedium.otf") format("opentype");
 }
 
 /* Defining a different bold font face for the same family */
 @font-face {
   font-family: MainText;
-  src: local(Gill Sans Bold), /* full font name */
-    local(GillSans-Bold), /* postscript name */
-    url('GillSansBold.woff') format("woff"),
-    url('GillSansBold.otf') format("opentype"),
+  src:
+    local(Gill Sans Bold),
+    /* full font name */ local(GillSans-Bold),
+    /* postscript name */ url("GillSansBold.woff") format("woff"),
+    url("GillSansBold.otf") format("opentype"),
     url("GillSansBold.svg#MyFontBold"); /* Referencing an SVG font fragment by id */
   font-weight: bold;
 }
-
 /* Using the regular font face */
 p {
   font-family: MainText;
 }
-
 /* Font-family is inherited, but bold fonts are used */
 p.bold {
   font-weight: bold;

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -182,7 +182,6 @@ The example below shows how to define two font faces with the same font family. 
   src: local(Futura-Medium),
     url('FuturaMedium.woff') format("woff"),
     url('FuturaMedium.otf') format("opentype");
-    format("opentype");
 }
 
 /* Defining a different bold font face for the same family */

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -196,10 +196,12 @@ The example below shows how to define two font faces with the same font family. 
     url("GillSansBold.svg#MyFontBold"); /* Referencing an SVG font fragment by id */
   font-weight: bold;
 }
+
 /* Using the regular font face */
 p {
   font-family: MainText;
 }
+
 /* Font-family is inherited, but bold fonts are used */
 p.bold {
   font-weight: bold;

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -189,8 +189,8 @@ The example below shows how to define two font faces with the same font family. 
 @font-face {
   font-family: MainText;
   src:
-    /* full font name */ local(Gill Sans Bold),
-    /* postscript name */ local(GillSans-Bold),
+    local(Gill Sans Bold) /* full font name */,
+    local(GillSans-Bold) /* postscript name */,
     url("GillSansBold.woff") format("woff"),
     url("GillSansBold.otf") format("opentype"),
     url("GillSansBold.svg#MyFontBold"); /* Referencing an SVG font fragment by id */


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove a `format();` argument which was accidentally doubled while applying suggested changes during review of #20691. The CSS example as currently shown in the documentation is invalid, having `format("opentype");` on its own in a `@font-face` definition (not as an argument to `src:`).

### Motivation

Ensure that example CSS in the repo is valid and works as intended.

### Additional details

[This suggested change](https://github.com/mdn/content/pull/20691#discussion_r975834790) overlooked that `format("opentype");` was present on a separate line immediately below the suggestion, and accidentally duplicated it when applied.

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
