### PR TITLE
Remove compat table from deprecated Tk HTTP header

### DIFF
--- a/files/en-us/web/http/headers/tk/index.md
+++ b/files/en-us/web/http/headers/tk/index.md
@@ -5,7 +5,6 @@ page-type: http-header
 status:
   - deprecated
   - non-standard
-browser-compat: http.headers.Tk
 ---
 
 {{HTTPSidebar}}{{Deprecated_header}}{{non-standard_header}}
@@ -83,10 +82,6 @@ Tk: N
 ## Specifications
 
 Part of the discontinued [Tracking Preference Expression (DNT)](https://www.w3.org/TR/tracking-dnt/#response-header-field) specification.
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/23758 for motivation and compat data removal.