### PR TITLE
Remove undefined, undocumented nonexistent SVG API types

### DIFF
--- a/files/en-us/web/api/svg_api/index.md
+++ b/files/en-us/web/api/svg_api/index.md
@@ -103,14 +103,10 @@ Here are the DOM APIs for data types used in the definitions of SVG properties a
 #### Static type
 
 - {{DOMxRef("SVGAngle")}}
-- {{DOMxRef("SVGElementInstance")}}
-- {{DOMxRef("SVGElementInstanceList")}}
 - {{DOMxRef("SVGLength")}}
 - {{DOMxRef("SVGLengthList")}}
-- {{DOMxRef("SVGNameList")}}
 - {{DOMxRef("SVGNumber")}}
 - {{DOMxRef("SVGNumberList")}}
-- {{DOMxRef("SVGPaint")}}
 - {{DOMxRef("SVGPreserveAspectRatio")}}
 - {{DOMxRef("SVGStringList")}}
 - {{DOMxRef("SVGTransform")}}
@@ -138,9 +134,7 @@ Here are the DOM APIs for data types used in the definitions of SVG properties a
 
 ### Other SVG interfaces
 
-- {{DOMxRef("GetSVGDocument")}}
 - {{DOMxRef("ShadowAnimation")}}
-- {{DOMxRef("SVGDocument")}}
 - {{DOMxRef("SVGUnitTypes")}}
 - {{DOMxRef("SVGUseElementShadowRoot")}}
 

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -110,8 +110,6 @@ SVG makes use of a number of data types. This article lists these types along wi
 
     where `color-keyword` matches (case insensitively) one of the color keywords listed in [CSS Color Module Level 3](https://www.w3.org/TR/css-color-3/), or one of the system color keywords listed in [User preferences for colors](https://www.w3.org/TR/2008/REC-CSS2-20080411/ui.html#system-colors) (CSS2, section 18.2).
 
-    The corresponding SVG DOM interface definitions for \<color> are defined the one defined by CSS. SVG's extension to color, including the ability to specify ICC-based colors, are represented using DOM interface {{domxref("SVGColor")}}.
-
 ## Coordinate
 
 - \<coordinate>


### PR DESCRIPTION
These types don't exist in the latest SVG spec, we don't have docs for them, and they don't seem to exist in browsers. Some of them are mixins.