### PR TITLE
Fix UA CH header list

### DIFF
--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -104,7 +104,7 @@ Sec-CH-Prefers-Reduced-Motion: "reduce"
 ### User-agent client hints
 
 User agent (UA) client hint headers allow a server to vary responses based on the user agent (browser), operating system, and device.
-Headers include: {{HTTPHeader("Sec-CH-UA")}}, {{HTTPHeader("Sec-CH-UA-Arch")}}, {{HTTPHeader("Sec-CH-UA-Bitness")}}, {{HTTPHeader("Sec-CH-UA-Full-Version-List")}}, {{HTTPHeader("Sec-CH-UA-Full-Version")}}, {{HTTPHeader("Sec-CH-UA-Mobile")}}, {{HTTPHeader("Sec-CH-UA-Model")}}, {{HTTPHeader("Sec-CH-UA-Platform")}}, and {{HTTPHeader("Sec-CH-UA-Platform-Version")}}.
+For a list of `Sec-CH-UA-*` headers, see [User agent client hints headers](/en-US/docs/Web/HTTP/Headers#user-agent_client_hints).
 
 Client hints are available to web page JavaScript via the [User Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API).
 

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -313,6 +313,10 @@ The [UA client hints](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints)
   - : User agent's underlying platform architecture.
 - {{HTTPHeader("Sec-CH-UA-Bitness")}} {{experimental_inline}}
   - : User agent's underlying CPU architecture bitness (for example "64" bit).
+- {{HTTPHeader("Sec-CH-UA-Form-Factor")}} {{experimental_inline}}
+  - : User agent's form-factors, describing how the user interacts with the user-agent.
+- {{HTTPHeader("Sec-CH-UA-Full-Version")}} {{deprecated_inline}}
+  - : User agent's full version string.
 - {{HTTPHeader("Sec-CH-UA-Full-Version-List")}} {{experimental_inline}}
   - : Full version for each brand in the user agent's brand list.
 - {{HTTPHeader("Sec-CH-UA-Mobile")}} {{experimental_inline}}
@@ -323,9 +327,11 @@ The [UA client hints](/en-US/docs/Web/HTTP/Client_hints#user-agent_client_hints)
   - : User agent's underlying operation system/platform.
 - {{HTTPHeader("Sec-CH-UA-Platform-Version")}} {{experimental_inline}}
   - : User agent's underlying operation system version.
-- {{HTTPHeader("Sec-CH-UA-Prefers-Color-Scheme")}} {{experimental_inline}}
+- {{HTTPHeader("Sec-CH-UA-WoW64")}} {{experimental_inline}}
+  - : Whether or not the user agent binary is running in 32-bit mode on 64-bit Windows.
+- {{HTTPHeader("Sec-CH-Prefers-Color-Scheme")}} {{experimental_inline}}
   - : User's preference of dark or light color scheme.
-- {{HTTPHeader("Sec-CH-UA-Prefers-Reduced-Motion")}} {{experimental_inline}}
+- {{HTTPHeader("Sec-CH-Prefers-Reduced-Motion")}} {{experimental_inline}}
   - : User's preference to see fewer animations and content layout shifts.
 
 > **Note:** User-agent client hints are not available inside [fenced frames](/en-US/docs/Web/API/Fenced_frame_API) because they rely on [permissions policy](/en-US/docs/Web/HTTP/Permissions_Policy) delegation, which could be used to leak data.


### PR DESCRIPTION
While maitaining https://github.com/mdn/content/issues/1458, noticed the two UA CH header links are misspelled and broken. Also added two new headers as broken links, as has already been done in https://github.com/mdn/content/pull/30147.