### PR TITLE
Adds a warning about two different replace() methods

### DIFF
--- a/files/en-us/web/api/location/replace/index.md
+++ b/files/en-us/web/api/location/replace/index.md
@@ -13,6 +13,7 @@ interface replaces the current resource with the one at the provided URL. The di
 from the {{domxref("Location.assign","assign()")}} method is that after using
 `replace()` the current page will not be saved in session {{domxref("History")}},
 meaning the user won't be able to use the _back_ button to navigate to it.
+Not to be confused with the {{jsxref("String")}} method {{jsxref("String.prototype.replace()")}}.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There are at least two different replace() methods in JavaScript. One for String and one for Location. The former is more well-known though. They also act slightly differently, later requiring only one parameter. A warning about the existence of a different replace() method has been added.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

See previous section.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

None.
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

None.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
