### PR TITLE
fix(css): update min max content size pages

### DIFF
--- a/files/en-us/web/css/max-content/index.md
+++ b/files/en-us/web/css/max-content/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.width.max-content
 
 {{CSSRef}}
 
-The `max-content` sizing keyword represents the {{glossary("intrinsic size", "intrinsic")}} maximum width or height of the content. For text content this means that the content will not wrap at all even if it causes overflows.
+The `max-content` sizing keyword represents the maximum {{glossary("intrinsic size")}} of the content. For text content this means that the content will not wrap at all even if it causes overflows.
 
 ## Syntax
 

--- a/files/en-us/web/css/min-content/index.md
+++ b/files/en-us/web/css/min-content/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.width.min-content
 
 {{CSSRef}}
 
-The `min-content` sizing keyword represents the {{glossary("intrinsic size", "intrinsic")}} minimum width of the content. For text content this means that the content will take all soft-wrapping opportunities, becoming as small as the longest word.
+The `min-content` sizing keyword represents the minimum {{glossary("intrinsic size")}} of the content. For text content this means that the content will take all soft-wrapping opportunities, becoming as small as the longest word.
 
 ## Syntax
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/14454

The issue was raised considering writing mode. But the size value has nothing to do with 'how setting height to any value has no effect in horizontal writing modes`.

The intros on the pages use height and width words but the words could easily be confused with `height` or `width` properties.