### PR TITLE
fixed return value of CSSNumericValue: toSum()

### DIFF
--- a/files/en-us/web/api/cssnumericvalue/tosum/index.md
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.md
@@ -25,7 +25,7 @@ toSum(units)
 
 ### Return value
 
-A {{domxref('CSSNumericValue')}}.
+A {{domxref('CSSMathSum')}}.
 
 ### Exceptions
 


### PR DESCRIPTION
Changed return value of CSSNumericValue: toSum() from `CSSNumericValue` to `CSSMathSum` to better match the first paragraph of this page, as well as the spec (https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-tosum)