### PR TITLE
Remove compat table for HTTP TRACE method

### DIFF
--- a/files/en-us/web/http/methods/trace/index.md
+++ b/files/en-us/web/http/methods/trace/index.md
@@ -2,7 +2,7 @@
 title: TRACE
 slug: Web/HTTP/Methods/TRACE
 page-type: http-method
-browser-compat: http.methods.TRACE
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#TRACE
 ---
 
 {{HTTPSidebar}}
@@ -51,10 +51,6 @@ TRACE /index.html
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/23748. There isn't really a compat story for browsers here. 
Proposing to remove the table. 

See also PATCH were this is also done like this: http://localhost:3000/en-US/docs/Web/HTTP/Methods/PATCH