### PR TITLE
Remove mention of "cols" attribute of pre HTML element

### DIFF
--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -21,8 +21,6 @@ If you have to display reserved characters such as `<`, `>`, `&`, and `"` within
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- `cols` {{non-standard_inline}} {{deprecated_inline}}
-  - : Contains the _preferred_ count of characters that a line should have. It was a non-standard synonym of [`width`](#width). To achieve such an effect, use CSS {{Cssxref("width")}} instead.
 - `width` {{deprecated_inline}} {{Non-standard_Inline}}
   - : Contains the _preferred_ count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS {{Cssxref("width")}} instead.
 - `wrap` {{non-standard_inline}} {{Deprecated_Inline}}


### PR DESCRIPTION
This PR removes the mention of the `cols` attribute of the `pre` HTML element.  This is no longer supported in any browser, and is being removed in BCD, see https://github.com/mdn/browser-compat-data/pull/23698.