### PR TITLE
fix: incorrect path on url api resolving relative references page

### DIFF
--- a/files/en-us/web/api/url_api/resolving_relative_references/index.md
+++ b/files/en-us/web/api/url_api/resolving_relative_references/index.md
@@ -18,16 +18,16 @@ The code below shows how the methods are used with the same `url` and `base` URL
 const url = "articles";
 const base = "https://developer.mozilla.org/some/path";
 const constructorResult = new URL(url, base);
-// => https://developer.mozilla.org/url/some/articles
+// => https://developer.mozilla.org/some/articles
 const parseResult = URL.parse(url, base);
-// => https://developer.mozilla.org/url/some/articles
+// => https://developer.mozilla.org/some/articles
 ```
 
-You can see from the example that resolving the `URL` from a supplied base URL and relative reference is not simply a concantenation of the supplied parameters.
+You can see from the example that resolving the `URL` from a supplied base URL and relative reference is not simply a concatenation of the supplied parameters.
 
 In this case a path relative to the current directory is passed (`articles`).
 The current directory of the `base` URL is the URL string up to the last forward slash.
-Here `https://developer.mozilla.org/some/path` has no trailing forward slash, so the current directory is `https://developer.mozilla.org/some/`, and hence resolves to a final URL of `https://developer.mozilla.org/url/some/articles`.
+Here `https://developer.mozilla.org/some/path` has no trailing forward slash, so the current directory is `https://developer.mozilla.org/some/`, and hence resolves to a final URL of `https://developer.mozilla.org/some/articles`.
 
 Relative references are resolved against the base URL using a path reference that is relative to: the current directory (`./`), the parent directory of the current directory (`../`), or the site root (`/`).
 The following sections show how resolution works for each type of relative path.


### PR DESCRIPTION
### Description

Fixed incorrect URL in the [Resolving relative references (URL API)](https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references) page.

### Motivation

![image](https://github.com/user-attachments/assets/69baee1f-ae2f-432e-8eb6-3729fff5ebb5)