### PR TITLE
SVG fill attribute: BCD frontmatter

### DIFF
--- a/files/en-us/web/svg/attribute/fill/index.md
+++ b/files/en-us/web/svg/attribute/fill/index.md
@@ -2,7 +2,17 @@
 title: fill
 slug: Web/SVG/Attribute/fill
 page-type: svg-attribute
-browser-compat: svg.global_attributes.fill
+browser-compat:
+  - svg.elements.circle.fill
+  - svg.elements.ellipse.fill
+  - svg.elements.path.fill
+  - svg.elements.polygon.fill
+  - svg.elements.polyline.fill
+  - svg.elements.rect.fill
+  - svg.elements.text.fill
+  - svg.elements.textPath.fill
+  - svg.elements.tref.fill
+  - svg.elements.tspan.fill
 ---
 
 {{SVGRef}}


### PR DESCRIPTION
fill is not a global attribute, so removed invalid BCD and added valid BCD.