### PR TITLE
Remove mentions of PaymentOptions

### DIFF
--- a/files/en-us/web/api/paymentrequest/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingaddress/index.md
@@ -21,7 +21,7 @@ user. It is `null` by default.
 
 Generally, the user agent will fill the `shippingAddress` property value.
 You can trigger this by setting
-`PaymentOptions.requestShipping` to `true` when calling
+`options.requestShipping` to `true` when calling
 the `PaymentRequest` constructor.
 
 In the example below, the cost of shipping varies by geography. When the

--- a/files/en-us/web/api/paymentresponse/payeremail/index.md
+++ b/files/en-us/web/api/paymentresponse/payeremail/index.md
@@ -14,7 +14,7 @@ browser-compat: api.PaymentResponse.payerEmail
 The `payerEmail` read-only property of the {{domxref("PaymentResponse")}}
 interface returns the email address supplied by the user. This option is only present
 when the `requestPayerEmail` option is set to `true` in the
-{{domxref('PaymentOptions')}} object passed to the
+`options` object passed to the
 {{domxref('PaymentRequest.PaymentRequest','PaymentRequest')}} constructor.
 
 ## Value

--- a/files/en-us/web/api/paymentresponse/payerphone/index.md
+++ b/files/en-us/web/api/paymentresponse/payerphone/index.md
@@ -14,7 +14,7 @@ browser-compat: api.PaymentResponse.payerPhone
 The `payerPhone` read-only property of the {{domxref("PaymentResponse")}}
 interface returns the phone number supplied by the user. This option is only present
 when the `requestPayerPhone` option is set to `true` in the
-{{domxref('PaymentOptions')}} object passed to the
+`options` object passed to the
 {{domxref('PaymentRequest.PaymentRequest','PaymentRequest')}} constructor.
 
 ## Value

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.md
@@ -24,7 +24,7 @@ address provided by the user.
 
 Generally, the user agent will fill the `shippingAddress` property for you.
 You can trigger this by
-setting `PaymentOptions.requestShipping` to `true` when calling
+setting `options.requestShipping` to `true` when calling
 the {{domxref('PaymentRequest.paymentRequest','PaymentRequest')}} constructor.
 
 In the example below, the cost of shipping varies by geography. When the

--- a/files/en-us/web/api/paymentresponse/shippingoption/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingoption/index.md
@@ -15,7 +15,7 @@ The **`shippingOption`** read-only property of
 the `PaymentRequest` interface returns the ID attribute of the shipping
 option selected by the user. This option is only present when the
 `requestShipping` option is set to `true` in the
-{{domxref('PaymentOptions')}} object passed to the
+`options` object passed to the
 {{domxref('PaymentRequest.PaymentRequest','PaymentRequest')}} constructor.
 
 ## Value


### PR DESCRIPTION
PaymentOptions doesn't even exist in the spec anymore, and all members related to it are deprecated. We don't document dictionaries so we should do this change regardless.