### PR TITLE
Move and rename "Accessibility concerns" section in CSS page templates

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -144,8 +144,7 @@ _To use this macro, remove the backticks and backslash in the markdown file._
 
 ## Accessibility
 
-Warn of any potential accessibility concerns with using this function and how to work around them.
-Remove this section if there is no list.
+This is an optional section. Include accessibility guidelines, best practices, and potential concerns that developers should be aware of while using this property. You can also include workarounds or solutions where applicable.
 
 ## Examples
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -142,6 +142,11 @@ Not all functions have formal syntax: if a function doesn't, omit this whole sec
 
 _To use this macro, remove the backticks and backslash in the markdown file._
 
+## Accessibility
+
+Warn of any potential accessibility concerns with using this function and how to work around them.
+Remove this section if there is no list.
+
 ## Examples
 
 Note that we use the plural "Examples" even if the page only contains one example.
@@ -180,10 +185,6 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 >
 > For examples of this function, see [the page on basic-shape](https://example.org).
 > ```
-
-## Accessibility concerns
-
-This is an optional section. You can include any warnings here for accessibility concerns that developers should be aware of while using this function. You can also include workarounds for these accessibility concerns if there are any.
 
 ## Specifications
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -125,6 +125,11 @@ _To use this macro, remove the backticks and backslash in the markdown file._
 
 _To use this macro, remove the backticks and backslash in the markdown file._
 
+## Accessibility
+
+Warn of any potential accessibility concerns with using this property and how to work around them.
+Remove this section if there is no list.
+
 ## Examples
 
 Note that we use the plural "Examples" even if the page only contains one example.
@@ -163,10 +168,6 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 >
 > For examples of this API, see [the page on fetch()](https://example.org).
 > ```
-
-## Accessibility concerns
-
-This is an optional section. You can include any warnings here for accessibility concerns that developers should be aware of while using this property. You can also include workarounds for these accessibility concerns if there are any.
 
 ## Specifications
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -127,8 +127,7 @@ _To use this macro, remove the backticks and backslash in the markdown file._
 
 ## Accessibility
 
-Warn of any potential accessibility concerns with using this property and how to work around them.
-Remove this section if there is no list.
+This is an optional section. Include accessibility guidelines, best practices, and potential concerns that developers should be aware of while using this property. You can also include workarounds or solutions where applicable.
 
 ## Examples
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -94,8 +94,7 @@ _To use this macro, remove the backticks and backslash in the markdown file._
 
 ## Accessibility
 
-Warn of any potential accessibility concerns with using this selector and how to work around them.
-Remove this section if there is no list.
+This is an optional section. Include accessibility guidelines, best practices, and potential concerns that developers should be aware of while using this property. You can also include workarounds or solutions where applicable.
 
 ## Examples
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -92,6 +92,11 @@ The summary paragraph — start by naming the selector and saying what it does. 
 
 _To use this macro, remove the backticks and backslash in the markdown file._
 
+## Accessibility
+
+Warn of any potential accessibility concerns with using this selector and how to work around them.
+Remove this section if there is no list.
+
 ## Examples
 
 Note that we use the plural "Examples" even if the page only contains one example.
@@ -130,11 +135,6 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/P
 >
 > For examples of this API, see [the page on fetch()](https://example.org).
 > ```
-
-## Accessibility concerns
-
-Optionally, warn of any potential accessibility concerns with using this selector and how to work around them.
-Remove this section if there is no list.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Renames "Accessibility concerns" to "Accessibility" and moves it above "Examples". In line with this discussion: [github.com/orgs/mdn/discussions/430](https://github.com/orgs/mdn/discussions/430#discussioncomment-6633135)

Also removed the "optional" notice from the start of the section, as it's already clear that the section should be removed if no guidance is needed.

### Motivation

Make accessibility guidance more prominent.

### Additional details

Full discussion: [github.com/orgs/mdn/discussions/430](https://github.com/orgs/mdn/discussions/430)

### Related issues and pull requests

* mdn/content#33628