### PR TITLE
Notification.requestPermission() - remove confusing text and version …

### DIFF
--- a/files/en-us/web/api/notification/requestpermission_static/index.md
+++ b/files/en-us/web/api/notification/requestpermission_static/index.md
@@ -10,24 +10,27 @@ browser-compat: api.Notification.requestPermission_static
 
 The **`requestPermission()`** static method of the {{domxref("Notification")}} interface requests permission from the user for the current origin to display notifications.
 
+The method returns a {{jsxref("Promise")}} that fulfills with a string indicating whether permission was granted or denied.
+
 ## Syntax
 
 ```js-nolint
-// The latest spec has updated this method to a promise-based syntax that works like this:
 Notification.requestPermission()
 
-// Previously, the syntax was based on a simple callback; this version is now deprecated:
+// Deprecated syntax using a callback
 Notification.requestPermission(callback)
 ```
 
 ### Parameters
 
 - `callback` {{optional_inline}} {{deprecated_inline}}
-  - : An optional callback function that is called with the permission value. Deprecated in favor of the promise return value.
+  - : An optional callback function that is called with the permission value.
+    Deprecated in favor of the {{jsxref("Promise")}} return value.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to a string with the permission picked by the user. Possible values for this string are:
+A {{jsxref("Promise")}} that resolves to a string with the permission picked by the user.
+Possible values for this string are:
 
 - `granted`
   - : The user has explicitly granted permission for the current origin to display system notifications.
@@ -35,6 +38,8 @@ A {{jsxref("Promise")}} that resolves to a string with the permission picked by 
   - : The user has explicitly denied permission for the current origin to display system notifications.
 - `default`
   - : The user decision is unknown; in this case the application will act as if permission was `denied`.
+
+The deprecated version of the method returns `undefined`
 
 ## Examples
 
@@ -45,6 +50,8 @@ Assume this basic HTML:
 ```
 
 It's possible to send a notification as follows — here we present a fairly verbose and complete set of code you could use if you wanted to first check whether notifications are supported, then check if permission has been granted for the current origin to send notifications, then request permission if required, before then sending a notification.
+
+Note that the request should be made in response to user interaction: below the method is called in the click event handler.
 
 ```js
 function notifyMe() {
@@ -73,8 +80,6 @@ function notifyMe() {
 ```
 
 We no longer show a live sample on this page, as Chrome and Firefox no longer allow notification permissions to be requested from cross-origin {{htmlelement("iframe")}}s, with other browsers to follow. To see an example in action, check out our [To-do list example](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) (also see [the app running live](https://mdn.github.io/dom-examples/to-do-notifications/)).
-
-> **Note:** In the above example we spawn notifications in response to a user gesture (clicking a button). This is not only best practice — you should not be spamming users with notifications they didn't agree to — but going forward browsers will explicitly disallow notifications not triggered in response to a user gesture. Firefox is already doing this from version 72, for example.
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/requestpermission_static/index.md
+++ b/files/en-us/web/api/notification/requestpermission_static/index.md
@@ -51,7 +51,7 @@ Assume this basic HTML:
 
 It's possible to send a notification as follows — here we present a fairly verbose and complete set of code you could use if you wanted to first check whether notifications are supported, then check if permission has been granted for the current origin to send notifications, then request permission if required, before then sending a notification.
 
-Note that the request should be made in response to user interaction: below the method is called in the click event handler.
+Note that the request should be made in response to user interaction: below, the method is called in the click event handler.
 
 ```js
 function notifyMe() {

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -15,7 +15,8 @@ The Notifications API allows web pages to control the display of system notifica
 
 ## Concepts and usage
 
-On supported platforms, showing a system notification generally involves two things. First, the user needs to grant the current origin permission to display system notifications, which is generally done when the app or site initializes, using the {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}} method. This should be done in response to a user gesture, such as clicking a button, for example:
+On supported platforms, showing a system notification generally involves two things. First, the user needs to grant the current origin permission to display system notifications, which is generally done when the app or site initializes, using the {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}} method.
+This method should only be called when handling a user gesture, such as when handling a mouse click. For example:
 
 ```js
 btn.addEventListener("click", () => {
@@ -24,15 +25,11 @@ btn.addEventListener("click", () => {
 });
 ```
 
-This is not only best practice — you should not be spamming users with notifications they didn't agree to — but going forward browsers will explicitly disallow notifications not triggered in response to a user gesture. Firefox is already doing this from version 72, for example.
-
 This will spawn a request dialog, along the following lines:
 
 ![A dialog box asking the user to allow notifications from that origin. There are options to never allow or allow notifications.](screen_shot_2019-12-11_at_9.59.14_am.png)
 
 From here the user can choose to allow notifications from this origin, or block them. Once a choice has been made, the setting will generally persist for the current session.
-
-> **Note:** As of Firefox 44, the permissions for Notifications and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is granted for notifications, push will also be enabled.
 
 Next, a new notification is created using the {{domxref("Notification.Notification","Notification()")}} constructor. This must be passed a title argument, and can optionally be passed an options object to specify options, such as text direction, body text, icon to display, notification sound to play, and more.
 


### PR DESCRIPTION
There was some confusing text in Notifcation API, and [`Notification/requestPermission()`](https://developer.mozilla.org/en-US/docs/Web/API/Notification/requestPermission_static) that implied notifications could only be sent following user interaction, whereas in FF notifications permission can only be requested following user permission.

This removes that text, and also the FF specific versioning hints, replacing the text with "you _should_ only request permission following user interaction". Reason being there is no evidence I can see that spec requires this or that other browser do it - but it is still appropriate/good.

The version info should live in compat data, and already mostly does. I did a fix in https://github.com/mdn/browser-compat-data/pull/23911 to make it more clear that the Promise returning version is supported everywhere.

Fixes #34945