### PR TITLE
Web animations API: links and tweaks

### DIFF
--- a/files/en-us/web/api/web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/index.md
@@ -22,13 +22,13 @@ The Web Animations API provides a common language for browsers and developers to
 - {{domxref("AnimationTimeline")}}
   - : Represents the timeline of animation. This interface exists to define timeline features (inherited by {{domxref("DocumentTimeline")}} and future timeline objects) and is not itself accessed by developers.
 - {{domxref("AnimationEvent")}}
-  - : Actually part of CSS Animations.
+  - : Part of the [CSS Animations](/en-US/docs/Web/CSS/CSS_animations) module, capturing the animation name and elapsed time.
 - {{domxref("DocumentTimeline")}}
   - : Represents animation timelines, including the default document timeline (accessed using the {{domxref("Document.timeline")}} property).
 
 ## Extensions to other interfaces
 
-The Web Animations API adds some new features to {{domxref("document")}} and {{domxref("element")}}.
+The Web Animations API adds features to {{domxref("document")}} and {{domxref("element")}}.
 
 ### Extensions to the `Document` interface
 
@@ -50,8 +50,9 @@ The Web Animations API adds some new features to {{domxref("document")}} and {{d
 
 ## See also
 
+- CSS {{cssxref("animation")}} shorthand property
+- CSS {{cssxref("animation-timeline")}} property
 - [Using the Web Animations API](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API)
-- [Web Animations demos](https://mozdevs.github.io/Animation-examples/)
-- [Polyfill](https://github.com/web-animations/web-animations-js)
-- Firefox's current implementation: [AreWeAnimatedYet](https://birtles.github.io/areweanimatedyet/)
-- [Browser support test](https://codepen.io/danwilson/pen/xGBKVq)
+- [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations)
+- [CSS animations](/en-US/docs/Web/CSS/CSS_animations) module
+- [CSS scroll-driven animations](/en-US/docs/Web/CSS/CSS_scroll-driven_animations) module


### PR DESCRIPTION
the page was 8 years old. Animations are no longer new, so the 8 year old see also links were yeeted.