### PR TITLE
Use officially known term "percent-encoding" instead of "URL encoding"

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rulecondition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rulecondition/index.md
@@ -29,7 +29,7 @@ Values of this type are objects. They contain these properties:
   - : A `string`. Regular expression to match against the network request URL. Note that:
     - The supported format is not stable and varies across browsers, see ["Regular expressions in DNR API (regexFilter)" in WECG issue 344](https://github.com/w3c/webextensions/issues/344) for details.
     - Only one of [`urlFilter`](#urlfilter) or [`regexFilter`](#regexfilter) can be specified.
-    - The [`regexFilter`](#regexfilter) must be composed of only {{Glossary("ASCII")}} characters. This is matched against a URL where the host is encoded in the [punycode](https://en.wikipedia.org/wiki/Punycode) format (in case of internationalized domains) and any other non-ascii characters are URL encoded in utf-8.
+    - The [`regexFilter`](#regexfilter) must be composed of only {{Glossary("ASCII")}} characters. This is matched against a URL where the host is encoded in the [punycode](https://en.wikipedia.org/wiki/Punycode) format (in case of internationalized domains) and any other non-ascii characters are percent-encoded in UTF-8.
 - `requestDomains` {{optional_inline}}
   - : An array of `string`. The rule only matches network requests when the domain matches one from this list. If the list is omitted, the rule is applied to requests from all domains. An empty list is not allowed. A [canonical domain](#canonical_domain) should be used.
 - `excludedRequestDomains` {{optional_inline}}
@@ -61,7 +61,7 @@ Values of this type are objects. They contain these properties:
     Note that:
 
     - Only one of `urlFilter` or [`regexFilter`](#regexfilter) can be specified.
-    - The `urlFilter` must be composed of only ASCII characters. This is matched against a URL where the host is encoded in the [punycode](https://en.wikipedia.org/wiki/Punycode) format (in case of internationalized domains) and any other non-ASCII characters are URL encoded in utf-8. For example, when the request URL is `http://abc.рф?q=ф`, the `urlFilter` is matched against the URL `http://abc.xn--p1ai/?q=%D1%84`.
+    - The `urlFilter` must be composed of only ASCII characters. This is matched against a URL where the host is encoded in the [punycode](https://en.wikipedia.org/wiki/Punycode) format (in case of internationalized domains) and any other non-ASCII characters are percent-encoded in UTF-8. For example, when the request URL is `http://abc.рф?q=ф`, the `urlFilter` is matched against the URL `http://abc.xn--p1ai/?q=%D1%84`.
 
 ### Canonical domain
 

--- a/files/en-us/web/api/htmlareaelement/hash/index.md
+++ b/files/en-us/web/api/htmlareaelement/hash/index.md
@@ -8,13 +8,9 @@ browser-compat: api.HTMLAreaElement.hash
 
 {{ APIRef("HTML DOM") }}
 
-The
-**`HTMLAreaElement.hash`** property returns a
-string containing a `'#'` followed by the fragment
-identifier of the URL.
+The **`HTMLAreaElement.hash`** property returns a string containing a `'#'` followed by the fragment identifier of the URL.
 
-The fragment is not [URL decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
-have a fragment identifier, this property contains an empty string, `""`.
+The fragment is not [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value
 
@@ -46,7 +42,7 @@ you can get the hash of the area link like this:
 
 ```js
 const area = document.getElementById("mdn-circle");
-area.hash; // returns '#ExampleSection'
+area.hash; // '#ExampleSection'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/location/hash/index.md
+++ b/files/en-us/web/api/location/hash/index.md
@@ -8,13 +8,9 @@ browser-compat: api.Location.hash
 
 {{ APIRef("Location") }}
 
-The **`hash`** property of the
-{{domxref("Location")}} interface returns a string containing a
-`'#'` followed by the fragment identifier of the URL — the ID on the page
-that the URL is trying to target.
+The **`hash`** property of the {{domxref("Location")}} interface returns a string containing a `'#'` followed by the fragment identifier of the URL — the ID on the page that the URL is trying to target.
 
-The fragment is not [URL decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
-have a fragment identifier, this property contains an empty string, `""`.
+The fragment is not [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value
 
@@ -23,10 +19,10 @@ A string.
 ## Examples
 
 ```html
-<a id="myAnchor" href="/en-US/docs/Location.href#Examples">Examples</a>
+<a id="myAnchor" href="/en-US/docs/Location.href#examples">Examples</a>
 <script>
   const anchor = document.getElementById("myAnchor");
-  console.log(anchor.hash); // Returns '#Examples'
+  console.log(anchor.hash); // '#examples'
 </script>
 ```
 

--- a/files/en-us/web/api/url/hash/index.md
+++ b/files/en-us/web/api/url/hash/index.md
@@ -8,12 +8,9 @@ browser-compat: api.URL.hash
 
 {{ APIRef("URL API") }} {{AvailableInWorkers}}
 
-The **`hash`** property of the
-{{domxref("URL")}} interface is a string containing a
-`'#'` followed by the fragment identifier of the URL.
+The **`hash`** property of the {{domxref("URL")}} interface is a string containing a `'#'` followed by the fragment identifier of the URL.
 
-The fragment is not [URL decoded](https://en.wikipedia.org/wiki/URL_encoding). If the URL does not
-have a fragment identifier, this property contains an empty string — `""`.
+The fragment is not [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string — `""`.
 
 ## Value
 
@@ -23,9 +20,9 @@ A string.
 
 ```js
 const url = new URL(
-  "https://developer.mozilla.org/en-US/docs/Web/API/URL/href#Examples",
+  "https://developer.mozilla.org/en-US/docs/Web/API/URL/href#examples",
 );
-console.log(url.hash); // Logs: '#Examples'
+console.log(url.hash); // '#examples'
 ```
 
 ## Specifications

--- a/files/en-us/web/html/element/input/image/index.md
+++ b/files/en-us/web/html/element/input/image/index.md
@@ -40,7 +40,7 @@ This attribute is also available on [`<input type="submit">`](/en-US/docs/Web/HT
 A string that identifies the encoding method to use when submitting the form data to the server. There are three permitted values:
 
 - `application/x-www-form-urlencoded`
-  - : This, the default value, sends the form data as a string after [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
+  - : This, the default value, sends the form data as a string after [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -46,7 +46,7 @@ This attribute is also available on [`<input type="image">`](/en-US/docs/Web/HTM
 A string that identifies the encoding method to use when submitting the form data to the server. There are three permitted values:
 
 - `application/x-www-form-urlencoded`
-  - : This, the default value, sends the form data as a string after [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
+  - : This, the default value, sends the form data as a string after [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -21,14 +21,14 @@ data:[<mediatype>][;base64],<data>
 
 The `mediatype` is a [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) string, such as `'image/jpeg'` for a JPEG image file. If omitted, defaults to `text/plain;charset=US-ASCII`
 
-If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [URL encoded](https://en.wikipedia.org/wiki/URL_encoding).
+If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
 
 If the data is textual, you can embed the text (using the appropriate entities or escapes based on the enclosing document's type). Otherwise, you can specify `base64` to embed base64-encoded binary data. You can find more info on MIME types [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) and [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 
 A few examples:
 
 - `data:,Hello%2C%20World%21`
-  - : The text/plain data `Hello, World!`. Note how the comma is [URl encoded](https://en.wikipedia.org/wiki/URL_encoding) as `%2C`, and the space character as `%20`.
+  - : The text/plain data `Hello, World!`. Note how the comma is [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding) as `%2C`, and the space character as `%20`.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`
@@ -115,7 +115,7 @@ lots of text…
 ## See also
 
 - [Base64](/en-US/docs/Glossary/Base64)
-- [URL encoding](https://en.wikipedia.org/wiki/URL_encoding)
+- [Percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding)
 - {{domxref("WorkerGlobalScope.atob()", "atob()")}}
 - {{domxref("WorkerGlobalScope.btoa()", "btoa()")}}
 - [CSS `url()`](/en-US/docs/Web/CSS/url)

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -18,7 +18,7 @@ Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
 - `<uri-reference>`
-  - : The URI reference, must be enclosed between `<` and `>` and [URL encoded](https://en.wikipedia.org/wiki/URL_encoding).
+  - : The URI reference, must be enclosed between `<` and `>` and [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ### Parameters
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -62,9 +62,9 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding control characters (ASCII characters 0 up to 31 and ASCII character 127), {{glossary("Whitespace")}}, double quotes, commas, semicolons, and backslashes.
 
-    **Encoding**: Many implementations perform [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) on cookie values.
+    **Encoding**: Many implementations perform [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) on cookie values.
     However, this is not required by the RFC specification.
-    The URL encoding does help to satisfy the requirements of the characters allowed for `<cookie-value>`.
+    The percent-encoding does help to satisfy the requirements of the characters allowed for `<cookie-value>`.
 
     > **Note:** Some `<cookie-name>` have a specific semantic:
     >

--- a/files/en-us/web/http/methods/post/index.md
+++ b/files/en-us/web/http/methods/post/index.md
@@ -13,7 +13,7 @@ The difference between {{HTTPMethod("PUT")}} and `POST` is that `PUT` is idempot
 
 A `POST` request is typically sent via an [HTML form](/en-US/docs/Learn/Forms) and results in a change on the server. In this case, the content type is selected by putting the adequate string in the [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) attribute of the {{HTMLElement("form")}} element or the [`formenctype`](/en-US/docs/Web/HTML/Element/input#formenctype) attribute of the {{HTMLElement("input") }} or {{HTMLElement("button")}} elements:
 
-- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are [URL encoded](https://en.wikipedia.org/wiki/URL_encoding): this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
+- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding): this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
 - `multipart/form-data`: each value is sent as a block of data ("body part"), with a user agent-defined delimiter ("boundary") separating each part. The keys are given in the `Content-Disposition` header of each part.
 - `text/plain`
 

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.md
@@ -34,7 +34,7 @@ A new string in which certain characters have been escaped.
 
 The `escape()` function replaces all characters with escape sequences, with the exception of {{Glossary("ASCII")}} word characters (A–Z, a–z, 0–9, \_) and `@\*_+-./`. Characters are escaped by UTF-16 code units. If the code unit's value is less than 256, it is represented by a two-digit hexadecimal number in the format `%XX`, left-padded with 0 if necessary. Otherwise, it is represented by a four-digit hexadecimal number in the format `%uXXXX`, left-padded with 0 if necessary.
 
-> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(1738)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
+> **Note:** This function was used mostly for [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) and is partly based on the escape format in {{rfc(1738)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/unescape/index.md
@@ -34,7 +34,7 @@ A new string in which certain characters have been unescaped.
 
 The `unescape()` function replaces any escape sequence with the character that it represents. Specifically, it replaces any escape sequence of the form `%XX` or `%uXXXX` (where `X` represents one hexadecimal digit) with the character that has the hexadecimal value `XX`/`XXXX`. If the escape sequence is not a valid escape sequence (for example, if `%` is followed by one or no hex digit), it is left as-is.
 
-> **Note:** This function was used mostly for [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) and is partly based on the escape format in {{rfc(1738)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
+> **Note:** This function was used mostly for [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) and is partly based on the escape format in {{rfc(1738)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Ths PR updates all links to https://en.wikipedia.org/wiki/URL_encoding (changed to actual https://en.wikipedia.org/wiki/Percent-encoding).

### Additional details

Also updates formatting and improves example style on changed pages.

### Related issues and pull requests

Relates to #34575
