### PR TITLE
docs(manifest): Improve `icons` member page

### DIFF
--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -49,7 +49,7 @@ After a browser applies a `display` mode to an {{Glossary("application context")
 
 If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`.
 
-Use the {{cssxref("@media/display-mode", "display-mode")}} media feature to determine the current `display` mode applied by the browser, which is useful for ensuring your app behaves as expected in different display contexts. Additionally, the `display-mode` media feature allows you to adjust your app's styles based on the `display` mode currently being used. This can help provide a consistent user experience regardless of whether the website is launched from a URL or from a desktop icon.
+The {{cssxref("@media/display-mode", "display-mode")}} media feature can be used to configure your application styles and other behavior based on the current `display` mode. This can help provide a consistent user experience regardless of whether the website is launched from a URL or from a desktop icon.
 
 > [!NOTE]
 > The value of the `display-mode` media feature reflects the actual `display` mode being used by the browser.

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -12,34 +12,38 @@ The `display` manifest member is used to specify your preferred display mode for
 ## Syntax
 
 ```json
-"display": "standalone"
+"display": "<display-keyword>"
 ```
 
-### Values
+### Keys
 
-The value of the `display` member is a string. The possible values include `fullscreen`, `standalone`, `minimal-ui`, and `browser`. If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`. If `display` is not specified, the default value `browser` is used.
+- `display`
 
-- `fullscreen`
+  - : A string with keyword values. If not specified, the default value `browser` is used. The keyword values include:
 
-  - : Opens the app with browser UI elements hidden and uses the entirety of the available display area. Use this value for apps where fullscreen engagement is crucial and desired. For example, use it for a game app that can take up the entire screen without any browser controls visible, providing a fully immersive gaming experience.
+    - `fullscreen`
 
-    > [!NOTE]
-    > The `fullscreen` value of the manifest's `display` member works separately from the [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API). The `fullscreen` display mode changes the state of the entire browser window to full screen, while the Fullscreen API only makes a specific element within the window go full screen. Therefore, a web app can be in `fullscreen` display mode while {{DOMxRef("Document.fullscreenElement")}} is `null` and {{DOMxRef("Document.fullscreenEnabled")}} is `false`.
+      - : Opens the app with browser UI elements hidden and uses the entirety of the available display area. Use this value for apps where fullscreen engagement is crucial and desired. For example, use it for a game app that can take up the entire screen without any browser controls visible, providing a fully immersive gaming experience.
 
-- `standalone`
+        > [!NOTE]
+        > The `fullscreen` value of the manifest's `display` member works separately from the [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API). The `fullscreen` display mode changes the state of the entire browser window to full screen, while the Fullscreen API only makes a specific element within the window go full screen. Therefore, a web app can be in `fullscreen` display mode while {{DOMxRef("Document.fullscreenElement")}} is `null` and {{DOMxRef("Document.fullscreenEnabled")}} is `false`.
 
-  - : Opens the app to look and feel like a standalone native app. This can include the app having a different window and its own icon in the app launcher. The browser will exclude UI elements such as a URL bar but can still include other UI elements such as the status bar. For example, use it for a task manager app that opens in its own window without the browser's URL bar, while still displaying the device's status bar for battery and notifications, thereby providing an integrated experience.
+    - `standalone`
 
-- `minimal-ui`
+      - : Opens the app to look and feel like a standalone native app. This can include the app having a different window and its own icon in the app launcher. The browser will exclude UI elements such as a URL bar but can still include other UI elements such as the status bar. For example, use it for a task manager app that opens in its own window without the browser's URL bar, while still displaying the device's status bar for battery and notifications, thereby providing an integrated experience.
 
-  - : Opens the app to look and feel like a standalone app but with a minimal set of UI elements for navigation. The specific elements can vary by browser but typically include navigation controls like back, forward, reload, and possibly a way to view the app's URL. Additionally, the browser may include platform-specific UI elements that provide functionality for sharing and printing content. Use this value for apps where displaying a minimal browser interface is beneficial. For example, use it for a news reading or other general reading apps that show only the essential browser controls like back and reload buttons, providing a cleaner and less distracting interface.
+    - `minimal-ui`
 
-- `browser`
-  - : Opens the app in a conventional browser tab or new window, using the platform-specific convention for opening links. Use this value for apps that are designed to be used within a browser context, where full browser functionality is needed. This is the default value if no `display` mode is specified.
+      - : Opens the app to look and feel like a standalone app but with a minimal set of UI elements for navigation. The specific elements can vary by browser but typically include navigation controls like back, forward, reload, and possibly a way to view the app's URL. Additionally, the browser may include platform-specific UI elements that provide functionality for sharing and printing content. Use this value for apps where displaying a minimal browser interface is beneficial. For example, use it for a news reading or other general reading apps that show only the essential browser controls like back and reload buttons, providing a cleaner and less distracting interface.
+
+    - `browser`
+      - : Opens the app in a conventional browser tab or new window, using the platform-specific convention for opening links. Use this value for apps that are designed to be used within a browser context, where full browser functionality is needed. This is the default value if no `display` mode is specified.
 
 ## Description
 
 After a browser applies a `display` mode to an {{Glossary("application context")}}, it becomes the default display mode for the top-level browsing context. The browser may override this display mode for security reasons or provide users with a means for switching to another `display` mode.
+
+If a browser does not support the specified display mode, it follows a pre-defined fallback chain: `fullscreen` → `standalone` → `minimal-ui` → `browser`.
 
 Use the {{cssxref("@media/display-mode", "display-mode")}} media feature to determine the current `display` mode applied by the browser, which is useful for ensuring your app behaves as expected in different display contexts. Additionally, the `display-mode` media feature allows you to adjust your app's styles based on the `display` mode currently being used. This can help provide a consistent user experience regardless of whether the website is launched from a URL or from a desktop icon.
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -11,11 +11,15 @@ The `display` manifest member is used to specify your preferred display mode for
 
 ## Syntax
 
-```json
-"display": "<display-keyword>"
+```json-nolint
+/* Keyword values */
+"display": "fullscreen"
+"display": "standalone"
+"display": "minimal-ui"
+"display": "browser"
 ```
 
-### Keys
+### Values
 
 - `display`
 
@@ -67,6 +71,8 @@ As shown in the code below, you can adjust an app's style depending on the `disp
 ```
 
 ## Examples
+
+### Specifying standalone display mode
 
 The following example manifest file for the web app named "HackerWeb" defines how the app should appear and behave when installed on a user's device. The `display` member is set to `standalone`, which specifies that the app should open in a separate window without the typical browser UI elements like the URL bar.
 

--- a/files/en-us/web/manifest/display/index.md
+++ b/files/en-us/web/manifest/display/index.md
@@ -52,7 +52,8 @@ If a browser does not support the specified display mode, it follows a pre-defin
 Use the {{cssxref("@media/display-mode", "display-mode")}} media feature to determine the current `display` mode applied by the browser, which is useful for ensuring your app behaves as expected in different display contexts. Additionally, the `display-mode` media feature allows you to adjust your app's styles based on the `display` mode currently being used. This can help provide a consistent user experience regardless of whether the website is launched from a URL or from a desktop icon.
 
 > [!NOTE]
-> The value of the `display-mode` media feature reflects the actual `display` mode being used, which might differ from the one requested in the manifest's `display`, because the browser might not support the requested mode.
+> The value of the `display-mode` media feature reflects the actual `display` mode being used by the browser.
+> This might differ from the mode requested in the manifest, because the browser might not support the requested mode.
 
 As shown in the code below, you can adjust an app's style depending on the `display-mode` used.
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -31,7 +31,7 @@ Each icon object can have one or more properties, with `src` being the only requ
 
 - `<icon-url>`
 
-  - : A string that specifies the path to the icon image file. If `src` is a relative URL, the path is resolved relative to the URL of the manifest file. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
+  - : A string that specifies the path to the icon image file. If `<icon-url>` is relative, the path is resolved relative to the manifest file's URL. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
 - `<size-values>` {{Optional_Inline}}
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -115,7 +115,10 @@ For example, if the `img-src` directive in a CSP header specifies `icons.example
 
 ## Performance considerations
 
-The `type` property plays a part in determining performance. While this property is optional, specifying it can improve performance significantly. It allows browsers to quickly ignore images with formats they do not support. If you don't specify the `type` property, it is recommended to specify appropriate and unambiguous file extensions for the icon images to ensure correct handling by the browser.
+Specifying the `type` property can significantly improve performance because it allows browsers to ignore images with unsupported formats more easily.
+If you don't specify the `type` property, browsers may need to infer the image format using more resource-intensive methods, such as [MIME sniffing](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#mime_sniffing) the file for a signature.
+
+At a minimum, if you omit the `type` property, use appropriate and unambiguous file extensions for your icon images.
 
 ## Examples
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -24,9 +24,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 ### Values
 
-The value of the `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes. You can add different icons for integration with various operating systems. You can also add icons for splash screens or app notifications.
-
-### Properties
+The value of the `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
 
 Each object in the array includes one or more of the following properties (`src` is the only required property):
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -125,3 +125,5 @@ This example shows how to declare multiple icons for different scenarios and dev
 ## See also
 
 - [Image file type and format guide](/en-US/docs/Web/Media/Formats/Image_types#webp_image)
+- [Monochrome icons and solid fills](https://w3c.github.io/manifest/#monochrome-icons-and-solid-fills)
+- [Icon masks and safe zone](https://w3c.github.io/manifest/#icon-masks)

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -31,33 +31,33 @@ These icons uniquely identify your web app in different contexts, such as in an 
     Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
     Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 
-  - `src`
+    - `src`
 
-    - : A string that specifies the path to the icon image file.
+      - : A string that specifies the path to the icon image file.
       If `src` is relative, the path is resolved relative to the manifest file's URL.
       For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
-  - `sizes` {{Optional_Inline}}
+    - `sizes` {{Optional_Inline}}
 
-    - : A string that specifies one or more sizes at which the icon file can be used.
-      Each `<size-value>` is specified as `<width in pixels>x<height in pixels>`.
-      Multiple `<size-value>` tokens can be specified, separated by spaces, for example: `48x48 96x96`.
-      When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context.
-      For raster formats like PNG, specifying the exact available sizes is recommended.
-      For vector formats like SVG, you can use `any` to indicate scalability.
-      If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
+      - : A string that specifies one or more sizes at which the icon file can be used.
+        Each `<size-value>` is specified as `<width in pixels>x<height in pixels>`.
+        Multiple `<size-value>` tokens can be specified, separated by spaces, for example: `48x48 96x96`.
+        When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context.
+        For raster formats like PNG, specifying the exact available sizes is recommended.
+        For vector formats like SVG, you can use `any` to indicate scalability.
+        If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
 
-      Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
+        Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
 
-  - `type` {{Optional_Inline}}
+    - `type` {{Optional_Inline}}
 
-    - : A string that specifies the {{Glossary("MIME type")}} of the icon.
-      The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
-      If omitted, browsers typically infer the image type from the file extension.
+      - : A string that specifies the {{Glossary("MIME type")}} of the icon.
+        The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
+        If omitted, browsers typically infer the image type from the file extension.
 
-  - `purpose` {{Optional_Inline}}
+    - `purpose` {{Optional_Inline}}
 
-    - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
+      - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
       The value can be a single keyword or multiple space-separated keywords.
       If omitted, the browser can use the icon for any purpose.
 
@@ -69,15 +69,15 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
       Valid values include:
 
-      - `monochrome`
-
-        - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
+        - `monochrome`
+          - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
           With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
 
-      - `maskable`
-        - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
-      - `any`
-        - : Indicates that the icon can be used in any context. This is the default value.
+        - `maskable`
+          - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
+        
+        - `any`
+          - : Indicates that the icon can be used in any context. This is the default value.
 
 ## Description
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -27,51 +27,56 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 - `icons`
   : - An array of objects.
-      Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
-      Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
+  Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+  Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 
   - `src`
+
     - : A string that specifies the path to the icon image file.
-        If `src` is relative, the path is resolved relative to the manifest file's URL.
-        For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
+      If `src` is relative, the path is resolved relative to the manifest file's URL.
+      For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
   - `sizes` {{Optional_Inline}}
+
     - : A string that specifies one or more sizes at which the icon file can be used.
-        Each `<size-value>` is specified as `<width in pixels>x<height in pixels>`.
-        Multiple `<size-value>` tokens can be specified, separated by spaces, for example: `48x48 96x96`.
-        When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context.
-        For raster formats like PNG, specifying the exact available sizes is recommended.
-        For vector formats like SVG, you can use `any` to indicate scalability.
-        If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
-        
-        Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
+      Each `<size-value>` is specified as `<width in pixels>x<height in pixels>`.
+      Multiple `<size-value>` tokens can be specified, separated by spaces, for example: `48x48 96x96`.
+      When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context.
+      For raster formats like PNG, specifying the exact available sizes is recommended.
+      For vector formats like SVG, you can use `any` to indicate scalability.
+      If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
+
+      Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
 
   - `type` {{Optional_Inline}}
+
     - : A string that specifies the {{Glossary("MIME type")}} of the icon.
-        The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
-        If omitted, browsers typically infer the image type from the file extension.
+      The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
+      If omitted, browsers typically infer the image type from the file extension.
 
   - `purpose` {{Optional_Inline}}
-    - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
-        The value can be a single keyword or multiple space-separated keywords.
-        If omitted, the browser can use the icon for any purpose.
-        
-        Browsers use these values as hints to determine where and how an icon is displayed.
-        For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
-        With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
-        If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
-        However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
-        
-        Valid values include:
 
-        - `monochrome`
-          - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
-              With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
-              
-        - `maskable`
-          - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
-        - `any`
-          - : Indicates that the icon can be used in any context. This is the default value.
+    - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
+      The value can be a single keyword or multiple space-separated keywords.
+      If omitted, the browser can use the icon for any purpose.
+
+      Browsers use these values as hints to determine where and how an icon is displayed.
+      For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
+      With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
+      If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
+      However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
+
+      Valid values include:
+
+      - `monochrome`
+
+        - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
+          With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
+
+      - `maskable`
+        - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
+      - `any`
+        - : Indicates that the icon can be used in any context. This is the default value.
 
 ## Description
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -43,7 +43,7 @@ Each object in the array can have one or more of the following properties (`src`
 - `purpose`
 
   - : A string that specifies one or more purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
-    Valid values (case-sensitive) are listed below, in order of precedence:
+    Valid values are case-sensitive and listed below in order of precedence:
     - `monochrome`
       - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
     - `maskable`

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -7,18 +7,67 @@ browser-compat: html.manifest.icons
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>Array</code></td>
-    </tr>
-  </tbody>
-</table>
+The `icons` manifest member is used to specify one or more image files that serve as iconic representations of your web application in different contexts. These icons represent your web app among a list of other applications. They can also be used to integrate your web app with an operating system's task switcher, system settings, home screen, and other places when an app icon is needed.
 
-The `icons` member specifies an array of objects representing image files that can serve as application icons for different contexts. For example, they can be used to represent the web application amongst a list of other applications, or to integrate the web application with an OS's task switcher and/or system preferences.
+## Syntax
+
+```json
+"icons": [
+  {
+    "src": "icon/lowres.webp",
+    "sizes": "48x48",
+    "type": "image/webp"
+  }
+]
+```
+
+### Values
+
+The value of the `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes. You can add different icons for integration with various operating systems. You can also add icons for splash screens or app notifications.
+
+### Properties
+
+Each object in the array includes one or more of the following properties (`src` is the only required property):
+
+- `src`
+
+  - : A string that specifies the path to the icon image file. If `src` is a relative URL, the path is resolved relative to the URL of the manifest file. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`. `src` is a required property.
+
+- `sizes`
+
+  - : A string that specifies one or more dimensions of the icon. Each dimension is specified as `<width>x<height>`. Mutiple dimensions are separated by spaces, as in `48x48 96x96`. Specifying multiple sizes allows a browser to select the most appropriate one for the context. The `sizes` property uses the same syntax as the [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute of the `<link>` HTML element. This property is optional; if not specifed, the default value of `any` is used, which indicates that the icon can be used at any size.
+
+- `type`
+
+  - : A string that specifies the media type (also known as the {{Glossary("MIME type")}}) of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
+
+- `purpose`
+  - : A string that specifies one or more the purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. Valid keyword values include `monochrome`, `maskable`, and `any` and are case-sensitive. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in the following order of precedence:
+    - `monochrome`: Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
+    - `maskable`: Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away by a browser.
+    - `any`: Indicates that the icon can be used in any context. This is the default value.
+
+## Description
+
+The context in which an icon can be used is determined by the browser and the operating system, based on the specified sizes and formats.
+
+When working with icon images, both security and performance are important considerations.
+
+The browser's ability to fetch an icon image is governed by the Content Security Policy ({{Glossary("CSP")}}) of the manifest's owner document, specifically by the [`img-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) directive. This security aspect is related to the `src` property. For example, if the `img-src` directive in a CSP header specifies `icons.example.com`, icons from only that domain would be fetchable. In a manifest with two icons, one from `icons.example.com/lowres` and another from `other.com/hi-res`, only the former would be fetched successfully because of CSP restrictions.
+
+The `type` property plays a part in determining performance. While this property is optional, specifying it can improve performance significantly. It allows browsers to quickly ignore images with formats they do not support. If you don't specify the `type` property, it is recommended to specify clear file extensions for the icon images to ensure correct handling by the browser.
 
 ## Examples
+
+### Declaring multiple icons
+
+This example shows how to declare multiple icons for different scenarios and devices. If an icon for a specific situation is not supported or not available, browsers will fall back to other available formats and sizes.
+
+- Two icons of the same size (`48x48`) are provided in different formats. The first is explicitly specified as [WebP](/en-US/docs/Web/Media/Formats/Image_types#webp_image) using the `type` property. If a browser doesn't support WebP, it will fall back to the second icon of the same size. For the second icon, the browser will determine the MIME type either from the HTTP header or by inferring it from the image file's content. Icons at this size are typically used for browser tabs and bookmarks.
+
+- For smaller icons (up to `256x256`), an [ICO](/en-US/docs/Web/Media/Formats/Image_types#ico_microsoft_windows_icon) file is provided. ICO files contain multiple raster icons that are individually optimized for small display sizes. icons at these sizes are commonly used for desktop shortcuts.
+
+- For larger icons (`257x257` and above), an [SVG](/en-US/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics) file is specified. The `sizes` value of this icon is set to `any`, which allows a browser to use this icon at any size. SVG icons maintain their quality at larger sizes. These icons ate ideal for high-resolution displays like in [progressive web apps (PWAs)](/en-US/docs/Web/Progressive_web_apps).
 
 ```json
 "icons": [
@@ -42,84 +91,6 @@ The `icons` member specifies an array of objects representing image files that c
 ]
 ```
 
-## Values
-
-Image objects may contain the following values:
-
-<table class="fullwidth-table standard-table">
-  <thead>
-    <tr>
-      <th scope="col">Member</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>sizes</code></td>
-      <td>
-        A string containing space-separated image dimensions using the same syntax as the
-        <a href="/en-US/docs/Web/HTML/Element/link#sizes"><code>sizes</code></a>
-        attribute.
-      </td>
-    </tr>
-    <tr>
-      <td><code>src</code></td>
-      <td>
-        The path to the image file. If <code>src</code> is a relative URL, the
-        base URL will be the URL of the manifest.
-      </td>
-    </tr>
-    <tr>
-      <td><code>type</code></td>
-      <td>
-        A hint as to the media type of the image. The purpose of this member is
-        to allow a user agent to quickly ignore images with media types it does
-        not support.
-      </td>
-    </tr>
-    <tr>
-      <td><code>purpose</code></td>
-      <td>
-        <p>
-          Defines the purpose of the image, for example if the image is intended
-          to serve some special purpose in the context of the host OS (i.e., for
-          better integration).
-        </p>
-        <p>
-          <a href="https://w3c.github.io/manifest/#purpose-member"
-            ><code>purpose</code></a
-          >
-          can have one or more of the following values, separated by spaces:
-        </p>
-        <ul>
-          <li>
-            <code>monochrome</code>: A user agent can present this icon where a
-            <a
-              href="https://w3c.github.io/manifest/#monochrome-icons-and-solid-fills"
-              >monochrome icon with a solid fill</a
-            >
-            is needed. The color information in the icon is discarded and only
-            the alpha data is used. The icon can then be used by the user agent
-            like a mask over any solid fill.
-          </li>
-          <li>
-            <code>maskable</code>: The image is designed with
-            <a href="https://w3c.github.io/manifest/#icon-masks"
-              >icon masks and safe zone</a
-            >
-            in mind, such that any part of the image outside the safe zone can
-            safely be ignored and masked away by the user agent.
-          </li>
-          <li>
-            <code>any</code>: The user agent is free to display the icon in any
-            context (this is the default value).
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## Specifications
 
 {{Specifications}}
@@ -127,3 +98,7 @@ Image objects may contain the following values:
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Image file type and format guide](/en-US/docs/Web/Media/Formats/Image_types#webp_image)

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -36,9 +36,9 @@ Each icon object can have one or more properties, with `src` being the only requ
 - `<size-values>` {{Optional_Inline}}
 
   - : A string that specifies one or more sizes at which the icon file can be used.
-    For raster formats like PNG, each size is specified as `<width in pixels>x<height in pixels>`.
+    Each size is specified as `<width in pixels>x<height in pixels>`.
     Multiple sizes can be specified, separated by spaces, for example: `48x48 96x96`.
-    When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context. For raster images, specifying the exact available sizes is recommended. For vector formats like SVG, you can use `any` to indicate scalability.
+    When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context. For raster formats like PNG, specifying the exact available sizes is recommended. For vector formats like SVG, you can use `any` to indicate scalability.
     If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
 
     Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -36,12 +36,12 @@ Each icon object can have one or more properties, with `src` being the only requ
 - `<size-values>` {{Optional_Inline}}
 
   - : A string that specifies one or more sizes at which the icon file can be used.
-     For raster formats like PNG, each size is specified as `<width in pixels>x<height in pixels>`.
-     Multiple sizes can be specified, separated by spaces, for example: `48x48 96x96`.
-     When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context. For raster images, specifying the exact available sizes is recommended. For vector formats like SVG, you can use `any` to indicate scalability.
-     If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
-     
-     Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute. 
+    For raster formats like PNG, each size is specified as `<width in pixels>x<height in pixels>`.
+    Multiple sizes can be specified, separated by spaces, for example: `48x48 96x96`.
+    When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context. For raster images, specifying the exact available sizes is recommended. For vector formats like SVG, you can use `any` to indicate scalability.
+    If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
+
+    Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
 
 - `<mime-type>` {{Optional_Inline}}
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -19,11 +19,11 @@ These icons uniquely identify your web app in different contexts, such as in an 
     "src": "icon/basic-icon.png"
   }
 
-/* Single icon with the multiple purposes */
+/* Single icon with multiple purposes */
 "icons":
   {
     "src": "icon/basic-icon.png",
-    "purpose": "maskable any"
+    "purpose": "monochrome maskable any"
   }
 
 /* Two icons with various properties */

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -38,7 +38,7 @@ Each object in the array can have one or more of the following properties (`src`
 
 - `type`
 
-  - : A string that specifies the media type (also known as the {{Glossary("MIME type")}}) of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
+  - : A string that specifies the {{Glossary("MIME type")}} of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
 
 - `purpose`
   - : A string that specifies one or more the purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. Valid keyword values include `monochrome`, `maskable`, and `any` and are case-sensitive. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in the following order of precedence:

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -25,9 +25,9 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 ### Values
 
-The value of the `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+The `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
 
-Each object in the array can have one or more of the following properties (`src` is the only required property):
+Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 
 - `<icon-url>`
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -18,7 +18,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
     "src": "<icon-url>",
     "sizes": "<size-values>",
     "type": "<mime-type>",
-    "purpose": "<purpose-keyword>"
+    "purpose": "<purpose-keywords>"
   }
 ]
 ```
@@ -49,7 +49,7 @@ Each icon object can have one or more properties, with `src` being the only requ
     The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
     If omitted, browsers typically infer the image type from the file extension.
 
-- `<purpose-keyword>` {{Optional_Inline}}
+- `<purpose-keywords>` {{Optional_Inline}}
 
   - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
     The value can be a single keyword or multiple space-separated keywords.

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -8,7 +8,6 @@ browser-compat: html.manifest.icons
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
 The `icons` manifest member is used to specify one or more image files that define the icons to represent your web application.
-These icons uniquely identify your web app in different contexts, such as in an operating system's task switcher, system settings, home screen, app listings, and other places when application icons are displayed.
 
 ## Syntax
 
@@ -24,7 +23,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
 "icons": [
   {
     "src": "icon/basic-icon.png",
-    "purpose": "monochrome maskable any"
+    "purpose": "monochrome maskable"
   }
 ]
 
@@ -61,14 +60,14 @@ These icons uniquely identify your web app in different contexts, such as in an 
     - `sizes` {{Optional_Inline}}
 
       - : A string that specifies one or more sizes at which the icon file can be used.
-        Each `<size-value>` is specified as `<width in pixels>x<height in pixels>`.
-        Multiple `<size-value>` tokens can be specified, separated by spaces, for example: `48x48 96x96`.
-        When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context.
+        Each size is specified as `<width in pixels>x<height in pixels>`.
+        If multiple sizes are specified, they are separated by spaces; for example, `48x48 96x96`.
+        When multiple icons are available, browsers may select the most suitable icon for a particular display context.
         For raster formats like PNG, specifying the exact available sizes is recommended.
         For vector formats like SVG, you can use `any` to indicate scalability.
-        If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
+        If `sizes` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
 
-        Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
+        Note that the format of `sizes` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
 
     - `type` {{Optional_Inline}}
 
@@ -104,11 +103,17 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 ## Description
 
+Icons uniquely identify your web app in different contexts, such as in an operating system's task switcher, system settings, home screen, app listings, and other places when application icons are displayed.
+
 The context in which an icon can be used is determined by the browser and the operating system, based on the specified sizes and formats.
 
-When working with icon images, both security and performance are important considerations.
+## Security considerations
 
-The browser's ability to fetch an icon image is governed by the Content Security Policy ({{Glossary("CSP")}}) of the manifest's owner document, specifically by the [`img-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) directive. This security aspect is related to the `src` property. For example, if the `img-src` directive in a CSP header specifies `icons.example.com`, icons from only that domain would be fetchable. In a manifest with two icons, one from `icons.example.com/lowres` and another from `other.com/hi-res`, only the former would be fetched successfully because of CSP restrictions.
+The browser's ability to fetch an icon image is governed by the Content Security Policy ({{Glossary("CSP")}}) of the manifest's owner document, specifically by the [`img-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) directive. This security aspect is related to the `src` property.
+
+For example, if the `img-src` directive in a CSP header specifies `icons.example.com`, icons from only that domain would be fetchable. In a manifest with two icons, one from `icons.example.com/lowres` and another from `other.com/hi-res`, only the former would be fetched successfully because of CSP restrictions.
+
+## Performance considerations
 
 The `type` property plays a part in determining performance. While this property is optional, specifying it can improve performance significantly. It allows browsers to quickly ignore images with formats they do not support. If you don't specify the `type` property, it is recommended to specify appropriate and unambiguous file extensions for the icon images to ensure correct handling by the browser.
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -26,7 +26,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 The value of the `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
 
-Each object in the array includes one or more of the following properties (`src` is the only required property):
+Each object in the array can have one or more of the following properties (`src` is the only required property):
 
 - `src`
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -26,7 +26,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
 ### Keys
 
 - `icons`
-  : - An array of objects.
+  - : An array of objects.
   Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
   Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -41,10 +41,16 @@ Each object in the array can have one or more of the following properties (`src`
   - : A string that specifies the {{Glossary("MIME type")}} of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
 
 - `purpose`
-  - : A string that specifies one or more the purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. Valid keyword values include `monochrome`, `maskable`, and `any` and are case-sensitive. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in the following order of precedence:
-    - `monochrome`: Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
-    - `maskable`: Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away by a browser.
-    - `any`: Indicates that the icon can be used in any context. This is the default value.
+  - : A string that specifies one or more the purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
+ 
+    Valid values (case-sensitive) are listed below, in order of precedence:
+  
+    - `monochrome`
+      - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
+    - `maskable`
+      - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away by a browser.
+    - `any`
+      - : Indicates that the icon can be used in any context. This is the default value.
 
 ## Description
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -35,7 +35,7 @@ Each object in the array can have one or more of the following properties (`src`
 
 - `sizes` {{Optional_Inline}}
 
-  - : A string that specifies one or more dimensions of the icon. Each dimension is specified as `<width>x<height>`. Mutiple dimensions are separated by spaces, as in `48x48 96x96`. Specifying multiple sizes allows a browser to select the most appropriate one for the context. The `sizes` property uses the same syntax as the [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute of the `<link>` HTML element. This property is optional; if not specifed, the default value of `any` is used, which indicates that the icon can be used at any size.
+  - : A string that specifies one or more sizes at which the icon can be used, and is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute. Each size is specified as `<width>x<height>`. Multiple sizes can be specified, separated by spaces, as in `48x48 96x96`. When multiple icons are available, browsers may use the `sizes` value to use the most suitable icon for a display context. This property is optional; if not specified, the behavior may vary depending on the browser's implementation. For raster images like PNG, specifying exact available sizes is recommended. For vector formats like SVG, you can use "any" to indicate scalability.
 
 - `type` {{Optional_Inline}}
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -31,7 +31,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
     Each object represents an icon to be used in a specific context.
     For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
 
-    Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
+    Each icon object can have one or more keys. Of these, only `src` is a required key. The possible keys include:
 
     - `src`
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -28,7 +28,9 @@ These icons uniquely identify your web app in different contexts, such as in an 
 - `icons`
 
   - : An array of objects.
-    Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+    Each object represents an icon to be used in a specific context.
+    For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+
     Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 
     - `src`
@@ -61,25 +63,25 @@ These icons uniquely identify your web app in different contexts, such as in an 
         The value can be a single keyword or multiple space-separated keywords.
         If omitted, the browser can use the icon for any purpose.
 
-      Browsers use these values as hints to determine where and how an icon is displayed.
-      For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
-      With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
-      If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
-      However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
+        Browsers use these values as hints to determine where and how an icon is displayed.
+        For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
+        With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
+        If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
+        However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
 
-      Valid values include:
+        Valid values include:
 
-      - `monochrome`
+        - `monochrome`
 
-        - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
-          With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
+          - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
+            With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
 
-      - `maskable`
+        - `maskable`
 
-        - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
+          - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
 
-      - `any`
-        - : Indicates that the icon can be used in any context. This is the default value.
+        - `any`
+          - : Indicates that the icon can be used in any context. This is the default value.
 
 ## Description
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -35,11 +35,19 @@ Each icon object can have one or more properties, with `src` being the only requ
 
 - `<size-values>` {{Optional_Inline}}
 
-  - : A string that specifies one or more sizes at which the icon can be used, and is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute. Each size is specified as `<width>x<height>`. Multiple sizes can be specified, separated by spaces, as in `48x48 96x96`. When multiple icons are available, browsers may use the `sizes` value to use the most suitable icon for a display context. This property is optional; if not specified, the behavior may vary depending on the browser's implementation. For raster images like PNG, specifying exact available sizes is recommended. For vector formats like SVG, you can use "any" to indicate scalability.
+  - : A string that specifies one or more sizes at which the icon file can be used.
+     For raster formats like PNG, each size is specified as `<width in pixels>x<height in pixels>`.
+     Multiple sizes can be specified, separated by spaces, for example: `48x48 96x96`.
+     When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context. For raster images, specifying the exact available sizes is recommended. For vector formats like SVG, you can use `any` to indicate scalability.
+     If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
+     
+     Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute. 
 
 - `<mime-type>` {{Optional_Inline}}
 
-  - : A string that specifies the {{Glossary("MIME type")}} of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
+  - : A string that specifies the {{Glossary("MIME type")}} of the icon.
+    The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
+    If omitted, browsers typically infer the image type from the file extension.
 
 - `<purpose-keyword>` {{Optional_Inline}}
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -15,10 +15,10 @@ These icons uniquely identify your web app in different contexts, such as in an 
 ```json
 "icons": [
   {
-    "src": "iconURL",
-    "sizes": "widthxheight",
-    "type": "mimeType",
-    "purpose": "keywordValue"
+    "src": "<icon-url>",
+    "sizes": "<size-values>",
+    "type": "<mime-type>",
+    "purpose": "<purpose-keyword>"
   }
 ]
 ```
@@ -31,7 +31,7 @@ Each object in the array can have one or more of the following properties (`src`
 
 - `src`
 
-  - : A string that specifies the path to the icon image file. If `src` is a relative URL, the path is resolved relative to the URL of the manifest file. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`. `src` is a required property.
+  - : A string that specifies the path to the icon image file. If `src` is a relative URL, the path is resolved relative to the URL of the manifest file. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
 - `sizes` {{Optional_Inline}}
 
@@ -48,7 +48,7 @@ Each object in the array can have one or more of the following properties (`src`
     - `monochrome`
       - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
     - `maskable`
-      - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away by a browser.
+      - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
     - `any`
       - : Indicates that the icon can be used in any context. This is the default value.
 
@@ -60,7 +60,7 @@ When working with icon images, both security and performance are important consi
 
 The browser's ability to fetch an icon image is governed by the Content Security Policy ({{Glossary("CSP")}}) of the manifest's owner document, specifically by the [`img-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src) directive. This security aspect is related to the `src` property. For example, if the `img-src` directive in a CSP header specifies `icons.example.com`, icons from only that domain would be fetchable. In a manifest with two icons, one from `icons.example.com/lowres` and another from `other.com/hi-res`, only the former would be fetched successfully because of CSP restrictions.
 
-The `type` property plays a part in determining performance. While this property is optional, specifying it can improve performance significantly. It allows browsers to quickly ignore images with formats they do not support. If you don't specify the `type` property, it is recommended to specify clear file extensions for the icon images to ensure correct handling by the browser.
+The `type` property plays a part in determining performance. While this property is optional, specifying it can improve performance significantly. It allows browsers to quickly ignore images with formats they do not support. If you don't specify the `type` property, it is recommended to specify appropriate and unambiguous file extensions for the icon images to ensure correct handling by the browser.
 
 ## Examples
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -15,9 +15,10 @@ These icons uniquely identify your web app in different contexts, such as in an 
 ```json
 "icons": [
   {
-    "src": "icon/lowres.webp",
-    "sizes": "48x48",
-    "type": "image/webp"
+    "src": "iconURL",
+    "sizes": "widthxheight",
+    "type": "mimeType",
+    "purpose": "keywordValue"
   }
 ]
 ```
@@ -32,15 +33,15 @@ Each object in the array can have one or more of the following properties (`src`
 
   - : A string that specifies the path to the icon image file. If `src` is a relative URL, the path is resolved relative to the URL of the manifest file. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`. `src` is a required property.
 
-- `sizes`
+- `sizes` {{Optional_Inline}}
 
   - : A string that specifies one or more dimensions of the icon. Each dimension is specified as `<width>x<height>`. Mutiple dimensions are separated by spaces, as in `48x48 96x96`. Specifying multiple sizes allows a browser to select the most appropriate one for the context. The `sizes` property uses the same syntax as the [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute of the `<link>` HTML element. This property is optional; if not specifed, the default value of `any` is used, which indicates that the icon can be used at any size.
 
-- `type`
+- `type` {{Optional_Inline}}
 
   - : A string that specifies the {{Glossary("MIME type")}} of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
 
-- `purpose`
+- `purpose` {{Optional_Inline}}
 
   - : A string that specifies one or more purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
     Valid values are case-sensitive and listed below in order of precedence:

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -26,9 +26,10 @@ These icons uniquely identify your web app in different contexts, such as in an 
 ### Keys
 
 - `icons`
+
   - : An array of objects.
-  Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
-  Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
+    Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+    Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 
   - `src`
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -7,7 +7,8 @@ browser-compat: html.manifest.icons
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `icons` manifest member is used to specify one or more image files that serve as iconic representations of your web application in different contexts. These icons represent your web app among a list of other applications. They can also be used to integrate your web app with an operating system's task switcher, system settings, home screen, and other places when an app icon is needed.
+The `icons` manifest member is used to specify one or more image files that define the icons to represent your web application.
+These icons uniquely identify your web app in different contexts, such as in an operating system's task switcher, system settings, home screen, app listings, and other places when application icons are displayed.
 
 ## Syntax
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -69,7 +69,7 @@ This example shows how to declare multiple icons for different scenarios and dev
 
 - Two icons of the same size (`48x48`) are provided in different formats. The first is explicitly specified as [WebP](/en-US/docs/Web/Media/Formats/Image_types#webp_image) using the `type` property. If a browser doesn't support WebP, it will fall back to the second icon of the same size. For the second icon, the browser will determine the MIME type either from the HTTP header or by inferring it from the image file's content. Icons at this size are typically used for browser tabs and bookmarks.
 
-- For smaller icons (up to `256x256`), an [ICO](/en-US/docs/Web/Media/Formats/Image_types#ico_microsoft_windows_icon) file is provided. ICO files contain multiple raster icons that are individually optimized for small display sizes. icons at these sizes are commonly used for desktop shortcuts.
+- An [ICO](/en-US/docs/Web/Media/Formats/Image_types#ico_microsoft_windows_icon) file is provided with multiple sizes ranging from `72x72` to `256x256`. ICO files contain multiple raster icons that are individually optimized for various display sizes. Icons at these sizes are commonly used for desktop shortcuts.
 
 - For larger icons (`257x257` and above), an [SVG](/en-US/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics) file is specified. The `sizes` value of this icon is set to `any`, which allows a browser to use this icon at any size. SVG icons maintain their quality at larger sizes. These icons ate ideal for high-resolution displays like in [progressive web apps (PWAs)](/en-US/docs/Web/Progressive_web_apps).
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -41,7 +41,8 @@ Each object in the array can have one or more of the following properties (`src`
   - : A string that specifies the {{Glossary("MIME type")}} of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
 
 - `purpose`
-  - : A string that specifies one or more the purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
+
+  - : A string that specifies one or more purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
     Valid values (case-sensitive) are listed below, in order of precedence:
     - `monochrome`
       - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -42,9 +42,7 @@ Each object in the array can have one or more of the following properties (`src`
 
 - `purpose`
   - : A string that specifies one or more the purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
- 
     Valid values (case-sensitive) are listed below, in order of precedence:
-  
     - `monochrome`
       - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
     - `maskable`

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -19,7 +19,6 @@ These icons uniquely identify your web app in different contexts, such as in an 
     "src": "icon/basic-icon.png"
   }
 
-
 /* Single icon with the multiple purposes */
 "icons":
   {

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -12,26 +12,44 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 ## Syntax
 
-```json
+```json-nolint
+/* Single icon with the minimum required property */
+"icons":
+  {
+    "src": "icon/basic-icon.png"
+  }
+
+
+/* Single icon with the multiple purposes */
+"icons":
+  {
+    "src": "icon/basic-icon.png",
+    "purpose": "maskable any"
+  }
+
+/* Two icons with various properties */
 "icons": [
   {
-    "src": "<icon-url>",
-    "sizes": "<size-values>",
-    "type": "<mime-type>",
-    "purpose": "<purpose-keywords>"
+  "src": "icon/lowres.png",
+  "sizes": "48x48"
+  },
+  {
+  "src": "maskable_icon.png",
+  "sizes": "48x48",
+  "type": "image/png"
   }
 ]
 ```
 
-### Keys
+### Values
 
 - `icons`
 
-  - : An array of objects.
+  - : An object or an array of objects.
     Each object represents an icon to be used in a specific context.
     For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
 
-    Each icon object can have one or more keys. Of these, only `src` is a required key. The possible keys include:
+    Each icon object can have one or more properties. Of these, only `src` is required. The possible properties include:
 
     - `src`
 
@@ -106,25 +124,27 @@ This example shows how to declare multiple icons for different scenarios and dev
 - For larger icons (`257x257` and above), an [SVG](/en-US/docs/Web/Media/Formats/Image_types#svg_scalable_vector_graphics) file is specified. The `sizes` value of this icon is set to `any`, which allows a browser to use this icon at any size. SVG icons maintain their quality at larger sizes. These icons ate ideal for high-resolution displays like in [progressive web apps (PWAs)](/en-US/docs/Web/Progressive_web_apps).
 
 ```json
-"icons": [
-  {
-    "src": "icon/lowres.webp",
-    "sizes": "48x48",
-    "type": "image/webp"
-  },
-  {
-    "src": "icon/lowres",
-    "sizes": "48x48"
-  },
-  {
-    "src": "icon/hd_hi.ico",
-    "sizes": "72x72 96x96 128x128 256x256"
-  },
-  {
-    "src": "icon/hd_hi.svg",
-    "sizes": "any"
-  }
-]
+{
+  "icons": [
+    {
+      "src": "icon/lowres.webp",
+      "sizes": "48x48",
+      "type": "image/webp"
+    },
+    {
+      "src": "icon/lowres",
+      "sizes": "48x48"
+    },
+    {
+      "src": "icon/hd_hi.ico",
+      "sizes": "72x72 96x96 128x128 256x256"
+    },
+    {
+      "src": "icon/hd_hi.svg",
+      "sizes": "any"
+    }
+  ]
+}
 ```
 
 ## Specifications

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -14,17 +14,19 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 ```json-nolint
 /* Single icon with the minimum required property */
-"icons":
+"icons": [
   {
     "src": "icon/basic-icon.png"
   }
+]
 
 /* Single icon with multiple purposes */
-"icons":
+"icons": [
   {
     "src": "icon/basic-icon.png",
     "purpose": "monochrome maskable any"
   }
+]
 
 /* Two icons with various properties */
 "icons": [
@@ -44,7 +46,7 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
 - `icons`
 
-  - : An object or an array of objects.
+  - : An array of objects.
     Each object represents an icon to be used in a specific context.
     For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -29,19 +29,19 @@ The value of the `icons` member is an array of objects. Each object represents a
 
 Each object in the array can have one or more of the following properties (`src` is the only required property):
 
-- `src`
+- `<icon-url>`
 
   - : A string that specifies the path to the icon image file. If `src` is a relative URL, the path is resolved relative to the URL of the manifest file. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
-- `sizes` {{Optional_Inline}}
+- `<size-values>` {{Optional_Inline}}
 
   - : A string that specifies one or more sizes at which the icon can be used, and is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute. Each size is specified as `<width>x<height>`. Multiple sizes can be specified, separated by spaces, as in `48x48 96x96`. When multiple icons are available, browsers may use the `sizes` value to use the most suitable icon for a display context. This property is optional; if not specified, the behavior may vary depending on the browser's implementation. For raster images like PNG, specifying exact available sizes is recommended. For vector formats like SVG, you can use "any" to indicate scalability.
 
-- `type` {{Optional_Inline}}
+- `<mime-type>` {{Optional_Inline}}
 
   - : A string that specifies the {{Glossary("MIME type")}} of the icon. The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image. This property is optional; if not specified, a browser typically uses the file extension to determine the image type.
 
-- `purpose` {{Optional_Inline}}
+- `<purpose-keyword>` {{Optional_Inline}}
 
   - : A string that specifies one or more purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
     Valid values are case-sensitive and listed below in order of precedence:

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -51,8 +51,17 @@ Each icon object can have one or more properties, with `src` being the only requ
 
 - `<purpose-keyword>` {{Optional_Inline}}
 
-  - : A string that specifies one or more purposes of the icon, which indicate how the icon should be used by the browser or operating system. The value can be a single keyword or multiple space-separated keywords. This property is optional; `any` is assumed if no value is specified. If multiple values are specified, they should be listed in order of precedence.
-    Valid values are case-sensitive and listed below in order of precedence:
+  - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
+     The value can be a single keyword or multiple space-separated keywords.
+     If omitted, the browser can use the icon for `any` purpose.
+     
+     Browsers use these values as hints to determine where and how an icon is displayed.
+     For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
+     With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
+     If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
+     However, if only unrecognized purposes are specified (e.g., "fizzbuzz"), those values will be ignored.
+    
+    Valid values include:
     - `monochrome`
       - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
     - `maskable`

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -34,8 +34,8 @@ These icons uniquely identify your web app in different contexts, such as in an 
     - `src`
 
       - : A string that specifies the path to the icon image file.
-      If `src` is relative, the path is resolved relative to the manifest file's URL.
-      For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
+        If `src` is relative, the path is resolved relative to the manifest file's URL.
+        For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
     - `sizes` {{Optional_Inline}}
 
@@ -58,8 +58,8 @@ These icons uniquely identify your web app in different contexts, such as in an 
     - `purpose` {{Optional_Inline}}
 
       - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
-      The value can be a single keyword or multiple space-separated keywords.
-      If omitted, the browser can use the icon for any purpose.
+        The value can be a single keyword or multiple space-separated keywords.
+        If omitted, the browser can use the icon for any purpose.
 
       Browsers use these values as hints to determine where and how an icon is displayed.
       For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
@@ -69,15 +69,17 @@ These icons uniquely identify your web app in different contexts, such as in an 
 
       Valid values include:
 
-        - `monochrome`
-          - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
+      - `monochrome`
+
+        - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
           With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
 
-        - `maskable`
-          - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
-        
-        - `any`
-          - : Indicates that the icon can be used in any context. This is the default value.
+      - `maskable`
+
+        - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
+
+      - `any`
+        - : Indicates that the icon can be used in any context. This is the default value.
 
 ## Description
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -59,7 +59,7 @@ Each icon object can have one or more properties, with `src` being the only requ
     For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
     With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
     If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
-    However, if only unrecognized purposes are specified (e.g., "fizzbuzz"), then it will be ignored.
+    However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
 
     Valid values include:
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -52,16 +52,17 @@ Each icon object can have one or more properties, with `src` being the only requ
 - `<purpose-keyword>` {{Optional_Inline}}
 
   - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
-     The value can be a single keyword or multiple space-separated keywords.
-     If omitted, the browser can use the icon for `any` purpose.
-     
-     Browsers use these values as hints to determine where and how an icon is displayed.
-     For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
-     With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
-     If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
-     However, if only unrecognized purposes are specified (e.g., "fizzbuzz"), those values will be ignored.
-    
+    The value can be a single keyword or multiple space-separated keywords.
+    If omitted, the browser can use the icon for `any` purpose.
+
+    Browsers use these values as hints to determine where and how an icon is displayed.
+    For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
+    With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
+    If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
+    However, if only unrecognized purposes are specified (e.g., "fizzbuzz"), those values will be ignored.
+
     Valid values include:
+
     - `monochrome`
       - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
     - `maskable`

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -53,13 +53,13 @@ Each icon object can have one or more properties, with `src` being the only requ
 
   - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
     The value can be a single keyword or multiple space-separated keywords.
-    If omitted, the browser can use the icon for `any` purpose.
+    If omitted, the browser can use the icon for any purpose.
 
     Browsers use these values as hints to determine where and how an icon is displayed.
     For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
     With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
     If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
-    However, if only unrecognized purposes are specified (e.g., "fizzbuzz"), those values will be ignored.
+    However, if only unrecognized purposes are specified (e.g., "fizzbuzz"), then it will be ignored.
 
     Valid values include:
 

--- a/files/en-us/web/manifest/icons/index.md
+++ b/files/en-us/web/manifest/icons/index.md
@@ -23,52 +23,55 @@ These icons uniquely identify your web app in different contexts, such as in an 
 ]
 ```
 
-### Values
+### Keys
 
-The `icons` member is an array of objects. Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+- `icons`
+  : - An array of objects.
+      Each object represents an icon to be used in a specific context. For example, you can add icons to represent your web app on devices with different screen sizes, for integration with various operating systems, for splash screens, or for app notifications.
+      Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
 
-Each icon object can have one or more properties, with `src` being the only required property. The possible values for these properties are:
+  - `src`
+    - : A string that specifies the path to the icon image file.
+        If `src` is relative, the path is resolved relative to the manifest file's URL.
+        For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
 
-- `<icon-url>`
+  - `sizes` {{Optional_Inline}}
+    - : A string that specifies one or more sizes at which the icon file can be used.
+        Each `<size-value>` is specified as `<width in pixels>x<height in pixels>`.
+        Multiple `<size-value>` tokens can be specified, separated by spaces, for example: `48x48 96x96`.
+        When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context.
+        For raster formats like PNG, specifying the exact available sizes is recommended.
+        For vector formats like SVG, you can use `any` to indicate scalability.
+        If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
+        
+        Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
 
-  - : A string that specifies the path to the icon image file. If `<icon-url>` is relative, the path is resolved relative to the manifest file's URL. For example, the relative URL `images/icon-192x192.png` for the manifest file located at `https://example.com/manifest.json` will be resolved as `https://example.com/images/icon-192x192.png`.
+  - `type` {{Optional_Inline}}
+    - : A string that specifies the {{Glossary("MIME type")}} of the icon.
+        The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
+        If omitted, browsers typically infer the image type from the file extension.
 
-- `<size-values>` {{Optional_Inline}}
+  - `purpose` {{Optional_Inline}}
+    - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
+        The value can be a single keyword or multiple space-separated keywords.
+        If omitted, the browser can use the icon for any purpose.
+        
+        Browsers use these values as hints to determine where and how an icon is displayed.
+        For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
+        With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
+        If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
+        However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
+        
+        Valid values include:
 
-  - : A string that specifies one or more sizes at which the icon file can be used.
-    Each size is specified as `<width in pixels>x<height in pixels>`.
-    Multiple sizes can be specified, separated by spaces, for example: `48x48 96x96`.
-    When multiple icons are available, browsers may use `<size-values>` to select the most suitable icon for a display context. For raster formats like PNG, specifying the exact available sizes is recommended. For vector formats like SVG, you can use `any` to indicate scalability.
-    If `<size-values>` is not specified, the selection and display of the icon may vary depending on the browser's implementation.
-
-    Note that the format of `<size-values>` is similar to the HTML `<link>` element's [`sizes`](/en-US/docs/Web/HTML/Element/link#sizes) attribute.
-
-- `<mime-type>` {{Optional_Inline}}
-
-  - : A string that specifies the {{Glossary("MIME type")}} of the icon.
-    The value should be in the format `image/<subtype>`, where `<subtype>` is a specific image format; for example, `image/png` indicates a PNG image.
-    If omitted, browsers typically infer the image type from the file extension.
-
-- `<purpose-keywords>` {{Optional_Inline}}
-
-  - : A case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system.
-    The value can be a single keyword or multiple space-separated keywords.
-    If omitted, the browser can use the icon for any purpose.
-
-    Browsers use these values as hints to determine where and how an icon is displayed.
-    For example, a `monochrome` icon might be used as a badge or pinned icon with a solid fill, which is visually distinct from a full-color launch icon.
-    With multiple keywords, say `monochrome maskable`, the browser can use the icon for any of those purposes.
-    If an unrecognized purpose is included along with valid values (e.g., `monochrome fizzbuzz`), the icon can still be used for the valid purposes.
-    However, if only unrecognized purposes are specified (e.g., `fizzbuzz`), then it will be ignored.
-
-    Valid values include:
-
-    - `monochrome`
-      - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill. With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
-    - `maskable`
-      - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
-    - `any`
-      - : Indicates that the icon can be used in any context. This is the default value.
+        - `monochrome`
+          - : Indicates that the icon is intended to be used as a monochrome icon with a solid fill.
+              With this value, a browser discards the color information in the icon and uses only the alpha channel as a mask over any solid fill.
+              
+        - `maskable`
+          - : Indicates that the icon is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can be ignored and masked away.
+        - `any`
+          - : Indicates that the icon can be used in any context. This is the default value.
 
 ## Description
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -19,9 +19,9 @@ This color application can provide a more native app-like experience for your we
 "theme_color": "<color-value>"
 ```
 
-### Values
+### Keys
 
-- `<color-value>`
+- `theme_color`
 
   - : A string that specifies a [valid color value](/en-US/docs/Web/CSS/color_value).
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -15,11 +15,13 @@ This color application can provide a more native app-like experience for your we
 
 ## Syntax
 
-```json
-"theme_color": "<color-value>"
+```json-nolint
+/* Valid color value */
+"theme_color": "rebeccapurple"
+"theme_color": "#4285f4"
 ```
 
-### Keys
+### Values
 
 - `theme_color`
 
@@ -81,13 +83,17 @@ body {
 ### Using a named color
 
 ```json
-"theme_color": "red"
+{
+  "theme_color": "red"
+}
 ```
 
 ### Using an RGB value
 
 ```json
-"theme_color": "rgb(66, 133, 244)"
+{
+  "theme_color": "rgb(66, 133, 244)"
+}
 ```
 
 ### Using a hexadecimal value


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This work is part of improving the web/manifest docs. This PR focuses on the [`icons`](https://developer.mozilla.org/en-US/docs/Web/Manifest/icons) member page.

Some notable changes in this PR:

- Removed the "Type" table from the top of the page. The type can be covered in the Syntax section and does not need a table. (On some other pages like [file_handlers](https://developer.mozilla.org/en-US/docs/Web/Manifest/file_handlers), this Type table overcrowds with technology status banners.)
- Created a "Syntax" section with "Values" and "Properties" subsections. Replaced the table describing the values with a definition list format.
- Created a "Description" section to include details about security and performance aspects.
- Added an explanation for the example.

### Motivation

To better explain the properties and example and make the page compliant with our page templates

### Additional details

Spec links:
- https://w3c.github.io/manifest/#icons-member
- https://w3c.github.io/manifest/#declaring-multiple-icons

### Related issues and pull requests

Tracking issue: https://github.com/mdn/mdn/issues/560
`display` page PR: https://github.com/mdn/content/pull/34386
