### PR TITLE
Reformat references to `[InterfaceName].message_event` to "the message event of InterfaceName"

### DIFF
--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -15,7 +15,7 @@ This is used to represent messages in:
 - [Web sockets](/en-US/docs/Web/API/WebSockets_API) (see the {{domxref("WebSocket.message_event", "message")}} event of {{domxref("WebSocket")}}).
 - Cross-document messaging (see {{domxref("Window.postMessage()")}} and the {{domxref("Window.message_event", "message")}} event of {{domxref("Window")}}).
 - [Channel messaging](/en-US/docs/Web/API/Channel_Messaging_API) (see {{domxref("MessagePort.postMessage()")}} and the {{domxref("MessagePort.message_event", "message")}} event of {{domxref("MessagePort")}}).
-- Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, the {{domxref("Worker.message_event", "message")}} event of {{domxref("Worker")}}, the {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event of  {{domxref("ServiceWorkerGlobalScope")}}, etc.)
+- Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, the {{domxref("Worker.message_event", "message")}} event of {{domxref("Worker")}}, the {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event of {{domxref("ServiceWorkerGlobalScope")}}, etc.)
 - [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and the {{domxref("BroadcastChannel.message_event", "message")}} event of {{domxref("BroadcastChannel")}}).
 - WebRTC data channels (see the {{domxref("RTCDataChannel.message_event", "message")}} event of {{domxref("RTCDataChannel")}}).
 

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -11,13 +11,13 @@ The **`MessageEvent`** interface represents a message received by a target objec
 
 This is used to represent messages in:
 
-- [Server-sent events](/en-US/docs/Web/API/Server-sent_events) (see EventSource's {{domxref("EventSource.message_event", "message")}} event).
-- [Web sockets](/en-US/docs/Web/API/WebSockets_API) (see the `onmessage` property of the [WebSocket](/en-US/docs/Web/API/WebSocket) interface).
-- Cross-document messaging (see {{domxref("Window.postMessage()")}} and Window's {{domxref("Window.message_event", "message")}} event).
-- [Channel messaging](/en-US/docs/Web/API/Channel_Messaging_API) (see {{domxref("MessagePort.postMessage()")}} and MessagePort's {{domxref("MessagePort.message_event", "message")}} event).
-- Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, Worker's {{domxref("Worker.message_event", "message")}} event, ServiceWorkerGlobalScope's {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event, etc.)
-- [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and BroadcastChannel's {{domxref("BroadcastChannel.message_event", "message")}} event).
-- WebRTC data channels (see RTCDataChannel's {{domxref("RTCDataChannel.message_event", "message")}} event).
+- [Server-sent events](/en-US/docs/Web/API/Server-sent_events) (see the {{domxref("EventSource.message_event", "message")}} event of {{domxref("EventSource")}}).
+- [Web sockets](/en-US/docs/Web/API/WebSockets_API) (see the {{domxref("WebSocket.message_event", "message")}} event of {{domxref("WebSocket")}}).
+- Cross-document messaging (see {{domxref("Window.postMessage()")}} and the {{domxref("Window.message_event", "message")}} event of {{domxref("Window")}}).
+- [Channel messaging](/en-US/docs/Web/API/Channel_Messaging_API) (see {{domxref("MessagePort.postMessage()")}} and the {{domxref("MessagePort.message_event", "message")}} event of {{domxref("MessagePort")}}).
+- Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, the {{domxref("Worker.message_event", "message")}} event of {{domxref("Worker")}}, the {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event of  {{domxref("ServiceWorkerGlobalScope")}}, etc.)
+- [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and the {{domxref("BroadcastChannel.message_event", "message")}} event of {{domxref("BroadcastChannel")}}).
+- WebRTC data channels (see the {{domxref("RTCDataChannel.message_event", "message")}} event of {{domxref("RTCDataChannel")}}).
 
 The action triggered by this event is defined in a function set as the event handler for the relevant `message` event (e.g. using an `onmessage` handler as listed above).
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -11,13 +11,13 @@ The **`MessageEvent`** interface represents a message received by a target objec
 
 This is used to represent messages in:
 
-- [Server-sent events](/en-US/docs/Web/API/Server-sent_events) (see {{domxref("EventSource.message_event")}}).
+- [Server-sent events](/en-US/docs/Web/API/Server-sent_events) (see EventSource's {{domxref("EventSource.message_event", "message")}} event).
 - [Web sockets](/en-US/docs/Web/API/WebSockets_API) (see the `onmessage` property of the [WebSocket](/en-US/docs/Web/API/WebSocket) interface).
-- Cross-document messaging (see {{domxref("Window.postMessage()")}} and {{domxref("Window.message_event")}}).
-- [Channel messaging](/en-US/docs/Web/API/Channel_Messaging_API) (see {{domxref("MessagePort.postMessage()")}} and {{domxref("MessagePort.message_event")}}).
-- Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, {{domxref("Worker.message_event")}}, {{domxref("ServiceWorkerGlobalScope.message_event")}}, etc.)
-- [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and {{domxref("BroadcastChannel.message_event")}}).
-- WebRTC data channels (see {{domxref("RTCDataChannel.message_event", "onmessage")}}).
+- Cross-document messaging (see {{domxref("Window.postMessage()")}} and Window's {{domxref("Window.message_event", "message")}} event).
+- [Channel messaging](/en-US/docs/Web/API/Channel_Messaging_API) (see {{domxref("MessagePort.postMessage()")}} and MessagePort's {{domxref("MessagePort.message_event", "message")}} event).
+- Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, Worker's {{domxref("Worker.message_event", "message")}} event, ServiceWorkerGlobalScope's {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event, etc.)
+- [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and BroadcastChannel's {{domxref("BroadcastChannel.message_event", "message")}} event).
+- WebRTC data channels (see RTCDataChannel's {{domxref("RTCDataChannel.message_event", "message")}} event).
 
 The action triggered by this event is defined in a function set as the event handler for the relevant `message` event (e.g. using an `onmessage` handler as listed above).
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -19,7 +19,8 @@ This is used to represent messages in:
 - [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and the {{domxref("BroadcastChannel.message_event", "message")}} event of {{domxref("BroadcastChannel")}}).
 - WebRTC data channels (see the {{domxref("RTCDataChannel.message_event", "message")}} event of {{domxref("RTCDataChannel")}}).
 
-The action triggered by this event is defined in a function set as the event handler for the relevant `message` event (e.g. using an `onmessage` handler as listed above).
+The action triggered by this event is defined in a function set as the event handler for the relevant `message` event.
+
 {{InheritanceDiagram}}
 
 ## Constructor

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -16,7 +16,7 @@ This is used to represent messages in:
 - Cross-document messaging (see {{domxref("Window.postMessage()")}} and the {{domxref("Window.message_event", "message")}} event of {{domxref("Window")}}).
 - [Channel messaging](/en-US/docs/Web/API/Channel_Messaging_API) (see {{domxref("MessagePort.postMessage()")}} and the {{domxref("MessagePort.message_event", "message")}} event of {{domxref("MessagePort")}}).
 - Cross-worker/document messaging (see the above two entries, but also {{domxref("Worker.postMessage()")}}, the {{domxref("Worker.message_event", "message")}} event of {{domxref("Worker")}}, the {{domxref("ServiceWorkerGlobalScope.message_event", "message")}} event of {{domxref("ServiceWorkerGlobalScope")}}, etc.)
-- [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}}) and the {{domxref("BroadcastChannel.message_event", "message")}} event of {{domxref("BroadcastChannel")}}).
+- [Broadcast channels](/en-US/docs/Web/API/Broadcast_Channel_API) (see {{domxref("BroadcastChannel.postMessage()")}} and the {{domxref("BroadcastChannel.message_event", "message")}} event of {{domxref("BroadcastChannel")}}).
 - WebRTC data channels (see the {{domxref("RTCDataChannel.message_event", "message")}} event of {{domxref("RTCDataChannel")}}).
 
 The action triggered by this event is defined in a function set as the event handler for the relevant `message` event.


### PR DESCRIPTION
Since the relevant interfaces have no property named e.g. `message_event`, the current references can be misleading.

I have reformatted them along the lines of:
> [InterfaceName]'s `message` event

There may be an existing convention for formatting these references that I'm not aware of. If so, please feel free to edit as you see fit.