### PR TITLE
Fix for Add a warning/suggestion to canvas.toDataURL to prefer toBlob

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -18,7 +18,7 @@ Browsers are required to support `image/png`; many will support additional forma
 
 The created image data will have a resolution of 96dpi for file formats that support encoding resolution metadata.
 
-> **Warning:** It is recommended to use [toBlob](/en-US/docs/Web/API/HTMLCanvasElement/toBlob) for better performance and memory efficiency, when working with larger images.
+> **Warning:** `toDataURL()` encodes the whole image in an in-memory string. For larger images, this can have performance implications, and may even overflow browsers' URL length limit when assigned to {{domxref("HTMLImageElement.src")}}. You should generally prefer [`toBlob()`](/en-US/docs/Web/API/HTMLCanvasElement/toBlob) instead, in combination with {{domxref("URL/createObjectURL_static", "URL.createObjectURL()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -18,6 +18,8 @@ Browsers are required to support `image/png`; many will support additional forma
 
 The created image data will have a resolution of 96dpi for file formats that support encoding resolution metadata.
 
+> **Warning:** It is recommended to use [toBlob](/en-US/docs/Web/API/HTMLCanvasElement/toBlob) for better performance and memory efficiency, when working with larger images.
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
### Description
Fixes #33748. Added a Warning to use `toBlob` instead of `toDataURL`.
