### PR TITLE
Document the default Button layout

### DIFF
--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -104,7 +104,7 @@ If your buttons are not for submitting form data to a server, be sure to set the
 
 While `<button type="button">` has no default behavior, event handlers can be scripted to trigger behaviors. An activated button can perform programmable actions using [JavaScript](/en-US/docs/Learn/JavaScript), such as removing an item from a list.
 
-By default, user agents style buttons as `display: flow-root`, which establishes a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) and centers the button's children both horizontally and vertically as long as they do not overflow. If the button is defined as a flex or grid container, the children will behave as flex or grid items. A button set to `display: inline` will be styled as if the value were set to `display: inline-block`. 
+By default, user agents style buttons as `display: flow-root`, which establishes a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) and centers the button's children both horizontally and vertically as long as they do not overflow. If the button is defined as a flex or grid container, the children will behave as flex or grid items. A button set to `display: inline` will be styled as if the value were set to `display: inline-block`.
 
 ## Accessibility
 

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -104,13 +104,7 @@ If your buttons are not for submitting form data to a server, be sure to set the
 
 While `<button type="button">` has no default behavior, event handlers can be scripted to trigger behaviors. An activated button can perform programmable actions using [JavaScript](/en-US/docs/Learn/JavaScript), such as removing an item from a list.
 
-### Button layout
-
-The default layout of a button changes depending on the {{cssxref("display") }} value. Most notably when the value is not
-`inline-grid`, `grid`, `inline-flex`, or `flex` then children are centered (horizontally and vertically) as long as they
-do not overflow.
-
-- [Button Rendering HTML Living Standard](https://html.spec.whatwg.org/multipage/rendering.html#button-layout)
+By default, user agents style buttons as `display: flow-root`, which establishes a new [block formatting context](/en-US/docs/Web/CSS/CSS_display/Block_formatting_context) and centers the button's children both horizontally and vertically as long as they do not overflow. If the button is defined as a flex or grid container, the children will behave as flex or grid items. A button set to `display: inline` will be styled as if the value were set to `display: inline-block`. 
 
 ## Accessibility
 

--- a/files/en-us/web/html/element/button/index.md
+++ b/files/en-us/web/html/element/button/index.md
@@ -104,6 +104,14 @@ If your buttons are not for submitting form data to a server, be sure to set the
 
 While `<button type="button">` has no default behavior, event handlers can be scripted to trigger behaviors. An activated button can perform programmable actions using [JavaScript](/en-US/docs/Learn/JavaScript), such as removing an item from a list.
 
+### Button layout
+
+The default layout of a button changes depending on the {{cssxref("display") }} value. Most notably when the value is not
+`inline-grid`, `grid`, `inline-flex`, or `flex` then children are centered (horizontally and vertically) as long as they
+do not overflow.
+
+- [Button Rendering HTML Living Standard](https://html.spec.whatwg.org/multipage/rendering.html#button-layout)
+
 ## Accessibility
 
 ### Icon buttons


### PR DESCRIPTION
### Description

Button has a special rendering documented in the
standard but not in MDN.

This documents some part of it and adds a link
to the entire spec.

### Motivation
Internally we had a discussion about why were the children of <button> being centered  while the children of <div> with the same properties were not. We could not find any mention of this on MDN nor through the usual searches. We ended up reading the Chromium default user agent css where we noticed they were using an internal css property `-internal-align-content-block`.

After that we went straight to the specification and realized that Button has special layout behavior that does not seem to be documented anywhere but in the spec and in [Ladybird](https://github.com/SerenityOS/serenity/pull/20314/files) source code.

Having it mentioned in MDN would have saved us a good hour of research.

### Notes
I'm uncertain on how to add the spec in the Specification section or if it should even be done. I'm also uncertain of how much Button layout behavior should be commented so I just wrote what I saw relevant.