### PR TITLE
fix(css): update variable font slant example

### DIFF
--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -121,7 +121,7 @@ font-style: oblique 14deg;
 font-variation-settings: "slnt" -14;
 ```
 
-Prefer the `font-style` property over `font-variation-settings` property. The `deg` keyword is not used when using the `font-variation-settings` property. Also, in the case of the `font-variation-settings` property, a positive angle means counter-clockwise slant.
+Prefer the `font-style` property over  the `font-variation-settings` property. The `deg` keyword is not used when using the `font-variation-settings` property. Also, in the case of the `font-variation-settings` property, a positive angle means a counter-clockwise slant.
 
 In the following live example, you can adjust the slant.
 

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -168,7 +168,7 @@ p {
 @font-face {
   font-family: "SlantFont";
   font-style: oblique -15 15;
-  src: url("https://github.com/mdn/shared-assets/raw/d1fad181a5ea4a30503c3f6e48739c1bdf5ab722/fonts/font_with_slant_axis.woff2")
+  src: url("https://mdn.github.io/shared-assets/fonts/font_with_slant_axis.woff2")
     format("woff2");
 }
 
@@ -201,7 +201,7 @@ angle.addEventListener("input", (e) => {
 });
 ```
 
-{{EmbedLiveSample("slant", "100%", "300")}}
+{{EmbedLiveSample("slant", "100%", "350")}}
 
 ### Optical size
 

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -121,7 +121,7 @@ font-style: oblique 14deg;
 font-variation-settings: "slnt" -14;
 ```
 
-Prefer the `font-style` property over  the `font-variation-settings` property. The `deg` keyword is not used when using the `font-variation-settings` property. Also, in the case of the `font-variation-settings` property, a positive angle means a counter-clockwise slant.
+Prefer the `font-style` property over the `font-variation-settings` property. The `deg` keyword is not used when using the `font-variation-settings` property. Also, in the case of the `font-variation-settings` property, a positive angle means a counter-clockwise slant.
 
 In the following live example, you can adjust the slant.
 

--- a/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/variable_fonts_guide/index.md
@@ -111,19 +111,97 @@ The following live example's CSS can be edited to allow you to play with font it
 
 ### Slant
 
-Slant (represented by the `slnt` tag), or as it's often referred to, 'oblique' — is different from true italics in that it changes the angle of the letterforms but doesn't perform any kind of character substitution. It is also variable, in that it is expressed as a numeric range. This allows the font to be varied anywhere along that axis. The allowed range is generally 0 (upright) to 20 degrees — any number value along that range can be supplied, so the font can be slanted just a tiny bit. However, any value from -90 to 90 degrees is valid.
+Slant (represented by the `slnt` tag), or as it's often referred to, 'oblique' — is different from true italics in that it changes the angle of the letterforms but doesn't perform any kind of character substitution. It is also variable, in that it is expressed as a numeric range. This allows the font to be varied anywhere along the slant axis. The allowed range is from -90 to 90 degrees.
 
-> **Note:** The `deg` keyword is not used when utilizing `font-variation-settings`.
+The two properties that can control the slant are [`font-style`](/en-US/docs/Web/CSS/font-style) and [`font-variation-settings`](/en-US/docs/Web/CSS/font-variation-settings). The following two property declarations are the same:
 
-```css
+```plain
 font-style: oblique 14deg;
 
-font-variation-settings: "slnt" 14;
+font-variation-settings: "slnt" -14;
 ```
 
-The following live example's CSS can be edited to allow you to play with font slant/oblique values.
+Prefer the `font-style` property over `font-variation-settings` property. The `deg` keyword is not used when using the `font-variation-settings` property. Also, in the case of the `font-variation-settings` property, a positive angle means counter-clockwise slant.
 
-{{EmbedGHLiveSample("css-examples/variable-fonts/slant.html", '100%', 520)}}
+In the following live example, you can adjust the slant.
+
+```html hidden
+<div>
+  <p class="font-style">Slant</p>
+  <span>(font-style: oblique 5deg)</span>
+</div>
+<div>
+  <p class="font-variation">Slant</p>
+  <span>(font-variation-settings: 'slnt' -5)</span>
+</div>
+<div class="adjustable-box">
+  <p class="adjustable">Slant</p>
+  (font-variation-settings: 'slnt' <span id="angle-text">-5</span>)<br />
+
+  <label for="slant-angle">Adjust Slant: </label>
+  <input
+    type="range"
+    name="range-slider"
+    value="5"
+    id="slant-angle"
+    min="-15"
+    max="15" />
+</div>
+```
+
+```css hidden
+:root {
+  --text-axis: -5;
+}
+
+p {
+  display: inline-block;
+  font-size: 2rem;
+}
+
+.adjustable-box {
+  border: 1px dashed;
+}
+```
+
+```css
+@font-face {
+  font-family: "SlantFont";
+  font-style: oblique -15 15;
+  src: url("https://github.com/mdn/shared-assets/raw/d1fad181a5ea4a30503c3f6e48739c1bdf5ab722/fonts/font_with_slant_axis.woff2")
+    format("woff2");
+}
+
+p {
+  font-family: "SlantFont";
+}
+
+.font-style {
+  font-style: oblique 5deg;
+}
+
+.font-variation {
+  font-variation-settings: "slnt" -5;
+}
+
+.adjustable {
+  font-variation-settings: "slnt" var(--slant-angle);
+}
+```
+
+```js hidden
+const angle = document.querySelector("#slant-angle");
+const text = document.querySelector("#angle-text");
+const adjustable = document.querySelector(".adjustable");
+
+angle.addEventListener("input", (e) => {
+  const angle = -1 * e.target.value;
+  text.innerText = angle;
+  adjustable.style.setProperty("--slant-angle", angle);
+});
+```
+
+{{EmbedLiveSample("slant", "100%", "300")}}
 
 ### Optical size
 


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/33439

In case of the `font-style: oblique <angle>`, the selected font needs to have a `slnt` axis. Otherwise the slant is synthesized by the browsers. And the browsers seem to always synthesize it to `14deg`.

The PR uses [a font with a slant axis](https://github.com/mdn/shared-assets/pull/19). Using the font `font-style` angles work well. ~The font link will be updated once the `mdn/shared-assets` PR gets merged.~

Also, the PR converts the GitHub sample to a local live sample.