### PR TITLE
Add RFC 4918 to WebDAV glossary specifications.

### DIFF
--- a/files/en-us/glossary/webdav/index.md
+++ b/files/en-us/glossary/webdav/index.md
@@ -26,3 +26,4 @@ WebDAV allows clients to
   - {{rfc(2518)}}
   - {{rfc(3253)}}
   - {{rfc(3744)}}
+  - {{rfc(4918)}} (obsoletes RFC 2518)


### PR DESCRIPTION
### Description

Add RFC 4918 to WebDAV glossary specifications.

### Motivation

RFC 4918 (Jun 2007) obsoletes the primary WebDAV RFC 2518 (Feb 1999). 

### Additional details

See:

https://datatracker.ietf.org/doc/html/rfc4918

### Related issues and pull requests

None.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
