### PR TITLE
clarify ambiguity on when the TDZ ends

### DIFF
--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -64,7 +64,7 @@ The list that follows the `let` keyword is called a _{{Glossary("binding")}} lis
 
 ### Temporal dead zone (TDZ)
 
-A variable declared with `let`, `const`, or `class` is said to be in a "temporal dead zone" (TDZ) from the start of the block until code execution reaches the place where the variable is declared and initialized.
+A variable declared with `let`, `const`, or `class` is said to be in a "temporal dead zone" (TDZ) from the start of the block until code execution reaches the place where the variable has been declared and initialized (either explicitly or implicitly).
 
 While inside the TDZ, the variable has not been initialized with a value, and any attempt to access it will result in a {{jsxref("ReferenceError")}}. The variable is initialized with a value when execution reaches the place in the code where it was declared. If no initial value was specified with the variable declaration, it will be initialized with a value of `undefined`.
 


### PR DESCRIPTION
*2 main changes*

1. swapping out "is" with "has been": more accurately reflects that declaration and initialization can happen at different times or as separate steps. It removes the implication that these always occur simultaneously.

2. clarifying Initialization by adding "(either explicitly or implicitly)": there is currently some ambiguity without this clarification, especially for newer developers who will take initialization to be explicit intialization (and not consider the implicit initialization).

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Clearly stating that initialization can be either explicit (when a value is assigned at declaration) or implicit (when no value is assigned and it defaults to undefined for let) would be a great help for less experienced devs like myself who had misunderstood it, and was wondering how come the TDZ is no longer there after declaration and before the "coded out" initialization (aka explicit initialization).

### Motivation

Its good to be extra clear because TDZ is a common "hard" topic and is common for devs to end up at this header without other surrounding context.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
