### PR TITLE
docs: add See Also links of Declarative Shadow DOM polyfill

### DIFF
--- a/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
+++ b/files/en-us/web/api/document/parsehtmlunsafe_static/index.md
@@ -45,3 +45,4 @@ None.
 
 - {{domxref("DOMParser.parseFromString()")}} for parsing HTML or XML into a DOM tree
 - {{domxref("Element.setHTMLUnsafe")}}
+- [Declarative Shadow DOM polyfill](https://github.com/EasyWebApp/declarative-shadow-dom-polyfill)

--- a/files/en-us/web/api/element/gethtml/index.md
+++ b/files/en-us/web/api/element/gethtml/index.md
@@ -57,3 +57,4 @@ None.
 - {{domxref("Element.innerHTML")}}
 - {{domxref("Element.setHTMLUnsafe()")}}
 - {{domxref("ShadowRoot.setHTMLUnsafe()")}}
+- [Declarative Shadow DOM polyfill](https://github.com/EasyWebApp/declarative-shadow-dom-polyfill)

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -62,3 +62,4 @@ document.getElementById("target").setHTMLUnsafe(value);
 - {{domxref("ShadowRoot.setHTMLUnsafe()")}}
 - {{domxref("Element.innerHTML")}}
 - {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}
+- [Declarative Shadow DOM polyfill](https://github.com/EasyWebApp/declarative-shadow-dom-polyfill)

--- a/files/en-us/web/api/shadowroot/gethtml/index.md
+++ b/files/en-us/web/api/shadowroot/gethtml/index.md
@@ -57,3 +57,4 @@ None.
 - {{domxref("Element.innerHTML")}}
 - {{domxref("ShadowRoot.setHTMLUnsafe()")}}
 - {{domxref("Element.setHTMLUnsafe()")}}
+- [Declarative Shadow DOM polyfill](https://github.com/EasyWebApp/declarative-shadow-dom-polyfill)

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -49,3 +49,4 @@ None.
 - {{domxref("Element.setHTMLUnsafe()")}}
 - {{domxref("ShadowRoot.innerHTML")}}
 - {{domxref("Document.parseHTMLUnsafe_static", "Document.parseHTMLUnsafe()")}}
+- [Declarative Shadow DOM polyfill](https://github.com/EasyWebApp/declarative-shadow-dom-polyfill)


### PR DESCRIPTION
## Description

add See Also links of Declarative Shadow DOM polyfill

## Motivation

Web developers can use Declarative Shadow DOM API immediately with a polyfill loaded.

## Additional details

https://github.com/EasyWebApp/declarative-shadow-dom-polyfill

## Related issues and pull requests

#32731