### PR TITLE
fix(api): InstallEvent is not deprecated but constructor is

### DIFF
--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -2,12 +2,10 @@
 title: InstallEvent
 slug: Web/API/InstallEvent
 page-type: web-api-interface
-status:
-  - deprecated
 browser-compat: api.InstallEvent
 ---
 
-{{APIRef("Service Workers API")}}{{Deprecated_Header}}
+{{APIRef("Service Workers API")}}
 
 > **Note:** Instead of using the deprecated `ServiceWorkerGlobalScope.oninstall` handler to catch events of this type, handle the (non-deprecated) {{domxref("ServiceWorkerGlobalScope/install_event", "install")}} event using a listener added with {{domxref("EventTarget/addEventListener", "addEventListener")}}.
 


### PR DESCRIPTION
As per [BCD](https://github.com/mdn/browser-compat-data/blob/8f41ee3464ac4168b6f09f9f2c71417fbcddad0c/api/InstallEvent.json#L35) InstallEvent is not deprecated. Only the constructor is deprecated.

Aligning content with BCD.