### PR TITLE
Fix note syntax for text-combine-upright CSS property

### DIFF
--- a/files/en-us/web/css/text-combine-upright/index.md
+++ b/files/en-us/web/css/text-combine-upright/index.md
@@ -35,7 +35,7 @@ text-combine-upright: unset;
 - `all`
   - : Attempts to typeset all consecutive characters within the box horizontally, such that they take up the space of a single character within the vertical line of the box.
 
-> ![NOTE]
+> [!NOTE]
 > The [CSS writing modes](/en-US/docs/Web/CSS/CSS_writing_modes) module defines a `digits <integer>` value for the `text-combine-upright` property to display two to four consecutive {{Glossary("ASCII")}} digits (U+0030–U+0039) such that it takes up the space of a single character within the vertical line box, however, this is not supported in any browsers.
 
 ## Formal definition


### PR DESCRIPTION
This fixes a typo in the note syntax on the page for this CSS property.