### PR TITLE
Remove compat table for HTTP Expect header

### DIFF
--- a/files/en-us/web/http/headers/expect/index.md
+++ b/files/en-us/web/http/headers/expect/index.md
@@ -2,7 +2,7 @@
 title: Expect
 slug: Web/HTTP/Headers/Expect
 page-type: http-header
-browser-compat: http.headers.Expect
+spec-urls: https://www.rfc-editor.org/rfc/rfc9110#field.expect
 ---
 
 {{HTTPSidebar}}
@@ -74,10 +74,6 @@ The server sends {{HTTPStatus("100")}} (Continue), which instructs the client to
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect

> The Expect HTTP request header indicates expectations that need to be met by the **server** to handle the request successfully.

I don't think there is anything for browsers to do here. https://github.com/mdn/browser-compat-data/pull/23755 removes the compat data.