### PR TITLE
CODEOWNERS - Firefox release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,9 @@
 # MathML
 /files/en-us/web/mathml/ @mdn/content-mathml
 
+# MDN Firefox Release Notes
+/files/en-us/mozilla/firefox @mdn/core-yari-content
+
 # ============================= CONTROL FILES ============================= #
 # The CODEOWNERS file must end with these matches: Any pull request changing
 # one or more of these files should be escalated to the owners specified here.


### PR DESCRIPTION
Reviewing release notes is a priority for the MDN team employed by Mozilla (currently @dipikabh @hamishwillee @bsmth @pepelsbey @Rumyra @dletorey ) but not other members of the team. They might do it, but not to our timelines. 

This proposes default assignment to other members of our team first. Note, that we might want to consider updating the group to include all members or having a new group  https://github.com/orgs/mdn/teams/core-yari-content. 