### PR TITLE
34700 webkit font feature settings

### DIFF
--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -156,6 +156,8 @@ For each of them, use the standard equivalent provided.
   - : Use the [CSS multicolumn layout](/en-US/docs/Web/CSS/CSS_multicol_layout) with the standard {{cssxref("break-before")}} property instead.
 - `-webkit-column-break-inside`
   - : Use the [CSS multicolumn layout](/en-US/docs/Web/CSS/CSS_multicol_layout) with the standard {{cssxref("break-inside")}} property instead.
+- `-webkit-font-feature-settings`
+  - : Use the [`font-feature-settings`](/en-US/docs/Web/CSS/font-feature-settings) property instead.
 - `-webkit-hyphenate-character`
   - : Use the standard {{cssxref("hyphenate-character")}} property instead.
 - `-webkit-initial-letter`
@@ -163,7 +165,7 @@ For each of them, use the standard equivalent provided.
 
 ### J-Z
 
-- `webkit-margin-end`
+- `-webkit-margin-end`
   - : Use the standard {{CSSxRef("margin-block-end")}} property instead.
 - `-webkit-margin-start`
 

--- a/files/en-us/web/css/webkit_extensions/index.md
+++ b/files/en-us/web/css/webkit_extensions/index.md
@@ -168,9 +168,7 @@ For each of them, use the standard equivalent provided.
 - `-webkit-margin-end`
   - : Use the standard {{CSSxRef("margin-block-end")}} property instead.
 - `-webkit-margin-start`
-
   - : Use the standard {{CSSxRef("margin-block-start")}} property instead.
-
 - `-webkit-padding-after`
   - : Use the standard {{CSSxRef("padding-block-end")}} property instead.
 - `-webkit-padding-before`


### PR DESCRIPTION
### Description

- Added `-webkit-font-feature-settings` to [WebKit_extensions](https://developer.mozilla.org/en-US/docs/Web/CSS/WebKit_Extensions#-webkit-prefixed_properties_with_standard_equivalents)

### Motivation

- Working on [34700](https://github.com/mdn/content/issues/34700)

### Related issues and pull requests

- [FF release note PR](https://github.com/mdn/content/pull/34966)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/23923)