### PR TITLE
Update BCD keys for "display-outside" CSS type

### DIFF
--- a/files/en-us/web/css/display-outside/index.md
+++ b/files/en-us/web/css/display-outside/index.md
@@ -3,8 +3,8 @@ title: <display-outside>
 slug: Web/CSS/display-outside
 page-type: css-type
 browser-compat:
- - css.properties.display.block
- - css.properties.display.inline
+  - css.properties.display.block
+  - css.properties.display.inline
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/display-outside/index.md
+++ b/files/en-us/web/css/display-outside/index.md
@@ -2,7 +2,9 @@
 title: <display-outside>
 slug: Web/CSS/display-outside
 page-type: css-type
-browser-compat: css.properties.display.display-outside
+browser-compat:
+ - css.properties.display.block
+ - css.properties.display.inline
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
This change is to go along with the separation of the BCD feature in https://github.com/mdn/browser-compat-data/pull/23680.