### PR TITLE
Convert noteblocks for mozilla/firefox folder

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -15,7 +15,8 @@ After a feature is enabled by default in a release build, it is no longer consid
 
 Experimental features can be enabled or disabled using the [Firefox Configuration Editor](https://support.mozilla.org/en-US/kb/about-config-editor-firefox) (enter `about:config` in the Firefox address bar) by modifying the associated _preference_ listed below.
 
-> **Note:** For editors - when adding features to these tables, please try to include a link to the relevant bug or bugs using `[Firefox bug <number>](https://bugzil.la/<number>)`.
+> [!NOTE]
+> For editors - when adding features to these tables, please try to include a link to the relevant bug or bugs using `[Firefox bug <number>](https://bugzil.la/<number>)`.
 
 ## HTML
 
@@ -913,7 +914,8 @@ Specifically, the disabled properties are:
 
 The `<h1>` heading doesn't decrease in font size now when nested within [sectioning elements](/en-US/docs/Web/HTML/Content_categories#sectioning_content) `<article>`, `<aside>`, `<nav>`, and `<section>`. The UA styles for `<h1>` nested within sectioning elements are no longer relevant since the outline algorithm [has been removed](https://github.com/whatwg/html/pull/7829) from the HTML specification. ([Firefox bug 1883896](https://bugzil.la/1883896)).
 
-> **Note:** The preference for this feature works in reverse: it's set to `false` in the Nightly build, which removes the UA styling for headings nested in sectioning elements. It's set to `true` in all other channels, which retains the existing UA styling for the nested headings.
+> [!NOTE]
+> The preference for this feature works in reverse: it's set to `false` in the Nightly build, which removes the UA styling for headings nested in sectioning elements. It's set to `true` in all other channels, which retains the existing UA styling for the nested headings.
 
 <table>
   <thead>
@@ -2203,7 +2205,8 @@ Note that supported policies can be set through the [`allow`](/en-US/docs/Web/HT
 
 The [`Clear-Site-Data`](/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) HTTP response header `cache` directive clears the browser cache for the requesting website.
 
-> **Note:** This was originally enabled by default, but put behind a preference in version 94 ([Firefox bug 1729291](https://bugzil.la/1729291)).
+> [!NOTE]
+> This was originally enabled by default, but put behind a preference in version 94 ([Firefox bug 1729291](https://bugzil.la/1729291)).
 
 <table>
   <thead>

--- a/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
@@ -6,7 +6,8 @@ page-type: guide
 
 {{FirefoxSidebar}}
 
-> **Warning:** The approach described in this topic is non-standard, and not recommended.
+> [!WARNING]
+> The approach described in this topic is non-standard, and not recommended.
 >
 > The best way to request resources over HTTP is to use [`fetch()`](/en-US/docs/Web/API/Window/fetch), which allows you to specify the priority in [`Request.priority`](/en-US/docs/Web/API/Request/priority).
 > You can also set the HTTP priority on [`HTMLLinkElement`](/en-US/docs/Web/API/HTMLLinkElement/fetchPriority), [`HTMLIFrameElement`](/en-US/docs/Web/API/HTMLIFrameElement), and [`HTMLImageElement`](/en-US/docs/Web/API/HTMLImageElement/fetchPriority) elements (and associated tags) using the `fetchpriority` attribute.
@@ -54,7 +55,8 @@ if (req.channel instanceof Components.interfaces.nsISupportsPriority) {
 req.send(null);
 ```
 
-> **Note:** This example uses a synchronous [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest), which you should not use in practice.
+> [!NOTE]
+> This example uses a synchronous [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest), which you should not use in practice.
 
 ## Adjusting priority
 

--- a/files/en-us/mozilla/firefox/releases/1.5/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/index.md
@@ -17,7 +17,8 @@ Several tools and browser extensions are available to help developers support Fi
 - View page source, with syntax highlighting and find features.
 - [Browser extensions](https://addons.mozilla.org/en-US/firefox/search/?q=Developer%20Tools) including the [FireBug](https://web.archive.org/web/20061205073236/http://www.joehewitt.com/software/firebug/), [Web Developer toolbar](</en-US/docs/Web_Developer_Extension_(external)>), [Live HTTP Headers](</en-US/docs/Live_HTTP_Headers_(external)>), [HTML Validator](</en-US/docs/HTML_Validator_(external)>) and many more.
 
-> **Note:** Some extensions do not currently support Firefox 1.5, and will be automatically disabled.
+> [!NOTE]
+> Some extensions do not currently support Firefox 1.5, and will be automatically disabled.
 
 ## Overview
 

--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 Firefox 10 shipped on January 31, 2012. This article provides information about the new features and key bugs fixed in this release, as well as links to more detailed documentation for both web developers and add-on developers.
 
-> **Note:** Firefox 10 is the first release of this browser with two digits. This may lead to problem with some UA-sniffing scripts. Be sure to check them, and those contained in 3rd-party software you embed in your pages, like libraries. For more information about this, look at the [Firefox goes 2-digit article on hack.mozilla.org](https://hacks.mozilla.org/2012/01/firefox-goes-2-digit-time-to-check-your-ua-sniffing-scripts/).
+> [!NOTE]
+> Firefox 10 is the first release of this browser with two digits. This may lead to problem with some UA-sniffing scripts. Be sure to check them, and those contained in 3rd-party software you embed in your pages, like libraries. For more information about this, look at the [Firefox goes 2-digit article on hack.mozilla.org](https://hacks.mozilla.org/2012/01/firefox-goes-2-digit-time-to-check-your-ua-sniffing-scripts/).
 
 ## Changes for Web developers
 
@@ -116,7 +117,8 @@ Great progress has been made to update IndexedDB to the latest draft specificati
 
 For an overview of likely issues that may arise when updating your add-ons to support Firefox 10, see [Updating add-ons for Firefox 10](/en-US/docs/Mozilla/Firefox/Updating_add-ons_for_Firefox_10).
 
-> **Note:** The old [`PRBool`](/en-US/docs/PRBool) data type has been retired! Anywhere in the documentation that refers to it now uses the standard C++ `bool` type instead. Documentation will be updated in the future, but for now, just keep this in mind.
+> [!NOTE]
+> The old [`PRBool`](/en-US/docs/PRBool) data type has been retired! Anywhere in the documentation that refers to it now uses the standard C++ `bool` type instead. Documentation will be updated in the future, but for now, just keep this in mind.
 
 ### Manifests
 

--- a/files/en-us/mozilla/firefox/releases/10/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/updating_add-ons/index.md
@@ -12,7 +12,8 @@ Although a lot of things have changed in Firefox 10 that, in theory, can cause a
 
 The first and most important thing to note is that starting in Firefox 10, add-ons are assumed to be compatible by default. Unless you use the [`<em:strictCompatibility>`](/en-US/docs/Install_Manifests#strictcompatibility) flag in your manifest, Firefox will no longer mark your add-on as incompatible after an upgrade to Firefox 10 or later. You can use that flag to ensure that an add-on that is likely to break will not try to run in updated copies of Firefox. It's worth noting that add-ons that have binary components will always be strictly checked for compatibility, since binary components always need to be recompiled for each major Firefox release.
 
-> **Note:** You should still test your add-on on Firefox 10, even in the world of compatibility by default. Read over the rest of this article to see if there's anything you need to change.
+> [!NOTE]
+> You should still test your add-on on Firefox 10, even in the world of compatibility by default. Read over the rest of this article to see if there's anything you need to change.
 
 ## DOM changes
 

--- a/files/en-us/mozilla/firefox/releases/19/index.md
+++ b/files/en-us/mozilla/firefox/releases/19/index.md
@@ -44,7 +44,8 @@ Support for XForms has been [**removed**](https://www.philipp-wagner.com/blog/20
 
 ## Changes for add-on and Mozilla developers
 
-> **Note:** A key change in Firefox 19 is that `nsresult` is now strongly typed. This will help make it easier to detect bugs that are caused by mishandling of return values, but may cause existing code to break if it's making incorrect assumptions in this regard.
+> [!NOTE]
+> A key change in Firefox 19 is that `nsresult` is now strongly typed. This will help make it easier to detect bugs that are caused by mishandling of return values, but may cause existing code to break if it's making incorrect assumptions in this regard.
 
 - `getBrowserSelection()` now returns the selected text in a text input field. As a result, `gContextMenu.isTextSelected` will be `true` when the user selects text in a text input field that is not a password field. ([Firefox bug 565717](https://bugzil.la/565717))
 - Dict.jsm: `Dict()` now takes a JSON String. `Dict.toJSON()` was added, and it returns a JSON String. ([Firefox bug 727967](https://bugzil.la/727967))

--- a/files/en-us/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/icc_color_correction_in_firefox/index.md
@@ -109,7 +109,8 @@ The following table lists the possible values.
   </tbody>
 </table>
 
-> **Note:** In Firefox 3.5, perceptual, media-relative, and saturation intents all render the same way.
+> [!NOTE]
+> In Firefox 3.5, perceptual, media-relative, and saturation intents all render the same way.
 
 ### Caveats
 

--- a/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/updating_extensions/index.md
@@ -49,4 +49,5 @@ Support for the obsolete `contents.rdf` method for registering chrome has been r
 
 Make sure you include a [chrome.manifest](/en-US/docs/Chrome_Registration) in your XPI.
 
-> **Note:** Add-ons that are already installed using the old contents.rdf method for registering chrome will continue to function if already installed. Make sure that you test your add-on by actually removing and reinstalling it to ensure that the install works after updating it to use an install manifest.
+> [!NOTE]
+> Add-ons that are already installed using the old contents.rdf method for registering chrome will continue to function if already installed. Make sure that you test your add-on by actually removing and reinstalling it to ensure that the install works after updating it to use an install manifest.

--- a/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -32,7 +32,8 @@ Note that Firefox 3 does away with the extra ".0" in the version number, so inst
 
 There have been (and will continue to be) a number of API changes that will likely break some extensions. We're still working on compiling a complete list of these changes.
 
-> **Note:** If your extension still uses an [`Install.js`](/en-US/docs/Install.js) script instead of an [install manifest](/en-US/docs/Install_Manifests), you need to make the transition to an install manifest now. Firefox 3 no longer supports `install.js` scripts in XPI files.
+> [!NOTE]
+> If your extension still uses an [`Install.js`](/en-US/docs/Install.js) script instead of an [install manifest](/en-US/docs/Install_Manifests), you need to make the transition to an install manifest now. Firefox 3 no longer supports `install.js` scripts in XPI files.
 
 ### Add localizations to the install manifest
 

--- a/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -63,7 +63,8 @@ content mypackage location/ contentaccessible=yes
 
 This shouldn't be something you need to do very often, but it's available for those rare cases in which it's needed. Note that it's possible that Firefox may alert the user that your extension uses the `contentaccessible` flag in this way, as it does constitute a potential security risk.
 
-> **Note:** Because Firefox 2 doesn't understand the `contentaccessible` flag (it will ignore the entire line containing the flag), if you want your add-on to be compatible with both Firefox 2 and Firefox 3, you should do something like this:
+> [!NOTE]
+> Because Firefox 2 doesn't understand the `contentaccessible` flag (it will ignore the entire line containing the flag), if you want your add-on to be compatible with both Firefox 2 and Firefox 3, you should do something like this:
 >
 > ```bash
 > content mypackage location/

--- a/files/en-us/mozilla/firefox/releases/3/wai_aria_live_regions_api_support/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/wai_aria_live_regions_api_support/index.md
@@ -6,7 +6,8 @@ page-type: guide
 
 {{FirefoxSidebar}}
 
-> **Warning:** These notes are for developers of screen readers. Developers should use the [ARIA live regions developer documentation](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
+> [!WARNING]
+> These notes are for developers of screen readers. Developers should use the [ARIA live regions developer documentation](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 
 Firefox 3 contains important improvements to the way the Mozilla engine exposes live changes in a document.
 

--- a/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/the_add-on_bar/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 Firefox 4 eliminates the status bar from the bottom of the browser window in favor of a new toolbar located at the bottom of the window. This new toolbar, with the ID "addon-bar", is a standard XUL `<toolbar>`; add-ons can insert content into it, and the user can drag buttons into it while customizing their toolbars. This is the primary difference between the add-on bar and the old status bar; you can now put any XUL element into it, since it's a standard toolbar.
 
-> **Note:** For the time being, there is a status bar shim included so that add-ons that expect the status bar to be present will still work.
+> [!NOTE]
+> For the time being, there is a status bar shim included so that add-ons that expect the status bar to be present will still work.
 
 ## Adding an element to the add-on bar
 

--- a/files/en-us/mozilla/firefox/releases/5/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/index.md
@@ -81,7 +81,8 @@ Firefox 5, based on Gecko 5.0, was released on June 21, 2011. This article provi
 
 For a guide to updating your add-on for Firefox 5, please see [Updating add-ons for Firefox 5](/en-US/docs/Mozilla/Firefox/Updating_add-ons_for_Firefox_5).
 
-> **Note:** Firefox 5 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
+> [!NOTE]
+> Firefox 5 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
 
 ### Changes to JavaScript code modules
 

--- a/files/en-us/mozilla/firefox/releases/5/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/updating_add-ons/index.md
@@ -14,7 +14,8 @@ If your add-on is distributed on [addons.mozilla.org](https://addons.mozilla.org
 
 So you should start by visiting AMO and looking to see if your add-on needs any work done at all.
 
-> **Note:** You should still test your add-on on Firefox 5, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
+> [!NOTE]
+> You should still test your add-on on Firefox 5, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
 
 Once you've confirmed that you need to make changes, come on back to this page and read on.
 
@@ -43,7 +44,8 @@ The following keywords are now reserved in JavaScript, even when you're not in [
 
 Don't use those keywords anywhere in your code, even as object property names.
 
-> **Note:** This is one of those things that AMO's automatically upgrade tool may not always catch, so check your code for these if your add-on was automatically upgraded but is still not working properly.
+> [!NOTE]
+> This is one of those things that AMO's automatically upgrade tool may not always catch, so check your code for these if your add-on was automatically upgraded but is still not working properly.
 
 ## Interface changes
 

--- a/files/en-us/mozilla/firefox/releases/57/index.md
+++ b/files/en-us/mozilla/firefox/releases/57/index.md
@@ -12,7 +12,8 @@ This article provides information about the changes in Firefox 57 (a.k.a. Firefo
 
 Firefox 57 has been given the release name **Quantum**, after the [Firefox Quantum](https://wiki.mozilla.org/Quantum) engineering project that has aimed to rebuild Firefox from the ground up, bringing with it major performance, stability, and visual improvements. This is the first version of Firefox to ship some of these improvements, so we wanted to mark the occasion.
 
-> **Note:** To read more about the Quantum features in this release, see [Firefox Quantum Developer Edition: the fastest Firefox ever with Photon UI and better tooling](https://hacks.mozilla.org/2017/09/firefox-quantum-developer-edition-fastest-firefox-ever/) by Dan Callahan.
+> [!NOTE]
+> To read more about the Quantum features in this release, see [Firefox Quantum Developer Edition: the fastest Firefox ever with Photon UI and better tooling](https://hacks.mozilla.org/2017/09/firefox-quantum-developer-edition-fastest-firefox-ever/) by Dan Callahan.
 
 [Firefox's new parallel CSS engine](https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/) — also known as **Quantum CSS** or **Stylo** — is enabled by default in Firefox 57 for desktop, with Mobile versions of Firefox to follow later on. Developers shouldn't notice anything significantly different, aside from a whole host of performance improvements. There are however a number of minor functional differences in Stylo, implemented to fix non-standard Gecko behavior that should be eliminated. We will report on such differences on reference pages and in the release notes as appropriate (see [Quantum CSS notes](#quantum_css_notes)).
 
@@ -125,7 +126,8 @@ _No changes._
 
 ## Changes for add-on and Mozilla developers
 
-> **Note:** Starting in Firefox 57, all support for XPCOM-based add-ons has been removed. All extensions must be converted into the new [browser extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions) (also known as WebExtensions) or they will not work.
+> [!NOTE]
+> Starting in Firefox 57, all support for XPCOM-based add-ons has been removed. All extensions must be converted into the new [browser extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions) (also known as WebExtensions) or they will not work.
 
 ### WebExtensions
 

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -117,7 +117,8 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 
 For an overview of the changes you may need to make in order to make your add-on compatible with Firefox 6, see [Updating add-ons for Firefox 6](/en-US/docs/Mozilla/Firefox/Updating_add-ons_for_Firefox_6).
 
-> **Note:** Firefox 6 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
+> [!NOTE]
+> Firefox 6 requires that binary components be recompiled, as do all major releases of Firefox. See [Binary Interfaces](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) for details.
 
 ### JavaScript code modules
 

--- a/files/en-us/mozilla/firefox/releases/6/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/updating_add-ons/index.md
@@ -14,7 +14,8 @@ If your add-on is distributed on [addons.mozilla.org](https://addons.mozilla.org
 
 So you should start by visiting AMO and looking to see if your add-on needs any work done at all.
 
-> **Note:** You should still test your add-on on Firefox 6, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
+> [!NOTE]
+> You should still test your add-on on Firefox 6, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
 
 Once you've confirmed that you need to make changes, come on back to this page and read on.
 

--- a/files/en-us/mozilla/firefox/releases/7/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/index.md
@@ -88,7 +88,8 @@ Firefox 7 shipped on September 27, 2011. This article provides information about
 
 These changes affect add-on developers as well as developers working on or with Mozilla code itself. Add-on developers should see [Updating extensions for Firefox 7](/en-US/docs/Mozilla/Firefox/Releases/7/Updating_extensions) for additional information.
 
-> **Note:** Firefox 7 requires that binary components be recompiled, as do all major releases of Firefox.
+> [!NOTE]
+> Firefox 7 requires that binary components be recompiled, as do all major releases of Firefox.
 
 ### JavaScript code modules
 

--- a/files/en-us/mozilla/firefox/releases/7/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/7/updating_extensions/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article offers advice for add-on developers that want to update their extensions to work in Firefox 7. Fortunately, most of the changes are relatively minor in this release, and few add-ons should need significant changes to work in Firefox 7.
 
-> **Note:** For a complete list of developer-related changes in Firefox 7, see [Firefox 7 for developers](/en-US/docs/Mozilla/Firefox/Releases/7).
+> [!NOTE]
+> For a complete list of developer-related changes in Firefox 7, see [Firefox 7 for developers](/en-US/docs/Mozilla/Firefox/Releases/7).
 
 As always, you will need to [recompile any binary components](/en-US/docs/Mozilla/Developer_guide/Interface_Compatibility#binary_interfaces) to make them compatible with Firefox 7.
 

--- a/files/en-us/mozilla/firefox/releases/75/index.md
+++ b/files/en-us/mozilla/firefox/releases/75/index.md
@@ -37,7 +37,8 @@ New [ARIA](/en-US/docs/Web/Accessibility/ARIA) roles and attributes are now expo
 - [`role="comment"`](/en-US/docs/Web/Accessibility/ARIA/Roles/comment_role) ([Firefox bug 1608969](https://bugzil.la/1608969)).
 - Multiple IDs on `aria-details` ([Firefox bug 1608883](https://bugzil.la/1608883)).
 
-> **Note:** On macOS, we are first waiting for Apple to define what Safari will expose as Apple-dialect attributes to VoiceOver, and will then follow suit.
+> [!NOTE]
+> On macOS, we are first waiting for Apple to define what Safari will expose as Apple-dialect attributes to VoiceOver, and will then follow suit.
 
 ### JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/8/index.md
+++ b/files/en-us/mozilla/firefox/releases/8/index.md
@@ -89,7 +89,8 @@ Firefox 8 was released on November 8, 2011. This article provides information bo
 
 See [Updating add-ons for Firefox 8](/en-US/docs/Mozilla/Firefox/Releases/8/Updating_add-ons) for a guide to changes you're likely to have to make your add-ons compatible with Firefox 8.
 
-> **Note:** Firefox 8 requires that binary components be recompiled, as do all major releases of Firefox.
+> [!NOTE]
+> Firefox 8 requires that binary components be recompiled, as do all major releases of Firefox.
 
 ### XPCOM
 

--- a/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/8/updating_add-ons/index.md
@@ -14,7 +14,8 @@ If your add-on is distributed on [addons.mozilla.org](https://addons.mozilla.org
 
 So you should start by visiting AMO and looking to see if your add-on needs any work done at all.
 
-> **Note:** You should still test your add-on on Firefox 8, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
+> [!NOTE]
+> You should still test your add-on on Firefox 8, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
 
 Once you've confirmed that you need to make changes, come on back to this page and read on.
 

--- a/files/en-us/mozilla/firefox/releases/82/index.md
+++ b/files/en-us/mozilla/firefox/releases/82/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 82 that will affect developers. Firefox 82 was released on October 20, 2020.
 
-> **Note:** See also [Coming through with Firefox 82](https://hacks.mozilla.org/2020/10/coming-through-with-firefox-82/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Coming through with Firefox 82](https://hacks.mozilla.org/2020/10/coming-through-with-firefox-82/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/83/index.md
+++ b/files/en-us/mozilla/firefox/releases/83/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 83 that will affect developers. Firefox 83 was released on November 17, 2020.
 
-> **Note:** See also [Firefox 83 is upon us](https://hacks.mozilla.org/2020/11/firefox-83-is-upon-us/) on Mozilla hacks
+> [!NOTE]
+> See also [Firefox 83 is upon us](https://hacks.mozilla.org/2020/11/firefox-83-is-upon-us/) on Mozilla hacks
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/84/index.md
+++ b/files/en-us/mozilla/firefox/releases/84/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 84 that will affect developers. Firefox 84 was released on December 15, 2020.
 
-> **Note:** See also [And now for … Firefox 84](https://hacks.mozilla.org/2020/12/and-now-for-firefox-84/) on Mozilla Hacks.
+> [!NOTE]
+> See also [And now for … Firefox 84](https://hacks.mozilla.org/2020/12/and-now-for-firefox-84/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/85/index.md
+++ b/files/en-us/mozilla/firefox/releases/85/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 85 that will affect developers. Firefox 85 was released on January 26, 2021.
 
-> **Note:** See also [January brings us Firefox 85](https://hacks.mozilla.org/2021/01/january-brings-us-firefox-85/) on Mozilla Hacks.
+> [!NOTE]
+> See also [January brings us Firefox 85](https://hacks.mozilla.org/2021/01/january-brings-us-firefox-85/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/86/index.md
+++ b/files/en-us/mozilla/firefox/releases/86/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 86 that will affect developers. Firefox 86 was released on February 23, 2021.
 
-> **Note:** See also [A Fabulous February Firefox — 86!](https://hacks.mozilla.org/2021/02/a-fabulous-february-firefox-86/) on Mozilla Hacks.
+> [!NOTE]
+> See also [A Fabulous February Firefox — 86!](https://hacks.mozilla.org/2021/02/a-fabulous-february-firefox-86/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/87/index.md
+++ b/files/en-us/mozilla/firefox/releases/87/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 87 that will affect developers. Firefox 87 was released on March 23, 2021.
 
-> **Note:** See also [In March, we see Firefox 87](https://hacks.mozilla.org/2021/03/in-march-we-see-firefox-87/) on Mozilla Hacks.
+> [!NOTE]
+> See also [In March, we see Firefox 87](https://hacks.mozilla.org/2021/03/in-march-we-see-firefox-87/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/88/index.md
+++ b/files/en-us/mozilla/firefox/releases/88/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 88 that will affect developers. Firefox 88 was released on April 19, 2021.
 
-> **Note:** See also [Never too late for Firefox 88](https://hacks.mozilla.org/2021/04/never-too-late-for-firefox-88/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Never too late for Firefox 88](https://hacks.mozilla.org/2021/04/never-too-late-for-firefox-88/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/89/index.md
+++ b/files/en-us/mozilla/firefox/releases/89/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 89 that will affect developers. Firefox 89 was released on June 1, 2021.
 
-> **Note:** See also [Looking fine with Firefox 89](https://hacks.mozilla.org/2021/06/looking-fine-with-firefox-89/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Looking fine with Firefox 89](https://hacks.mozilla.org/2021/06/looking-fine-with-firefox-89/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/updating_add-ons/index.md
@@ -14,7 +14,8 @@ If your add-on is distributed on [addons.mozilla.org](https://addons.mozilla.org
 
 So you should start by visiting AMO and looking to see if your add-on needs any work done at all.
 
-> **Note:** You should still test your add-on on Firefox 9, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
+> [!NOTE]
+> You should still test your add-on on Firefox 9, even if it's been automatically upgraded. There are edge cases that may not be automatically detected.
 
 Once you've confirmed that you need to make changes, come on back to this page and read on.
 

--- a/files/en-us/mozilla/firefox/releases/90/index.md
+++ b/files/en-us/mozilla/firefox/releases/90/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 90 that will affect developers. Firefox 90 was released on July 13th, 2021.
 
-> **Note:** See also [Getting lively with Firefox 90](https://hacks.mozilla.org/2021/07/getting-lively-with-firefox-90/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Getting lively with Firefox 90](https://hacks.mozilla.org/2021/07/getting-lively-with-firefox-90/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/91/index.md
+++ b/files/en-us/mozilla/firefox/releases/91/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 91 that will affect developers. Firefox 91 was released on August 10, 2021.
 
-> **Note:** See also [Hopping on Firefox 91](https://hacks.mozilla.org/2021/08/hopping-on-firefox-91/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Hopping on Firefox 91](https://hacks.mozilla.org/2021/08/hopping-on-firefox-91/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/92/index.md
+++ b/files/en-us/mozilla/firefox/releases/92/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 92 that will affect developers. Firefox 92 was released on September 7, 2021.
 
-> **Note:** See also [Time for a review of Firefox 92](https://hacks.mozilla.org/2021/09/time-for-a-review-of-firefox-92/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Time for a review of Firefox 92](https://hacks.mozilla.org/2021/09/time-for-a-review-of-firefox-92/) on Mozilla Hacks.
 
 ## Changes for web developers
 

--- a/files/en-us/mozilla/firefox/releases/93/index.md
+++ b/files/en-us/mozilla/firefox/releases/93/index.md
@@ -8,7 +8,8 @@ page-type: firefox-release-notes
 
 This article provides information about the changes in Firefox 93 that will affect developers. Firefox 93 was released on October 5, 2021.
 
-> **Note:** See also [Lots to see in Firefox 93](https://hacks.mozilla.org/2021/10/lots-to-see-in-firefox-93/) on Mozilla Hacks.
+> [!NOTE]
+> See also [Lots to see in Firefox 93](https://hacks.mozilla.org/2021/10/lots-to-see-in-firefox-93/) on Mozilla Hacks.
 
 ## Changes for web developers
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'mozilla/firefox' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
