### PR TITLE
Fixed ungrammatical sentence + rewrite to improve clarity

### DIFF
--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -255,7 +255,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - a white-space separated list of sizes, each in the format `<width in pixels>x<height in pixels>` or `<width in pixels>X<height in pixels>`. Each of these sizes must be contained in the resource.
 
     > **Note:** Most icon formats are only able to store one single icon; therefore, most of the time, the [`sizes`](#sizes) attribute contains only one entry.
-    > MS's ICO format does, as well as Apple's ICNS. ICO is more ubiquitous, so you should use this format if cross-browser support is a concern (especially for old IE versions).
+    > Microsoft's ICO format and Apple's ICNS format can store multiple icon sizes in a single file. ICO has better browser support, especially in older versions of Internet Explorer, so you should use this format if cross-browser support is a concern.
 
 - `title`
   - : The `title` attribute has special semantics on the `<link>` element.

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -255,7 +255,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - a white-space separated list of sizes, each in the format `<width in pixels>x<height in pixels>` or `<width in pixels>X<height in pixels>`. Each of these sizes must be contained in the resource.
 
     > **Note:** Most icon formats are only able to store one single icon; therefore, most of the time, the [`sizes`](#sizes) attribute contains only one entry.
-    > Microsoft's ICO format and Apple's ICNS format can store multiple icon sizes in a single file. ICO has better browser support, especially in older versions of Internet Explorer, so you should use this format if cross-browser support is a concern.
+    > Microsoft's ICO format and Apple's ICNS format can store multiple icon sizes in a single file. ICO has better browser support, so you should use this format if cross-browser support is a concern.
 
 - `title`
   - : The `title` attribute has special semantics on the `<link>` element.


### PR DESCRIPTION
Rewrote the bolded sentences in:

> Note: Most icon formats are only able to store one single icon; therefore, most of the time, the sizes attribute contains only one entry. **MS's ICO format does, as well as Apple's ICNS. ICO is more ubiquitous, so you should use this format if cross-browser support is a concern (especially for old IE versions).**

Problems addressed:
1. Rewrote "MS's ICO format does, as well as Apple's ICNS" so it's grammatical and at the very least clearer;
2. Changed "ICO is more ubiquitous" to "ICO has better browser support" since mere ubiquity of a file format doesn't necessarily translate into wider browser support (which I assume is what the orignial author meant).


