### PR TITLE
changed 'returns a Boolean' to 'returns a boolean'

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/defineproperty/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Reflect.defineProperty
 
 {{JSRef}}
 
-The **`Reflect.defineProperty()`** static method is like {{jsxref("Object.defineProperty()")}} but returns a {{jsxref("Boolean")}}.
+The **`Reflect.defineProperty()`** static method is like {{jsxref("Object.defineProperty()")}} but returns a boolean.
 
 {{EmbedInteractiveExample("pages/js/reflect-defineproperty.html")}}
 


### PR DESCRIPTION
What was intended was probably 'a boolean' (primitive value) rather than 'a Boolean' (object). "returns a Boolean" wouldn't technically be correct since `Reflect.defineProperty({}, 'property1', { value: 42 }) instanceof Boolean` evaluates to false