### PR TITLE
Autocomplete attribute: order of tokens matters

### DIFF
--- a/files/en-us/web/html/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/attributes/autocomplete/index.md
@@ -2,7 +2,11 @@
 title: "HTML attribute: autocomplete"
 slug: Web/HTML/Attributes/autocomplete
 page-type: html-attribute
-browser-compat: html.global_attributes.autocomplete
+browser-compat:
+  - html.elements.form.autocomplete
+  - html.elements.input.autocomplete
+  - html.elements.select.autocomplete
+  - html.elements.textarea.autocomplete
 ---
 
 {{HTMLSidebar}}
@@ -42,6 +46,9 @@ If including the `autocomplete` attribute on {{HTMLElement("input/hidden", "hidd
 
 The source of the suggested values is generally up to the browser; typically values come from past values entered by the user, but they may also come from pre-configured values. For instance, a browser might let the user save their name, address, phone number, and email addresses for autocomplete purposes. The browser may also offer the ability to save encrypted credit card information, for autocompletion following an authentication procedure.
 
+> [!NOTE]
+> The `autocomplete` attribute also controls whether Firefox will — unlike other browsers — [persist the dynamic disabled state and (if applicable) dynamic checkedness](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` element, `<textarea>` element, or entire `<form>` across page loads. The persistence feature is enabled by default. Setting the value of the `autocomplete` attribute to `off` disables this feature. This works even when the `autocomplete` attribute would normally not apply by virtue of its `type`. See [Firefox bug 654072](https://bugzil.la/654072).
+
 ## Values
 
 The attribute value is either the keyword `off` or `on`, or a space-separated `<token-list>` that describes the meaning of the autocompletion value.
@@ -58,139 +65,181 @@ The attribute value is either the keyword `off` or `on`, or a space-separated `<
 
 - `<token-list>`
 
-  - : An ordered set of space-separated tokens consisting of autofill detail tokens. The detail tokens include:
+  - : An ordered set of [space-separated tokens](#token_list_tokens) consisting of autofill detail tokens preceded by optional sectioning and either billing or shipping grouping tokens. Phone numbers, email addresses, and messaging protocol tokens are preceded by a token identifying the type of recipient.
 
-    - "`section-*`"
+See the [WHATWG Standard](https://html.spec.whatwg.org/multipage/forms.html#autofill) for more detailed information.
 
-      - : Defines the name for a group of form controls. A token whose first eight characters are the string "section-", case-insensitive, followed by additional characters. If present, this token must be the first token in the space-separated list of tokens. All form controls that start with the same token belong to the named group.
+### Token list tokens
 
-    - "`name`"
+The `<token-list>` options include, in order:
 
-      - : The field expects the value to be a person's full name. Using "`name`" rather than breaking the name down into its components is generally preferred because it avoids dealing with the wide diversity of human names and how they are structured; however, you can use the following `autocomplete` values if you do need to break the name down into its components:
+1. [Group naming token](#name_groups)
+2. [Grouping identifier](#grouping_identifier)
+3. [Detail tokens](#detail_tokens)
+4. [Web authorization](#web_authorization)
 
-        - "`honorific-prefix`"
-          - : The prefix or title, such as "Mrs.", "Mr.", "Miss", "Ms.", "Dr.", or "Mlle.".
-        - "`given-name`"
-          - : The given (or "first") name.
-        - "`additional-name`"
-          - : The middle name.
-        - "`family-name`"
-          - : The family (or "last") name.
-        - "`honorific-suffix`"
-          - : The suffix, such as "Jr.", "B.Sc.", "PhD.", "MBASW", or "IV".
-        - "`nickname`"
-          - : A nickname or handle.
+#### Named groups
 
-    - "`email`"
-      - : An email address.
-    - "`username`"
-      - : A username or account name.
-    - "`new-password`"
-      - : A new password. When creating a new account or changing passwords, this should be used for an "Enter your new password" or "Confirm new password" field, as opposed to a general "Enter your current password" field that might be present. This may be used by the browser both to avoid accidentally filling in an existing password and to offer assistance in creating a secure password.
-    - "`current-password`"
-      - : The user's current password.
-    - "`one-time-code`"
-      - : A one-time password (OTP) for verifying user identity that is used as an additional factor in a sign-in flow.
-        Most commonly this is a code received via some out-of-channel mechanism, such as SMS, email, or authenticator application.
-    - "`organization-title`"
-      - : A job title, or the title a person has within an organization, such as "Senior Technical Writer", "President", or "Assistant Troop Leader".
-    - "`organization`"
-      - : A company or organization name, such as "Acme Widget Company" or "Girl Scouts of America".
-    - "`street-address`"
-      - : A street address. This can be multiple lines of text, and should fully identify the location of the address within its second administrative level (typically a city or town), but should not include the city name, ZIP or postal code, or country name.
-        - "`shipping`"
-          - : The street address to send the product. This can be combined with other tokens, such as "`shipping street-address`" and "`shipping address-level2`".
-        - "`billing`"
-          - : The street address to associate with the form of payment used. This can be combined with other tokens, such as "`billing street-address`" and "`billing address-level2`".
+To create a named group of form fields, the optional `section-*` token can be used. If present, this token must be the first token in the space-separated list of tokens.
+
+- "`section-*`"
+
+  - : Defines the name for a group of form controls. A token whose first eight characters are the string "section-", case-insensitive, followed by additional characters. All form controls that start with the same token belong to the named group.
+
+#### Grouping identifier
+
+An optional `shipping` or `billing` grouping identifier
+
+- "`shipping`"
+
+  - : The field identified by subsequent tokens is part of the shipping address or contact information
+
+- "`billing`"
+  - : The field identified by subsequent tokens is part of the billing address or contact information
+
+#### Detail tokens
+
+Each space-separated detail token list includes either a recipient type with digital contact information, in that order, or a space-separated token list of other tokens.
+
+##### Recipient type
+
+The tokens that identify the type of recipient include:
+
+- "`home`"
+  - : The contact type identified by subsequent tokens is for contacting the recipient at their residence.
+- "`work`"
+  - : The contact type identified by subsequent tokens is for contacting the recipient at their work.
+- "`mobile`"
+  - : The contact type identified by subsequent tokens is for contacting the recipient regardless of location.
+- "`fax`"
+  - : The recipient identified by subsequent tokens is for a fax machine.
+- "`page`"
+  - : The recipient identified by subsequent tokens is for a pager or beeper.
+
+##### Digital contact tokens
+
+The token or group of tokens for telephone numbers or a number's component parts, phone extensions, email addresses, or instant messaging protocols.
+
+- "`tel`"
+
+  - : A full telephone number, including the country code. If you need to break the phone number up into its components, you can use these values for those fields:
+    - "`tel-country-code`"
+      - : The country code, such as "1" for the United States, Canada, and other areas in North America and parts of the Caribbean.
+    - "`tel-national`"
+      - : The entire phone number without the country code component, including a country-internal prefix. For the phone number "1-855-555-6502", this field's value would be "855-555-6502".
+    - "`tel-area-code`"
+      - : The area code, with any country-internal prefix applied if appropriate.
+    - "`tel-local`"
+      - : The phone number without the country or area code. This can be split further into two parts, for phone numbers which have an exchange number and then a number within the exchange. For the phone number "555-6502", use "`tel-local-prefix`" for "555" and "`tel-local-suffix`" for "6502".
+
+- "`tel-extension`"
+  - : A telephone extension code within the phone number, such as a room or suite number in a hotel or an office extension in a company.
+- "`email`"
+  - : An email address.
+- "`impp`"
+  - : A URL for an instant messaging protocol endpoint, such as "xmpp:username\@example.net".
+
+##### Other tokens
+
+When the form field is not a phone number, email address, or instant messaging protocol, the space-separated list of tokens is not preceded by a contact type:
+
+- "`name`"
+
+  - : The field expects the value to be a person's full name. Using "`name`" rather than breaking the name down into its components is generally preferred because it avoids dealing with the wide diversity of human names and how they are structured; however, you can use the following `autocomplete` values if you do need to break the name down into its components:
+
+    - "`honorific-prefix`"
+      - : The prefix or title, such as "Mrs.", "Mr.", "Miss", "Ms.", "Dr.", or "Mlle.".
+    - "`given-name`"
+      - : The given (or "first") name.
+    - "`additional-name`"
+      - : The middle name.
+    - "`family-name`"
+      - : The family (or "last") name.
+    - "`honorific-suffix`"
+      - : The suffix, such as "Jr.", "B.Sc.", "PhD.", "MBASW", or "IV".
+    - "`nickname`"
+      - : A nickname or handle.
+
+- "`username`"
+  - : A username or account name.
+- "`new-password`"
+  - : A new password. When creating a new account or changing passwords, this should be used for an "Enter your new password" or "Confirm new password" field, as opposed to a general "Enter your current password" field that might be present. This may be used by the browser both to avoid accidentally filling in an existing password and to offer assistance in creating a secure password.
+- "`current-password`"
+  - : The user's current password.
+- "`one-time-code`"
+  - : A one-time password (OTP) for verifying user identity that is used as an additional factor in a sign-in flow.
+    Most commonly this is a code received via some out-of-channel mechanism, such as SMS, email, or authenticator application.
+- "`organization-title`"
+  - : A job title, or the title a person has within an organization, such as "Senior Technical Writer", "President", or "Assistant Troop Leader".
+- "`organization`"
+  - : A company or organization name, such as "Acme Widget Company" or "Girl Scouts of America".
+- "`street-address`"
+  - : A street address. This can be multiple lines of text, and should fully identify the location of the address within its second administrative level (typically a city or town), but should not include the city name, ZIP or postal code, or country name.
     - "`address-line1`", "`address-line2`", "`address-line3`"
       - : Each individual line of the street address. These should only be present if the "`street-address`" is not present.
-    - "`address-level4`"
-      - : The finest-grained [administrative level](#administrative_levels_in_addresses), in addresses which have four levels.
-    - "`address-level3`"
-      - : The third [administrative level](#administrative_levels_in_addresses), in addresses with at least three administrative levels.
-    - "`address-level2`"
-      - : The second [administrative level](#administrative_levels_in_addresses), in addresses with at least two of them. In countries with two administrative levels, this would typically be the city, town, village, or other locality in which the address is located.
-    - "`address-level1`"
-      - : The first [administrative level](#administrative_levels_in_addresses) in the address. This is typically the province in which the address is located. In the United States, this would be the state. In Switzerland, the canton. In the United Kingdom, the post town.
-    - "`country`"
-      - : A country or territory code.
-    - "`country-name`"
-      - : A country or territory name.
-    - "`postal-code`"
-      - : A postal code (in the United States, this is the ZIP code).
-    - "`cc-name`"
-      - : The full name as printed on or associated with a payment instrument such as a credit card. Using a full name field is preferred, typically, over breaking the name into pieces.
+- "`address-level4`"
+  - : The finest-grained [administrative level](#administrative_levels_in_addresses), in addresses which have four levels.
+- "`address-level3`"
+  - : The third [administrative level](#administrative_levels_in_addresses), in addresses with at least three administrative levels.
+- "`address-level2`"
+  - : The second [administrative level](#administrative_levels_in_addresses), in addresses with at least two of them. In countries with two administrative levels, this would typically be the city, town, village, or other locality in which the address is located.
+- "`address-level1`"
+  - : The first [administrative level](#administrative_levels_in_addresses) in the address. This is typically the province in which the address is located. In the United States, this would be the state. In Switzerland, the canton. In the United Kingdom, the post town.
+- "`country`"
+  - : A country or territory code.
+- "`country-name`"
+  - : A country or territory name.
+- "`postal-code`"
+
+  - : A postal code (in the United States, this is the ZIP code).
+
+- "`cc-name`"
+  - : The full name as printed on or associated with a payment instrument such as a credit card. Using a full name field is preferred, typically, over breaking the name into pieces.
     - "`cc-given-name`"
       - : A given (first) name as given on a payment instrument like a credit card.
     - "`cc-additional-name`"
       - : A middle name as given on a payment instrument or credit card.
     - "`cc-family-name`"
       - : A family name, as given on a credit card.
-    - "`cc-number`"
-      - : A credit card number or other number identifying a payment method, such as an account number.
-    - "`cc-exp`"
-      - : A payment method expiration date, typically in the form "MM/YY" or "MM/YYYY".
+- "`cc-number`"
+  - : A credit card number or other number identifying a payment method, such as an account number.
+- "`cc-exp`"
+  - : A payment method expiration date, typically in the form "MM/YY" or "MM/YYYY".
     - "`cc-exp-month`"
       - : The month in which the payment method expires.
     - "`cc-exp-year`"
       - : The year in which the payment method expires.
-    - "`cc-csc`"
-      - : The security code for the payment instrument; on credit cards, this is the 3-digit verification number on the back of the card.
-    - "`cc-type`"
-      - : The type of payment instrument (such as "Visa" or "Master Card").
-    - "`transaction-currency`"
-      - : The currency in which the transaction is to take place.
-    - "`transaction-amount`"
-      - : The amount, given in the currency specified by "`transaction-currency`", of the transaction, for a payment form.
-    - "`language`"
-      - : A preferred language, given as a valid [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag).
-    - "`bday`"
-      - : A birth date, as a full date.
+- "`cc-csc`"
+  - : The security code for the payment instrument; on credit cards, this is the 3-digit verification number on the back of the card.
+- "`cc-type`"
+  - : The type of payment instrument (such as "Visa" or "Master Card").
+- "`transaction-currency`"
+  - : The currency in which the transaction is to take place.
+- "`transaction-amount`"
+  - : The amount, given in the currency specified by "`transaction-currency`", of the transaction, for a payment form.
+- "`language`"
+  - : A preferred language, given as a valid [BCP 47 language tag](https://en.wikipedia.org/wiki/IETF_language_tag).
+- "`bday`"
+  - : A birth date, as a full date.
     - "`bday-day`"
       - : The day of the month of a birth date.
     - "`bday-month`"
       - : The month of the year of a birth date.
     - "`bday-year`"
       - : The year of a birth date.
-    - "`sex`"
-      - : A gender identity (such as "Female", "Fa'afafine", "Hijra", "Male", "Nonbinary"), as freeform text without newlines.
-    - "`tel`"
+- "`sex`"
+  - : A gender identity (such as "Female", "Fa'afafine", "Hijra", "Male", "Nonbinary"), as freeform text without newlines.
+- "`url`"
+  - : A URL, such as a home page or company website address as appropriate given the context of the other fields in the form.
+- "`photo`"
+  - : The URL of an image representing the person, company, or contact information given in the other fields in the form.
 
-      - : A full telephone number, including the country code. If you need to break the phone number up into its components, you can use these values for those fields:
+#### Web authorization
 
-        - "`tel-country-code`"
-          - : The country code, such as "1" for the United States, Canada, and other areas in North America and parts of the Caribbean.
-        - "`tel-national`"
-          - : The entire phone number without the country code component, including a country-internal prefix. For the phone number "1-855-555-6502", this field's value would be "855-555-6502".
-        - "`tel-area-code`"
-          - : The area code, with any country-internal prefix applied if appropriate.
-        - "`tel-local`"
-          - : The phone number without the country or area code. This can be split further into two parts, for phone numbers which have an exchange number and then a number within the exchange. For the phone number "555-6502", use "`tel-local-prefix`" for "555" and "`tel-local-suffix`" for "6502".
+With {{htmlelement("input")}} and {{htmlelement("textarea")}}, the `webauthn` token can be included last to indicate the user agent should show public key credentials when the user is interacting with the control.
 
-    - "`tel-extension`"
-      - : A telephone extension code within the phone number, such as a room or suite number in a hotel or an office extension in a company.
-    - "`impp`"
-      - : A URL for an instant messaging protocol endpoint, such as "xmpp:username\@example.net".
-    - "`url`"
-      - : A URL, such as a home page or company website address as appropriate given the context of the other fields in the form.
-    - "`photo`"
-      - : The URL of an image representing the person, company, or contact information given in the other fields in the form.
-    - "`home`"
-      - : The field is for contacting someone at their residence.
-    - "`work`"
-      - : The field is for contacting someone at their work.
-    - "`mobile`"
-      - : The field is for contacting someone regardless of location.
-    - "`fax`"
-      - : Fax machine's contact details.
-    - "`page`"
-      - : Pager or beeper's contact details.
-    - "`webauthn`"
-      - : Passkeys generated by the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API), as requested by a conditional {{domxref("CredentialsContainer.get()", "navigator.credentials.get()")}} call (i.e., one that includes `mediation: 'conditional'`). See [Sign in with a passkey through form autofill](https://web.dev/articles/passkey-form-autofill) for more details.
-
-See the [WHATWG Standard](https://html.spec.whatwg.org/multipage/forms.html#autofill) for more detailed information.
-
-> **Note:** The `autocomplete` attribute also controls whether Firefox will — unlike other browsers — [persist the dynamic disabled state and (if applicable) dynamic checkedness](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` element, `<textarea>` element, or entire `<form>` across page loads. The persistence feature is enabled by default. Setting the value of the `autocomplete` attribute to `off` disables this feature. This works even when the `autocomplete` attribute would normally not apply by virtue of its `type`. See [Firefox bug 654072](https://bugzil.la/654072).
+- "`webauthn`"
+  - : Passkeys generated by the [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API), as requested by a conditional {{domxref("CredentialsContainer.get()", "navigator.credentials.get()")}} call (i.e., one that includes `mediation: 'conditional'`). If included, this is the last token in the space-separated token list. See [Sign in with a passkey through form autofill](https://web.dev/articles/passkey-form-autofill) for more details.
 
 ## Examples
 

--- a/files/en-us/web/html/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/attributes/autocomplete/index.md
@@ -250,7 +250,7 @@ With {{htmlelement("input")}} and {{htmlelement("textarea")}}, the `webauthn` to
 </div>
 ```
 
-## Administrative levels in addresses
+### Administrative levels in addresses
 
 The four administrative level fields (`address-level1` through `address-level4`) describe the address in terms of increasing levels of precision within the country in which the address is located. Each country has its own system of administrative levels, and may arrange the levels in different orders when addresses are written.
 

--- a/files/en-us/web/html/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/attributes/autocomplete/index.md
@@ -76,7 +76,6 @@ The `<token-list>` options include, in order:
 1. [Group naming token](#name_groups)
 2. [Grouping identifier](#grouping_identifier)
 3. [Detail tokens](#detail_tokens)
-4. [Web authorization](#web_authorization)
 
 #### Named groups
 
@@ -234,7 +233,7 @@ When the form field is not a phone number, email address, or instant messaging p
 - "`photo`"
   - : The URL of an image representing the person, company, or contact information given in the other fields in the form.
 
-#### Web authorization
+#### Web authorization token
 
 With {{htmlelement("input")}} and {{htmlelement("textarea")}}, the `webauthn` token can be included last to indicate the user agent should show public key credentials when the user is interacting with the control.
 

--- a/files/en-us/web/html/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/attributes/autocomplete/index.md
@@ -76,6 +76,7 @@ The `<token-list>` options include, in order:
 1. [Group naming token](#name_groups)
 2. [Grouping identifier](#grouping_identifier)
 3. [Detail tokens](#detail_tokens)
+4. [Web authorization](#web_authorization_token)
 
 #### Named groups
 


### PR DESCRIPTION
it wasn't obvious that the order of tokens mattered in the list of tokens.
divided the tokens into the order in which they should appear. Added headers and DL nesting to match specs.

Also added the spec (origing browser compat didn't exist. this isn't "global", but rather form related)