### PR TITLE
Point Wikipedia link to specific article

### DIFF
--- a/files/en-us/web/api/encoding_api/encodings/index.md
+++ b/files/en-us/web/api/encoding_api/encodings/index.md
@@ -312,7 +312,7 @@ These are generally applicable anywhere character encodings are used.
         "<code>iso-ir-58</code>", "<code>x-gbk</code>"
       </td>
       <td>
-        <a href="https://en.wikipedia.org/wiki/GBK">gbk</a>
+        <a href="https://en.wikipedia.org/wiki/GBK_(character_encoding)">gbk</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Wikipedia link led to a disambiguation page. Updated link leads to specific article

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Wikipedia link led to a disambiguation page. Updated link leads to specific article

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Wikipedia link led to a disambiguation page. Updated link leads to specific article.

Perhaps in the link followed directly to the article in the past, and then, due to increasing number of articles in Wikipedia, creating a disambiguation page was needed, leaving the link pointing to the disambiguation page instead to the original article link.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

In order to the link follows the correct destination

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->

<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
