### PR TITLE
Replace <section> with correct elements

### DIFF
--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -9,7 +9,7 @@ browser-compat: api.HTMLTableSectionElement.insertRow
 {{APIRef("HTML DOM")}}
 
 The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface inserts a new row
-({{HtmlElement("tr")}}) in the given  ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or
+({{HtmlElement("tr")}}) in the given ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or
 {{HTMLElement("tbody")}} element then returns a reference to this new row.
 
 > **Note:** `insertRow()` inserts the row directly into the

--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -9,8 +9,8 @@ browser-compat: api.HTMLTableSectionElement.insertRow
 {{APIRef("HTML DOM")}}
 
 The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface inserts a new row
-({{HtmlElement("tr")}}) in the given ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or
-{{HTMLElement("tbody")}} element then returns a reference to this new row.
+({{HtmlElement("tr")}}) in the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or
+{{HTMLElement("tbody")}}), then returns a reference to this new row.
 
 > **Note:** `insertRow()` inserts the row directly into the
 > section. The row does not need to be appended separately as would be the case if

--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -9,8 +9,8 @@ browser-compat: api.HTMLTableSectionElement.insertRow
 {{APIRef("HTML DOM")}}
 
 The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface inserts a new row
-({{HtmlElement("tr")}}) in the given {{HtmlElement("section")}}, and returns a reference to
-this new row.
+({{HtmlElement("tr")}}) in the given  ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or
+{{HTMLElement("tbody")}} element then returns a reference to this new row.
 
 > **Note:** `insertRow()` inserts the row directly into the
 > section. The row does not need to be appended separately as would be the case if


### PR DESCRIPTION
The main doc page for HTMLTableSectionElement says that HTMLTableSectionElement represents a `<thead>`, `<tbody>`, or `<tfoot>`. `<section>` elements are not mentioned. This commit updates the docs for `HTMLTableSectionElement.insertRow()` to be consistent with the main page of `HTMLTableSectionElement` by having `<thead>`, `<tbody>`, and `<tfoot>` instead of `<section>`

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Replace `<section>` with `<thead>`, `<tbody>`, or `<tfoot>`

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Makes the docs reference the right html elements that are represented by the `HTMLTableSectionElement`.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
