### PR TITLE
Convert noteblocks for web/html/global_attributes folder

### DIFF
--- a/files/en-us/web/html/global_attributes/accesskey/index.md
+++ b/files/en-us/web/html/global_attributes/accesskey/index.md
@@ -11,7 +11,8 @@ The **`accesskey`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) p
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-accesskey.html","tabbed-shorter")}}
 
-> **Note:** In the WHATWG spec, it says you can specify multiple space-separated characters, and the browser will use the first one it supports. However, this does not work in most browsers. IE/Edge uses the first one it supports without problems, provided there are no conflicts with other commands.
+> [!NOTE]
+> In the WHATWG spec, it says you can specify multiple space-separated characters, and the browser will use the first one it supports. However, this does not work in most browsers. IE/Edge uses the first one it supports without problems, provided there are no conflicts with other commands.
 
 The way to activate the accesskey depends on the browser and its platform:
 

--- a/files/en-us/web/html/global_attributes/anchor/index.md
+++ b/files/en-us/web/html/global_attributes/anchor/index.md
@@ -12,7 +12,8 @@ browser-compat: html.global_attributes.anchor
 
 The **`anchor`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is used to associate a positioned element with an anchor element. The attribute's value is the [`id`](/en-US/docs/Web/HTML/Global_attributes/id) value of the element you want to anchor the positioned element to. The element can then be positioned using [CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using).
 
-> **Note:** Alternatively, you can associate a positioned element with an anchor element via CSS, using the {{cssxref("anchor-name")}} and {{cssxref("position-anchor")}} properties. If both anchoring techniques are used on the same element, the CSS technique takes precedence over the HTML technique.
+> [!NOTE]
+> Alternatively, you can associate a positioned element with an anchor element via CSS, using the {{cssxref("anchor-name")}} and {{cssxref("position-anchor")}} properties. If both anchoring techniques are used on the same element, the CSS technique takes precedence over the HTML technique.
 
 ## Examples
 

--- a/files/en-us/web/html/global_attributes/autofocus/index.md
+++ b/files/en-us/web/html/global_attributes/autofocus/index.md
@@ -15,7 +15,8 @@ The **`autofocus`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) i
 
 No more than one element in the document or dialog may have the autofocus attribute. If applied to multiple elements the first one will receive focus.
 
-> **Note:** The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Global_attributes/contenteditable) area.
+> [!NOTE]
+> The `autofocus` attribute applies to all elements, not just form controls. For example, it might be used on a [contenteditable](/en-US/docs/Web/HTML/Global_attributes/contenteditable) area.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/html/global_attributes/dir/index.md
+++ b/files/en-us/web/html/global_attributes/dir/index.md
@@ -17,14 +17,16 @@ It can have the following values:
 - `rtl`, which means _right to left_ and is to be used for languages that are written from the right to the left (like Arabic);
 - `auto`, which lets the user agent decide. It uses a basic algorithm as it parses the characters inside the element until it finds a character with a strong directionality, then applies that directionality to the whole element.
 
-> **Note:** This attribute is mandatory for the {{ HTMLElement("bdo") }} element where it has a different semantic meaning.
+> [!NOTE]
+> This attribute is mandatory for the {{ HTMLElement("bdo") }} element where it has a different semantic meaning.
 >
 > - This attribute is _not_ inherited by the {{ HTMLElement("bdi") }} element. If not set, its value is `auto`.
 > - This attribute can be overridden by the CSS properties {{ cssxref("direction") }} and {{ cssxref("unicode-bidi") }}, if a CSS page is active and the element supports these properties.
 > - As the directionality of the text is semantically related to its content and not to its presentation, it is recommended that web developers use this attribute instead of the related CSS properties when possible. That way, the text will display correctly even on a browser that doesn't support CSS or has the CSS deactivated.
 > - The `auto` value should be used for data with an unknown directionality, like data coming from user input, eventually stored in a database.
 
-> **Note:** Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields while Legacy Edge uses the key combinations <kbd>Ctrl</kbd> + <kbd>Left Shift</kbd> and <kbd>Ctrl</kbd> + <kbd>Right Shift</kbd>. Firefox uses <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> but does NOT update the **`dir`** attribute value.
+> [!NOTE]
+> Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }}s in order to assist with authoring content. Chrome and Safari provide a directionality option in the contextual menu of input fields while Legacy Edge uses the key combinations <kbd>Ctrl</kbd> + <kbd>Left Shift</kbd> and <kbd>Ctrl</kbd> + <kbd>Right Shift</kbd>. Firefox uses <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> but does NOT update the **`dir`** attribute value.
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/draggable/index.md
+++ b/files/en-us/web/html/global_attributes/draggable/index.md
@@ -17,7 +17,8 @@ For more information about what namespace declarations look like, and what they 
 - `true`: the element can be dragged.
 - `false`: the element cannot be dragged.
 
-> **Warning:** This attribute is _[enumerated](/en-US/docs/Glossary/Enumerated)_ and not _Boolean_. A value of `true` or `false` is mandatory, and shorthand like `<img draggable>` is forbidden. The correct usage is `<img draggable="false">`.
+> [!WARNING]
+> This attribute is _[enumerated](/en-US/docs/Glossary/Enumerated)_ and not _Boolean_. A value of `true` or `false` is mandatory, and shorthand like `<img draggable>` is forbidden. The correct usage is `<img draggable="false">`.
 
 If this attribute is not set, its default value is `auto`, which means drag behavior is the default browser behavior: only text selections, images, and links can be dragged. For other elements, the event {{domxref('HTMLElement.dragstart_event', 'ondragstart')}} must be set for drag and drop to work, as shown in this [comprehensive example](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations).
 

--- a/files/en-us/web/html/global_attributes/id/index.md
+++ b/files/en-us/web/html/global_attributes/id/index.md
@@ -11,7 +11,8 @@ The **`id`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) defines 
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-id.html","tabbed-shorter")}}
 
-> **Warning:** This attribute's value is an opaque string: this means that web authors should not rely on it to convey human-readable information (although having your IDs somewhat human-readable can be useful for code comprehension, e.g. consider `ticket-18659` versus `r45tgfe-freds&$@`).
+> [!WARNING]
+> This attribute's value is an opaque string: this means that web authors should not rely on it to convey human-readable information (although having your IDs somewhat human-readable can be useful for code comprehension, e.g. consider `ticket-18659` versus `r45tgfe-freds&$@`).
 
 An `id`'s value must not contain {{glossary("whitespace")}} (spaces, tabs, etc.). Browsers treat non-conforming IDs that contain whitespace as if the whitespace is part of the ID. In contrast to the [`class`](/en-US/docs/Web/HTML/Global_attributes#class) attribute, which allows space-separated values, elements can only have one single ID value.
 

--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -69,7 +69,8 @@ In addition to the basic HTML global attributes, the following global attributes
 - [`is`](/en-US/docs/Web/HTML/Global_attributes/is)
   - : Allows you to specify that a standard HTML element should behave like a registered custom built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
 
-> **Note:** The `item*` attributes are part of the [WHATWG HTML Microdata feature](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
+> [!NOTE]
+> The `item*` attributes are part of the [WHATWG HTML Microdata feature](https://html.spec.whatwg.org/multipage/microdata.html#microdata).
 
 - [`itemid`](/en-US/docs/Web/HTML/Global_attributes/itemid)
   - : The unique, global identifier of an item.

--- a/files/en-us/web/html/global_attributes/inert/index.md
+++ b/files/en-us/web/html/global_attributes/inert/index.md
@@ -28,7 +28,8 @@ The `inert` attribute can be added to sections of content that should not be int
 
 The `inert` attribute can also be added to elements that should be offscreen or hidden. An inert element, along with its descendants, gets removed from the tab order and accessibility tree.
 
-> **Note:** While `inert` is a global attribute and can be applied to any element, it is generally used for sections of content. To make individual controls "inert", consider using the [`disabled`](/en-US/docs/Web/HTML/Attributes/disabled) attribute, along with CSS [`:disabled`](/en-US/docs/Web/CSS/:disabled) styles, instead.
+> [!NOTE]
+> While `inert` is a global attribute and can be applied to any element, it is generally used for sections of content. To make individual controls "inert", consider using the [`disabled`](/en-US/docs/Web/HTML/Attributes/disabled) attribute, along with CSS [`:disabled`](/en-US/docs/Web/CSS/:disabled) styles, instead.
 
 ## Accessibility concerns
 

--- a/files/en-us/web/html/global_attributes/is/index.md
+++ b/files/en-us/web/html/global_attributes/is/index.md
@@ -7,7 +7,7 @@ browser-compat: html.global_attributes.is
 
 {{HTMLSidebar("Global_attributes")}}
 
-> [!NOTE] > [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
+> **Note:** [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
 
 The **`is`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) allows you to specify that a standard HTML element should behave like a defined custom built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
 

--- a/files/en-us/web/html/global_attributes/is/index.md
+++ b/files/en-us/web/html/global_attributes/is/index.md
@@ -7,7 +7,7 @@ browser-compat: html.global_attributes.is
 
 {{HTMLSidebar("Global_attributes")}}
 
-> **Note:** [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
+> [!NOTE] > [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
 
 The **`is`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) allows you to specify that a standard HTML element should behave like a defined custom built-in element (see [Using custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) for more details).
 

--- a/files/en-us/web/html/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/global_attributes/itemid/index.md
@@ -13,7 +13,8 @@ An `itemid` attribute can only be specified for an element that has both [`items
 
 The exact meaning of an `itemtype`'s global identifier is provided by the definition of that identifier within the specified vocabulary. The vocabulary defines whether several items with the same global identifier can coexist and, if so, how items with the same identifier are handled.
 
-> **Note:** The {{glossary("WHATWG")}} definition specifies that an `itemid` must be a {{glossary("URL")}}. However, the following example correctly illustrates that a {{glossary("URN")}} may also be used. This inconsistency may reflect the incomplete nature of the Microdata specification.
+> [!NOTE]
+> The {{glossary("WHATWG")}} definition specifies that an `itemid` must be a {{glossary("URL")}}. However, the following example correctly illustrates that a {{glossary("URN")}} may also be used. This inconsistency may reflect the incomplete nature of the Microdata specification.
 
 ## Examples
 

--- a/files/en-us/web/html/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/global_attributes/itemprop/index.md
@@ -196,7 +196,8 @@ An element introducing a property can also introduce multiple properties at once
 </div>
 ```
 
-> **Note:** There is no relationship between the microdata and the content of the document where the microdata is marked up.
+> [!NOTE]
+> There is no relationship between the microdata and the content of the document where the microdata is marked up.
 
 ### Same structured data marked up in two different ways
 
@@ -284,7 +285,8 @@ A property is an unordered set of unique tokens that are case-sensitive and repr
 
    1. A string that contains no "`.`" (U+002E FULL STOP) characters and no "`:`" characters (U+003A COLON) and is used as a proprietary item property name (again, one not defined in a public specification).
 
-> **Note:** The rules above disallow ":" characters in non-URL values because otherwise they could not be distinguished from URLs. Values with "." characters are reserved for future extensions. Space characters are disallowed because otherwise the values would be parsed as multiple tokens.
+> [!NOTE]
+> The rules above disallow ":" characters in non-URL values because otherwise they could not be distinguished from URLs. Values with "." characters are reserved for future extensions. Space characters are disallowed because otherwise the values would be parsed as multiple tokens.
 
 ## Values
 

--- a/files/en-us/web/html/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/global_attributes/itemref/index.md
@@ -13,7 +13,8 @@ Properties that are not descendants of an element with the [`itemscope`](/en-US/
 
 The `itemref` attribute can only be specified on elements that have an `itemscope` attribute specified.
 
-> **Note:** The `itemref` attribute is not part of the microdata data model. It is merely a syntactic construct to aid authors in adding annotations to pages where the data to be annotated does not follow a convenient tree structure. For example, it allows authors to mark up data in a table so that each column defines a separate item while keeping the properties in the cells.
+> [!NOTE]
+> The `itemref` attribute is not part of the microdata data model. It is merely a syntactic construct to aid authors in adding annotations to pages where the data to be annotated does not follow a convenient tree structure. For example, it allows authors to mark up data in a table so that each column defines a separate item while keeping the properties in the cells.
 
 ## Examples
 

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -13,7 +13,8 @@ A related attribute, [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtyp
 
 Every HTML element may have an `itemscope` attribute specified. An `itemscope` element that does not have an associated `itemtype` must have an associated `itemref`.
 
-> **Note:** Find more about `itemtype` attributes at <https://schema.org/Thing>
+> [!NOTE]
+> Find more about `itemtype` attributes at <https://schema.org/Thing>
 
 ### itemscope id attributes
 
@@ -191,7 +192,8 @@ There are four `itemscope` attributes in the following example. Each `itemscope`
   </tbody>
 </table>
 
-> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Rich Results Testing Tool](https://search.google.com/test/rich-results). Try it on the HTML shown here.
+> [!NOTE]
+> A handy tool for extracting microdata structures from HTML is Google's [Rich Results Testing Tool](https://search.google.com/test/rich-results). Try it on the HTML shown here.
 
 #### HTML
 

--- a/files/en-us/web/html/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/global_attributes/itemtype/index.md
@@ -13,7 +13,8 @@ The [global attribute](/en-US/docs/Web/HTML/Global_attributes) **`itemtype`** sp
 
 Google and other major search engines support the [schema.org](https://schema.org/) vocabulary for structured data. This vocabulary defines a standard set of type names and property names. For example, `MusicEvent` indicates a concert performance, with [`startDate`](https://schema.org/startDate) and [`location`](https://schema.org/location) properties specifying the concert's key details. In this case, [`MusicEvent`](https://schema.org/MusicEvent) would be the URL used by `itemtype`, with `startDate` and location as `itemprop`'s which [`MusicEvent`](https://schema.org/MusicEvent) defines.
 
-> **Note:** More about `itemtype` attributes can be found at <https://schema.org/Thing>
+> [!NOTE]
+> More about `itemtype` attributes can be found at <https://schema.org/Thing>
 
 - The **itemtype** attribute must have a value that is an unordered set of unique tokens which are case-sensitive, each is a valid and absolute URL, and all defined to use the same vocabulary. The attribute's value must have at least one token.
 - The item types must all be types defined in applicable specifications (such as [schema.org](https://schema.org/)), and must all be defined to use the same vocabulary.
@@ -129,7 +130,8 @@ This example uses microdata attributes to represent structured data for a produc
   </tbody>
 </table>
 
-> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data). Try it on the HTML shown here.
+> [!NOTE]
+> A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data). Try it on the HTML shown here.
 
 #### HTML
 

--- a/files/en-us/web/html/global_attributes/lang/index.md
+++ b/files/en-us/web/html/global_attributes/lang/index.md
@@ -9,7 +9,8 @@ browser-compat: html.global_attributes.lang
 
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single "language tag" in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 
-> **Note:** The default value of `lang` is the empty string, which means that the language is unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.
+> [!NOTE]
+> The default value of `lang` is the empty string, which means that the language is unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-lang.html","tabbed-shorter")}}
 

--- a/files/en-us/web/html/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/global_attributes/nonce/index.md
@@ -17,7 +17,8 @@ be allowed to proceed for a given element.
 The `nonce` attribute is useful to allowlist specific elements, such as a particular inline script or style elements.
 It can help you to avoid using the [CSP](/en-US/docs/Web/HTTP/CSP) `unsafe-inline` directive, which would allowlist _all_ inline scripts or styles.
 
-> **Note:** Only use `nonce` for cases where you have no way around using unsafe inline script
+> [!NOTE]
+> Only use `nonce` for cases where you have no way around using unsafe inline script
 > or style contents. If you don't need `nonce`, don't use it. If your script is static, you could also use a CSP hash instead.
 > (See usage notes on [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script).)
 > Always try to take full advantage of [CSP](/en-US/docs/Web/HTTP/CSP) protections and avoid nonces or unsafe inline scripts whenever possible.

--- a/files/en-us/web/html/global_attributes/popover/index.md
+++ b/files/en-us/web/html/global_attributes/popover/index.md
@@ -31,7 +31,8 @@ The following renders a button that will open a popover element when activated.
 
 {{EmbedLiveSample('Examples', 600, 200)}}
 
-> **Note:** See our [Popover API examples landing page](https://mdn.github.io/dom-examples/popover-api/) to access the full collection of MDN popover examples.
+> [!NOTE]
+> See our [Popover API examples landing page](https://mdn.github.io/dom-examples/popover-api/) to access the full collection of MDN popover examples.
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.md
@@ -9,7 +9,8 @@ browser-compat: html.global_attributes.spellcheck
 
 The **`spellcheck`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that defines whether the element may be checked for spelling errors.
 
-> **Note:** This attribute is merely a hint for the browser: browsers are not required to check for spelling errors. Typically non-editable elements are not checked for spelling errors, even if the `spellcheck` attribute is set to `true` and the browser supports spellchecking.
+> [!NOTE]
+> This attribute is merely a hint for the browser: browsers are not required to check for spelling errors. Typically non-editable elements are not checked for spelling errors, even if the `spellcheck` attribute is set to `true` and the browser supports spellchecking.
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-spellcheck.html","tabbed-shorter")}}
 

--- a/files/en-us/web/html/global_attributes/style/index.md
+++ b/files/en-us/web/html/global_attributes/style/index.md
@@ -11,7 +11,8 @@ The **`style`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) conta
 
 {{EmbedInteractiveExample("pages/tabbed/attribute-style.html","tabbed-shorter")}}
 
-> **Note:** This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute.
+> [!NOTE]
+> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute.
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/tabindex/index.md
+++ b/files/en-us/web/html/global_attributes/tabindex/index.md
@@ -13,7 +13,8 @@ The **`tabindex`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) al
 
 It accepts an integer as a value, with different results depending on the integer's value:
 
-> **Note:** If an HTML element renders and has `tabindex` attribute with any valid integer value, the element can be focused with JavaScript (by calling the [`focus()`](/en-US/docs/Web/API/HTMLElement/focus) method) or visually by clicking with the mouse. The particular `tabindex` value controls whether the element is `tabbable` (i.e. reachable via sequential keyboard navigation, usually with the <kbd>Tab</kbd> key).
+> [!NOTE]
+> If an HTML element renders and has `tabindex` attribute with any valid integer value, the element can be focused with JavaScript (by calling the [`focus()`](/en-US/docs/Web/API/HTMLElement/focus) method) or visually by clicking with the mouse. The particular `tabindex` value controls whether the element is `tabbable` (i.e. reachable via sequential keyboard navigation, usually with the <kbd>Tab</kbd> key).
 
 - A _negative value_ (the exact negative value doesn't actually matter, usually `tabindex="-1"`) means that the element is not reachable via sequential keyboard navigation.
 
@@ -27,7 +28,8 @@ It accepts an integer as a value, with different results depending on the intege
 
 Some focusable HTML elements have a default `tabindex` value of `0` set under the hood by the [user agent](/en-US/docs/Glossary/User_agent). These elements are an {{HTMLElement("a")}} or {{HTMLElement("area")}} with `href` attribute, {{HTMLElement("button")}}, {{HTMLElement("frame")}} {{deprecated_inline}}, {{HTMLElement("iframe")}}, {{HTMLElement("input")}}, {{HTMLElement("object")}}, {{HTMLElement("select")}}, {{HTMLElement("textarea")}}, and SVG {{SVGElement("a")}} element, or a {{HTMLElement("summary")}} element that provides summary for a {{HTMLElement("details")}} element. Developers shouldn't add the `tabindex` attribute to these elements unless it changes the default behavior (for example, including a negative value will remove the element from the focus navigation order).
 
-> **Warning:** The tabindex attribute must not be used on the {{HTMLElement("dialog")}} element.
+> [!WARNING]
+> The tabindex attribute must not be used on the {{HTMLElement("dialog")}} element.
 
 ## Accessibility concerns
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/html/global_attributes' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
