### PR TITLE
Fixed instanceof summary to better match instanceof page

### DIFF
--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -1035,10 +1035,10 @@ The [`instanceof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/insta
 if the specified object is of the specified object type. The syntax is:
 
 ```js-nolint
-objectName instanceof objectType
+object instanceof objectType
 ```
 
-where `objectName` is the name of the object to compare to `objectType`, and `objectType` is an object type, such as {{jsxref("Date")}} or {{jsxref("Array")}}.
+where `object` is the object to test against `objectType`, and `objectType` is an object type, such as {{jsxref("Date")}} or {{jsxref("Array")}}.
 
 Use `instanceof` when you need to confirm the type of an object at runtime.
 For example, when catching exceptions, you can branch to different exception-handling code depending on the type of exception thrown.

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -1038,7 +1038,7 @@ if the specified object is of the specified object type. The syntax is:
 object instanceof objectType
 ```
 
-where `object` is the object to test against `objectType`, and `objectType` is an object type, such as {{jsxref("Date")}} or {{jsxref("Array")}}.
+where `object` is the object to test against `objectType`, and `objectType` is a constructor representing a type, such as {{jsxref("Date")}} or {{jsxref("Array")}}.
 
 Use `instanceof` when you need to confirm the type of an object at runtime.
 For example, when catching exceptions, you can branch to different exception-handling code depending on the type of exception thrown.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The wording describing [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#instanceof) on the `Expressions and operators` page does not match the wording on the page for [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) and could lead to a misunderstanding of how it functions.

From:
[Expressions and operators - instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_operators#instanceof)
Current wording:
> ```js-nolint
> objectName instanceof objectType
> ```
>
> where `objectName` is the name of the object to compare to `objectType`, and `objectType` is an object type, such as {{jsxref("Date")}} or {{jsxref("Array")}}.

Updated (in patch):
> ```js-nolint
> object instanceof objectType
> ```
>
>where `object` is the object to test against `objectType`, and `objectType` is an object type, such as {{jsxref("Date")}} or {{jsxref("Array")}}.

The updated wording matches the wording on the [instanceof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) page.

### Motivation

I found the issue while using MDN and I feel new users may get confused by the current wording and example.