### PR TITLE
Clarify that the load event only depends on eagerly-loaded resources

### DIFF
--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Window.load_event
 
 {{APIRef}}
 
-The **`load`** event is fired when the whole page has loaded, including all dependent resources such as stylesheets, scripts, iframes, and images.
+The **`load`** event is fired when the whole page has loaded, including all dependent resources such as stylesheets, scripts, iframes, and images, except those that are [loaded lazily](/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes).
 This is in contrast to {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}}, which is fired as soon as the page DOM has been loaded, without waiting for resources to finish loading.
 
 This event is not cancelable and does not bubble.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clarify that the load event only depends on eagerly-loaded resources.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Previously, the page could be interpreted to suggest that the `load` event does not fire until *all* resources are loaded, including images and iframes with `loading="lazy"`, but that's not the case, as can be verified with a simple example like:

```
<html>
<body onload="alert(document.getElementById('cat').complete)">
<img id="cat" src="https://cataas.com/cat" loading="lazy">
</body>
</html>
```

which alerts `false` when `loading="lazy"`, and `true` when `loading="eager"` (the default).

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
