### PR TITLE
Change value links from HTML refs to DOM interface refs

### DIFF
--- a/files/en-us/web/api/document/body/index.md
+++ b/files/en-us/web/api/document/body/index.md
@@ -16,8 +16,8 @@ The **`Document.body`** property represents the
 
 One of the following:
 
-- {{domxref("HTMLBodyElement")}}.
-- {{domxref("HTMLFrameSetElement")}}.
+- {{domxref("HTMLBodyElement")}}
+- {{domxref("HTMLFrameSetElement")}}
 - `null`
 
 ## Examples

--- a/files/en-us/web/api/document/body/index.md
+++ b/files/en-us/web/api/document/body/index.md
@@ -16,8 +16,8 @@ The **`Document.body`** property represents the
 
 One of the following:
 
-- {{HTMLElement("body")}}
-- {{HTMLElement("frameset")}}
+- {{domxref("HTMLBodyElement")}}.
+- {{domxref("HTMLFrameSetElement")}}.
 - `null`
 
 ## Examples


### PR DESCRIPTION
### Description

This changes the HTML links to DOM interface links to allow users to remain in the DOM interface and not be directed to HTML when following a path from Document, a DOM interface.

HTML links for these respective elements still exist in the description.

### Motivation

Confusing to transition from interface to html when looking up properties like `body`.

### Additional details

This is consistent with what the `head` property already does.

https://developer.mozilla.org/en-US/docs/Web/API/Document/head

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
