### PR TITLE
fix wrong heading

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -171,8 +171,6 @@ Have a play with the other options shown in the documentation and see what you c
 
 Now let's look at another API example — the [New York Times API](https://developer.nytimes.com). This API allows you to retrieve New York Times news story information and display it on your site. This type of API is known as a **RESTful API** — instead of getting data using the features of a JavaScript library like we did with Mapquest, we get data by making HTTP requests to specific URLs, with data like search terms and other properties encoded in the URL (often as URL parameters). This is a common pattern you'll encounter with APIs.
 
-## An approach for using third-party APIs
-
 Below we'll take you through an exercise to show you how to use the NYTimes API, which also provides a more general set of steps to follow that you can use as an approach for working with new APIs.
 
 ### Find the documentation


### PR DESCRIPTION
remove a (possibly) misplaced heading, as we now have the following structure in NY Times example:

- h2: [A RESTful API — NYTimes](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Third_party_APIs#a_restful_api_%E2%80%94_nytimes)
- h2: [An approach for using third-party APIs](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Third_party_APIs#an_approach_for_using_third-party_apis)
  - h3: [Find the documentation](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Third_party_APIs#find_the_documentation)
  - h3: [Get a developer key](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Third_party_APIs#get_a_developer_key)
  - ...

while content between these two `h2` got only *ONE* paragraph?

the heading has been here ever since cbe151a06d6e5b4d1fbb46081bd16e69ef4c1630. see https://github.com/mdn/content/blob/cbe151a06d6e5b4d1fbb46081bd16e69ef4c1630/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.html#L171

---

furthermore, the sentence `(which seems to be documented in the related Leaflet.js docs)` in L142 (https://github.com/mdn/content/blob/main/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md?plain=1#L142) seems to be...of much uncertainty?
