### PR TITLE
Remove innerHTML assignments, API docs 1

### DIFF
--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.md
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.md
@@ -35,7 +35,7 @@ const button = document.querySelector("button");
 const pre = document.querySelector("pre");
 const myScript = document.querySelector("script");
 
-pre.innerHTML = myScript.innerHTML;
+pre.textContent = myScript.textContent;
 
 // Stereo
 const channels = 2;

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
@@ -98,7 +98,7 @@ if (navigator.mediaDevices) {
 
 // dump script to pre element
 
-pre.innerHTML = myScript.innerHTML;
+pre.textContent = myScript.textContent;
 ```
 
 > **Note:** As a consequence of calling

--- a/files/en-us/web/api/audiocontext/setsinkid/index.md
+++ b/files/en-us/web/api/audiocontext/setsinkid/index.md
@@ -57,7 +57,7 @@ We also provide the user with a dropdown menu to allow them to change the audio 
    ```js
    mediaDeviceBtn.addEventListener('click', async () => {
      if ("setSinkId" in AudioContext.prototype) {
-       selectDiv.innerHTML = '';
+       selectDiv.textContent = "";
 
        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
        const devices = await navigator.mediaDevices.enumerateDevices();

--- a/files/en-us/web/api/audioparam/setvalueattime/index.md
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.md
@@ -51,7 +51,7 @@ const myAudio = document.querySelector("audio");
 const pre = document.querySelector("pre");
 const myScript = document.querySelector("script");
 
-pre.innerHTML = myScript.innerHTML;
+pre.textContent = myScript.textContent;
 
 const targetAtTimePlus = document.querySelector(".set-target-at-time-plus");
 const targetAtTimeMinus = document.querySelector(".set-target-at-time-minus");

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
@@ -46,7 +46,7 @@ const button = document.querySelector("button");
 const pre = document.querySelector("pre");
 const myScript = document.querySelector("script");
 
-pre.innerHTML = myScript.innerHTML;
+pre.textContent = myScript.textContent;
 
 // Stereo
 const channels = 2;

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
@@ -62,7 +62,7 @@ const panNode = audioCtx.createStereoPanner();
 
 panControl.oninput = () => {
   panNode.pan.setValueAtTime(panControl.value, audioCtx.currentTime);
-  panValue.innerHTML = panControl.value;
+  panValue.textContent = panControl.value;
 };
 
 // connect the MediaElementAudioSourceNode to the panNode

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
@@ -103,7 +103,11 @@ function calcFrequencyResponse() {
 
   for (let i = 0; i <= myFrequencyArray.length - 1; i++) {
     const listItem = document.createElement("li");
-    listItem.innerHTML = `<strong>${myFrequencyArray[i]}Hz</strong>: Magnitude ${magResponseOutput[i]}, Phase ${phaseResponseOutput[i]} radians.`;
+    listItem.textContent = `: Magnitude ${magResponseOutput[i]}, Phase ${phaseResponseOutput[i]} radians.`;
+    listItem.insertBefore(
+      document.createElement("strong"),
+      listItem.firstChild,
+    ).textContent = `${myFrequencyArray[i]}Hz`;
     freqResponseOutput.appendChild(listItem);
   }
 }

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -111,17 +111,20 @@ class LabeledCheckbox extends HTMLElement {
   connectedCallback() {
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
-        :host {
-          display: block;
-        }
-       :host::before {
-         content: '[ ]';
-         white-space: pre;
-         font-family: monospace;
-       }
-       :host(:state(checked))::before { content: '[x]'; }
-       </style>
-       <slot>Label</slot>`;
+  :host {
+    display: block;
+  }
+  :host::before {
+    content: "[ ]";
+    white-space: pre;
+    font-family: monospace;
+  }
+  :host(:state(checked))::before {
+    content: "[x]";
+  }
+</style>
+<slot>Label</slot>
+`;
   }
 
   get checked() {
@@ -226,17 +229,20 @@ class LabeledCheckbox extends HTMLElement {
   connectedCallback() {
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
-        :host {
-          display: block;
-        }
-       :host::before {
-         content: '[ ]';
-         white-space: pre;
-         font-family: monospace;
-       }
-       :host(:state(checked))::before { content: '[x]'; }
-       </style>
-       <slot>Label</slot>`;
+  :host {
+    display: block;
+  }
+  :host::before {
+    content: "[ ]";
+    white-space: pre;
+    font-family: monospace;
+  }
+  :host(:state(checked))::before {
+    content: "[x]";
+  }
+</style>
+<slot>Label</slot>
+`;
   }
 
   get checked() {
@@ -286,7 +292,8 @@ class QuestionBox extends HTMLElement {
     super();
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<div><slot>Question</slot></div>
-       <labeled-checkbox part='checkbox'>Yes</labeled-checkbox>`;
+<labeled-checkbox part="checkbox">Yes</labeled-checkbox>
+`;
   }
 }
 ```
@@ -367,16 +374,26 @@ class ManyStateElement extends HTMLElement {
 
     const shadowRoot = this.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<style>
-        :host {
-          display: block;
-          font-family: monospace;
-        }
-       :host::before { content: '[ unknown ]'; white-space: pre; }
-       :host(:state(loading))::before { content: '[ loading ]' }
-       :host(:state(interactive))::before { content: '[ interactive ]' }
-       :host(:state(complete))::before { content: '[ complete ]' }
-       </style>
-       <slot>Click me</slot>`;
+  :host {
+    display: block;
+    font-family: monospace;
+  }
+  :host::before {
+    content: "[ unknown ]";
+    white-space: pre;
+  }
+  :host(:state(loading))::before {
+    content: "[ loading ]";
+  }
+  :host(:state(interactive))::before {
+    content: "[ interactive ]";
+  }
+  :host(:state(complete))::before {
+    content: "[ complete ]";
+  }
+</style>
+<slot>Click me</slot>
+`;
   }
 
   get state() {

--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -64,8 +64,8 @@ function onMouseUp(e) {
 
   const outputElement = document.getElementById("output-element");
   const outputText = document.getElementById("output-text");
-  outputElement.innerHTML = activeTextarea.id;
-  outputText.innerHTML = selection;
+  outputElement.textContent = activeTextarea.id;
+  outputText.textContent = selection;
 }
 
 const textarea1 = document.getElementById("ta-example-one");

--- a/files/en-us/web/api/document/elementsfrompoint/index.md
+++ b/files/en-us/web/api/document/elementsfrompoint/index.md
@@ -57,10 +57,11 @@ if (document.elementsFromPoint) {
     }
   });
 } else {
-  output.innerHTML =
-    '<span style="color: red;">' +
-    "Browser does not support <code>document.elementsFromPoint()</code>" +
-    "</span>";
+  output.innerHTML = `<span style="color: red">
+  Browser does not support
+  <code>document.elementsFromPoint()</code>
+</span>
+`;
 }
 ```
 

--- a/files/en-us/web/api/document/scrollend_event/index.md
+++ b/files/en-us/web/api/document/scrollend_event/index.md
@@ -79,11 +79,11 @@ When the user stops scrolling, the `scrollend` event fires:
 const output = document.querySelector("p#output");
 
 document.addEventListener("scroll", (event) => {
-  output.innerHTML = `Document scroll event fired!`;
+  output.textContent = "Document scroll event fired!";
 });
 
 document.addEventListener("scrollend", (event) => {
-  output.innerHTML = `Document scrollend event fired!`;
+  output.textContent = "Document scrollend event fired!";
 });
 ```
 
@@ -133,11 +133,11 @@ This builds on the first example, but uses `document.onscrollend` instead of an 
 
 ```js
 document.onscroll = (event) => {
-  output.innerHTML = "Document scroll event fired!";
+  output.textContent = "Document scroll event fired!";
 };
 
 document.onscrollend = (event) => {
-  output.innerHTML = "Document scrollend event fired!";
+  output.textContent = "Document scrollend event fired!";
 };
 ```
 

--- a/files/en-us/web/api/document_object_model/examples/index.md
+++ b/files/en-us/web/api/document_object_model/examples/index.md
@@ -40,10 +40,10 @@ The following example shows the use of the `height` and `width` properties along
             arrImages[i].style.height +
             ", style.width=" +
             arrImages[i].style.width +
-            "<\/li>";
+            "</li>";
         }
 
-        strHtml += "<\/ul>";
+        strHtml += "</ul>";
 
         objOutput.innerHTML = strHtml;
       }
@@ -346,7 +346,7 @@ Put the following code into a blank text file and load it into a variety of brow
         }
 
         const event = e || window.event;
-        document.getElementById("eventType").innerHTML = event.type;
+        document.getElementById("eventType").textContent = event.type;
 
         const table = document.createElement("table");
         const thead = table.createTHead();

--- a/files/en-us/web/api/editcontext_api/guide/index.md
+++ b/files/en-us/web/api/editcontext_api/guide/index.md
@@ -100,7 +100,7 @@ let currentTokens = [];
 
 function render(text, selectionStart, selectionEnd) {
   // Empty the editor. We're re-rendering everything.
-  editorEl.innerHTML = "";
+  editorEl.textContent = "";
 
   // Tokenize the text.
   currentTokens = tokenizeHTML(text);

--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -139,7 +139,7 @@ function update() {
   const elem = document.getElementById("example");
   const rect = elem.getBoundingClientRect();
 
-  container.innerHTML = "";
+  container.textContent = "";
   for (const key in rect) {
     if (typeof rect[key] !== "function") {
       let para = document.createElement("p");

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -59,7 +59,7 @@ Setting the value of `innerHTML` lets you easily replace the existing contents o
 For example, you can erase the entire contents of a document by clearing the contents of the document's {{domxref("Document.body", "body")}} attribute:
 
 ```js
-document.body.innerHTML = "";
+document.body.textContent = "";
 ```
 
 This example fetches the document's current HTML markup and replaces the `"<"` characters with the {{glossary("character reference")}} `"&lt;"`, thereby essentially converting the HTML into raw text.

--- a/files/en-us/web/api/element/queryselector/index.md
+++ b/files/en-us/web/api/element/queryselector/index.md
@@ -132,8 +132,8 @@ applying `selectors`, so that levels outside the specified
 
 ```js
 const baseElement = document.querySelector("p");
-document.getElementById("output").innerHTML =
-  baseElement.querySelector("div span").innerHTML;
+document.getElementById("output").textContent =
+  baseElement.querySelector("div span").textContent;
 ```
 
 #### Result

--- a/files/en-us/web/api/element/scroll_event/index.md
+++ b/files/en-us/web/api/element/scroll_event/index.md
@@ -49,9 +49,9 @@ const element = document.querySelector("div#scroll-box");
 const output = document.querySelector("p#output");
 
 element.addEventListener("scroll", (event) => {
-  output.innerHTML = "Scroll event fired!";
+  output.textContent = "Scroll event fired!";
   setTimeout(() => {
-    output.innerHTML = "Waiting on scroll events...";
+    output.textContent = "Waiting on scroll events...";
   }, 1000);
 });
 ```
@@ -76,9 +76,9 @@ const element = document.querySelector("div#scroll-box");
 const output = document.querySelector("p#output");
 
 element.onscroll = (event) => {
-  output.innerHTML = "Element scroll event fired!";
+  output.textContent = "Element scroll event fired!";
   setTimeout(() => {
-    output.innerHTML = "Waiting on scroll events...";
+    output.textContent = "Waiting on scroll events...";
   }, 1000);
 };
 ```

--- a/files/en-us/web/api/element/scrollend_event/index.md
+++ b/files/en-us/web/api/element/scrollend_event/index.md
@@ -77,11 +77,11 @@ const element = document.querySelector("div#scroll-box");
 const output = document.querySelector("p#output");
 
 element.addEventListener("scroll", (event) => {
-  output.innerHTML = "Scroll event fired, waiting for scrollend...";
+  output.textContent = "Scroll event fired, waiting for scrollend...";
 });
 
 element.addEventListener("scrollend", (event) => {
-  output.innerHTML = "Scrollend event fired!";
+  output.textContent = "Scrollend event fired!";
 });
 ```
 
@@ -131,11 +131,11 @@ const element = document.querySelector("div#scroll-box");
 const output = document.querySelector("p#output");
 
 element.onscroll = (event) => {
-  output.innerHTML = "Element scroll event fired, waiting for scrollend...";
+  output.textContent = "Element scroll event fired, waiting for scrollend...";
 };
 
 element.onscrollend = (event) => {
-  output.innerHTML = "Element scrollend event fired!";
+  output.textContent = "Element scrollend event fired!";
 };
 ```
 

--- a/files/en-us/web/api/event/preventdefault/index.md
+++ b/files/en-us/web/api/event/preventdefault/index.md
@@ -42,8 +42,8 @@ const checkbox = document.querySelector("#id-checkbox");
 checkbox.addEventListener("click", checkboxClick, false);
 
 function checkboxClick(event) {
-  let warn = "preventDefault() won't let you check this!<br>";
-  document.getElementById("output-box").innerHTML += warn;
+  const warn = "preventDefault() won't let you check this!\n";
+  document.getElementById("output-box").innerText += warn;
   event.preventDefault();
 }
 ```
@@ -121,9 +121,7 @@ function checkName(evt) {
   const lowerCaseAlphabet = "abcdefghijklmnopqrstuvwxyz";
   if (!lowerCaseAlphabet.includes(key)) {
     evt.preventDefault();
-    displayWarning(
-      "Please use lowercase letters only.\n" + `Key pressed: ${key}\n`,
-    );
+    displayWarning(`Please use lowercase letters only.\nKey pressed: ${key}\n`);
   }
 }
 ```
@@ -137,7 +135,7 @@ const warningBox = document.createElement("div");
 warningBox.className = "warning";
 
 function displayWarning(msg) {
-  warningBox.innerHTML = msg;
+  warningBox.innerText = msg;
 
   if (document.body.contains(warningBox)) {
     clearTimeout(warningTimeout);

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -334,10 +334,12 @@ fileSelect.addEventListener(
 fileElem.addEventListener("change", handleFiles, false);
 
 function handleFiles() {
+  fileList.textContent = "";
   if (!this.files.length) {
-    fileList.innerHTML = "<p>No files selected!</p>";
+    const p = document.createElement("p");
+    p.textContent = "No files selected!";
+    fileList.appendChild(p);
   } else {
-    fileList.innerHTML = "";
     const list = document.createElement("ul");
     fileList.appendChild(list);
     for (let i = 0; i < this.files.length; i++) {
@@ -352,7 +354,7 @@ function handleFiles() {
       };
       li.appendChild(img);
       const info = document.createElement("span");
-      info.innerHTML = `${this.files[i].name}: ${this.files[i].size} bytes`;
+      info.textContent = `${this.files[i].name}: ${this.files[i].size} bytes`;
       li.appendChild(info);
     }
   }

--- a/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
@@ -27,9 +27,9 @@ When a fragment of JavaScript code runs, it runs inside an **execution context**
 Each context is, in essence, a level of scope within your code. As one of these code segments begins execution, a new context is constructed in which to run it; that context is then destroyed when the code exits. Consider the JavaScript program below:
 
 ```js
-let outputElem = document.getElementById("output");
+const outputElem = document.getElementById("output");
 
-let userLanguages = {
+const userLanguages = {
   Mike: "en",
   Teresa: "es",
 };
@@ -37,7 +37,7 @@ let userLanguages = {
 function greetUser(user) {
   function localGreeting(user) {
     let greeting;
-    let language = userLanguages[user];
+    const language = userLanguages[user];
 
     switch (language) {
       case "es":
@@ -50,7 +50,7 @@ function greetUser(user) {
     }
     return greeting;
   }
-  outputElem.innerHTML += `${localGreeting(user)}<br>\r`;
+  outputElem.innerText += `${localGreeting(user)}\n`;
 }
 
 greetUser("Mike");

--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.md
@@ -186,8 +186,8 @@ In this simple example, we see that enqueueing a microtask causes the microtask'
 #### JavaScript
 
 ```js hidden
-let logElem = document.getElementById("log");
-let log = (s) => (logElem.innerHTML += `${s}<br>`);
+const logElem = document.getElementById("log");
+const log = (s) => (logElem.innerText += `${s}\n`);
 ```
 
 In the following code, we see a call to {{domxref("queueMicrotask()")}} used to schedule a microtask to run. This call is bracketed by calls to `log()`, a custom function that outputs text to the screen.
@@ -215,8 +215,8 @@ In this example, a timeout is scheduled to fire after zero milliseconds (or "as 
 #### JavaScript
 
 ```js hidden
-let logElem = document.getElementById("log");
-let log = (s) => (logElem.innerHTML += `${s}<br>`);
+const logElem = document.getElementById("log");
+const log = (s) => (logElem.innerText += `${s}\n`);
 ```
 
 In the following code, we see a call to {{domxref("queueMicrotask()")}} used to schedule a microtask to run. This call is bracketed by calls to `log()`, a custom function that outputs text to the screen.
@@ -224,9 +224,9 @@ In the following code, we see a call to {{domxref("queueMicrotask()")}} used to 
 The code below schedules a timeout to occur in zero milliseconds, then enqueues a microtask. This is bracketed by calls to `log()` to output additional messages.
 
 ```js
-let callback = () => log("Regular timeout callback has run");
+const callback = () => log("Regular timeout callback has run");
 
-let urgentCallback = () => log("*** Oh noes! An urgent callback has run!");
+const urgentCallback = () => log("*** Oh noes! An urgent callback has run!");
 
 log("Main program started");
 setTimeout(callback, 0);
@@ -251,18 +251,18 @@ This example expands slightly on the previous one by adding a function that does
 #### JavaScript
 
 ```js hidden
-let logElem = document.getElementById("log");
-let log = (s) => (logElem.innerHTML += `${s}<br>`);
+const logElem = document.getElementById("log");
+const log = (s) => (logElem.innerText += `${s}\n`);
 ```
 
 The main program code follows. The `doWork()` function here calls `queueMicrotask()`, yet the microtask still doesn't fire until the entire program exits, since that's when the task exits and there's nothing else on the execution stack.
 
 ```js
-let callback = () => log("Regular timeout callback has run");
+const callback = () => log("Regular timeout callback has run");
 
-let urgentCallback = () => log("*** Oh noes! An urgent callback has run!");
+const urgentCallback = () => log("*** Oh noes! An urgent callback has run!");
 
-let doWork = () => {
+const doWork = () => {
   let result = 1;
 
   queueMicrotask(urgentCallback);

--- a/files/en-us/web/api/htmlelement/load_event/index.md
+++ b/files/en-us/web/api/htmlelement/load_event/index.md
@@ -44,7 +44,8 @@ This example prints to the screen whenever the {{HtmlElement("img")}} element su
 ```js
 const image = document.getElementById("image");
 image.onload = () => {
-  document.body.innerHTML += "<div>loaded!</div>";
+  document.body.appendChild(document.createElement("div")).textContent =
+    "loaded!";
 };
 
 function reload() {

--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -132,11 +132,13 @@ the URL selected by the browser from the `srcset`.
 
 ```js
 window.addEventListener("load", () => {
-  let box = document.querySelector(".box");
-  let image = box.querySelector("img");
+  const box = document.querySelector(".box");
+  const image = box.querySelector("img");
 
-  let newElem = document.createElement("p");
-  newElem.innerHTML = `Image: <code>${image.currentSrc}</code>`;
+  const newElem = document.createElement("p");
+  newElem.textContent = "Image: ";
+  newElem.appendChild(document.createElement("code")).textContent =
+    image.currentSrc;
   box.appendChild(newElem);
 });
 ```

--- a/files/en-us/web/api/htmlimageelement/x/index.md
+++ b/files/en-us/web/api/htmlimageelement/x/index.md
@@ -78,15 +78,15 @@ The JavaScript code that fetches the image from the table and looks up its
 `x` and `y` values is below.
 
 ```js
-let logBox = document.querySelector("pre");
-let tbl = document.getElementById("userinfo");
+const logBox = document.querySelector("pre");
+const tbl = document.getElementById("userinfo");
 
-let log = (msg) => {
-  logBox.innerHTML += `${msg}<br>`;
+const log = (msg) => {
+  logBox.innerText += `${msg}\n`;
 };
 
-let cell = tbl.rows[1].cells[2];
-let image = cell.querySelector("img");
+const cell = tbl.rows[1].cells[2];
+const image = cell.querySelector("img");
 
 log(`Image's global X: ${image.x}`);
 log(`Image's global Y: ${image.y}`);

--- a/files/en-us/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/invalid_event/index.md
@@ -56,10 +56,8 @@ const input = document.querySelector("input");
 const log = document.getElementById("log");
 
 input.addEventListener("invalid", (e) => {
-  log.appendChild(
-    Object.assign(document.createElement("li"), {
-      textContent: JSON.stringify(e.target.value),
-    }),
+  log.appendChild(document.createElement("li")).textContent = JSON.stringify(
+    e.target.value,
   );
 });
 ```

--- a/files/en-us/web/api/htmlselectelement/selectedoptions/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedoptions/index.md
@@ -94,7 +94,7 @@ orderButton.addEventListener(
       output = "You didn't order anything!";
     }
 
-    outputBox.innerHTML = output;
+    outputBox.textContent = output;
   },
   false,
 );

--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -287,13 +287,13 @@ startup = () => {
 
 intersectionCallback = (entries) => {
   entries.forEach((entry) => {
-    let box = entry.target;
-    let visiblePct = `${Math.floor(entry.intersectionRatio * 100)}%`;
+    const box = entry.target;
+    const visiblePct = `${Math.floor(entry.intersectionRatio * 100)}%`;
 
-    box.querySelector(".topLeft").innerHTML = visiblePct;
-    box.querySelector(".topRight").innerHTML = visiblePct;
-    box.querySelector(".bottomLeft").innerHTML = visiblePct;
-    box.querySelector(".bottomRight").innerHTML = visiblePct;
+    box.querySelector(".topLeft").textContent = visiblePct;
+    box.querySelector(".topRight").textContent = visiblePct;
+    box.querySelector(".bottomLeft").textContent = visiblePct;
+    box.querySelector(".bottomRight").textContent = visiblePct;
   });
 };
 

--- a/files/en-us/web/api/keyboardevent/key/index.md
+++ b/files/en-us/web/api/keyboardevent/key/index.md
@@ -122,12 +122,12 @@ Try experimenting using the following two test cases:
 ### JavaScript
 
 ```js
-let textarea = document.getElementById("test-target"),
-  consoleLog = document.getElementById("console-log"),
-  btnReset = document.getElementById("btn-reset");
+const textarea = document.getElementById("test-target");
+const consoleLog = document.getElementById("console-log");
+const btnReset = document.getElementById("btn-reset");
 
 function logMessage(message) {
-  consoleLog.innerHTML += `${message}<br>`;
+  consoleLog.innerText += `${message}\n`;
 }
 
 textarea.addEventListener("keydown", (e) => {


### PR DESCRIPTION
Part 2 of https://github.com/mdn/content/issues/13496. Use `innerText` where line breaks are needed, `textContent` otherwise, and `appendChild` if necessary.