### PR TITLE
Convert noteblocks for web/accessibility folder

### DIFF
--- a/files/en-us/web/accessibility/accessibility_and_spacial_patterns/index.md
+++ b/files/en-us/web/accessibility/accessibility_and_spacial_patterns/index.md
@@ -22,7 +22,8 @@ Stripes and patterns are typical of the kinds of images that create problems, an
 
 In 2005, Arnold Wilkins, John Emmett, and Graham Harding evaluated the guidelines for characterizing patterned images that could precipitate seizures. They revised the guidelines to their fundamental core, and came up with a surprisingly simple, but powerful [test](https://onlinelibrary.wiley.com/doi/full/10.1111/j.1528-1167.2005.01405.x). which they published in the paper, **[Characterizing the Patterned Images That Precipitate Seizures and Optimizing Guidelines To Prevent Them](https://onlinelibrary.wiley.com/doi/full/10.1111/j.1528-1167.2005.01405.x)**
 
-> **Note:** The steps necessary to evaluate material reduce to the following:
+> [!NOTE]
+> The steps necessary to evaluate material reduce to the following:
 >
 > Look at the screen:
 >

--- a/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
+++ b/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
@@ -41,7 +41,8 @@ _Example 2: How the tabs widget might be styled visually. Users might recognize 
 
 **ARIA** enables developers to describe their widgets in more detail by adding special attributes to the markup. Designed to fill the gap between standard HTML tags and the desktop-style controls found in dynamic web applications, ARIA provides roles and states that describe the behavior of most familiar UI widgets.
 
-> **Warning:** Many of these were later added when browsers didn't fully support modern HTML features. **Developers should always prefer using the correct semantic HTML element over using ARIA**.
+> [!WARNING]
+> Many of these were later added when browsers didn't fully support modern HTML features. **Developers should always prefer using the correct semantic HTML element over using ARIA**.
 
 The ARIA specification is split up into three different types of attributes: roles, states, and properties. Roles describe widgets that aren't otherwise available in HTML 4, such as sliders, menu bars, tabs, and dialogs. Properties describe characteristics of these widgets, such as if they are draggable, have a required element, or have a popup associated with them. States describe the current interaction state of an element, informing the assistive technology if it is busy, disabled, selected, or hidden.
 
@@ -150,7 +151,8 @@ Do not do this. Instead, implement the "view" mode using a different element alt
 
 ### Asynchronous content changes
 
-> **Note:** Under construction. See also [Live Regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
+> [!NOTE]
+> Under construction. See also [Live Regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
 
 ## Keyboard navigation
 

--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.md
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 Using JavaScript, it is possible to dynamically change parts of a page without requiring the entire page to reload — for instance, to update a list of search results on the fly, or to display a discreet alert or notification which does not require user interaction. While these changes are usually visually apparent to users who can see the page, they may not be obvious to users of assistive technologies. ARIA live regions fill this gap and provide a way to programmatically expose dynamic content changes in a way that can be announced by assistive technologies.
 
-> **Note:** Assistive technologies will generally only announce _dynamic_ changes in the content of a live region.
+> [!NOTE]
+> Assistive technologies will generally only announce _dynamic_ changes in the content of a live region.
 > Including an `aria-live` attribute or a specialized live region `role` (such as [`role="status"`](/en-US/docs/Web/Accessibility/ARIA/Roles/status_role)) on the element you want to announce changes to works as long as you add the attribute before the changes occur — either in the original markup, or dynamically using JavaScript. Start with an empty live region, then – in a separate step – change the content inside the region.
 > While not explicitly documented in the specification, browsers/assistive technologies do include special handling for [`role="alert"`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role): in most cases, the content inside `role="alert"` regions is announced, even when the region (which already contains the notification/message) is present in the initial markup of the page, or injected dynamically into the page. However, note that `role="alert"` regions are – depending on the specific browser/assistive technology combination – automatically prefixed with "Alert" when they are announced.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-activedescendant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-activedescendant/index.md
@@ -27,9 +27,11 @@ When the element with DOM focus is a combobox, textbox, or searchbox, include [`
 
 The value of `aria-activedescendant` refers to an owned element of the controlled element. For example, in a combobox, focus may remain on the combobox while the value of `aria-activedescendant` on the combobox element refers to a descendant of a popup listbox that is controlled by the combobox.
 
-> **Note:** The attribute is supported only on a few roles. For example, `dialog`s do not support `aria-activedescendant`. When a combobox opens a dialog, DOM focus moves into the dialog from the combobox as it is not referenceable with this attribute.
+> [!NOTE]
+> The attribute is supported only on a few roles. For example, `dialog`s do not support `aria-activedescendant`. When a combobox opens a dialog, DOM focus moves into the dialog from the combobox as it is not referenceable with this attribute.
 
-> **Note:** When a descendant of a `listbox`, `grid`, or `tree` popup is focused, DOM focus remains on the combobox and the combobox has `aria-activedescendant` set to a value that refers to the focused element within the popup.
+> [!NOTE]
+> When a descendant of a `listbox`, `grid`, or `tree` popup is focused, DOM focus remains on the combobox and the combobox has `aria-activedescendant` set to a value that refers to the focused element within the popup.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-braillelabel/index.md
@@ -23,7 +23,8 @@ When using `aria-braillelabel`, ensure that:
 - The `aria-braillelabel` values are localized to align with the document language.
 - Communicate to the user that this attribute is available, especially if the content contains unicode braille patterns, so the user knows to set the settings to apply user specific braille translations
 
-> **Note:** Assistive technologies with braille support can convert the accessible names to braille.
+> [!NOTE]
+> Assistive technologies with braille support can convert the accessible names to braille.
 > Therefore, only use `aria-braillelabel` when the accessible name is not the user experience you want.
 
 Using only the accessible name, e.g., from content or via `aria-label` is almost always the better user experience, so don't use aria-braillelabel to replicate aria-label. Only use `aria-braillelabel` if the accessible name cannot provide an adequate braille representation.

--- a/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-brailleroledescription/index.md
@@ -42,9 +42,11 @@ A few rules to remember:
 - Avoid using Unicode Braille Patterns. If they must be used, ensure the `aria-brailleroledescription` value contains content other than unicode braille patterns, whitespace, and braille battern dots-0.
 - Ensure the value is always localized to the document's language.
 
-> **Warning:** If the content is only in unicode braille patterns, the value will not be translated according to the user's preferred translation table.
+> [!WARNING]
+> If the content is only in unicode braille patterns, the value will not be translated according to the user's preferred translation table.
 
-> **Note:** Do NOT use `aria-brailleroledescription` to replicate `aria-roledescription`. Only include this attribute when `aria-roledescription` does not provide an adequate braille representation.
+> [!NOTE]
+> Do NOT use `aria-brailleroledescription` to replicate `aria-roledescription`. Only include this attribute when `aria-roledescription` does not provide an adequate braille representation.
 
 The `aria-brailleroledescription` value will not be exposed to the braille user if:
 
@@ -52,7 +54,8 @@ The `aria-brailleroledescription` value will not be exposed to the braille user 
 - The element to which the attribute is applied has an explicit or implicit WAI-ARIA role where `aria-brailleroledescription` is prohibited, including the `generic` role.
 - The element to which the attribute is applied does not have a valid `aria-roledescription`.
 
-> **Note:** Test your sites and applications with daily users of assistive technologies, including braille readers, to ensure your content makes sense in braille.
+> [!NOTE]
+> Test your sites and applications with daily users of assistive technologies, including braille readers, to ensure your content makes sense in braille.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-checked/index.md
@@ -11,7 +11,8 @@ spec-urls:
 
 The `aria-checked` attribute indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` and `type="radio"` as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` and `type="radio"` as these have built in semantics and do not require ARIA attributes.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colindextext/index.md
@@ -61,7 +61,8 @@ In the above example, the table has 128 columns of which only 4 columns are show
 
 Only use `aria-colindextext` when the provided or calculated value of `aria-colindex` is not meaningful or does not reflect the displayed index. Whenever you include `aria-colindextext`, also keep the `aria-colindex` as some assistive technologies rely on the numeric column index for the purpose of keeping track of the user's position and in providing alternative table navigation.
 
-> **Note:** While `aria-colindex` can be added to a row when all the columns present are contiguous as sequential values can be deduced, `aria-colindextext` is NOT a supported property of [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role).
+> [!NOTE]
+> While `aria-colindex` can be added to a row when all the columns present are contiguous as sequential values can be deduced, `aria-colindextext` is NOT a supported property of [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role).
 
 See related [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext).
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colspan/index.md
@@ -15,7 +15,8 @@ Intended for [`cell`s](/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role) and [
 
 In HTML, {{HTMLElement('th')}} and {{HTMLElement('td')}} elements have the [`colspan`](/en-US/docs/Web/HTML/Element/td#attributes) attribute. When using the semantic {{HTMLElement('table')}}, use the native `colspan` attribute as designed. This ARIA attribute is intended for cells and gridcells which are not contained in a native table, and will be ignored if used on a cell in a {{HTMLElement('table')}}.
 
-> **Note:** The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of repurposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ HTML {{HTMLelement('table')}} elements, including {{HTMLelement('td')}} and {{HTMLelement('th')}} with the `colspan` attribute instead of non-semantic elements with ARIA roles and attributes whenever possible.
+> [!NOTE]
+> The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of repurposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ HTML {{HTMLelement('table')}} elements, including {{HTMLelement('td')}} and {{HTMLelement('th')}} with the `colspan` attribute instead of non-semantic elements with ARIA roles and attributes whenever possible.
 
 The value of `aria-colspan` should be a positive integer. The default or assumed value of a cell span is 1. Make sure that the included value does cause the cell or gridcell to overlap the next cell or gridcell in the same row and does not cause the cell to span outside of the containing table, grid, or treegrid.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-controls/index.md
@@ -75,7 +75,8 @@ In this tabs example, each tab controls one tabpanel:
 </div>
 ```
 
-> **Note:** ARIA only modifies the accessibility tree for an element, identifying how assistive technology can present the content to users. ARIA doesn't change any implicit functionality or styling.
+> [!NOTE]
+> ARIA only modifies the accessibility tree for an element, identifying how assistive technology can present the content to users. ARIA doesn't change any implicit functionality or styling.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-current/index.md
@@ -21,7 +21,8 @@ The `aria-current` attribute accepts a limited list of [values](#values) includi
 
 When something is selected rather than current, such as a [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) in a [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role), use [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) to indicate the currently-displayed tabpanel.
 
-> **Note:** Don't use `aria-current` as a substitute for [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) in [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role), [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/option_role), [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role) or [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role).
+> [!NOTE]
+> Don't use `aria-current` as a substitute for [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) in [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role), [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/option_role), [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role) or [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role).
 
 ## Example
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-describedby/index.md
@@ -23,7 +23,8 @@ The elements linked via `aria-describedby` don't need to be visible. It is possi
 
 The `aria-describedby` property is appropriate when the associated content contains descriptions experienced as plain text. If the content contains a large amount of content, useful semantics, or has a complex structure requiring user navigation, use [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details). `aria-details` allows assistive technology users to visit the associated structured content and provides additional navigation commands, making it easier to understand the structure, or to experience the information in smaller pieces.
 
-> **Note:** The `aria-describedby` content should only be a text string. If there are important underlying semantics in the content, consider using [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details).
+> [!NOTE]
+> The `aria-describedby` content should only be a text string. If there are important underlying semantics in the content, consider using [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details).
 
 ## Example
 
@@ -35,7 +36,8 @@ The `aria-describedby` property is appropriate when the associated content conta
 </p>
 ```
 
-> **Note:** The `aria-describedby` attribute is not designed to reference descriptions from external resources. As its value is one or more `id`s (space-separated if multiple), it must reference elements in the same DOM document.
+> [!NOTE]
+> The `aria-describedby` attribute is not designed to reference descriptions from external resources. As its value is one or more `id`s (space-separated if multiple), it must reference elements in the same DOM document.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
@@ -9,7 +9,7 @@ spec-urls: https://w3c.github.io/aria/#aria-description
 
 The global `aria-description` attribute defines a string value that describes or annotates the current element.
 
-> [!NOTE] > `aria-description` is still in W3C Editor's Draft for ARIA 1.3. For the time being, continue to use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby), which has been supported since ARIA 1.1.
+> **Note:** `aria-description` is still in W3C Editor's Draft for ARIA 1.3. For the time being, continue to use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby), which has been supported since ARIA 1.1.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-description/index.md
@@ -9,7 +9,7 @@ spec-urls: https://w3c.github.io/aria/#aria-description
 
 The global `aria-description` attribute defines a string value that describes or annotates the current element.
 
-> **Note:** `aria-description` is still in W3C Editor's Draft for ARIA 1.3. For the time being, continue to use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby), which has been supported since ARIA 1.1.
+> [!NOTE] > `aria-description` is still in W3C Editor's Draft for ARIA 1.3. For the time being, continue to use [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby), which has been supported since ARIA 1.1.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-details/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-details/index.md
@@ -23,7 +23,7 @@ Elements referenced by `aria-details` are intended to contain more information t
 
 The elements referenced by `aria-details` should be visible to all users. `aria-details` informs users that otherwise might not be able to scan a screen and discern quickly that the explanatory content is available.
 
-> **Note:** `aria-details` has no impact on the accessible description.
+> [!NOTE] > `aria-details` has no impact on the accessible description.
 
 Unlike `aria-describedby`, elements referenced by `aria-details` are not used in accessible descriptions and are not turned into a plain string when presented to assistive technology users. If the associated content is not too long and flattening the contents of the referenced element to a simple string of text wouldn't cause loss of information, consider using `aria-describedby` instead. That said, it is valid for an element to have both `aria-details` and a description specified with either `aria-describedby` or `aria-description`.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-details/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-details/index.md
@@ -23,7 +23,7 @@ Elements referenced by `aria-details` are intended to contain more information t
 
 The elements referenced by `aria-details` should be visible to all users. `aria-details` informs users that otherwise might not be able to scan a screen and discern quickly that the explanatory content is available.
 
-> [!NOTE] > `aria-details` has no impact on the accessible description.
+> **Note:** `aria-details` has no impact on the accessible description.
 
 Unlike `aria-describedby`, elements referenced by `aria-details` are not used in accessible descriptions and are not turned into a plain string when presented to assistive technology users. If the associated content is not too long and flattening the contents of the referenced element to a simple string of text wouldn't cause loss of information, consider using `aria-describedby` instead. That said, it is valid for an element to have both `aria-details` and a description specified with either `aria-describedby` or `aria-description`.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-disabled/index.md
@@ -23,7 +23,8 @@ When needing to disable native HTML form controls, developers will need to speci
 
 In each of these cases, one may want users to find these elements through standard keyboard navigation, though the functionality of that control is removed or "disabled". Developers will still need to use JavaScript to fully disable the functionality of the element while also changing the appearance of the element so sighted users know it is disabled.
 
-> **Note:** The state of being disabled applies to the element with `aria-disabled="true"` and all of its focusable descendants. Take care when using this attribute on container elements. Particularly in the case where a container may have both form controls and links - where the intent may be to expose the form controls as being in the disabled state, but <strong>not</strong> to communicate the links as being "disabled".
+> [!NOTE]
+> The state of being disabled applies to the element with `aria-disabled="true"` and all of its focusable descendants. Take care when using this attribute on container elements. Particularly in the case where a container may have both form controls and links - where the intent may be to expose the form controls as being in the disabled state, but <strong>not</strong> to communicate the links as being "disabled".
 
 Another reason to use the `aria-disabled` attribute over the HTML `disabled` attribute is if you have created custom controls which need to be marked as disabled, but are not using an element that allows for the `disabled` attribute. For instance, in the following snippet a `<div>` was used to create a custom button which needs to be marked as disabled. However, the `<div>` element does not expect, nor respect the `disabled` attribute - even if it were to be given a `role="button"` to change its exposed ARIA role. The `aria-disabled` attribute is required to disable such custom controls.
 
@@ -54,7 +55,8 @@ The [`forced-colors` media query](/en-US/docs/Web/CSS/@media/forced-colors) dete
 
 Another thing to keep in mind, when using `aria-disabled` over the native HTML attribute, is that the ARIA attribute will require the manual styling necessary to visually communicate the element as disabled in Windows High Contrast Mode.
 
-> **Note:** If you are using CSS's [`pointer-events: none;`](/en-US/docs/Web/CSS/pointer-events) to make an element non-clickable, make sure you disable interactivity with JavaScript as well. `pointer-events: none;` prevents mouse clicks, but does not prevent the element from being activated via the keyboard.
+> [!NOTE]
+> If you are using CSS's [`pointer-events: none;`](/en-US/docs/Web/CSS/pointer-events) to make an element non-clickable, make sure you disable interactivity with JavaScript as well. `pointer-events: none;` prevents mouse clicks, but does not prevent the element from being activated via the keyboard.
 
 ```js
 function onClick(event) {

--- a/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-expanded/index.md
@@ -56,7 +56,8 @@ By default, some roles are hidden or collapsed and other roles are open or expan
 </p>
 ```
 
-> **Note:** The presence of the `aria-expanded` attribute indicates control. Avoid including it on elements that do not control the expanded state of other elements.
+> [!NOTE]
+> The presence of the `aria-expanded` attribute indicates control. Avoid including it on elements that do not control the expanded state of other elements.
 
 ### Treeitems
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-flowto/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-flowto/index.md
@@ -17,7 +17,8 @@ The global `aria-flowto` attribute lets the author indicate to assistive technol
 
 When `aria-flowto` has a single [id](/en-US/docs/Web/HTML/Global_attributes/id) reference, it allows assistive technologies to, at the user's request, go to the element targeted via that `id` instead of reading the document in the order of the DOM. When the `aria-flowto` value uses a space separated list of multiple `id` references, assistive technology can provide the user with a list of path choices, with each `id` referenced being a choice. The path choice names are determined by the accessible name of each target element of the `aria-flowto` attribute.
 
-> **Note:** Setting `aria-flowto` does not impact the content's tab order. It only provides users the option to follow a content path that doesn't match the DOM order when using tech that supports this attribute.
+> [!NOTE]
+> Setting `aria-flowto` does not impact the content's tab order. It only provides users the option to follow a content path that doesn't match the DOM order when using tech that supports this attribute.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-grabbed/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-grabbed/index.md
@@ -23,7 +23,8 @@ When `aria-grabbed` is set to `true`, the [`aria-dropeffect`](/en-US/docs/Web/Ac
 
 The `aria-grabbed` property is expected to be replaced by a new feature in a future version of WAI-ARIA and is considered deprecated.
 
-> **Note:** ARIA does not enable accessible functionality. ARIA only conveys the intended behavior of your functionality.
+> [!NOTE]
+> ARIA does not enable accessible functionality. ARIA only conveys the intended behavior of your functionality.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
@@ -17,15 +17,18 @@ The presence of the `aria-haspopup`, with one of six enumerated values - `menu`,
 
 A [`tooltip`](/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role) is not considered to be a popup in this context, as it is not interactive.
 
-> **Note:** Make sure the role of the element that serves as the container for the popup content is a [`menu`](/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role), [`listbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role), [`tree`](/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role), [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) or [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and that the value of `aria-haspopup` matches the role of the popup container.
+> [!NOTE]
+> Make sure the role of the element that serves as the container for the popup content is a [`menu`](/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role), [`listbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role), [`tree`](/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role), [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) or [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and that the value of `aria-haspopup` matches the role of the popup container.
 
 The `aria-haspopup` state informs assistive technology users that there is a popup and the type of popup it is, but provides no interactivity. For the popup to be keyboard accessible, make sure the element with `aria-haspopup` is focusable and can trigger the popup, that there is a keyboard mechanism for opening the popup, and that the popup element manages focus of all its descendants.
 
-> **Note:** ARIA does not enable accessible functionality. ARIA only conveys the intended behavior of your functionality.
+> [!NOTE]
+> ARIA does not enable accessible functionality. ARIA only conveys the intended behavior of your functionality.
 
 When creating a [`menubar`](/en-US/docs/Web/Accessibility/ARIA/Roles/menubar_role), a parent [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role) should have `aria-haspopup="menu"` (or `true`) set. Any button that open a menu should have a role of [`button`](/en-US/docs/Web/Accessibility/ARIA/Roles/button_role) or, preferably, be a {{HTMLElement('button')}}, and also have `aria-haspopup="menu"` (or `true`) set. [`Tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) elements with popup menus should also have `aria-haspopup="menu"` set. Note that `menubar`s should not be used to create website navigation.
 
-> **Note:** Elements with role [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) have an implicit `aria-haspopup` value of `listbox`.
+> [!NOTE]
+> Elements with role [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role) have an implicit `aria-haspopup` value of `listbox`.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
@@ -23,13 +23,15 @@ The presence of the `aria-hidden` attribute hides content from assistive technol
 
 `aria-hidden="true"` should not be used on elements that can receive focus. Additionally, since this attribute is inherited by an element's children, it should not be added onto the parent or ancestor of a focusable element.
 
-> **Warning:** Do not use `aria-hidden="true"` on focusable elements.
+> [!WARNING]
+> Do not use `aria-hidden="true"` on focusable elements.
 
 An element's hidden status is based on whether it is rendered. Rendering is usually controlled by CSS. For example, an element whose `display` property is set to `none` via CSS is not rendered. An element is considered hidden if it, or any of its ancestors are not rendered or have their `aria-hidden` attribute value set to true. Note that an element and its children that has `aria-hidden="true"` declared on it will still be visible, unless also hidden by CSS.
 
 Use caution when using `aria-hidden` to hide visibly rendered content from assistive technologies. You should not be hiding visible content unless doing so improves the experience for users of assistive technologies by removing redundant or extraneous content. Only when identical or equivalent meaning and functionality is exposed to assistive technologies can removing visible content from the accessibility API be considered.
 
-> **Note:** Consider all disabilities when hiding visibly rendered content from assistive technologies. Not all users of assistive technology are visually impaired. If visible content doesn't match text content in the accessibility API, the user experience will be negatively impacted for sighted users.
+> [!NOTE]
+> Consider all disabilities when hiding visibly rendered content from assistive technologies. Not all users of assistive technology are visually impaired. If visible content doesn't match text content in the accessibility API, the user experience will be negatively impacted for sighted users.
 
 On the surface, the `aria-hidden="true"` and the `role="presentation"` and its synonym `role="none"` seem similar, but the intent behind each is different.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-invalid/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-invalid/index.md
@@ -17,7 +17,8 @@ The `aria-invalid` attribute can be used with any typical HTML form element, and
 
 The attribute should be set with JavaScript as a result of a validation process. If a value is determined to be invalid or out-of-range, set `aria-invalid="true"` **and** tell the user there is an error. For better user experience, provide suggestions for how the error can be corrected. Do not set `aria-invalid="true"` on empty required elements until after the user attempts to submit the form. They may still be working on filling it out.
 
-> **Note:** When `aria-invalid` is used in conjunction with the `aria-required` attribute, `aria-invalid` should not be set to true before the form is submitted - only in response to validation.
+> [!NOTE]
+> When `aria-invalid` is used in conjunction with the `aria-required` attribute, `aria-invalid` should not be set to true before the form is submitted - only in response to validation.
 
 There are currently four values: in addition to `true` and `false` we have `grammar` which can be used when a grammatical error is detected and `spelling` for spelling errors. If the attribute is not present, or its value is false, or its value is an empty string, the default value of false applies. Any other value is treated as if `true` were set.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -32,7 +32,7 @@ The code below shows an example of how to use the `aria-label` attribute to prov
 </button>
 ```
 
-> [!NOTE] > `aria-label` is intended for interactive elements or for elements made interactive via other ARIA declarations when there's no visible text in the DOM to serve as a label.
+> **Note:** `aria-label` is intended for interactive elements or for elements made interactive via other ARIA declarations when there's no visible text in the DOM to serve as a label.
 
 Most content has an accessible name generated from its immediate wrapping element's text content. Accessible names can also be created by certain attributes or associated elements.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -32,7 +32,7 @@ The code below shows an example of how to use the `aria-label` attribute to prov
 </button>
 ```
 
-> **Note:** `aria-label` is intended for interactive elements or for elements made interactive via other ARIA declarations when there's no visible text in the DOM to serve as a label.
+> [!NOTE] > `aria-label` is intended for interactive elements or for elements made interactive via other ARIA declarations when there's no visible text in the DOM to serve as a label.
 
 Most content has an accessible name generated from its immediate wrapping element's text content. Accessible names can also be created by certain attributes or associated elements.
 
@@ -40,7 +40,8 @@ By default, a button's accessible name is the content between the opening and cl
 
 If none of these options are available or if the default accessible name is not appropriate, use the `aria-label` attribute to define the accessible name of an element.
 
-> **Note:** While `aria-label` can be used on any element that can have an accessible name, in practice however, it is supported only on interactive elements, [widgets](/en-US/docs/Web/Accessibility/ARIA/Roles#2._widget_roles), [landmarks](/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles), images, and iframes.
+> [!NOTE]
+> While `aria-label` can be used on any element that can have an accessible name, in practice however, it is supported only on interactive elements, [widgets](/en-US/docs/Web/Accessibility/ARIA/Roles#2._widget_roles), [landmarks](/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles), images, and iframes.
 
 When using `aria-label`, you also need to consider [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby):
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-labelledby/index.md
@@ -23,7 +23,8 @@ The purpose of `aria-labelledby` is the same as that of `aria-label`. It provide
 
 The `aria-labelledby` and [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attributes both reference other elements to calculate text alternatives. `aria-labelledby` should reference brief text that provides the element with an accessible name. `aria-describedby` is used to reference longer content that provides a description. If there is no element in the DOM that provides a brief label appropriate for an accessible name for an interactive element, use `aria-label` to define the accessible name for an interactive element.
 
-> **Note:** While in U.S. English the attribute would be assumed to be spelled "labeledby", the "labelledby" spelling has been established and is the spelling used in accessibility APIs.
+> [!NOTE]
+> While in U.S. English the attribute would be assumed to be spelled "labeledby", the "labelledby" spelling has been established and is the spelling used in accessibility APIs.
 
 The following example uses `aria-labelledby` to provide an accessible name for a checkbox input by using the text content of a sibling element:
 
@@ -81,7 +82,8 @@ Fortunately, the HTML {{HTMLElement('input')}} with `type="checkbox"` works with
 
 7. The `aria-labelledby` property cannot be chained. If an element with `aria-labelledby` references another element that also has `aria-labelledby`, the `aria-labelledby` attribute on the referenced element is ignored.
 
-> **Warning:** Because calculating the name of an element with `aria-labelledby` can be complex and reference hidden content, testing with assistive technologies to ensure the expected name is presented to users is very important.
+> [!WARNING]
+> Because calculating the name of an element with `aria-labelledby` can be complex and reference hidden content, testing with assistive technologies to ensure the expected name is presented to users is very important.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-live/index.md
@@ -55,7 +55,8 @@ In this time-limit scenario, to be accessible, you need to also [provide a way f
 
 A live region includes the element and all its descendants. When not set on updating content, `aria-live`'s value comes from the nearest ancestor with a valid `aria-live` attribute value set. When set to `off`, or when the attribute is omitted altogether on the updated element and all the ancestor nodes in the DOM tree, the user is not informed. Users will still be able to hear the updates if they navigate to the live region, however.
 
-> **Warning:** Because an interruption may disorient users or cause them to not complete their current task, don't use the `assertive` value unless the interruption is imperative.
+> [!WARNING]
+> Because an interruption may disorient users or cause them to not complete their current task, don't use the `assertive` value unless the interruption is imperative.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -13,7 +13,8 @@ The `aria-modal` attribute indicates whether an element is modal when displayed.
 
 A section of content is "modal" means navigation is limited to the area itself and the background (the ancestors and siblings of the modal) is hidden. Setting `aria-modal="true"` on [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and [`alertdialog` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) containers indicates the presence of a "modal" element to users of assistive technology, but does not actually make the element modal. The features that make the element actually modal must be implemented by the developer.
 
-> **Note:** ARIA only modifies the accessibility tree, modifying how assistive technology presents the content to your users. ARIA doesn't change anything about an element's function or behavior. To create a modal effect you must use JavaScript to manage behavior, focus, and ARIA states.
+> [!NOTE]
+> ARIA only modifies the accessibility tree, modifying how assistive technology presents the content to your users. ARIA doesn't change anything about an element's function or behavior. To create a modal effect you must use JavaScript to manage behavior, focus, and ARIA states.
 
 Relevant only on `dialog` and `alertdialog` containers, setting `aria-modal="true"` tells assistive technologies to let the user know the ability to interact with, or access other content on the page requires the modal dialog to be closed or otherwise lose focus.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiline/index.md
@@ -15,7 +15,8 @@ The default behavior of the <kbd>Enter</kbd> or <kbd>Return</kbd> key differs be
 
 When user focus is in a multi-line {{HTMLElement('textarea')}}, the keystroke inserts a line break. Only relevant for elements with the [`textbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role) role set, the `aria-multiline` attribute indicates to assistive technologies whether that text box accepts multiple lines of input or only a single line, setting expectations as to what type of data to enter and what those keystroke will do.
 
-> **Note:** Where possible, use the HTML {{HTMLElement('input')}} or the {{HTMLElement('textarea')}}, as these have built in semantics and behaviors, do not require ARIA attributes or scripting, and have keyboard support built in.
+> [!NOTE]
+> Where possible, use the HTML {{HTMLElement('input')}} or the {{HTMLElement('textarea')}}, as these have built in semantics and behaviors, do not require ARIA attributes or scripting, and have keyboard support built in.
 
 If the `aria-multiline="true"` is set, it means the textbox widget will accept line breaks within the input, similar to the HTML {{HTMLElement('textarea')}}. Elements with a role of `textbox` that do not have the attribute, or with the value set to `false`, are simple text box.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -13,7 +13,8 @@ The `aria-multiselectable` attribute indicates that the user may select more tha
 
 The default behavior of selection lists, such as {{HTMLElement('select')}}, is to be able to choose only one item or option. By default or by convention, when a user is presented with list from which they must select an item, they assume they can only select a single item unless otherwise notified. The `aria-multiselectable` attribute is the way to inform assistive technology users that they may select more than one item from the current selectable items if they so choose. Lists and trees are examples of roles that might allow users to select more than one item at a time.
 
-> **Note:** When allowing for multiple selections, inform the user that multiple values are allowed and provide directions on how to provide multiple values, such as "to select more than one value, keep the control key pressed during selection."
+> [!NOTE]
+> When allowing for multiple selections, inform the user that multiple values are allowed and provide directions on how to provide multiple values, such as "to select more than one value, keep the control key pressed during selection."
 
 ### Used with `aria-selected`
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-owns/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-owns/index.md
@@ -21,7 +21,8 @@ An "owning element" is any DOM ancestor of an element. If an element visually, f
 
 Referencing the ID of one or more elements allows any element to "own" any other element with an `aria-owns` declaration. The value of the `aria-owns` attribute is a space-separated ID reference list that references the IDs of one or more elements in the document.
 
-> **Note:** An "owned" element is any DOM descendant of the element, any element specified as a child via `aria-owns`, or any DOM descendant of the owned child. The `aria-owns`-owned element should be an element that belongs to a separate parent tree in the DOM but should be treated as a child of the current element.
+> [!NOTE]
+> An "owned" element is any DOM descendant of the element, any element specified as a child via `aria-owns`, or any DOM descendant of the owned child. The `aria-owns`-owned element should be an element that belongs to a separate parent tree in the DOM but should be treated as a child of the current element.
 
 Do not use `aria-owns` as a replacement for the DOM hierarchy. If the relationship is represented in the DOM, do not use `aria-owns`.
 
@@ -31,7 +32,8 @@ When using `aria-owns`, make sure you [manage focus order](https://css-tricks.co
 
 An example of when to use `aria-owns` includes pop-up sub-menus that visually appear positioned near a parent menu, but cannot be nested in the DOM within the parent menu because it would affect the visual presentation. In this case, use `aria-owns` to present the sub-menu as a child of the parent menu to a screen reader.
 
-> **Note:** The `aria-owns` attribute should only be used when the parent/child relationship cannot be determined from the DOM.
+> [!NOTE]
+> The `aria-owns` attribute should only be used when the parent/child relationship cannot be determined from the DOM.
 
 If an element has both `aria-owns` and DOM children, the order of the child elements:
 
@@ -44,7 +46,8 @@ The {{CSSXRef('order')}} property, part of flex or grid layouts, can be used to 
 
 Make sure your owned elements have only one owner. Do not specify the `id` of an element in more than one other element's `aria-owns` attribute. An element can have only one owner.
 
-> **Warning:** While [`aria-owns` is now supported](https://a11ysupport.io/tech/aria/aria-owns_attribute) in all modern browsers, `aria-owns` may not be exposed to users of MacOS and iOS using VoiceOver prior to iOS 17.3 and macOS 14.3.
+> [!WARNING]
+> While [`aria-owns` is now supported](https://a11ysupport.io/tech/aria/aria-owns_attribute) in all modern browsers, `aria-owns` may not be exposed to users of MacOS and iOS using VoiceOver prior to iOS 17.3 and macOS 14.3.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
@@ -28,13 +28,16 @@ If you are creating a `textbox` using any other element, `placeholder` is not su
 
 The placeholder hint should be shown to the user whenever the control's value is empty, including when a value is deleted.
 
-> **Note:** ARIA is only modify the accessibility tree for an element and therefore how assistive technology presents the content to your users. ARIA doesn't change anything about an elements function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior.
+> [!NOTE]
+> ARIA is only modify the accessibility tree for an element and therefore how assistive technology presents the content to your users. ARIA doesn't change anything about an elements function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior.
 
 The `aria-placeholder` is used in addition to, not instead of, a label. They have different purposes and different functionality. A label explains what kind of information is expected. Placeholder text provides a hint about the expected value.
 
-> **Warning:** Using a placeholder instead of a visible label harms accessibility and usability for many users including older users and users with cognitive, mobility, fine motor skill and vision impairments. Labels are better: they are always visible and they provide for a larger hit region to focus on the control. Placeholders have several drawbacks: they disappear when the control has any value including just white space, they can confuse users into thinking the value is pre-filled, and the default color has insufficient contrast.
+> [!WARNING]
+> Using a placeholder instead of a visible label harms accessibility and usability for many users including older users and users with cognitive, mobility, fine motor skill and vision impairments. Labels are better: they are always visible and they provide for a larger hit region to focus on the control. Placeholders have several drawbacks: they disappear when the control has any value including just white space, they can confuse users into thinking the value is pre-filled, and the default color has insufficient contrast.
 
-> **Note:** Placeholders should only be used to show an example of the type of data that should be entered into a form; they don't replace a proper label.
+> [!NOTE]
+> Placeholders should only be used to show an example of the type of data that should be entered into a form; they don't replace a proper label.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-posinset/index.md
@@ -29,7 +29,8 @@ The following example shows a listbox with four element options out of the 118 i
 
 The value of each `aria-posinset` is an integer greater than or equal to `1`, and less than or equal to the size of the set when that size is known.
 
-> **Note:** When using `aria-posinset` you must also include value for [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize), which is the size of the entire set. If the size of the entire set is unknown, set `aria-setsize="-1"`.
+> [!NOTE]
+> When using `aria-posinset` you must also include value for [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize), which is the size of the entire set. If the size of the entire set is unknown, set `aria-setsize="-1"`.
 
 For [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role), [`menuitemcheckbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemcheckbox_role), or [`menuitemradio`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitemradio_role), set the value of `aria-posinset` with respect to the total number of items in the menu, excluding any separators.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-readonly/index.md
@@ -23,9 +23,11 @@ Examples include:
 
 If the non-changeable value shouldn't be able to receive focus, use [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) instead.
 
-> **Note:** When using semantic HTML form controls, if you set the `readonly` attribute, you don't need to include `aria-readonly="true"`.
+> [!NOTE]
+> When using semantic HTML form controls, if you set the `readonly` attribute, you don't need to include `aria-readonly="true"`.
 
-> **Note:** The value of `<input type="checkbox">` can not be edited making `readonly` not relevant. However, when creating checkboxes with `role="checkbox"` the `aria-readonly` attribute _is_ supported.
+> [!NOTE]
+> The value of `<input type="checkbox">` can not be edited making `readonly` not relevant. However, when creating checkboxes with `role="checkbox"` the `aria-readonly` attribute _is_ supported.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-required/index.md
@@ -17,13 +17,15 @@ When form controls are created using non-semantic elements, such as a {{HTMLElem
 
 Similar to the HTML `required` attribute set on semantic HTML form controls, the `aria-required` attribute explicitly conveys to assistive technologies that the element is required before a form may be submitted. The `required` attribute on a semantic HTML form control will prevent the form control from being submitted if no value is present — providing native error messaging in some browsers if a required value is invalid when the user attempts to submit the form. The `aria-required` attribute, like all ARIA states and properties, has no impact on element functionality. Functionality and behavior must be added in with JavaScript.
 
-> **Note:** ARIA only modifies the accessibility tree, modifying how assistive technology presents content to users. ARIA does not change anything about an element's function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior, focus, and ARIA states.
+> [!NOTE]
+> ARIA only modifies the accessibility tree, modifying how assistive technology presents content to users. ARIA does not change anything about an element's function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior, focus, and ARIA states.
 
 The CSS {{CSSXRef(':required')}} and {{CSSXRef(':optional')}} pseudoclasses match {{htmlelement("input")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}} elements based on whether they are required or optional, respectively. When using non-semantic elements as form controls, you don't get this CSS pseudoclass selector benefit. You can, however, use attribute selectors if the attribute is present: `[aria-required="true"]` or `[aria-required="false"]`.
 
 If a form contains both required and optional form elements, the required elements should be indicated visually using a treatment that does not rely solely on color to convey meaning. Typically, descriptive text and/or an icon are used.
 
-> **Note:** Which elements are required should be apparent to all users. Ensure the visual presentation indicates the form control is required in a consistent, visible manner, remembering that color is not enough to convey information.
+> [!NOTE]
+> Which elements are required should be apparent to all users. Ensure the visual presentation indicates the form control is required in a consistent, visible manner, remembering that color is not enough to convey information.
 
 ## Examples
 
@@ -39,7 +41,8 @@ The attribute should be added to the form-control role. If the user needs to fil
   id="email1"></div>
 ```
 
-> **Note:** If the field's label already contains the word "required", it is recommended to leave out the `aria-required` attribute. This avoids that screen readers read out the term "required" twice.
+> [!NOTE]
+> If the field's label already contains the word "required", it is recommended to leave out the `aria-required` attribute. This avoids that screen readers read out the term "required" twice.
 
 In this example, JavaScript must be used to prevent the containing form from being submitted if the textbox has no content.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-roledescription/index.md
@@ -13,7 +13,8 @@ The `aria-roledescription` attribute defines a human-readable, author-localized 
 
 Some assistive technologies (<abbr>AT</abbr>), such as screen readers, present the role of an element as part of the user experience. The `aria-roledescription` attribute provides a way to define a different human-readable name to be presented by AT as the role of an element.
 
-> **Note:** Only use aria-roledescription to clarify the purpose of non-interactive container roles and to provide a more specific description to a widget.
+> [!NOTE]
+> Only use aria-roledescription to clarify the purpose of non-interactive container roles and to provide a more specific description to a widget.
 
 Users depend on the presentation of known role name to understand the purpose of the element and, if it is a widget, how to interact with it. So, only use `aria-roledescription` to clarify the purpose of non-interactive container roles like `group` or `region` and to provide a more specific description to a widget.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
@@ -23,7 +23,8 @@ If all of the rows are loaded and in the DOM, you don't need to include `aria-ro
 
 If the table with only a subset of rows has a cell that spans more than one row, both the row and cell need to have the `aria-rowspan` set. If a cell spans more than one row－when a cell role includes the `aria-rowspan` attribute or HTML cell has a `rowspan` attribute set to a value greater than 1－include the row's `aria-rowindex` value on the spanning cell in addition to the appropriate row spanning attribute. The value should be the row index of the row where the span starts.
 
-> **Note:** The `aria-rowindex` must be added to each row, but is optional on the cells, except for cells that span rows: the `aria-rowindex` attribute is required on all spanning cells.
+> [!NOTE]
+> The `aria-rowindex` must be added to each row, but is optional on the cells, except for cells that span rows: the `aria-rowindex` attribute is required on all spanning cells.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowspan/index.md
@@ -15,7 +15,8 @@ Similar to the `rowspan` attribute of the {{HTMLElement('td')}} and {{HTMLElemen
 
 This attribute is intended for cells and gridcells which are **not** part of an HTML {{HTMLElement('table')}}. When a cell is nested in a semantic `<table>`, the `rowspan` attribute should be used when a <td> or <th> spans more than one row. If both are present, `rowspan` takes precedence over `aria-rowspan`. But, like all ARIA attributes, `aria-rowspan` only impacts the accessibility tree. It doesn't change your layout.
 
-> **Note:** ARIA modifies the accessibility tree and how assistive technology presents content to your users. ARIA doesn't change anything about an element's function, behavior, or appearance. When using non-semantic elements, you must use CSS to manage layout and appearance.
+> [!NOTE]
+> ARIA modifies the accessibility tree and how assistive technology presents content to your users. ARIA doesn't change anything about an element's function, behavior, or appearance. When using non-semantic elements, you must use CSS to manage layout and appearance.
 
 The value of `aria-rowspan` is an integer greater than or equal to 0 and less than the value which would cause the cell or gridcell to overlap the next cell or gridcell in the same column. Setting the value to `0` indicates that the cell or gridcell is to span all the remaining rows in the row group. The default value is `1`.
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-selected/index.md
@@ -87,7 +87,8 @@ In this `tablist` example, the first `tab` is selected:
 </div>
 ```
 
-> **Note:** ARIA only modifies the accessibility tree for an element and how assistive technology presents the content to users. ARIA doesn't change anything about an element's function or behavior.
+> [!NOTE]
+> ARIA only modifies the accessibility tree for an element and how assistive technology presents the content to users. ARIA doesn't change anything about an element's function or behavior.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemax/index.md
@@ -17,7 +17,8 @@ When creating a range type role, including [`meter`](/en-US/docs/Web/Accessibili
 
 Declaring the minimum and maximum values allows assistive technologies to convey the size of the range to users. The minimum value is defined with [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin).
 
-> **Warning:** The [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role) role itself should **NOT** be used as it is an ["abstract"](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). The `aria-valuemax` attribute is used on all of the range roles subtypes.
+> [!WARNING]
+> The [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role) role itself should **NOT** be used as it is an ["abstract"](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). The `aria-valuemax` attribute is used on all of the range roles subtypes.
 
 ## Example
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuemin/index.md
@@ -19,7 +19,8 @@ Declaring the minimum and maximum values allows assistive technologies to convey
 
 The maximum value is defined with [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax).
 
-> **Warning:** The [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role) role itself should **NOT** be used as it is an ["abstract"](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). The `aria-valuemin` attribute is used on all of the range roles subtypes.
+> [!WARNING]
+> The [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role) role itself should **NOT** be used as it is an ["abstract"](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). The `aria-valuemin` attribute is used on all of the range roles subtypes.
 
 ## Values
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-valuenow/index.md
@@ -15,7 +15,8 @@ The `aria-valuenow` attribute defines the current value for range widgets. It is
 
 When creating a range type role, including [`meter`](/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role), [`scrollbar`](/en-US/docs/Web/Accessibility/ARIA/Roles/scrollbar_role), [`slider`](/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role), and [`spinbutton`](/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role) on a non-semantic element, the `aria-valuenow` enables defining a current numeric value between the minimum and maximum values. The minimum and maximum values are defined with [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) and [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax).
 
-> **Warning:** The [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role) role itself should **NOT** be used as it is an ["abstract"](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). The `aria-valuenow` attribute is used on all of the range roles subtypes.
+> [!WARNING]
+> The [`range`](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role) role itself should **NOT** be used as it is an ["abstract"](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). The `aria-valuenow` attribute is used on all of the range roles subtypes.
 
 ```html
 <p id="birthyearLabel">What year were you born?</p>

--- a/files/en-us/web/accessibility/aria/attributes/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/index.md
@@ -10,7 +10,8 @@ This page lists reference pages covering all the <abbr>WAI-ARIA</abbr> attribute
 
 <abbr>ARIA</abbr> attributes enable modifying an element's states and properties as defined in the accessibility tree.
 
-> **Note:** ARIA only modifies the accessibility tree, modifying how assistive technology presents the content to your users. ARIA doesn't change anything about an element's function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior, focus, and ARIA states.
+> [!NOTE]
+> ARIA only modifies the accessibility tree, modifying how assistive technology presents the content to your users. ARIA doesn't change anything about an element's function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior, focus, and ARIA states.
 
 ## ARIA attribute types
 

--- a/files/en-us/web/accessibility/aria/index.md
+++ b/files/en-us/web/accessibility/aria/index.md
@@ -10,11 +10,13 @@ Accessible Rich Internet Applications **(<abbr>ARIA</abbr>)** is a set of [roles
 
 It supplements HTML so that interactions and widgets commonly used in applications can be passed to assistive technologies when there is not otherwise a mechanism. For example, ARIA enables accessible JavaScript widgets, form hints and error messages, live content updates, and more.
 
-> **Warning:** Many of these widgets are fully supported in modern browsers. **Developers should prefer using the correct semantic HTML element over using ARIA**, if such an element exists. For instance, native elements have built-in [keyboard accessibility](/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets), roles and states. However, if you choose to use ARIA, you are responsible for mimicking the equivalent browser behavior in script.
+> [!WARNING]
+> Many of these widgets are fully supported in modern browsers. **Developers should prefer using the correct semantic HTML element over using ARIA**, if such an element exists. For instance, native elements have built-in [keyboard accessibility](/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets), roles and states. However, if you choose to use ARIA, you are responsible for mimicking the equivalent browser behavior in script.
 
 [The first rule of ARIA](https://www.w3.org/TR/using-aria/#rule1) use is "If you can use a native HTML element or attribute with the semantics and behavior you require already built in, instead of re-purposing an element and adding an ARIA role, state or property to make it accessible, then do so."
 
-> **Note:** There is a saying "No ARIA is better than bad ARIA." In [WebAim's survey of over one million home pages](https://webaim.org/projects/million/#aria), they found that Home pages with ARIA present averaged 41% more detected errors than those without ARIA. While ARIA is designed to make web pages more accessible, if used incorrectly, it can do more harm than good.
+> [!NOTE]
+> There is a saying "No ARIA is better than bad ARIA." In [WebAim's survey of over one million home pages](https://webaim.org/projects/million/#aria), they found that Home pages with ARIA present averaged 41% more detected errors than those without ARIA. While ARIA is designed to make web pages more accessible, if used incorrectly, it can do more harm than good.
 
 Here's the markup for a progress bar widget:
 
@@ -56,9 +58,11 @@ It would have been much simpler to use the native {{HTMLElement('progress')}} el
 <progress id="percent-loaded" value="75" max="100">75 %</progress>
 ```
 
-> **Note:** The `min` attribute is not allowed for the {{HTMLElement('progress')}} element; its minimum value is always `0`.
+> [!NOTE]
+> The `min` attribute is not allowed for the {{HTMLElement('progress')}} element; its minimum value is always `0`.
 
-> **Note:** HTML landmark elements ({{HTMLElement("main")}}, {{HTMLElement("header")}}, {{HTMLElement("nav")}}, etc.) have built-in implicit ARIA roles, so there is no need to duplicate them.
+> [!NOTE]
+> HTML landmark elements ({{HTMLElement("main")}}, {{HTMLElement("header")}}, {{HTMLElement("nav")}}, etc.) have built-in implicit ARIA roles, so there is no need to duplicate them.
 
 ## Support
 

--- a/files/en-us/web/accessibility/aria/multipart_labels/index.md
+++ b/files/en-us/web/accessibility/aria/multipart_labels/index.md
@@ -46,7 +46,8 @@ body {
 
 JAWS 8.0 has its own logic to find labels, causing it to always override the accessibleName the textbox of an HTML document gets. With JAWS 8, I have not found a way to make it to accept the label from the example above. But NVDA and Window-Eyes do it just fine, and Orca on Linux also has no problems.
 
-> **Note:** TBD: add more compatibility info
+> [!NOTE]
+> TBD: add more compatibility info
 
 ## Can this be done without ARIA?
 

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -25,7 +25,8 @@ The `alert` role should only be used for text content, not interactive elements 
 
 The `alert` role is added to the node containing an alert message, **not** the element causing the alert to be triggered. Alerts are [assertive live regions](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). Setting `role="alert"` is equivalent to setting [`aria-live="assertive"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) and [`aria-atomic="true"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic). As they don't receive focus, focus does not need to be managed and no user interaction should be required.
 
-> **Warning:** Because of its intrusive nature, the `alert` role must be used sparingly and only in situations where the user's immediate attention is required.
+> [!WARNING]
+> Because of its intrusive nature, the `alert` role must be used sparingly and only in situations where the user's immediate attention is required.
 
 The [`alert`](https://www.w3.org/TR/wai-aria-1.1/#alert) role is of the five [live region](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) roles. Dynamic changes that are less urgent should use a less aggressive method, such as including `aria-live="polite"` or using an other live region role like [`status`](/en-US/docs/Web/Accessibility/ARIA/Roles/status_role). If the user is expected to close the alert, then the [`alertdialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) role should be used instead.
 

--- a/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alertdialog_role/index.md
@@ -17,7 +17,8 @@ The `alertdialog` role is used to notify users of urgent information that demand
 
 As the name implies, `alertdialog` is a mashup of the [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) roles. `alertdialog` is a type of `dialog` with similar use cases as `alert`, but for when a user response is required.
 
-> **Note:** The `alertdialog` role should only be used for alert messages that have associated interactive controls. If an alert dialog only contains static content and has no interactive controls at all, use [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) instead.
+> [!NOTE]
+> The `alertdialog` role should only be used for alert messages that have associated interactive controls. If an alert dialog only contains static content and has no interactive controls at all, use [`alert`](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) instead.
 
 Being a type of dialog, the [`dialog`](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) role's states, properties, and keyboard focus requirements are applicable to the `alertdialog` role as well.
 

--- a/files/en-us/web/accessibility/aria/roles/application_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/application_role/index.md
@@ -69,7 +69,8 @@ The <kbd>Tab</kbd>, <kbd>Space</kbd> and <kbd>Enter</kbd> keys, as well as <kbd>
 - Changing attribute values
   - : [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant) is used to manage the focus inside the application container. Set in response to keyboard or other application events that change focus or point of interaction.
 
-> **Note:** The `application` role does not have a related HTML widget and thus is completely free form. The author of the application must take full responsibility for not letting users get stuck in a focus trap inside something the user cannot exit from. All aspects of interaction, including returning to the regular web content on other parts of the page, must be handled. Use wisely, and cautiously, and remember to test!
+> [!NOTE]
+> The `application` role does not have a related HTML widget and thus is completely free form. The author of the application must take full responsibility for not letting users get stuck in a focus trap inside something the user cannot exit from. All aspects of interaction, including returning to the regular web content on other parts of the page, must be handled. Use wisely, and cautiously, and remember to test!
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/article_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/article_role/index.md
@@ -23,7 +23,8 @@ The `article` role indicates a section of a page that could easily stand on its 
 
 This example shows two articles side by side on one page that could be structured similarly and are related.
 
-> **Note:** Instead of a `<div>` with an `article` role, use the {{HTMLElement('article')}} element. **Always use native element if available**
+> [!NOTE]
+> Instead of a `<div>` with an `article` role, use the {{HTMLElement('article')}} element. **Always use native element if available**
 
 Don't use `role="article"`. Instead use the `<article>` element.
 
@@ -69,7 +70,7 @@ This role does not support any specific keyboard interaction.
 - Changing attribute values
   - : When constructing a feed, set the `aria-posinset` and `aria-setsize` attributes on each article role to the appropriate values, bearing in mind that `aria-posinset` is 1-based.
 
-> **Note:** **Always use native element if available.** Instead of a `<div>` with the `article` role, the `<article>` element should be used.
+> [!NOTE] > **Always use native element if available.** Instead of a `<div>` with the `article` role, the `<article>` element should be used.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/article_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/article_role/index.md
@@ -70,7 +70,7 @@ This role does not support any specific keyboard interaction.
 - Changing attribute values
   - : When constructing a feed, set the `aria-posinset` and `aria-setsize` attributes on each article role to the appropriate values, bearing in mind that `aria-posinset` is 1-based.
 
-> [!NOTE] > **Always use native element if available.** Instead of a `<div>` with the `article` role, the `<article>` element should be used.
+> **Note:** **Always use native element if available.** Instead of a `<div>` with the `article` role, the `<article>` element should be used.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/button_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.md
@@ -27,7 +27,8 @@ The above example creates a focusable button, but requires JavaScript and CSS to
 <button type="button" id="saveChanges">Save</button>
 ```
 
-> **Note:** If using `role="button"` instead of the semantic `<button>` or `<input type="button">` elements, you will need to make the element focusable and define event handlers for {{domxref("Element/click_event", "click")}} and {{domxref("Element/keydown_event", "keydown")}} events. This includes handling the <kbd>Enter</kbd> and <kbd>Space</kbd> keypresses in order to process all forms of user input. See [the official WAI-ARIA example code](https://www.w3.org/WAI/ARIA/apg/patterns/button/examples/button/).
+> [!NOTE]
+> If using `role="button"` instead of the semantic `<button>` or `<input type="button">` elements, you will need to make the element focusable and define event handlers for {{domxref("Element/click_event", "click")}} and {{domxref("Element/keydown_event", "keydown")}} events. This includes handling the <kbd>Enter</kbd> and <kbd>Space</kbd> keypresses in order to process all forms of user input. See [the official WAI-ARIA example code](https://www.w3.org/WAI/ARIA/apg/patterns/button/examples/button/).
 
 In addition to the ordinary button widget, `role="button"` should be included when creating a toggle button or menu button using a non-button element.
 
@@ -270,7 +271,8 @@ function toggleButton(element) {
 
 Buttons are interactive controls and thus focusable. If the `button` role is added to an element that is not focusable by itself (such as `<span>`, `<div>` or `<p>`) then, the `tabindex` attribute has to be used to make the button focusable.
 
-> **Warning:** Be careful when marking up links with the button role. Buttons are expected to be triggered using the <kbd>Space</kbd> or <kbd>Enter</kbd> key, while links are expected to be triggered using the <kbd>Enter</kbd> key. In other words, when links are used to behave like buttons, adding `role="button"` alone is not sufficient. It will also be necessary to add a key event handler that listens for the <kbd>Space</kbd> key in order to be consistent with native buttons.
+> [!WARNING]
+> Be careful when marking up links with the button role. Buttons are expected to be triggered using the <kbd>Space</kbd> or <kbd>Enter</kbd> key, while links are expected to be triggered using the <kbd>Enter</kbd> key. In other words, when links are used to behave like buttons, adding `role="button"` alone is not sufficient. It will also be necessary to add a key event handler that listens for the <kbd>Space</kbd> key in order to be consistent with native buttons.
 
 When the `button` role is used, screen readers announce the element as a button, generally saying "click" followed by the button's accessible name. The accessible name is either the content of the element or the value of an `aria-label` or element referenced by an `aria-labelledby` attribute, or description, if included.
 

--- a/files/en-us/web/accessibility/aria/roles/cell_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/cell_role/index.md
@@ -35,7 +35,8 @@ Each element with `role="cell"` MUST be nested in a container element with [`rol
 
 A cell can contain a number of property attributes clarifying the cell's position within the tabular data structure, including [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex), [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan), [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex), and [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan).
 
-> **Note:** Using the native HTML table element ({{HTMLElement('table')}}) element, along with the table row element ({{HTMLElement('tr')}}), and table cell element ({{HTMLElement('td')}}), whenever possible, is strongly encouraged.
+> [!NOTE]
+> Using the native HTML table element ({{HTMLElement('table')}}) element, along with the table row element ({{HTMLElement('tr')}}), and table cell element ({{HTMLElement('td')}}), whenever possible, is strongly encouraged.
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/checkbox_role/index.md
@@ -17,7 +17,8 @@ The `checkbox` role is for checkable interactive controls. Elements containing `
 <label id="chk1-label">Remember my preferences</label>
 ```
 
-> **Note:** The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML checkbox of `<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox) (with an associated {{HTMLElement('label')}}), which natively provides all the functionality required:
+> [!NOTE]
+> The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML checkbox of `<input type="checkbox">`](/en-US/docs/Web/HTML/Element/input/checkbox) (with an associated {{HTMLElement('label')}}), which natively provides all the functionality required:
 
 ```html
 <input type="checkbox" id="chk1-label" name="RememberPreferences" />
@@ -165,7 +166,8 @@ People implementing checkboxes should do the following:
 - Keep the `aria-checked` attribute up to date following user interactions
 - Provide styles that indicate when the checkbox has focus
 
-> **Note:** Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and may change.
+> [!NOTE]
+> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and may change.
 
 ## Best practices
 

--- a/files/en-us/web/accessibility/aria/roles/command_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/command_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#command
 
 The `command` role defines a widget that performs an action but does not receive input data.
 
-> **Note:** The `command` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `command` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/comment_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/comment_role/index.md
@@ -8,7 +8,8 @@ page-type: aria-role
 
 The `comment` role semantically denotes a comment/reaction to some content on the page, or to a previous comment.
 
-> **Note:** The comment role is proposed in WAI-ARIA 1.3 ([Most recent ARIA draft](https://w3c.github.io/aria/)), which is still being drafted.
+> [!NOTE]
+> The comment role is proposed in WAI-ARIA 1.3 ([Most recent ARIA draft](https://w3c.github.io/aria/)), which is still being drafted.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/complementary_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/complementary_role/index.md
@@ -24,7 +24,8 @@ This is a sidebar containing links to project sponsors.
 
 The `complementary` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#landmark_roles) role. Landmarks can be used by assistive technology to quickly identify and navigate to large sections of the document. Content listed within a container with the `complementary` landmark role should make sense if separated from the main content of the document.
 
-> **Note:** Using the {{HTMLElement('aside')}} element will automatically communicate a section has a role of `complementary`. Developers should always prefer using the correct semantic HTML element over using ARIA.
+> [!NOTE]
+> Using the {{HTMLElement('aside')}} element will automatically communicate a section has a role of `complementary`. Developers should always prefer using the correct semantic HTML element over using ARIA.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/composite_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/composite_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#composite
 
 The `composite` [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles) indicates a widget that may contain navigable descendants or owned children.
 
-> **Note:** The `composite` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `composite` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/contentinfo_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/contentinfo_role/index.md
@@ -33,7 +33,8 @@ The `contentinfo` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/Roles#
 
 Each page should only include one `contentinfo` landmark, created by either using the {{HTMLElement('footer')}} element or by declaring `role="contentinfo"`. `contentinfo` landmarks present in content embedded via {{HTMLElement('iframe')}} do not count towards this limit.
 
-> **Note:** Using the {{HTMLElement('footer')}} element will automatically communicate a section has a role of `contentinfo`. Developers should always prefer using the correct semantic HTML element over using ARIA, making sure to {{HTMLElement('footer#accessibility', 'test for known issues')}} in VoiceOver.
+> [!NOTE]
+> Using the {{HTMLElement('footer')}} element will automatically communicate a section has a role of `contentinfo`. Developers should always prefer using the correct semantic HTML element over using ARIA, making sure to {{HTMLElement('footer#accessibility', 'test for known issues')}} in VoiceOver.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/definition_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/definition_role/index.md
@@ -24,7 +24,8 @@ The `definition` ARIA role can be included on an element that is a definition of
 </p>
 ```
 
-> **Note:** Instead of a `<span>` with the [`term`](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role) and `definition` roles, use the {{HTMLElement('dfn')}} element. **Always use native element if available.**
+> [!NOTE]
+> Instead of a `<span>` with the [`term`](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role) and `definition` roles, use the {{HTMLElement('dfn')}} element. **Always use native element if available.**
 
 ```html
 <p>

--- a/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/dialog_role/index.md
@@ -54,7 +54,8 @@ If a dialog already has a visible title bar, the text inside that bar can be use
 </div>
 ```
 
-> **Note:** Keep in mind that a dialog's title and description text do not have to be focusable in order to be perceived by screen readers operating in a non-virtual mode. The combination of the ARIA dialog role and labeling techniques should make the screen reader announce the dialog's information when focus is moved into it.
+> [!NOTE]
+> Keep in mind that a dialog's title and description text do not have to be focusable in order to be perceived by screen readers operating in a non-virtual mode. The combination of the ARIA dialog role and labeling techniques should make the screen reader announce the dialog's information when focus is moved into it.
 
 ### Required JavaScript features
 
@@ -84,7 +85,8 @@ When the `dialog` role is used, the user agent should do the following:
 
 When the dialog is correctly labeled and focus is moved to an element (often an interactive element, such as a button) inside the dialog, screen readers should announce the dialog's accessible role, name and optionally description, along with announcing the focused element.
 
-> **Note:** Opinions may differ on how assistive technology should handle this technique, and the order of announcements may differ depending on the assistive technology used. The information provided above is one of those opinions and may change as the specification is defined.
+> [!NOTE]
+> Opinions may differ on how assistive technology should handle this technique, and the order of announcements may differ depending on the assistive technology used. The information provided above is one of those opinions and may change as the specification is defined.
 
 ## Examples
 
@@ -127,7 +129,8 @@ When the dialog is correctly labeled and focus is moved to an element (often an 
 
 ### Notes
 
-> **Note:** While it is possible to prevent keyboard users from moving focus to elements outside of the dialog, screen reader users may still be able to navigate to that content using their screen reader's virtual cursor.
+> [!NOTE]
+> While it is possible to prevent keyboard users from moving focus to elements outside of the dialog, screen reader users may still be able to navigate to that content using their screen reader's virtual cursor.
 > It is important for developers to ensure that content outside of the modal dialog is inaccessible to all users while the modal dialog is active.
 
 ## Specifications

--- a/files/en-us/web/accessibility/aria/roles/directory_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/directory_role/index.md
@@ -11,7 +11,8 @@ spec-urls: https://w3c.github.io/aria/#directory
 
 The `directory` role was for a list of references to members of a group, such as a static table of contents.
 
-> **Warning:** The `directory` role was deprecated in ARIA 1.2
+> [!WARNING]
+> The `directory` role was deprecated in ARIA 1.2
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/figure_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/figure_role/index.md
@@ -45,7 +45,8 @@ This can be done semantically, without ARIA, with HTML's {{HTMLElement('figure')
 </figure>
 ```
 
-> **Note:** If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a figure and its caption — {{htmlelement("figure")}} and {{htmlelement("figcaption")}}.
+> [!NOTE]
+> If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a figure and its caption — {{htmlelement("figure")}} and {{htmlelement("figcaption")}}.
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/accessibility/aria/roles/form_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/form_role/index.md
@@ -19,14 +19,16 @@ The `form` role can be used to identify a group of elements on a page that provi
 
 This is a form that collects and saves a user's contact information.
 
-> **Warning:** Use an HTML {{htmlelement("form")}} element to contain your form controls, rather than the ARIA `form` role, unless you have a very good reason.
+> [!WARNING]
+> Use an HTML {{htmlelement("form")}} element to contain your form controls, rather than the ARIA `form` role, unless you have a very good reason.
 > The HTML `<form>` element is sufficient to tell assistive technologies that there is a form.
 
 ## Description
 
 A `form` [landmark](/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles) identifies a region of content that contains a collection of items and objects that, as a whole, combine to create a form when no other named landmark is appropriate (e.g. [`main`](/en-US/docs/Web/Accessibility/ARIA/Roles/main_role) or [`search`](/en-US/docs/Web/Accessibility/ARIA/Roles/search_role)).
 
-> **Note:** Using the {{HTMLElement('form')}} element will automatically communicate a section of content as a `form` landmark, if it is provided an accessible name. Developers should always prefer using the correct semantic HTML element over using ARIA.
+> [!NOTE]
+> Using the {{HTMLElement('form')}} element will automatically communicate a section of content as a `form` landmark, if it is provided an accessible name. Developers should always prefer using the correct semantic HTML element over using ARIA.
 
 Use the HTML {{HTMLElement('form')}} element if possible. The `<form>` element defines a `form` landmark when it has an accessible name (e.g. [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby), [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`title`](/en-US/docs/Web/HTML/Global_attributes#title)). Make sure to have a unique label on each form in a document to help users understand the purpose of the form. This label should be visible to all users, not just assistive technology users. Use the `search` landmark instead of the `form` landmark when the form is used for search functionality.
 

--- a/files/en-us/web/accessibility/aria/roles/generic_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/generic_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#generic
 
 The `generic` role creates a nameless container element which has no semantic meaning on its own.
 
-> **Note:** The `generic` role is the implicit role of generic elements used by user agents. It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `generic` role is the implicit role of generic elements used by user agents. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 
@@ -21,7 +22,8 @@ Like an element with role `presentation`, an element with `role="generic"` can p
 
 Because the generic role is nameless, the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) and [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attributes are prohibited. Because the role is generic, the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) and [`aria-brailleroledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-brailleroledescription) attributes are also prohibited.
 
-> **Note:** The element with `role="generic"` should not have an accessible name or role description.
+> [!NOTE]
+> The element with `role="generic"` should not have an accessible name or role description.
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -74,7 +74,8 @@ If the grid is used as an interactive widget, [keyboard interactions](#keyboard_
 - [aria-readonly](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly)
   - : If the user can navigate the grid but not change the value or values of the grid, the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) should be set to `true`. The default value is `false`.
 
-> **Note:** For many use cases, an HTML {{HTMLElement('table')}} element is sufficient as it and the various table elements already include many ARIA roles.
+> [!NOTE]
+> For many use cases, an HTML {{HTMLElement('table')}} element is sufficient as it and the various table elements already include many ARIA roles.
 
 ### Keyboard interactions
 

--- a/files/en-us/web/accessibility/aria/roles/heading_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/heading_role/index.md
@@ -41,7 +41,8 @@ This role does not require any special keyboard navigation. As with any heading,
 - Changing attribute values
   - : Usually not required, unless dynamically inserting content. In that case, the newly-added headings need `aria-level` attributes whose values are consistent with the rest of the document structure.
 
-> **Note:** Instead of using a `<div>` or `<span>` with a `heading` role and `aria-level`, consider using a native {{HTMLElement("Heading_Elements", "h1")}} through {{HTMLElement("Heading_Elements", "h6")}} elements instead to indicate that this text is a heading, and what part of the structure it represents.
+> [!NOTE]
+> Instead of using a `<div>` or `<span>` with a `heading` role and `aria-level`, consider using a native {{HTMLElement("Heading_Elements", "h1")}} through {{HTMLElement("Heading_Elements", "h6")}} elements instead to indicate that this text is a heading, and what part of the structure it represents.
 
 ## Examples
 
@@ -77,7 +78,8 @@ However, instead, you should do:
 
 ## Accessibility concerns
 
-> **Warning:** Using [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) will hide the content of your heading from assistive technologies, reading the label instead of the heading.
+> [!WARNING]
+> Using [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) will hide the content of your heading from assistive technologies, reading the label instead of the heading.
 
 If you must use the `heading` role and [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, do not go over level 6 so that you are consistent with HTML. Although theoretically you can go higher, and some screen readers may support it, the results can be unpredictable with other browser and screen reader combinations.
 

--- a/files/en-us/web/accessibility/aria/roles/index.md
+++ b/files/en-us/web/accessibility/aria/roles/index.md
@@ -136,9 +136,11 @@ Abstract roles are only intended for use by browsers to help organize and stream
 
 Avoid using [command](/en-US/docs/Web/Accessibility/ARIA/Roles/command_role), [composite](/en-US/docs/Web/Accessibility/ARIA/Roles/composite_role), [input](/en-US/docs/Web/Accessibility/ARIA/Roles/input_role), [landmark](/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role), [range](/en-US/docs/Web/Accessibility/ARIA/Roles/range_role), [roletype](/en-US/docs/Web/Accessibility/ARIA/Roles/roletype_role), [section](/en-US/docs/Web/Accessibility/ARIA/Roles/section_role), [sectionhead](/en-US/docs/Web/Accessibility/ARIA/Roles/sectionhead_role), [select](/en-US/docs/Web/Accessibility/ARIA/Roles/select_role), [structure](/en-US/docs/Web/Accessibility/ARIA/Roles/structure_role), [widget](/en-US/docs/Web/Accessibility/ARIA/Roles/widget_role),and [window](/en-US/docs/Web/Accessibility/ARIA/Roles/window_role).
 
-> **Note:** Don't use abstract roles in your sites and applications. They are for use by browsers. They are included for reference only.
+> [!NOTE]
+> Don't use abstract roles in your sites and applications. They are for use by browsers. They are included for reference only.
 
-> **Warning:** "Abstract roles are used for the ontology. Authors **MUST NOT** use abstract roles in content." - The <abbr>WAI-ARIA</abbr> specification
+> [!WARNING]
+> "Abstract roles are used for the ontology. Authors **MUST NOT** use abstract roles in content." - The <abbr>WAI-ARIA</abbr> specification
 
 ## Roles defined on MDN
 

--- a/files/en-us/web/accessibility/aria/roles/input_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/input_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#input
 
 The `input` abstract role is a generic type of widget that allows user input.
 
-> **Note:** The `input` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It is not to be used by web authors.
+> [!NOTE]
+> The `input` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It is not to be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/landmark_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/landmark_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#landmark
 
 A landmark is an important subsection of a page. The `landmark` role is an abstract superclass for the aria role values for sections of content that are important enough that users will likely want to be able to navigate directly to them.
 
-> **Note:** The `landmark` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `landmark` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/link_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/link_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#link
 
 A `link` widget provides an interactive reference to a resource. The target resource can be either external or local; i.e., either outside or within the current page or application.
 
-> **Note:** Where possible, it is recommended that you use a native {{HTMLElement("a")}} element rather than the `link` role, as native elements are more widely supported by user agents and assistive technology. Native {{HTMLElement("a")}} elements also support keyboard and focus requirements by default, without need for additional customization.
+> [!NOTE]
+> Where possible, it is recommended that you use a native {{HTMLElement("a")}} element rather than the `link` role, as native elements are more widely supported by user agents and assistive technology. Native {{HTMLElement("a")}} elements also support keyboard and focus requirements by default, without need for additional customization.
 
 ## Description
 
@@ -19,7 +20,8 @@ When not using semantic HTML for its intended purpose, interactive features must
 
 Use the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes#tabindex) attribute with a value of `0` to ensure the link is in the correct tab focus order.
 
-> **Warning:** Applying the `link` role to an element will not cause browsers to enhance the element with standard link appearance or behaviors, such as underlining, focus rings, navigation to the link target, or context menu actions. That's the developer's responsibility.
+> [!WARNING]
+> Applying the `link` role to an element will not cause browsers to enhance the element with standard link appearance or behaviors, such as underlining, focus rings, navigation to the link target, or context menu actions. That's the developer's responsibility.
 
 ## Examples
 
@@ -86,7 +88,8 @@ Avoid using `link`, which we've included for completeness. The {{HTMLElement('a'
 
 Using the {{HTMLElement('a')}} instead.
 
-> **Note:** There is no need to include `role="link"` on an HTML link as the `<a>`, by default, has that role already.
+> [!NOTE]
+> There is no need to include `role="link"` on an HTML link as the `<a>`, by default, has that role already.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/roles/list_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/list_role/index.md
@@ -23,7 +23,8 @@ Any content that consists of an outer container with a list of elements inside c
 
 There are no hard and fast rules about which elements you should use to mark up the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.
 
-> **Note:** Best practices dictate using the appropriate semantic HTML elements over ARIA roles to mark up lists and listitems — {{HTMLElement("ul")}}, {{HTMLElement("ol")}} and {{HTMLElement("li")}}. See [Best practices](#best_practices) for a full example.
+> [!NOTE]
+> Best practices dictate using the appropriate semantic HTML elements over ARIA roles to mark up lists and listitems — {{HTMLElement("ul")}}, {{HTMLElement("ol")}} and {{HTMLElement("li")}}. See [Best practices](#best_practices) for a full example.
 
 ### Associated WAI-ARIA Roles, States, and Properties
 
@@ -54,11 +55,13 @@ or use an ordered list if the order of the list items matters:
 </ol>
 ```
 
-> **Note:** The ARIA `list` / `listitem` roles don't distinguish between ordered and unordered lists.
+> [!NOTE]
+> The ARIA `list` / `listitem` roles don't distinguish between ordered and unordered lists.
 
 As an aside, note that if you are using the semantic HTML elements of `<ol>` or `<ul>` and apply a role of [`presentation`](/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role), each child `<li>` element inherits the `presentation` role because ARIA requires the `listitem` elements to have the parent `list` element. So, the `<li>` elements are not exposed to assistive technologies, but elements contained inside of those `<li>` elements, including nested lists, are visible to assistive technologies.
 
-> **Note:** If you are marking up a list of items that will function as a tabbed interface, you should instead use the [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role), [`tabpanel`](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role), and [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) roles.
+> [!NOTE]
+> If you are marking up a list of items that will function as a tabbed interface, you should instead use the [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role), [`tabpanel`](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role), and [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) roles.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
@@ -155,7 +155,8 @@ When the user clicks on an option, hits <kbd>Space</kbd> when focused on an opti
 2. Change the appearance of the option to reflect its selected state
 3. Update the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant) value on the listbox to the ID of the option the user just interacted with, even if they toggled the option to be unselected.
 
-> **Note:** The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. The {{HTMLElement('select')}} element with descendant {{HTMLElement('option')}} elements handles all the needed interactions natively.
+> [!NOTE]
+> The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. The {{HTMLElement('select')}} element with descendant {{HTMLElement('option')}} elements handles all the needed interactions natively.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/listitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listitem_role/index.md
@@ -23,7 +23,8 @@ Any content that consists of an outer container with a list of elements inside i
 
 There are no hard and fast rules about which elements you should use to mark up the list and list items, but you should make sure that the list items make sense in the context of a list, e.g. a shopping list, recipe steps, driving directions.
 
-> **Note:** If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{HTMLElement("ul")}}/{{HTMLElement("ol")}} and {{HTMLElement("li")}}. See [Best practices](#best_practices) for a full example.
+> [!NOTE]
+> If at all possible in your work, you should use the appropriate semantic HTML elements to mark up a list and its listitems — {{HTMLElement("ul")}}/{{HTMLElement("ol")}} and {{HTMLElement("li")}}. See [Best practices](#best_practices) for a full example.
 
 ### Associated WAI-ARIA Roles, States, and Properties
 
@@ -56,11 +57,14 @@ or use an ordered list if the order of the list items matters:
 </ol>
 ```
 
-> **Note:** The ARIA `list` / `listitem` roles don't distinguish between ordered and unordered lists.
+> [!NOTE]
+> The ARIA `list` / `listitem` roles don't distinguish between ordered and unordered lists.
 
-> **Note:** Styling a list with `list-style: none;` in CSS removes the list semantics. Adding `role="listitem"` returns the semantics.
+> [!NOTE]
+> Styling a list with `list-style: none;` in CSS removes the list semantics. Adding `role="listitem"` returns the semantics.
 
-> **Note:** If you are marking up a list of items that will function as a tabbed interface, you should instead use the [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role), [`tabpanel`](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role), and [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) roles.
+> [!NOTE]
+> If you are marking up a list of items that will function as a tabbed interface, you should instead use the [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role), [`tabpanel`](/en-US/docs/Web/Accessibility/ARIA/Roles/tabpanel_role), and [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Roles/tablist_role) roles.
 
 ## Specifications
 

--- a/files/en-us/web/accessibility/aria/roles/meter_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/meter_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://www.w3.org/TR/wai-aria-1.2/#meter
 
 The `meter` role is used to identify an element being used as a meter.
 
-> **Note:** Where possible, it is recommended that you use a native {{HTMLElement("meter")}} element rather than the `meter` role, as native elements are more widely supported by user agents and assistive technology.
+> [!NOTE]
+> Where possible, it is recommended that you use a native {{HTMLElement("meter")}} element rather than the `meter` role, as native elements are more widely supported by user agents and assistive technology.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/navigation_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/navigation_role/index.md
@@ -25,7 +25,8 @@ The `navigation` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/Roles#3
 
 It is preferable to use the HTML5 [`<nav>` element](/en-US/docs/Web/HTML/Element/nav) to define a navigation landmark. If the HTML5 nav element technique is not being used, use a `role="navigation"` attribute to define a navigation landmark.
 
-> **Note:** Using the {{HTMLElement('nav')}} element will automatically communicate a section has a role of `navigation`. Developers should always prefer using the correct semantic HTML element over using ARIA
+> [!NOTE]
+> Using the {{HTMLElement('nav')}} element will automatically communicate a section has a role of `navigation`. Developers should always prefer using the correct semantic HTML element over using ARIA
 
 ### Associated WAI-ARIA Roles, States, and Properties
 

--- a/files/en-us/web/accessibility/aria/roles/presentation_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/presentation_role/index.md
@@ -39,7 +39,8 @@ Because the `presentation` role was applied to the {{HTMLElement('ul')}} element
 
 The {{HTMLElement('a')}} is a special case. Its role would have been exposed even if it had the `presentation` or `none` role directly applied to it. Browsers ignore `role="presentation"` and `role="none"`on focusable elements, including link and inputs, or anything with a [tabindex](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute set. Browsers also ignore the inclusion of the role if any of the element contains any global ARIA states and properties, such as [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby).
 
-> **Note:** The element with `role="presentation"` is not part of the accessibility tree and should not have an accessible name. Do **not** use [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label).
+> [!NOTE]
+> The element with `role="presentation"` is not part of the accessibility tree and should not have an accessible name. Do **not** use [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label).
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -47,7 +47,8 @@ A radio button is a checkable input that when associated with other radio button
 
 The `role` attribute only adds semantics; all of the functionality that comes natively with the [HTML radio](/en-US/docs/Web/HTML/Element/input/radio) needs to be added with JavaScript and the HTML [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 
-> **Note:** The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML `<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio) (with an associated {{HTMLElement('label')}}), which natively provides all the functionality required:
+> [!NOTE]
+> The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML `<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio) (with an associated {{HTMLElement('label')}}), which natively provides all the functionality required:
 
 ```html
 <fieldset>
@@ -116,7 +117,8 @@ From the assistive technology user's perspective, the heading does not exist sin
     - `false`
       - : The radio is not checked.
 
-> **Note:** use the [`tabindex` attribute](/en-US/docs/Web/HTML/Global_attributes/tabindex) if the `role="radio"` is used on an element that does not natively accept keyboard focus. E.g., a `<div>` or `<span>`.
+> [!NOTE]
+> use the [`tabindex` attribute](/en-US/docs/Web/HTML/Global_attributes/tabindex) if the `role="radio"` is used on an element that does not natively accept keyboard focus. E.g., a `<div>` or `<span>`.
 
 ## Keyboard interactions
 

--- a/files/en-us/web/accessibility/aria/roles/range_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/range_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#range
 
 The `range` abstract role is a generic type of structure role representing a range of values.
 
-> **Note:** The `range` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It is not to be used by web authors.
+> [!NOTE]
+> The `range` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It is not to be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/roletype_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/roletype_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#roletype
 
 The **`roletype`** role, an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles), is the base role from which all other ARIA roles inherit.
 
-> **Note:** The `roletype` role is an abstract role used for the ontology. It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `roletype` role is an abstract role used for the ontology. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/row_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/row_role/index.md
@@ -48,7 +48,8 @@ If the row is within a treegrid, rows can include the [`aria-expanded`](/en-US/d
 
 To create an interactive widget that has a tabular structure, use the grid pattern instead. If the interaction provides for the selection state of individual cells, if left to right and top to bottom navigation is provided, or if the user interface allows the rearranging of cell order or otherwise changing individual cell order such as through drag and drop, use [grid](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) or [treegrid](/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role) instead.
 
-> **Note:** Using the native HTML table element ({{HTMLElement('table')}}) along with the table row element ({{HTMLElement('tr')}}) whenever possible is strongly encouraged.
+> [!NOTE]
+> Using the native HTML table element ({{HTMLElement('table')}}) along with the table row element ({{HTMLElement('tr')}}) whenever possible is strongly encouraged.
 
 ### Associated WAI-ARIA roles, states, and properties
 
@@ -118,7 +119,8 @@ None
 
 None. For sortable columns, see the [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role) aria role.
 
-> **Note:** The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML {{HTMLElement('table')}} element instead of the ARIA role of table whenever possible.
+> [!NOTE]
+> The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML {{HTMLElement('table')}} element instead of the ARIA role of table whenever possible.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/rowgroup_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/rowgroup_role/index.md
@@ -40,7 +40,8 @@ An element with `role="rowgroup"` is a group of [rows](/en-US/docs/Web/Accessibi
 
 To create an ARIA table header, table footer or table body, add `role="rowgroup"` to the element. That rowgroup should be nested within a grid, table or treegrid, encompassing a group of one or more rows. Each row, in turn, contains child cells. These cells can be of different types, depending on whether they are column or row headers, or plain or grid cells.
 
-> **Note:** Using the native HTML table element ({{HTMLElement('table')}}) along with the table header ({{HTMLElement('thead')}}), footer ({{HTMLElement('tfoot')}}), and body ({{HTMLElement('tbody')}}) elements whenever possible is strongly encouraged.
+> [!NOTE]
+> Using the native HTML table element ({{HTMLElement('table')}}) along with the table header ({{HTMLElement('thead')}}), footer ({{HTMLElement('tfoot')}}), and body ({{HTMLElement('tbody')}}) elements whenever possible is strongly encouraged.
 
 ### Associated WAI-ARIA roles, states, and properties
 
@@ -66,7 +67,8 @@ None
 
 None.
 
-> **Note:** The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML `<table>` element instead of the ARIA role of table whenever possible.
+> [!NOTE]
+> The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML `<table>` element instead of the ARIA role of table whenever possible.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/rowheader_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/rowheader_role/index.md
@@ -42,7 +42,8 @@ It is a structural equivalent to the {{HTMLElement('th')}} element with a scope 
 
 To create an ARIA row header, add `role="rowheader"` to the element. That row header must be nested within a `row`, which, in turn, is nested within a `rowgroup`, or directly within a `grid`, `table` or `treegrid`.
 
-> **Note:** Using the native [table elements](/en-US/docs/Learn/HTML/Tables/Basics) whenever possible, is strongly encouraged.
+> [!NOTE]
+> Using the native [table elements](/en-US/docs/Learn/HTML/Tables/Basics) whenever possible, is strongly encouraged.
 
 ### Associated WAI-ARIA roles, states, and properties
 
@@ -59,7 +60,8 @@ None
 
 None.
 
-> **Note:** The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML `<table>`, `<tr>`, `<th>`, `<td>`, and other [table elements](/en-US/docs/Learn/HTML/Tables/Basics) instead of the ARIA table roles whenever possible.
+> [!NOTE]
+> The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML `<table>`, `<tr>`, `<th>`, `<td>`, and other [table elements](/en-US/docs/Learn/HTML/Tables/Basics) instead of the ARIA table roles whenever possible.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/scrollbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/scrollbar_role/index.md
@@ -37,7 +37,8 @@ While the `aria-valuenow` is always required, the [`aria-valuemin`](/en-US/docs/
 
 A `scrollbar` represents the current value and range of possible values via the size of the scrollbar and position of the thumb with respect to the visible range of the orientation (horizontal or vertical) it controls. In other words, the `scrollbar` length (height or width) represents all the content within a viewport. The `aria-valuemin` value represents the beginning of the content and the scrollbar, the `aria-valuemax` value represents the end of the content and the end of the scrollbar. The `aria-valuenow` represents the content that is currently visible in the viewport and the current position, or value, of the movable thumb. The `aria-valuenow` value will generally be exposed as a percentage between `aria-valuemin` and `aria-valuemax` calculated by assistive technologies.
 
-> **Note:** Assistive technologies generally render the value of `aria-valuenow` as a percent of a range between the value of `aria-valuemin` and `aria-valuemax`, unless [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) is set. It is recommended to set the values for `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` in a manner that is appropriate for this calculation.
+> [!NOTE]
+> Assistive technologies generally render the value of `aria-valuenow` as a percent of a range between the value of `aria-valuemin` and `aria-valuemax`, unless [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) is set. It is recommended to set the values for `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` in a manner that is appropriate for this calculation.
 
 Like a native scroll bar, users interact with `scrollbar` elements directly or indirectly using mouse, touchpad, keyboard, and voice input. `scrollbar` role implementations must also accommodate all these interaction methods.
 
@@ -53,7 +54,8 @@ JavaScript must be used to translate the `scrollbar` action into scrolling comma
 
 The default orientation of the `scrollbar` role is vertical. Including [`aria-orientation="vertical"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation), in this case, is optional. The orientation represents the orientation of the scrollbar and the scrolling effect on the viewing area controlled by the scrollbar. If the scrolling is left to right or right to left and not top to bottom, include `aria-orientation="horizontal"` on the element with the `scrollbar` role.
 
-> **Note:** An accessible name is **required**. If the `scrollbar` role is applied to an HTML {{HTMLElement('input')}} element (or `<meter>` or `<progress>` element), the accessible name can come from the associated {{HTMLElement('label')}}. Otherwise use [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) if a visible label is present or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) if a visible label is not present.
+> [!NOTE]
+> An accessible name is **required**. If the `scrollbar` role is applied to an HTML {{HTMLElement('input')}} element (or `<meter>` or `<progress>` element), the accessible name can come from the associated {{HTMLElement('label')}}. Otherwise use [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) if a visible label is present or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) if a visible label is not present.
 
 ### All descendants are presentational
 

--- a/files/en-us/web/accessibility/aria/roles/section_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/section_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#section
 
 The **`section` role**, an abstract role, is a superclass role for renderable structural containment components.
 
-> **Note:** The `section` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It **should not be used** by web authors.
+> [!NOTE]
+> The `section` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It **should not be used** by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/sectionhead_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/sectionhead_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#sectionhead
 
 The **`sectionhead` role**, an abstract role, is superclass role for labels or summaries of the topic of its related section.
 
-> **Note:** The `sectionhead` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `sectionhead` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/select_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/select_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#select
 
 The **`select` role**, an abstract role, is superclass role for form widgets that allows the user to make selections from a set of choices.
 
-> **Note:** The `select` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It **should not be used** by web authors.
+> [!NOTE]
+> The `select` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It **should not be used** by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/slider_role/index.md
@@ -25,7 +25,8 @@ The `slider` role, similar to HTML's `input` of type `range`, [`<input type="ran
 
 While all three of these ranges have the same ARIA states and properties, the `slider` role is the only read-write range: it is the only one whose value changes via user interaction. As such, it must be able to receive focus. In addition, keyboard interaction, mouse clicks, and touch interaction must be supported.
 
-> **Warning:** To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
+> [!WARNING]
+> To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
 > Fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before using the `slider` role (and all range widgets).
 
 #### Common attributes
@@ -56,7 +57,8 @@ Unlike the read-only `meter` and `progressbar` roles, a `slider` is an input, ac
 
 The slider represents the range of possible values. The position of the slider thumb along the slider represents the current value. User actions that must be supported include changing the value by dragging the thumb or clicking the slider for pointing devices and using directional keys such as arrow keys for the keyboard users. See [keyboard interactions](#keyboard_interactions) below.
 
-> **Note:** It is recommended to use native [`<input type="range">`](/en-US/docs/Web/HTML/Element/input/range) elements rather than the `slider` role. User agents provide a stylized widget for the range input element, based on the current `value` as it relates to the minimum and maximum values. When using non-semantic elements, all features of the native semantic element need to be recreated with ARIA attributes, JavaScript and CSS.
+> [!NOTE]
+> It is recommended to use native [`<input type="range">`](/en-US/docs/Web/HTML/Element/input/range) elements rather than the `slider` role. User agents provide a stylized widget for the range input element, based on the current `value` as it relates to the minimum and maximum values. When using non-semantic elements, all features of the native semantic element need to be recreated with ARIA attributes, JavaScript and CSS.
 
 ### Range with multiple thumbs
 

--- a/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
@@ -19,7 +19,8 @@ Spinbuttons often have three components, including a text field that displays th
 
 In addition to including the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes#tabindex) attribute to enable spinbutton focus, keyboard and pointer device support must be implemented. Directional keys such as the arrow keys must be supported for keyboard users. Changing the value when increment and decrement buttons are clicked must be supported for pointing devices. See [keyboard interactions](#keyboard_interactions) below.
 
-> **Note:** It is recommended to use [`<input type="number">`](/en-US/docs/Web/HTML/Element/input/number) element, or other input types for dates and time that also implicitly have the `role="spinbutton"` semantic, rather than the `spinbutton` role. User agents provide stylized widget for the these input elements which provide default increment, decrement, and native range limiting functionality. When using non-semantic elements, all features of the native semantic element need to be recreated with ARIA attributes, JavaScript, and CSS.
+> [!NOTE]
+> It is recommended to use [`<input type="number">`](/en-US/docs/Web/HTML/Element/input/number) element, or other input types for dates and time that also implicitly have the `role="spinbutton"` semantic, rather than the `spinbutton` role. User agents provide stylized widget for the these input elements which provide default increment, decrement, and native range limiting functionality. When using non-semantic elements, all features of the native semantic element need to be recreated with ARIA attributes, JavaScript, and CSS.
 
 ### ARIA range widget options
 
@@ -33,7 +34,8 @@ The `slider` role, similar to HTML's `input` of type `range`, [`<input type="ran
 
 While all three of these ranges have the same ARIA states and properties, the `spinbutton` role is the only read-write range: it is the only one whose value changes via user interaction. As such, it must be able to receive focus. In addition, keyboard interaction, mouse clicks, and touch interaction must be supported.
 
-> **Warning:** To change the spinbutton value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
+> [!WARNING]
+> To change the spinbutton value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
 > Fully test spinbutton widgets using assistive technologies on devices where touch is a primary input mechanism before using the `spinbutton` role (and all range widgets).
 
 #### Common attributes

--- a/files/en-us/web/accessibility/aria/roles/structural_roles/index.md
+++ b/files/en-us/web/accessibility/aria/roles/structural_roles/index.md
@@ -11,7 +11,8 @@ ARIA document-structure roles are used to provide a structural description for a
 
 Structural ARIA roles were originally created as a bridge to inform assistive technologies of HTML5 elements that were not yet fully supported in browsers. Some roles, like `presentation`, `toolbar` and `tooltip`, provide information on the document structure to assistive technologies in cases where equivalent native HTML elements don't exist. Other roles, including those listed in the table below, are not needed, as there are semantic HTML elements with the same meanings. In many cases, these equivalent HTML elements have always been supported.
 
-> **Note:** These structural roles all have semantic HTML equivalents. They are included here for completeness of documentation. Preferably, they should not be used by web authors.
+> [!NOTE]
+> These structural roles all have semantic HTML equivalents. They are included here for completeness of documentation. Preferably, they should not be used by web authors.
 
 Some structural roles, like [`suggestion`](/en-US/docs/Web/Accessibility/ARIA/Roles/suggestion_role), don't have HTML equivalents, and therefore have separate documentation. Some structural roles with HTML equivalents, like [`heading`](/en-US/docs/Web/Accessibility/ARIA/Roles/heading_role), have ARIA-attribute requirements. They are listed below with links to their individual role documentation.
 
@@ -47,7 +48,8 @@ The structure roles with HTML equivalents are listed below:
 | [`term`](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role)<br/>Word or phrase with an optional corresponding definition.<br/> Prohibited attributes: `aria-label` and `aria-labelledby`.<br/>See [`term` role](/en-US/docs/Web/Accessibility/ARIA/Roles/term_role) for more information.                                               | {{HTMLElement('dfn')}}                                                                                                                                                                                                                                               |
 | **`time`** <br> A valid date or time string format list a specific point in time.<br/> Prohibited attributes: `aria-label` and `aria-labelledby`.                                                                                                                                                                                        | {{HTMLElement('time')}}                                                                                                                                                                                                                                              |
 
-> **Note:** The `aria-label` and `aria-labelledby` attributes are prohibited on `code`, `caption`, `deletion`, `emphasis`, `generic`, `insertion`, `mark`, `paragraph`, `presentation`, `none`, `strong`, `subscript`, `superscript`, `suggestion`, `term`, and `time`, and should only be used on interactive content.
+> [!NOTE]
+> The `aria-label` and `aria-labelledby` attributes are prohibited on `code`, `caption`, `deletion`, `emphasis`, `generic`, `insertion`, `mark`, `paragraph`, `presentation`, `none`, `strong`, `subscript`, `superscript`, `suggestion`, `term`, and `time`, and should only be used on interactive content.
 
 ## Best Practices
 

--- a/files/en-us/web/accessibility/aria/roles/structure_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/structure_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#structure
 
 The `structure` role is for document structural elements.
 
-> **Note:** The `structure` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `structure` role is an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles). It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.md
@@ -82,7 +82,8 @@ The assistive technology, if it supports the `switch` role, responds by doing th
 
 - Screen readers should announce the element as a switch, optionally providing instructions as to how to activate the switch.
 
-> **Note:** There are varying opinions on how assistive technologies should handle this role; the above is a suggested practice and may differ from other sources.
+> [!NOTE]
+> There are varying opinions on how assistive technologies should handle this role; the above is a suggested practice and may differ from other sources.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/tab_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tab_role/index.md
@@ -67,7 +67,8 @@ From the assistive technology user's perspective, the heading does not exist sin
 
 ### Required JavaScript features
 
-> **Note:** While there are ways to build tab-like functionality without JavaScript, there is no substitute combination using only HTML and CSS that will provide the same set of functionality that's required above for accessible tabs with content.
+> [!NOTE]
+> While there are ways to build tab-like functionality without JavaScript, there is no substitute combination using only HTML and CSS that will provide the same set of functionality that's required above for accessible tabs with content.
 
 ## Example
 

--- a/files/en-us/web/accessibility/aria/roles/table_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/table_role/index.md
@@ -51,7 +51,8 @@ The `table` value of the ARIA `role` attribute identifies the element containing
 
 An element with `role="table"` is a static tabular structure with rows containing cells. The cells are not focusable or selectable, though widgets within individual cells of the table can be interactive. Using a native HTML {{HTMLElement('table')}} element whenever possible is strongly encouraged.
 
-> **Warning:** If a table maintains a selection state, has two-dimensional navigation, or allows the user to rearrange cell order use [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) or [`treegrid`](/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role) instead.
+> [!WARNING]
+> If a table maintains a selection state, has two-dimensional navigation, or allows the user to rearrange cell order use [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) or [`treegrid`](/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role) instead.
 
 To create an ARIA table, add `role="table"` to the container element. Within that container, each row has `role="row"` set and contains child cells. Each cell has a role of either `columnheader`, `rowheader`, or `cell`. Rows can be children of the table or within a `rowgroup`.
 
@@ -61,7 +62,8 @@ If the table contains sortable columns or rows, the [`aria-sort`](/en-US/docs/We
 
 To create an interactive widget that has a tabular structure, use the `grid` pattern instead. If the interaction provides for the selection state of individual cells, if left to right and top to bottom navigation is provided, or if the user interface allows the rearranging of cell order or otherwise changing individual cell order such as through drag and drop, use [`grid`](/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role) or [`treegrid`](/en-US/docs/Web/Accessibility/ARIA/Roles/treegrid_role) instead.
 
-> **Note:** Using a native HTML table element whenever possible is strongly encouraged.
+> [!NOTE]
+> Using a native HTML table element whenever possible is strongly encouraged.
 
 ### Associated WAI-ARIA roles, states, and properties
 
@@ -86,7 +88,8 @@ None
 
 None. For sortable columns, see the [columnheader](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role) aria role.
 
-> **Note:** The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML {{HTMLElement('table')}} element instead of the ARIA role of table whenever possible.
+> [!NOTE]
+> The first rule of ARIA use is if you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. Employ the HTML {{HTMLElement('table')}} element instead of the ARIA role of table whenever possible.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/term_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/term_role/index.md
@@ -17,7 +17,8 @@ The `term` role is used to explicitly identify a word or phrase for which a defi
 
 Don't use the `role="term"` on interactive elements like links because it can interfere with assistive technology users ability to interact with the element. Also, the term itself is the accessible name, so do not use [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby).
 
-> **Warning:** The accessible name should be the term itself, so DO NOT use `aria-label` or `aria-labelledby`.
+> [!WARNING]
+> The accessible name should be the term itself, so DO NOT use `aria-label` or `aria-labelledby`.
 
 ### Associated WAI-ARIA roles, states, and properties
 

--- a/files/en-us/web/accessibility/aria/roles/textbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/textbox_role/index.md
@@ -83,7 +83,8 @@ All features associated with any and all properties and states must be maintaine
 - Focus event handler and aria-activedescendant attribute
   - : If you are implementing a composite widget, such as a combobox composed of a text box and a listbox, you need to manage the `aria-activedescendant` attribute using a handler. Before using this technique, ensure that the browsers you need to target currently support it. See the [specification of aria-descendant](https://www.w3.org/TR/wai-aria-1.1/#aria-activedescendant) for further information.
 
-> **Note:** It is a better practice to use an {{HTMLElement("input")}} element with type="text", or a {{HTMLElement("textarea")}} element instead of the ARIA textbox role. When using either semantic element, the ARIA textbox role is not necessary. See [Notes on Using ARIA in HTML](https://www.w3.org/TR/aria-in-html/).
+> [!NOTE]
+> It is a better practice to use an {{HTMLElement("input")}} element with type="text", or a {{HTMLElement("textarea")}} element instead of the ARIA textbox role. When using either semantic element, the ARIA textbox role is not necessary. See [Notes on Using ARIA in HTML](https://www.w3.org/TR/aria-in-html/).
 
 ## Possible effects on user agents and assistive technology
 
@@ -97,7 +98,8 @@ Assistive technology products should listen for such an event and notify the use
 - Screen readers should announce its label and role when focus first lands on a textbox. If it also contains content, this should be announced as with a regular textbox.
 - Screen magnifiers may enlarge the textbox.
 
-> **Note:** Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and may be experienced differently.
+> [!NOTE]
+> Opinions may differ on how assistive technology should handle this technique. The information provided above is one of those opinions and may be experienced differently.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/tree_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tree_role/index.md
@@ -19,7 +19,8 @@ An example of a `tree` is a file system selection user interface: a tree view di
 
 ARIA tree views are navigated primarily with arrow keys on the keyboard instead of the <kbd>Tab</kbd>. This form of navigation is not common for most browser content, though normal and expected for native applications. For this reason, before creating a tree view, consider alternative options to address the functionality you need.
 
-> **Warning:** Tree views use navigation more similar to native applications than to web applications. For this reason, consider alternative options to address the functionality you need before creating a tree view.
+> [!WARNING]
+> Tree views use navigation more similar to native applications than to web applications. For this reason, consider alternative options to address the functionality you need before creating a tree view.
 
 ### Single and multiple select trees
 

--- a/files/en-us/web/accessibility/aria/roles/treeitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/treeitem_role/index.md
@@ -25,7 +25,8 @@ Each parent node contains or owns an element with role [`group`](/en-US/docs/Web
 
 Each parent node should include the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute. It is set to `false` when closed `true` when open. End nodes should not have the `aria-expanded` attribute included as the presence of the attribute indicates to assistive technologies that the node is a parent.
 
-> **Note:** ARIA tree views use navigation more similar to native applications than to web applications and are navigated primarily with arrow keys on the keyboard instead of the <kbd>Tab</kbd>. This form of navigation is not common for most browser content, though normal and expected for native applications. For this reason, consider alternative options to address the functionality you need before creating a tree view.
+> [!NOTE]
+> ARIA tree views use navigation more similar to native applications than to web applications and are navigated primarily with arrow keys on the keyboard instead of the <kbd>Tab</kbd>. This form of navigation is not common for most browser content, though normal and expected for native applications. For this reason, consider alternative options to address the functionality you need before creating a tree view.
 
 Any element with a `treeitem` role must be nested in, or owned by, an element with role `tree`. Tree items can be a child of `tree`, `treeitem`, or an element with role `group` that is contained in, or owned by, an element with role `tree` or `treeitem`. If a `treeitem` is not nested within a `tree`, or nested in a `group` that is owned by a `tree`, include the [`id`](/en-US/docs/Web/HTML/Global_attributes#id) of the `treeitem` in the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns) attribute value on the owning `tree`, `treeitem` or `group` element.
 

--- a/files/en-us/web/accessibility/aria/roles/widget_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/widget_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#widget
 
 The **`widget`** role, an [abstract role](/en-US/docs/Web/Accessibility/ARIA/Roles#6._abstract_roles), is an interactive component of a graphical user interface (GUI).
 
-> **Note:** The `widget` role is an abstract role used for the ontology. It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `widget` role is an abstract role used for the ontology. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/aria/roles/window_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/window_role/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/aria/#window
 
 The `window` role defines a browser or app window.
 
-> **Note:** The `window` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
+> [!NOTE]
+> The `window` role is an abstract role. It is included here for completeness of documentation. It should not be used by web authors.
 
 ## Description
 

--- a/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.md
+++ b/files/en-us/web/accessibility/keyboard-navigable_javascript_widgets/index.md
@@ -14,7 +14,8 @@ By default, when people use the tab key to browse a webpage, only interactive el
 
 The order in which elements gain focus when using a keyboard, is the source order by default. In exceptional circumstances, authors may want to redefine the order. To do this, authors can set `tabindex` to any positive number.
 
-> **Warning:** avoid using positive values for `tabindex`. Elements with a positive `tabindex` are put before the default interactive elements on the page, which means page authors will have to set (and maintain) `tabindex` values for all focusable elements on the page whenever they use one or more positive values for `tabindex`.
+> [!WARNING]
+> avoid using positive values for `tabindex`. Elements with a positive `tabindex` are put before the default interactive elements on the page, which means page authors will have to set (and maintain) `tabindex` values for all focusable elements on the page whenever they use one or more positive values for `tabindex`.
 
 The following table describes `tabindex` behavior in modern browsers:
 

--- a/files/en-us/web/accessibility/mobile_accessibility_checklist/index.md
+++ b/files/en-us/web/accessibility/mobile_accessibility_checklist/index.md
@@ -77,4 +77,5 @@ This document provides a concise checklist of accessibility requirements for mob
 
 - Touch targets must be large enough for the user to interact with (see the [BBC Mobile Accessibility Guidelines](https://www.bbc.co.uk/accessibility/forproducts/guides/mobile/target-touch-size) for useful touch target size guidelines).
 
-> **Note:** The [original version of this document](https://yzen.github.io/firefoxos/2014/04/30/mobile-accessibility-checklist.html) was written by [Yura Zenevich](https://yzen.github.io/).
+> [!NOTE]
+> The [original version of this document](https://yzen.github.io/firefoxos/2014/04/30/mobile-accessibility-checklist.html) was written by [Yura Zenevich](https://yzen.github.io/).

--- a/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/understanding_colors_and_luminance/index.md
@@ -125,7 +125,8 @@ As noted earlier, the [CSS color module](/en-US/docs/Web/CSS/CSS_colors) include
 
 Where accessibility is concerned, however, standards and guidelines are currently written predominantly using the sRGB color space, especially as it applies to color contrast ratios.
 
-> **Note:** Almost all systems used today to view Web content assume sRGB encoding. Unless it is known that another color space will be used to process and display the content, authors should evaluate using sRGB colorspace. If using other color spaces, apply the principles of [minimum contrast ratios](https://webaim.org/articles/contrast/#sc143).
+> [!NOTE]
+> Almost all systems used today to view Web content assume sRGB encoding. Unless it is known that another color space will be used to process and display the content, authors should evaluate using sRGB colorspace. If using other color spaces, apply the principles of [minimum contrast ratios](https://webaim.org/articles/contrast/#sc143).
 
 ### Querying color values
 

--- a/files/en-us/web/accessibility/understanding_wcag/keyboard/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/keyboard/index.md
@@ -12,7 +12,8 @@ To be fully accessible, a web page must be operable by someone using only a keyb
 
 If an element can be focused using the keyboard, then it should be interactive; that is, the user should be able to do something to it and produce a change of some kind (for example, activating a link or changing an option).
 
-> **Note:** One important exception to this rule is if the element has `role="document"` applied to it, **inside** an interactive context (such as `role="application"`). In such a case, focusing the nested document is the only way of returning assistive technology to a non-interactive state (often called "browse mode").
+> [!NOTE]
+> One important exception to this rule is if the element has `role="document"` applied to it, **inside** an interactive context (such as `role="application"`). In such a case, focusing the nested document is the only way of returning assistive technology to a non-interactive state (often called "browse mode").
 
 Most interactive elements are focusable by default; you can make an element focusable by adding a `tabindex=0` attribute value to it. However, you should only add `tabindex` if you have also made the element interactive, for example, by defining appropriate event handlers keyboard events.
 

--- a/files/en-us/web/accessibility/understanding_wcag/operable/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/operable/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article provides practical advice on how to write your web content so that it conforms to the success criteria outlined in the **Operable** principle of the Web Content Accessibility Guidelines (WCAG) 2.0 and 2.1. Operable states that user interface components and navigation must be operable.
 
-> **Note:** To read the W3C definitions for Operable and its guidelines and success criteria, see [Principle 2: Operable — User interface components and navigation must be operable.](https://www.w3.org/TR/WCAG21/#operable)
+> [!NOTE]
+> To read the W3C definitions for Operable and its guidelines and success criteria, see [Principle 2: Operable — User interface components and navigation must be operable.](https://www.w3.org/TR/WCAG21/#operable)
 
 ## Guideline 2.1 — Keyboard Accessible: Make all functionality available from a keyboard
 
@@ -106,7 +107,8 @@ This guideline covers the necessity of making core website functionality availab
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 2.1 Keyboard Accessible: Make all functionality available from a keyboard](https://www.w3.org/TR/WCAG21/#keyboard-accessible).
+> [!NOTE]
+> Also see the WCAG description for [Guideline 2.1 Keyboard Accessible: Make all functionality available from a keyboard](https://www.w3.org/TR/WCAG21/#keyboard-accessible).
 
 ## Guideline 2.2 — Enough Time: Provide users enough time to read and use content
 
@@ -208,7 +210,8 @@ This guideline covers situations in which functionality may have a time limit. F
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 2.2 Enough Time: Provide users enough time to read and use content](https://www.w3.org/TR/WCAG21/#enough-time).
+> [!NOTE]
+> Also see the WCAG description for [Guideline 2.2 Enough Time: Provide users enough time to read and use content](https://www.w3.org/TR/WCAG21/#enough-time).
 
 ## Guideline 2.3 — Seizures and Physical Reactions: Do not design content in a way that is known to cause seizures or physical reactions
 
@@ -241,7 +244,8 @@ This refers to content that, if not changed, could cause seizures in users with 
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 2.3 Seizures and Physical Reactions: Do not design content in a way that is known to cause seizures or physical reactions.](https://www.w3.org/TR/WCAG21/#seizures-and-physical-reactions)
+> [!NOTE]
+> Also see the WCAG description for [Guideline 2.3 Seizures and Physical Reactions: Do not design content in a way that is known to cause seizures or physical reactions.](https://www.w3.org/TR/WCAG21/#seizures-and-physical-reactions)
 
 ## Guideline 2.4 — Navigable: Provide ways to help users navigate, find content, and determine where they are
 
@@ -500,7 +504,8 @@ The conformance criteria under this guideline relate to ways in which users can 
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 2.4 Navigable: Provide ways to help users navigate, find content, and determine where they are.](https://www.w3.org/TR/WCAG21/#navigable)
+> [!NOTE]
+> Also see the WCAG description for [Guideline 2.4 Navigable: Provide ways to help users navigate, find content, and determine where they are.](https://www.w3.org/TR/WCAG21/#navigable)
 
 ## Guideline 2.5 Input Modalities: Make it easier for users to operate functionality through various inputs beyond keyboard
 
@@ -561,7 +566,8 @@ The conformance criteria under this guideline ensures that users are able to int
  </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 2.5: Input Modalities: Make it easier for users to operate functionality through various inputs beyond keyboard.](https://www.w3.org/TR/WCAG21/#input-modalities)
+> [!NOTE]
+> Also see the WCAG description for [Guideline 2.5: Input Modalities: Make it easier for users to operate functionality through various inputs beyond keyboard.](https://www.w3.org/TR/WCAG21/#input-modalities)
 
 ## See also
 

--- a/files/en-us/web/accessibility/understanding_wcag/perceivable/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/perceivable/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article provides practical advice on how to write your web content so that it conforms to the success criteria outlined in the **Perceivable** principle of the Web Content Accessibility Guidelines (WCAG) 2.0 and 2.1. Perceivable states that users must be able to perceive it in some way, using one or more of their senses.
 
-> **Note:** To read the W3C definitions for Perceivable and its guidelines and success criteria, see [Principle 1: Perceivable - Information and user interface components must be presentable to users in ways they can perceive.](https://www.w3.org/TR/WCAG21/#perceivable)
+> [!NOTE]
+> To read the W3C definitions for Perceivable and its guidelines and success criteria, see [Principle 1: Perceivable - Information and user interface components must be presentable to users in ways they can perceive.](https://www.w3.org/TR/WCAG21/#perceivable)
 
 ## Guideline 1.1 — Providing text alternatives for non-text content
 
@@ -115,7 +116,8 @@ The key here is that text can be converted to other forms that people with disab
   </tbody>
 </table>
 
-> **Note:** Also see the [WCAG description for Guideline 1.1: Text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives).
+> [!NOTE]
+> Also see the [WCAG description for Guideline 1.1: Text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives).
 
 ## Guideline 1.2 — Providing text alternatives for time-based media
 
@@ -178,7 +180,8 @@ Time-based media refers to multimedia with a duration, such as audio and video. 
  </tbody>
 </table>
 
-> **Note:** Also see the [WCAG description for Guideline 1.2: Time-based Media: Provide alternatives for time-based media](https://www.w3.org/TR/WCAG21/#time-based-media).
+> [!NOTE]
+> Also see the [WCAG description for Guideline 1.2: Time-based Media: Provide alternatives for time-based media](https://www.w3.org/TR/WCAG21/#time-based-media).
 
 ## Guideline 1.3 — Create content that can be presented in different ways
 
@@ -363,7 +366,8 @@ This guideline refers to the ability of content to be consumed by users in multi
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 1.3: Adaptable: Create content that can be presented in different ways without losing information or structure.](https://www.w3.org/TR/WCAG21/#adaptable)
+> [!NOTE]
+> Also see the WCAG description for [Guideline 1.3: Adaptable: Create content that can be presented in different ways without losing information or structure.](https://www.w3.org/TR/WCAG21/#adaptable)
 
 ## Guideline 1.4: Make it easier for users to see and hear content including separating foreground from background
 
@@ -645,7 +649,8 @@ This guideline relates to making sure core content is easy to discern from backg
   </thead>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 1.4: Distinguishable: Make it easier for users to see and hear content including separating foreground from background.](https://www.w3.org/TR/WCAG21/#distinguishable)
+> [!NOTE]
+> Also see the WCAG description for [Guideline 1.4: Distinguishable: Make it easier for users to see and hear content including separating foreground from background.](https://www.w3.org/TR/WCAG21/#distinguishable)
 
 ## See also
 

--- a/files/en-us/web/accessibility/understanding_wcag/robust/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/robust/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article provides practical advice on how to write your web content so that it conforms to the success criteria outlined in the **Robust** principle of the Web Content Accessibility Guidelines (WCAG) 2.0 and 2.1. Robust states that content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies. This can generally be achieved by following web standards and [testing rigorously](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing).
 
-> **Note:** To read the W3C definitions for Robust and its guidelines and success criteria, see [Principle 4: Robust — Content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies.](https://www.w3.org/TR/WCAG21/#robust)
+> [!NOTE]
+> To read the W3C definitions for Robust and its guidelines and success criteria, see [Principle 4: Robust — Content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies.](https://www.w3.org/TR/WCAG21/#robust)
 
 ## Guideline 4.1 — Compatible: Maximize compatibility with current and future user agents, including assistive technologies
 
@@ -98,7 +99,8 @@ This guideline focuses on making content as compatible as possible, not only wit
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 4.1: Compatible: Maximize compatibility with current and future user agents, including assistive technologies.](https://www.w3.org/TR/WCAG21/#compatible)
+> [!NOTE]
+> Also see the WCAG description for [Guideline 4.1: Compatible: Maximize compatibility with current and future user agents, including assistive technologies.](https://www.w3.org/TR/WCAG21/#compatible)
 
 ## See also
 

--- a/files/en-us/web/accessibility/understanding_wcag/understandable/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/understandable/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article provides practical advice on how to write your web content so that it conforms to the success criteria outlined in the **Understandable** principle of the Web Content Accessibility Guidelines (WCAG) 2.0 and 2.1. Understandable states that information and the operation of user interface must be understandable.
 
-> **Note:** To read the W3C definitions for Understandable and its guidelines and success criteria, see [Principle 3: Understandable — Information and the operation of user interface must be understandable](https://www.w3.org/TR/WCAG21/#understandable).
+> [!NOTE]
+> To read the W3C definitions for Understandable and its guidelines and success criteria, see [Principle 3: Understandable — Information and the operation of user interface must be understandable](https://www.w3.org/TR/WCAG21/#understandable).
 
 ## Guideline 3.1 — Readable: Make text content readable and understandable
 
@@ -156,7 +157,8 @@ This guideline focuses on making text content as understandable as possible.
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 3.1 Readable: Make text content readable and understandable](https://www.w3.org/TR/WCAG21/#readable).
+> [!NOTE]
+> Also see the WCAG description for [Guideline 3.1 Readable: Make text content readable and understandable](https://www.w3.org/TR/WCAG21/#readable).
 
 ## Guideline 3.2 — Predictable: Make Web pages appear and operate in predictable ways
 
@@ -296,7 +298,8 @@ This guideline focuses on making user interfaces intuitive and understandable.
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 3.2 Predictable: Make Web pages appear and operate in predictable ways](https://www.w3.org/TR/WCAG21/#predictable).
+> [!NOTE]
+> Also see the WCAG description for [Guideline 3.2 Predictable: Make Web pages appear and operate in predictable ways](https://www.w3.org/TR/WCAG21/#predictable).
 
 ## Guideline 3.3 — Input Assistance: Help users avoid and correct mistakes
 
@@ -499,7 +502,8 @@ A cognitive function test, like remembering a password, must not be required for
   </tbody>
 </table>
 
-> **Note:** Also see the WCAG description for [Guideline 3.3 Input Assistance: Help users avoid and correct mistakes](https://www.w3.org/TR/WCAG21/#input-assistance).
+> [!NOTE]
+> Also see the WCAG description for [Guideline 3.3 Input Assistance: Help users avoid and correct mistakes](https://www.w3.org/TR/WCAG21/#input-assistance).
 
 ## See also
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/accessibility' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
