### PR TITLE
fix: explicitly use `<i>` tag for italic text

### DIFF
--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -29,9 +29,27 @@ By default, the visual result is the same. However, the semantic meaning is diff
 
 This means the right one to use depends on the situation. Neither is for purely decorative purposes, that's what CSS styling is for.
 
-An example for `<em>` could be: "Just _do_ it already!", or: "We _had_ to do something about it". A person or software reading the text would pronounce the words in italics with an emphasis, using verbal stress.
+Examples for `<em>` could be:
 
-An example for `<i>` could be: "The <i>Queen Mary</i> sailed last night". Here, there is no added emphasis or importance on the word "Queen Mary". It is merely indicated that the object in question is not a queen named Mary, but a ship named <i>Queen Mary</i>. Another example for `<i>` could be: "The word <i>the</i> is an article".
+```html html live-sample___em-example
+<p>Just <em>do</em> it already!</p>
+<p>We <em>had</em> to do something about it</p>
+```
+
+{{EmbedLiveSample('em-example', "", 85)}}
+
+A person or software reading the text would pronounce the words in italics with an emphasis, using verbal stress.
+
+Example for `<i>` could be:
+
+```html live-sample___i-example
+<p>The word <i>the</i> is an article</p>
+<p>The <i>Queen Mary</i> sailed last night</p>
+```
+
+{{EmbedLiveSample('i-example', "", 85)}}
+
+Here, there is no added emphasis or importance on the word "Queen Mary". It is merely indicated that the object in question is not a queen named Mary but a ship named "Queen Mary".
 
 ## Examples
 

--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -31,7 +31,7 @@ This means the right one to use depends on the situation. Neither is for purely 
 
 Examples for `<em>` could be:
 
-```html html live-sample___em-example
+```html live-sample___em-example
 <p>Just <em>do</em> it already!</p>
 <p>We <em>had</em> to do something about it</p>
 ```

--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -33,18 +33,18 @@ Examples for `<em>` could be:
 
 ```html live-sample___em-example
 <p>Just <em>do</em> it already!</p>
-<p>We <em>had</em> to do something about it</p>
+<p>We <em>had</em> to do something about it.</p>
 ```
 
 {{EmbedLiveSample('em-example', "", 85)}}
 
 A person or software reading the text would pronounce the words in italics with an emphasis, using verbal stress.
 
-Example for `<i>` could be:
+Examples for `<i>` could be:
 
 ```html live-sample___i-example
-<p>The word <i>the</i> is an article</p>
-<p>The <i>Queen Mary</i> sailed last night</p>
+<p>The word <i>the</i> is an article.</p>
+<p>The <i>Queen Mary</i> sailed last night.</p>
 ```
 
 {{EmbedLiveSample('i-example', "", 85)}}

--- a/files/en-us/web/html/element/em/index.md
+++ b/files/en-us/web/html/element/em/index.md
@@ -31,7 +31,7 @@ This means the right one to use depends on the situation. Neither is for purely 
 
 An example for `<em>` could be: "Just _do_ it already!", or: "We _had_ to do something about it". A person or software reading the text would pronounce the words in italics with an emphasis, using verbal stress.
 
-An example for `<i>` could be: "The _Queen Mary_ sailed last night". Here, there is no added emphasis or importance on the word "Queen Mary". It is merely indicated that the object in question is not a queen named Mary, but a ship named _Queen Mary_. Another example for `<i>` could be: "The word _the_ is an article".
+An example for `<i>` could be: "The <i>Queen Mary</i> sailed last night". Here, there is no added emphasis or importance on the word "Queen Mary". It is merely indicated that the object in question is not a queen named Mary, but a ship named <i>Queen Mary</i>. Another example for `<i>` could be: "The word <i>the</i> is an article".
 
 ## Examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Use the `<i>` tags explicitly since markdown syntax generates `<em>` tags for italic text by default.

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/d1d2c110-8845-43aa-a3cb-b1302b72e181">


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The article explains the difference between the `<i>` and `<em>` tags but uses `<em>` instead of `<i>` in its source code.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
