### PR TITLE
Remove HTMLIsIndexElement link

### DIFF
--- a/files/en-us/web/api/html_dom_api/index.md
+++ b/files/en-us/web/api/html_dom_api/index.md
@@ -156,7 +156,6 @@ These interfaces represent specific HTML elements (or sets of related elements w
 - {{DOMxRef("HTMLFontElement")}} {{deprecated_inline}}
 - {{DOMxRef("HTMLFrameElement")}} {{deprecated_inline}}
 - {{DOMxRef("HTMLFrameSetElement")}} {{deprecated_inline}}
-- {{DOMxRef("HTMLIsIndexElement")}} {{deprecated_inline}}
 
 ### Web app and browser integration interfaces
 


### PR DESCRIPTION
This interface doesn't exist in browsers, has been long-deprecated, and we don't have pages for it anyway.