### PR TITLE
fix(css): update font-palette example

### DIFF
--- a/files/en-us/web/css/font-palette/index.md
+++ b/files/en-us/web/css/font-palette/index.md
@@ -83,14 +83,14 @@ In the CSS, we import a [color font](https://www.colorfonts.wtf/) called [Nabla]
   base-palette: 2; /* this is Nabla's blue palette */
 }
 
-@font-palette-values --yellowNabla {
+@font-palette-values --greyNabla {
   font-family: Nabla;
-  base-palette: 7; /* this is Nabla's yellow palette */
+  base-palette: 3; /* this is Nabla's grey palette */
 }
 
 @keyframes animate-palette {
   from {
-    font-palette: --yellowNabla;
+    font-palette: --greyNabla;
   }
 
   to {
@@ -103,7 +103,7 @@ p {
   font-size: 5rem;
   margin: 0;
   text-align: center;
-  animation: animate-palette 2s infinite alternate linear;
+  animation: animate-palette 4s infinite alternate linear;
 }
 ```
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/34790

1. The [Nabla font](https://nabla.typearture.com/#font-palette) doesn't have 7th pallet. Changing it to the grey palette at 3.
2. Firefox doesn't implement smooth transitions. So doubling the animation duration to reduce the flashing frequency.