### PR TITLE
Remove non-existent SVG element

### DIFF
--- a/files/en-us/web/api/svg_api/index.md
+++ b/files/en-us/web/api/svg_api/index.md
@@ -65,8 +65,6 @@ The SVG API is a set of interfaces that have been categorized into the following
 - {{DOMxRef("SVGGeometryElement")}}
 - {{DOMxRef("SVGGradientElement")}}
 - {{DOMxRef("SVGGraphicsElement")}}
-- {{DOMxRef("SVGHatchElement")}} {{Experimental_Inline}}
-- {{DOMxRef("SVGHatchpathElement")}} {{Experimental_Inline}}
 - {{DOMxRef("SVGImageElement")}}
 - {{DOMxRef("SVGLinearGradientElement")}}
 - {{DOMxRef("SVGLineElement")}}

--- a/files/en-us/web/svg/attribute/opacity/index.md
+++ b/files/en-us/web/svg/attribute/opacity/index.md
@@ -14,13 +14,10 @@ The **`opacity`** attribute specifies the transparency of an object or of a grou
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("a")}}
-- {{SVGElement("audio")}}
-- {{SVGElement("canvas")}}
 - {{SVGElement("circle")}}
 - {{SVGElement("ellipse")}}
 - {{SVGElement("foreignObject")}}
 - {{SVGElement("g")}}
-- {{SVGElement("iframe")}}
 - {{SVGElement("image")}}
 - {{SVGElement("line")}}
 - {{SVGElement("marker")}}
@@ -35,8 +32,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tspan")}}
 - {{SVGElement("use")}}
-- {{SVGElement("unknown")}}
-- {{SVGElement("video")}}
 
 Unlike {{SVGAttr("fill-opacity")}}, {{SVGAttr("stroke-opacity")}}, and {{SVGAttr("stop-opacity")}}, which are applied to individual operations and are rendered _when_ the element is rendered, `opacity` is applied to whole objects or groups, and is more like a post-processing operation on the rendered image of the object or group. Therefore, when you have both `opacity` and the other opacity attributes in the same area, they will be overlaid on top of each other and cause the opacity to be multiplied.
 

--- a/files/en-us/web/svg/attribute/overflow/index.md
+++ b/files/en-us/web/svg/attribute/overflow/index.md
@@ -23,7 +23,6 @@ This attribute has the same parameter values and meaning as the {{cssxref("overf
 You can use this attribute with the following SVG elements:
 
 - {{SVGElement("foreignObject")}}
-- {{SVGElement("iframe")}}
 - {{SVGElement("image")}}
 - {{SVGElement("marker")}}
 - {{SVGElement("pattern")}}

--- a/files/en-us/web/svg/attribute/systemlanguage/index.md
+++ b/files/en-us/web/svg/attribute/systemlanguage/index.md
@@ -15,8 +15,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("animate")}}
 - {{SVGElement("animateMotion")}}
 - {{SVGElement("animateTransform")}}
-- {{SVGElement("audio")}}
-- {{SVGElement("canvas")}}
 - {{SVGElement("circle")}}
 - {{SVGElement("clipPath")}}
 - {{SVGElement("cursor")}}
@@ -24,7 +22,6 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("ellipse")}}
 - {{SVGElement("foreignObject")}}
 - {{SVGElement("g")}}
-- {{SVGElement("iframe")}}
 - {{SVGElement("image")}}
 - {{SVGElement("line")}}
 - {{SVGElement("mask")}}
@@ -40,9 +37,7 @@ You can use this attribute with the following SVG elements:
 - {{SVGElement("textPath")}}
 - {{SVGElement("tref")}}
 - {{SVGElement("tspan")}}
-- {{SVGElement("unknown")}}
 - {{SVGElement("use")}}
-- {{SVGElement("video")}}
 
 ## Usage notes
 

--- a/files/en-us/web/svg/element/index.md
+++ b/files/en-us/web/svg/element/index.md
@@ -66,11 +66,6 @@ SVG drawings and images are created using a wide array of elements which are ded
 
 - {{SVGElement("g")}}
 
-### H
-
-- {{SVGElement("hatch")}}
-- {{SVGElement("hatchpath")}}
-
 ### I
 
 - {{SVGElement("image")}}
@@ -170,11 +165,11 @@ SVG drawings and images are created using a wide array of elements which are ded
 
 ### Never-rendered elements
 
-{{SVGElement("clipPath")}}, {{SVGElement("defs")}}, {{SVGElement("hatch")}}, {{SVGElement("linearGradient")}}, {{SVGElement("marker")}}, {{SVGElement("mask")}}, {{SVGElement("metadata")}}, {{SVGElement("pattern")}}, {{SVGElement("radialGradient")}}, {{SVGElement("script")}}, {{SVGElement("style")}}, {{SVGElement("symbol")}}, {{SVGElement("title")}}
+{{SVGElement("clipPath")}}, {{SVGElement("defs")}}, {{SVGElement("linearGradient")}}, {{SVGElement("marker")}}, {{SVGElement("mask")}}, {{SVGElement("metadata")}}, {{SVGElement("pattern")}}, {{SVGElement("radialGradient")}}, {{SVGElement("script")}}, {{SVGElement("style")}}, {{SVGElement("symbol")}}, {{SVGElement("title")}}
 
 ### Paint server elements
 
-{{SVGElement("hatch")}}, {{SVGElement("linearGradient")}}, {{SVGElement("pattern")}}, {{SVGElement("radialGradient")}}, {{SVGElement("solidcolor")}}
+{{SVGElement("linearGradient")}}, {{SVGElement("pattern")}}, {{SVGElement("radialGradient")}}
 
 ### Renderable elements
 
@@ -200,7 +195,7 @@ SVG drawings and images are created using a wide array of elements which are ded
 
 ### Uncategorized elements
 
-{{SVGElement("clipPath")}}, {{SVGElement("cursor")}}, {{SVGElement("filter")}}, {{SVGElement("foreignObject")}}, {{SVGElement("hatchpath")}}, {{SVGElement("script")}}, {{SVGElement("style")}}, {{SVGElement("view")}}
+{{SVGElement("clipPath")}}, {{SVGElement("cursor")}}, {{SVGElement("filter")}}, {{SVGElement("foreignObject")}}, {{SVGElement("script")}}, {{SVGElement("style")}}, {{SVGElement("view")}}
 
 ## Obsolete and deprecated elements
 


### PR DESCRIPTION
The `audio`, `video`, `canvas`, `iframe`, and `unknown` were removed from SVG 2: https://github.com/w3c/svgwg/pull/571 it seemed no one implemented them.

Similarly `hatch`, `solidcolor`, and `hatchpath` were removed before SVG 2: https://github.com/w3c/svgwg/issues/449