### PR TITLE
FF129 MediaCapabilities.decodingInfo() with keySystemAccept arg

### DIFF
--- a/files/en-us/web/api/encrypted_media_extensions_api/index.md
+++ b/files/en-us/web/api/encrypted_media_extensions_api/index.md
@@ -7,7 +7,7 @@ browser-compat: api.Navigator.requestMediaKeySystemAccess
 
 {{DefaultAPISidebar("Encrypted Media Extensions")}} {{securecontext_header}}
 
-The Encrypted Media Extensions API provides interfaces for controlling the playback of content which is subject to a digital restrictions management scheme.
+The **Encrypted Media Extensions API** provides interfaces for controlling the playback of content which is subject to a digital restrictions management scheme.
 
 Access to this API is provided through {{domxref("Navigator.requestMediaKeySystemAccess()")}}.
 

--- a/files/en-us/web/api/media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/index.md
@@ -9,6 +9,30 @@ browser-compat: api.MediaCapabilities
 
 The **Media Capabilities API** allows developers to determine decoding and encoding abilities of the device, exposing information such as whether media is supported and whether playback should be smooth and power efficient, with real time feedback about playback to better enable adaptive streaming, and access to display property information.
 
+## Concepts
+
+There are a myriad of video and audio codecs. Different browsers support different media types and new media types are always being developed. With the Media Capabilities API, developers can ensure each user is getting the best bitrate and storage savings for their browser, device, and OS capabilities.
+
+Whether a device uses hardware or software decoding impacts how smooth and power efficient the video decoding is and how efficient the playback will be. The Media Capabilities API enables determining which codecs are supported and how performant a media file will be both in terms of smoothness and power efficiency.
+
+The Media Capabilities API provide more powerful features than say {{DOMxref("MediaRecorder.isTypeSupported_static", "MediaRecorder.isTypeSupported()")}} or {{DOMxRef("HTMLMediaElement.canPlayType()")}}, which only address general browser support, not performance. The API also provides abilities to access display property information such as supported color {{glossary("gamut")}}, dynamic range abilities, and real-time feedback about the playback.
+
+To test support, smoothness, and power efficiency for encoding and decoding video or audio content, you use the {{DOMxRef("MediaCapabilities")}} interface's {{DOMxRef("MediaCapabilities.encodingInfo()","encodingInfo()")}} and {{DOMxRef("MediaCapabilities.decodingInfo()","decodingInfo()")}} methods.
+
+Media capabilities information enables websites to enable adaptive streaming to alter the quality of content based on actual user-perceived quality, and react to a pick of CPU/GPU usage in real time.
+
+## Interfaces
+
+- {{DOMxRef("MediaCapabilities")}}
+  - : Provides information about the decoding abilities of the device, system and browser based on codecs, profile, resolution, and bitrates. The information can be used to serve optimal media streams to the user and determine if playback should be smooth and power efficient.
+
+### Extensions to other interfaces
+
+- {{domxref("Navigator.mediaCapabilities")}} {{readonlyinline}}
+  - : A {{domxref("MediaCapabilities")}} object that can expose information about the decoding and encoding capabilities for a given media format and output capabilities.
+- {{DOMxRef("WorkerNavigator.mediaCapabilities")}} {{readonlyinline}}
+  - : A {{domxref("MediaCapabilities")}} object that can expose information about the decoding and encoding capabilities for a given media format and output capabilities.
+
 ## Examples
 
 ### Detect audio file support and expected performance
@@ -42,27 +66,6 @@ if ("mediaCapabilities" in navigator) {
 }
 ```
 
-## Media Capabilities API concepts and usage
-
-There are a myriad of video and audio codecs. Different browsers support different media types and new media types are always being developed. With the Media Capabilities API, developers can ensure each user is getting the best bitrate and storage savings for their browser, device, and OS capabilities.
-
-Whether a device uses hardware or software decoding impacts how smooth and power efficient the video decoding is and how efficient the playback will be. The Media Capabilities API enables determining which codecs are supported and how performant a media file will be both in terms of smoothness and power efficiency.
-
-The Media Capabilities API provide more powerful features than say {{DOMxref("MediaRecorder.isTypeSupported_static", "MediaRecorder.isTypeSupported()")}} or {{DOMxRef("HTMLMediaElement.canPlayType()")}}, which only address general browser support, not performance. The API also provides abilities to access display property information such as supported color {{glossary("gamut")}}, dynamic range abilities, and real-time feedback about the playback.
-
-To test support, smoothness, and power efficiency of a video or audio file, you use the {{DOMxRef("MediaCapabilities")}} interface's {{DOMxRef("MediaCapabilities.encodingInfo()","encodingInfo()")}} and {{DOMxRef("MediaCapabilities.decodingInfo()","decodingInfo()")}} methods.
-
-Media capabilities information enables websites to enable adaptive streaming to alter the quality of content based on actual user-perceived quality, and react to a pick of CPU/GPU usage in real time.
-
-## Media Capabilities Interfaces
-
-- {{DOMxRef("MediaCapabilities")}}
-  - : Provides information about the decoding abilities of the device, system and browser based on codecs, profile, resolution, and bitrates. The information can be used to serve optimal media streams to the user and determine if playback should be smooth and power efficient .
-- ScreenColorGamut
-  - : Will describe the color {{glossary("gamut")}}, or the range of color, the screen can display (not currently supported anywhere).
-- ScreenLuminance
-  - : Will describe the known luminance characteristics of the screen (not currently supported anywhere).
-
 ## Specifications
 
 {{Specifications}}
@@ -75,5 +78,4 @@ Media capabilities information enables websites to enable adaptive streaming to 
 
 - [HTMLMediaElement](/en-US/docs/Web/API/HTMLMediaElement)'s method [canPlayType()](/en-US/docs/Web/API/HTMLMediaElement/canPlayType)
 - [MediaSource](/en-US/docs/Web/API/MediaSource)'s method [isTypeSupported()](/en-US/docs/Web/API/MediaSource/isTypeSupported_static)
-- {{DOMxRef("Navigator")}} interface
 - [Using the Media Capabilities API](/en-US/docs/Web/API/Media_Capabilities_API/Using_the_Media_Capabilities_API)

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -82,7 +82,8 @@ Now that we've created a video decoding configuration we can pass it as a parame
 let promise = navigator.mediaCapabilities.decodingInfo(videoConfiguration);
 ```
 
-The `decodingInfo()` and {{domxref("MediaCapabilities.encodingInfo", "encodingInfo()")}} methods both return promises. Once the promises state is fulfilled, you can access the `supported`, `smooth`, and `powerEfficient` properties from the returned object.
+The `decodingInfo()` and {{domxref("MediaCapabilities.encodingInfo", "encodingInfo()")}} methods both return promises.
+Once the promise states are fulfilled, you can access the `supported`, `smooth`, and `powerEfficient` properties from the returned object.
 
 ### Handling the response
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -74,6 +74,8 @@ decodingInfo(configuration)
     - `keySystemConfiguration` {{optional_inline}}
 
       - : Object specifying the key system configuration for encrypted media.
+      
+        Note that [`Navigator.requestMediaKeySystemAccess()`](/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess) takes arrays some of the same data types in its `supportedConfigurations` argument.
 
         If specified, the [`type`](#type) must be `media-source` or `file` (not `webrtc`).
         This has the following properties: <!-- MediaCapabilitiesKeySystemConfiguration in the spec -->
@@ -87,7 +89,6 @@ decodingInfo(configuration)
 
           - : A string indicating the data type name the initialization data format, such as `"cenc"`, `"keyids"` and `"webm"`.
             Allowed names are defined in the [Encrypted Media Extensions Initialization Data Format Registry](https://www.w3.org/TR/eme-initdata-registry/).
-            Note that [`Navigator.requestMediaKeySystemAccess()`](/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess) takes an array of data type names in the `supportedConfigurations.initDataTypes` argument.
 
         - `distinctiveIdentifier` {{optional_inline}}
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -86,8 +86,8 @@ decodingInfo(configuration)
         - `initDataType` {{optional_inline}}
 
           - : A string indicating the data type name the initialization data format, such as `"cenc"`, `"keyids"` and `"webm"`.
-            This is a single value from the array defined in the [`supportedConfigurations.initDataTypes`](/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess#initdatatypes) option passed to `Navigator.requestMediaKeySystemAccess()`.
             Allowed names are defined in the [Encrypted Media Extensions Initialization Data Format Registry](https://www.w3.org/TR/eme-initdata-registry/).
+            Note that [`Navigator.requestMediaKeySystemAccess()`](/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess) takes an array of data type names in the `supportedConfigurations.initDataTypes` argument.
 
         - `distinctiveIdentifier` {{optional_inline}}
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -74,7 +74,7 @@ decodingInfo(configuration)
     - `keySystemConfiguration` {{optional_inline}}
 
       - : Object specifying the key system configuration for encrypted media.
-      
+
         Note that [`Navigator.requestMediaKeySystemAccess()`](/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess) takes arrays some of the same data types in its `supportedConfigurations` argument.
 
         If specified, the [`type`](#type) must be `media-source` or `file` (not `webrtc`).
@@ -203,9 +203,30 @@ In other words, the selection decision is devolved to the caller.
 
 This example shows how to create a media configuration for an audio file and then use it in `MediaCapabilities.decodingInfo()`.
 
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
 ```js
 //Create media configuration to be tested
-const mediaConfig = {
+const audioConfig = {
   type: "file", // or 'media-source' or 'webrtc'
   audio: {
     contentType: "audio/ogg; codecs=vorbis", // valid content type
@@ -216,19 +237,23 @@ const mediaConfig = {
 };
 
 // check support and performance
-navigator.mediaCapabilities.decodingInfo(mediaConfig).then((result) => {
-  console.log(
-    `This configuration is ${result.supported ? "" : "not "}supported,`,
-  );
-  console.log(`${result.smooth ? "" : "not "}smooth, and`);
-  console.log(`${result.powerEfficient ? "" : "not "}power efficient.`);
+navigator.mediaCapabilities.decodingInfo(audioConfig).then((result) => {
+  console.log(result);
+
+  if (result.supported) {
+    log(
+      `The audio configuration is supported${result.smooth ? ", smooth" : ", not smooth"}${result.powerEfficient ? ", power efficient" : ", not power efficient"}.`,
+    );
+  } else {
+    log("The audio configuration is not supported");
+  }
 });
 ```
 
 Similarly, the code below shows the configuration for a video file.
 
 ```js
-const mediaConfig = {
+const videoConfig = {
   type: "file",
   video: {
     contentType: "video/webm;codecs=vp8", // valid content type
@@ -238,7 +263,22 @@ const mediaConfig = {
     framerate: 30, // number of frames making up that 1s.
   },
 };
+
+// check support and performance
+navigator.mediaCapabilities.decodingInfo(audioConfig).then((result) => {
+  console.log(result);
+
+  if (result.supported) {
+    log(
+      `The video configuration is supported${result.smooth ? ", smooth" : ", not smooth"}${result.powerEfficient ? ", power efficient" : ", not power efficient"}.`,
+    );
+  } else {
+    log("The video configuration is not supported");
+  }
+});
 ```
+
+{{EmbedLiveSample("Getting decoding information for unencrypted media files")}}
 
 ### Getting decoding information for encrypted media
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -6,10 +6,17 @@ page-type: web-api-instance-method
 browser-compat: api.MediaCapabilities.decodingInfo
 ---
 
-{{APIRef("MediaCapabilities")}}
+{{APIRef("Media Capabilities API")}}
 
-The **`MediaCapabilities.decodingInfo()`** method, part of the [Media Capabilities API](/en-US/docs/Web/API/MediaCapabilities), returns a promise with the tested media configuration's capabilities info.
-This contains the three boolean properties `supported`, `smooth`, and `powerefficient`, which describe whether decoding the media described would be supported, smooth, and powerefficient.
+The **`decodingInfo()`** method of the {{domxref("MediaCapabilities")}} interface returns a promise that fulfils with information about how well the user agent can decode/display media with a given configuration.
+
+The resolved object contains three boolean properties `supported`, `smooth`, and `powerefficient`, which indicate whether decoding the media described would be supported, and if so, whether decoding would be smooth and power-efficient.
+
+The method can also be used to test the user agent capabilities for decoding media encoded with a key system, but only when called in the main thread and in a secure context.
+If the configuration passed in the `configuration.keySystemConfiguration` property is supported for decoding the data, the resolved promise also includes a {{domxref("MediaKeySystemAccess")}} object that can be used to create a {{domxref("MediaKeys")}} object to setup encrypted playback.
+
+> **Note:** Calling `decodingInfo()` with this property may result in user-visible effects, such as asking for permission to access one or more system resources.
+> As such, this function should only be called when the application is ready to create and use a `MediaKeys` object with the provided configuration.
 
 ## Syntax
 
@@ -21,7 +28,7 @@ decodingInfo(configuration)
 
 - `configuration`
 
-  - : An object with a property `type` and _either_ a `video` or `audio` property containing a configuration of the appropriate type: <!-- MediaDecodingConfiguration in the spec -->
+  - : An object with a property `type`, _either_ a `video` or `audio` property containing a configuration of the appropriate type, and optionally a `keySystemConfiguration` when decoding media encrypted with a key system: <!-- MediaDecodingConfiguration in the spec -->
 
     - `type`
 
@@ -32,7 +39,7 @@ decodingInfo(configuration)
         - `media-source`
           - : Represents a configuration that is meant to be used for playback of a {{domxref("MediaSource")}}.
         - `webrtc`
-          - : Represents a configuration that is meant to be received using {{domxref("RTCPeerConnection")}}.
+          - : Represents a configuration that is meant to be received using {{domxref("RTCPeerConnection")}} (not allowed when `keySystemConfiguration` is set).
 
     - `video`
 
@@ -64,26 +71,134 @@ decodingInfo(configuration)
         - `samplerate`
           - : The number of audio samples making up one second of the audio file.
 
+    - `keySystemConfiguration` {{optional_inline}}
+
+      - : Object specifying the key system configuration for encrypted media.
+
+        If specified, the [`type`](#type) must be `media-source` or `file` (not `webrtc`).
+        This has the following properties: <!-- MediaCapabilitiesKeySystemConfiguration in the spec -->
+
+        - `keySystem`
+
+          - : A string identifying the media key system.
+            For example `com.example.somesystem` or `org.w3.clearkey`.
+
+        - `initDataType` {{optional_inline}}
+
+          - : A string indicating the data type name the initialization data format, such as `"cenc"`, `"keyids"` and `"webm"`.
+            This is a single value from the array defined in the [`supportedConfigurations.initDataTypes`](/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess#initdatatypes) option passed to `Navigator.requestMediaKeySystemAccess()`.
+            Allowed names are defined in the [Encrypted Media Extensions Initialization Data Format Registry](https://www.w3.org/TR/eme-initdata-registry/).
+
+        - `distinctiveIdentifier` {{optional_inline}}
+
+          - : A string indicating whether the implementation may use "distinctive identifiers" (or distinctive permanent identifiers) for any operations associated with any object created from this configuration.
+            The allowed values are:
+
+            - `required`
+              - : The returned object must support this feature.
+            - `optional`
+              - : The returned object may support this feature.
+                This is the default
+            - `not-allowed`
+              - : The returned object must not support or use this feature.
+
+        - `persistentState` {{optional_inline}}
+
+          - : A string indicating whether whether the returned object must be able to persist session data or any other type of state.
+            The allowed values are:
+
+            - `required`
+              - : The returned object must support this feature.
+            - `optional`
+              - : The returned object may support this feature.
+                This is the default
+            - `not-allowed`
+              - : The returned object must not support or use this feature.
+                Only "temporary" sessions may be created when persistent state is not allowed.
+
+        - `sessionTypes` {{optional_inline}}
+
+          - : An array of strings indicating the session types that must be supported.
+            Permitted values include:
+
+            - `temporary`
+              - : A session for which the license, key(s) and record of or data related to the session are not persisted.
+                The application does not need to manage such storage.
+                Implementations must support this option, and it is the default.
+            - `persistent-license`
+              - : A session for which the license (and potentially other data related to the session) will be persisted.
+                A record of the license and associated keys persists even if the license is destroyed, providing an attestation that the license and key(s) it contains are no longer usable by the client.
+
+        - `audio` {{optional_inline}}
+
+          - : The audio key system track configuration associated with the [`audio` configuration](#audio) above.
+            If set, then the [`audio` configuration](#audio) must also be set.
+
+            - `encryptionScheme`
+              - : The encryption scheme associated with the content type, such as `cenc`, `cbcs`, `cbcs-1-9`.
+                This value should be set by an application (it defaults to `null`, indicating that any encryption scheme may be used).
+            - `robustness`
+              - : The robustness level associated with the content type.
+                The empty string indicates that any ability to decrypt and decode the content type is acceptable.
+
+        - `video` {{optional_inline}}
+
+          - : The video key system track configuration associated with the [`video` configuration](#video) above.
+            If set, then the [`video` configuration](#video) must also be set.
+
+            - `encryptionScheme`
+              - : The encryption scheme associated with the content type, such as `cenc`, `cbcs`, `cbcs-1-9`.
+                This value should be set by an application (it defaults to `null`, indicating that any encryption scheme may be used).
+            - `robustness`
+              - : The robustness level associated with the content type.
+                The empty string indicates that any ability to decrypt and decode the content type is acceptable.
+
 ### Return value
 
-A {{jsxref('Promise')}} fulfilling with an object containing three Boolean attributes:
+A {{jsxref('Promise')}} fulfilling with an object containing the following attributes:
 
 - `supported`
   - : `true` if the media content can be decoded at all. Otherwise, it is `false`.
 - `smooth`
-  - : `true` if playback of the media will be smooth (of high quality). Otherwise it is `false`.
+  - : `true` if playback of the media can be played at the frame rate specified by the configuration without needing to drop frames. Otherwise it is `false`.
 - `powerEfficient`
   - : `true` if playback of the media will be power efficient. Otherwise, it is `false`.
+- `keySystemAccess`
+  - : A {{domxref("MediaKeySystemAccess")}} that can be used to create a {{domxref("MediaKeys")}} object to setup encrypted playback, or `null` if decoding is not supported using the supplied configuration.
+- `configuration`
+  - : The [`configuration`](#configuration) used to generate this returned object.
 
 Browsers will report a supported media configuration as `smooth` and `powerEfficient` until stats on this device have been recorded.
-All supported audio codecs are reported to be power efficient.
+All supported audio codecs report `powerEfficient` as true.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
+
   - : Thrown if the `configuration` passed to the `decodingInfo()` method is invalid, either because the type is not video or audio, the `contentType` is not a valid codec MIME type, the media decoding configuration is not a valid value for the `type` (file, media-source, or webrtc), or any other error in the media configuration passed to the method, including omitting any values.
 
+- `InvalidStateError` {{domxref("DOMException")}}
+
+  - : The method is called in a worker when [`configuration.keySystemConfiguration`](#keysystemconfiguration) is defined.
+
+- `SecurityError` {{domxref("DOMException")}}
+  - : The method is called outside of a secure context and [`configuration.keySystemConfiguration`](#keysystemconfiguration) is defined.
+
+## Usage notes
+
+### Comparision with Navigator.requestMediaKeySystemAccess()
+
+`decodingInfo()` and the {{domxref("Navigator.requestMediaKeySystemAccess()")}} method of the [Encrypted Media Extensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) reflect fundamentally different approaches for selecting a configuration for decoding encrypted media.
+
+The configuration parameter for `Navigator.requestMediaKeySystemAccess()` takes an array of possible configurations and allows the system to choose the one that it considers appropriate.
+
+By contrast, `decodingInfo()` takes one configuration at a time.
+The expectation is that the caller will execute `decodingInfo()` multiple times, starting with the most preferred configurations and stopping as soon as it finds a configuration that meets application requirements for being smooth, power-efficient, or both.
+In other words, the selection decision is devolved to the caller.
+
 ## Examples
+
+### Getting decoding information for unencrypted media files
 
 This example shows how to create a media configuration for an audio file and then use it in `MediaCapabilities.decodingInfo()`.
 
@@ -124,6 +239,62 @@ const mediaConfig = {
 };
 ```
 
+### Getting decoding information for encrypted media
+
+This example shows how to use `decodingInfo()` to select a media configuration for encrypted content that is both supported and smooth.
+Note that the code uses `await`/`async`, and would need to be called within a function (not in the top level context).
+
+Assuming we already have an `Array` of media configurations named `orderedMediaConfigs`, which we have ordered from most to least wanted, we can use the [`Array.prototype.map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) to call `decodingInfo()` for each configuration and get an array containing all the returned {{jsxref("Promise")}} objects.
+
+```js
+const capabilitiesPromises = orderedMediaConfigs.map((mediaConfig) =>
+  navigator.mediaCapabilities.decodingInfo(mediaConfig),
+);
+```
+
+We then use a [`for await...of` loop](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) to iterate the promises as they resolve.
+In the loop we store the last supported configuration to `nonSmoothConfig`, and we exit the loop as soon as we find a smooth configuration, setting this as our `bestConfig`.
+
+```js
+// Assume this app wants a supported && smooth config.
+let bestConfig = null;
+let nonSmoothConfig = null;
+for await (const mediaCapabilityInfo of capabilitiesPromises) {
+  if (!mediaCapabilityInfo.supported) continue;
+
+  if (!mediaCapabilityInfo.smooth) {
+    nonSmoothConfig = mediaCapabilityInfo;
+    continue;
+  }
+
+  bestConfig = mediaCapabilityInfo;
+  break;
+}
+```
+
+If we found a smooth and supported configuration (`bestConfig`) we use it to [create our media keys](/en-US/docs/Web/API/MediaKeySystemAccess/createMediaKeys) and decode the media.
+If we didn't discover any smooth configurations we might instead use `nonSmoothConfig` to decode the media.
+This will be the supported configuration that was found last, which because of the way we ordered the original `orderedMediaConfigs`, should be the one with the lowest framerate.
+
+```js
+let keys = null;
+if (bestConfig) {
+  keys = await bestConfig.keySystemAccess.createMediaKeys();
+  // ... use keys to decode media with best config
+} else if (nonSmoothConfig) {
+  console.log(
+    "No smooth configs found. Using lowest resolution configuration!",
+  );
+  keys = await nonSmoothConfig.keySystemAccess.createMediaKeys();
+  // ... use keys to decode media with best config
+} else {
+  console.log("No supported configs!");
+  // Fail!
+}
+```
+
+If there are no supported configuration, we have no choice but to fail and notify the user.
+
 ## Specifications
 
 {{Specifications}}
@@ -137,3 +308,4 @@ const mediaConfig = {
 - {{domxref("MediaCapabilities.encodingInfo()")}}
 - {{domxref("HTMLMediaElement.canPlayType()")}} for file
 - {{domxref("MediaSource.isTypeSupported_static", "MediaSource.isTypeSupported()")}} for media-source
+- {{domxref("Navigator.requestMediaKeySystemAccess()")}}

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-method
 browser-compat: api.MediaCapabilities.encodingInfo
 ---
 
-{{APIRef("MediaCapabilities")}}
+{{APIRef("Media Capabilities API")}}
 
-The **`MediaCapabilities.encodingInfo()`** method, part of the {{domxref("MediaCapabilities")}} interface of the [Media Capabilities API](/en-US/docs/Web/API/MediaCapabilities), returns a promise with the tested media configuration's capabilities information.
+The **`encodingInfo()`** method of the {{domxref("MediaCapabilities")}} interface returns a promise that fulfills with the tested media configuration's capabilities for encoding media.
 This contains the three boolean properties `supported`, `smooth`, and `powerefficient`, which describe how compatible the device is with the type of media.
 
 ## Syntax
@@ -69,7 +69,7 @@ encodingInfo(configuration)
 A {{jsxref('Promise')}} fulfilling with an object containing three Boolean attributes:
 
 - `supported`
-  - : `true` if the media content can be decoded at all. Otherwise, it is `false`.
+  - : `true` if the media content can be encoded at all. Otherwise, it is `false`.
 - `smooth`
   - : `true` if playback of the media will be smooth (of high quality). Otherwise it is `false`.
 - `powerEfficient`

--- a/files/en-us/web/api/mediacapabilities/index.md
+++ b/files/en-us/web/api/mediacapabilities/index.md
@@ -9,7 +9,7 @@ browser-compat: api.MediaCapabilities
 
 The **`MediaCapabilities`** interface of the [Media Capabilities API](/en-US/docs/Web/API/Media_Capabilities_API) provides information about the decoding abilities of the device, system and browser. The API can be used to query the browser about the decoding abilities of the device based on codecs, profile, resolution, and bitrates. The information can be used to serve optimal media streams to the user and determine if playback should be smooth and power efficient.
 
-The information is accessed through the **`mediaCapabilities`** property of the {{domxref("Navigator")}} interface.
+The information is accessed through the **`mediaCapabilities`** property of the {{domxref("Navigator")}} and {{domxref("WorkerNavigator")}} interface.
 
 ## Instance methods
 

--- a/files/en-us/web/api/navigator/mediacapabilities/index.md
+++ b/files/en-us/web/api/navigator/mediacapabilities/index.md
@@ -8,10 +8,7 @@ browser-compat: api.Navigator.mediaCapabilities
 
 {{APIRef("HTML DOM")}}
 
-The **`Navigator.mediaCapabilities`** read-only property
-returns a {{domxref("MediaCapabilities")}} object that can expose information about the
-decoding and encoding capabilities for a given format and output capabilities as defined
-by the [Media Capabilities API](/en-US/docs/Web/API/Media_Capabilities_API).
+The **`mediaCapabilities`** read-only property of the {{domxref("Navigator")}} interface references a {{domxref("MediaCapabilities")}} object that can expose information about the decoding and encoding capabilities for a given media format and output capabilities.
 
 ## Value
 

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -108,7 +108,7 @@ In case of an error, the returned {{jsxref('Promise')}} is rejected with a {{dom
   - : Either the specified `keySystem` isn't supported by the platform or the browser, or none of the configurations specified by `supportedConfigurations` can be satisfied (if, for example, none of the `codecs` specified in `contentType` are available).
 - `SecurityError` {{domxref("DOMException")}}
   - : Use of this feature was blocked by [`Permissions-Policy: encrypted-media`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/encrypted-media).
-- {{jsxref("TypeError")}}`
+- {{jsxref("TypeError")}}
   - : Either `keySystem` is an empty string or the `supportedConfigurations` array is empty.
 
 ## Examples

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -150,3 +150,4 @@ navigator
 - [Encrypted Media Extensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API)
 - [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API)
 - [WebRTC API](/en-US/docs/Web/API/WebRTC_API)
+- {{domxref("MediaCapabilities.decodingInfo()")}}

--- a/files/en-us/web/api/workernavigator/mediacapabilities/index.md
+++ b/files/en-us/web/api/workernavigator/mediacapabilities/index.md
@@ -8,10 +8,7 @@ browser-compat: api.WorkerNavigator.mediaCapabilities
 
 {{APIRef("HTML DOM")}}
 
-The read-only **`WorkerNavigator.mediaCapabilities`** property
-returns a {{domxref("MediaCapabilities")}} object that can expose information about the
-decoding and encoding capabilities for a given format and output capabilities as defined
-by the [Media Capabilities API](/en-US/docs/Web/API/Media_Capabilities_API).
+The read-only **`mediaCapabilities`** property of the {{domxref("WorkerNavigator")}} interface references a {{domxref("MediaCapabilities")}} object that can expose information about the decoding and encoding capabilities for a given format and output capabilities (as defined by the [Media Capabilities API](/en-US/docs/Web/API/Media_Capabilities_API)).
 
 ## Value
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -965,12 +965,12 @@
       "guides": [
         "/docs/Web/API/Media_Capabilities_API/Using_the_Media_Capabilities_API"
       ],
-      "interfaces": ["MediaCapabilities", "Screen"],
-      "methods": [
-        "MediaCapabilities.decodingInfo()",
-        "MediaCapabilities.encodingInfo()"
+      "interfaces": ["MediaCapabilities"],
+      "methods": [],
+      "properties": [
+        "Navigator.mediaCapabilities",
+        "WorkerNavigator.mediaCapabilities"
       ],
-      "properties": ["Navigator.mediaCapabilities"],
       "events": []
     },
     "Media Capture and Streams": {


### PR DESCRIPTION
FF129 Adds support for using [`MediaCapabilities.decodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo) with encoded media, by supplying a capability object that has key system configuration information, and returning an object that has a new property `keySystemAccess` that can be used to create media keys for decyrption and playback.

This updates the doc with the property for specifying the key system `keySystemConfiguration` and the updated return value, and also fixes a bunch of other related values.

The spec indicates that the return object also has a configuration property that matches the original configuration passed in, but this does  not appear to have been implemented anywhere, so is not documented (confirmed in https://bugzilla.mozilla.org/show_bug.cgi?id=1898344#c20)

Related docs work can be tracked in https://github.com/mdn/content/issues/34696