### PR TITLE
feat: improvements on attribute & boolean/html

### DIFF
--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -20,7 +20,7 @@ Attributes may be _reflected_ into a particular property of the specific interfa
 It means that the value of the attribute can be read by accessing the property,
 and can be modified by setting the property to a different value.
 
-For example, the `placeholder` below is reflected into {{domxref("HTMLInputElement.placeholder")}}.
+For example, the `placeholder` below is reflected into {{domxref("HTML/Attributes/placeholder")}}.
 
 Considering the following HTML:
 
@@ -28,7 +28,7 @@ Considering the following HTML:
 <input placeholder="Original placeholder" />
 ```
 
-We can check the reflection between {{domxref("HTMLInputElement.placeholder")}} and the attribute using:
+We can check the reflection between {{domxref("HTML/Attributes/placeholder")}} and the attribute using:
 
 ```js
 const input = document.querySelector("input");

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -10,7 +10,9 @@ An **attribute** extends an {{Glossary("HTML")}} or {{Glossary("XML")}} {{Glossa
 
 An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value).
 
-You may see attributes without an equals sign or a value. They are {{Glossary("Boolean/HTML", "boolean attributes")}}, the shorthand for providing the empty string in HTML and are considered to be `true`. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
+## Boolean attribute
+
+A number of attributes are {{Glossary("Boolean/HTML", "boolean attributes")}}. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. They might be set without an equals sign or a value, and in this case they are the shorthand for providing the empty string in HTML and are considered to be `true` for the boolean attribute. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
 
 See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
 

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -54,3 +54,4 @@ console.log(attr.value); // Prints `Modified placeholder`
   - {{Glossary("HTML")}}
   - {{Glossary("XML")}}
   - {{Glossary("Boolean/HTML", "Boolean attributes")}}
+  - {{Glossary("Enumerated", "Enumerated attributes")}}

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -8,13 +8,9 @@ page-type: glossary-definition
 
 An **attribute** extends an {{Glossary("HTML")}} or {{Glossary("XML")}} {{Glossary("element")}}, changing its behavior or providing metadata.
 
-An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value).
+An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value). You may see attributes without an equals sign or a value. That is a shorthand for providing the empty string in HTML.
 
-## Boolean attribute
-
-A number of attributes are {{Glossary("Boolean/HTML", "boolean attributes")}}. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. They might be set without an equals sign or a value, and in this case they are the shorthand for providing the empty string in HTML and are considered to be `true` for the boolean attribute. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
-
-See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
+A number of attributes are {{Glossary("Boolean/HTML", "boolean attributes")}}. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
 
 ## Reflection of an attribute
 

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -20,7 +20,7 @@ Attributes may be _reflected_ into a particular property of the specific interfa
 It means that the value of the attribute can be read by accessing the property,
 and can be modified by setting the property to a different value.
 
-For example, the `placeholder` below is reflected into {{domxref("HTML/Attributes/placeholder")}}.
+For example, the `placeholder` below is reflected into {{domxref("HTMLInputElement.placeholder")}}.
 
 Considering the following HTML:
 
@@ -28,7 +28,7 @@ Considering the following HTML:
 <input placeholder="Original placeholder" />
 ```
 
-We can check the reflection between {{domxref("HTML/Attributes/placeholder")}} and the attribute using:
+We can check the reflection between {{domxref("HTMLInputElement.placeholder")}} and the attribute using:
 
 ```js
 const input = document.querySelector("input");

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -10,7 +10,7 @@ An **attribute** extends an {{Glossary("HTML")}} or {{Glossary("XML")}} {{Glossa
 
 An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value). You may see attributes without an equals sign or a value. That is a shorthand for providing the empty string in HTML.
 
-A number of attributes are {{Glossary("Boolean/HTML", "boolean attributes")}}. The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value. See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
+A number of HTML attributes are {{Glossary("Boolean/HTML", "boolean attributes")}}. These attributes' values are only controlled by the presence or absence of the attribute. See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
 
 ## Reflection of an attribute
 

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -6,27 +6,13 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **attribute** extends an HTML or XML {{Glossary("element")}}, changing its behavior or providing metadata.
+An **attribute** extends an {{Glossary("HTML")}} or {{Glossary("XML")}} {{Glossary("element")}}, changing its behavior or providing metadata.
 
 An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value).
 
-You may see attributes without an equals sign or a value. That is a shorthand for providing the empty string in HTML; such attributes are considered to be [boolean attributes](/en-US/docs/Web/HTML/Attributes#boolean_attributes). However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
+You may see attributes without an equals sign or a value. They are {{Glossary("Boolean/HTML", "boolean attributes")}}, the shorthand for providing the empty string in HTML and are considered to be `true`. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
 
-The following code provides examples of different boolean attribute forms in HTML:
-
-```html example-good
-<input required />
-<!-- is equivalent to -->
-<input required="" />
-<!-- or -->
-<input required="anything" />
-```
-
-In XML, attributes without equals sign or value will throw a syntax error:
-
-```xml-nolint example-bad
-<tag id />
-```
+See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
 
 ## Reflection of an attribute
 
@@ -60,3 +46,9 @@ console.log(attr.value); // Prints `Modified placeholder`
 - [HTML attribute reference](/en-US/docs/Web/HTML/Attributes)
 - Information about HTML's [global attributes](/en-US/docs/Web/HTML/Global_attributes)
 - XML StartTag Attribute Recommendation in [W3C XML Recommendation](https://www.w3.org/TR/xml#sec-starttags)
+- Related glossary terms:
+  - {{Glossary("Element")}}
+  - {{Glossary("Tag")}}
+  - {{Glossary("HTML")}}
+  - {{Glossary("XML")}}
+  - {{Glossary("Boolean/HTML", "Boolean attributes")}}

--- a/files/en-us/glossary/attribute/index.md
+++ b/files/en-us/glossary/attribute/index.md
@@ -8,7 +8,7 @@ page-type: glossary-definition
 
 An **attribute** extends an {{Glossary("HTML")}} or {{Glossary("XML")}} {{Glossary("element")}}, changing its behavior or providing metadata.
 
-An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value). You may see attributes without an equals sign or a value. That is a shorthand for providing the empty string in HTML.
+An attribute always has the form `name="value"` (the attribute's identifier followed by its associated value). You may see attributes without an equals sign or a value. That is a shorthand for providing the empty string in HTML. However, this is not valid in XML: XML requires all attributes to have an explicit value.
 
 A number of HTML attributes are {{Glossary("Boolean/HTML", "boolean attributes")}}. These attributes' values are only controlled by the presence or absence of the attribute. See {{Glossary("Boolean/HTML", "boolean attributes")}} for more information.
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -21,12 +21,6 @@ The following code provides examples of different boolean attribute forms in HTM
 
 > **Note:** Though setting the value of a boolean attribute to anything may be parsed as true across different browsers, it's suggested to follow the [specification](https://html.spec.whatwg.org/#boolean-attributes) to set its value to either be the empty string or a value that is an ASCII case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace.
 
-In XML, attributes without equals sign or value will throw a syntax error:
-
-```xml-nolint example-bad
-<tag id />
-```
-
 > **Note:** Any presence of a boolean attribute on an element represents `true`, regardless of the attribute's value. To set the attribute to `false`, you should just omit the attribute altogether.
 
 ## See also

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -15,9 +15,11 @@ The following code provides examples of different boolean attribute forms in HTM
 <input required />
 <!-- is equivalent to -->
 <input required="" />
-<!-- or -->
-<input required="anything" />
+<!-- and -->
+<input required="required" />
 ```
+
+> **Note:** Though setting the value of a boolean attribute to anything may be parsed as true across different browsers, it's suggested to follow the [specification](https://html.spec.whatwg.org/#boolean-attributes) to set its value to either be the empty string or a value that is an ASCII case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace.
 
 In XML, attributes without equals sign or value will throw a syntax error:
 
@@ -25,10 +27,11 @@ In XML, attributes without equals sign or value will throw a syntax error:
 <tag id />
 ```
 
-> **Note:** Any presence of a boolean attribute on an element represents `true`, regardless of the attribute's value.
+> **Note:** Any presence of a boolean attribute on an element represents `true`, regardless of the attribute's value. To set the attribute to `false`, you should just omit the attribute altogether.
 
 ## See also
 
 - [Boolean attributes](/en-US/docs/Web/HTML/Attributes#boolean_attributes)
+- [Boolean attributes](https://html.spec.whatwg.org/#boolean-attributes) in HTML specification
 - Related glossary terms:
   - {{Glossary("Attribute")}}

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -7,29 +7,28 @@ spec-urls: https://html.spec.whatwg.org/#boolean-attributes
 
 {{GlossarySidebar}}
 
-A **boolean attribute** in HTML is an attribute that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
+A **boolean attribute** in {{Glossary("HTML")}} is an attribute that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
 
-If the attribute is present, it can have one of the following values:
+The following code provides examples of different boolean attribute forms in HTML:
 
-- no value at all, e.g. `attribute`
-- the empty string, e.g. `attribute=""`
-- attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
-
-> **Note:** The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should not be present in the element tag. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
-
-Here's an example of a HTML boolean attribute `checked`:
-
-```html
-<!-- The following checkboxes will be checked on initial rendering -->
-<input type="checkbox" checked />
-<input type="checkbox" checked="" />
-<input type="checkbox" checked="checked" />
-
-<!-- The following checkbox will not be checked on initial rendering -->
-<input type="checkbox" />
+```html example-good
+<input required />
+<!-- is equivalent to -->
+<input required="" />
+<!-- or -->
+<input required="anything" />
 ```
+
+In XML, attributes without equals sign or value will throw a syntax error:
+
+```xml-nolint example-bad
+<tag id />
+```
+
+> **Note:** Any presence of a boolean attribute on an element represents `true`, regardless of the attribute's value.
 
 ## See also
 
+- [Boolean attributes](/en-US/docs/Web/HTML/Attributes#boolean_attributes)
 - Related glossary terms:
-  - {{Glossary("Enumerated")}}
+  - {{Glossary("Attribute")}}

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -9,19 +9,13 @@ spec-urls: https://html.spec.whatwg.org/#boolean-attributes
 
 A **boolean attribute** in {{Glossary("HTML")}} is an attribute that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
 
-The following code provides examples of different boolean attribute forms in HTML:
+If the boolean attribute is present, the value of it shuold be of the following cases:
 
-```html example-good
-<input required />
-<!-- is equivalent to -->
-<input required="" />
-<!-- and -->
-<input required="required" />
-```
+- no value at all, e.g. `attribute`
+- the empty string, e.g. `attribute=""`
+- attribute's canonical name, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 
-> **Note:** Though setting the value of a boolean attribute to anything may be parsed as true across different browsers, it's suggested to follow the [specification](https://html.spec.whatwg.org/#boolean-attributes) to set its value to either be the empty string or a value that is an ASCII case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace.
-
-> **Note:** Any presence of a boolean attribute on an element represents `true`, regardless of the attribute's value. To set the attribute to `false`, you should just omit the attribute altogether.
+> **Note:** The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
 
 ## See also
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -7,7 +7,7 @@ spec-urls: https://html.spec.whatwg.org/#boolean-attributes
 
 {{GlossarySidebar}}
 
-A **boolean attribute** in {{Glossary("HTML")}} is an attribute that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
+A **boolean attribute** in {{Glossary("HTML")}} is an {{glossary("attribute")}} that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
 
 If the attribute is present, it can have one of the following values:
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -7,11 +7,11 @@ spec-urls: https://html.spec.whatwg.org/#boolean-attributes
 
 {{GlossarySidebar}}
 
-A **boolean attribute** in {{Glossary("HTML")}} is an attribute that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`. However, this is not allowed in XML: XML requires the equals sign followed by the attribute name.
+A **boolean attribute** in {{Glossary("HTML")}} is an attribute that represents `true` or `false` values. If an HTML tag contains a boolean attribute - no matter the value of that attribute - the attribute is set to `true` on that element. If an HTML tag does not contain the attribute, the attribute is set to `false`.
 
-If the boolean attribute is present, the value of it shuold be of the following cases:
+If the attribute is present, it can have one of the following values:
 
-- no value at all, e.g. `attribute`
+- no value at all, e.g. `attribute` (This is not allowed in XML: XML requires the equals sign followed by the attribute name.)
 - the empty string, e.g. `attribute=""`
 - attribute's canonical name, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -11,7 +11,7 @@ A **boolean attribute** in {{Glossary("HTML")}} is an attribute that represents 
 
 If the attribute is present, it can have one of the following values:
 
-- no value at all, e.g. `attribute` (This is not allowed in XML: XML requires the equals sign followed by the attribute name.)
+- no value at all, e.g. `attribute`
 - the empty string, e.g. `attribute=""`
 - attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -13,7 +13,7 @@ If the attribute is present, it can have one of the following values:
 
 - no value at all, e.g. `attribute` (This is not allowed in XML: XML requires the equals sign followed by the attribute name.)
 - the empty string, e.g. `attribute=""`
-- attribute's canonical name, with no leading or trailing whitespace, e.g. `attribute="attribute"`
+- attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 
 Here's an example of a HTML boolean attribute `checked`:
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -15,6 +15,8 @@ If the attribute is present, it can have one of the following values:
 - the empty string, e.g. `attribute=""`
 - attribute's name itself, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 
+> **Note:** The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
+
 Here's an example of a HTML boolean attribute `checked`:
 
 ```html
@@ -26,8 +28,6 @@ Here's an example of a HTML boolean attribute `checked`:
 <!-- The following checkbox will not be checked on initial rendering -->
 <input type="checkbox" />
 ```
-
-> **Note:** The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
 
 ## See also
 

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -25,6 +25,8 @@ Here's an example of a HTML boolean attribute `checked`:
 
 <!-- The following checkbox will not be checked on initial rendering -->
 <input type="checkbox" />
+```
+
 > **Note:** The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
 
 ## See also

--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -15,6 +15,16 @@ If the attribute is present, it can have one of the following values:
 - the empty string, e.g. `attribute=""`
 - attribute's canonical name, with no leading or trailing whitespace, e.g. `attribute="attribute"`
 
+Here's an example of a HTML boolean attribute `checked`:
+
+```html
+<!-- The following checkboxes will be checked on initial rendering -->
+<input type="checkbox" checked />
+<input type="checkbox" checked="" />
+<input type="checkbox" checked="checked" />
+
+<!-- The following checkbox will not be checked on initial rendering -->
+<input type="checkbox" />
 > **Note:** The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
 
 ## See also
@@ -23,3 +33,4 @@ If the attribute is present, it can have one of the following values:
 - [Boolean attributes](https://html.spec.whatwg.org/#boolean-attributes) in HTML specification
 - Related glossary terms:
   - {{Glossary("Attribute")}}
+  - {{Glossary("Enumerated", "Enumerated attribute")}}


### PR DESCRIPTION
@chrisdavidmills a further update than #33386 - boolean attribute actually *have an individual entry* `/Glossary/Boolean/HTML`

- **fixed**: trimed down `/Glossary/Attribute`, moving the detailed information of boolean attribute onto `/Glossary/Boolean/HTML`
- **fixed**: out-dated information according to the HTML spec *2.3.2* under `/Glossary/Boolean/HTML`

<img width="1288" alt="Screenshot 2024-07-09 at 4 00 07 PM" src="https://github.com/mdn/content/assets/41184947/5840f572-6af6-4810-8e8e-52003e7c8804">

- **added**: inter-glossary links