### PR TITLE
Replaced references to 'string objects' with 'strings'

### DIFF
--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
@@ -29,13 +29,13 @@ Now that we've looked at the very basics of strings, let's move up a gear and st
 
 ## Strings as objects
 
-Most things are objects in JavaScript. When you create a string, for example by using
+Most values can be used as if they are objects in JavaScript. When you create a string, for example by using
 
 ```js
 const string = "This is my string";
 ```
 
-your variable becomes a string object instance, and as a result has a large number of properties and methods available to it. You can see this if you go to the {{jsxref("String")}} object page and look down the list on the side of the page!
+although the variable itself isn't an object, it still has a large number of properties and methods available to it, by virtue of being usable as an object when accessing properties. You can see this if you go to the {{jsxref("String")}} object page and look down the list on the side of the page!
 
 **Now, before your brain starts melting, don't worry!** You really don't need to know about most of these early on in your learning journey. But there are a few that you'll potentially use quite often that we'll look at here.
 

--- a/files/en-us/web/api/characterdata/after/index.md
+++ b/files/en-us/web/api/characterdata/after/index.md
@@ -23,7 +23,7 @@ after(...nodes)
 ### Parameters
 
 - `nodes`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Exceptions
 

--- a/files/en-us/web/api/characterdata/before/index.md
+++ b/files/en-us/web/api/characterdata/before/index.md
@@ -23,7 +23,7 @@ before(...nodes)
 ### Parameters
 
 - `nodes`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Exceptions
 

--- a/files/en-us/web/api/csscounterstylerule/index.md
+++ b/files/en-us/web/api/csscounterstylerule/index.md
@@ -16,27 +16,27 @@ The **`CSSCounterStyleRule`** interface represents an {{CSSxRef("@counter-style"
 _This interface also inherits properties from its parent {{DOMxRef("CSSRule")}}._
 
 - {{DOMxRef("CSSCounterStyleRule.name")}}
-  - : A string object that contains the serialization of the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the `name` for the associated rule.
+  - : A string that contains the serialization of the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the `name` for the associated rule.
 - {{DOMxRef("CSSCounterStyleRule.system")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/system", "system")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/system", "system")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.symbols")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/symbols", "symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/symbols", "symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.additiveSymbols")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/additive-symbols", "additive-symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/additive-symbols", "additive-symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.negative")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/negative", "negative")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/negative", "negative")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.prefix")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/prefix", "prefix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/prefix", "prefix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.suffix")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/suffix", "suffix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/suffix", "suffix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.range")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/range", "range")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/range", "range")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.pad")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/pad", "pad")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/pad", "pad")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.speakAs")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/speak-as", "speak-as")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/speak-as", "speak-as")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.fallback")}}
-  - : A string object that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : A string that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 
 ## Instance methods
 

--- a/files/en-us/web/api/document/append/index.md
+++ b/files/en-us/web/api/document/append/index.md
@@ -26,7 +26,7 @@ append(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/document/append/index.md
+++ b/files/en-us/web/api/document/append/index.md
@@ -9,8 +9,8 @@ browser-compat: api.Document.append
 {{APIRef("DOM")}}
 
 The **`Document.append()`** method
-inserts a set of {{domxref("Node")}} objects or string objects after
-the last child of the document. String objects
+inserts a set of {{domxref("Node")}} objects or strings after
+the last child of the document. Strings
 are inserted as equivalent {{domxref("Text")}} nodes.
 
 This method appends a child to a `Document`. To append to an arbitrary element in the tree, see {{domxref("Element.append()")}}.
@@ -26,7 +26,7 @@ append(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -173,7 +173,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.adoptNode()")}}
   - : Adopt node from an external document.
 - {{DOMxRef("Document.append()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or string objects after the last child of the document.
+  - : Inserts a set of {{domxref("Node")}} objects or strings after the last child of the document.
 - {{DOMxRef("Document.browsingTopics()")}} {{Experimental_Inline}} {{non-standard_inline}}
   - : Returns a promise that fulfills with an array of objects representing the top topics for the user, one from each of the last three epochs. By default, the method also causes the browser to record the current page visit as observed by the caller, so the page's hostname can later be used in topics calculation. See the [Topics API](/en-US/docs/Web/API/Topics_API) for more details.
 - {{DOMxRef("Document.captureEvents()")}} {{Deprecated_Inline}}
@@ -247,7 +247,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.mozSetImageElement()")}} {{Non-standard_Inline}}
   - : Allows you to change the element being used as the background image for a specified element ID.
 - {{DOMxRef("Document.prepend()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or string objects before the first child of the document.
+  - : Inserts a set of {{domxref("Node")}} objects or strings before the first child of the document.
 - {{DOMxRef("Document.querySelector()")}}
   - : Returns the first Element node within the document, in document order, that matches the specified selectors.
 - {{DOMxRef("Document.querySelectorAll()")}}

--- a/files/en-us/web/api/document/prepend/index.md
+++ b/files/en-us/web/api/document/prepend/index.md
@@ -26,7 +26,7 @@ prepend(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/document/prepend/index.md
+++ b/files/en-us/web/api/document/prepend/index.md
@@ -9,8 +9,8 @@ browser-compat: api.Document.prepend
 {{APIRef("DOM")}}
 
 The **`Document.prepend()`** method
-inserts a set of {{domxref("Node")}} objects or string objects before
-the first child of the document. String objects
+inserts a set of {{domxref("Node")}} objects or strings before
+the first child of the document. Strings
 are inserted as equivalent {{domxref("Text")}} nodes.
 
 This method prepends a child to a `Document`. To prepend to an arbitrary element in the tree, see {{domxref("Element.prepend()")}}.
@@ -26,7 +26,7 @@ prepend(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/document/replacechildren/index.md
+++ b/files/en-us/web/api/document/replacechildren/index.md
@@ -22,7 +22,7 @@ replaceChildren(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to replace the
+  - : A set of {{domxref("Node")}} objects or strings to replace the
     `Document`'s existing children with. If no replacement objects are
     specified, then the `Document` is emptied of all child nodes.
 

--- a/files/en-us/web/api/document/replacechildren/index.md
+++ b/files/en-us/web/api/document/replacechildren/index.md
@@ -22,7 +22,7 @@ replaceChildren(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to replace the
+  - : A set of {{domxref("Node")}} or strings to replace the
     `Document`'s existing children with. If no replacement objects are
     specified, then the `Document` is emptied of all child nodes.
 

--- a/files/en-us/web/api/documentfragment/append/index.md
+++ b/files/en-us/web/api/documentfragment/append/index.md
@@ -26,7 +26,7 @@ append(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/documentfragment/append/index.md
+++ b/files/en-us/web/api/documentfragment/append/index.md
@@ -9,8 +9,8 @@ browser-compat: api.DocumentFragment.append
 {{APIRef("DOM")}}
 
 The **`DocumentFragment.append()`** method
-inserts a set of {{domxref("Node")}} objects or string objects after
-the last child of the document fragment. String objects
+inserts a set of {{domxref("Node")}} objects or strings after
+the last child of the document fragment. Strings
 are inserted as equivalent {{domxref("Text")}} nodes.
 
 This method appends a child to a `DocumentFragment`. To append to an arbitrary element in the tree, see {{domxref("Element.append()")}}.
@@ -26,7 +26,7 @@ append(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/index.md
@@ -36,9 +36,9 @@ _This interface has no specific properties, but inherits those of its parent, {{
 _This interface inherits the methods of its parent, {{domxref("Node")}}._
 
 - {{DOMxRef("DocumentFragment.append()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or string objects after the last child of the document fragment.
+  - : Inserts a set of {{domxref("Node")}} objects or strings after the last child of the document fragment.
 - {{DOMxRef("DocumentFragment.prepend()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or string objects before the first child of the document fragment.
+  - : Inserts a set of {{domxref("Node")}} objects or strings before the first child of the document fragment.
 - {{domxref("DocumentFragment.querySelector()")}}
   - : Returns the first {{domxref("Element")}} node within the `DocumentFragment`, in document order, that matches the specified selectors.
 - {{domxref("DocumentFragment.querySelectorAll()")}}

--- a/files/en-us/web/api/documentfragment/prepend/index.md
+++ b/files/en-us/web/api/documentfragment/prepend/index.md
@@ -26,7 +26,7 @@ prepend(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/documentfragment/prepend/index.md
+++ b/files/en-us/web/api/documentfragment/prepend/index.md
@@ -9,8 +9,8 @@ browser-compat: api.DocumentFragment.prepend
 {{APIRef("DOM")}}
 
 The **`DocumentFragment.prepend()`** method
-inserts a set of {{domxref("Node")}} objects or string objects before
-the first child of the document fragment. String objects
+inserts a set of {{domxref("Node")}} objects or strings before
+the first child of the document fragment. Strings
 are inserted as equivalent {{domxref("Text")}} nodes.
 
 This method prepends a child to a `DocumentFragment`. To prepend to an arbitrary element in the tree, see {{domxref("Element.prepend()")}}.
@@ -26,7 +26,7 @@ prepend(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/documentfragment/replacechildren/index.md
+++ b/files/en-us/web/api/documentfragment/replacechildren/index.md
@@ -23,7 +23,7 @@ replaceChildren(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to replace the
+  - : A set of {{domxref("Node")}} or strings to replace the
     `DocumentFragment`'s existing children with. If no replacement objects are
     specified, then the `DocumentFragment` is emptied of all child nodes.
 

--- a/files/en-us/web/api/documentfragment/replacechildren/index.md
+++ b/files/en-us/web/api/documentfragment/replacechildren/index.md
@@ -23,7 +23,7 @@ replaceChildren(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to replace the
+  - : A set of {{domxref("Node")}} objects or strings to replace the
     `DocumentFragment`'s existing children with. If no replacement objects are
     specified, then the `DocumentFragment` is emptied of all child nodes.
 

--- a/files/en-us/web/api/documenttype/index.md
+++ b/files/en-us/web/api/documenttype/index.md
@@ -27,10 +27,10 @@ _Inherits properties from its parent, {{domxref("Node")}}._
 _Inherits methods from its parent, {{domxref("Node")}}._
 
 - {{domxref("DocumentType.after()")}}
-  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the
+  - : Inserts a set of {{domxref("Node")}} or strings in the children list of the
     object's parent, just after this node.
 - {{domxref("DocumentType.before()")}}
-  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the
+  - : Inserts a set of {{domxref("Node")}} or strings in the children list of the
     object's parent, just before this node.
 - {{domxref("DocumentType.remove()")}}
   - : Removes this object from its parent children list.

--- a/files/en-us/web/api/documenttype/index.md
+++ b/files/en-us/web/api/documenttype/index.md
@@ -27,10 +27,10 @@ _Inherits properties from its parent, {{domxref("Node")}}._
 _Inherits methods from its parent, {{domxref("Node")}}._
 
 - {{domxref("DocumentType.after()")}}
-  - : Inserts a set of {{domxref("Node")}} or strings in the children list of the
+  - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the
     object's parent, just after this node.
 - {{domxref("DocumentType.before()")}}
-  - : Inserts a set of {{domxref("Node")}} or strings in the children list of the
+  - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the
     object's parent, just before this node.
 - {{domxref("DocumentType.remove()")}}
   - : Removes this object from its parent children list.

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -75,7 +75,7 @@ _This interface doesn't inherit any methods. None of the following methods alter
   - : Returns a JSON representation of the `DOMMatrixReadOnly` object.
 - {{domxref("DOMMatrixReadOnly.toString()")}}
 
-  - : Creates and returns a string object which contains a string representation of the matrix in CSS matrix syntax, using the appropriate CSS matrix notation. See the {{cssxref("transform-function/matrix", "matrix()")}} CSS function for details on this syntax.
+  - : Creates and returns a string which contains a string representation of the matrix in CSS matrix syntax, using the appropriate CSS matrix notation. See the {{cssxref("transform-function/matrix", "matrix()")}} CSS function for details on this syntax.
 
     For a 2D matrix, the elements `a` through `f` are listed, for a total of six values and the form `matrix(a, b, c, d, e, f)`.
 

--- a/files/en-us/web/api/element/after/index.md
+++ b/files/en-us/web/api/element/after/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Element.after
 {{APIRef("DOM")}}
 
 The **`Element.after()`** method inserts a set of
-{{domxref("Node")}} or strings in the children list of the
+{{domxref("Node")}} objects or strings in the children list of the
 `Element`'s parent, just after the `Element`.
 Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
@@ -24,7 +24,7 @@ after(node1, node2, /* …, */ nodeN)
 ### Parameters
 
 - `node1`, …, `nodeN`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/element/after/index.md
+++ b/files/en-us/web/api/element/after/index.md
@@ -9,9 +9,9 @@ browser-compat: api.Element.after
 {{APIRef("DOM")}}
 
 The **`Element.after()`** method inserts a set of
-{{domxref("Node")}} or string objects in the children list of the
+{{domxref("Node")}} or strings in the children list of the
 `Element`'s parent, just after the `Element`.
-String objects are inserted as equivalent {{domxref("Text")}} nodes.
+Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ after(node1, node2, /* …, */ nodeN)
 ### Parameters
 
 - `node1`, …, `nodeN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/element/append/index.md
+++ b/files/en-us/web/api/element/append/index.md
@@ -9,8 +9,8 @@ browser-compat: api.Element.append
 {{APIRef("DOM")}}
 
 The **`Element.append()`** method
-inserts a set of {{domxref("Node")}} objects or string objects after
-the last child of the `Element`. String objects
+inserts a set of {{domxref("Node")}} objects or strings after
+the last child of the `Element`. Strings
 are inserted as equivalent {{domxref("Text")}} nodes.
 
 Differences from {{domxref("Node.appendChild()")}}:
@@ -34,7 +34,7 @@ append(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/element/append/index.md
+++ b/files/en-us/web/api/element/append/index.md
@@ -15,8 +15,7 @@ are inserted as equivalent {{domxref("Text")}} nodes.
 
 Differences from {{domxref("Node.appendChild()")}}:
 
-- `Element.append()` allows you to also append string
-  objects, whereas `Node.appendChild()` only accepts {{domxref("Node")}}
+- `Element.append()` allows you to also append strings, whereas `Node.appendChild()` only accepts {{domxref("Node")}}
   objects.
 - `Element.append()` has no return value, whereas
   `Node.appendChild()` returns the appended {{domxref("Node")}} object.

--- a/files/en-us/web/api/element/before/index.md
+++ b/files/en-us/web/api/element/before/index.md
@@ -9,7 +9,7 @@ browser-compat: api.Element.before
 {{APIRef("DOM")}}
 
 The **`Element.before()`** method inserts a set of
-{{domxref("Node")}} or strings in the children list of this
+{{domxref("Node")}} objects or strings in the children list of this
 `Element`'s parent, just before this `Element`.
 Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
@@ -24,7 +24,7 @@ before(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/element/before/index.md
+++ b/files/en-us/web/api/element/before/index.md
@@ -9,9 +9,9 @@ browser-compat: api.Element.before
 {{APIRef("DOM")}}
 
 The **`Element.before()`** method inserts a set of
-{{domxref("Node")}} or string objects in the children list of this
+{{domxref("Node")}} or strings in the children list of this
 `Element`'s parent, just before this `Element`.
-String objects are inserted as equivalent {{domxref("Text")}} nodes.
+Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ before(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/element/prepend/index.md
+++ b/files/en-us/web/api/element/prepend/index.md
@@ -9,8 +9,8 @@ browser-compat: api.Element.prepend
 {{APIRef("DOM")}}
 
 The **`Element.prepend()`** method inserts a set of
-{{domxref("Node")}} objects or string objects before the first child
-of the {{domxref("Element")}}. String objects are inserted as
+{{domxref("Node")}} objects or strings before the first child
+of the {{domxref("Element")}}. Strings are inserted as
 equivalent {{domxref("Text")}} nodes.
 
 ## Syntax
@@ -24,7 +24,7 @@ prepend(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/element/replacechildren/index.md
+++ b/files/en-us/web/api/element/replacechildren/index.md
@@ -23,7 +23,7 @@ replaceChildren(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to replace the
+  - : A set of {{domxref("Node")}} objects or strings to replace the
     `Element`'s existing children with. If no replacement objects are
     specified, then the `Element` is emptied of all child nodes.
 

--- a/files/en-us/web/api/element/replacechildren/index.md
+++ b/files/en-us/web/api/element/replacechildren/index.md
@@ -23,7 +23,7 @@ replaceChildren(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to replace the
+  - : A set of {{domxref("Node")}} or strings to replace the
     `Element`'s existing children with. If no replacement objects are
     specified, then the `Element` is emptied of all child nodes.
 

--- a/files/en-us/web/api/element/replacewith/index.md
+++ b/files/en-us/web/api/element/replacewith/index.md
@@ -10,8 +10,7 @@ browser-compat: api.Element.replaceWith
 
 The **`Element.replaceWith()`** method replaces this
 `Element` in the children list of its parent with a set of
-{{domxref("Node")}} or string objects. String
-objects are inserted as equivalent {{domxref("Text")}} nodes.
+{{domxref("Node")}} or strings. Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
 ## Syntax
 
@@ -24,7 +23,7 @@ replaceWith(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to replace.
+  - : A set of {{domxref("Node")}} or strings to replace.
 
 ### Return value
 

--- a/files/en-us/web/api/element/replacewith/index.md
+++ b/files/en-us/web/api/element/replacewith/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Element.replaceWith
 
 The **`Element.replaceWith()`** method replaces this
 `Element` in the children list of its parent with a set of
-{{domxref("Node")}} or strings. Strings are inserted as equivalent {{domxref("Text")}} nodes.
+{{domxref("Node")}} objects or strings. Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
 ## Syntax
 
@@ -23,7 +23,7 @@ replaceWith(param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or strings to replace.
+  - : A set of {{domxref("Node")}} objects or strings to replace.
 
 ### Return value
 

--- a/files/en-us/web/api/filesystementry/index.md
+++ b/files/en-us/web/api/filesystementry/index.md
@@ -55,7 +55,7 @@ _This interface provides the following properties._
 - {{domxref("FileSystemEntry.filesystem", "filesystem")}} {{ReadOnlyInline}}
   - : A {{domxref("FileSystem")}} object representing the file system in which the entry is located.
 - {{domxref("FileSystemEntry.fullPath", "fullPath")}} {{ReadOnlyInline}}
-  - : A string object which provides the full, absolute path from the file system's root to the entry; it can also be thought of as a path which is relative to the root directory, prepended with a "/" character.
+  - : A string which provides the full, absolute path from the file system's root to the entry; it can also be thought of as a path which is relative to the root directory, prepended with a "/" character.
 - {{domxref("FileSystemEntry.isDirectory", "isDirectory")}} {{ReadOnlyInline}}
   - : A boolean value which is `true` if the entry represents a directory; otherwise, it's `false`.
 - {{domxref("FileSystemEntry.isFile", "isFile")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -8,7 +8,7 @@ browser-compat: api.FormData.entries
 
 {{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers}}
 
-The **`FormData.entries()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all key/value pairs contained in the {{domxref("FormData")}}. The key of each pair is a string object, and the value is either a string or a {{domxref("Blob")}}.
+The **`FormData.entries()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all key/value pairs contained in the {{domxref("FormData")}}. The key of each pair is a string, and the value is either a string or a {{domxref("Blob")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -127,7 +127,7 @@ article img {
 
 The JavaScript code handles the two buttons that let you toggle the third width option
 between 40em and 50em; this is done by handling the {{domxref("Element.click_event", "click")}}
-event, using the JavaScript string object {{jsxref("String.replace", "replace()")}} method to replace the relevant portion of the `sizes` string.
+event, using the JavaScript string {{jsxref("String.replace", "replace()")}} method to replace the relevant portion of the `sizes` string.
 
 ```js
 const image = document.querySelector("article img");

--- a/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
@@ -15,7 +15,7 @@ is an empty string if the `networkState` property is `EMPTY`.
 
 ## Value
 
-A string object containing the absolute URL of the chosen media
+A string containing the absolute URL of the chosen media
 source; this may be an empty string if `networkState` is `EMPTY`;
 otherwise, it will be one of the resources listed by the
 {{domxref("HTMLSourceElement")}} contained within the media element, or the value or src

--- a/files/en-us/web/api/htmlmediaelement/src/index.md
+++ b/files/en-us/web/api/htmlmediaelement/src/index.md
@@ -21,7 +21,7 @@ resource to use in the element.
 
 ## Value
 
-A string object containing the URL of a media resource to use in the
+A string containing the URL of a media resource to use in the
 element; this property reflects the value of the HTML element's `src`
 attribute.
 

--- a/files/en-us/web/api/htmltrackelement/src/index.md
+++ b/files/en-us/web/api/htmltrackelement/src/index.md
@@ -14,7 +14,7 @@ indicates the URL of the text track's data.
 
 ## Value
 
-A string object containing the URL of the text track data.
+A string containing the URL of the text track data.
 
 ## Example
 

--- a/files/en-us/web/api/ndefreader/write/index.md
+++ b/files/en-us/web/api/ndefreader/write/index.md
@@ -23,11 +23,11 @@ write(message, options)
 
 - `message`
 
-  - : The message to be written, either a string object or literal, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}},
+  - : The message to be written, either a string, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}},
     a {{jsxref("DataView")}}, or an array of records. A record has the following members:
 
     - `data` {{optional_inline}}
-      - : Contains the data to be transmitted, a string object or literal, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}},
+      - : Contains the data to be transmitted, a string, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}},
         a {{jsxref("DataView")}}, or an array of nested records
     - `encoding` {{optional_inline}}
       - : A string specifying the record's encoding.

--- a/files/en-us/web/api/ndefreadingevent/ndefreadingevent/index.md
+++ b/files/en-us/web/api/ndefreadingevent/ndefreadingevent/index.md
@@ -34,7 +34,7 @@ new NDEFReadingEvent(type, options)
       - : An object with the following members:
 
         - `data` {{optional_inline}}
-          - : Contains the data to be transmitted. It can be a string object or literal, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, or an array of nested records.
+          - : Contains the data to be transmitted. It can be a string, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, or an array of nested records.
         - `encoding` {{optional_inline}}
           - : A string specifying the record's encoding.
         - `id` {{optional_inline}}

--- a/files/en-us/web/api/ndefrecord/ndefrecord/index.md
+++ b/files/en-us/web/api/ndefrecord/ndefrecord/index.md
@@ -28,7 +28,7 @@ new NDEFRecord(options)
   - : An object with the following properties:
 
     - `data` {{optional_inline}}
-      - : Contains the data to be transmitted. It can be a string object or literal, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, or an array of nested records.
+      - : Contains the data to be transmitted. It can be a string, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, or an array of nested records.
     - `encoding` {{optional_inline}}
       - : A string specifying the record's encoding.
     - `id` {{optional_inline}}

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -32,7 +32,7 @@ observe(options)
       - : A {{domxref("DOMHighResTimeStamp")}} defining the threshold for {{domxref("PerformanceEventTiming")}} entries. Defaults to 104ms and is rounded to the nearest of 8ms. Lowest possible threshold is 16ms. May not be used together with the `entryTypes` option.
     - `entryTypes`
 
-      - : An array of string objects, each specifying one performance entry type to observe. May not be used together with
+      - : An array of strings, each specifying one performance entry type to observe. May not be used together with
         the "`type`", "`buffered`", or "`durationThreshold`" options.
 
         See {{domxref("PerformanceEntry.entryType")}} for a list of valid performance entry type names. Unrecognized types are ignored, though the browser may output a warning message to the console to help developers debug their code. If no valid types are found, `observe()` has no effect.

--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -11,8 +11,7 @@ browser-compat: api.URLSearchParams.entries
 The **`entries()`** method of the
 {{domxref("URLSearchParams")}} interface returns an
 {{jsxref("Iteration_protocols",'iterator')}} allowing iteration through all key/value
-pairs contained in this object. The iterator returns key/value pairs in the same order as they appear in the query string. The key and value of each pair are
-string objects.
+pairs contained in this object. The iterator returns key/value pairs in the same order as they appear in the query string. The key and value of each pair are strings.
 
 ## Syntax
 

--- a/files/en-us/web/api/urlsearchparams/keys/index.md
+++ b/files/en-us/web/api/urlsearchparams/keys/index.md
@@ -10,8 +10,7 @@ browser-compat: api.URLSearchParams.keys
 
 The **`keys()`** method of the {{domxref("URLSearchParams")}}
 interface returns an {{jsxref("Iteration_protocols",'iterator')}} allowing iteration
-through all keys contained in this object. The keys are string
-objects.
+through all keys contained in this object. The keys are strings.
 
 ## Syntax
 

--- a/files/en-us/web/api/urlsearchparams/values/index.md
+++ b/files/en-us/web/api/urlsearchparams/values/index.md
@@ -10,8 +10,7 @@ browser-compat: api.URLSearchParams.values
 
 The **`values()`** method of the {{domxref("URLsearchParams")}}
 interface returns an {{jsxref("Iteration_protocols",'iterator')}} allowing iteration
-through all values contained in this object. The values are string
-objects.
+through all values contained in this object. The values are strings.
 
 ## Syntax
 


### PR DESCRIPTION
Currently the pages for Element.append() says:

> The Element.append() method inserts a set of Node objects or string objects after the last child of the Element 

Javscript distinguishes between primitive values of the type "string" (`'hello'`) and `String` objects (`new String('hello')`) (see e.g. "String primitives and String objects" in [1]). The reference to 'string objects' (setting aside the fact that strictly speaking it should be written as '`String` objects' like in [1]) in this context only makes sense if a special point is being made, e.g. if (A) Element.append() would not accept primitive string values as arguments, or if (B) Element.append() implicitly coerces primitive string arguments to `String` objects). But (A) is clearly not true, and there's no evidence for (B) either (e.g. the spec [2] says of Element.append() that it "Inserts nodes after the last child of node, while replacing **strings** in nodes with equivalent Text nodes")

(Same point applies to Element.prepend())

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_primitives_and_string_objects
[2] https://dom.spec.whatwg.org/#ref-for-dom-parentnode-append%E2%91%A0
