### PR TITLE
Add reference for SyntaxError: await/yield in default parameter

### DIFF
--- a/files/en-us/web/javascript/reference/errors/await_yield_in_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/await_yield_in_parameter/index.md
@@ -1,0 +1,67 @@
+---
+title: "SyntaxError: await/yield expression can't be used in parameter"
+slug: Web/JavaScript/Reference/Errors/await_yield_in_parameter
+page-type: javascript-error
+---
+
+{{jsSidebar("Errors")}}
+
+The JavaScript exception "await expression can't be used in parameter" or "yield expression can't be used in parameter" occurs when the [default parameter](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) expression contains the {{jsxref("Operators/await", "await")}} or {{jsxref("Operators/yield", "yield")}} keyword and has the effect of pausing default parameter evaluation.
+
+## Message
+
+```plain
+SyntaxError: Illegal await-expression in formal parameters of async function (V8-based)
+SyntaxError: await expression can't be used in parameter (Firefox)
+SyntaxError: Cannot use 'await' within a parameter default expression. (Safari)
+
+SyntaxError: Yield expression not allowed in formal parameter (V8-based)
+SyntaxError: yield expression can't be used in parameter (Firefox)
+SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression within parameters. (Safari)
+```
+
+## Error type
+
+{{jsxref("SyntaxError")}}
+
+## What went wrong?
+
+The default expression must be able to evaluate _synchronously_. If it contains an `await` or `yield` expression, it will pause the evaluation of the default expression, which is not allowed.
+
+> **Note:** This error is only generated when `await` or `yield` are valid operators in this function context. Otherwise, `await` or `yield` would be parsed as an identifier, and either not cause an error, or cause an error like "reserved identifier", or "unexpected token" if there's an expression following it.
+
+## Examples
+
+### Invalid cases
+
+```js example-bad
+function *gen(a = yield 1) {}
+
+async function f(a = await Promise.resolve(1)) {}
+```
+
+### Valid cases
+
+You can use the [nullish coalescing assignment](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment) to provide a default value instead. If you want to treat `null` and `undefined` differently, you would need to use a condition.
+
+```js example-good
+function* gen(a) {
+  a ??= yield 1;
+}
+
+async function f(a) {
+  a ??= await Promise.resolve(1);
+}
+```
+
+You are also allowed to use `await` or `yield` if the expression is contained in a function expression of the initializer and would not pause the evaluation of the default expression.
+
+```js example-good
+async function f(a = (async () => await Promise.resolve(1))()) {}
+```
+
+## See also
+
+- [Default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
+- {{jsxref("Operators/await", "await")}}
+- {{jsxref("Operators/yield", "yield")}}

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -99,6 +99,16 @@ f(); // undefined
 f(5); // 5
 ```
 
+The default parameter allows any expression, but you cannot use {{jsxref("Operators/await", "await")}} or {{jsxref("Operators/yield", "yield")}} that would pause the evaluation of the default expression. The parameter must be initialized _synchronously_.
+
+```js example-bad
+async function f(a = await Promise.resolve(1)) {
+  return a;
+}
+```
+
+> **Note:** Because the default parameter is evaluated when the function is called, not when the function is defined, the validity of the `await` and `yield` operators depends on the function itself, not its surrounding function. For example, if the current function is not `async`, `await` will be parsed as an identifier and follow normal [identifier syntax rules](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), even when this function is nested in an `async` function.
+
 ## Examples
 
 ### Passing undefined vs. other falsy values


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/38439