### PR TITLE
fix: not all events are tasks, callbacks are part of the event task

### DIFF
--- a/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
@@ -91,7 +91,7 @@ Here we look at how the runtime functions in slightly more detail.
 
 ### Event loops
 
-Each agent is driven by an **event loop**, which collects any user and other events, enqueuing tasks to handle each callback. It then runs any pending JavaScript tasks, then any pending microtasks, then performs any needed rendering and painting before looping again to check for pending tasks.
+Each agent is driven by an **event loop**, which collects any user and other events, enqueuing tasks to handle each callback. It then runs at most one pending JavaScript task, then any pending microtasks, then performs any needed rendering and painting before looping again to check for pending tasks.
 
 Your website or app's code runs in the same **{{Glossary("thread")}}**, sharing the same **event loop**, as the user interface of the web browser itself. This is the **{{Glossary("main thread")}}**, and in addition to running your site's main code body, it handles receiving and dispatching user and other events, rendering and painting web content, and so forth.
 
@@ -122,8 +122,8 @@ A **task** is any JavaScript scheduled to be run by the standard mechanisms such
 
 The difference between the task queue and the microtask queue is simple but very important:
 
-- When executing tasks from the task queue, the runtime executes each task that is in the queue at the moment a new iteration of the event loop begins. Tasks added to the queue after the iteration begins _will not run until the next iteration_.
-- Each time a task exits, and the execution context stack is empty, each microtask in the microtask queue is executed, one after another. The difference is that execution of microtasks continues until the queue is empty—even if new ones are scheduled in the interim. In other words, microtasks can enqueue new microtasks and those new microtasks will execute before the next task begins to run, and before the end of the current event loop iteration.
+- When a new iteration of the event loop begins, the runtime executes the next task from the task queue. Further tasks and tasks added to the queue after the start of the iteration _will not run until the next iteration_.
+- Whenever a task exits and the execution context stack is empty, all microtasks in the microtask queue are executed in turn. The difference is that execution of microtasks continues until the queue is empty—even if new ones are scheduled in the interim. In other words, microtasks can enqueue new microtasks and those new microtasks will execute before the next task begins to run, and before the end of the current event loop iteration.
 
 ### Problems
 

--- a/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
@@ -91,7 +91,7 @@ Here we look at how the runtime functions in slightly more detail.
 
 ### Event loops
 
-Each agent is driven by an **event loop**, which collects any user and other events, enqueuing tasks to handle each callback. It then runs at most one pending JavaScript task, then any pending microtasks, then performs any needed rendering and painting before looping again to check for pending tasks.
+Each agent is driven by an **event loop**, which is repeatedly processed. During each iteration, it runs at most one pending JavaScript task, then any pending microtasks, then performs any needed rendering and painting before looping again.
 
 Your website or app's code runs in the same **{{Glossary("thread")}}**, sharing the same **event loop**, as the user interface of the web browser itself. This is the **{{Glossary("main thread")}}**, and in addition to running your site's main code body, it handles receiving and dispatching user and other events, rendering and painting web content, and so forth.
 
@@ -118,7 +118,7 @@ The specifics may vary from browser to browser, depending on how they're impleme
 
 #### Tasks vs. microtasks
 
-A **task** is any JavaScript scheduled to be run by the standard mechanisms such as initially starting to execute a program, an event triggering a callback, and so forth. Other than by using events, you can enqueue a task by using {{domxref("setTimeout()")}} or {{domxref("setInterval()")}}.
+A **task** is anything scheduled to be run by the standard mechanisms such as initially starting to execute a script, asynchronously dispatching an event, and so forth. Other than by using events, you can enqueue a task by using {{domxref("setTimeout()")}} or {{domxref("setInterval()")}}.
 
 The difference between the task queue and the microtask queue is simple but very important:
 

--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.md
@@ -18,12 +18,12 @@ To properly discuss microtasks, it's first useful to know what a JavaScript task
 
 ### Tasks
 
-A **task** is any JavaScript code which is scheduled to be run by the standard mechanisms such as initially starting to run a program, an event callback being run, or an interval or timeout being fired. These all get scheduled on the **task queue**.
+A **task** is anything which is scheduled to be run by the standard mechanisms such as initially starting to run a program, an event being dispatched asynchronously, or an interval or timeout being fired. These all get scheduled on the **task queue**.
 
-Tasks get added to the task queue when:
+For example, tasks get added to the task queue when:
 
 - A new JavaScript program or subprogram is executed (such as from a console, or by running the code in a {{HTMLElement("script")}} element) directly.
-- An event fires, adding the event's callback function to the task queue.
+- The user clicks an element. A task is then created and executes all event callbacks.
 - A timeout or interval created with {{domxref("setTimeout()")}} or {{domxref("setInterval()")}} is reached, causing the corresponding callback to be added to the task queue.
 
 The event loop driving your code handles these tasks one after another, in the order in which they were enqueued. The oldest runnable task in the task queue will be executed during a single iteration of the event loop. After that, microtasks will be executed until the microtask queue is empty, and then the browser may choose to update rendering. Then the browser moves on to the next iteration of event loop.

--- a/files/en-us/web/javascript/event_loop/index.md
+++ b/files/en-us/web/javascript/event_loop/index.md
@@ -77,7 +77,7 @@ A downside of this model is that if a message takes too long to complete, the we
 
 ### Adding messages
 
-In web browsers, messages are often added when an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event. However, some events happen synchronously without a message — for example, simulated clicks via the {{domxref("HTMLElement/click", "click")}} method.
+In web browsers, messages are often added when an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event. However, some events happen synchronously without a message — for example, simulated clicks via the {{domxref("HTMLElement/click", "click")}} method.
 
 The first two arguments to the function [`setTimeout`](/en-US/docs/Web/API/setTimeout) are a message to add to the queue and a time value (optional; defaults to `0`). The _time value_ represents the (minimum) delay after which the message will be pushed into the queue. If there is no other message in the queue, and the stack is empty, the message is processed right after the delay. However, if there are messages, the `setTimeout` message will have to wait for other messages to be processed. For this reason, the second argument indicates a _minimum_ time — not a _guaranteed_ time.
 

--- a/files/en-us/web/javascript/event_loop/index.md
+++ b/files/en-us/web/javascript/event_loop/index.md
@@ -77,7 +77,7 @@ A downside of this model is that if a message takes too long to complete, the we
 
 ### Adding messages
 
-In web browsers, messages are added anytime an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event.
+In web browsers, messages are often added when an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event. Though some events happen synchronously without a message, e.g. simulated clicks via the {{domxref("HTMLElement/click", "click")}} method.
 
 The first two arguments to the function [`setTimeout`](/en-US/docs/Web/API/setTimeout) are a message to add to the queue and a time value (optional; defaults to `0`). The _time value_ represents the (minimum) delay after which the message will be pushed into the queue. If there is no other message in the queue, and the stack is empty, the message is processed right after the delay. However, if there are messages, the `setTimeout` message will have to wait for other messages to be processed. For this reason, the second argument indicates a _minimum_ time — not a _guaranteed_ time.
 

--- a/files/en-us/web/javascript/event_loop/index.md
+++ b/files/en-us/web/javascript/event_loop/index.md
@@ -77,7 +77,7 @@ A downside of this model is that if a message takes too long to complete, the we
 
 ### Adding messages
 
-In web browsers, messages are often added when an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event. Though some events happen synchronously without a message, e.g. simulated clicks via the {{domxref("HTMLElement/click", "click")}} method.
+In web browsers, messages are often added when an event occurs and there is an event listener attached to it. If there is no listener, the event is lost. So a click on an element with a click event handler will add a message — likewise with any other event. However, some events happen synchronously without a message — for example, simulated clicks via the {{domxref("HTMLElement/click", "click")}} method.
 
 The first two arguments to the function [`setTimeout`](/en-US/docs/Web/API/setTimeout) are a message to add to the queue and a time value (optional; defaults to `0`). The _time value_ represents the (minimum) delay after which the message will be pushed into the queue. If there is no other message in the queue, and the stack is empty, the message is processed right after the delay. However, if there are messages, the `setTimeout` message will have to wait for other messages to be processed. For this reason, the second argument indicates a _minimum_ time — not a _guaranteed_ time.
 


### PR DESCRIPTION
### Description

This PR contains multiple clarifications regarding what tasks are, whether events are tasks, and how callbacks fit in here.
- Not only JavaScript code is a task, tasks can also come from the spec and be implemented in the browser. See "queue a global task" e.g. [here](https://html.spec.whatwg.org/#close-request-steps) in the spec and the [task definition](https://html.spec.whatwg.org/multipage/webappapis.html#concept-task).
- The callbacks for handling an event are not separate tasks, the event dispatching itself is the task. See the second code example in https://github.com/mdn/content/pull/34990#issuecomment-2245175804
- Not all events are tasks, see the first code example in https://github.com/mdn/content/pull/34990#issuecomment-2245175804 and [the spec](https://html.spec.whatwg.org/multipage/webappapis.html#task-queue):
> Not all events are dispatched using the [task queue](https://html.spec.whatwg.org/multipage/webappapis.html#task-queue); many are dispatched during other tasks.

### Motivation

These resources have been helpful for me as I tried to understand the event loop. I think the changes in this PR ensure readers are not confused if they experiment with similar code examples as I did in https://github.com/mdn/content/pull/34990#issuecomment-2245175804 .

### Related issues and pull requests

Depends on: #34990