### PR TITLE
fix incorrect comments in codesnippets

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/routes/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/routes/index.md
@@ -688,10 +688,10 @@ To test the routes, first start the website using your usual approach
 - The default method
 
   ```bash
-  // Windows
+  # Windows
   SET DEBUG=express-locallibrary-tutorial:* & npm start
 
-  // macOS or Linux
+  # macOS or Linux
   DEBUG=express-locallibrary-tutorial:* npm start
   ```
 


### PR DESCRIPTION
bash have the comment with hashtag `#`

```bash
bash-3.2$ // macOS or Linux
bash: //: is a directory
```