### PR TITLE
Update validation rules for creating a texture view

### DIFF
--- a/files/en-us/web/api/gputexture/createview/index.md
+++ b/files/en-us/web/api/gputexture/createview/index.md
@@ -101,7 +101,7 @@ The following criteria must be met when calling **`createView()`**, otherwise a 
 - `mipLevelCount` is greater than 0.
 - `mipLevelCount` + `baseMipLevel` is less than or equal to {{domxref("GPUTexture.mipLevelCount")}}.
 - `arrayLayerCount` is greater than 0.
-- `arrayLayerCount` + `baseArrayLayer` is less than or equal to {{domxref("GPUTexture.depthOrArrayLayers")}}.
+- `arrayLayerCount` + `baseArrayLayer` is less than or equal to {{domxref("GPUTexture.depthOrArrayLayers")}} if {domxref("GPUTexture.dimension")}} is `"2d"`, or less than or equal to 1 if {domxref("GPUTexture.dimension")}} is `"1d"` or `"3d"`.
 - If `sampleCount` is greater than 1, `dimension` is `"2d"`.
 - If `dimension` is:
   - `"1d"`

--- a/files/en-us/web/api/gputexture/createview/index.md
+++ b/files/en-us/web/api/gputexture/createview/index.md
@@ -101,7 +101,7 @@ The following criteria must be met when calling **`createView()`**, otherwise a 
 - `mipLevelCount` is greater than 0.
 - `mipLevelCount` + `baseMipLevel` is less than or equal to {{domxref("GPUTexture.mipLevelCount")}}.
 - `arrayLayerCount` is greater than 0.
-- `arrayLayerCount` + `baseArrayLayer` is less than or equal to {{domxref("GPUTexture.depthOrArrayLayers")}} if {domxref("GPUTexture.dimension")}} is `"2d"`, or less than or equal to 1 if {domxref("GPUTexture.dimension")}} is `"1d"` or `"3d"`.
+- `arrayLayerCount` + `baseArrayLayer` is less than or equal to {{domxref("GPUTexture.depthOrArrayLayers")}} if {{domxref("GPUTexture.dimension")}} is `"2d"`, or less than or equal to 1 if {{domxref("GPUTexture.dimension")}} is `"1d"` or `"3d"`.
 - If `sampleCount` is greater than 1, `dimension` is `"2d"`.
 - If `dimension` is:
   - `"1d"`


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I think the WebGPU API validation rules for creating a texture view was slightly incorrect and I updated them to correctly follow the WebGPU API spec. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Clarifies confusion on validation rules when using WebGPU through their current implementations.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
The API validation rules can be found here: https://www.w3.org/TR/webgpu/#dom-gputexture-createview. In the doc, they state that the view's baseArrayLayer + the view's arrayLayerCount must be ≤ the texture's array layer count. 

In the MDN docs, this was written as  ≤ GPUTexture.depthOrArrayLayers, which is slightly different. The way the texture's array layer count is calculated can be found here: https://www.w3.org/TR/webgpu/#abstract-opdef-array-layer-count. The way the MDN docs were originally written would only apply if the GPUTexture had a dimension of "2d". 


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
