### PR TITLE
fix(css): use better terms for statement and block @layers

### DIFF
--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -156,7 +156,7 @@ If the above statement is the first line of a site's CSS, the layer order will b
 
 Layers can be created using the block `@layer` at-rule. If an `@layer` at-rule is followed by an identifier and a block of styles, the identifier is used to name the layer, and the styles in this at-rule are added to the layer's styles. If a layer with the specified name does not already exist, a new layer will be created. If a layer with the specified name already exists, the styles are added to the previously existing layer. If no name is specified while creating a block of styles using `@layer`, the styles in the at-rule will be added to a new anonymous layer.
 
-In the example below, we've used four block and one inline `@layer` at-rules. This CSS does the following in the order listed:
+In the example below, we've used four `@layer` block at-rules and one `@layer` statement at-rule. This CSS does the following in the order listed:
 
 1. Creates a named `layout` layer
 2. Creates an unnamed, anonymous layer
@@ -348,7 +348,7 @@ Transitioning styles have the highest precedence. When a normal property value i
 
 {{EmbedGHLiveSample("css-examples/learn/layers/layer-precedence.html", '100%', 500)}}
 
-In this example, there are two inline layers `A` and `B` without styles, a block of unlayered styles, and two blocks of styles in named layers `A` and `B`.
+In this example, there are two layers `A` and `B`, first defined using an `@layer` statement at-rule(without styles) and then using two `@layer` blocks at-rules. There is also a CSS rule rule without a layer.
 
 The inline styles added on the `h1` element using the `style` attribute, set a normal `color` and an important `background-color`. Normal inline styles override all layered and unlayered normal styles. Important inline styles override all layered and unlayered normal and important author styles. There is no way for author styles to override important inline styles.
 

--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -348,7 +348,7 @@ Transitioning styles have the highest precedence. When a normal property value i
 
 {{EmbedGHLiveSample("css-examples/learn/layers/layer-precedence.html", '100%', 500)}}
 
-In this example, there are two layers `A` and `B`, first defined using an `@layer` statement at-rule(without styles) and then using two `@layer` blocks at-rules. There is also a CSS rule without a layer.
+In this example, two layers (`A` and `B`) are initially defined using an `@layer` statement at-rule without any styles. The layer styles are defined in two `@layer` block at-rules appearing after the `h1` CSS rule declared outside of any layer.
 
 The inline styles added on the `h1` element using the `style` attribute, set a normal `color` and an important `background-color`. Normal inline styles override all layered and unlayered normal styles. Important inline styles override all layered and unlayered normal and important author styles. There is no way for author styles to override important inline styles.
 

--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -348,7 +348,7 @@ Transitioning styles have the highest precedence. When a normal property value i
 
 {{EmbedGHLiveSample("css-examples/learn/layers/layer-precedence.html", '100%', 500)}}
 
-In this example, there are two layers `A` and `B`, first defined using an `@layer` statement at-rule(without styles) and then using two `@layer` blocks at-rules. There is also a CSS rule rule without a layer.
+In this example, there are two layers `A` and `B`, first defined using an `@layer` statement at-rule(without styles) and then using two `@layer` blocks at-rules. There is also a CSS rule without a layer.
 
 The inline styles added on the `h1` element using the `style` attribute, set a normal `color` and an important `background-color`. Normal inline styles override all layered and unlayered normal styles. Important inline styles override all layered and unlayered normal and important author styles. There is no way for author styles to override important inline styles.
 

--- a/files/en-us/learn/css/building_blocks/cascade_layers/index.md
+++ b/files/en-us/learn/css/building_blocks/cascade_layers/index.md
@@ -128,7 +128,7 @@ The ability to create nested layers also removes the worry of having conflicting
 
 Layers can be created using any one of the following methods:
 
-- The `@layer` statement at-rule, declaring layers using `@layer` followed by the names of one or more layers. This creates named layers without assigning any styles to them.
+- The [`@layer`](/en-US/docs/Web/CSS/@layer) statement at-rule, declaring layers using `@layer` followed by the names of one or more layers. This creates named layers without assigning any styles to them.
 - The `@layer` block at-rule, in which all styles within a block are added to a named or unnamed layer.
 - The [`@import`](/en-US/docs/Web/CSS/@import) rule with the `layer` keyword or `layer()` function, which assigns the contents of the imported file into that layer.
 

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -14,10 +14,13 @@ The **`@layer`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rul
 ## Syntax
 
 ```css
-@layer layer-name {rules}
+/* statement at-rules */
 @layer layer-name;
 @layer layer-name, layer-name, layer-name;
+
+/* block at-rules */
 @layer {rules}
+@layer layer-name {rules}
 ```
 
 where:
@@ -37,9 +40,9 @@ The following diagram shows layer priorities where layers are declared in 1, 2, 
 
 The declaration order matters. The first declared layer gets the lowest priority and the last declared layer gets the highest priority. However, the priority is reversed when the [`!important`](/en-US/docs/Web/CSS/important) flag is used.
 
-The `@layer` at-rule is used to create a cascade layer in one of three ways.
+The `@layer` at-rule is used to create an inline cascade layer in one of three ways.
 
-The first way is to create a named cascade layer with the CSS rules for that layer inside, like so:
+The first way is to use block at-rule to create a named cascade layer with the CSS rules for that layer inside, like so:
 
 ```css
 @layer utilities {
@@ -53,7 +56,7 @@ The first way is to create a named cascade layer with the CSS rules for that lay
 }
 ```
 
-The second way is to create a named cascade layer without assigning any styles. This can be a single layer, as shown below:
+The second way is to use statement at-rule to create a named cascade layer without assigning any styles. This can be a single layer, as shown below:
 
 ```css
 @layer utilities;
@@ -71,7 +74,7 @@ A rule in `utilities` would be applied _even if it has lower specificity_ than t
 
 > **Note:** Having declared your layer names, thus setting their order, you can add CSS rules to the layer by re-declaring the name. The styles are then appended to the layer and the layer order will not be changed.
 
-The third way is to create a cascade layer with no name. For example:
+The third way is to use block at-rule without a layer name. For example:
 
 ```css
 @layer {

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -40,9 +40,9 @@ The following diagram shows layer priorities where layers are declared in 1, 2, 
 
 The declaration order matters. The first declared layer gets the lowest priority and the last declared layer gets the highest priority. However, the priority is reversed when the [`!important`](/en-US/docs/Web/CSS/important) flag is used.
 
-The `@layer` at-rule is used to create an inline cascade layer in one of three ways.
+The `@layer` at-rule is used to create a cascade layer in one of three ways.
 
-The first way is to use block at-rule to create a named cascade layer with the CSS rules for that layer inside, like so:
+The first way is to use a `@layer` block at-rule to create a named cascade layer with the CSS rules for that layer inside, like so:
 
 ```css
 @layer utilities {
@@ -56,7 +56,7 @@ The first way is to use block at-rule to create a named cascade layer with the C
 }
 ```
 
-The second way is to use statement at-rule to create a named cascade layer without assigning any styles. This can be a single layer, as shown below:
+The second way is to use a `@layer` statement at-rule to create one or more comma-separated named cascade layers without assigning any styles. This can be a single layer, as shown below:
 
 ```css
 @layer utilities;
@@ -74,7 +74,7 @@ A rule in `utilities` would be applied _even if it has lower specificity_ than t
 
 > **Note:** Having declared your layer names, thus setting their order, you can add CSS rules to the layer by re-declaring the name. The styles are then appended to the layer and the layer order will not be changed.
 
-The third way is to use block at-rule without a layer name. For example:
+The third way is to create an unnamed layer using a `@layer` block at-rule without including a layer name. For example:
 
 ```css
 @layer {


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/34953

There are two types of layers, imported and inline. All the layers defined using `@layer` at-rule are inline. Because the spec nameed the related heading as [`Declaring Layers Inline: the @layer rule`](https://drafts.csswg.org/css-cascade-5/#at-layer).

The [spec uses](https://drafts.csswg.org/css-cascade-5/#layer-declaration) the terms `@layer block at-rule` and `@layer statement at-rule` to distinguish between the `@layer` rules with and without a block(empty).