### PR TITLE
Remove DataView BigInt pseudo-polyfill

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/dataview/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/index.md
@@ -27,48 +27,6 @@ console.log(littleEndian); // true or false
 
 > **Note:** `DataView` defaults to big-endian read and write, but most platforms use little-endian.
 
-### 64-bit Integer Values
-
-Some browsers don't have support for {{jsxref("DataView.prototype.setBigInt64()")}} and {{jsxref("DataView.prototype.setBigUint64()")}}. So to enable 64-bit operations in your code that will work across browsers, you could implement your own `getUint64()` function, to obtain values with precision up to {{jsxref("Number.MAX_SAFE_INTEGER")}} — which could suffice for certain cases.
-
-```js
-function getUint64(dataview, byteOffset, littleEndian) {
-  // split 64-bit number into two 32-bit (4-byte) parts
-  const left = dataview.getUint32(byteOffset, littleEndian);
-  const right = dataview.getUint32(byteOffset + 4, littleEndian);
-
-  // combine the two 32-bit values
-  const combined = littleEndian
-    ? left + 2 ** 32 * right
-    : 2 ** 32 * left + right;
-
-  if (!Number.isSafeInteger(combined))
-    console.warn(combined, "exceeds MAX_SAFE_INTEGER. Precision may be lost");
-
-  return combined;
-}
-```
-
-Alternatively, if you need full 64-bit range, you can create a {{jsxref("BigInt")}}. Further, although native BigInts are much faster than user-land library equivalents, BigInts will always be much slower than 32-bit integers in JavaScript due to the nature of their variable size.
-
-```js
-const BigInt = window.BigInt,
-  bigThirtyTwo = BigInt(32),
-  bigZero = BigInt(0);
-function getUint64BigInt(dataview, byteOffset, littleEndian) {
-  // split 64-bit number into two 32-bit (4-byte) parts
-  const left = BigInt(dataview.getUint32(byteOffset | 0, !!littleEndian) >>> 0);
-  const right = BigInt(
-    dataview.getUint32(((byteOffset | 0) + 4) | 0, !!littleEndian) >>> 0,
-  );
-
-  // combine the two 32-bit values and return
-  return littleEndian
-    ? (right << bigThirtyTwo) | left
-    : (left << bigThirtyTwo) | right;
-}
-```
-
 ## Constructor
 
 - {{jsxref("DataView/DataView", "DataView()")}}


### PR DESCRIPTION
This thing has been well-supported for four years, so no reason we need a pseudo-polyfill. If compatibility is needed, users should install a real polyfill.