### PR TITLE
Update Inheritance_and_the_prototype_chain index.md

### DIFF
--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -456,7 +456,7 @@ We have encountered many ways to create objects and change their prototype chain
 ```js
 const o = { a: 1 };
 // The newly created object o has Object.prototype as its [[Prototype]]
-// Object.prototype has null as its prototype.
+// Object.prototype has null as its [[prototype]].
 // o ---> Object.prototype ---> null
 
 const b = ["yo", "whadup", "?"];

--- a/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
+++ b/files/en-us/web/javascript/inheritance_and_the_prototype_chain/index.md
@@ -456,7 +456,7 @@ We have encountered many ways to create objects and change their prototype chain
 ```js
 const o = { a: 1 };
 // The newly created object o has Object.prototype as its [[Prototype]]
-// Object.prototype has null as its [[prototype]].
+// Object.prototype has null as its [[Prototype]].
 // o ---> Object.prototype ---> null
 
 const b = ["yo", "whadup", "?"];


### PR DESCRIPTION
Adding brackets for prototype in comments.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description
The place should have the brackets to indicate the __proto__ / [[prototype]] of the Object.prototype, which is the same as Object.getPrototypeOf(Object.prototype).
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
It can help other readers get the idea more clear. Note the difference between [[prototype]] and prototype.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
