### PR TITLE
Add missing http version in status line

### DIFF
--- a/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/evolution_of_http/index.md
@@ -54,7 +54,7 @@ At this point in time, a typical request and response looked like this:
 GET /mypage.html HTTP/1.0
 User-Agent: NCSA_Mosaic/2.0 (Windows 3.1)
 
-200 OK
+HTTP/1.0 200 OK
 Date: Tue, 15 Nov 1994 08:12:31 GMT
 Server: CERN/3.0 libwww/2.17
 Content-Type: text/html
@@ -70,7 +70,7 @@ It was followed by a second connection and a request to fetch the image (with th
 GET /myimage.gif HTTP/1.0
 User-Agent: NCSA_Mosaic/2.0 (Windows 3.1)
 
-200 OK
+HTTP/1.0 200 OK
 Date: Tue, 15 Nov 1994 08:12:32 GMT
 Server: CERN/3.0 libwww/2.17
 Content-Type: text/gif
@@ -103,7 +103,7 @@ Accept-Language: en-US,en;q=0.5
 Accept-Encoding: gzip, deflate, br
 Referer: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
 
-200 OK
+HTTP/1.1 200 OK
 Connection: Keep-Alive
 Content-Encoding: gzip
 Content-Type: text/html; charset=utf-8
@@ -125,7 +125,7 @@ Accept-Language: en-US,en;q=0.5
 Accept-Encoding: gzip, deflate, br
 Referer: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
 
-200 OK
+HTTP/1.1 200 OK
 Age: 9578461
 Cache-Control: public, max-age=315360000
 Connection: keep-alive


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add missing HTTP versions in status line.

### Motivation

Both RFC 1945 and RFC 2068 require that the status line contains protocol version before the status code. This MR adds it to the examples.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
