### PR TITLE
fix(ci): reviewdog fix diff issue

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -130,6 +130,7 @@ jobs:
             -name="mdn-linter" \
             -f=diff \
             -f.diff.strip=1 \
+            -filter-mode=diff_context \
             -reporter=github-pr-review < "${TMPFILE}"
 
       - name: Add reviews for markdownlint errors


### PR DESCRIPTION
At the moment reviewdog doesn't report blank lines in GitHub PR checks. For example, [consider this test PR](https://github.com/mdn/content/pull/34879). The [`lint-and-review-docs` workflow failed](https://github.com/mdn/content/actions/runs/9968527497/job/27543962790?pr=34879) but reviewdog didn't make any suggestion. 

As [suggested](https://github.com/reviewdog/reviewdog/issues/1580#issuecomment-2227838953) by a reviewdog maintainer, `-filter-mode=diff_context` fixes it.

The code change has been tested [here](https://github.com/OnkarRuikar/content/pull/26#discussion_r1680391749).

After we merge this PR, we'll rebase https://github.com/mdn/content/pull/34879 and reviewdog should make suggestions about the blank lines.