### PR TITLE
Convert noteblocks for related folder

### DIFF
--- a/files/en-us/related/imsc/basics/index.md
+++ b/files/en-us/related/imsc/basics/index.md
@@ -6,7 +6,8 @@ page-type: guide
 
 IMSC allows you to add subtitles or captions to your online video. In this article we'll take you through what you need to get started, including basic document structure, and the basics of how to style, time, and position subtitles.
 
-> **Note:** IMSC can be used for any kind of timed text you might want to include on a web document, not just for subtitles and captions. But because subtitles and captions represent the most common use cases for IMSC, we will focus on those. For readability we only use the term subtitles. In the technical context we describe, the term "subtitles" is interchangeable with "captions".
+> [!NOTE]
+> IMSC can be used for any kind of timed text you might want to include on a web document, not just for subtitles and captions. But because subtitles and captions represent the most common use cases for IMSC, we will focus on those. For readability we only use the term subtitles. In the technical context we describe, the term "subtitles" is interchangeable with "captions".
 
 ## So what is IMSC?
 
@@ -17,13 +18,15 @@ If you are not already familiar with XML or HTML, read up on them first and then
 - [XML Introduction](/en-US/docs/Web/XML/XML_introduction)
 - [HTML Basics](/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics)
 
-> **Note:** If you want to know what you can do with IMSC in real-world scenarios have a look at the expanded example at the end of this tutorial.
+> [!NOTE]
+> If you want to know what you can do with IMSC in real-world scenarios have a look at the expanded example at the end of this tutorial.
 
 ## Minimal IMSC document
 
 IMSC is always specified as a complete XML document. As a file it should have the extension "_ttml_".
 
-> **Note:** IMSC does not have native support in browsers at this current moment, but the [imscJS](https://github.com/sandflow/imscJS) polyfill can be used to bridge this gap. All the examples below are rendered by using imscJS. It creates dynamically HTML and CSS from an IMSC XML document.
+> [!NOTE]
+> IMSC does not have native support in browsers at this current moment, but the [imscJS](https://github.com/sandflow/imscJS) polyfill can be used to bridge this gap. All the examples below are rendered by using imscJS. It creates dynamically HTML and CSS from an IMSC XML document.
 
 Let's look at a minimal IMSC document and how it is rendered:
 
@@ -52,7 +55,8 @@ This includes the following new attributes:
 
 Play around with the second values in the code sample and push the reload button when you are ready.
 
-> **Note:** The end times in IMSC are not "inclusive". The subtitle "Hello, I am Mork from Ork." is not shown anymore when it reaches the second value in time.
+> [!NOTE]
+> The end times in IMSC are not "inclusive". The subtitle "Hello, I am Mork from Ork." is not shown anymore when it reaches the second value in time.
 
 You can also use the `dur` attribute for timing:
 
@@ -83,7 +87,8 @@ Try setting some other colors for the text and background colors:
 - You can use other color schemes like `rgb(0 255 255)`.
 - Finally, try semi-transparent variations, like `rgb(0 0 0 / .8)`.
 
-> **Note:** Don't worry for now about namespaces. We will explain the meaning of `xmlns:tts` and `tts:backgroundColor` in a separate guide.
+> [!NOTE]
+> Don't worry for now about namespaces. We will explain the meaning of `xmlns:tts` and `tts:backgroundColor` in a separate guide.
 
 As explained in the [IMSC Styling](/en-US/docs/Related/IMSC/Styling) guide, it is possible to define a collection of styling properties that can be used any number of times. The style `s1` below is applied three times:
 

--- a/files/en-us/related/imsc/imsc_and_other_standards/index.md
+++ b/files/en-us/related/imsc/imsc_and_other_standards/index.md
@@ -31,7 +31,8 @@ IMSC 1.1 was designed such that valid IMSC 1.0.1 documents are valid IMSC 1.1 do
 - Support for author-controlled luminance when compositing onto absolute luminance High-Dynamic Range video.
 - Support for stereoscopic 3D.
 
-> **Note:** IMSC 1.1 also deprecates, but does not prohibit, a limited number features that have no practical use or for which better alternatives exist.
+> [!NOTE]
+> IMSC 1.1 also deprecates, but does not prohibit, a limited number features that have no practical use or for which better alternatives exist.
 
 In summary, authors are encouraged to create IMSC 1.0.1 documents if possible and for maximal compatibility, and implementers are encouraged to implement support for IMSC 1.1 for worldwide coverage.
 

--- a/files/en-us/related/imsc/namespaces/index.md
+++ b/files/en-us/related/imsc/namespaces/index.md
@@ -129,7 +129,8 @@ By defining `xmlns:tts="http://www.w3.org/ns/ttml#styling` on the `<tt>` element
 
 Much more readable, isn't it?
 
-> **Note:** The namespace/prefix match is only a document-wide agreement. Theoretically you can use another prefix than `tts` to bind the styling namespace. It is completely legal to define `xmlns:foo="http://www.w3.org/ns/ttml#styling"` and then write `<p foo:color="yellow">`. But it makes your IMSC document much more readable if you use the official prefixes listed in [namespace section](https://www.w3.org/TR/ttml-imsc1.0.1/#namespaces) of the IMSC standard.
+> [!NOTE]
+> The namespace/prefix match is only a document-wide agreement. Theoretically you can use another prefix than `tts` to bind the styling namespace. It is completely legal to define `xmlns:foo="http://www.w3.org/ns/ttml#styling"` and then write `<p foo:color="yellow">`. But it makes your IMSC document much more readable if you use the official prefixes listed in [namespace section](https://www.w3.org/TR/ttml-imsc1.0.1/#namespaces) of the IMSC standard.
 
 <section id="Quick_links">
   <ol>

--- a/files/en-us/related/imsc/timing_in_imsc/index.md
+++ b/files/en-us/related/imsc/timing_in_imsc/index.md
@@ -76,7 +76,8 @@ Now that a frame rate of 23.98 is declared, you are able to describe time expres
 
 The advantage of using this method is that the time expression frame number is the same as the frame number of the media asset. A value of 86400f is frame number 86400 in the video file.
 
-> **Note:** You can find an additional explanation of these values in [Mapping video time codes to IMSC](/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC).
+> [!NOTE]
+> You can find an additional explanation of these values in [Mapping video time codes to IMSC](/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC).
 
 <section id="Quick_links">
   <ol>

--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
@@ -202,7 +202,8 @@ While we loop through the `timeEvents` we can take the value of the time event a
 myCue = new Cue(timeEvents[i], timeEvents[i + 1], "");
 ```
 
-> **Note:** In most browsers text track cues are currently only implemented for the WebVTT format. So usually you create a cue with all WebVTT properties including the WebVTT text property. We never use these properties but it is important to remember that they are still there. In the constructor we also have to add the VTTCue text as a third parameter.
+> [!NOTE]
+> In most browsers text track cues are currently only implemented for the WebVTT format. So usually you create a cue with all WebVTT properties including the WebVTT text property. We never use these properties but it is important to remember that they are still there. In the constructor we also have to add the VTTCue text as a third parameter.
 
 But how should we calculate the end time of the last time event? It does not have a "next" time event we can take the end time from.
 

--- a/files/en-us/related/index.md
+++ b/files/en-us/related/index.md
@@ -6,7 +6,8 @@ page-type: landing-page
 
 This section of the site is a home for documentation on web-related technologies that aren't central to the MDN's remit (i.e. they aren't web standards technologies), but are nonetheless related to the web and of interest to web developers.
 
-> **Note:** These documentation resources generally aren't maintained by the MDN writer's team — if you have suggestions or queries related to these resources, check out the landing pages for those technologies for contact details of the relevant maintenance team.
+> [!NOTE]
+> These documentation resources generally aren't maintained by the MDN writer's team — if you have suggestions or queries related to these resources, check out the landing pages for those technologies for contact details of the relevant maintenance team.
 
 ## Technology list
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'related' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
