### PR TITLE
Add two common relative URL forms for context

### DIFF
--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -297,7 +297,9 @@ Spacing may be created using CSS properties like {{CSSxRef("margin")}}.
 ```html
 <a href="//example.com">Scheme-relative URL</a>
 <a href="/en-US/docs/Web/HTML">Origin-relative URL</a>
+<a href="p">Directory-relative URL</a>
 <a href="./p">Directory-relative URL</a>
+<a href="../p">Parent-directory-relative URL</a>
 ```
 
 ```css hidden


### PR DESCRIPTION
### Description

Add two common relative URL forms to the relative URL examples.

### Motivation

`<a href="page">` is a more minimal directory-relative example. In addition, I sometimes see it while browsing the general web, but I have only seen the `<a href="./page">` directory-relative form in source code and developer docs. Showing the duplication could be helpful for new developers. 

The `<a href="../page">` parent-directory-relative example highlights the URL scheme’s basic similarity to CLI directory navigation. It also adds context to the single-dot directory-relative form.

Together, the three directory-relative examples are a better description of a part of the URL scheme that’s a common point of confusion.