### PR TITLE
Explain proxy invariants, align lists with spec

### DIFF
--- a/files/en-us/web/javascript/guide/meta_programming/index.md
+++ b/files/en-us/web/javascript/guide/meta_programming/index.md
@@ -52,7 +52,6 @@ The following table summarizes the available traps available to `Proxy` objects.
     <tr>
       <th>Handler / trap</th>
       <th>Interceptions</th>
-      <th>Invariants</th>
     </tr>
   </thead>
   <tbody>
@@ -63,20 +62,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       <td>
         {{jsxref("Object.getPrototypeOf()")}}<br />{{jsxref("Reflect.getPrototypeOf()")}}<br />{{jsxref("Object/proto", "__proto__")}}<br />{{jsxref("Object.prototype.isPrototypeOf()")}}<br />{{jsxref("Operators/instanceof", "instanceof")}}
       </td>
-      <td>
-        <ul>
-          <li>
-            <code>getPrototypeOf</code> method must return an object or
-            <code>null</code>.
-          </li>
-          <li>
-            If <code><var>target</var></code> is not extensible,
-            <code>Object.getPrototypeOf(<var>proxy</var>)</code> method must
-            return the same value as
-            <code>Object.getPrototypeOf(<var>target</var>)</code>.
-          </li>
-        </ul>
-      </td>
     </tr>
     <tr>
       <td>
@@ -84,11 +69,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       </td>
       <td>
         {{jsxref("Object.setPrototypeOf()")}}<br />{{jsxref("Reflect.setPrototypeOf()")}}
-      </td>
-      <td>
-        If <code><var>target</var></code> is not extensible, the
-        <code>prototype</code> parameter must be the same value as
-        <code>Object.getPrototypeOf(<var>target</var>)</code>.
       </td>
     </tr>
     <tr>
@@ -98,10 +78,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       <td>
         {{jsxref("Object.isExtensible()")}}<br />{{jsxref("Reflect.isExtensible()")}}
       </td>
-      <td>
-        <code>Object.isExtensible(<var>proxy</var>)</code> must return the same
-        value as <code>Object.isExtensible(<var>target</var>)</code>.
-      </td>
     </tr>
     <tr>
       <td>
@@ -109,12 +85,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       </td>
       <td>
         {{jsxref("Object.preventExtensions()")}}<br />{{jsxref("Reflect.preventExtensions()")}}
-      </td>
-      <td>
-        <code>Object.preventExtensions(<var>proxy</var>)</code> only returns
-        <code>true</code> if
-        <code>Object.isExtensible(<var>proxy</var>)</code> is
-        <code>false</code>.
       </td>
     </tr>
     <tr>
@@ -124,42 +94,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       <td>
         {{jsxref("Object.getOwnPropertyDescriptor()")}}<br />{{jsxref("Reflect.getOwnPropertyDescriptor()")}}
       </td>
-      <td>
-        <ul>
-          <li>
-            <code>getOwnPropertyDescriptor</code> must return an object or
-            <code>undefined</code>.
-          </li>
-          <li>
-            A property cannot be reported as non-existent if it exists as a
-            non-configurable own property of <code><var>target</var></code
-            >.
-          </li>
-          <li>
-            A property cannot be reported as non-existent if it exists as an own
-            property of <code><var>target</var></code> and
-            <code><var>target</var></code> is not extensible.
-          </li>
-          <li>
-            A property cannot be reported as existent if it does not exists as
-            an own property of <code><var>target</var></code> and
-            <code><var>target</var></code> is not extensible.
-          </li>
-          <li>
-            A property cannot be reported as non-configurable if it does not
-            exist as an own property of <code><var>target</var></code> or if it
-            exists as a configurable own property of
-            <code><var>target</var></code
-            >.
-          </li>
-          <li>
-            The result of
-            <code>Object.getOwnPropertyDescriptor(<var>target</var>)</code> can
-            be applied to <code><var>target</var></code> using
-            <code>Object.defineProperty</code> and will not throw an exception.
-          </li>
-        </ul>
-      </td>
     </tr>
     <tr>
       <td>
@@ -167,37 +101,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       </td>
       <td>
         {{jsxref("Object.defineProperty()")}}<br />{{jsxref("Reflect.defineProperty()")}}
-      </td>
-      <td>
-        <ul>
-          <li>
-            A property cannot be added if <code><var>target</var></code
-            > is not extensible.
-          </li>
-          <li>
-            A property cannot be added as (or modified to be)
-            non-configurable if it does not exist as a non-configurable own
-            property of <code><var>target</var></code
-            >.
-          </li>
-          <li>
-            A property may not be non-configurable if a corresponding
-            configurable property of <code><var>target</var></code> exists.
-          </li>
-          <li>
-            If a property has a corresponding target object property, then
-            <code
-              >Object.defineProperty(<var>target</var>, <var>prop</var>,
-              <var>descriptor</var>)</code
-            >
-            will not throw an exception.
-          </li>
-          <li>
-            In strict mode, a <code>false</code> value returned from the
-            <code>defineProperty</code> handler will throw a
-            {{jsxref("TypeError")}} exception.
-          </li>
-        </ul>
       </td>
     </tr>
     <tr>
@@ -214,20 +117,6 @@ The following table summarizes the available traps available to `Proxy` objects.
             ><br />{{jsxref("Reflect.has()")}}
           </dd>
         </dl>
-      </td>
-      <td>
-        <ul>
-          <li>
-            A property cannot be reported as non-existent, if it exists as a
-            non-configurable own property of <code><var>target</var></code
-            >.
-          </li>
-          <li>
-            A property cannot be reported as non-existent if it exists as an own
-            property of <code><var>target</var></code> and
-            <code><var>target</var></code> is not extensible.
-          </li>
-        </ul>
       </td>
     </tr>
     <tr>
@@ -250,22 +139,6 @@ The following table summarizes the available traps available to `Proxy` objects.
           </dd>
         </dl>
       </td>
-      <td>
-        <ul>
-          <li>
-            The value reported for a property must be the same as the value of
-            the corresponding <code><var>target</var></code> property if
-            <code><var>target</var></code
-            >'s property is a non-writable, non-configurable data property.
-          </li>
-          <li>
-            The value reported for a property must be <code>undefined</code> if
-            the corresponding <code><var>target</var></code> property is
-            non-configurable accessor property that has undefined as its
-            <code>[[Get]]</code> attribute.
-          </li>
-        </ul>
-      </td>
     </tr>
     <tr>
       <td>
@@ -287,27 +160,6 @@ The following table summarizes the available traps available to `Proxy` objects.
             <!-- markdownlint-enable MD011 -->
         </dl>
       </td>
-      <td>
-        <ul>
-          <li>
-            Cannot change the value of a property to be different from the value
-            of the corresponding <code><var>target</var></code> property if the
-            corresponding <code><var>target</var></code> property is a
-            non-writable, non-configurable data property.
-          </li>
-          <li>
-            Cannot set the value of a property if the corresponding
-            <code><var>target</var></code> property is a non-configurable
-            accessor property that has <code>undefined</code> as its
-            <code>[[Set]]</code> attribute.
-          </li>
-          <li>
-            In strict mode, a <code>false</code> return value from the
-            <code>set</code> handler will throw a
-            {{jsxref("TypeError")}} exception.
-          </li>
-        </ul>
-      </td>
     </tr>
     <tr>
       <td>
@@ -323,11 +175,6 @@ The following table summarizes the available traps available to `Proxy` objects.
           </dd>
         </dl>
       </td>
-      <td>
-        A property cannot be deleted if it exists as a non-configurable own
-        property of <code><var>target</var></code
-        >.
-      </td>
     </tr>
     <tr>
       <td>
@@ -335,26 +182,6 @@ The following table summarizes the available traps available to `Proxy` objects.
       </td>
       <td>
         {{jsxref("Object.getOwnPropertyNames()")}}<br />{{jsxref("Object.getOwnPropertySymbols()")}}<br />{{jsxref("Object.keys()")}}<br />{{jsxref("Reflect.ownKeys()")}}
-      </td>
-      <td>
-        <ul>
-          <li>The result of <code>ownKeys</code> is a List.</li>
-          <li>
-            The Type of each result List element is either
-            {{jsxref("String")}} or {{jsxref("Symbol")}}.
-          </li>
-          <li>
-            The result List must contain the keys of all non-configurable own
-            properties of <code><var>target</var></code
-            >.
-          </li>
-          <li>
-            If the <code><var>target</var></code> object is not extensible, then
-            the result List must contain all the keys of the own properties of
-            <code><var>target</var></code
-            > and no other values.
-          </li>
-        </ul>
       </td>
     </tr>
     <tr>
@@ -366,10 +193,6 @@ The following table summarizes the available traps available to `Proxy` objects.
         ><br />{{jsxref("Function.prototype.apply()")}} and
         {{jsxref("Function.prototype.call()")}}<br />{{jsxref("Reflect.apply()")}}
       </td>
-      <td>
-        There are no invariants for the
-        <code><var>handler</var>.apply</code> method.
-      </td>
     </tr>
     <tr>
       <td>
@@ -379,7 +202,6 @@ The following table summarizes the available traps available to `Proxy` objects.
         <code>new proxy(...args)</code
         ><br />{{jsxref("Reflect.construct()")}}
       </td>
-      <td>The result must be an <code>Object</code>.</td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/apply/index.md
@@ -17,7 +17,7 @@ The **`handler.apply()`** method is a trap for the `[[Call]]` [object internal m
 new Proxy(target, {
   apply(target, thisArg, argumentsList) {
   }
-});
+})
 ```
 
 ### Parameters
@@ -29,11 +29,11 @@ The following parameters are passed to the `apply()` method. `this` is bound to 
 - `thisArg`
   - : The `this` argument for the call.
 - `argumentsList`
-  - : The list of arguments for the call.
+  - : An {{jsxref("Array")}} containing the arguments passed to the function.
 
 ### Return value
 
-The `apply()` method can return any value.
+The `apply()` method can return any value, representing the return value of the function call.
 
 ## Description
 
@@ -49,7 +49,7 @@ Or any other operation that invokes the `[[Call]]` [internal method](/en-US/docs
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[Call]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
 - The `target` must be a callable itself. That is, it must be a function object.
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/construct/index.md
@@ -17,7 +17,7 @@ The **`handler.construct()`** method is a trap for the `[[Construct]]` [object i
 new Proxy(target, {
   construct(target, argumentsList, newTarget) {
   }
-});
+})
 ```
 
 ### Parameters
@@ -25,15 +25,15 @@ new Proxy(target, {
 The following parameters are passed to the `construct()` method. `this` is bound to the handler.
 
 - `target`
-  - : The target object.
+  - : The target constructor object.
 - `argumentsList`
-  - : The list of arguments for the constructor.
+  - : An {{jsxref("Array")}} containing the arguments passed to the constructor.
 - `newTarget`
   - : The constructor that was originally called.
 
 ### Return value
 
-The `construct` method must return an object.
+The `construct()` method must return an object, representing the newly created object.
 
 ## Description
 
@@ -48,9 +48,10 @@ Or any other operation that invokes the `[[Construct]]` [internal method](/en-US
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[Construct]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- The result must be an `Object`.
+- The `target` must be a constructor itself.
+- The result must be an {{jsxref("Object")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/defineproperty/index.md
@@ -17,26 +17,25 @@ The **`handler.defineProperty()`** method is a trap for the `[[DefineOwnProperty
 new Proxy(target, {
   defineProperty(target, property, descriptor) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameters are passed to the `defineProperty()` method.
-`this` is bound to the handler.
+The following parameters are passed to the `defineProperty()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 - `property`
-  - : The name or {{jsxref("Symbol")}} of the property whose description is to be
-    retrieved.
+  - : A string or {{jsxref("Symbol")}} representing the property name.
 - `descriptor`
   - : The descriptor for the property being defined or modified.
 
 ### Return value
 
-The `defineProperty()` method must return a {{jsxref("Boolean")}} indicating
-whether or not the property has been successfully defined.
+The `defineProperty()` method must return a {{jsxref("Boolean")}} indicating whether or not the property has been successfully defined. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
+
+Many operations, including {{jsxref("Object.defineProperty()")}} and {{jsxref("Object.defineProperties()")}}, throw a {{jsxref("TypeError")}} if the `[[DefineOwnProperty]]` internal method returns `false`.
 
 ## Description
 
@@ -51,18 +50,16 @@ Or any other operation that invokes the `[[DefineOwnProperty]]` [internal method
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[DefineOwnProperty]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- A property cannot be added, if the target object is not extensible.
-- A property cannot be added as or modified to be non-configurable, if it does not
-  exists as a non-configurable own property of the target object.
-- A property may not be non-configurable, if a corresponding configurable property of
-  the target object exists.
-- If a property has a corresponding target object property then
-  `Object.defineProperty(target, prop, descriptor)`
-  will not throw an exception.
-- In strict mode, a `false` return value from the
-  `defineProperty()` handler will throw a {{jsxref("TypeError")}} exception.
+- A property cannot be added, if the target object is not extensible. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` on `target`, and {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `undefined` for the property on `target`, then the trap must return a falsy value.
+- A property cannot be non-configurable, unless there exists a corresponding non-configurable own property of the target object. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `undefined` or `configurable: true` for the property on `target`, and `descriptor.configurable` is `false`, then the trap must return a falsy value.
+- A non-configurable property cannot be non-writable, unless there exists a corresponding non-configurable, non-writable own property of the target object. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false, writable: true` for the property on `target`, and `descriptor.writable` is `false`, then the trap must return a falsy value.
+- If a property has a corresponding property on the target object, then the target object property's descriptor must be compatible with `descriptor`. That is, pretending `target` is an ordinary object, and {{jsxref("Object/defineProperty", "Object.defineProperty(target, property, descriptor)")}} would throw an error, then the trap must return a falsy value. The `Object.defineProperty()` reference contains more information, but to summarize, when the target property is non-configurable, the following must hold:
+  - `configurable`, `enumerable`, `get`, and `set` cannot be changed
+  - the property cannot be switched between data and accessor
+  - the `writable` attribute can only be changed from `true` to `false`
+  - the `value` attribute can only be changed if `writable` is `true`
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/deleteproperty/index.md
@@ -17,23 +17,23 @@ The **`handler.deleteProperty()`** method is a trap for the `[[Delete]]` [object
 new Proxy(target, {
   deleteProperty(target, property) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameters are passed to the `deleteProperty()` method.
-`this` is bound to the handler.
+The following parameters are passed to the `deleteProperty()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 - `property`
-  - : The name or {{jsxref("Symbol")}} of the property to delete.
+  - : A string or {{jsxref("Symbol")}} representing the property name.
 
 ### Return value
 
-The `deleteProperty()` method must return a boolean value indicating
-whether or not the property has been successfully deleted.
+The `deleteProperty()` method must return a {{jsxref("Boolean")}} indicating whether or not the property has been successfully deleted. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
+
+Many operations, including the {{jsxref("Operators/delete", "delete")}} operator when in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), throw a {{jsxref("TypeError")}} if the `[[Delete]]` internal method returns `false`.
 
 ## Description
 
@@ -49,10 +49,10 @@ Or any other operation that invokes the `[[Delete]]` [internal method](/en-US/do
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[Delete]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- A property cannot be deleted, if it exists as a non-configurable own property of the
-  target object.
+- A property cannot be reported as deleted, if it exists as a non-configurable own property of the target object. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false` for the property on `target`, then the trap must return a falsy value.
+- A property cannot be reported as deleted, if it exists as an own property of the target object and the target object is non-extensible. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` on `target`, and {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns a property descriptor for the property on `target`, then the trap must return a falsy value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/get/index.md
@@ -17,24 +17,23 @@ The **`handler.get()`** method is a trap for the `[[Get]]` [object internal meth
 new Proxy(target, {
   get(target, property, receiver) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameters are passed to the `get()` method. `this`
-is bound to the handler.
+The following parameters are passed to the `get()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 - `property`
-  - : The name or {{jsxref("Symbol")}} of the property to get.
+  - : A string or {{jsxref("Symbol")}} representing the property name.
 - `receiver`
-  - : Either the proxy or an object that inherits from the proxy.
+  - : The `this` value for getters; see {{jsxref("Reflect.get()")}}. This is usually either the proxy itself or an object that inherits from the proxy.
 
 ### Return value
 
-The `get()` method can return any value.
+The `get()` method can return any value, representing the property value.
 
 ## Description
 
@@ -49,14 +48,10 @@ Or any other operation that invokes the `[[Get]]` [internal method](/en-US/docs/
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[Get]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- The value reported for a property must be the same as the value of the corresponding
-  target object property if the target object property is a non-writable,
-  non-configurable own data property.
-- The value reported for a property must be undefined if the corresponding target
-  object property is a non-configurable own accessor property that has
-  `undefined` as its `[[Get]]` attribute.
+- The value reported for a property must be the same as the value of the corresponding target object property, if the target object property is a non-writable, non-configurable own data property. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false, writable: false` for the property on `target`, then the trap must return the same value as the `value` attribute in the `target`'s property descriptor.
+- The value reported for a property must be `undefined`, if the corresponding target object property is a non-configurable own accessor property that has an undefined getter. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false, get: undefined` for the property on `target`, then the trap must return `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getownpropertydescriptor/index.md
@@ -15,9 +15,9 @@ The **`handler.getOwnPropertyDescriptor()`** method is a trap for the `[[GetOwnP
 
 ```js-nolint
 new Proxy(target, {
-  getOwnPropertyDescriptor(target, prop) {
+  getOwnPropertyDescriptor(target, property) {
   }
-});
+})
 ```
 
 ### Parameters
@@ -26,12 +26,12 @@ The following parameters are passed to the `getOwnPropertyDescriptor()` method. 
 
 - `target`
   - : The target object.
-- `prop`
-  - : The name of the property whose description should be retrieved.
+- `property`
+  - : A string or {{jsxref("Symbol")}} representing the property name.
 
 ### Return value
 
-The `getOwnPropertyDescriptor()` method must return an object or `undefined`.
+The `getOwnPropertyDescriptor()` method must return an object or `undefined`, representing the property descriptor. Missing attributes are normalized in the same way as {{jsxref("Object.defineProperty()")}}.
 
 ## Description
 
@@ -46,14 +46,18 @@ Or any other operation that invokes the `[[GetOwnProperty]]` [internal method](/
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[GetOwnProperty]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- `getOwnPropertyDescriptor()` must return an object or `undefined`.
-- A property cannot be reported as non-existent, if it exists as a non-configurable own property of the target object.
-- A property cannot be reported as non-existent, if it exists as an own property of the target object and the target object is not extensible.
-- A property cannot be reported as existent, if it does not exists as an own property of the target object and the target object is not extensible.
-- A property cannot be reported as non-configurable, if it does not exists as an own property of the target object or if it exists as a configurable own property of the target object.
-- The result of `Object.getOwnPropertyDescriptor(target)` can be applied to the target object using `Object.defineProperty()` and will not throw an exception.
+- The result must be either an {{jsxref("Object")}} or `undefined`.
+- A property cannot be reported as non-existent, if it exists as a non-configurable own property of the target object. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false` for the property on `target`, then the trap must not return `undefined`.
+- A property cannot be reported as non-existent, if it exists as an own property of a non-extensible target object. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` for the target object, then the trap must not return `undefined`.
+- A property cannot be reported as existent, if it does not exist as an own property of the target object and the target object is not extensible. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` for the target object, and {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `undefined` for the property on `target`, then the trap must return `undefined`.
+- A property cannot be reported as non-configurable, unless it exists as a non-configurable own property of the target object. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `undefined` or `configurable: true` for the property on `target`, then the trap must not return `configurable: false`.
+- A property cannot be reported as both non-configurable and non-writable, unless it exists as a non-configurable, non-writable own property of the target object. That is, in addition to the previous invariant, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false, writable: true` for the property on `target`, then the trap must not return `configurable: false, writable: false`.
+- If a property has a corresponding property on the target object, then the target object property's descriptor must be compatible with `descriptor`. That is, pretending `target` is an ordinary object, then {{jsxref("Object/defineProperty", "Object.defineProperty(target, property, resultObject)")}} must not throw an error. The `Object.defineProperty()` reference contains more information, but to summarize, when the target property is non-configurable, the following must hold:
+  - `configurable`, `enumerable`, `get`, and `set` must be the same as original. `writable` must also be the original by virtue of the previous invariant.
+  - the property must stay as data or accessor
+  - the `value` attribute can only be changed if `writable` is `true`
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/getprototypeof/index.md
@@ -14,24 +14,22 @@ The **`handler.getPrototypeOf()`** method is a trap for the `[[GetPrototypeOf]]`
 ## Syntax
 
 ```js-nolint
-new Proxy(obj, {
+new Proxy(target, {
   getPrototypeOf(target) {
-    // …
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameter is passed to the `getPrototypeOf()` method.
-`this` is bound to the handler.
+The following parameter is passed to the `getPrototypeOf()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 
 ### Return value
 
-The `getPrototypeOf()` method must return an object or `null`.
+The `getPrototypeOf()` method must return an object or `null`, representing the prototype of the target object.
 
 ## Description
 
@@ -49,12 +47,10 @@ Or any other operation that invokes the `[[GetPrototypeOf]]` [internal method](/
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[GetPrototypeOf]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- `getPrototypeOf()` method must return an object or `null`.
-- If `target` is not extensible,
-  `Object.getPrototypeOf(proxy)` method must return the same
-  value as `Object.getPrototypeOf(target)`.
+- The result must be either an {{jsxref("Object")}} or `null`.
+- If the target object is not extensible (that is, {{jsxref("Reflect.isExtensible()")}} returns `false` on `target`), the result must be the same as the result of `Reflect.getPrototypeOf(target)`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/has/index.md
@@ -15,24 +15,23 @@ The **`handler.has()`** method is a trap for the `[[HasProperty]]` [object inter
 
 ```js-nolint
 new Proxy(target, {
-  has(target, prop) {
+  has(target, property) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameters are passed to `has()` method. `this` is
-bound to the handler.
+The following parameters are passed to `has()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
-- `prop`
-  - : The name or {{jsxref("Symbol")}} of the property to check for existence.
+- `property`
+  - : A string or {{jsxref("Symbol")}} representing the property name.
 
 ### Return value
 
-The `has()` method must return a boolean value.
+The `has()` method must return a {{jsxref("Boolean")}} indicating whether or not the property exists. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
 
 ## Description
 
@@ -48,12 +47,10 @@ Or any other operation that invokes the `[[HasProperty]]` [internal method](/en-
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[HasProperty]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- A property cannot be reported as non-existent, if it exists as a non-configurable
-  own property of the target object.
-- A property cannot be reported as non-existent, if it exists as an own property of
-  the target object and the target object is not extensible.
+- A property cannot be reported as non-existent, if it exists as a non-configurable own property of the target object. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false` for the property on `target`, the trap must return `true`.
+- A property cannot be reported as non-existent, if it exists as an own property of the target object and the target object is not extensible. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` on `target`, and {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns a property descriptor for the property on `target`, the trap must return `true`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/isextensible/index.md
@@ -17,20 +17,19 @@ The **`handler.isExtensible()`** method is a trap for the `[[IsExtensible]]` [ob
 new Proxy(target, {
   isExtensible(target) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameter is passed to the `isExtensible()` method.
-`this` is bound to the handler.
+The following parameter is passed to the `isExtensible()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 
 ### Return value
 
-The `isExtensible()` method must return a boolean value.
+The `isExtensible()` method must return a {{jsxref("Boolean")}} indicating whether or not the target object is extensible. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
 
 ## Description
 
@@ -45,10 +44,9 @@ Or any other operation that invokes the `[[IsExtensible]]` [internal method](/en
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[IsExtensible]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- `Object.isExtensible(proxy)` must return the same value as
-  `Object.isExtensible(target)`.
+- The result must be the same as {{jsxref("Reflect.isExtensible()")}} on the target object.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/ownkeys/index.md
@@ -17,20 +17,19 @@ The **`handler.ownKeys()`** method is a trap for the `[[OwnPropertyKeys]]` [obje
 new Proxy(target, {
   ownKeys(target) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameter is passed to the `ownKeys()` method.
-`this` is bound to the handler.
+The following parameter is passed to the `ownKeys()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 
 ### Return value
 
-The `ownKeys()` method must return an enumerable object.
+The `ownKeys()` method must return an [array-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array-like_objects) where each element is either a {{jsxref("String")}} or a {{jsxref("Symbol")}} containing no duplicate items.
 
 ## Description
 
@@ -47,15 +46,13 @@ Or any other operation that invokes the `[[OwnPropertyKeys]]` [internal method](
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[OwnPropertyKeys]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- The result of `ownKeys()` must be an array.
-- The type of each array element is either a {{jsxref("String")}} or a
-  {{jsxref("Symbol")}}.
-- The result List must contain the keys of all non-configurable own properties of the
-  target object.
-- If the target object is not extensible, then the result List must contain all the
-  keys of the own properties of the target object and no other values.
+- The result is an {{jsxref("Object")}}.
+- The list of keys contains no duplicate values.
+- The type of each key is either a {{jsxref("String")}} or a {{jsxref("Symbol")}}.
+- The result list must contain the keys of all non-configurable own properties of the target object. That is, for all keys returned by {{jsxref("Reflect.ownKeys()")}} on the target object, if the key reports `configurable: false` by {{jsxref("Reflect.getOwnPropertyDescriptor()")}}, then the key must be included in the result List.
+- If the target object is not extensible, then the result list must contain all the keys of the own properties of the target object and no other values. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` on `target`, then the result list must contain the same values as the result of {{jsxref("Reflect.ownKeys()")}} on `target`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/preventextensions/index.md
@@ -17,7 +17,7 @@ The **`handler.preventExtensions()`** method is a trap for the `[[PreventExtensi
 new Proxy(target, {
   preventExtensions(target) {
   }
-});
+})
 ```
 
 ### Parameters
@@ -29,7 +29,9 @@ The following parameter is passed to the `preventExtensions()` method. `this` is
 
 ### Return value
 
-The `preventExtensions()` method must return a boolean value.
+The `preventExtensions()` method must return a {{jsxref("Boolean")}} indicating whether or not the operation was successful. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
+
+Many operations, including {{jsxref("Object.preventExtensions()")}}, throw a {{jsxref("TypeError")}} if the `[[PreventExtensions]]` internal method returns `false`.
 
 ## Description
 
@@ -46,9 +48,9 @@ Or any other operation that invokes the `[[PreventExtensions]]` [internal method
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[PreventExtensions]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- `Object.preventExtensions(proxy)` only returns `true` if `Object.isExtensible(proxy)` is `false`.
+- The result is only `true` if {{jsxref("Reflect.isExtensible()")}} on the target object returns `false` after calling `handler.preventExtensions()`.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/set/index.md
@@ -17,39 +17,27 @@ The **`handler.set()`** method is a trap for the `[[Set]]` [object internal meth
 new Proxy(target, {
   set(target, property, value, receiver) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameters are passed to the `set()` method. `this`
-is bound to the handler.
+The following parameters are passed to the `set()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
 - `property`
-  - : The name or {{jsxref("Symbol")}} of the property to set.
+  - : A string or {{jsxref("Symbol")}} representing the property name.
 - `value`
   - : The new value of the property to set.
 - `receiver`
-
-  - : The object to which the assignment was originally directed. This is usually the
-    proxy itself. But a `set()` handler can also be called indirectly, via
-    the prototype chain or various other ways.
-
-    For example, suppose a script does
-    `obj.name = "jen"`, and `obj` is not a
-    proxy, and has no own property `.name`, but it has a proxy on its
-    prototype chain. That proxy's `set()` handler will be called, and
-    `obj` will be passed as the receiver.
+  - : The `this` value for setters; see {{jsxref("Reflect.set()")}}. This is usually either the proxy itself or an object that inherits from the proxy.
 
 ### Return value
 
-The `set()` method should return a boolean value.
+The `set()` method must return a {{jsxref("Boolean")}} indicating whether or not the assignment succeeded. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
 
-- Return `true` to indicate that assignment succeeded.
-- If the `set()` method returns `false`, and the assignment
-  happened in strict-mode code, a {{jsxref("TypeError")}} will be thrown.
+Many operations, including using property accessors in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), throw a {{jsxref("TypeError")}} if the `[[Set]]` internal method returns `false`.
 
 ## Description
 
@@ -64,16 +52,10 @@ Or any other operation that invokes the `[[Set]]` [internal method](/en-US/docs/
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[Set]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- Cannot change the value of a property to be different from the value of the
-  corresponding target object property if the corresponding target object property is a
-  non-writable, non-configurable data property.
-- Cannot set the value of a property if the corresponding target object property is a
-  non-configurable accessor property that has `undefined` as its
-  `[[Set]]` attribute.
-- In strict mode, a `false` return value from the `set()`
-  handler will throw a {{jsxref("TypeError")}} exception.
+- Cannot change the value of a property to be different from the value of the corresponding target object property, if the corresponding target object property is a non-writable, non-configurable own data property. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false, writable: false` for the property on `target`, and `value` is different from the `value` attribute in the `target`'s property descriptor, then the trap must return a falsy value.
+- Cannot set the value of a property if the corresponding target object property is a non-configurable own accessor property that has an undefined setter. That is, if {{jsxref("Reflect.getOwnPropertyDescriptor()")}} returns `configurable: false, set: undefined` for the property on `target`, then the trap must return a falsy value.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/proxy/setprototypeof/index.md
@@ -17,13 +17,12 @@ The **`handler.setPrototypeOf()`** method is a trap for the `[[SetPrototypeOf]]`
 new Proxy(target, {
   setPrototypeOf(target, prototype) {
   }
-});
+})
 ```
 
 ### Parameters
 
-The following parameters are passed to the `setPrototypeOf()` method.
-`this` is bound to the handler.
+The following parameters are passed to the `setPrototypeOf()` method. `this` is bound to the handler.
 
 - `target`
   - : The target object.
@@ -32,8 +31,9 @@ The following parameters are passed to the `setPrototypeOf()` method.
 
 ### Return value
 
-The `setPrototypeOf()` method returns `true` if the
-`[[Prototype]]` was successfully changed, otherwise `false`.
+The `setPrototypeOf()` method must return a {{jsxref("Boolean")}} indicating whether or not the prototype was successfully changed. Other values are [coerced to booleans](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#boolean_coercion).
+
+Many operations, including {{jsxref("Object.setPrototypeOf()")}}, throw a {{jsxref("TypeError")}} if the `[[SetPrototypeOf]]` internal method returns `false`.
 
 ## Description
 
@@ -48,11 +48,9 @@ Or any other operation that invokes the `[[SetPrototypeOf]]` [internal method](/
 
 ### Invariants
 
-If the following invariants are violated, the trap throws a {{jsxref("TypeError")}} when invoked.
+The proxy's `[[SetPrototypeOf]]` internal method throws a {{jsxref("TypeError")}} if the handler definition violates one of the following invariants:
 
-- If `target` is not extensible, the `prototype`
-  parameter must be the same value as
-  `Object.getPrototypeOf(target)`.
+- If the target object is not extensible, the prototype cannot be changed. That is, if {{jsxref("Reflect.isExtensible()")}} returns `false` on `target`, and `prototype` is not the same as the result of `Reflect.getPrototypeOf(target)`, then the trap must return a falsy value.
 
 ## Examples
 


### PR DESCRIPTION
As part of https://github.com/mdn/content/issues/38439, I'm going through the proxy invariants' error conditions. I noticed that some conditions are wrongly regarded as invariants while others are unlisted. The existing ones are also a bit harder to interpret, so I added a lot more explanations.