### PR TITLE
Remove prefixed webkitAudioContext

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
@@ -128,7 +128,6 @@ Next, let's look at the JavaScript for this example.
 We start by creating an `AudioContext` instance inside which to manipulate our track:
 
 ```js
-const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 ```
 

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/javascript/index.md
@@ -390,7 +390,7 @@ In the previous article, we included quite a lot of discussion about [handling C
 - Chrome/Opera/Safari would use `webkitObject`
 - Microsoft would use `msObject`
 
-Here's an example, taken from our [violent-theremin demo](https://mdn.github.io/webaudio-examples/violent-theremin/) (see [source code](https://github.com/mdn/webaudio-examples/tree/main/violent-theremin)), which uses a combination of the [Canvas API](/en-US/docs/Web/API/Canvas_API) and the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) to create a fun (and noisy) drawing tool:
+Here's an example that uses the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API):
 
 ```js
 const AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/files/en-us/web/api/analysernode/fftsize/index.md
+++ b/files/en-us/web/api/analysernode/fftsize/index.md
@@ -27,7 +27,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 
 // …

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -22,7 +22,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo.
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bar graph style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 
 // …

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
@@ -34,7 +34,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 
 // …

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -32,7 +32,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 
 // …

--- a/files/en-us/web/api/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/index.md
@@ -83,7 +83,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/webaudio-examples/voice-change-o-matic/) demo (see [app.js lines 108-193](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // …
 

--- a/files/en-us/web/api/analysernode/maxdecibels/index.md
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.md
@@ -27,7 +27,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -24,7 +24,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -28,7 +28,7 @@ For more complete applied examples/information, check out our [Voice-change-O-ma
 If you are curious about the effect the `smoothingTimeConstant()` has, try cloning the above example and setting `analyser.smoothingTimeConstant = 0;` instead. You'll notice that the value changes are much more jarring.
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.md
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.md
@@ -30,7 +30,7 @@ A {{jsxref("Float32Array")}}.
 In the following example we create a two second buffer, fill it with white noise, and then play it via an {{ domxref("AudioBufferSourceNode") }}. The comments should clearly explain what is going on. You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const button = document.querySelector("button");
 const pre = document.querySelector("pre");
 const myScript = document.querySelector("script");

--- a/files/en-us/web/api/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/index.md
@@ -41,7 +41,7 @@ Objects of these types are designed to hold small audio snippets, typically less
 The following simple example shows how to create an `AudioBuffer` and fill it with random white noise. You can find the full source code at our [webaudio-examples](https://github.com/mdn/webaudio-examples) repository; a [running live](https://mdn.github.io/webaudio-examples/audio-buffer/) version is also available.
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // Create an empty three-second stereo buffer at the sample rate of the AudioContext
 const myArrayBuffer = audioCtx.createBuffer(

--- a/files/en-us/web/api/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/index.md
@@ -74,7 +74,7 @@ In this example, we create a two-second buffer, fill it with white noise, and th
 > **Note:** You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // Create an empty three-second stereo buffer at the sample rate of the AudioContext
 const myArrayBuffer = audioCtx.createBuffer(

--- a/files/en-us/web/api/audionode/context/index.md
+++ b/files/en-us/web/api/audionode/context/index.md
@@ -21,7 +21,6 @@ used to construct this `AudioNode`.
 ## Examples
 
 ```js
-const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/audionode/disconnect/index.md
+++ b/files/en-us/web/api/audionode/disconnect/index.md
@@ -41,8 +41,6 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-const AudioContext = window.AudioContext || window.webkitAudioContext;
-
 const audioCtx = new AudioContext();
 
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/audioparam/setvalueattime/index.md
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.md
@@ -43,7 +43,6 @@ to set the gain value equal to `currGain`, one second from now
 
 ```js
 // create audio context
-const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 
 // set basic variables for example

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
@@ -42,7 +42,7 @@ examples/information, check out our [Voice-change-O-matic](https://mdn.github.io
 [app.js lines 108-193](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const analyser = audioCtx.createAnalyser();
 
 // …

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
@@ -96,7 +96,7 @@ create a three-second buffer, fill it with white noise, and then play it via an 
 You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // Create an empty three-second stereo buffer at the sample rate of the AudioContext
 const myArrayBuffer = audioCtx.createBuffer(

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
@@ -41,7 +41,7 @@ what is going on.
 > or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const button = document.querySelector("button");
 const pre = document.querySelector("pre");
 const myScript = document.querySelector("script");

--- a/files/en-us/web/api/baseaudiocontext/index.md
+++ b/files/en-us/web/api/baseaudiocontext/index.md
@@ -78,16 +78,7 @@ _Also implements methods from the interface_ {{domxref("EventTarget")}}.
 
 ## Examples
 
-Basic audio context declaration:
-
 ```js
-const audioContext = new AudioContext();
-```
-
-Cross browser variant:
-
-```js
-const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioContext = new AudioContext();
 
 const oscillatorNode = audioContext.createOscillator();

--- a/files/en-us/web/api/iirfilternode/iirfilternode/index.md
+++ b/files/en-us/web/api/iirfilternode/iirfilternode/index.md
@@ -60,7 +60,6 @@ A new {{domxref("IIRFilterNode")}} object instance.
 let feedForward = [0.00020298, 0.0004059599, 0.00020298];
 let feedBackward = [1.0126964558, -1.9991880801, 0.9873035442];
 
-const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 
 const iirFilter = new IIRFilterNode(audioCtx, {

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
@@ -53,7 +53,7 @@ access to the user's camera, then creates a new
 
 ```js
 // define variables
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // getUserMedia block - grab stream
 // put it into a MediaStreamAudioSourceNode

--- a/files/en-us/web/api/oscillatornode/detune/index.md
+++ b/files/en-us/web/api/oscillatornode/detune/index.md
@@ -22,7 +22,7 @@ The following example shows basic usage of an {{ domxref("AudioContext") }} to c
 
 ```js
 // create web audio api context
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // create Oscillator node
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/oscillatornode/frequency/index.md
+++ b/files/en-us/web/api/oscillatornode/frequency/index.md
@@ -22,7 +22,7 @@ The following example shows basic usage of an {{ domxref("AudioContext") }} to c
 
 ```js
 // create web audio api context
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // create Oscillator node
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/index.md
@@ -73,7 +73,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 
 ```js
 // create web audio api context
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // create Oscillator node
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/oscillatornode/type/index.md
+++ b/files/en-us/web/api/oscillatornode/type/index.md
@@ -46,7 +46,7 @@ an oscillator node. For an applied example, check out our [Violent Theremin demo
 
 ```js
 // create web audio api context
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 
 // create Oscillator node
 const oscillator = audioCtx.createOscillator();

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -197,7 +197,7 @@ const oscList = [];
 let mainGainNode = null;
 ```
 
-1. `audioContext` is set to reference the global {{domxref("AudioContext")}} object (or `webkitAudioContext` if necessary).
+1. `audioContext` is created as an instance of {{domxref("AudioContext")}}.
 2. `oscList` is set up to be ready to contain a list of all currently-playing oscillators. It starts off empty, since there are none playing yet.
 3. `mainGainNode` is set to null; during the setup process, it will be configured to contain a {{domxref("GainNode")}} which all playing oscillators will connect to and play through to allow the overall volume to be controlled using a single slider control.
 

--- a/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
@@ -35,9 +35,6 @@ Several audio sources with different channel layouts are supported, even within 
 To be able to do anything with the Web Audio API, we need to create an instance of the audio context. This then gives us access to all the features and functionality of the API.
 
 ```js
-// for legacy browsers
-const AudioContext = window.AudioContext || window.webkitAudioContext;
-
 const audioContext = new AudioContext();
 ```
 

--- a/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
+++ b/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
@@ -46,7 +46,6 @@ They remain static. The `pannerNode` can then calculate its sound position relat
 Let's create our context and listener and set the listener's position to emulate a person looking into our room:
 
 ```js
-const AudioContext = window.AudioContext || window.webkitAudioContext;
 const audioCtx = new AudioContext();
 const listener = audioCtx.listener;
 


### PR DESCRIPTION
This has been supported in Chrome unprefixed for 10 years and is even explicitly said in our style guide as an antipattern.