### PR TITLE
Fix documentation of FocusOptions.focusVisible.

### DIFF
--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -33,8 +33,8 @@ focus(options)
         A value of `false` for `preventScroll` (the default) means that the browser will scroll the element into view after focusing it.
         If `preventScroll` is set to `true`, no scrolling will occur.
     - `focusVisible` {{optional_inline}} {{experimental_inline}}
-      - : A boolean value that should be set to `true` to force visible indication that the element is focused.
-        By default, or if the property is not `true`, a browser may still provide visible indication if it determines that this would improve accessibility for users.
+      - : A boolean value that should be set to `true` to force, or `false` to prevent visible indication that the element is focused.
+        If the property is not specified, a browser will provide visible indication if it determines that this would improve accessibility for users.
 
 ### Return value
 


### PR DESCRIPTION
### Description

`focusVisible: false` is not equivalent to not specifying the option as the current text implies.

The spec is clear, and only indicates focus if focusVisible is true, or not specified and a browser-heuristic matches, see [1]:

> If the value of the `focusVisible` dictionary member of options is
> `true`, or is not present but in an implementation-defined way the
> user agent determines it would be best to do so, then indicate focus.

That condition doesn't match if the member is present and is `false` :)

[1]: https://html.spec.whatwg.org/#dom-focus

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Motivation

It's wrong. There seems to be confusion in issues like https://github.com/w3c/csswg-drafts/issues/5885, partially due to the wrong MDN documentation.

### Additional details

I wrote the spec (see https://github.com/whatwg/html/pull/8087), and this was explicitly discussed in the WHATWG in the various meetings referenced from https://github.com/whatwg/html/issues/7830 :)