### PR TITLE
Fix code-links containing spaces, API1

### DIFF
--- a/files/en-us/web/api/audiocontext/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/audiocontext/index.md
@@ -104,4 +104,4 @@ const audioCtx = new AudioContext({
 
 ## See also
 
-- {{domxref("OfflineAudioContext.OfflineAudioContext()", "new OfflineAudioContext()")}} constructor
+- {{domxref("OfflineAudioContext.OfflineAudioContext()", "OfflineAudioContext()")}} constructor

--- a/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.md
@@ -28,7 +28,7 @@ new AudioWorkletProcessor(options)
 - `options`
 
   - : An object that is passed as _options_ parameter to the
-    {{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode constructor")}} and
+    {{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode()")}} constructor and
     passed through [the structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
     Available properties are as follows:
 
@@ -46,7 +46,7 @@ new AudioWorkletProcessor(options)
       - : Any additional data that can be used for custom initialization of the underlying {{domxref("AudioWorkletProcessor")}}.
 
     Note that there are default values for the first two properties, so even if there are no
-    _options_ object passed to the {{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode constructor")}}, the _options_ object passed by the node to the `AudioWorkletProcessor` constructor will exist and at minimum have `numberOfInputs` and `numberOfOutputs`.
+    _options_ object passed to the {{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode()")}} constructor, the _options_ object passed by the node to the `AudioWorkletProcessor` constructor will exist and at minimum have `numberOfInputs` and `numberOfOutputs`.
 
 ### Return value
 
@@ -55,7 +55,7 @@ The newly constructed {{domxref("AudioWorkletProcessor")}} instance.
 ## Examples
 
 In this example we pass custom options to the
-{{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode constructor")}} and
+{{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode()")}} constructor and
 observe how a [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) of them gets passed to our `AudioWorkletProcessor` constructor.
 
 First, we need to define a custom {{domxref("AudioWorkletProcessor")}} and register it.

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.md
@@ -29,7 +29,7 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistrat
 
 ## Examples
 
-The following examples shows how to use `get()` to retrieve a {{domxref("BackgroundFetchRegistration")}}. With an active {{domxref('ServiceWorker', 'service worker')}}, use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} to access the `BackgroundFetchManager` object and call its `get()` method.
+The following examples shows how to use `get()` to retrieve a {{domxref("BackgroundFetchRegistration")}}. With an active [service worker](/en-US/docs/Web/API/ServiceWorker), use the {{domxref('ServiceWorkerRegistration.backgroundFetch')}} to access the `BackgroundFetchManager` object and call its `get()` method.
 
 ```js
 navigator.serviceWorker.ready.then(async (swReg) => {

--- a/files/en-us/web/api/badging_api/index.md
+++ b/files/en-us/web/api/badging_api/index.md
@@ -28,7 +28,7 @@ A badge can have one of three possible values, which are set internally:
   - : Indicating that no badge is currently set. A badge can be in this state due to it being cleared by the application, or being reset by the user agent.
 - `flag`
   - : Indicating that the badge is set, but has no specific data to display. A badge will be in this state if the application has set a badge, but has not passed any value to the method.
-- `an integer`
+- an integer
   - : A value passed when setting the badge. This value will never be `0`, passing a value of `0` when setting a badge will cause the user agent to clear the badge by setting it to `nothing`.
 
 ### Setting badges

--- a/files/en-us/web/api/barprop/index.md
+++ b/files/en-us/web/api/barprop/index.md
@@ -7,7 +7,7 @@ browser-compat: api.BarProp
 
 {{APIRef("DOM")}}
 
-The **`BarProp`** interface of the {{domxref('Document Object Model')}} represents the web browser user interface elements that are exposed to scripts in web pages. Each of the following interface elements are represented by a `BarProp` object.
+The **`BarProp`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) represents the web browser user interface elements that are exposed to scripts in web pages. Each of the following interface elements are represented by a `BarProp` object.
 
 - {{domxref("Window.locationbar")}}
   - : The browser location bar.

--- a/files/en-us/web/api/bluetoothuuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/index.md
@@ -7,7 +7,7 @@ browser-compat: api.BluetoothUUID
 
 {{APIRef("Bluetooth API")}}
 
-The **`BluetoothUUID`** interface of the {{domxref('Web Bluetooth API')}} provides a way to look up Universally Unique Identifier (UUID) values by name in the
+The **`BluetoothUUID`** interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) provides a way to look up Universally Unique Identifier (UUID) values by name in the
 [registry](https://www.bluetooth.com/specifications/assigned-numbers/) maintained by the Bluetooth SIG.
 
 ## Description

--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -19,19 +19,19 @@ You are also responsible for periodically purging cache entries. Each browser ha
 
 ## Instance methods
 
-- {{domxref("Cache.match", "Cache.match(request, options)")}}
+- {{domxref("Cache.match()")}}
   - : Returns a {{jsxref("Promise")}} that resolves to the response associated with the first matching request in the `Cache` object.
-- {{domxref("Cache.matchAll", "Cache.matchAll(request, options)")}}
+- {{domxref("Cache.matchAll()")}}
   - : Returns a {{jsxref("Promise")}} that resolves to an array of all matching responses in the `Cache` object.
-- {{domxref("Cache.add", "Cache.add(request)")}}
+- {{domxref("Cache.add()")}}
   - : Takes a URL, retrieves it and adds the resulting response object to the given cache. This is functionally equivalent to calling `fetch()`, then using `put()` to add the results to the cache.
-- {{domxref("Cache.addAll", "Cache.addAll(requests)")}}
+- {{domxref("Cache.addAll()")}}
   - : Takes an array of URLs, retrieves them, and adds the resulting response objects to the given cache.
-- {{domxref("Cache.put", "Cache.put(request, response)")}}
+- {{domxref("Cache.put()")}}
   - : Takes both a request and its response and adds it to the given cache.
-- {{domxref("Cache.delete", "Cache.delete(request, options)")}}
+- {{domxref("Cache.delete()")}}
   - : Finds the `Cache` entry whose key is the request, returning a {{jsxref("Promise")}} that resolves to `true` if a matching `Cache` entry is found and deleted. If no `Cache` entry is found, the promise resolves to `false`.
-- {{domxref("Cache.keys", "Cache.keys(request, options)")}}
+- {{domxref("Cache.keys()")}}
   - : Returns a {{jsxref("Promise")}} that resolves to an array of `Cache` keys.
 
 ## Examples

--- a/files/en-us/web/api/canmakepaymentevent/index.md
+++ b/files/en-us/web/api/canmakepaymentevent/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CanMakePaymentEvent
 
 {{APIRef("Payment Handler API")}}{{SeeCompatTable}}{{AvailableInWorkers("service")}}
 
-The **`CanMakePaymentEvent`** interface of the {{domxref("Payment Handler API", "", "", "nocode")}} is the event object for the {{domxref("ServiceWorkerGlobalScope.canmakepayment_event", "canmakepayment")}} event, fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}.
+The **`CanMakePaymentEvent`** interface of the {{domxref("Payment Handler API", "", "", "nocode")}} is the event object for the {{domxref("ServiceWorkerGlobalScope.canmakepayment_event", "canmakepayment")}} event, fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls the {{domxref("PaymentRequest.PaymentRequest", "PaymentRequest()")}} constructor.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -295,7 +295,7 @@ Once you have generated a data URL from your canvas, you are able to use it as t
 
 You can also create a {{domxref("Blob")}} from the canvas.
 
-- {{domxref("HTMLCanvasElement.toBlob", "canvas.toBlob(_callback_, _type_, _encoderOptions_)")}}
+- {{domxref("HTMLCanvasElement.toBlob", "canvas.toBlob(callback, type, encoderOptions)")}}
   - : Creates a `Blob` object representing the image contained in the canvas.
 
 ## See also

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
@@ -248,17 +248,17 @@ Finally, the following transformation methods allow modifications directly to th
 
 The parameters of this function are:
 
-- `a (m11)`
+- `a` (`m11`)
   - : Horizontal scaling.
-- `b (m12)`
+- `b` (`m12`)
   - : Horizontal skewing.
-- `c (m21)`
+- `c` (`m21`)
   - : Vertical skewing.
-- `d (m22)`
+- `d` (`m22`)
   - : Vertical scaling.
-- `e (dx)`
+- `e` (`dx`)
   - : Horizontal moving.
-- `f (dy)`
+- `f` (`dy`)
   - : Vertical moving.
 - {{domxref("CanvasRenderingContext2D.setTransform", "setTransform(a, b, c, d, e, f)")}}
   - : Resets the current transform to the identity matrix, and then invokes the `transform()` method with the same arguments. This basically undoes the current transformation, then sets the specified transform, all in one step.

--- a/files/en-us/web/api/characterboundsupdateevent/index.md
+++ b/files/en-us/web/api/characterboundsupdateevent/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CharacterBoundsUpdateEvent
 
 {{APIRef("EditContext API")}}{{SeeCompatTable}}
 
-The **`CharacterBoundsUpdateEvent`** interface is a {{domxref("Event", "DOM event")}} that represents a request from the operating system to know the bounds of certain characters within an editable region that's attached to an {{domxref("EditContext")}} instance.
+The **`CharacterBoundsUpdateEvent`** interface is a [DOM event](/en-US/docs/Web/API/Event) that represents a request from the operating system to know the bounds of certain characters within an editable region that's attached to an {{domxref("EditContext")}} instance.
 
 This interface inherits properties from {{domxref("Event")}}.
 

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -44,11 +44,11 @@ The Clipboard API extends the following APIs, adding the listed features.
 
 - {{domxref("Navigator.clipboard")}} {{readonlyinline}} {{securecontext_inline}}
   - : Returns a {{domxref("Clipboard")}} object that provides read and write access to the system clipboard.
-- [`Element: copy`](/en-US/docs/Web/API/Element/copy_event) event
+- `Element` [`copy`](/en-US/docs/Web/API/Element/copy_event) event
   - : An event fired whenever the user initiates a copy action.
-- [`Element: cut`](/en-US/docs/Web/API/Element/cut_event) event
+- `Element` [`cut`](/en-US/docs/Web/API/Element/cut_event) event
   - : An event fired whenever the user initiates a cut action.
-- [`Element: paste`](/en-US/docs/Web/API/Element/paste_event) event
+- `Element` [`paste`](/en-US/docs/Web/API/Element/paste_event) event
   - : An event fired whenever the user initiates a paste action.
 
 <!-- Note `Window: clipboardchange` event is in spec but not implemented -->

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -34,7 +34,7 @@ new ClipboardItem(data, options)
 
 ## Examples
 
-The below example requests a PNG image using the {{domxref("Fetch API")}}, and in turn, the {{domxref("Response.blob()", "responses' blob()")}} method, to create a new {{domxref("ClipboardItem")}}.
+The below example requests a PNG image using {{domxref("Window/fetch", "fetch()")}}, and in turn, the {{domxref("Response.blob()")}} method, to create a new {{domxref("ClipboardItem")}}.
 This item is then written to the clipboard, using the {{domxref("Clipboard.write()")}} method.
 
 > **Note:** You can only pass in one clipboard item at a time.

--- a/files/en-us/web/api/contactsmanager/index.md
+++ b/files/en-us/web/api/contactsmanager/index.md
@@ -9,7 +9,7 @@ browser-compat: api.ContactsManager
 
 {{securecontext_header}}{{APIRef("Contact Picker API")}}{{SeeCompatTable}}
 
-The **`ContactsManager`** interface of the {{domxref('Contact Picker API')}} allows users to select entries from their contact list and share limited details of the selected entries with a website or application.
+The **`ContactsManager`** interface of the [Contact Picker API](/en-US/docs/Web/API/Contact_Picker_API) allows users to select entries from their contact list and share limited details of the selected entries with a website or application.
 
 The `ContactsManager` is available through the global {{domxref('navigator.contacts')}} property.
 

--- a/files/en-us/web/api/contentindex/add/index.md
+++ b/files/en-us/web/api/contentindex/add/index.md
@@ -36,7 +36,7 @@ add(contentDescription)
     - `url`
       - : A {{jsxref('String')}} containing the URL of the corresponding
         HTML document. Needs to be under the scope of the current
-        {{domxref('ServiceWorker','service worker')}}.
+        [service worker](/en-US/docs/Web/API/ServiceWorker).
     - `category` {{Optional_Inline}}
 
       - : A {{jsxref('String')}} defining the

--- a/files/en-us/web/api/contentindex/getall/index.md
+++ b/files/en-us/web/api/contentindex/getall/index.md
@@ -43,7 +43,7 @@ Returns a {{jsxref("Promise")}} that resolves with an {{jsxref('Array')}} of
         Used in user-visible lists of content.
     - `url`
       - : A {{jsxref('String')}} containing the URL of the corresponding HTML document.
-        Needs to be under the scope of the current {{domxref('ServiceWorker','service worker')}}.
+        Needs to be under the scope of the current [service worker](/en-US/docs/Web/API/ServiceWorker).
     - `category` {{Optional_Inline}}
 
       - : A {{jsxref('String')}} defining the category of content.

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -43,5 +43,5 @@ console.log(uuid); // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 
 ## See also
 
-- {{ domxref("Web Crypto API") }}
+- [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API)
 - {{ domxref("Crypto.getRandomValues") }}, a source for arbitrary amounts of secure random bytes.

--- a/files/en-us/web/api/cryptokey/usages/index.md
+++ b/files/en-us/web/api/cryptokey/usages/index.md
@@ -14,14 +14,14 @@ The read-only **`usages`** property of the {{DOMxRef("CryptoKey")}} interface in
 
 An {{jsxref("Array")}} of strings from the following list:
 
-- `"encrypt"`: The key may be used to {{domxref("SubtleCrypto.encrypt()", "encrypt")}} messages.
-- `"decrypt"`: The key may be used to {{domxref("SubtleCrypto.decrypt()", "decrypt")}} messages.
-- `"sign"`: The key may be used to {{domxref("SubtleCrypto.sign()", "sign")}} messages.
-- `"verify"`: The key may be used to {{domxref("SubtleCrypto.verify()", "verify")}} signatures.
-- `"deriveKey"`: The key may be used in {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
-- `"deriveBits"`: The key may be used in {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
-- `"wrapKey"`: The key may be used to {{domxref("SubtleCrypto.wrapKey()", "wrap a key")}}.
-- `"unwrapKey"`: The key may be used to {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
+- `"encrypt"`: The key may be used to [encrypt](/en-US/docs/Web/API/SubtleCrypto/encrypt) messages.
+- `"decrypt"`: The key may be used to [decrypt](/en-US/docs/Web/API/SubtleCrypto/decrypt) messages.
+- `"sign"`: The key may be used to [sign](/en-US/docs/Web/API/SubtleCrypto/sign) messages.
+- `"verify"`: The key may be used to [verify](/en-US/docs/Web/API/SubtleCrypto/verify) signatures.
+- `"deriveKey"`: The key may be used in [deriving a new key](/en-US/docs/Web/API/SubtleCrypto/deriveKey).
+- `"deriveBits"`: The key may be used in [deriving bits](/en-US/docs/Web/API/SubtleCrypto/deriveBits).
+- `"wrapKey"`: The key may be used to [wrap a key](/en-US/docs/Web/API/SubtleCrypto/wrapKey).
+- `"unwrapKey"`: The key may be used to [unwrap a key](/en-US/docs/Web/API/SubtleCrypto/unwrapKey).
 
 ## Examples
 

--- a/files/en-us/web/api/css/index.md
+++ b/files/en-us/web/api/css/index.md
@@ -28,12 +28,12 @@ _The CSS interface is a utility interface and no object of this type can be crea
 _No inherited static methods_.
 
 - {{DOMxRef("CSS/registerProperty_static", "CSS.registerProperty()")}}
-  - : Registers {{cssxref('--*', 'custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
+  - : Registers [custom properties](/en-US/docs/Web/CSS/--*), allowing for property type checking, default values, and properties that do or do not inherit their value.
 - {{DOMxRef("CSS/supports_static", "CSS.supports()")}}
   - : Returns a boolean value indicating if the pair _property-value_, or the condition, given in parameter is supported.
 - {{DOMxRef("CSS/escape_static", "CSS.escape()")}}
   - : Can be used to escape a string mostly for use as part of a CSS selector.
-- {{DOMxRef("CSS/factory_functions_static", 'CSS factory functions')}}
+- [CSS factory functions](/en-US/docs/Web/API/CSS/factory_functions_static)
 
   - : Can be used to return a new [`CSSUnitValue`](/en-US/docs/Web/API/CSSUnitValue) with a value of the parameter number of the units of the name of the factory function method used.
 

--- a/files/en-us/web/api/css/registerproperty_static/index.md
+++ b/files/en-us/web/api/css/registerproperty_static/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSS.registerProperty_static
 {{APIRef("CSSOM")}}
 
 The **`CSS.registerProperty()`** static method registers
-{{cssxref('--*', 'custom properties')}}, allowing for property type checking, default
+[custom properties](/en-US/docs/Web/CSS/--*), allowing for property type checking, default
 values, and properties that do or do not inherit their value.
 
 Registering a custom property allows you to tell the browser how the custom property
@@ -57,7 +57,7 @@ members:
 
 ## Examples
 
-The following will register a {{cssxref('--*', 'custom property')}},
+The following will register a [custom property](/en-US/docs/Web/CSS/--*),
 `--my-color`, using `registerProperty()`, as a color, give it a
 default value, and have it not inherit its value:
 
@@ -125,5 +125,5 @@ We can add these styles to some buttons:
 - {{DOMxRef("CSS")}}
 - {{DOMxRef("CSS/supports_static", "CSS.supports()")}}
 - {{DOMxRef("CSS/escape_static", "CSS.escape()")}}
-- {{DOMxRef("CSS/factory_functions_static", 'CSS factory functions')}}
+- [CSS factory functions](/en-US/docs/Web/API/CSS/factory_functions_static)
 - CSS {{cssxref("@property")}}

--- a/files/en-us/web/api/css_properties_and_values_api/guide/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/guide/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSS.registerProperty_static
 
 {{DefaultAPISidebar("CSS Properties and Values API")}}
 
-The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini_APIs) umbrella of APIs — allows the registration of {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
+The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini_APIs) umbrella of APIs — allows the registration of [CSS custom properties](/en-US/docs/Web/CSS/--*), allowing for property type checking, default values, and properties that do or do not inherit their value.
 
 ## Registering a custom property
 
@@ -15,7 +15,7 @@ Registering a custom property allows you to tell the browser how the custom prop
 
 ### CSS.registerProperty
 
-The following will register a {{cssxref('--*', 'CSS custom property')}} named `--my-prop` using {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}}. `--my-prop` will use the CSS color syntax, it will have a default value of `#c0ffee`, and it will not inherit its value:
+The following will register a [custom property](/en-US/docs/Web/CSS/--*) named `--my-prop` using {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}}. `--my-prop` will use the CSS color syntax, it will have a default value of `#c0ffee`, and it will not inherit its value:
 
 ```js
 window.CSS.registerProperty({
@@ -28,7 +28,7 @@ window.CSS.registerProperty({
 
 ### @property
 
-The same registration can take place in CSS. The following will register a {{cssxref('--*', 'CSS custom property')}} named `--my-prop` using the {{cssxref('@property')}} [at-rule](/en-US/docs/Web/CSS/At-rule). `--my-prop` will use the CSS color syntax, it will have a default value of `#c0ffee`, and it will not inherit its value:
+The same registration can take place in CSS. The following will register a [custom property](/en-US/docs/Web/CSS/--*) named `--my-prop` using the {{cssxref('@property')}} [at-rule](/en-US/docs/Web/CSS/At-rule). `--my-prop` will use the CSS color syntax, it will have a default value of `#c0ffee`, and it will not inherit its value:
 
 ```css
 @property --my-prop {

--- a/files/en-us/web/api/css_properties_and_values_api/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/index.md
@@ -9,18 +9,18 @@ browser-compat:
 
 {{DefaultAPISidebar("CSS Properties and Values API")}}
 
-The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini_APIs) umbrella of APIs — allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
+The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/API/Houdini_APIs) umbrella of APIs — allows developers to explicitly define their [CSS custom properties](/en-US/docs/Web/CSS/--*), allowing for property type checking, default values, and properties that do or do not inherit their value.
 
 ## Interfaces
 
 - {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}}
-  - : Defines how a browser should parse {{cssxref('--*', 'CSS custom properties')}}. Access this interface through {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}} in [JavaScript](/en-US/docs/Web/JavaScript).
+  - : Defines how a browser should parse [CSS custom properties](/en-US/docs/Web/CSS/--*). Access this interface through {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}} in [JavaScript](/en-US/docs/Web/JavaScript).
 - {{cssxref('@property')}}
-  - : Defines how a browser should parse {{cssxref('--*', 'CSS custom properties')}}. Access this interface through {{cssxref('@property')}} [at-rule](/en-US/docs/Web/CSS/At-rule) in [CSS](/en-US/docs/Web/CSS).
+  - : Defines how a browser should parse [CSS custom properties](/en-US/docs/Web/CSS/--*). Access this interface through {{cssxref('@property')}} [at-rule](/en-US/docs/Web/CSS/At-rule) in [CSS](/en-US/docs/Web/CSS).
 
 ## Examples
 
-The following will register a {{cssxref('--*', 'CSS custom property')}} named `--my-color` using {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}} in [JavaScript](/en-US/docs/Web/JavaScript). `--my-color` will use the CSS color syntax, it will have a default value of `#c0ffee`, and it will not inherit its value:
+The following will register a [custom property](/en-US/docs/Web/CSS/--*) named `--my-color` using {{domxref('CSS/registerProperty_static', 'CSS.registerProperty')}} in [JavaScript](/en-US/docs/Web/JavaScript). `--my-color` will use the CSS color syntax, it will have a default value of `#c0ffee`, and it will not inherit its value:
 
 ```js
 window.CSS.registerProperty({

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -124,7 +124,7 @@ for (const value of ofInterest) {
 
 We included {{cssxref('border-left-color')}} to demonstrate that, had we included all the properties, every value that defaults to [`currentcolor`](/en-US/docs/Web/CSS/color_value) (including {{cssxref('caret-color')}}, {{cssxref('outline-color')}}, {{cssxref('text-decoration-color')}}, {{cssxref('column-rule-color')}}, etc.) would return `rgb(255 0 0)`. The link has inherited `font-weight: bold;` from the paragraph's styles, listing it as `font-weight: 700`. Custom properties, like our `--color: red`, are properties. As such, they are accessible via `get()`.
 
-You'll note that custom properties retain the value as written in the stylesheet, whereas computed styles will be listed as the computed value — {{cssxref('color')}} was listed as an [`rgb()`](/en-US/docs/Web/CSS/color_value) value and the {{cssxref('font-weight')}} returned was `700` even though we use a {{cssxref('&lt;color&gt;', 'named color')}} and the `bold` keyword.
+You'll note that custom properties retain the value as written in the stylesheet, whereas computed styles will be listed as the computed value — {{cssxref('color')}} was listed as an [`rgb()`](/en-US/docs/Web/CSS/color_value) value and the {{cssxref('font-weight')}} returned was `700` even though we use a [named color](/en-US/docs/Web/CSS/named-color) and the `bold` keyword.
 
 ### CSSUnitValue and CSSKeywordValue
 

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -20,7 +20,7 @@ The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/e
   - : Returns a new {{domxref('DOMMatrix')}} object.
 - {{domxref("CSSTransformComponent.toString()")}}
 
-  - : A string in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
+  - : A string in the form of a CSS [transform function](/en-US/docs/Web/CSS/transform-function).
 
     This will use the value of `is2D` to return either a 2D or 3D transform. For example if the component represents {{domxref("CSSRotate")}} and `is2D` is false then the string returned will be in the form of the CSS transformation [`rotate3D()`](/en-US/docs/Web/CSS/transform-function/rotate3d) function. If true the string returned will be in the form of the 2-dimensional [`rotate3D()`](/en-US/docs/Web/CSS/transform-function/rotate) function.
 

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A string in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
+A string in the form of a CSS [transform function](/en-US/docs/Web/CSS/transform-function).
 
 This will use the value of `is2D` to return either a 2D or 3D transform. For example if the component represents {{domxref("CSSRotate")}} and `is2D` is false then the string returned will be in the form of the CSS transformation [`rotate3D()`](/en-US/docs/Web/CSS/transform-function/rotate3d) function. If true the string returned will be in the form of the 2-dimensional [`rotate3D()`](/en-US/docs/Web/CSS/transform-function/rotate) function.
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -9,7 +9,7 @@ browser-compat: api.DataTransfer.clearData
 {{APIRef("HTML Drag and Drop API")}}
 
 The **`DataTransfer.clearData()`** method removes the drag
-operation's {{domxref("DataTransfer","drag data")}} for the given type. If data for the
+operation's [drag data](/en-US/docs/Web/API/DataTransfer) for the given type. If data for the
 given type does not exist, this method does nothing.
 
 If this method is called with no arguments or the format is an empty

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -8,7 +8,7 @@ browser-compat: api.DataTransfer.files
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`files`** read-only property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects is a {{domxref("FileList","list of the files")}} in the drag operation. If the operation includes no files, the list is empty.
+The **`files`** read-only property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects is a [list of the files](/en-US/docs/Web/API/FileList) in the drag operation. If the operation includes no files, the list is empty.
 
 This feature can be used to drag files from a user's desktop to the browser.
 

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -9,7 +9,7 @@ browser-compat: api.DataTransfer.setData
 {{APIRef("HTML Drag and Drop API")}}
 
 The **`DataTransfer.setData()`** method sets the drag
-operation's {{domxref("DataTransfer","drag data")}} to the specified data and type. If
+operation's [drag data](/en-US/docs/Web/API/DataTransfer) to the specified data and type. If
 data for the given type does not exist, it is added at the end of the drag data store,
 such that the last item in the {{domxref("DataTransfer.types","types")}} list will be
 the new type. If data for the given type already exists, the existing data is replaced
@@ -28,11 +28,9 @@ setData(format, data)
 ### Parameters
 
 - `format`
-  - : A string representing the type of the drag data to add to the
-    {{domxref("DataTransfer","drag object")}}.
+  - : A string representing the type of the drag data to add to the {{domxref("DataTransfer")}}.
 - `data`
-  - : A string representing the data to add to the
-    {{domxref("DataTransfer","drag object")}}.
+  - : A string representing the data to add to the {{domxref("DataTransfer")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/datatransferitem/getasstring/index.md
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.md
@@ -21,7 +21,7 @@ getAsString(callbackFn)
 - `callbackFn`
   - : A callback function that receives following arguments:
     - `data`
-      - : The {{domxref("DataTransferItem", "data transfer item's")}} string data.
+      - : The {{domxref("DataTransferItem")}}'s string data.
 
 ### Return value
 

--- a/files/en-us/web/api/datatransferitem/index.md
+++ b/files/en-us/web/api/datatransferitem/index.md
@@ -7,7 +7,7 @@ browser-compat: api.DataTransferItem
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransferItem`** object represents one drag data item. During a _drag operation_, each {{domxref("DragEvent","drag event")}} has a {{domxref("DragEvent.dataTransfer","dataTransfer")}} property which contains a {{domxref("DataTransferItemList","list")}} of drag data items. Each item in the list is a `DataTransferItem` object.
+The **`DataTransferItem`** object represents one drag data item. During a _drag operation_, each {{domxref("DragEvent")}} has a {{domxref("DragEvent.dataTransfer","dataTransfer")}} property which contains a {{domxref("DataTransferItemList","list")}} of drag data items. Each item in the list is a `DataTransferItem` object.
 
 `DataTransferItem` was primarily designed for the [HTML Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API), and is still specified in the HTML drag-and-drop section, but it is now also used by other APIs, such as {{domxref("ClipboardEvent.clipboardData")}} and {{domxref("InputEvent.dataTransfer")}}. Documentation of `DataTransferItem` will primarily discuss its usage in drag-and-drop operations, and you should refer to the other APIs' documentation for usage of `DataTransferItem` in those contexts.
 

--- a/files/en-us/web/api/document/afterscriptexecute_event/index.md
+++ b/files/en-us/web/api/document/afterscriptexecute_event/index.md
@@ -50,5 +50,5 @@ Not part of any specification.
 
 ## See also
 
-- {{domxref("Document.beforescriptexecute_event")}}
+- {{domxref("Document.beforescriptexecute_event", "beforescriptexecute")}} event of `Document`
 - {{domxref("Document.currentScript")}}

--- a/files/en-us/web/api/document/beforescriptexecute_event/index.md
+++ b/files/en-us/web/api/document/beforescriptexecute_event/index.md
@@ -50,5 +50,5 @@ Not part of any specification.
 
 ## See also
 
-- {{domxref("Document.afterscriptexecute_event")}}
+- {{domxref("Document.afterscriptexecute_event", "afterscriptexecute")}} event of `Document`
 - {{domxref("Document.currentScript")}}

--- a/files/en-us/web/api/document/currentscript/index.md
+++ b/files/en-us/web/api/document/currentscript/index.md
@@ -44,5 +44,5 @@ if (document.currentScript.async) {
 
 - [`import.meta`](/en-US/docs/Web/JavaScript/Reference/Operators/import.meta)
 - {{HTMLElement("script")}}
-- {{DOMxRef("document.afterscriptexecute_event")}}
-- {{DOMxRef("document.beforescriptexecute_event")}}
+- {{DOMxRef("document.afterscriptexecute_event", "afterscriptexecute")}} event of `Document`
+- {{DOMxRef("document.beforescriptexecute_event", "beforescriptexecute")}} event of `Document`

--- a/files/en-us/web/api/document/domain/index.md
+++ b/files/en-us/web/api/document/domain/index.md
@@ -141,7 +141,7 @@ modern isolation features:
 Finally, setting `document.domain` does not change the origin used for
 origin-checks by some Web APIs, preventing sub-domain access via this mechanism.
 Affected APIs include (but are not limited to):
-{{domxref("Window.localStorage")}}, {{domxref("IndexedDB_API")}}, {{domxref("BroadcastChannel")}}, {{domxref("SharedWorker")}} .
+{{domxref("Window.localStorage")}}, [IndexDB API](/en-US/docs/Web/API/IndexedDB_API), {{domxref("BroadcastChannel")}}, {{domxref("SharedWorker")}} .
 
 ## Specifications
 

--- a/files/en-us/web/api/document/scroll_event/index.md
+++ b/files/en-us/web/api/document/scroll_event/index.md
@@ -9,8 +9,8 @@ browser-compat: api.Document.scroll_event
 {{APIRef}}
 
 The **`scroll`** event fires when the document view has been scrolled.
-To detect when scrolling has completed, see the {{domxref("Document/scrollend_event", "Document: scrollend event")}}.
-For element scrolling, see {{domxref("Element/scroll_event", "Element: scroll event")}}.
+To detect when scrolling has completed, see the {{domxref("Document/scrollend_event", "scrollend")}} event of `Document`.
+For element scrolling, see {{domxref("Element/scroll_event", "scroll")}} event of `Element`.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/scrollend_event/index.md
+++ b/files/en-us/web/api/document/scrollend_event/index.md
@@ -15,7 +15,7 @@ Scroll position updates include smooth or instant mouse wheel scrolling, keyboar
 User gestures like touch panning or trackpad scrolling aren't complete until pointers or keys have released.
 If the scroll position did not change, then no scrollend event fires.
 
-For detecting when scrolling inside an element is complete, see {{domxref("Element/scrollend_event", "Element: scrollend event")}}.
+For detecting when scrolling inside an element is complete, see the {{domxref("Element/scrollend_event", "scrollend")}} event of `Element`.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -14,7 +14,7 @@ This event is not cancelable and does not bubble.
 
 The event can be handled by adding an event listener for `selectionchange` or using the `onselectionchange` event handler.
 
-> **Note:** This event is not quite the same as the `selectionchange` events fired when the text selection in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is changed. See {{domxref("HTMLInputElement.selectionchange_event")}} for more details.
+> **Note:** This event is not quite the same as the `selectionchange` events fired when the text selection in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is changed. See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` for more details.
 
 ## Syntax
 

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -95,7 +95,7 @@ _This interface doesn't inherit any methods. None of the following methods alter
 - {{domxref("DOMMatrixReadOnly.fromFloat64Array", "fromFloat64Array()")}}
   - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrixReadOnly.fromMatrix", "fromMatrix()")}}
-  - : Creates a new mutable `DOMMatrix` object given an existing matrix or a {{domxref("DOMMatrixInit")}} dictionary which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
+  - : Creates a new mutable `DOMMatrix` object given an existing matrix or an object which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
 
 ## Specifications
 

--- a/files/en-us/web/api/dompoint/frompoint_static/index.md
+++ b/files/en-us/web/api/dompoint/frompoint_static/index.md
@@ -8,12 +8,10 @@ browser-compat: api.DOMPoint.fromPoint_static
 
 {{APIRef("DOM")}}
 
-The **{{domxref("DOMPoint")}}** static method
-`fromPoint()` creates and returns a new mutable `DOMPoint`
-object given a source point.
+The **`fromPoint()`** static method of the {{domxref("DOMPoint")}} interface creates and returns a new mutable `DOMPoint` object given a source point.
 
 You can also create a new `DOMPoint` object using the
-{{domxref("DOMPoint.DOMPoint", "new DOMPoint()")}} constructor.
+{{domxref("DOMPoint.DOMPoint", "DOMPoint()")}} constructor.
 
 Although this interface is based on `DOMPointReadOnly`, it is not read-only;
 the properties within may be changed at will.

--- a/files/en-us/web/api/dompointreadonly/frompoint_static/index.md
+++ b/files/en-us/web/api/dompointreadonly/frompoint_static/index.md
@@ -13,7 +13,7 @@ method `fromPoint()` creates and returns a new
 `DOMPointReadOnly` object given a source point.
 
 You can also create a new `DOMPointReadOnly` object using the
-{{domxref("DOMPointReadOnly.DOMPointReadOnly", "new DOMPointReadOnly()")}} constructor.
+{{domxref("DOMPointReadOnly.DOMPointReadOnly", "DOMPointReadOnly()")}} constructor.
 
 ## Syntax
 
@@ -57,7 +57,7 @@ const point2D = DOMPointReadOnly.fromPoint({ x: 25, y: 25 });
 ### Creating a 3D point using an existing point
 
 This example creates a point, `origPoint`, of type
-{{domxref("DOMPoint")}}, using {{domxref("DOMPoint.DOMPoint", "new DOMPoint()")}}. That
+{{domxref("DOMPoint")}}, using {{domxref("DOMPoint.DOMPoint", "DOMPoint()")}}. That
 point is then used as the input for `fromPoint()` to create a new point,
 `newPoint`.
 

--- a/files/en-us/web/api/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.DragEvent
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DragEvent`** interface is a {{domxref("Event","DOM event")}} that represents a drag and drop interaction. The user initiates a drag by placing a pointer device (such as a mouse) on the touch surface and then dragging the pointer to a new location (such as another DOM element). Applications are free to interpret a drag and drop interaction in an application-specific way.
+The **`DragEvent`** interface is a [DOM event](/en-US/docs/Web/API/Event) that represents a drag and drop interaction. The user initiates a drag by placing a pointer device (such as a mouse) on the touch surface and then dragging the pointer to a new location (such as another DOM element). Applications are free to interpret a drag and drop interaction in an application-specific way.
 
 This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref("Event")}}.
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -244,7 +244,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.querySelectorAll()")}}
   - : Returns a {{DOMxRef("NodeList")}} of nodes which match the specified selector string relative to the element.
 - {{DOMxRef("Element.releasePointerCapture()")}}
-  - : Releases (stops) pointer capture that was previously set for a specific {{DOMxRef("PointerEvent","pointer event")}}.
+  - : Releases (stops) pointer capture that was previously set for a specific {{DOMxRef("PointerEvent")}}.
 - {{DOMxRef("Element.remove()")}}
   - : Removes the element from the children list of its parent.
 - {{DOMxRef("Element.removeAttribute()")}}

--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -97,4 +97,4 @@ slider.onpointerup = stopSliding;
 
 - {{ domxref("Element.hasPointerCapture","Element.hasPointerCapture()") }}
 - {{ domxref("Element.setPointerCapture","Element.setPointerCapture()") }}
-- {{ domxref("Pointer_events","Pointer Events") }}
+- [Pointer events](/en-US/docs/Web/API/Pointer_events)

--- a/files/en-us/web/api/file_system_api/origin_private_file_system/index.md
+++ b/files/en-us/web/api/file_system_api/origin_private_file_system/index.md
@@ -100,7 +100,7 @@ await (await navigator.storage.getDirectory()).remove({ recursive: true });
 
 ### Listing the contents of a folder
 
-{{domxref("FileSystemDirectoryHandle")}} is an [asynchronous iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols). As such, you can iterate over it with a [`for await…of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop and standard methods such as [`entries()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries), [`values()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries), and [`keys()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries).
+{{domxref("FileSystemDirectoryHandle")}} is an [asynchronous iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols). As such, you can iterate over it with a [`for await...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loop and standard methods such as [`entries()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries), [`values()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries), and [`keys()`](/en-US/docs/Web/API/FileSystemDirectoryHandle/entries).
 
 For example:
 

--- a/files/en-us/web/api/hiddevice/collections/index.md
+++ b/files/en-us/web/api/hiddevice/collections/index.md
@@ -42,9 +42,9 @@ An array of report formats. Each entry contains the following:
       - : Usage switch
     - `0x06`
       - : Usage modified
-    - `0x07 to 0x7F`
+    - `0x07` to `0x7F`
       - : Reserved for future use
-    - `0x80 to 0xFF`
+    - `0x80` to `0xFF`
       - : Vendor-defined
 
     More information on these types can be found in the [Device Class Definition](https://www.usb.org/document-library/device-class-definition-hid-111) document.

--- a/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -213,7 +213,7 @@ function takepicture() {
 }
 ```
 
-As is the case any time we need to work with the contents of a canvas, we start by getting the {{domxref("CanvasRenderingContext2D","2D drawing context")}} for the hidden canvas.
+As is the case any time we need to work with the contents of a canvas, we start by getting the [2D drawing context](/en-US/docs/Web/API/CanvasRenderingContext2D) for the hidden canvas.
 
 Then, if the width and height are both non-zero (meaning that there's at least potentially valid image data), we set the width and height of the canvas to match that of the captured frame, then call {{domxref("CanvasRenderingContext2D.drawImage()", "drawImage()")}} to draw the current frame of the video into the context, filling the entire canvas with the frame image.
 

--- a/files/en-us/web/api/payment_handler_api/index.md
+++ b/files/en-us/web/api/payment_handler_api/index.md
@@ -147,7 +147,7 @@ async function checkCanMakePayment() {
 }
 ```
 
-The Payment Handler API adds an additional mechanism to prepare for handling a payment. The {{domxref("ServiceWorkerGlobalScope.canmakepayment_event", "canmakepayment")}} event is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}. The service worker can then use the {{domxref("CanMakePaymentEvent.respondWith()")}} method to respond appropriately:
+The Payment Handler API adds an additional mechanism to prepare for handling a payment. The {{domxref("ServiceWorkerGlobalScope.canmakepayment_event", "canmakepayment")}} event is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls the {{domxref("PaymentRequest.PaymentRequest", "PaymentRequest()")}} constructor. The service worker can then use the {{domxref("CanMakePaymentEvent.respondWith()")}} method to respond appropriately:
 
 ```js
 self.addEventListener("canmakepayment", (e) => {

--- a/files/en-us/web/api/positionsensorvrdevice/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/index.md
@@ -32,7 +32,7 @@ _This interface doesn't define any properties of its own, but it does inherit th
 
 ## Examples
 
-The following example uses the WebVR API to update the view of a simple {{domxref("CanvasRenderingContext2D","2D canvas")}} scene on each frame of a {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} loop.
+The following example uses the WebVR API to update the view of a simple [2D canvas](/en-US/docs/Web/API/CanvasRenderingContext2D) scene on each frame of a {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} loop.
 
 ```js
 function setView() {

--- a/files/en-us/web/api/response/redirect_static/index.md
+++ b/files/en-us/web/api/response/redirect_static/index.md
@@ -26,7 +26,7 @@ Response.redirect(url, status)
 - `url`
   - : The URL that the new response is to originate from.
 - `status` {{optional_inline}}
-  - : An optional number indicating the status code for the response: one of {{HTTPStatus("301", "301")}}, {{HTTPStatus("302", "302")}}, {{HTTPStatus("303", "303")}}, {{HTTPStatus("307", "307")}}, or {{HTTPStatus("308", "308")}}. If omitted, {{HTTPStatus("302", "302 (Found)")}} is used by default.
+  - : An optional number indicating the status code for the response: one of {{HTTPStatus("301", "301")}}, {{HTTPStatus("302", "302")}}, {{HTTPStatus("303", "303")}}, {{HTTPStatus("307", "307")}}, or {{HTTPStatus("308", "308")}}. If omitted, {{HTTPStatus("302", "302 Found")}} is used by default.
 
 ### Return value
 

--- a/files/en-us/web/api/serviceworkerglobalscope/canmakepayment_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/canmakepayment_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ServiceWorkerGlobalScope.canmakepayment_event
 
 {{APIRef("Payment Handler API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers("service")}}
 
-The **`canmakepayment`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}.
+The **`canmakepayment`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls the {{domxref("PaymentRequest.PaymentRequest", "PaymentRequest()")}} constructor.
 
 ## Syntax
 
@@ -30,7 +30,7 @@ A {{domxref("CanMakePaymentEvent")}}. Inherits from {{domxref("ExtendableEvent")
 
 ## Examples
 
-The `canmakepayment` event is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}. The service worker can then use the {{domxref("CanMakePaymentEvent.respondWith()")}} method to respond appropriately:
+The `canmakepayment` event is fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls the {{domxref("PaymentRequest.PaymentRequest", "PaymentRequest()")}} constructor. The service worker can then use the {{domxref("CanMakePaymentEvent.respondWith()")}} method to respond appropriately:
 
 ```js
 self.addEventListener("canmakepayment", (e) => {

--- a/files/en-us/web/api/serviceworkerglobalscope/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/index.md
@@ -54,7 +54,7 @@ Listen to this event using {{domxref("EventTarget/addEventListener()", "addEvent
 - {{domxref("ServiceWorkerGlobalScope/backgroundfetchsuccess_event", "backgroundfetchsuccess")}} {{Experimental_Inline}}
   - : Fired when all of the requests in a [background fetch](/en-US/docs/Web/API/Background_Fetch_API) operation have succeeded.
 - {{domxref("ServiceWorkerGlobalScope/canmakepayment_event", "canmakepayment")}} {{Experimental_Inline}}
-  - : Fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls {{domxref("PaymentRequest.PaymentRequest", "new PaymentRequest()")}}.
+  - : Fired on a payment app's service worker to check whether it is ready to handle a payment. Specifically, it is fired when the merchant website calls the {{domxref("PaymentRequest.PaymentRequest", "PaymentRequest()")}} constructor.
 - {{domxref("ServiceWorkerGlobalScope/contentdelete_event", "contentdelete")}} {{Experimental_Inline}}
   - : Occurs when an item is removed from the {{domxref("ContentIndex", "Content Index")}}.
 - {{domxref("ServiceWorkerGlobalScope/cookiechange_event", "cookiechange")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/speculation_rules_api/index.md
+++ b/files/en-us/web/api/speculation_rules_api/index.md
@@ -23,7 +23,7 @@ The Speculation Rules API provides an alternative to the widely-available [`<lin
 
 ## Concepts and usage
 
-Speculation rules can be specified inside inline [`<script type="speculationrules"> ... </script>`](/en-US/docs/Web/HTML/Element/script/type/speculationrules) elements and external text files referenced by the {{httpheader("Speculation-Rules")}} response header. The rules are specified as a JSON structure.
+Speculation rules can be specified inside inline [`<script type="speculationrules">`](/en-US/docs/Web/HTML/Element/script/type/speculationrules) elements and external text files referenced by the {{httpheader("Speculation-Rules")}} response header. The rules are specified as a JSON structure.
 
 A script example:
 
@@ -418,7 +418,7 @@ The Speculation Rules API does not define any interfaces of its own.
 
 ## HTML features
 
-- [`<script type="speculationrules"> ... </script>`](/en-US/docs/Web/HTML/Element/script/type/speculationrules) {{experimental_inline}}
+- [`<script type="speculationrules">`](/en-US/docs/Web/HTML/Element/script/type/speculationrules) {{experimental_inline}}
   - : Used to define a set of prefetch and/or prerender speculation rules inside the current document, which are added to the document's speculation rule set.
 
 ## Examples

--- a/files/en-us/web/api/taskattributiontiming/containername/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.md
@@ -15,7 +15,7 @@ attribute. A container is the iframe, embed or object etc. that is being implica
 
 ## Value
 
-A string containing the container's `name` HTML content attribute (e.g. [`<iframe name="myIframe"`](/en-US/docs/Web/HTML/Element/iframe#name) or [`<object name="myObject"`](/en-US/docs/Web/HTML/Element/object#name)).
+A string containing the container's `name` HTML content attribute (e.g. [`<iframe name="myIframe">`](/en-US/docs/Web/HTML/Element/iframe#name) or [`<object name="myObject">`](/en-US/docs/Web/HTML/Element/object#name)).
 
 ## Specifications
 

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.md
@@ -15,7 +15,7 @@ attribute. A container is the iframe, embed or object etc. that is being implica
 
 ## Value
 
-A string containing the container's `src` attribute (e.g. [`<iframe src="url.html"`](/en-US/docs/Web/HTML/Element/iframe#src)).
+A string containing the container's `src` attribute (e.g. [`<iframe src="url.html">`](/en-US/docs/Web/HTML/Element/iframe#src)).
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/catch/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Promise.catch
 
 {{JSRef}}
 
-The **`catch()`** method of {{jsxref("Promise")}} instances schedules a function to be called when the promise is rejected. It immediately returns another {{jsxref("Promise")}} object, allowing you to [chain](/en-US/docs/Web/JavaScript/Guide/Using_promises#chaining) calls to other promise methods. It is a shortcut for {{jsxref("Promise/then", "Promise.prototype.then(undefined, onRejected)")}}.
+The **`catch()`** method of {{jsxref("Promise")}} instances schedules a function to be called when the promise is rejected. It immediately returns another {{jsxref("Promise")}} object, allowing you to [chain](/en-US/docs/Web/JavaScript/Guide/Using_promises#chaining) calls to other promise methods. It is a shortcut for {{jsxref("Promise/then", "then(undefined, onRejected)")}}.
 
 {{EmbedInteractiveExample("pages/js/promise-catch.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/input/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/input/index.md
@@ -43,7 +43,7 @@ RegExp.$_; // "hi world!"
 
 ## See also
 
-- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- [`RegExp.lastMatch` (`$&`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch)
 - [`RegExp.lastParen` (`$+`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastParen)
 - [`RegExp.leftContext` (`` $` ``)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/leftContext)
 - [`RegExp.rightContext` (`$'`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/lastparen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/lastparen/index.md
@@ -43,7 +43,7 @@ RegExp["$+"]; // "hi"
 ## See also
 
 - [`RegExp.input` (`$_`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/input)
-- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- [`RegExp.lastMatch` (`$&`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch)
 - [`RegExp.leftContext` (`` $` ``)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/leftContext)
 - [`RegExp.rightContext` (`$'`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext)
 - [`RegExp.$1`, …, `RegExp.$9`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/leftcontext/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/leftcontext/index.md
@@ -45,7 +45,7 @@ RegExp["$`"]; // "hello "
 ## See also
 
 - [`RegExp.input` (`$_`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/input)
-- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- [`RegExp.lastMatch` (`$&`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch)
 - [`RegExp.lastParen` (`$+`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastParen)
 - [`RegExp.rightContext` (`$'`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext)
 - [`RegExp.$1`, …, `RegExp.$9`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/n/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/n/index.md
@@ -48,7 +48,7 @@ Please note that any operation involving the usage of other regular expressions 
 ## See also
 
 - [`RegExp.input` (`$_`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/input)
-- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- [`RegExp.lastMatch` (`$&`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch)
 - [`RegExp.lastParen` (`$+`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastParen)
 - [`RegExp.leftContext` (`` $` ``)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/leftContext)
 - [`RegExp.rightContext` (`$'`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/rightcontext/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/rightcontext/index.md
@@ -45,7 +45,7 @@ RegExp["$'"]; // " world!"
 ## See also
 
 - [`RegExp.input` (`$_`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/input)
-- {{jsxref("RegExp/lastMatch", "RegExp.lastMatch ($&amp;)")}}
+- [`RegExp.lastMatch` (`$&`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch)
 - [`RegExp.lastParen` (`$+`)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastParen)
 - [`RegExp.leftContext` (`` $` ``)](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/leftContext)
 - [`RegExp.$1`, …, `RegExp.$9`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n)


### PR DESCRIPTION
Fix wrong macro usage that results in non-code-entities being code formatted.