### PR TITLE
Removed `optional` as the index parameter of HTMLTableRowElement: deleteCell() is not optional

### DIFF
--- a/files/en-us/web/api/htmltablerowelement/deletecell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/deletecell/index.md
@@ -19,7 +19,7 @@ deleteCell(index)
 
 ### Parameters
 
-- `index` {{optional_inline}}
+- `index`
   - : The cell index of the cell to remove. If `index` is `-1` or equal to the number of cells, the last cell of the row is removed.
 
 ### Return value


### PR DESCRIPTION
Spec link: https://html.spec.whatwg.org/multipage/tables.html#dom-tr-deletecell

Also:
![image](https://github.com/mdn/content/assets/148152939/baf01015-3e25-473b-b49f-ac47c0a96f27)
