### PR TITLE
fix(css): update variable font_style examples

### DIFF
--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -179,7 +179,7 @@ The basic syntax is the same, but the font technology can be specified, and allo
 }
 ```
 
-The `font-style: oblique 0deg` and `font-style: oblique 0deg 20deg` values also indicate the font has normal glyphs.
+In this case, the `normal` value indicates that this font file should be used when in a style rule the `font-family` property is `MyVariableFontName` and the [font-style](/en-US/docs/Web/CSS/font-style) property is `normal`. The `oblique 0deg` and `oblique 0deg 20deg` values, because of the `0deg`, also indicate the font has normal upright glyphs.
 
 #### Example for a font that contains only italics and no upright characters
 
@@ -193,7 +193,7 @@ The `font-style: oblique 0deg` and `font-style: oblique 0deg 20deg` values also 
 }
 ```
 
-The `font-style: oblique 14deg` also indicates that the font has italics glyphs.
+In this case, the `italic` value indicates that this font file should be used when in a style rule the `font-family` property is `MyVariableFontName` and the [font-style](/en-US/docs/Web/CSS/font-style) property is `italic`. The `oblique 14deg` value also indicates the font has italic glyphs.
 
 #### Example for a font that contains an oblique (slant) axis
 
@@ -206,6 +206,8 @@ The `font-style: oblique 14deg` also indicates that the font has italics glyphs.
   font-style: oblique 0deg 12deg;
 }
 ```
+
+In this case, the `oblique 0deg 12deg` value indicates that this font file should be used when in a style rule the `font-family` property is `MyVariableFontName` and the [font-style](/en-US/docs/Web/CSS/font-style) property is oblique with an angle between zero and 12 degrees inclusive.
 
 > **Note:** Not all browsers have implemented the full syntax for font format, so test carefully. All browsers that support variable fonts will still render them if you set the format to just the file format, rather than format-variations (i.e. `woff2` instead of `woff2-variations`), but it's best to use the proper syntax if possible.
 

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -179,19 +179,7 @@ The basic syntax is the same, but the font technology can be specified, and allo
 }
 ```
 
-#### Example for a font that includes both upright and italics
-
-```css
-@font-face {
-  font-family: "MyVariableFontName";
-  src: url("path/to/font/file/myvariablefont.woff2") format("woff2-variations");
-  font-weight: 125 950;
-  font-stretch: 75% 125%;
-  font-style: oblique 0deg 20deg;
-}
-```
-
-> **Note:** there is no set specific value for the upper-end degree measurement in this case; they indicate that there is an axis so the browser can know to render upright or italic (remember that italics are only on or off)
+The `font-style: oblique 0deg` and `font-style: oblique 0deg 20deg` values also indicate the font has normal glyphs.
 
 #### Example for a font that contains only italics and no upright characters
 
@@ -204,6 +192,8 @@ The basic syntax is the same, but the font technology can be specified, and allo
   font-style: italic;
 }
 ```
+
+The `font-style: oblique 14deg` also indicates that the font has italics glyphs.
 
 #### Example for a font that contains an oblique (slant) axis
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/17852

Actually `font-style: oblique 0deg 20deg` [does indicate normal value](https://developer.mozilla.org/en-US/play?id=U%2BXDMliKVg721YXt2tFSMMk%2BPZuvj0JOrR%2Bth5nZ%2BFJU80HB3YoKEV%2BWIVenUbKjHvBADveephybeT39), but it [doesn't indicate italics value](https://developer.mozilla.org/en-US/play?id=WIPfVH0yV97nIlD4n3cWF4h90ITmuNad%2F%2B9FUmoUlhEH9zDqI2XE4P4SjlnQdDSYW7qQUESOZnQ8Q9%2B1). Hoever, if other italics font are not available then it could get bet fallen back to.

