### PR TITLE
SVG attributes: geometry property notes

### DIFF
--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -64,7 +64,7 @@ For {{SVGElement('circle')}}, `cx` defines the x-axis coordinate of the center o
 </table>
 
 > [!Note]
-> The x-axis coordinate of the center of the `<circle>` can also be defined with the {{cssxref("cx")}} _geometry property_.
+> The x-axis coordinate of the center of the `<circle>` can also be defined with the {{cssxref("cx")}} _geometry property_. If set in CSS, the `cx` property value overrides the `cx` attribute value.
 
 ## ellipse
 
@@ -88,7 +88,7 @@ For {{SVGElement('ellipse')}}, `cx` defines the x-axis coordinate of the center 
 </table>
 
 > [!Note]
-> The x-axis coordinate of the center of the `<ellipse>` can also be defined with the {{cssxref("cx")}} _geometry property_.
+> The x-axis coordinate of the center of the `<ellipse>` can also be defined with the {{cssxref("cx")}} _geometry property_. If set in CSS, the `cx` property value overrides the `cx` attribute value.
 
 ## radialGradient
 

--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -63,7 +63,8 @@ For {{SVGElement('circle')}}, `cx` defines the x-axis coordinate of the center o
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2 `cx`, is a _Geometry Property_, meaning this attribute can also be used as CSS property for circles.
+> [!Note]
+> The x-axis coordinate of the center of the `<circle>` can also be defined with the {{cssxref("cx")}} _geometry property_.
 
 ## ellipse
 
@@ -86,7 +87,8 @@ For {{SVGElement('ellipse')}}, `cx` defines the x-axis coordinate of the center 
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2 `cx`, is a _Geometry Property_, meaning this attribute can also be used as CSS property for ellipses.
+> [!Note]
+> The x-axis coordinate of the center of the `<ellipse>` can also be defined with the {{cssxref("cx")}} _geometry property_.
 
 ## radialGradient
 

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -64,7 +64,7 @@ For {{SVGElement('circle')}}, `cy` defines the y-axis coordinate of the center o
 </table>
 
 > [!Note]
-> The y-axis coordinate of the center of the `<circle>` can also be defined with the {{cssxref("cy")}} _geometry property_.
+> The y-axis coordinate of the center of the `<circle>` can also be defined with the {{cssxref("cy")}} _geometry property_. If set in CSS, the `cy` property value overrides the `cy` attribute value.
 
 ## ellipse
 
@@ -88,7 +88,7 @@ For {{SVGElement('ellipse')}}, `cy` defines the y-axis coordinate of the center 
 </table>
 
 > [!Note]
-> The y-axis coordinate of the center of the `<ellipse>` can also be defined with the {{cssxref("cy")}} _geometry property_.
+> The y-axis coordinate of the center of the `<ellipse>` can also be defined with the {{cssxref("cy")}} _geometry property_. If set in CSS, the `cy` property value overrides the `cy` attribute value.
 
 ## radialGradient
 

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -63,7 +63,8 @@ For {{SVGElement('circle')}}, `cy` defines the y-axis coordinate of the center o
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `cy` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for circles.
+> [!Note]
+> The y-axis coordinate of the center of the `<circle>` can also be defined with the {{cssxref("cy")}} _geometry property_.
 
 ## ellipse
 
@@ -86,7 +87,8 @@ For {{SVGElement('ellipse')}}, `cy` defines the y-axis coordinate of the center 
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `cy` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for ellipses.
+> [!Note]
+> The y-axis coordinate of the center of the `<ellipse>` can also be defined with the {{cssxref("cy")}} _geometry property_.
 
 ## radialGradient
 

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -88,7 +88,8 @@ For {{SVGElement('circle')}}, `r` defines the radius of the circle and therefor 
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `r` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for circles.
+> [!Note]
+> The radius size of a `<circle>` can also be defined with the {{cssxref("r")}} _geometry property_.
 
 ## radialGradient
 

--- a/files/en-us/web/svg/attribute/rx/index.md
+++ b/files/en-us/web/svg/attribute/rx/index.md
@@ -72,7 +72,8 @@ For {{SVGElement('ellipse')}}, `rx` defines the x-radius of the shape. With a va
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `rx` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for ellipses.
+> [!Note]
+> The x-radius of the `<ellipse>` can also be defined with the {{cssxref("rx")}} _geometry property_. If set in CSS, the `rx` property value overrides the `rx` attribute value.
 
 ## rect
 
@@ -114,7 +115,8 @@ The way the value of the `rx` attribute is interpreted depend on both the {{SVGA
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `rx` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rects.
+> [!Note]
+> The horizontal curve of the corners of the `<rect>` can also be defined with the {{cssxref("rx")}} _geometry property_. If set in CSS, the `rx` property value overrides the `rx` attribute value.
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/ry/index.md
+++ b/files/en-us/web/svg/attribute/ry/index.md
@@ -72,7 +72,8 @@ For {{SVGElement('ellipse')}}, `ry` defines the y-radius of the shape. With a va
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `ry` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for ellipses.
+> [!Note]
+> The y-radius of the `<ellipse>` can also be defined with the {{cssxref("ry")}} _geometry property_. If set in CSS, the `ry` property value overrides the `ry` attribute value.
 
 ## rect
 
@@ -114,7 +115,8 @@ The way the value of the `ry` attribute is interpreted depend on both the {{SVGA
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `ry` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rects.
+> [!Note]
+> The vertical curve of the corners of the `<rect>` can also be defined with the {{cssxref("ry")}} _geometry property_. If set in CSS, the `ry` property value overrides the `ry` attribute value.
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -1298,7 +1298,8 @@ For {{SVGElement('use')}}, `x` defines the x coordinate of the upper left corner
 </table>
 
 > [!Note]
-> Declaring a `<length>` or `<percentage>` value in CSS using the {{cssxref("x")}} _geometry property_ overrides the x-axis coordinate of the `<use>` set by the `x` attribute in some browsers. This behavior is at-risk.
+> Declaring a `<length>` or `<percentage>` value in CSS using the {{cssxref("x")}} _geometry property_ overrides the x-axis coordinate of the `<use>` set by the `x` attribute in some browsers.
+> This behavior is non-standard, deprecated, and likely to be removed in future browser versions.
 
 ## Examples
 

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -867,7 +867,8 @@ For {{SVGElement('foreignObject')}}, `x` defines the x coordinate of the upper l
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<foreignObject>`.
+> [!Note]
+> The x-axis coordinate of the `<foreignObject>` can also be defined with the {{cssxref("x")}} _geometry property_.
 
 ### `<glyphRef>`
 
@@ -935,7 +936,8 @@ For {{SVGElement('image')}}, `x` defines the x coordinate of the upper left corn
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for images.
+> [!Note]
+> The x-axis coordinate of the `<image>` can also be defined with the {{cssxref("x")}} _geometry property_.
 
 ### `<mask>`
 
@@ -1030,7 +1032,8 @@ For {{SVGElement('rect')}}, `x` defines the x coordinate of the upper left corne
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rectangles.
+> [!Note]
+> The x-axis coordinate of the `<rect>` can also be defined with the {{cssxref("x")}} _geometry property_.
 
 ### `<svg>`
 
@@ -1065,7 +1068,8 @@ For {{SVGElement('svg')}}, `x` defines the x coordinate of the upper left corner
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<svg>`.
+> [!Note]
+> The x-axis coordinate of the `<svg>` can also be defined with the {{cssxref("x")}} _geometry property_.
 
 ### `<text>`
 
@@ -1293,7 +1297,8 @@ For {{SVGElement('use')}}, `x` defines the x coordinate of the upper left corner
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `x` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
+> [!Note]
+> Declaring a `<length>` or `<percentage>` value in CSS using the {{cssxref("x")}} _geometry property_ overrides the x-axis coordinate of the `<use>` set by the `x` attribute in some browsers. This behavior is at-risk.
 
 ## Examples
 

--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -868,7 +868,7 @@ For {{SVGElement('foreignObject')}}, `x` defines the x coordinate of the upper l
 </table>
 
 > [!Note]
-> The x-axis coordinate of the `<foreignObject>` can also be defined with the {{cssxref("x")}} _geometry property_.
+> The x-axis coordinate of the `<foreignObject>` can also be defined with the {{cssxref("x")}} _geometry property_. If set in CSS, the `x` property value overrides the `x` attribute value.
 
 ### `<glyphRef>`
 
@@ -937,7 +937,7 @@ For {{SVGElement('image')}}, `x` defines the x coordinate of the upper left corn
 </table>
 
 > [!Note]
-> The x-axis coordinate of the `<image>` can also be defined with the {{cssxref("x")}} _geometry property_.
+> The x-axis coordinate of the `<image>` can also be defined with the {{cssxref("x")}} _geometry property_. If set in CSS, the `x` property value overrides the `x` attribute value.
 
 ### `<mask>`
 
@@ -1033,7 +1033,7 @@ For {{SVGElement('rect')}}, `x` defines the x coordinate of the upper left corne
 </table>
 
 > [!Note]
-> The x-axis coordinate of the `<rect>` can also be defined with the {{cssxref("x")}} _geometry property_.
+> The x-axis coordinate of the `<rect>` can also be defined with the {{cssxref("x")}} _geometry property_. If set in CSS, the `x` property value overrides the `x` attribute value.
 
 ### `<svg>`
 
@@ -1069,7 +1069,7 @@ For {{SVGElement('svg')}}, `x` defines the x coordinate of the upper left corner
 </table>
 
 > [!Note]
-> The x-axis coordinate of the `<svg>` can also be defined with the {{cssxref("x")}} _geometry property_.
+> The x-axis coordinate of the `<svg>` can also be defined with the {{cssxref("x")}} _geometry property_. If set in CSS, the `x` property value overrides the `x` attribute value.
 
 ### `<text>`
 

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -867,7 +867,8 @@ For {{SVGElement('foreignObject')}}, `y` defines the y coordinate of the upper l
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<foreignObject>`.
+> [!Note]
+> The y-axis coordinate of the `<foreignObject>` can also be defined with the {{cssxref("y")}} _geometry property_.
 
 ### `<glyphRef>`
 
@@ -931,7 +932,8 @@ For {{SVGElement('image')}}, `y` defines the y coordinate of the upper left corn
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for images.
+> [!Note]
+> The y-axis coordinate of the `<image>` can also be defined with the {{cssxref("y")}} _geometry property_.
 
 ### `<mask>`
 
@@ -1026,7 +1028,8 @@ For {{SVGElement('rect')}}, `y` defines the y coordinate of the upper left corne
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for rectangles.
+> [!Note]
+> The y-axis coordinate of the `<rect>` can also be defined with the {{cssxref("y")}} _geometry property_.
 
 ### `<svg>`
 
@@ -1061,7 +1064,8 @@ For {{SVGElement('svg')}}, `y` defines the y coordinate of the upper left corner
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for `<svg>`.
+> [!Note]
+> The y-axis coordinate of the `<svg>` can also be defined with the {{cssxref("y")}} _geometry property_.
 
 ### `<text>`
 
@@ -1289,7 +1293,8 @@ For {{SVGElement('use')}}, `y` defines the y coordinate of the upper left corner
   </tbody>
 </table>
 
-> **Note:** Starting with SVG2, `y` is a _Geometry Property_ meaning this attribute can also be used as a CSS property for used elements.
+> [!Note]
+> Declaring a `<length>` or `<percentage>` value in CSS using the {{cssxref("y")}} _geometry property_ overrides the y-axis coordinate of the `<use>` set by the `y` attribute in some browsers. This behavior is at-risk.
 
 ## Examples
 

--- a/files/en-us/web/svg/attribute/y/index.md
+++ b/files/en-us/web/svg/attribute/y/index.md
@@ -868,7 +868,7 @@ For {{SVGElement('foreignObject')}}, `y` defines the y coordinate of the upper l
 </table>
 
 > [!Note]
-> The y-axis coordinate of the `<foreignObject>` can also be defined with the {{cssxref("y")}} _geometry property_.
+> The y-axis coordinate of the `<foreignObject>` can also be defined with the {{cssxref("y")}} _geometry property_. If set in CSS, the `y` property value overrides the `y` attribute value.
 
 ### `<glyphRef>`
 
@@ -933,7 +933,7 @@ For {{SVGElement('image')}}, `y` defines the y coordinate of the upper left corn
 </table>
 
 > [!Note]
-> The y-axis coordinate of the `<image>` can also be defined with the {{cssxref("y")}} _geometry property_.
+> The y-axis coordinate of the `<image>` can also be defined with the {{cssxref("y")}} _geometry property_. If set in CSS, the `y` property value overrides the `y` attribute value.
 
 ### `<mask>`
 
@@ -1029,7 +1029,7 @@ For {{SVGElement('rect')}}, `y` defines the y coordinate of the upper left corne
 </table>
 
 > [!Note]
-> The y-axis coordinate of the `<rect>` can also be defined with the {{cssxref("y")}} _geometry property_.
+> The y-axis coordinate of the `<rect>` can also be defined with the {{cssxref("y")}} _geometry property_. If set in CSS, the `y` property value overrides the `y` attribute value.
 
 ### `<svg>`
 
@@ -1065,7 +1065,7 @@ For {{SVGElement('svg')}}, `y` defines the y coordinate of the upper left corner
 </table>
 
 > [!Note]
-> The y-axis coordinate of the `<svg>` can also be defined with the {{cssxref("y")}} _geometry property_.
+> The y-axis coordinate of the `<svg>` can also be defined with the {{cssxref("y")}} _geometry property_. If set in CSS, the `y` property value overrides the `y` attribute value.
 
 ### `<text>`
 


### PR DESCRIPTION
the geometry propery pages were created. this adds links to those pages.
removing the "svg 2" info as it's well supported, and the browser doesn't care which version you're targeting.

related to https://github.com/mdn/content/issues/34763