### PR TITLE
fixed the syntax for CSSUnitValue() constructor

### DIFF
--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
@@ -16,15 +16,15 @@ would be represented by a `CSSNumericValue`.
 ## Syntax
 
 ```js-nolint
-new CSSUnitValue()
+new CSSUnitValue(value, unit)
 ```
 
 ### Parameters
 
 - `value`
-  - : Returns a double indicating the number of units.
+  - : A double indicating the number of units.
 - `unit`
-  - : Returns a string indicating the type of unit.
+  - : A string indicating the type of unit.
 
 ## Examples
 


### PR DESCRIPTION
The syntax for other constructor functions include parameters (e.g. https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent).

The parameters for CSSUnitValue() constructor are currently missing. 

Also the Parameters section currently say "[parameter name] *Returns a* ..." which I assume are typos. I've changed them so they match the format as in e.g. https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent