### PR TITLE
FF129 Relnote - GeolocationCoordinates.toJSON() and GeolocationPosition.toJSON()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -40,6 +40,8 @@ This article provides information about the changes in Firefox 129 that affect d
 
 ### APIs
 
+- The default `.toJSON()` methods {{domxref("GeolocationCoordinates.toJSON()")}} and {{domxref("GeolocationPosition.toJSON()")}} are now supported, enabling serialization of `GeolocationCoordinates` and `GeolocationPosition` objects with {{jsxref("JSON.stringify()")}} ([Firefox bug 1890706](https://bugzil.la/1890706)).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF129 supports [`GeolocationCoordinates.toJSON()`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationCoordinates/toJSON), [`GeolocationPosition.toJSON()`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition/toJSON) in https://bugzilla.mozilla.org/show_bug.cgi?id=1890706

This adds a release note.

Related docs work can be tracked in #34841
