### PR TITLE
Convert noteblocks for mdn folder

### DIFF
--- a/files/en-us/mdn/community/issues/index.md
+++ b/files/en-us/mdn/community/issues/index.md
@@ -125,7 +125,8 @@ If the bug is small, such as a typo or a minor sentence improvement, or involves
 For all other type of bugs, begin by [opening the issue](#guidelines_for_reporting_an_issue). Add a comment about your intent to work on the issue and if possible, describe your proposed solution or steps to fix the issue.
 Wait for the issue to be triaged, so that the MDN Web Docs team can verify that the issue is legit and approves your proposed solution.
 
-> **Note:** If you open a pull request before the issue has been triaged, your time and effort might go waste if the linked issue is deemed invalid or the solution does not match the one expected by the MDN Web Docs team.
+> [!NOTE]
+> If you open a pull request before the issue has been triaged, your time and effort might go waste if the linked issue is deemed invalid or the solution does not match the one expected by the MDN Web Docs team.
 > After the issue is triaged, assign the issue to yourself.
 
 Using the [guidelines on working on an issue](#guidelines_for_working_on_an_issue), try to fix the problem by updating the appropriate source, such as:

--- a/files/en-us/mdn/community/learn_forum/index.md
+++ b/files/en-us/mdn/community/learn_forum/index.md
@@ -34,4 +34,5 @@ If the post you are replying to is a general ask for help, reply to them, and gi
 
 If you need assistance with anything, ask for help in one of our [Communication channels](/en-US/docs/MDN/Community/Communication_channels).
 
-> **Note:** Important: Above all, be patient, be friendly, be kind. Remember — most of these folks are beginners.
+> [!NOTE]
+> Important: Above all, be patient, be friendly, be kind. Remember — most of these folks are beginners.

--- a/files/en-us/mdn/community/roles_teams/index.md
+++ b/files/en-us/mdn/community/roles_teams/index.md
@@ -110,7 +110,8 @@ To be eligible to be a maintainer, you must meet one or more of the following re
 - Consented to commit spending at least 16 hours per month working on the project.
 - Attended the community meeting that takes place once every two months.
 
-> **Note:** If there is someone you think is eligible for this role, you may [nominate a maintainer](#nominating_a_maintainer).
+> [!NOTE]
+> If there is someone you think is eligible for this role, you may [nominate a maintainer](#nominating_a_maintainer).
 
 **Privileges:**
 
@@ -121,7 +122,8 @@ Maintainers have the permissions to approve and merge pull requests.
 Owners have wide permissions to manage users and [GitHub teams](https://github.com/orgs/mdn/teams), maintain access across repositories in the [MDN organization](https://github.com/mdn), maintain repository settings, and deploy to production.
 Owners are bound by all the requirements of other contributor roles.
 
-> **Note:** The role of an owner is currently limited to Mozilla staff.
+> [!NOTE]
+> The role of an owner is currently limited to Mozilla staff.
 
 **Requirements:**
 

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -5,7 +5,8 @@ page-type: guide
 browser-compat: html.elements.video
 ---
 
-> **Warning:** Don't delete this page. It's used by [mdn/yari](https://github.com/mdn/yari) for its automation.
+> [!WARNING]
+> Don't delete this page. It's used by [mdn/yari](https://github.com/mdn/yari) for its automation.
 
 ## About this page
 
@@ -16,9 +17,11 @@ Let's start with some notes…
 
 Text that uses the `<kbd>` tag: <kbd>Shift</kbd>
 
-> **Note:** Here's a block indicator note.
+> [!NOTE]
+> Here's a block indicator note.
 
-> **Warning:** Here's a block indicator warning.
+> [!WARNING]
+> Here's a block indicator warning.
 
 ## Prev/Next buttons
 

--- a/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -14,7 +14,8 @@ This section covers the types of content we provide and the copyrights and licen
 
 ### Documentation
 
-> **Note:** The content on MDN Web Docs has been prepared with the contributions of authors from both inside and outside Mozilla. Unless otherwise indicated, the content is available under the terms of the [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA), v2.5 or any later version.
+> [!NOTE]
+> The content on MDN Web Docs has been prepared with the contributions of authors from both inside and outside Mozilla. Unless otherwise indicated, the content is available under the terms of the [Creative Commons Attribution-ShareAlike license](https://creativecommons.org/licenses/by-sa/2.5/) (CC-BY-SA), v2.5 or any later version.
 
 Your reuse of the content here is published under the same license as the original content—CC-BY-SA v2.5 or any later version. When reusing the content on MDN Web Docs, you need to ensure that attribution is given to the original content as well as to "Mozilla Contributors". Include a hyperlink (online) or URL (in print) to the specific page of the content being sourced. For example, to provide attribution for _this_ article, you can write:
 
@@ -34,7 +35,8 @@ Since the launch of the new Yari MDN platform on December 14 2020, there is curr
 
 If you wish to contribute to MDN Web Docs, you agree that your documentation is available under the Attribution-ShareAlike license (or occasionally an alternative license already specified by the page you are editing) and that your code samples are available under [Creative Commons CC-0](https://creativecommons.org/publicdomain/zero/1.0/) (a Public Domain dedication).
 
-> **Warning:** No new pages may be created using alternate licenses.
+> [!WARNING]
+> No new pages may be created using alternate licenses.
 
 **Copyright for contributed materials remains with the author unless the author assigns it to someone else.**
 
@@ -52,7 +54,8 @@ If we receive a pull request and discover that it contains plagiarized content, 
 
 ### If you want to reuse or republish content
 
-> **Note:** Unless there is a good reason to republish the content, we will probably say "no".
+> [!NOTE]
+> Unless there is a good reason to republish the content, we will probably say "no".
 > The MDN writing team's decision is final.
 
 If someone wants to donate an article to MDN that they previously published on their blog or it makes sense to copy a complex reference sheet to MDN, there may be justification for republishing it. For these cases, discuss your plan with the MDN team beforehand:

--- a/files/en-us/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
+++ b/files/en-us/mdn/writing_guidelines/experimental_deprecated_obsolete/index.md
@@ -20,7 +20,8 @@ For a technology marked **experimental**, one or more of the following condition
 - It is only supported through configuration changes such as preferences or flags, regardless of the number of supported rendering engines.
 - Its defining specification is likely to change significantly in backwards-incompatible ways (i.e., it may break existing code that relies on the feature).
 
-> **Note:** A feature released only on one rendering engine is still considered experimental even if it is available on preview builds of other rendering engines (or by setting a preference or flag).
+> [!NOTE]
+> A feature released only on one rendering engine is still considered experimental even if it is available on preview builds of other rendering engines (or by setting a preference or flag).
 
 The **experimental** status of a technology may expire if one or more of the following conditions is met:
 
@@ -46,7 +47,8 @@ For more information on the definition of **deprecated**, see the [deprecated fl
 On MDN Web Docs, the term **obsolete** was historically used to indicate an API or technology that is not only no longer recommended but is also no longer implemented in browsers.
 Because the distinction between **obsolete** and **deprecated** is not very helpful, we do not use the term **obsolete** on MDN Web Docs anymore.
 
-> **Note:** If you come across any instance of **obsolete**, it should be removed or replaced with the term **deprecated**.
+> [!NOTE]
+> If you come across any instance of **obsolete**, it should be removed or replaced with the term **deprecated**.
 
 ## Guidelines for removing content
 
@@ -54,7 +56,8 @@ Sometimes during the development of a new specification or over the course of th
 
 Here are some guidelines to help you decide what to do when something is removed from the specification.
 
-> **Note:** For the purposes of this discussion, the word "item" is used to mean anything that can be part of a specification: an element or an attribute of an element, an interface or any individual method, a property, or other member of an interface, and so forth.
+> [!NOTE]
+> For the purposes of this discussion, the word "item" is used to mean anything that can be part of a specification: an element or an attribute of an element, an interface or any individual method, a property, or other member of an interface, and so forth.
 
 ### If the item was never implemented
 
@@ -100,7 +103,8 @@ Sometimes, but rarely, there might be a conflict between different specification
 In such cases, consider what the reality is, that is, consider what browsers are actually doing, and write an "important" note to summarize that latest status.
 For example, as of Jan 2019, the [`inputmode`](/en-US/docs/Web/HTML/Global_attributes/inputmode) global attribute has a conflict, which was summarized like so: <!--this warning example for spec conflict does not exist anymore on that page. couldn't find any other examples as well -->
 
-> **Warning:** Specification conflict: The WHATWG specification lists [`inputmode`](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode) and modern browsers are working towards supporting it.
+> [!WARNING]
+> Specification conflict: The WHATWG specification lists [`inputmode`](https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode) and modern browsers are working towards supporting it.
 > The [W3C HTML 5.2 spec](https://html.spec.whatwg.org/multipage/index.html#contents), however, no longer lists it (i.e. marks it as obsolete).
 > You should consider the WHATWG definition as correct, until a consensus is reached.
 

--- a/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -12,7 +12,8 @@ This article describes how to create, move, delete, or edit a page. In all these
 
 All pages on MDN Web Docs are authored in Markdown format. The content is written in a file named `index.md`, which is stored in its own unique directory. The directory name represents the name of the page. For example, if `align-content` is a new CSS property for which you want to create a new reference page, you'd create a folder in `en-us/web/css` named `align-content` and create a file called `index.md` inside it.
 
-> **Note:** The name of the directory differs slightly from the slug of the page. Most notably, the slug follows sentence casing.
+> [!NOTE]
+> The name of the directory differs slightly from the slug of the page. Most notably, the slug follows sentence casing.
 
 There are a lot of different [page types](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types) with certain structures and supporting page templates for them, which you can copy to get you started.
 
@@ -99,7 +100,7 @@ For example, let's say you want to move the entire
 
 5. Create your pull request.
 
-> **Note:** `yarn content move` automatically adds the necessary redirect information to the `_redirects.txt` file so that the old location will redirect to the new one. Don't edit the `_redirects.txt` file manually! Mistakes can easily creep in if you do. If you need to add a redirect without moving a file, talk to the MDN Web Docs team on the [MDN Web Docs chat rooms](/en-US/docs/MDN/Community/Communication_channels#chat_rooms) about it.
+> [!NOTE] > `yarn content move` automatically adds the necessary redirect information to the `_redirects.txt` file so that the old location will redirect to the new one. Don't edit the `_redirects.txt` file manually! Mistakes can easily creep in if you do. If you need to add a redirect without moving a file, talk to the MDN Web Docs team on the [MDN Web Docs chat rooms](/en-US/docs/MDN/Community/Communication_channels#chat_rooms) about it.
 
 ## Deleting pages
 
@@ -112,7 +113,8 @@ details for you:
 yarn content delete <document-slug> [locale]
 ```
 
-> **Note:** You need to use the `yarn content delete` command to delete pages from MDN Web Docs. Don't just delete their directories from the repo. The `yarn content delete` command also handles other necessary changes such as updating the `_wikihistory.json` file.
+> [!NOTE]
+> You need to use the `yarn content delete` command to delete pages from MDN Web Docs. Don't just delete their directories from the repo. The `yarn content delete` command also handles other necessary changes such as updating the `_wikihistory.json` file.
 
 You just have to specify the slug of the existing document that you'd like
 to delete (e.g., `Learn/Accessibility`), optionally followed by the locale
@@ -158,7 +160,8 @@ entire `/en-US/Learn/Accessibility` tree, you'd perform the following steps:
 
 5. Create your pull request.
 
-> **Note:** If the slug of the page you wish to delete contains special characters, include it in quotes, like so:
+> [!NOTE]
+> If the slug of the page you wish to delete contains special characters, include it in quotes, like so:
 >
 > ```bash
 > yarn content delete "Mozilla/Add-ons/WebExtensions/Debugging_(before_Firefox_50)"

--- a/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -100,7 +100,7 @@ For example, let's say you want to move the entire
 
 5. Create your pull request.
 
-> [!NOTE] > `yarn content move` automatically adds the necessary redirect information to the `_redirects.txt` file so that the old location will redirect to the new one. Don't edit the `_redirects.txt` file manually! Mistakes can easily creep in if you do. If you need to add a redirect without moving a file, talk to the MDN Web Docs team on the [MDN Web Docs chat rooms](/en-US/docs/MDN/Community/Communication_channels#chat_rooms) about it.
+> **Note:** `yarn content move` automatically adds the necessary redirect information to the `_redirects.txt` file so that the old location will redirect to the new one. Don't edit the `_redirects.txt` file manually! Mistakes can easily creep in if you do. If you need to add a redirect without moving a file, talk to the MDN Web Docs team on the [MDN Web Docs chat rooms](/en-US/docs/MDN/Community/Communication_channels#chat_rooms) about it.
 
 ## Deleting pages
 

--- a/files/en-us/mdn/writing_guidelines/howto/document_a_css_property/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/document_a_css_property/index.md
@@ -14,7 +14,8 @@ Each CSS property reference page follows the same structure. This helps readers 
 
 First, you will need to find out the CSS property you want to document. You might have noticed that a page is missing, or you might have seen missing content reported in our [issues list](https://github.com/mdn/content/issues). For details about the CSS property, you will need to find a relevant specification for it (e.g., a [W3C specification](https://www.w3.org/Style/CSS/), or a bug report for a non-standard property used in rendering engines like Gecko or Blink).
 
-> **Note:** When using a W3C specification, always use the **Editor's Draft** (note the red banner on the left side) and not a published version (e.g., Working Draft). The Editor's Draft is always closer to the final version!
+> [!NOTE]
+> When using a W3C specification, always use the **Editor's Draft** (note the red banner on the left side) and not a published version (e.g., Working Draft). The Editor's Draft is always closer to the final version!
 
 If the implementation and specification diverge, feel free to mention it in the implementation bug. One of the following situations are possible:
 

--- a/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/images_media/index.md
@@ -123,7 +123,8 @@ There are several arguments against using video content for technical documentat
 - Video has accessibility problems: it's more expensive to produce generally than text, but especially to localize, or make usable by screen reader users.
 - Following on from the last point, video is much harder to edit/update/maintain than text content.
 
-> **Note:** It's worth keeping these problems in mind even when you are making videos, so you can try to alleviate some of them.
+> [!NOTE]
+> It's worth keeping these problems in mind even when you are making videos, so you can try to alleviate some of them.
 
 There are many popular video sites that provide a lot of video tutorials.
 MDN Web Docs isn't a video-driven site, but video does have a place on MDN Web Docs in certain contexts.
@@ -223,7 +224,8 @@ Plan carefully what you are actually going to record, and practice the steps a f
   Not everyone will be able to view your video in high definition.
   You will be able to zoom particular parts in post-production, but it's a good idea to zoom the app beforehand as well.
 
-> **Note:** Don't zoom so far that the UIs you are showing start to look unfamiliar or ugly.
+> [!NOTE]
+> Don't zoom so far that the UIs you are showing start to look unfamiliar or ugly.
 
 ### Recording
 
@@ -233,7 +235,8 @@ Make sure the mouse pointer doesn't obscure any icons or text that are important
 
 Remember to pause for a second or two at the end to show the result of the flow.
 
-> **Note:** If you are using a really simple tool like QuickTime Player and post production is not an option for some reason, you should get your windows set up in the right size to show the area you want to show. In the Firefox DevTools, you can use the [Rulers Tool](https://firefox-source-docs.mozilla.org/devtools-user/rulers/index.html) to make sure the viewport is at the right aspect ratio for the recording.
+> [!NOTE]
+> If you are using a really simple tool like QuickTime Player and post production is not an option for some reason, you should get your windows set up in the right size to show the area you want to show. In the Firefox DevTools, you can use the [Rulers Tool](https://firefox-source-docs.mozilla.org/devtools-user/rulers/index.html) to make sure the viewport is at the right aspect ratio for the recording.
 
 ### Post-processing
 
@@ -256,7 +259,8 @@ Crop the video to the desired aspect ratio, if required.
 Videos currently have to be uploaded to YouTube to be displayed on MDN Web Docs, for example, to the [mozhacks](https://www.youtube.com/user/mozhacks/videos) channel.
 Ask a member of MDN Web Docs team to upload the video if you don't have somewhere appropriate to put it.
 
-> **Note:** Mark the video as "unlisted" if it doesn't make sense out of the context of the page (if it's a short video, then it probably doesn't).
+> [!NOTE]
+> Mark the video as "unlisted" if it doesn't make sense out of the context of the page (if it's a short video, then it probably doesn't).
 
 ### Embedding
 

--- a/files/en-us/mdn/writing_guidelines/howto/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/index.md
@@ -8,6 +8,7 @@ page-type: mdn-writing-guide
 
 This section of MDN Web Docs writing guidelines contains all the step-by-step information for accomplishing specific tasks when contributing to MDN Web Docs: how we use markdown, how we add an entry to the glossary, how we move or delete pages, and more. To find out more about _how to contribute_ (which happens through GitHub), see our [contribution guidelines](/en-US/docs/MDN/Community/Contributing).
 
-> **Note:** All the way through this section, we assume that you've read the contribution guidelines, are familiar with the `mdn/content` repository, and know how to use git and GitHub.
+> [!NOTE]
+> All the way through this section, we assume that you've read the contribution guidelines, are familiar with the `mdn/content` repository, and know how to use git and GitHub.
 
 {{LandingPageListSubpages}}

--- a/files/en-us/mdn/writing_guidelines/howto/json_structured_data/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/json_structured_data/index.md
@@ -20,7 +20,8 @@ GroupData does exactly that: for each API, it lists the interfaces, properties, 
 
 ### Structure of GroupData
 
-> **Warning:** Non-existent pages listed in this file are ignored (in en-US).
+> [!WARNING]
+> Non-existent pages listed in this file are ignored (in en-US).
 
 An entry in `GroupData.json` has the following structure:
 
@@ -73,7 +74,8 @@ An entry in `GroupData.json` has the following structure:
 
 There are two other keys, `"dictionaries"` and `"callbacks"`, operating on the same principle. As we no longer document these entities in their own pages, their use is deprecated, and no new entry should be added to them (and we remove them little by little).
 
-> **Note:** Also, none of the keys are mandatory; it is good practice (and we'll enforce this) to add the non-deprecated ones with an empty list rather than omitting them. It shows that the absence of value is a conscious choice.
+> [!NOTE]
+> Also, none of the keys are mandatory; it is good practice (and we'll enforce this) to add the non-deprecated ones with an empty list rather than omitting them. It shows that the absence of value is a conscious choice.
 
 ### Update process for GroupData
 
@@ -85,7 +87,8 @@ The `GroupData.json` file is located [here](https://github.com/mdn/content/blob/
 
 ## InterfaceData: recording interface inheritance
 
-> **Note:** We hope to generate this file automatically from the data available via w3c/webref in the future.
+> [!NOTE]
+> We hope to generate this file automatically from the data available via w3c/webref in the future.
 
 `InterfaceData` describes the hierarchy of the interfaces. It lists inheritance. In the past, it also listed mixins implemented by each interface; but that usage is deprecated, and we remove mixins from this file at the same rate MDN is updated.
 
@@ -102,7 +105,8 @@ An entry in `InterfaceData.json` has the following structure:
 }
 ```
 
-> **Note:** As mixins are deprecated, `"impl"` must be an empty list for all new interfaces.
+> [!NOTE]
+> As mixins are deprecated, `"impl"` must be an empty list for all new interfaces.
 
 The value of `"Name_of_the_parent_interface"` is not a list but a single entry, mandatory; we must not list any interface that don't inherit from another one.
 
@@ -116,7 +120,8 @@ The `InterfaceData.json` file is located [here](https://github.com/mdn/content/b
 
 ## SpecData: Specification information
 
-> **Warning:** The `SpecData.json` file is no longer maintained. Canonical specification information is stored at w3c/browser-spec and in the `spec_url` key of features at mdn/browser-compat-data.
+> [!WARNING]
+> The `SpecData.json` file is no longer maintained. Canonical specification information is stored at w3c/browser-spec and in the `spec_url` key of features at mdn/browser-compat-data.
 
 The `\{{SpecName}}` and `\{{Spec2}}` macros that we are removing use the `SpecData.json` file. We do not accept any further contributions to the `SpecData.json` file; instead, either try to insert a specification table, using the `\{{Specifications}}` macro, or try to hardcode the (good) link to the specification. Note that most of the time, mentioning or linking to a specification outside the _Specifications_ section is a sign of something not appropriately documented on MDN.
 

--- a/files/en-us/mdn/writing_guidelines/howto/research_technology/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/research_technology/index.md
@@ -45,7 +45,8 @@ In addition, we have the [Information contained in a WebIDL file](/en-US/docs/MD
 
 You will return to writing code examples or building demos many times through the course of documenting a technology, but it is very useful to start by spending time familiarizing yourself with how the technology works. This is a really valuable exercise because it gives you a good understanding of what the use cases are (_why_ a developer would use this technology) and help with creating some code examples at the same time.
 
-> **Note:** If the specification has been recently updated so that, say, a method is now defined differently, but the old method still works in browsers, you will often have to document both in the same place so that the old and new methods are covered.
+> [!NOTE]
+> If the specification has been recently updated so that, say, a method is now defined differently, but the old method still works in browsers, you will often have to document both in the same place so that the old and new methods are covered.
 > If you need help, refer to demos you have found, or ask an engineering contact.
 
 ## Creating the list of pages to write or update

--- a/files/en-us/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_a_new_entry_in_the_glossary/index.md
@@ -30,7 +30,8 @@ The first paragraph of any glossary page is a simple and short description of th
 Preferably, this should be no more than two sentences.
 Make sure anyone reading the description can immediately understand the defined term.
 
-> **Note:** Please don't copy-and-paste from other definitions or content on the internet.
+> [!NOTE]
+> Please don't copy-and-paste from other definitions or content on the internet.
 > (And especially not Wikipedia, since its range of license versions is smaller and incompatible with MDN.) Your glossary entry should be original content.
 
 #### Writing a good glossary entry

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/index.md
@@ -46,7 +46,8 @@ You will return to build demos many times through the course of documenting an A
 
 When an API has changed, you need to be careful that existing demos you refer to or learn from are not out of date. Check the main constructs that are used in the demo to see if they match up to the latest spec. They may also not work in up-to-date browsers, but this is not a very reliable test, as often the old features continue to be supported for backwards compatibility.
 
-> **Note:** If the spec has been recently updated so that, say, a method is now defined differently, but the old method still works in browsers, you will often have to document both in the same place, so that the old and new methods are covered.
+> [!NOTE]
+> If the spec has been recently updated so that, say, a method is now defined differently, but the old method still works in browsers, you will often have to document both in the same place, so that the old and new methods are covered.
 > If you need help, refer to demos you have found, or ask an engineering contact.
 
 ### Create the list of documents you need to write or update
@@ -64,7 +65,8 @@ Before you start you should write down a list of all the pages you should create
 7. Concept/guide pages
 8. Examples
 
-> **Note:** We'll be referring to the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) for examples in this article.
+> [!NOTE]
+> We'll be referring to the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) for examples in this article.
 
 #### Overview pages
 
@@ -95,7 +97,8 @@ Examples:
 - Slug: _AudioNode_
 - URL: [https://developer.mozilla.org/en-US/docs/Web/API/AudioNode](/en-US/docs/Web/API/AudioNode)
 
-> **Note:** We document every member appearing in the interface. You should bear the following rules in mind:
+> [!NOTE]
+> We document every member appearing in the interface. You should bear the following rules in mind:
 
 - We document methods defined on the prototype of an object implementing this interface (instance methods), and methods defined on the actual class itself (static methods).
   On the rare occasions that they both exist on the same interface, you should list them in separate sections on the page (Static methods/Instance methods).

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -29,7 +29,8 @@ WebIDL is defined in [its specification](https://webidl.spec.whatwg.org/). But i
 - For Chromium, Google also created a [document](https://www.chromium.org/blink/webidl/) to describe its extensions.
 - For WebCore, Apple also made available a [page](https://trac.webkit.org/wiki/WebKitIDL) for its dialect.
 
-> **Note:** We describe here only the subset of WebIDL which is most useful when writing documentation. There are many more annotations useful for implementers; refer to the four documents linked above to have a complete overview.
+> [!NOTE]
+> We describe here only the subset of WebIDL which is most useful when writing documentation. There are many more annotations useful for implementers; refer to the four documents linked above to have a complete overview.
 
 ## Interfaces
 
@@ -171,7 +172,8 @@ Here, it is defined that when the global scope is of type `DedicatedWorkerGlobal
 
 ### Preferences
 
-> **Note:** this information is specific to Gecko and should only be used in the Browser compatibility section.
+> [!NOTE]
+> this information is specific to Gecko and should only be used in the Browser compatibility section.
 
 In Gecko, the availability of a partial interface, including its constructor, properties and methods may be controlled by a preference (usually called a "pref"). This is marked in the WebIDL too.
 
@@ -186,7 +188,8 @@ interface SpeechSynthesis {
 
 Here `media.webspeech.synth.enabled` controls the `SpeechSynthesis` interface and its properties (the full listing has more than 3.)
 
-> **Note:** the default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)
+> [!NOTE]
+> the default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)
 
 ### Available only in system code
 
@@ -243,7 +246,8 @@ If the keyword `readonly` is present, the property can't be modified. It must be
 - In the first sentence of its own page, by starting the description with: _The read-only **`HTMLMediaElement.error`** property…_
 - By starting its description in the interface page with _Returns…_
 
-> **Note:** Only read-only properties can be described as 'returning' a value. Non read-only properties can also be used to set a value.
+> [!NOTE]
+> Only read-only properties can be described as 'returning' a value. Non read-only properties can also be used to set a value.
 
 ### Throwing exceptions
 
@@ -292,7 +296,8 @@ Basic objects with types like {{jsxref("String")}} (being an IDL `DOMString`, or
 
 For interface objects, the default is to return a _reference_ to the internal object. This has to be mentioned both in the short description in the interface page, and in the description in the specific sub-pages.
 
-> **Note:** The keyword `readonly` used with a property returning an object applies to the reference (the internal object cannot be changed.) The properties of the returned object can be changed, even if they are marked as read-only in the relevant interface.
+> [!NOTE]
+> The keyword `readonly` used with a property returning an object applies to the reference (the internal object cannot be changed.) The properties of the returned object can be changed, even if they are marked as read-only in the relevant interface.
 
 Sometimes an API must return a _new_ object, or a _copy_ of an internal one. This case is indicated in the WebIDL using the `[NewObject]` annotation.
 
@@ -325,7 +330,8 @@ For documentation, the subpage must contain a sentence indicating if it is avail
 
 ### Preferences
 
-> **Note:** This information is specific to Gecko and should only be used in the Browser compatibility section.
+> [!NOTE]
+> This information is specific to Gecko and should only be used in the Browser compatibility section.
 
 In Gecko, the availability of some properties may be controlled by a preference. This is marked in the WebIDL too.
 
@@ -336,7 +342,8 @@ In Gecko, the availability of some properties may be controlled by a preference.
 
 Here `media.webvtt.enabled` controls the `textTracks` property.
 
-> **Note:** The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another).
+> [!NOTE]
+> The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another).
 
 ## Methods
 
@@ -396,7 +403,8 @@ For the documentation, the sub-page must contain a sentence indicating if it is 
 
 ### Preferences
 
-> **Note:** this information is specific to Gecko and should only be used in the Browser compatibility section.
+> [!NOTE]
+> this information is specific to Gecko and should only be used in the Browser compatibility section.
 
 In Gecko, the availability of some methods may be controlled by a preference. This is marked in the WebIDL too.
 
@@ -409,7 +417,8 @@ In Gecko, the availability of some methods may be controlled by a preference. Th
 
 Here `media.webvtt.enabled` controls the `addTextTrack()` method.
 
-> **Note:** The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)
+> [!NOTE]
+> The default value of the preference is not available directly in the WebIDL (it can be different from one product using Gecko to another.)
 
 ## Special methods
 
@@ -434,7 +443,8 @@ serializer; // Standard version
 
 The `toJSON()` method is listed just like any other method of the interface and has its own sub-page (E.g. {{domxref("Performance.toJSON()")}})
 
-> **Note:** the WebIDL specification uses `serializer` instead of `jsonifier`. This is not used in Gecko — only the non-standard likely early proposal `jsonifier` is found in mozilla-central.
+> [!NOTE]
+> the WebIDL specification uses `serializer` instead of `jsonifier`. This is not used in Gecko — only the non-standard likely early proposal `jsonifier` is found in mozilla-central.
 
 ### Iterator-like methods
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -48,9 +48,11 @@ The following macros are automatically added to the content in order to match th
 
 [Update the feature status in the browser-compat-data repository](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_to_add_or_update_feature_statuses) in order to change these values.
 
-> **Note:** While you can manually/update these macros in content, values that don't match the browser compatibility data will be replaced/removed.
+> [!NOTE]
+> While you can manually/update these macros in content, values that don't match the browser compatibility data will be replaced/removed.
 
-> **Note:** Pages that have the `\{{SeeCompatTable}}`, `\{{Deprecated_Header}}`, or `\{{Non-standard_Header}}` banners will also have the corresponding `experimental`, `deprecated` and `non-standard` status values in the page metadata.
+> [!NOTE]
+> Pages that have the `\{{SeeCompatTable}}`, `\{{Deprecated_Header}}`, or `\{{Non-standard_Header}}` banners will also have the corresponding `experimental`, `deprecated` and `non-standard` status values in the page metadata.
 > The metadata is automatically updated at the same time as the headers.
 > The banner macros do not depend on this status metadata (but may one day be generated from it).
 
@@ -63,7 +65,8 @@ It is important to clarify the current standardization status of such features t
 - Adding this banner to the landing page for that feature (not for every subpage for the feature):
 
   ```text
-  > **Warning:** This feature is currently opposed by <number> browser vendor(s). See the [Standards positions](#standards_positions) section below for details of opposition.
+  > [!WARNING]
+  > This feature is currently opposed by <number> browser vendor(s). See the [Standards positions](#standards_positions) section below for details of opposition.
   ```
 
   - Replace `<number>` with the number of browser vendors opposing the feature.
@@ -71,4 +74,5 @@ It is important to clarify the current standardization status of such features t
 
 - Adding a "Standards positions" section to the same page as the above banner, as a sub-section of the standard "Specifications" section.
 
-> **Note:** See [Related Website Sets](/en-US/docs/Web/API/Storage_Access_API/Related_website_sets) for an example of the "Standards positions" section and what it should contain, as well as the landing page banner.
+> [!NOTE]
+> See [Related Website Sets](/en-US/docs/Web/API/Storage_Access_API/Related_website_sets) for an example of the "Standards positions" section and what it should contain, as well as the landing page banner.

--- a/files/en-us/mdn/writing_guidelines/page_structures/code_examples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/code_examples/index.md
@@ -8,7 +8,8 @@ page-type: mdn-writing-guide
 
 On MDN, you'll see numerous code examples inserted throughout the pages to demonstrate usage of web platform features. This article discusses the different mechanisms available for adding code examples to pages, along with which ones you should use and when.
 
-> **Note:** If you want advice on the styling and linting of code as it appears on an MDN article, rather than the different ways of including code, see our [Code style guide](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide).
+> [!NOTE]
+> If you want advice on the styling and linting of code as it appears on an MDN article, rather than the different ways of including code, see our [Code style guide](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_style_guide).
 
 ## What types of code example are available?
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/feature_status/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/feature_status/index.md
@@ -21,7 +21,7 @@ To see detailed instructions on how to choose a status for a feature, refer to t
 
 The feature statuses of all the features documented on MDN are defined in its accompanying [@mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) (BCD) repository entry and are _automatically_ updated in the `mdn/content` repository whenever a new [version of BCD is released](https://github.com/mdn/browser-compat-data/releases).
 
-> **Warning:**
+> [!WARNING]
 > Do not manually update feature statuses in the `mdn/content` repository. To update a feature's status, you need to [submit a pull request](https://github.com/mdn/browser-compat-data/blob/main/docs/contributing.md#updating-the-compat-data) in the BCD repository. After your changes are approved and merged in BCD, an [automated pull request](https://github.com/search?q=repo%3Amdn%2Fcontent+Synchronize+with+BCD&type=pullrequests) updates the statuses in the `mdn/content` repository.
 
 The automation uses [`browser-compat`](/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables#using_bcd_data_in_mdn_pages) key in the front-matter. The key stores BCD query required to locate the feature in the compatiblity data. If the `browser-compat` key has multiple values then the automation uses only the first value to render status macros.

--- a/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/live_samples/index.md
@@ -219,7 +219,8 @@ The first step is to either add code snippets or ensure that existing ones are r
 
 Each piece of code must be in a code block, with a separate block for each language, properly marked as to which language it is. Most of the time, this has already been done, but it's always worth double-checking to be sure each piece of code is configured with the correct syntax. This is done with a language identifier on the code block of `language-type`, where _language-type_ is the type of language the block contains, e.g. `html`, `css`, or `js`.
 
-> **Note:** You may have more than one block for each language; they are all concatenated together. This lets you have a chunk of code, followed by an explanation of how it works, then another chunk, and so forth. This makes it even easier to produce tutorials and the like that utilize live samples interspersed with explanatory text.
+> [!NOTE]
+> You may have more than one block for each language; they are all concatenated together. This lets you have a chunk of code, followed by an explanation of how it works, then another chunk, and so forth. This makes it even easier to produce tutorials and the like that utilize live samples interspersed with explanatory text.
 
 So make sure the code blocks for your HTML, CSS, and/or JavaScript code are each configured correctly for that language's syntax highlighting, and you're good to go.
 
@@ -387,7 +388,8 @@ This example shows how to implement a simple single-entry log in your live sampl
 For clarity this example separates the logging code and the code that uses it, and displays the logging code first.
 Generally when implementing your own samples you should place logging elements below other UI elements.
 
-> **Note:** Displaying log output as part of the sample provides a much better user experience than using `console.log()`.
+> [!NOTE]
+> Displaying log output as part of the sample provides a much better user experience than using `console.log()`.
 
 #### HTML
 
@@ -453,9 +455,11 @@ The console appends a new line to the end of the output each time a log is added
 For clarity this example separates the logging code and the code that uses it, and displays the logging code first.
 Generally when implementing your own samples you should place logging elements below other UI elements.
 
-> **Note:** Displaying log output as part of the sample is a much better user experience than using `console.log()`.
+> [!NOTE]
+> Displaying log output as part of the sample is a much better user experience than using `console.log()`.
 
-> **Note:** See [`DataTransfer.effectAllowed`](/en-US/docs/Web/API/DataTransfer/effectAllowed#setting_effectallowed) for a more complete example.
+> [!NOTE]
+> See [`DataTransfer.effectAllowed`](/en-US/docs/Web/API/DataTransfer/effectAllowed#setting_effectallowed) for a more complete example.
 
 #### HTML
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >
@@ -119,7 +119,8 @@ Each example must have an H3 heading naming the example. The heading should be d
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing._
+> **Note:** _Remove this whole explanatory note before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing._
+> [!NOTE] > _Remove this whole explanatory note before publishing._
 >
 > ---
 >
@@ -146,7 +146,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -6,7 +6,7 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >
@@ -139,7 +139,8 @@ Each example must have an H3 heading naming the example. The heading should be d
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -6,7 +6,7 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing._
+> **Note:** _Remove this whole explanatory note before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing._
+> [!NOTE] > _Remove this whole explanatory note before publishing._
 >
 > ---
 >
@@ -98,7 +98,8 @@ Fill in a syntax box, according to the guidance in our [syntax sections](/en-US/
 - `parameter2`
   - : etc.
 
-> **Note:** This section is mandatory. If there aren't any parameters, put `None.` instead of the definition list.
+> [!NOTE]
+> This section is mandatory. If there aren't any parameters, put `None.` instead of the definition list.
 
 ### Return value
 
@@ -139,7 +140,8 @@ Each example must have an H3 heading naming the example. The heading should be d
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing._
+> [!NOTE] > _Remove this whole explanatory note before publishing._
 >
 > ---
 >
@@ -105,7 +105,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing._
+> **Note:** _Remove this whole explanatory note before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing._
+> [!NOTE] > _Remove this whole explanatory note before publishing._
 >
 > ---
 >
@@ -144,7 +144,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing._
+> **Note:** _Remove this whole explanatory note before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md
@@ -65,7 +65,8 @@ Include a complete description of the attribute or role.
 - Changing attribute values
   - : explanation of each
 
-> **Note:** Include a note about semantic alternatives to using this role or attribute. The first rule of ARIA use is that you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state, or property to make it accessible, then do so. Then post full details in best practices section below.
+> [!NOTE]
+> Include a note about semantic alternatives to using this role or attribute. The first rule of ARIA use is that you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state, or property to make it accessible, then do so. Then post full details in best practices section below.
 
 ## Examples
 
@@ -77,7 +78,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.functions.NameOfTheFunction
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this note block before publishing._
+> **Note:** _Remove this note block before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.functions.NameOfTheFunction
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this note block before publishing._
+> [!NOTE] > _Remove this note block before publishing._
 >
 > ---
 >
@@ -152,7 +152,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_module_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_module_landing_page_template/index.md
@@ -6,7 +6,7 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-> **Note:** _Remember to remove this note block before publishing._
+> [!NOTE] > _Remember to remove this note block before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_module_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_module_landing_page_template/index.md
@@ -6,7 +6,7 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remember to remove this note block before publishing._
+> **Note:** _Remember to remove this note block before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.NameOfTheProperty
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this note block before publishing._
+> [!NOTE] > _Remove this note block before publishing._
 >
 > ---
 >
@@ -135,7 +135,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.NameOfTheProperty
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this note block before publishing._
+> **Note:** _Remove this note block before publishing._
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.NameOfTheSelector
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: css.selectors.NameOfTheSelector
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >
@@ -102,7 +102,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes, you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes, you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/glossary_page_template/index.md
@@ -6,7 +6,7 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/glossary_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/glossary_page_template/index.md
@@ -6,7 +6,7 @@ page-type: mdn-writing-guide
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheElement
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheElement
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >
@@ -117,7 +117,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheHeader
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >
@@ -131,7 +131,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheHeader
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -90,7 +90,8 @@ In such a case, it would make more sense in terms of repetition and findability 
 
 ### API reference page
 
-> **Note:** Also known as an _Interface landing page_.
+> [!NOTE]
+> Also known as an _Interface landing page_.
 
 An **API reference page** lists all the methods, properties, events, and so forth that are members of a particular interface or class.
 It provides an overview of what the class or interface does or is used for, and gives links to the documentation for each of these members.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheElement
 
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+> [!NOTE] > _Remove this whole explanatory note before publishing_
 >
 > ---
 >
@@ -119,7 +119,8 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples) for more information.
 
-> **Note:** Sometimes you will want to link to examples given on another page.
+> [!NOTE]
+> Sometimes you will want to link to examples given on another page.
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -7,7 +7,7 @@ browser-compat: path.to.feature.NameOfTheElement
 
 {{MDNSidebar}}
 
-> [!NOTE] > _Remove this whole explanatory note before publishing_
+> **Note:** _Remove this whole explanatory note before publishing_
 >
 > ---
 >

--- a/files/en-us/mdn/writing_guidelines/page_structures/sidebars/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/sidebars/index.md
@@ -105,7 +105,8 @@ The `\{{ListSubpagesForSidebar(<parameters>)}}` macro inserts the tree of subpag
 
 Once you have determined the links to include in your sidebar, submit a pull request to [Yari with your proposed sidebar macro](https://github.com/mdn/yari/blob/main/kumascript/macros/).
 
-> **Note:** This `<section>` must be appended to the end of the document, instead of between the frontmatter and the page content. Only one sidebar is created per page, so any macro listed after the frontmatter must be removed.
+> [!NOTE]
+> This `<section>` must be appended to the end of the document, instead of between the frontmatter and the page content. Only one sidebar is created per page, so any macro listed after the frontmatter must be removed.
 
 The [macro source code](https://github.com/mdn/yari/tree/main/kumascript/macros) is on GitHub. Each macro includes the documentation for itself, including parameters, if any.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -26,7 +26,8 @@ slice(start, end)
 ```
 ````
 
-> **Note:** The markup-language used in this case is `js-nolint`, where `js` indicates that JavaScript syntax highlighting should be used.
+> [!NOTE]
+> The markup-language used in this case is `js-nolint`, where `js` indicates that JavaScript syntax highlighting should be used.
 > For JavaScript syntax sections `-nolint` is also required because the syntax section is deliberatively not "quite" JavaScript and we don't want the linter to "fix" it (return values and end-of-line semicolons are omitted).
 
 ### General style rules
@@ -188,7 +189,8 @@ Next, include a "Parameters" subsection, which explains what each parameter shou
 
 The name of each parameter in the list should be contained in markdown code fence notation `` ` ` ``.
 
-> **Note:** Even if the feature does not take any parameters, you need to include a "Parameters" section, with content of "None".
+> [!NOTE]
+> Even if the feature does not take any parameters, you need to include a "Parameters" section, with content of "None".
 
 #### Return value section
 
@@ -206,7 +208,8 @@ Determining what exceptions are thrown by a method can require a good perusal of
 
 The exception names and explanations should be included in a description list.
 
-> **Note:** If no exceptions can be raised on the feature, you don't need to include an "Exceptions" section, but you can if you wish include it with content of "None".
+> [!NOTE]
+> If no exceptions can be raised on the feature, you don't need to include an "Exceptions" section, but you can if you wish include it with content of "None".
 
 ### Properties
 
@@ -231,7 +234,8 @@ JavaScript built-in object reference pages follow the same basic rules as API re
 
 CSS property reference pages include a "Syntax" section, which used to be found at the top of the page but is increasingly commonly found below a section containing a block of code showing typical usage of the feature, plus a live example to illustrate what the feature does (see {{CSSxRef("animation")}} for example).
 
-> **Note:** We do this because CSS formal syntax is complex, not used by many of the MDN readership, and off-putting for beginners. Real syntax and examples are more useful to the majority of people.
+> [!NOTE]
+> We do this because CSS formal syntax is complex, not used by many of the MDN readership, and off-putting for beginners. Real syntax and examples are more useful to the majority of people.
 
 Inside the syntax section you'll find the following contents.
 

--- a/files/en-us/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
+++ b/files/en-us/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
@@ -50,7 +50,8 @@ There are many libraries and frameworks in existence, which are not web standard
 
 The MDN Web Docs team concentrates on documenting the open web platform. If you want a technology in this area to be considered for documentation on MDN Web Docs, you'll need to have a community assembled that is willing to write the documentation and maintain it after completion. Our team is happy to provide guidance in such cases, including edits and feedback, but we don't have the resource for more than that.
 
-> **Note:** MDN Web Docs work is carried out on GitHub and 'in the open'. Your team should be versed in git & GitHub and be comfortable with working in open source.
+> [!NOTE]
+> MDN Web Docs work is carried out on GitHub and 'in the open'. Your team should be versed in git & GitHub and be comfortable with working in open source.
 
 ## Process for selecting the new technology
 
@@ -78,7 +79,8 @@ Technologies will be considered for inclusion on MDN Web Docs on a case-by-case 
 
 You don't need to provide us with hundreds of pages of detail at this stage (in fact, we'd prefer it if you didn't). A couple of paragraphs on each of the above points is more than adequate.
 
-> **Note:** MDN Web Docs is primarily an English site (en-US). The primary language for your project should be in US English.
+> [!NOTE]
+> MDN Web Docs is primarily an English site (en-US). The primary language for your project should be in US English.
 
 ### Awaiting a response
 

--- a/files/en-us/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/en-us/mdn/writing_guidelines/what_we_write/index.md
@@ -57,7 +57,8 @@ Our primary focus is to write about the following front-end web technologies:
 
 We also document some broader topics, such as [SVG](/en-US/docs/Web/SVG), [XML](/en-US/docs/Web/XML), [WebAssembly](/en-US/docs/WebAssembly), and [Accessibility](/en-US/docs/Learn/Accessibility). In addition, we provide extensive [learning guides](/en-US/docs/Learn) for these technologies and also a [glossary](/en-US/docs/Glossary).
 
-> **Note:** Backend technologies usually have their own documentation elsewhere that MDN Web Docs does not attempt to supersede, although we [do have some exceptions](/en-US/docs/Learn/Server-side).
+> [!NOTE]
+> Backend technologies usually have their own documentation elsewhere that MDN Web Docs does not attempt to supersede, although we [do have some exceptions](/en-US/docs/Learn/Server-side).
 
 All content on MDN Web Docs must be relevant to the technology section in which it appears. Contributors are expected to follow these [MDN writing guidelines](/en-US/docs/MDN/Writing_guidelines) for writing style, code samples, and other topics.
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/html/index.md
@@ -20,7 +20,8 @@ Prettier formats all the code and keeps the style consistent. Nevertheless, ther
 
 ## Complete HTML document
 
-> **Note:** The guidelines in this section apply only when you need to show a complete HTML document. A snippet is usually enough to demonstrate a feature. When using the [EmbedLiveSample macro](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples#traditional_live_samples), just include the HTML snippet; it will automatically be inserted into a full HTML document when displayed.
+> [!NOTE]
+> The guidelines in this section apply only when you need to show a complete HTML document. A snippet is usually enough to demonstrate a feature. When using the [EmbedLiveSample macro](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples#traditional_live_samples), just include the HTML snippet; it will automatically be inserted into a full HTML document when displayed.
 
 ### Doctype
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/index.md
@@ -57,7 +57,8 @@ To ensure proper formatting and syntax highlighting of code blocks, writers must
 
 If the code block is pseudocode, the output of a command, or otherwise not a programming language, explicitly set the language to `plain`.
 
-> **Warning:** if the desired language is not yet supported by MDN, do **not** set the language of a code block to a similar language, as doing so may have unintended side effects with Prettier formatting and syntax highlighting.
+> [!WARNING]
+> if the desired language is not yet supported by MDN, do **not** set the language of a code block to a similar language, as doing so may have unintended side effects with Prettier formatting and syntax highlighting.
 
 ### Code line length
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/code_style_guide/javascript/index.md
@@ -390,9 +390,11 @@ When [loops](/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code) are requ
   }
   ```
 
-> **Warning:** Never use `for...in` with arrays and strings.
+> [!WARNING]
+> Never use `for...in` with arrays and strings.
 
-> **Note:** Consider not using a `for` loop at all. If you are using an [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) (or a [`String`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) for some operations), consider using more semantic iteration methods instead, like [`map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), and many more.
+> [!NOTE]
+> Consider not using a `for` loop at all. If you are using an [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) (or a [`String`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) for some operations), consider using more semantic iteration methods instead, like [`map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map), [`every()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every), [`findIndex()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`find()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), and many more.
 
 ### Control statements
 
@@ -515,7 +517,8 @@ Switch statements can be a little tricky.
   }
   ```
 
-> **Note:** Keep in mind that only _recoverable_ errors should be caught and handled. All non-recoverable errors should be let through and bubble up the call stack.
+> [!NOTE]
+> Keep in mind that only _recoverable_ errors should be caught and handled. All non-recoverable errors should be let through and bubble up the call stack.
 
 ## Objects
 
@@ -725,7 +728,8 @@ Good variable names are essential to understanding code.
   const s = d / t;
   ```
 
-> **Note:** The only place where it's allowed not to use human-readable, semantic names is where a very commonly recognized convention exists, such as using `i` and `j` for loop iterators.
+> [!NOTE]
+> The only place where it's allowed not to use human-readable, semantic names is where a very commonly recognized convention exists, such as using `i` and `j` for loop iterators.
 
 ### Variable declarations
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -10,7 +10,8 @@ This writing style guide describes how content should be written, organized, spe
 
 These guidelines are for ensuring language and style consistency across the website. That said, we are more interested in content rather than its formatting, so don't feel obligated to learn the entire writing style guide before contributing. Do not be upset or surprised, however, if another contributor later edits your work to conform to this guide. The reviewers might also point you to this style guide when you submit a content pull request.
 
-> **Note:** The language aspects of this guide apply primarily to English-language documentation. Other languages may have (and are welcome to create) their own style guides. These should be published as subpages of the respective localization team's page. However, this guide should still be consulted for formatting and organizing content.
+> [!NOTE]
+> The language aspects of this guide apply primarily to English-language documentation. Other languages may have (and are welcome to create) their own style guides. These should be published as subpages of the respective localization team's page. However, this guide should still be consulted for formatting and organizing content.
 
 After listing the general writing guidelines, this guide describes the recommended writing style for MDN Web Docs and then how to format different components on a page, such as lists and titles.
 
@@ -108,7 +109,8 @@ Both versions are gender-specific. To fix this, use gender-neutral pronouns like
 
 - **Correct**: "A confirmation dialog asks the user if they want to allow the web page to make use of their webcam."
 
-> **Note:** MDN Web Docs allows the use of third-person plural, commonly known as "[singular 'they'](https://en.wikipedia.org/wiki/Singular_they).". The gender-neutral pronouns include "they," "them", "their," and "theirs".
+> [!NOTE]
+> MDN Web Docs allows the use of third-person plural, commonly known as "[singular 'they'](https://en.wikipedia.org/wiki/Singular_they).". The gender-neutral pronouns include "they," "them", "their," and "theirs".
 
 Another option is to make the users plural, like so:
 
@@ -155,7 +157,8 @@ The following checklist is good to keep in mind while writing and reviewing cont
   - **Add image information**: Include proper [`alt`](/en-US/docs/Web/HTML/Element/img#alt) text on all images and diagrams. This text, as well as captions on tables and other figures, counts because spiders can't crawl images, and so `alt` text tells search engine crawlers what content the embedded media contains.
     > **Note:** It is not recommended to include too many keywords or keywords not related to the feature in an attempt to manipulate search engine rankings; this type of behavior is easy to spot and tends to be penalized.
     > Likewise, **do not** add repetitive, unhelpful material or blobs of keywords within the actual page, in an attempt to improve the page's size and search ranking. This does more harm than good, both to content readability and to our search results.
-  - **Focus on topic content**: It is far better to write content around the topic of the page than a specific keyword. It is highly likely that there will be many keywords you could include for a given topic; in fact, many SEOs compile a list of 5-100 different keywords (varying between short, medium, and long-tail keywords) to include within their article, depending on the length. Doing so will diversify your wording, leading to less repetition.
+
+- **Focus on topic content**: It is far better to write content around the topic of the page than a specific keyword. It is highly likely that there will be many keywords you could include for a given topic; in fact, many SEOs compile a list of 5-100 different keywords (varying between short, medium, and long-tail keywords) to include within their article, depending on the length. Doing so will diversify your wording, leading to less repetition.
 
 ## Writing style
 
@@ -233,7 +236,8 @@ An abbreviation is a shortened version of a longer word, while an acronym is a n
 
 Use standard English capitalization rules in body text, and capitalize "World Wide Web." It is acceptable to use lower case for "web" (used alone or as a modifier) and "internet".
 
-> **Note:** This guideline is a change from a previous version of this guide, so you may find many instances of "Web" and "Internet" on MDN.
+> [!NOTE]
+> This guideline is a change from a previous version of this guide, so you may find many instances of "Web" and "Internet" on MDN.
 > Feel free to change these as you are making other changes, but editing an article just to change capitalization is not necessary.
 
 Keyboard keys should use sentence-style capitalization, not all-caps capitalization.
@@ -457,7 +461,8 @@ In general, if you're considering adding an external link, you need to ensure th
 - Attempt to use MDN Web Docs to distribute spam
 - Shortlinks that obfuscate the link destination
 
-> **Note:** Before adding an external link, consider cross-referencing content within MDN Web Docs. Internal links are easier to maintain and make the entirety of MDN Web Docs more valuable to readers.
+> [!NOTE]
+> Before adding an external link, consider cross-referencing content within MDN Web Docs. Internal links are easier to maintain and make the entirety of MDN Web Docs more valuable to readers.
 
 - **Good external links**: Good external links take readers to resources that are relevant, durable, and widely trusted. You should prefer adding links to external content that is:
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'mdn' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
