### PR TITLE
Use link to `Percent-encoding` in Glossary instead of Wikipedia

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
+++ b/files/en-us/learn/html/introduction_to_html/creating_hyperlinks/index.md
@@ -346,7 +346,7 @@ Here's an example that includes a cc, bcc, subject and body:
 </a>
 ```
 
-> **Note:** The values of each field must be URL-encoded with non-printing characters (invisible characters like tabs, carriage returns, and page breaks) and spaces [percent-escaped](https://en.wikipedia.org/wiki/Percent-encoding).
+> **Note:** The values of each field must be URL-encoded with non-printing characters (invisible characters like tabs, carriage returns, and page breaks) and spaces {{Glossary("Percent-encoding", "percent-escaped")}}.
 > Also, note the use of the question mark (`?`) to separate the main URL from the field values, and ampersands (&) to separate each field in the `mailto:` URL.
 > This is standard URL query notation.
 > Read [The GET method](/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_get_method) to understand what URL query notation is more commonly used for.

--- a/files/en-us/web/api/htmlareaelement/hash/index.md
+++ b/files/en-us/web/api/htmlareaelement/hash/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLAreaElement.hash
 
 The **`HTMLAreaElement.hash`** property returns a string containing a `'#'` followed by the fragment identifier of the URL.
 
-The fragment is not [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
+The fragment is not {{Glossary("Percent-encoding", "percent-encoded")}}. If the URL does not have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value
 

--- a/files/en-us/web/api/location/hash/index.md
+++ b/files/en-us/web/api/location/hash/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Location.hash
 
 The **`hash`** property of the {{domxref("Location")}} interface returns a string containing a `'#'` followed by the fragment identifier of the URL — the ID on the page that the URL is trying to target.
 
-The fragment is not [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string, `""`.
+The fragment is not {{Glossary("Percent-encoding", "percent-encoded")}}. If the URL does not have a fragment identifier, this property contains an empty string, `""`.
 
 ## Value
 

--- a/files/en-us/web/api/url/hash/index.md
+++ b/files/en-us/web/api/url/hash/index.md
@@ -10,7 +10,7 @@ browser-compat: api.URL.hash
 
 The **`hash`** property of the {{domxref("URL")}} interface is a string containing a `'#'` followed by the fragment identifier of the URL.
 
-The fragment is not [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). If the URL does not have a fragment identifier, this property contains an empty string — `""`.
+The fragment is not {{Glossary("Percent-encoding", "percent-encoded")}}. If the URL does not have a fragment identifier, this property contains an empty string — `""`.
 
 ## Value
 

--- a/files/en-us/web/html/element/input/image/index.md
+++ b/files/en-us/web/html/element/input/image/index.md
@@ -40,7 +40,7 @@ This attribute is also available on [`<input type="submit">`](/en-US/docs/Web/HT
 A string that identifies the encoding method to use when submitting the form data to the server. There are three permitted values:
 
 - `application/x-www-form-urlencoded`
-  - : This, the default value, sends the form data as a string after [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
+  - : This, the default value, sends the form data as a string after {{Glossary("Percent-encoding", "percent-encoding")}} the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -46,7 +46,7 @@ This attribute is also available on [`<input type="image">`](/en-US/docs/Web/HTM
 A string that identifies the encoding method to use when submitting the form data to the server. There are three permitted values:
 
 - `application/x-www-form-urlencoded`
-  - : This, the default value, sends the form data as a string after [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
+  - : This, the default value, sends the form data as a string after {{Glossary("Percent-encoding", "percent-encoding")}} the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
   - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -21,14 +21,14 @@ data:[<mediatype>][;base64],<data>
 
 The `mediatype` is a [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) string, such as `'image/jpeg'` for a JPEG image file. If omitted, defaults to `text/plain;charset=US-ASCII`
 
-If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
+If the data contains [characters defined in RFC 3986 as reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2), or contains space characters, newline characters, or other non-printing characters, those characters must be {{Glossary("Percent-encoding", "percent-encoded")}}.
 
 If the data is textual, you can embed the text (using the appropriate entities or escapes based on the enclosing document's type). Otherwise, you can specify `base64` to embed base64-encoded binary data. You can find more info on MIME types [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) and [here](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 
 A few examples:
 
 - `data:,Hello%2C%20World%21`
-  - : The text/plain data `Hello, World!`. Note how the comma is [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding) as `%2C`, and the space character as `%20`.
+  - : The text/plain data `Hello, World!`. Note how the comma is {{Glossary("Percent-encoding", "percent-encoded")}} as `%2C`, and the space character as `%20`.
 - `data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==`
   - : base64-encoded version of the above
 - `data:text/html,%3Ch1%3EHello%2C%20World%21%3C%2Fh1%3E`
@@ -114,9 +114,9 @@ lots of text…
 
 ## See also
 
-- [Base64](/en-US/docs/Glossary/Base64)
-- [Percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding)
+- {{Glossary("Base64")}}
+- {{Glossary("Percent-encoding")}}
 - {{domxref("WorkerGlobalScope.atob()", "atob()")}}
 - {{domxref("WorkerGlobalScope.btoa()", "btoa()")}}
-- [CSS `url()`](/en-US/docs/Web/CSS/url)
-- [URI](/en-US/docs/Glossary/URI)
+- CSS {{CSSXref("url", "url()")}}
+- {{Glossary("URI")}}

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -18,7 +18,7 @@ Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
 - `<uri-reference>`
-  - : The URI reference, must be enclosed between `<` and `>` and [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
+  - : The URI reference, must be enclosed between `<` and `>` and {{Glossary("Percent-encoding", "percent-encoded")}}.
 
 ### Parameters
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -62,7 +62,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding control characters (ASCII characters 0 up to 31 and ASCII character 127), {{glossary("Whitespace")}}, double quotes, commas, semicolons, and backslashes.
 
-    **Encoding**: Many implementations perform [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) on cookie values.
+    **Encoding**: Many implementations perform {{Glossary("Percent-encoding", "percent-encoding")}} on cookie values.
     However, this is not required by the RFC specification.
     The percent-encoding does help to satisfy the requirements of the characters allowed for `<cookie-value>`.
 

--- a/files/en-us/web/http/methods/post/index.md
+++ b/files/en-us/web/http/methods/post/index.md
@@ -13,7 +13,7 @@ The difference between {{HTTPMethod("PUT")}} and `POST` is that `PUT` is idempot
 
 A `POST` request is typically sent via an [HTML form](/en-US/docs/Learn/Forms) and results in a change on the server. In this case, the content type is selected by putting the adequate string in the [`enctype`](/en-US/docs/Web/HTML/Element/form#enctype) attribute of the {{HTMLElement("form")}} element or the [`formenctype`](/en-US/docs/Web/HTML/Element/input#formenctype) attribute of the {{HTMLElement("input") }} or {{HTMLElement("button")}} elements:
 
-- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding): this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
+- `application/x-www-form-urlencoded`: the keys and values are encoded in key-value tuples separated by `'&'`, with a `'='` between the key and the value. Non-alphanumeric characters in both keys and values are {{Glossary("Percent-encoding", "percent-encoded")}}: this is the reason why this type is not suitable to use with binary data (use `multipart/form-data` instead)
 - `multipart/form-data`: each value is sent as a block of data ("body part"), with a user agent-defined delimiter ("boundary") separating each part. The keys are given in the `Content-Disposition` header of each part.
 - `text/plain`
 

--- a/files/en-us/web/javascript/reference/global_objects/escape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/escape/index.md
@@ -34,7 +34,7 @@ A new string in which certain characters have been escaped.
 
 The `escape()` function replaces all characters with escape sequences, with the exception of {{Glossary("ASCII")}} word characters (A–Z, a–z, 0–9, \_) and `@\*_+-./`. Characters are escaped by UTF-16 code units. If the code unit's value is less than 256, it is represented by a two-digit hexadecimal number in the format `%XX`, left-padded with 0 if necessary. Otherwise, it is represented by a four-digit hexadecimal number in the format `%uXXXX`, left-padded with 0 if necessary.
 
-> **Note:** This function was used mostly for [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) and is partly based on the escape format in {{rfc(1738)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
+> **Note:** This function was used mostly for {{Glossary("Percent-encoding", "percent-encoding")}} and is partly based on the escape format in {{rfc(1738)}}. The escape format is _not_ an [escape sequence](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `%XX` with `\xXX` and `%uXXXX` with `\uXXXX` to get a string containing actual string-literal escape sequences.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/unescape/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/unescape/index.md
@@ -34,7 +34,7 @@ A new string in which certain characters have been unescaped.
 
 The `unescape()` function replaces any escape sequence with the character that it represents. Specifically, it replaces any escape sequence of the form `%XX` or `%uXXXX` (where `X` represents one hexadecimal digit) with the character that has the hexadecimal value `XX`/`XXXX`. If the escape sequence is not a valid escape sequence (for example, if `%` is followed by one or no hex digit), it is left as-is.
 
-> **Note:** This function was used mostly for [percent-encoding](https://en.wikipedia.org/wiki/Percent-encoding) and is partly based on the escape format in {{rfc(1738)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
+> **Note:** This function was used mostly for {{Glossary("Percent-encoding", "percent-encoding")}} and is partly based on the escape format in {{rfc(1738)}}. The `unescape()` function does _not_ evaluate [escape sequences](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#escape_sequences) in string literals. You can replace `\xXX` with `%XX` and `\uXXXX` with `%uXXXX` to get a string that can be handled by `unescape()`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

This PR replaces links to `Percent-encoding` from Wikipedia to MDN Glossary.

### Related issues and pull requests

Relates to #34855, #24633