### PR TITLE
Convert noteblocks for web/html folder

### DIFF
--- a/files/en-us/web/html/comments/index.md
+++ b/files/en-us/web/html/comments/index.md
@@ -21,7 +21,8 @@ Comments can be used on a single line, or span multiple lines. They can be used 
 - Before and after the {{HTMLElement("html")}} element
 - As the content of most elements except: {{HTMLElement("script")}}, {{HTMLElement("style")}}, {{HTMLElement("title")}}, {{HTMLElement("textarea")}}, because these elements interpret their content as raw text
 
-> **Note:** While `<script>` elements should not have HTML comments and should use [JavaScript comments](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#comments) instead, there was a legacy practice to enclose the whole script content in an HTML comment so ancient browsers that don't support JavaScript don't render it as text. This is now a [legacy feature of JavaScript itself](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#html_comments) and you should not rely on it.
+> [!NOTE]
+> While `<script>` elements should not have HTML comments and should use [JavaScript comments](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#comments) instead, there was a legacy practice to enclose the whole script content in an HTML comment so ancient browsers that don't support JavaScript don't render it as text. This is now a [legacy feature of JavaScript itself](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#html_comments) and you should not rely on it.
 
 ## Syntax
 

--- a/files/en-us/web/html/constraint_validation/index.md
+++ b/files/en-us/web/html/constraint_validation/index.md
@@ -10,7 +10,8 @@ The creation of web forms has always been a complex task. While marking up the f
 
 For a basic introduction to these concepts, with examples, see the [Form validation tutorial](/en-US/docs/Learn/Forms/Form_validation).
 
-> **Note:** HTML Constraint validation doesn't remove the need for validation on the _server side_. Even though far fewer invalid form requests are to be expected, invalid ones can still be sent in many ways:
+> [!NOTE]
+> HTML Constraint validation doesn't remove the need for validation on the _server side_. Even though far fewer invalid form requests are to be expected, invalid ones can still be sent in many ways:
 >
 > - By modifying HTML via the browser's developer tools.
 > - By hand-crafting an HTTP request without using the form.
@@ -278,7 +279,7 @@ Constraint validation is done through the Constraint Validation API either on a 
 
 Calling `checkValidity()` is called _statically_ validating the constraints, while calling `reportValidity()` or submitting the form is called _interactively_ validating the constraints.
 
-> **Note:**
+> [!NOTE]
 >
 > - If the [`novalidate`](/en-US/docs/Web/HTML/Element/form#novalidate) attribute is set on the {{ HTMLElement("form") }} element, interactive validation of the constraints doesn't happen.
 > - Calling the `submit()` method on the [`HTMLFormElement`](/en-US/docs/Web/API/HTMLFormElement) interface doesn't trigger a constraint validation. In other words, this method sends the form data to the server even if it doesn't satisfy the constraints. Call the `click()` method on a submit button instead.
@@ -294,7 +295,8 @@ Basically, the idea is to trigger JavaScript on some form field event (like **on
 
 The postal code format varies from one country to another. Not only do most countries allow an optional prefix with the country code (like `D-` in Germany, `F-` in France or Switzerland), but some countries have postal codes with only a fixed number of digits; others, like the UK, have more complex structures, allowing letters at some specific positions.
 
-> **Note:** This is not a comprehensive postal code validation library, but rather a demonstration of the key concepts.
+> [!NOTE]
+> This is not a comprehensive postal code validation library, but rather a demonstration of the key concepts.
 
 As an example, we will add a script checking the constraint validation for this simple form:
 

--- a/files/en-us/web/html/content_categories/index.md
+++ b/files/en-us/web/html/content_categories/index.md
@@ -14,7 +14,8 @@ There are three types of content categories:
 - Form-related content categories, which describe rules common to form-related elements.
 - Specific content categories, which describe rare categories shared only by a few elements, sometimes only in a specific context.
 
-> **Note:** A more detailed discussion of these content categories and their comparative functionalities is beyond the scope of this article; for that, you may wish to read the [relevant portions of the HTML specification](https://html.spec.whatwg.org/multipage/dom.html#kinds-of-content).
+> [!NOTE]
+> A more detailed discussion of these content categories and their comparative functionalities is beyond the scope of this article; for that, you may wish to read the [relevant portions of the HTML specification](https://html.spec.whatwg.org/multipage/dom.html#kinds-of-content).
 
 ![A Venn diagram showing how the various content categories interrelate. The following sections explain these relationships in text.](content_categories_venn.png)
 
@@ -149,7 +150,8 @@ The heading elements are:
 - {{HTMLElement("Heading_Elements", "<code>&lt;h1&gt;</code>-<code>&lt;h6&gt;</code>")}}
 - {{HTMLElement("hgroup")}}
 
-> **Note:** Though likely to contain heading content, the {{HTMLElement("header")}} is not heading content itself.
+> [!NOTE]
+> Though likely to contain heading content, the {{HTMLElement("header")}} is not heading content itself.
 
 ### Phrasing content
 

--- a/files/en-us/web/html/microdata/index.md
+++ b/files/en-us/web/html/microdata/index.md
@@ -17,7 +17,8 @@ At a high level, microdata consists of a group of name-value pairs. The groups a
 
 Google and other major search engines support the [Schema.org](https://schema.org) vocabulary for structured data. This vocabulary defines a standard set of type names and property names, for example, [Schema.org Music Event](https://schema.org/MusicEvent) indicates a concert performance, with [`startDate`](https://schema.org/startDate) and [`location`](https://schema.org/location) properties to specify the concert's key details. In this case, [Schema.org Music Event](https://schema.org/MusicEvent) would be the URL used by `itemtype` and `startDate` and location would be `itemprop`'s that [Schema.org Music Event](https://schema.org/MusicEvent) defines.
 
-> **Note:** More about itemtype attributes can be found at <https://schema.org/Thing>.
+> [!NOTE]
+> More about itemtype attributes can be found at <https://schema.org/Thing>.
 
 Microdata vocabularies provide the semantics or meaning of an _`Item`_. Web developers can design a custom vocabulary or use vocabularies available on the web, such as the widely used [schema.org](https://schema.org) vocabulary. A collection of commonly used markup vocabularies are provided by Schema.org.
 
@@ -145,7 +146,8 @@ In some cases, search engines covering specific regions may provide locally-spec
 
 {{ EmbedLiveSample('HTML', '', '100') }}
 
-> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data). Try it on the HTML shown above.
+> [!NOTE]
+> A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data). Try it on the HTML shown above.
 
 ## See also
 

--- a/files/en-us/web/html/viewport_meta_tag/index.md
+++ b/files/en-us/web/html/viewport_meta_tag/index.md
@@ -46,7 +46,8 @@ The basic attributes of the "viewport" `<meta>` element include:
 - `interactive-widget`
   - : Specifies the effect that interactive UI widgets, such as a virtual keyboard, have on the page's viewports. Valid values: `resizes-visual`, `resizes-content`, or `overlays-content`. Default: `resizes-visual`.
 
-> **Warning:** Usage of `user-scalable=no` can cause accessibility issues to users with visual impairments such as low vision. [WCAG](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background) requires a minimum of 2× scaling; however, the best practice is to enable a 5× zoom.
+> [!WARNING]
+> Usage of `user-scalable=no` can cause accessibility issues to users with visual impairments such as low vision. [WCAG](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background) requires a minimum of 2× scaling; however, the best practice is to enable a 5× zoom.
 
 ## Screen density
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/html' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
