### PR TITLE
docs: Update index.md to clarify differences between window.onload = and addEventListener

### DIFF
--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -49,6 +49,8 @@ window.onload = (event) => {
 };
 ```
 
+> **Note:** `window.onload` is able to be overwritten by other sources (potentially a race condition). To attach more than one listener to the `Window` and prevent listeners from being inadvertently overwritten, prefer using `addEventListener`.
+
 ### Live example
 
 #### HTML


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Adds a note to the Examples section to clarify that using `window.onload = ` is prone to being overwritten by other application / vendor / etc logic and advises to prefer `addEventListener` to avoid that.

### Motivation

They will help readers to be clear on what to expect in `window.onload = ...` behavior vs that of `addEventListener`. This will help avoid difficult to diagnose bugs relating to overwriting expected `onload` behavior.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
