### PR TITLE
Fix Media events `ended` missing info

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.md
@@ -14,6 +14,8 @@ This event occurs based upon {{domxref("HTMLMediaElement")}} ({{HTMLElement("aud
 
 This event is not cancelable and does not bubble.
 
+> **Note:** The `ended` event will not be fired if the `loop` attribute is set to true on the HTMLMediaElement.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.md
@@ -14,7 +14,7 @@ This event occurs based upon {{domxref("HTMLMediaElement")}} ({{HTMLElement("aud
 
 This event is not cancelable and does not bubble.
 
-> **Note:** The `ended` event will not be fired if the `loop` attribute is set to true on the HTMLMediaElement.
+> **Note:** The `ended` event doesn't fire if the [`loop`](/en-US/docs/Web/API/HTMLMediaElement/loop) property is `true` and [`playbackRate`](/en-US/docs/Web/API/HTMLMediaElement/playbackRate) is non-negative.
 
 ## Syntax
 


### PR DESCRIPTION
### Description
Fixes #33398 
Added a note on `ended` event not firing when `loop` attribute is provided.
