### PR TITLE
FF129 Release/Expr feature Float16Array and friends

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1203,48 +1203,6 @@ This includes: `SVGPathSegList`, [SVGPathElement.getPathSegAtLength()](/en-US/do
 
 ## JavaScript
 
-### Float16Array Typed Arrays
-
-{{jsxref("Float16Array")}} typed arrays are now supported, along with {{jsxref("DataView.prototype.getFloat16()")}} and {{jsxref("DataView.prototype.setFloat16()")}} for reading and setting `Float16Array` values from a {{jsxref("DataView")}}, and the {{jsxref("Math.f16round()")}} static method, which can be used to round numbers to 16 bits.
-The new type is useful for sharing data with a GPU, in particular for use cases where it makes sense to trade off precision for memory consumption.
-([Firefox bug 1833647](https://bugzil.la/1833647).)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>127</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>127</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>127</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>127</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>javascript.options.experimental.float16array</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## APIs
 
 ### Graphics: Canvas, WebGL, and WebGPU

--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -22,6 +22,8 @@ This article provides information about the changes in Firefox 129 that affect d
 
 ### JavaScript
 
+- {{jsxref("Float16Array")}} typed arrays are now supported, along with {{jsxref("DataView.prototype.getFloat16()")}} and {{jsxref("DataView.prototype.setFloat16()")}} for reading and setting `Float16Array` values from a {{jsxref("DataView")}}, and the {{jsxref("Math.f16round()")}} static method, which can be used to round numbers to 16 bits. The new type is useful for sharing data with a GPU, in particular for use cases where it makes sense to trade off precision for memory consumption. ([Firefox bug 1903329](https://bugzil.la/1903329).)
+
 #### Removals
 
 ### SVG


### PR DESCRIPTION
FF129 ships `Float16Array` typed arrays support along with long with `DataView.prototype.getFloat16()` and `DataView.prototype.setFloat16()` and the `Math.f16round()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1903329

This adds a release note.

Related docs work can be tracked in https://github.com/mdn/content/issues/34697