### PR TITLE
Revert "Remove mention of constructors for PageRevealEvent/PageSwapEvent"

### DIFF
--- a/files/en-us/web/api/pagerevealevent/index.md
+++ b/files/en-us/web/api/pagerevealevent/index.md
@@ -26,6 +26,11 @@ requestAnimationFrame(() => reveal());
 window.onpagehide = () => requestAnimationFrame(() => reveal());
 ```
 
+## Constructor
+
+- {{domxref("PageRevealEvent.PageRevealEvent", "PageRevealEvent()")}} {{experimental_inline}}
+  - : Creates a new {{domxref("PageRevealEvent")}} object instance.
+
 ## Instance properties
 
 - {{domxref("PageRevealEvent.viewTransition", "viewTransition")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/pagerevealevent/pagerevealevent/index.md
+++ b/files/en-us/web/api/pagerevealevent/pagerevealevent/index.md
@@ -1,0 +1,45 @@
+---
+title: "PageRevealEvent: PageRevealEvent() constructor"
+short-title: PageRevealEvent()
+slug: Web/API/PageRevealEvent/PageRevealEvent
+page-type: web-api-constructor
+status:
+  - experimental
+browser-compat: api.PageRevealEvent.PageRevealEvent
+---
+
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+
+The **`PageRevealEvent()`** constructor creates a new
+{{domxref("PageRevealEvent")}} object instance.
+
+## Syntax
+
+```js-nolint
+new PageRevealEvent(type, init)
+```
+
+### Parameters
+
+- `type`
+  - : A string representing the type of event. In the case of `PageRevealEvent` this is always `pagereveal`.
+- `init`
+  - : An object containing the following properties:
+    - `viewTransition` {{optional_inline}}
+      - : A {{domxref("ViewTransition")}} object representing the active view transition for the related navigation. Defaults to `null` if there is no active view transition.
+
+## Examples
+
+A developer would not use this constructor manually. A new `PageRevealEvent` object is constructed when a handler is invoked as a result of the {{domxref("Window.pagereveal_event", "pagereveal")}} event firing.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [View Transitions API](/en-US/docs/Web/API/View_Transitions_API)

--- a/files/en-us/web/api/pageswapevent/index.md
+++ b/files/en-us/web/api/pageswapevent/index.md
@@ -13,6 +13,11 @@ The **`PageSwapEvent`** event object is made available inside handler functions 
 
 The `pageswap` event is fired when you navigate across documents, when the previous document is about to unload. During a cross-document navigation, the `PageSwapEvent` event object allows you to manipulate the related [view transition](/en-US/docs/Web/API/View_Transitions_API) (providing access to the relevant {{domxref("ViewTransition")}} object) from the document being navigated _from_, if a view transition was triggered by the navigation. It also provides access to information on the navigation type and current and destination documents.
 
+## Constructor
+
+- {{domxref("PageSwapEvent.PageSwapEvent", "PageSwapEvent()")}} {{experimental_inline}}
+  - : Creates a new {{domxref("PageSwapEvent")}} object instance.
+
 ## Instance properties
 
 - {{domxref("PageSwapEvent.activation", "activation")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/pageswapevent/pageswapevent/index.md
+++ b/files/en-us/web/api/pageswapevent/pageswapevent/index.md
@@ -1,0 +1,47 @@
+---
+title: "PageSwapEvent: PageSwapEvent() constructor"
+short-title: PageSwapEvent()
+slug: Web/API/PageSwapEvent/PageSwapEvent
+page-type: web-api-constructor
+status:
+  - experimental
+browser-compat: api.PageSwapEvent.PageSwapEvent
+---
+
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+
+The **`PageSwapEvent()`** constructor creates a new
+{{domxref("PageSwapEvent")}} object instance.
+
+## Syntax
+
+```js-nolint
+new PageSwapEvent(type, init)
+```
+
+### Parameters
+
+- `type`
+  - : A string representing the type of event. In the case of `PageSwapEvent` this is always `pageswap`.
+- `init`
+  - : An object containing the following properties:
+    - `activation`
+      - : A {{domxref("NavigationActivation")}} object representing the navigation type and current and destination document history entries. Defaults to `null` if the associated navigation is a cross-origin navigation.
+    - `viewTransition`
+      - : A {{domxref("ViewTransition")}} object representing the active view transition for the related navigation. Defaults to `null` if there is no active view transition.
+
+## Examples
+
+A developer would not use this constructor manually. A new `PageSwapEvent` object is constructed when a handler is invoked as a result of the {{domxref("Window.pageswap_event", "pageswap")}} event firing.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [View Transitions API](/en-US/docs/Web/API/View_Transitions_API)


### PR DESCRIPTION
Reverts mdn/content#34758

The constructors are in Chrome 128 now.
https://issues.chromium.org/issues/354588516