### PR TITLE
fix(CSS): clarify inline and block logical values with different writing modes

### DIFF
--- a/files/en-us/web/css/inset-area_value/index.md
+++ b/files/en-us/web/css/inset-area_value/index.md
@@ -236,7 +236,7 @@ The generic logical spanning keywords — when combined with a logical row or co
 
   - : Span the center tile and the inline-end tile of the specified block row.
 
-For example, `block-end span-inline-start` selects the center tile of the end block row and spans across the tiles in that row that are in the inline center and start columns. With `writing-mode: horizontal-tb` set, this would span the bottom-center and bottom-left grid tiles, whereas with `writing-mode: vertical-rl` set it would span the right-center and top-right grid tiles.
+For example, `block-end span-inline-start` selects the center tile of the end block row and spans across the tiles in that row that are in the inline center and start columns. With `writing-mode: horizontal-tb` set, this would span the bottom-center and bottom-left grid tiles, whereas with `writing-mode: vertical-rl` set it would span the left-center and top-left grid tiles.
 
 > **Note:** The specification defines `self` equivalents of these keywords, for example — `span-self-block-start`, `span-self-block-end`, `span-self-inline-start`, and `span-self-inline-end`. However, these are not currently supported in any browser.
 


### PR DESCRIPTION
The result of the final example given in the last paragraph under [Spanning explicit inline and block logical keywords]  (https://developer.mozilla.org/en-US/docs/Web/CSS/inset-area_value#explicit_inline_and_block_logical_keywords ) is wrong

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
