### PR TITLE
fixed syntax of CSSUnitValue() constructor

### DIFF
--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
@@ -16,7 +16,7 @@ would be represented by a `CSSNumericValue`.
 ## Syntax
 
 ```js-nolint
-new CSSUnitValue()
+new CSSUnitValue(value, unit)
 ```
 
 ### Parameters


### PR DESCRIPTION
The syntax for other constructor functions include parameters (e.g. https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent).

The parameters for CSSUnitValue() constructor are currently missing. 