### PR TITLE
Disambiguate RequestInit object's `credentials` property where related to the Set-Cookie header

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -188,7 +188,7 @@ Whether a request can be made cross-origin or not is determined by the value of 
 
 Credentials are cookies, {{glossary("TLS")}} client certificates, or authentication headers containing a username and password.
 
-To control whether or not the browser sends credentials, set the `credentials` option, which can take one of the following three values:
+To control whether or not the browser sends credentials, as well as whether the browser respects any **`Set-Cookie`** response headers, set the `credentials` option, which can take one of the following three values:
 
 - `omit`: never send credentials in the request or include credentials in the response.
 - `same-origin` (the default): only send and include credentials for same-origin requests.

--- a/files/en-us/web/api/request/credentials/index.md
+++ b/files/en-us/web/api/request/credentials/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Request.credentials
 
 {{APIRef("Fetch API")}}
 
-The **`credentials`** read-only property of the {{domxref("Request")}} interface reflects the value given to the {{domxref("Request.Request()", "Request()")}} constructor in the [`credentials`](/en-US/docs/Web/API/RequestInit#credentials) option, and determines whether or not the browser sends credentials with the request.
+The **`credentials`** read-only property of the {{domxref("Request")}} interface reflects the value given to the {{domxref("Request.Request()", "Request()")}} constructor in the [`credentials`](/en-US/docs/Web/API/RequestInit#credentials) option. It determines whether or not the browser sends credentials with the request, as well as whether any **`Set-Cookie`** response headers are respected.
 
 Credentials are cookies, {{glossary("TLS")}} client certificates, or authentication headers containing a username and password.
 

--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -89,7 +89,7 @@ You can also construct a `Request` with a `RequestInit`, and pass the `Request` 
 
 - `credentials` {{optional_inline}}
 
-  - : Controls whether or not the browser sends credentials with the request. Credentials are cookies, {{glossary("TLS")}} client certificates, or authentication headers containing a username and password. This option may be any one of the following values:
+  - : Controls whether or not the browser sends credentials with the request, as well as whether any **`Set-Cookie`** response headers are respected. Credentials are cookies, {{glossary("TLS")}} client certificates, or authentication headers containing a username and password. This option may be any one of the following values:
 
     - `omit`
       - : Never send credentials in the request or include credentials in the response.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
<!-- ✍️ Summarize your changes in one or two sentences -->
I have changed 3 files, adding to existing sentences that mention that the `credentials` property determine whether the browser sends credentials. These sentences now reflect that this `credentials` property also affects the browser's respect for the `Set-Cookie` header.
### Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
I spent the last day or two debugging an issue with authentication and authorization between an SPA and a back end using Laravel and Sanctum: my browsers weren't storing the CSRF token cookies that the back end sent in `Set-Cookie` headers when its `/csrf-token` endpoint was hit. Which resulted in javascript being unable to actually read the token and set it as an X-XSRF-TOKEN request header in subsequent requests, and a complete breakdown of the application.

Up to the 5th page of several google searches, the matter of the browser sending credentials is mentioned. Nowhere I looked did I find a single mention - not *one* - of the `credentials: 'include'` request option affecting the browser's respect for the `Set-Cookie` response header (except in the actual specification linked in the docs for using the fetch api, and even there only as an example). I believe this is caused by overuse of http client libraries that set `credentials: 'include'` on every fetch request, whether necessary or not. Since I want to avoid that and bloat, I use vanilla javascript as much as possible.
### Additional details
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
See https://fetch.spec.whatwg.org/#cors-protocol-examples, last example:

> The developer of foo.invalid returns, now fetching some data from bar.invalid while including credentials. [...] This also makes any `Set-Cookie` response headers bar.invalid includes fully functional (***they are ignored otherwise***).

(bold italic mine)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
None to my knowledge

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
