### PR TITLE
fix(css): correct grid `span` usage

### DIFF
--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -601,7 +601,7 @@ In addition to specifying the start and end lines by number, you can specify a s
 
 {{ EmbedLiveSample('Using_the_span_keyword', '300', '330') }}
 
-You can also use the `span` keyword in the value of `grid-row-start`/`grid-row-end` and `grid-column-start/grid-column-end`. The following two examples will create the same grid area. In the first we set the start row line, then the end line we specify that we want the area to cover 3 tracks. The area will start at line 1 and end at 3 lines from line 1 that is the area will end at line 4.
+You can also use the `span` keyword in the value of `grid-row-start`/`grid-row-end` and `grid-column-start/grid-column-end`. The following two examples will create the same grid area. In the first we set the start row line, then the end line we specify that we want the area to cover 3 tracks. The area will start at line 1 and end 3 lines from line 1; that is, the area will end at line 4.
 
 ```css
 .box1 {

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -601,7 +601,7 @@ In addition to specifying the start and end lines by number, you can specify a s
 
 {{ EmbedLiveSample('Using_the_span_keyword', '300', '330') }}
 
-You can also use the `span` keyword in the value of `grid-row-start`/`grid-row-end` and `grid-column-start/grid-column-end`. The following two examples will create the same grid area. In the first we set the start row line, then the end line we specify that we want to span 3 tracks. The area will start at line 1 and end at 3 lines from line 1 that is the area will end at line 4.
+You can also use the `span` keyword in the value of `grid-row-start`/`grid-row-end` and `grid-column-start/grid-column-end`. The following two examples will create the same grid area. In the first we set the start row line, then the end line we specify that we want the area to cover 3 tracks. The area will start at line 1 and end at 3 lines from line 1 that is the area will end at line 4.
 
 ```css
 .box1 {

--- a/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_layout_using_line-based_placement/index.md
@@ -601,7 +601,7 @@ In addition to specifying the start and end lines by number, you can specify a s
 
 {{ EmbedLiveSample('Using_the_span_keyword', '300', '330') }}
 
-You can also use the `span` keyword in the value of `grid-row-start`/`grid-row-end` and `grid-column-start/grid-column-end`. The following two examples will create the same grid area. In the first we set the start row line, then the end line we explain that we want to span 3 lines. The area will start at line 1 and span 3 lines to line 4.
+You can also use the `span` keyword in the value of `grid-row-start`/`grid-row-end` and `grid-column-start/grid-column-end`. The following two examples will create the same grid area. In the first we set the start row line, then the end line we specify that we want to span 3 tracks. The area will start at line 1 and end at 3 lines from line 1 that is the area will end at line 4.
 
 ```css
 .box1 {


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/33066

The following two statements describe the same thing about using `span` keyword:
a. specify a start line and then the number of tracks you would like the grid area to span
b. specify a start line and N lines from the start line where the grid area ends

Both statements are the same because `span 3` means 3 tracks and 1+3 lines. `N` tracks = 1 + `N` lines.

The [specification](https://drafts.csswg.org/css-grid/#grid-span) defines span in terms of tracks. Using track is easier to explain in this context.