### PR TITLE
fix(css): update animation tips page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11501,6 +11501,7 @@
 /en-US/docs/Web/CSS/CSS_User_Interface	/en-US/docs/Web/CSS/CSS_basic_user_interface
 /en-US/docs/Web/CSS/CSS_Variables	/en-US/docs/Web/CSS/CSS_cascading_variables
 /en-US/docs/Web/CSS/CSS_Viewport	/en-US/docs/Web/CSS
+/en-US/docs/Web/CSS/CSS_animations/Tips	/en-US/docs/Web/API/Web_Animations_API/Tips
 /en-US/docs/Web/CSS/CSS_charsets	/en-US/docs/Web/CSS/CSS_syntax
 /en-US/docs/Web/CSS/CSS_container_queries	/en-US/docs/Web/CSS/CSS_containment/Container_queries
 /en-US/docs/Web/CSS/CSS_descriptor_definition	/en-US/docs/Web/CSS

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -65325,6 +65325,17 @@
       "rachelnabors"
     ]
   },
+  "Web/API/Web_Animations_API/Tips": {
+    "modified": "2020-06-24T00:29:43.861Z",
+    "contributors": [
+      "emilhem",
+      "chrisdavidmills",
+      "morenoh149",
+      "tzthet",
+      "mfluehr",
+      "Sheppy"
+    ]
+  },
   "Web/API/Web_Animations_API/Using_the_Web_Animations_API": {
     "modified": "2020-11-11T08:34:26.031Z",
     "contributors": [
@@ -76475,17 +76486,6 @@
       "Sheppy",
       "MexieAndCo",
       "teoli"
-    ]
-  },
-  "Web/CSS/CSS_animations/Tips": {
-    "modified": "2020-06-24T00:29:43.861Z",
-    "contributors": [
-      "emilhem",
-      "chrisdavidmills",
-      "morenoh149",
-      "tzthet",
-      "mfluehr",
-      "Sheppy"
     ]
   },
   "Web/CSS/CSS_animations/Using_CSS_animations": {

--- a/files/en-us/web/api/web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/index.md
@@ -42,7 +42,7 @@ The Web Animations API adds features to {{domxref("document")}} and {{domxref("e
 - {{domxref("Element.animate()")}}
   - : A shortcut method for creating and playing an animation on an element. It returns the created {{domxref("Animation")}} object instance.
 - {{domxref("Element.getAnimations()")}}
-  - : Returns an Array of {{domxref("Animation")}} objects currently affecting an element or which are scheduled to do so in future.
+  - : Returns an Array of {{domxref("Animation")}} objects currently affecting an element or which are scheduled to do so in the future.
 
 ## Specifications
 

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -120,7 +120,9 @@ The code disables the button and starts the animation. The button is re-enabled 
 
 ## Stacking context in animations
 
-In the case of the `animation-fill-mode` [forwards](/en-US/docs/Web/CSS/animation-fill-mode#forwards) value, animated properties behave as if included in a set [`will-change`](/en-US/docs/Web/CSS/will-change) property value. If a new stacking context is created during the animation, the target element retains the stacking context after the animation has finished.
+The properties that are animated during a CSS animation behave as if they were included in the [' will-change](/en-US/docs/Web/CSS/will-change) property declaration. Any property that would create a stacking context, if marked as `will-change`, makes the element receive a new stacking context.
+
+In the case of the [`animation-fill-mode: forwards`](/en-US/docs/Web/CSS/animation-fill-mode#forwards), the animated properties remain at their final keyframe state after the animation is finished. The properties keep the `will-change` status, so if a new stacking context is created during the animation and is still present at the end of the animation, the target element retains the stacking context after the animation has finished. 
 
 ## See also
 

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -6,13 +6,13 @@ page-type: guide
 
 {{CSSRef}}
 
-CSS animations make it possible to do incredible things with the elements that make up your documents and apps. However, there are things you might want to do that aren't obvious, or clever ways to do things that you might not come up with right away. This article is a collection of tips and tricks we've found that may make your work easier, including how to run a stopped animation again.
+CSS animations make it possible to do incredible things with the elements that make up your documents and apps. There are things you might want to do that aren't obvious and many clever ways to do things that may not be immediately apparent. This article is a collection of tips and tricks we've found that will hopefully make your work easier, including how to re-run a completed animation.
 
 ## Run an animation again
 
-The [CSS Animations](/en-US/docs/Web/CSS/CSS_animations) specification doesn't offer a way to run an animation again. You can't just set the element's {{cssxref("animation-play-state")}} to `"running"` again. Instead, you have to use JavaScript to get a completed animation to replay.
+The [CSS Animations](/en-US/docs/Web/CSS/CSS_animations) specification doesn't offer a way to run an animation again. You can't just set the element's {{cssxref("animation-play-state")}} to `"running"` again once the animation ends. Instead, you have to use JavaScript to get a completed animation to replay.
 
-Here's one way to do it that we feel is stable and reliable enough to suggest to you.
+This is one way to do it that is a stable and reliable method.
 
 ### HTML
 
@@ -38,7 +38,7 @@ Let's style the box using CSS.
 
 ### JavaScript
 
-Next, we'll look at the JavaScript that does the work. The `playAnimation()` function is to be called when the user clicks on the run button. Instead of {{cssxref("@keyframes")}} at-rule we [define the keyframes in JavaScript](/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats).
+Next, we'll look at the JavaScript that does the work. The `playAnimation()` function is to be called when the user clicks on the run button. Instead of using the {{cssxref("@keyframes")}} at-rule, we [define the keyframes in JavaScript](/en-US/docs/Web/API/Web_Animations_API/Keyframe_Formats).
 
 ```js
 const box = document.querySelector(".box");
@@ -63,9 +63,9 @@ function playAnimation() {
 }
 ```
 
-The `playAnimation` method calls {{domxref("Element.animate()")}} method on the box to play the animation. The `animate` method takes the `colorChangeFrames` keyframe object and animation duration as arguments.
+The `playAnimation` method calls the {{domxref("Element.animate()")}} method on the box to play the animation. The `animate()` method takes a keyframe object or array of keyframe objects and animation and animation options as arguments. In this case, we pass the method the `colorChangeFrames` keyframe object and an animation duration.
 
-Of course, we also need to add an event handler to our run button so it'll actually do something:
+We also need to add an event handler to our run button so it will actually do something:
 
 ```js
 button.addEventListener("click", playAnimation);
@@ -79,7 +79,7 @@ button.addEventListener("click", playAnimation);
 
 In the previous example, if the run button is clicked before the animation is completed, the current animation will abruptly stop and the animation will restart from the `0%` or `from` starting keyframe. If you would like the current animation iteration to be complete before starting a new one, we can disable the `run` button while the animation is running, reenabling it based on the [`finish`](/en-US/docs/Web/API/Animation/finish) event. Alternatively, if we want to enable multiple iterations of the animation, we can check to see if an animation is running on the element and increment the `animation-iteration` count for each button click while the animation is running.
 
-The following demo shows how you'd achieve this. You'll have to do the following modification to the same code:
+In this example, we update our `playAnimation()` function to disable the button when clicked, and listen for the `finish` event to re-enable the button.
 
 ```html hidden
 <div class="box"></div>
@@ -114,7 +114,7 @@ button.addEventListener("click", playAnimation);
 
 {{ EmbedLiveSample("Waiting for an animation to complete before stopping", "100%", "160") }}
 
-The code disables the button and then starts the animation. The button remains disabled till the animation completes.
+The code disables the button and starts the animation. The button is re-enabled when the animation completes.
 
 ## Stacking context in animations
 

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -122,7 +122,7 @@ The code disables the button and starts the animation. The button is re-enabled 
 
 The properties that are animated during a CSS animation behave as if they were included in the [' will-change](/en-US/docs/Web/CSS/will-change) property declaration. Any property that would create a stacking context, if marked as `will-change`, makes the element receive a new stacking context.
 
-In the case of the [`animation-fill-mode: forwards`](/en-US/docs/Web/CSS/animation-fill-mode#forwards), the animated properties remain at their final keyframe state after the animation is finished. The properties keep the `will-change` status, so if a new stacking context is created during the animation and is still present at the end of the animation, the target element retains the stacking context after the animation has finished.
+In the case of [`animation-fill-mode: forwards`](/en-US/docs/Web/CSS/animation-fill-mode#forwards) (and `both`), the animated properties remain at their final keyframe state after the animation is finished. The properties keep the `will-change` status, so if a new stacking context is created during the animation and is still present at the end of the animation, the target element retains the stacking context after the animation has finished.
 
 ## See also
 

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -122,7 +122,7 @@ The code disables the button and starts the animation. The button is re-enabled 
 
 The properties that are animated during a CSS animation behave as if they were included in the [' will-change](/en-US/docs/Web/CSS/will-change) property declaration. Any property that would create a stacking context, if marked as `will-change`, makes the element receive a new stacking context.
 
-In the case of the [`animation-fill-mode: forwards`](/en-US/docs/Web/CSS/animation-fill-mode#forwards), the animated properties remain at their final keyframe state after the animation is finished. The properties keep the `will-change` status, so if a new stacking context is created during the animation and is still present at the end of the animation, the target element retains the stacking context after the animation has finished. 
+In the case of the [`animation-fill-mode: forwards`](/en-US/docs/Web/CSS/animation-fill-mode#forwards), the animated properties remain at their final keyframe state after the animation is finished. The properties keep the `will-change` status, so if a new stacking context is created during the animation and is still present at the end of the animation, the target element retains the stacking context after the animation has finished.
 
 ## See also
 

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -1,6 +1,6 @@
 ---
-title: CSS animation tips and tricks
-slug: Web/CSS/CSS_animations/Tips
+title: Web animation API tips and tricks
+slug: Web/API/Web_Animations_API/Tips
 page-type: guide
 ---
 
@@ -77,7 +77,7 @@ button.addEventListener("click", playAnimation);
 
 ## Waiting for an animation to complete before stopping
 
-In the previous example, if the run button is clicked before the animation is completed, the current animation will abruptly stop and the animation restarts from the `0%` or `from` starting keyframe. If you would like the current animation iteration to be complete before starting a new one, we can disable the `run` button while the animation is running, reenabling it based on the `animationend` event. Alternatively, if we want to enable multiple iterations of the animation, we can check to see if an animation is running on the element and increment the `animation-iteration` count for each button click while the animation is running.
+In the previous example, if the run button is clicked before the animation is completed, the current animation will abruptly stop and the animation will restart from the `0%` or `from` starting keyframe. If you would like the current animation iteration to be complete before starting a new one, we can disable the `run` button while the animation is running, reenabling it based on the [`finish`](/en-US/docs/Web/API/Animation/finish) event. Alternatively, if we want to enable multiple iterations of the animation, we can check to see if an animation is running on the element and increment the `animation-iteration` count for each button click while the animation is running.
 
 The following demo shows how you'd achieve this. You'll have to do the following modification to the same code:
 
@@ -99,13 +99,14 @@ The following demo shows how you'd achieve this. You'll have to do the following
 const box = document.querySelector(".box");
 const button = document.querySelector(".runButton");
 const colorChangeFrames = { backgroundColor: ["grey", "lime"] };
-```
 
-```js
 function playAnimation() {
-  if (box.getAnimations().length === 0) {
-    box.animate(colorChangeFrames, 4000);
-  }
+  button.setAttribute("disabled", true);
+  const anim = box.animate(colorChangeFrames, 4000);
+
+  anim.addEventListener("finish", (event) => {
+    button.removeAttribute("disabled");
+  });
 }
 ```
 
@@ -113,7 +114,7 @@ button.addEventListener("click", playAnimation);
 
 {{ EmbedLiveSample("Waiting for an animation to complete before stopping", "100%", "160") }}
 
-The code uses {{domxref("Element.getAnimations()")}} method to ensure there is no animation running on the element.
+The code disables the button and then starts the animation. The button remains disabled till the animation completes.
 
 ## Stacking context in animations
 
@@ -122,3 +123,4 @@ In the case of the `animation-fill-mode` [forwards](/en-US/docs/Web/CSS/animatio
 ## See also
 
 - [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)
+- [Animation Interface](/en-US/docs/Web/API/Animation/Animation)

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -100,6 +100,10 @@ const box = document.querySelector(".box");
 const button = document.querySelector(".runButton");
 const colorChangeFrames = { backgroundColor: ["grey", "lime"] };
 
+button.addEventListener("click", playAnimation);
+```
+
+```js
 function playAnimation() {
   button.setAttribute("disabled", true);
   const anim = box.animate(colorChangeFrames, 4000);
@@ -109,8 +113,6 @@ function playAnimation() {
   });
 }
 ```
-
-button.addEventListener("click", playAnimation);
 
 {{ EmbedLiveSample("Waiting for an animation to complete before stopping", "100%", "160") }}
 

--- a/files/en-us/web/api/web_animations_api/tips/index.md
+++ b/files/en-us/web/api/web_animations_api/tips/index.md
@@ -124,3 +124,4 @@ In the case of the `animation-fill-mode` [forwards](/en-US/docs/Web/CSS/animatio
 
 - [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)
 - [Animation Interface](/en-US/docs/Web/API/Animation/Animation)
+- [CSS animations](/en-US/docs/Web/CSS/CSS_animations) module

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -61,8 +61,8 @@ All animations, even those with 0 seconds duration, throw animation events.
 
 - [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations)
   - : Step-by-step tutorial on how to create animations using CSS. This article describes the animation-related CSS properties and at-rule and how they interact with each other.
-- [CSS animation tips and tricks](/en-US/docs/Web/CSS/CSS_animations/Tips)
-  - : Tips and tricks to help you get the most out of CSS animations.
+- - [Using the Web Animations API](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API)
+  - : Entry point to perform advanced animations using Web Animations API.
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -62,7 +62,7 @@ All animations, even those with 0 seconds duration, throw animation events.
 - [Using CSS animations](/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations)
   - : Step-by-step tutorial on how to create animations using CSS. This article describes the animation-related CSS properties and at-rule and how they interact with each other.
 - - [Using the Web Animations API](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API)
-  - : Entry point to perform advanced animations using Web Animations API.
+  - : Common animation requirements that can be solved with a few lines of JavaScript.
 
 ## Related concepts
 

--- a/files/en-us/web/css/css_animations/tips/index.md
+++ b/files/en-us/web/css/css_animations/tips/index.md
@@ -10,7 +10,7 @@ CSS animations make it possible to do incredible things with the elements that m
 
 ## Run an animation again
 
-The [CSS Animations](/en-US/docs/Web/CSS/CSS_animations) specification doesn't offer a way to run an animation again. You can't just set the element's {{cssxref("animation-play-state")}} to `"running"` again. Instead, you have to use JavaScript to get a stopped animation to replay.
+The [CSS Animations](/en-US/docs/Web/CSS/CSS_animations) specification doesn't offer a way to run an animation again. You can't just set the element's {{cssxref("animation-play-state")}} to `"running"` again. Instead, you have to use JavaScript to get a completed animation to replay.
 
 Here's one way to do it that we feel is stable and reliable enough to suggest to you.
 
@@ -63,7 +63,7 @@ function playAnimation() {
 }
 ```
 
-The `playAnimation` method simply calls {{domxref("Element.animate()")}} method on the box to play the animation. The `animate` method takes the `colorChangeFrames` keyframe object and animation duration as arguments.
+The `playAnimation` method calls {{domxref("Element.animate()")}} method on the box to play the animation. The `animate` method takes the `colorChangeFrames` keyframe object and animation duration as arguments.
 
 Of course, we also need to add an event handler to our run button so it'll actually do something:
 
@@ -77,7 +77,7 @@ button.addEventListener("click", playAnimation);
 
 ## Waiting for an animation to complete before stopping
 
-In the previous example if the run button is clicked before the animation is completed, then the current animation is stopped abruptly and the next animation starts from the start. If instead, you'd like the current animation to be complete before starting a new one then we need to check if any animation is still running on the element before accepting a new play request.
+In the previous example, if the run button is clicked before the animation is completed, the current animation will abruptly stop and the animation restarts from the `0%` or `from` starting keyframe. If you would like the current animation iteration to be complete before starting a new one, we can disable the `run` button while the animation is running, reenabling it based on the `animationend` event. Alternatively, if we want to enable multiple iterations of the animation, we can check to see if an animation is running on the element and increment the `animation-iteration` count for each button click while the animation is running.
 
 The following demo shows how you'd achieve this. You'll have to do the following modification to the same code:
 

--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -525,5 +525,5 @@ The code renders as follows:
 ## See also
 
 - {{domxref("AnimationEvent", "AnimationEvent")}}
-- [CSS animation tips and tricks](/en-US/docs/Web/CSS/CSS_animations/Tips)
 - [Using CSS transitions](/en-US/docs/Web/CSS/CSS_transitions/Using_CSS_transitions)
+- [Using the Web Animations API](/en-US/docs/Web/API/Web_Animations_API/Using_the_Web_Animations_API)


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/18869

There is no need to use tricks to achieve the discussed tips on the page. As we have to resort to JS then the Web animation API is the best way to achieve this. The new API also makes the examples simple.

The PR uses `element.animate()` and `element.getAnimations()` method in the examples.