### PR TITLE
Remove innerHTML assignments, API docs 2

### DIFF
--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -227,7 +227,7 @@ let mc = {
           result.powerEfficient ? " IS " : " IS NOT "
         }power efficient.`;
         const ul = document.getElementById("results");
-        li.innerHTML = content;
+        li.textContent = content;
         ul.appendChild(li);
       })
       .catch((error) => {

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.md
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.md
@@ -109,7 +109,7 @@ const logElement = document.querySelector("output");
 const startButton = document.querySelector("#startButton");
 
 function log(msg) {
-  logElement.innerHTML += `${msg}<br>`;
+  logElement.innerText += `${msg}\n`;
 }
 
 startButton.addEventListener(
@@ -159,8 +159,8 @@ displayed lists of audio and video devices using that information.
 ```js
 function updateDeviceList() {
   navigator.mediaDevices.enumerateDevices().then((devices) => {
-    audioList.innerHTML = "";
-    videoList.innerHTML = "";
+    audioList.textContent = "";
+    videoList.textContent = "";
 
     devices.forEach((device) => {
       const elem = document.createElement("li");

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
@@ -49,7 +49,7 @@ const supportedConstraints = navigator.mediaDevices.getSupportedConstraints();
 
 for (const constraint of Object.keys(supportedConstraints)) {
   const elem = document.createElement("li");
-  elem.innerHTML = `<code>${constraint}</code>`;
+  elem.appendChild(document.createElement("code")).textContent = constraint;
   constraintList.appendChild(elem);
 }
 ```

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -129,7 +129,7 @@ Next, we create some utility functions that will get used later.
 
 ```js
 function log(msg) {
-  logElement.innerHTML += `${msg}\n`;
+  logElement.innerText += `${msg}\n`;
 }
 ```
 

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -215,8 +215,8 @@ mediaRecorder.onstop = (e) => {
 
   clipContainer.classList.add("clip");
   audio.setAttribute("controls", "");
-  deleteButton.innerHTML = "Delete";
-  clipLabel.innerHTML = clipName;
+  deleteButton.textContent = "Delete";
+  clipLabel.textContent = clipName;
 
   clipContainer.appendChild(audio);
   clipContainer.appendChild(clipLabel);

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.md
@@ -107,7 +107,7 @@ None ({{jsxref("undefined")}}).
 ```js
 document.body.onclick = (event) => {
   const elementTag = event.target.tagName.toLowerCase();
-  document.getElementById("out").innerHTML = elementTag;
+  document.getElementById("out").textContent = elementTag;
 };
 
 const simulateClick = () => {

--- a/files/en-us/web/api/node/getrootnode/index.md
+++ b/files/en-us/web/api/node/getrootnode/index.md
@@ -70,8 +70,8 @@ const child = document.querySelector(".child");
 const shadowHost = document.querySelector(".shadowHost");
 const output = document.getElementById("output");
 
-output.textContent += `\nparent's root: ${parent.getRootNode().nodeName} \n`; // #document
-output.textContent += `child's  root: ${child.getRootNode().nodeName} \n\n`; // #document
+output.innerText += `\nparent's root: ${parent.getRootNode().nodeName}\n`; // #document
+output.innerText += `child's  root: ${child.getRootNode().nodeName}\n\n`; // #document
 
 // create a ShadowRoot
 const shadowRoot = shadowHost.attachShadow({ mode: "open" });
@@ -80,15 +80,15 @@ shadowRoot.innerHTML =
 const shadowChild = shadowRoot.querySelector(".shadowChild");
 
 // The default value of composed is false
-output.textContent += `shadowChild.getRootNode() === shadowRoot : ${
+output.innerText += `shadowChild.getRootNode() === shadowRoot : ${
   shadowChild.getRootNode() === shadowRoot
-} \n`; // true
-output.textContent += `shadowChild.getRootNode({composed:false}) === shadowRoot : ${
+}\n`; // true
+output.innerText += `shadowChild.getRootNode({ composed:false }) === shadowRoot : ${
   shadowChild.getRootNode({ composed: false }) === shadowRoot
-} \n`; // true
-output.textContent += `shadowChild.getRootNode({composed:true}).nodeName : ${
+}\n`; // true
+output.innerText += `shadowChild.getRootNode({ composed:true }).nodeName : ${
   shadowChild.getRootNode({ composed: true }).nodeName
-} \n`; // #document
+}\n`; // #document
 ```
 
 {{ EmbedLiveSample('Example 2', '100%', '200px') }}

--- a/files/en-us/web/api/node/isequalnode/index.md
+++ b/files/en-us/web/api/node/isequalnode/index.md
@@ -61,18 +61,18 @@ JavaScript to compare the nodes using `isEqualNode()` and output the results.
 ### JavaScript
 
 ```js
-let output = document.getElementById("output");
-let divList = document.getElementsByTagName("div");
+const output = document.getElementById("output");
+const divList = document.getElementsByTagName("div");
 
-output.innerHTML += `div 0 equals div 0: ${divList[0].isEqualNode(
+output.innerText += `div 0 equals div 0: ${divList[0].isEqualNode(
   divList[0],
-)}<br/>`;
-output.innerHTML += `div 0 equals div 1: ${divList[0].isEqualNode(
+)}\n`;
+output.innerText += `div 0 equals div 1: ${divList[0].isEqualNode(
   divList[1],
-)}<br/>`;
-output.innerHTML += `div 0 equals div 2: ${divList[0].isEqualNode(
+)}\n`;
+output.innerText += `div 0 equals div 2: ${divList[0].isEqualNode(
   divList[2],
-)}<br/>`;
+)}\n`;
 ```
 
 ### Results

--- a/files/en-us/web/api/node/issamenode/index.md
+++ b/files/en-us/web/api/node/issamenode/index.md
@@ -61,18 +61,18 @@ JavaScript to compare the nodes using `isSameNode()` and output the results.
 ### JavaScript
 
 ```js
-let output = document.getElementById("output");
-let divList = document.getElementsByTagName("div");
+const output = document.getElementById("output");
+const divList = document.getElementsByTagName("div");
 
-output.innerHTML += `div 0 same as div 0: ${divList[0].isSameNode(
+output.innerText += `div 0 same as div 0: ${divList[0].isSameNode(
   divList[0],
-)}<br/>`;
-output.innerHTML += `div 0 same as div 1: ${divList[0].isSameNode(
+)}\n`;
+output.innerText += `div 0 same as div 1: ${divList[0].isSameNode(
   divList[1],
-)}<br/>`;
-output.innerHTML += `div 0 same as div 2: ${divList[0].isSameNode(
+)}\n`;
+output.innerText += `div 0 same as div 2: ${divList[0].isSameNode(
   divList[2],
-)}<br/>`;
+)}\n`;
 ```
 
 ### Results

--- a/files/en-us/web/api/node/lookupnamespaceuri/index.md
+++ b/files/en-us/web/api/node/lookupnamespaceuri/index.md
@@ -68,17 +68,12 @@ const tbody = document.querySelector("tbody");
 for (const prefix of ["xmlns", "xml", "html", "svg", "xlink", "", null]) {
   const row = document.createElement("tr");
   tbody.appendChild(row);
-  row.appendChild(
-    Object.assign(document.createElement("td"), {
-      textContent: JSON.stringify(prefix),
-    }),
-  );
+  row.appendChild(document.createElement("td")).textContent =
+    JSON.stringify(prefix);
   for (const el of [htmlElt, svgElt, mathElt]) {
     console.log(el, prefix, el.lookupNamespaceURI(prefix));
-    row.appendChild(
-      Object.assign(document.createElement("td"), {
-        textContent: String(el.lookupNamespaceURI(prefix)),
-      }),
+    row.appendChild(document.createElement("td")).textContent = String(
+      el.lookupNamespaceURI(prefix),
     );
   }
 }

--- a/files/en-us/web/api/node/nextsibling/index.md
+++ b/files/en-us/web/api/node/nextsibling/index.md
@@ -45,16 +45,16 @@ or `null` if there are none.
 let el = document.getElementById("div-1").nextSibling;
 let i = 1;
 
-let result = "Siblings of div-1:<br/>";
+let result = "Siblings of div-1:\n";
 
 while (el) {
-  result += `${i}. ${el.nodeName}<br/>`;
+  result += `${i}. ${el.nodeName}\n`;
   el = el.nextSibling;
   i++;
 }
 
 const output = document.querySelector("output");
-output.innerHTML = result;
+output.innerText = result;
 ```
 
 {{ EmbedLiveSample("Example", "100%", 500)}}

--- a/files/en-us/web/api/node/nodename/index.md
+++ b/files/en-us/web/api/node/nodename/index.md
@@ -54,14 +54,14 @@ and the following script:
 
 ```js
 let node = document.querySelector("body").firstChild;
-let result = "Node names are:<br/>";
+let result = "Node names are:\n";
 while (node) {
-  result += `${node.nodeName}<br/>`;
+  result += `${node.nodeName}\n`;
   node = node.nextSibling;
 }
 
 const output = document.getElementById("result");
-output.innerHTML = result;
+output.innerText = result;
 ```
 
 {{ EmbedLiveSample("Example", "100%", "450")}}

--- a/files/en-us/web/api/node/nodevalue/index.md
+++ b/files/en-us/web/api/node/nodevalue/index.md
@@ -45,14 +45,14 @@ and the following script:
 
 ```js
 let node = document.querySelector("body").firstChild;
-let result = "<br/>Node names are:<br/>";
+let result = "Node names are:\n";
 while (node) {
-  result += `Value of ${node.nodeName}: ${node.nodeValue}<br/>`;
+  result += `Value of ${node.nodeName}: ${node.nodeValue}\n`;
   node = node.nextSibling;
 }
 
 const output = document.getElementById("result");
-output.innerHTML = result;
+output.innerText = result;
 ```
 
 {{ EmbedLiveSample("Example", "100%", "250")}}

--- a/files/en-us/web/api/node/normalize/index.md
+++ b/files/en-us/web/api/node/normalize/index.md
@@ -39,23 +39,23 @@ wrapper.appendChild(document.createTextNode("Part 1 "));
 wrapper.appendChild(document.createTextNode("Part 2 "));
 
 let node = wrapper.firstChild;
-let result = "Before normalization:<br/>";
+let result = "Before normalization:\n";
 while (node) {
-  result += ` ${node.nodeName}: ${node.nodeValue}<br/>`;
+  result += ` ${node.nodeName}: ${node.nodeValue}\n`;
   node = node.nextSibling;
 }
 
 wrapper.normalize();
 
 node = wrapper.firstChild;
-result += "<br/><br/>After normalization:<br/>";
+result += "\n\nAfter normalization:\n";
 while (node) {
-  result += ` ${node.nodeName}: ${node.nodeValue}<br/>`;
+  result += ` ${node.nodeName}: ${node.nodeValue}\n`;
   node = node.nextSibling;
 }
 
 const output = document.getElementById("result");
-output.innerHTML = result;
+output.innerText = result;
 ```
 
 {{ EmbedLiveSample("Example", "100%", "170")}}

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
@@ -246,16 +246,15 @@ function enableLog(ev) {
 
 function log(name, ev) {
   const o = document.getElementsByTagName("output")[0];
-  const s =
-    `${name}:<br>` +
-    `  pointerID   = ${ev.pointerId}<br>` +
-    `  pointerType = ${ev.pointerType}<br>` +
-    `  isPrimary   = ${ev.isPrimary}`;
-  o.innerHTML += `${s}<br>`;
+  o.innerText += `${name}:
+  pointerID   = ${ev.pointerId}
+  pointerType = ${ev.pointerType}
+  isPrimary   = ${ev.isPrimary}
+`;
 }
 
 function clearLog(event) {
   const o = document.getElementsByTagName("output")[0];
-  o.innerHTML = "";
+  o.textContent = "";
 }
 ```

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -202,17 +202,16 @@ function enableLog(ev) {
 function log(prefix, ev) {
   if (!logEvents) return;
   const o = document.getElementsByTagName("output")[0];
-  const s =
-    `${prefix}:<br>` +
-    `  pointerID   = ${ev.pointerId}<br>` +
-    `  pointerType = ${ev.pointerType}<br>` +
-    `  isPrimary   = ${ev.isPrimary}`;
-  o.innerHTML += `${s}<br>`;
+  o.innerText += `${prefix}:
+  pointerID   = ${ev.pointerId}
+  pointerType = ${ev.pointerType}
+  isPrimary   = ${ev.isPrimary}
+`;
 }
 
 function clearLog(event) {
   const o = document.getElementsByTagName("output")[0];
-  o.innerHTML = "";
+  o.textContent = "";
 }
 ```
 

--- a/files/en-us/web/api/pointer_events/using_pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/using_pointer_events/index.md
@@ -229,7 +229,7 @@ function ongoingTouchIndexById(idToFind) {
 ```js
 function log(msg) {
   const p = document.getElementById("log");
-  p.innerHTML = `${msg}\n${p.innerHTML}`;
+  p.innerText = `${msg}\n${p.innerText}`;
 }
 ```
 

--- a/files/en-us/web/api/presentation/receiver/index.md
+++ b/files/en-us/web/api/presentation/receiver/index.md
@@ -50,7 +50,8 @@ let listElem = document.getElementById("connectionview");
 
 navigator.presentation.receiver.connectionList.then((connections) => {
   connections.forEach((aConnection) => {
-    listElem.innerHTML += `<li>${aConnection.id}</li>`;
+    listElem.appendChild(document.createElement("li")).textContent =
+      aConnection.id;
   });
 });
 ```

--- a/files/en-us/web/api/rtcdatachannel/label/index.md
+++ b/files/en-us/web/api/rtcdatachannel/label/index.md
@@ -39,8 +39,12 @@ const dc = pc.createDataChannel("my channel");
 
 // …
 
-document.getElementById("channel-name").innerHTML =
-  `<span class='channelName'>${dc.label}</span>`;
+document.getElementById("channel-name").appendChild(
+  Object.assign(document.createElement("span"), {
+    className: "channelName",
+    textContent: dc.label,
+  }),
+);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -217,7 +217,7 @@ console.error = (msg) =>
   (logElem.textContent = `${logElem.textContent}\nError: ${msg}`);
 ```
 
-This allows us to use {{domxref("console/log_static", "console/log()")}} and {{domxref("console.error_static", "console.error()")}} to log information to the log box in the document.
+This allows us to use {{domxref("console/log_static", "console.log()")}} and {{domxref("console.error_static", "console.error()")}} to log information to the log box in the document.
 
 ##### Starting display capture
 
@@ -225,7 +225,7 @@ The `startCapture()` method, below, starts the capture of a {{domxref("MediaStre
 
 ```js
 async function startCapture() {
-  logElem.innerHTML = "";
+  logElem.textContent = "";
 
   try {
     videoElem.srcObject =

--- a/files/en-us/web/api/textupdateevent/selectionend/index.md
+++ b/files/en-us/web/api/textupdateevent/selectionend/index.md
@@ -50,7 +50,7 @@ editorEl.editContext = editContext;
 
 editContext.addEventListener("textupdate", (e) => {
   // Clear the current content.
-  editorEl.innerHTML = "";
+  editorEl.textContent = "";
 
   const text = editContext.text;
   const { selectionStart, selectionEnd } = e;

--- a/files/en-us/web/api/textupdateevent/selectionstart/index.md
+++ b/files/en-us/web/api/textupdateevent/selectionstart/index.md
@@ -50,7 +50,7 @@ editorEl.editContext = editContext;
 
 editContext.addEventListener("textupdate", (e) => {
   // Clear the current content.
-  editorEl.innerHTML = "";
+  editorEl.textContent = "";
 
   const text = editContext.text;
   const { selectionStart, selectionEnd } = e;

--- a/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
@@ -248,20 +248,20 @@ function log(name, ev, printTargetIds) {
     `${name}: touches = ${ev.touches.length} ; ` +
     `targetTouches = ${ev.targetTouches.length} ; ` +
     `changedTouches = ${ev.changedTouches.length}`;
-  o.innerHTML += `${s}<br>`;
+  o.innerText += `${s}\n`;
 
   if (printTargetIds) {
     s = "";
     for (let i = 0; i < ev.targetTouches.length; i++) {
-      s += `... id = ${ev.targetTouches[i].identifier}<br>`;
+      s += `... id = ${ev.targetTouches[i].identifier}\n`;
     }
-    o.innerHTML += s;
+    o.innerText += s;
   }
 }
 
 function clearLog(event) {
   const o = document.getElementsByTagName("output")[0];
-  o.innerHTML = "";
+  o.textContent = "";
 }
 ```
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.md
@@ -38,15 +38,18 @@ function reportDisplays() {
       const cap = display.capabilities;
       // cap is a VRDisplayCapabilities object
       const listItem = document.createElement("li");
-      listItem.innerHTML =
-        `<strong>Display ${i + 1}</strong><br>` +
-        `VR Display ID: ${display.displayId}<br>` +
-        `VR Display Name: ${display.displayName}<br>` +
-        `Display can present content: ${cap.canPresent}<br>` +
-        `Display is separate from the computer's main display: ${cap.hasExternalDisplay}<br>` +
-        `Display can return position info: ${cap.hasPosition}<br>` +
-        `Display can return orientation info: ${cap.hasOrientation}<br>` +
-        `Display max layers: ${cap.maxLayers}`;
+      listItem.innerText = `
+VR Display ID: ${display.displayId}
+VR Display Name: ${display.displayName}
+Display can present content: ${cap.canPresent}
+Display is separate from the computer's main display: ${cap.hasExternalDisplay}
+Display can return position info: ${cap.hasPosition}
+Display can return orientation info: ${cap.hasOrientation}
+Display max layers: ${cap.maxLayers}`;
+      listItem.insertBefore(
+        document.createElement("strong"),
+        listItem.firstChild,
+      ).textContent = `Display ${i + 1}`;
       list.appendChild(listItem);
     });
   });

--- a/files/en-us/web/api/vrfieldofview/index.md
+++ b/files/en-us/web/api/vrfieldofview/index.md
@@ -52,25 +52,31 @@ function reportFieldOfView() {
     const listitem1 = document.createElement("li");
     const listitem2 = document.createElement("li");
 
-    listitem1.innerHTML =
-      `<strong>Left eye parameters</strong><br>` +
-      `Offset: ${lEye.offset}<br>` +
-      `Render width: ${lEye.renderWidth}<br>` +
-      `Render height: ${lEye.renderHeight}<br>` +
-      `Up degrees: ${lFOV.upDegrees}<br>` +
-      `Right degrees: ${lFOV.rightDegrees}<br>` +
-      `Down degrees: ${lFOV.downDegrees}<br>` +
-      `Left degrees: ${lFOV.leftDegrees}`;
+    listitem1.innerText = `
+Offset: ${lEye.offset}
+Render width: ${lEye.renderWidth}
+Render height: ${lEye.renderHeight}
+Up degrees: ${lFOV.upDegrees}
+Right degrees: ${lFOV.rightDegrees}
+Down degrees: ${lFOV.downDegrees}
+Left degrees: ${lFOV.leftDegrees}`;
+    listitem1.insertBefore(
+      document.createElement("strong"),
+      listitem1.firstChild,
+    ).textContent = "Left eye parameters";
 
-    listitem2.innerHTML =
-      `<strong>Right eye parameters</strong><br>` +
-      `Offset: ${rEye.offset}<br>` +
-      `Render width: ${rEye.renderWidth}<br>` +
-      `Render height: ${rEye.renderHeight}<br>` +
-      `Up degrees: ${rFOV.upDegrees}<br>` +
-      `Right degrees: ${rFOV.rightDegrees}<br>` +
-      `Down degrees: ${rFOV.downDegrees}<br>` +
-      `Left degrees: ${rFOV.leftDegrees}`;
+    listitem2.innerText = `
+Offset: ${rEye.offset}
+Render width: ${rEye.renderWidth}
+Render height: ${rEye.renderHeight}
+Up degrees: ${rFOV.upDegrees}
+Right degrees: ${rFOV.rightDegrees}
+Down degrees: ${rFOV.downDegrees}
+Left degrees: ${rFOV.leftDegrees}`;
+    listitem2.insertBefore(
+      document.createElement("strong"),
+      listitem2.firstChild,
+    ).textContent = "Right eye parameters";
 
     list.appendChild(listitem1);
     list.appendChild(listitem2);

--- a/files/en-us/web/api/vrstageparameters/index.md
+++ b/files/en-us/web/api/vrstageparameters/index.md
@@ -40,11 +40,14 @@ navigator.getVRDisplays().then((displays) => {
     info.textContent =
       "Your VR Hardware does not support room-scale experiences.";
   } else {
-    info.innerHTML =
-      `<strong>Display stage parameters</strong><br>` +
-      `Sitting to standing transform: ${stageParams.sittingToStandingTransform}<br>` +
-      `Play area width (m): ${stageParams.sizeX}<br>` +
-      `Play area depth (m): ${stageParams.sizeY}`;
+    info.innerText = `
+Sitting to standing transform: ${stageParams.sittingToStandingTransform}
+Play area width (m): ${stageParams.sizeX}
+Play area depth (m): ${stageParams.sizeY}`;
+    info.insertBefore(
+      document.createElement("strong"),
+      info.firstChild,
+    ).textContent = "Display stage parameters";
   }
 });
 ```

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -484,8 +484,8 @@ function createKey(note, octave, freq) {
   keyElement.dataset["octave"] = octave;
   keyElement.dataset["note"] = note;
   keyElement.dataset["frequency"] = freq;
-
-  labelElement.innerHTML = `${note}<sub>${octave}</sub>`;
+  labelElement.appendChild(document.createTextNode(note));
+  labelElement.appendChild(document.createElement("sub")).textContent = octave;
   keyElement.appendChild(labelElement);
 
   keyElement.addEventListener("mousedown", notePressed, false);

--- a/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
+++ b/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
@@ -89,9 +89,9 @@ async function hashTheseFiles(e) {
   // iterate over each file in file select input
   for (const file of this.files) {
     // calculate its hash and list it in the output element.
-    outHTML += `${file.name}    ${await fileHash(file)}`;
+    outHTML += `${file.name}    ${await fileHash(file)}\n`;
   }
-  output.innerHTML = outHTML;
+  output.innerText = outHTML;
 }
 ```
 
@@ -192,9 +192,9 @@ function hashToString(arrayBuffer) {
 async function hashTheseFiles(e) {
   let outHTML = "";
   for (const file of this.files) {
-    outHTML += `${file.name}    ${await fileHash(file)}`;
+    outHTML += `${file.name}    ${await fileHash(file)}\n`;
   }
-  output.innerHTML = outHTML;
+  output.innerText = outHTML;
 }
 ```
 

--- a/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.md
@@ -62,9 +62,8 @@ window.addEventListener(
     const gl =
       canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
     if (!gl) {
-      paragraph.innerHTML =
-        "Failed to get WebGL context. " +
-        "Your browser or device may not support WebGL.";
+      paragraph.textContent =
+        "Failed to get WebGL context. Your browser or device may not support WebGL.";
       return;
     }
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);

--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
@@ -60,9 +60,8 @@ function getRenderingContext() {
     canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
   if (!gl) {
     const paragraph = document.querySelector("p");
-    paragraph.innerHTML =
-      "Failed to get WebGL context." +
-      "Your browser or device may not support WebGL.";
+    paragraph.textContent =
+      "Failed to get WebGL context. Your browser or device may not support WebGL.";
     return null;
   }
   gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);

--- a/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.md
@@ -69,12 +69,11 @@ window.addEventListener(
     // the drawing buffer (the viewport) and clear the context
     // with a solid color.
     if (!gl) {
-      paragraph.innerHTML =
-        "Failed to get WebGL context. " +
-        "Your browser or device may not support WebGL.";
+      paragraph.textContent =
+        "Failed to get WebGL context. Your browser or device may not support WebGL.";
       return;
     }
-    paragraph.innerHTML = "Congratulations! Your browser supports WebGL. ";
+    paragraph.textContent = "Congratulations! Your browser supports WebGL.";
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
     // Set the clear color to darkish green.
     gl.clearColor(0.0, 0.5, 0.0, 1.0);

--- a/files/en-us/web/api/webrtc_api/using_dtmf/index.md
+++ b/files/en-us/web/api/webrtc_api/using_dtmf/index.md
@@ -387,11 +387,11 @@ The `addstream` event includes a {{domxref("MediaStreamEvent.stream", "stream")}
 
 #### Logging
 
-A simple `log()` function is used throughout the code to append HTML to a {{HTMLElement("div")}} box for displaying status and errors to the user.
+A simple `log()` function is used throughout the code to append text to a {{HTMLElement("div")}} box for displaying status and errors to the user.
 
 ```js
 function log(msg) {
-  logElement.innerHTML += `${msg}<br/>`;
+  logElement.innerText += `${msg}\n`;
 }
 ```
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -157,7 +157,7 @@ exampleSocket.onmessage = (event) => {
       text = `Your username has been set to <em>${msg.name}</em> because the name you chose is in use.<br>`;
       break;
     case "userlist":
-      document.getElementById("userlistbox").innerHTML = msg.users.join("<br>");
+      document.getElementById("userlistbox").innerText = msg.users.join("\n");
       break;
   }
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -65,15 +65,18 @@ function reportDisplays() {
       const cap = display.capabilities;
       // cap is a VRDisplayCapabilities object
       const listItem = document.createElement("li");
-      listItem.innerHTML =
-        `<strong>Display ${i + 1}</strong><br>` +
-        `VR Display ID: ${display.displayId}<br>` +
-        `VR Display Name: ${display.displayName}<br>` +
-        `Display can present content: ${cap.canPresent}<br>` +
-        `Display is separate from the computer's main display: ${cap.hasExternalDisplay}<br>` +
-        `Display can return position info: ${cap.hasPosition}<br>` +
-        `Display can return orientation info: ${cap.hasOrientation}<br>` +
-        `Display max layers: ${cap.maxLayers}`;
+      listItem.innerText = `
+VR Display ID: ${display.displayId}
+VR Display Name: ${display.displayName}
+Display can present content: ${cap.canPresent}
+Display is separate from the computer's main display: ${cap.hasExternalDisplay}
+Display can return position info: ${cap.hasPosition}
+Display can return orientation info: ${cap.hasOrientation}
+Display max layers: ${cap.maxLayers}`;
+      listItem.insertBefore(
+        document.createElement("strong"),
+        listItem.firstChild,
+      ).textContent = `Display ${i + 1}`;
       list.appendChild(listItem);
     });
 
@@ -98,13 +101,17 @@ function reportGamepads() {
   for (const gp of gamepads) {
     const listItem = document.createElement("li");
     listItem.classList = "gamepad";
-    listItem.innerHTML =
-      `<strong>Gamepad ${gp.index}</strong> (${gp.id})<br>` +
-      `Associated with VR Display ID: ${gp.displayId}<br>` +
-      `Gamepad associated with which hand: ${gp.hand}<br>` +
-      `Available haptic actuators: ${gp.hapticActuators.length}<br>` +
-      `Gamepad can return position info: ${gp.pose.hasPosition}<br>` +
-      `Gamepad can return orientation info: ${gp.pose.hasOrientation}`;
+    listItem.innerText = `
+Associated with VR Display ID: ${gp.displayId}
+Gamepad associated with which hand: ${gp.hand}
+Available haptic actuators: ${gp.hapticActuators.length}
+Gamepad can return position info: ${gp.pose.hasPosition}
+Gamepad can return orientation info: ${gp.pose.hasOrientation}`;
+    listItem.insertBefore(
+      document.createElement("strong"),
+      }),
+      listItem.firstChild,
+    ).textContent = `Gamepad ${gp.index}`;
     list.appendChild(listItem);
   }
   initialRun = false;

--- a/files/en-us/web/api/window/getdefaultcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getdefaultcomputedstyle/index.md
@@ -63,7 +63,7 @@ const style = window.getDefaultComputedStyle(elem1);
 <script>
   const elem = document.getElementById("elem-container");
   const theCSSprop = window.getDefaultComputedStyle(elem).position;
-  document.getElementById("output").innerHTML = theCSSprop; // Will output "static"
+  document.getElementById("output").textContent = theCSSprop; // Will output "static"
 </script>
 ```
 


### PR DESCRIPTION
Part 3 of https://github.com/mdn/content/issues/13496. Use `innerText` where line breaks are needed, `textContent` otherwise, and `appendChild` if necessary.