### PR TITLE
Convert noteblocks for web/http folder

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -24,7 +24,8 @@ The challenge and response flow works like this:
 The general message flow above is the same for most (if not all) [authentication schemes](#authentication_schemes).
 The actual information in the headers and the way it is encoded does change!
 
-> **Warning:** The "Basic" authentication scheme used in the diagram above sends the credentials encoded but not encrypted.
+> [!WARNING]
+> The "Basic" authentication scheme used in the diagram above sends the credentials encoded but not encrypted.
 > This would be completely insecure unless the exchange was over a secure connection (HTTPS/TLS).
 
 ### Proxy authentication

--- a/files/en-us/web/http/basics_of_http/data_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/data_urls/index.md
@@ -9,7 +9,8 @@ browser-compat: http.data-url
 
 **Data URLs**, URLs prefixed with the `data:` scheme, allow content creators to embed small files inline in documents. They were formerly known as "data URIs" until that name was retired by the WHATWG.
 
-> **Note:** Data URLs are treated as unique opaque origins by modern browsers, rather than inheriting the origin of the settings object responsible for the navigation.
+> [!NOTE]
+> Data URLs are treated as unique opaque origins by modern browsers, rather than inheriting the origin of the settings object responsible for the navigation.
 
 ## Syntax
 

--- a/files/en-us/web/http/basics_of_http/mime_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.md
@@ -125,7 +125,7 @@ This is the default for binary files. As it means _unknown binary_ file, browser
 
 This is the default for textual files. Even if it really means "unknown textual file," browsers assume they can display it.
 
-> [!NOTE] > `text/plain` does not mean "any kind of textual data."
+> **Note:** `text/plain` does not mean "any kind of textual data."
 > If they expect a specific kind of textual data, they will likely not consider it a match.
 > Specifically if they download a `text/plain` file from a {{HTMLElement("link")}} element declaring a CSS file, they will not recognize it as a valid CSS file if presented with `text/plain`.
 > The CSS mime type `text/css` must be used.

--- a/files/en-us/web/http/basics_of_http/mime_types/index.md
+++ b/files/en-us/web/http/basics_of_http/mime_types/index.md
@@ -11,7 +11,8 @@ MIME types are defined and standardized in IETF's {{RFC(6838)}}.
 
 The [Internet Assigned Numbers Authority (IANA)](https://www.iana.org/) is responsible for all official MIME types, and you can find the most up-to-date and complete list at their [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) page.
 
-> **Warning:** Browsers use the MIME type, _not the file extension_, to determine how to process a URL,
+> [!WARNING]
+> Browsers use the MIME type, _not the file extension_, to determine how to process a URL,
 > so it's important that web servers send the correct MIME type in the response's {{HTTPHeader("Content-Type")}} header.
 > If this is not correctly configured, browsers are likely to misinterpret the contents of files, sites will not work correctly, and downloaded files may be mishandled.
 
@@ -124,7 +125,7 @@ This is the default for binary files. As it means _unknown binary_ file, browser
 
 This is the default for textual files. Even if it really means "unknown textual file," browsers assume they can display it.
 
-> **Note:** `text/plain` does not mean "any kind of textual data."
+> [!NOTE] > `text/plain` does not mean "any kind of textual data."
 > If they expect a specific kind of textual data, they will likely not consider it a match.
 > Specifically if they download a `text/plain` file from a {{HTMLElement("link")}} element declaring a CSS file, they will not recognize it as a valid CSS file if presented with `text/plain`.
 > The CSS mime type `text/css` must be used.
@@ -139,7 +140,8 @@ If so, they won't be recognized as CSS by most browsers and will be ignored.
 
 All HTML content should be served with this type. Alternative MIME types for XHTML (like `application/xhtml+xml`) are mostly useless nowadays.
 
-> **Note:** Use `application/xml` or `application/xhtml+xml` if you want XML's strict parsing rules, [`<![CDATA[…]]>`](/en-US/docs/Web/API/CDATASection) sections, or elements that aren't from HTML/SVG/MathML namespaces.
+> [!NOTE]
+> Use `application/xml` or `application/xhtml+xml` if you want XML's strict parsing rules, [`<![CDATA[…]]>`](/en-US/docs/Web/API/CDATASection) sections, or elements that aren't from HTML/SVG/MathML namespaces.
 
 ### text/javascript
 
@@ -171,7 +173,8 @@ out what to do with content that doesn't have a valid one) also allows JavaScrip
 - `text/x-ecmascript` {{Non-standard_Inline}}
 - `text/x-javascript` {{Non-standard_Inline}}
 
-> **Note:** Even though any given {{Glossary("user agent")}} may support any or all of these, you should only use `text/javascript`.
+> [!NOTE]
+> Even though any given {{Glossary("user agent")}} may support any or all of these, you should only use `text/javascript`.
 > It's the only MIME type guaranteed to work now and into the future.
 
 ### Image types

--- a/files/en-us/web/http/basics_of_http/resource_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/resource_urls/index.md
@@ -79,7 +79,8 @@ been moved to a new location named `resource://content-accessible/`, which is
 isolated and only contains non-sensitive resources. In this way we can keep essential
 resources exposed and have most threats eliminated.
 
-> **Note:** It is recommended that web and extension developers don't try
+> [!NOTE]
+> It is recommended that web and extension developers don't try
 > to use resource URLs anymore. Their usage was hacky at best, and most usage won't work
 > any more.
 

--- a/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
+++ b/files/en-us/web/http/browser_detection_using_the_user_agent/index.md
@@ -10,7 +10,8 @@ Serving different Web pages or services to different browsers is usually a bad i
 
 But browsers and standards are not perfect, and there are still some edge cases where detecting the browser is needed. Using the user agent to detect the browser looks simple, but doing it well is, in fact, a very hard problem. This document will guide you in doing this as correctly as possible.
 
-> **Note:** It's worth re-iterating: it's very rarely a good idea to use user agent sniffing. You can almost always find a better, more broadly compatible way to solve your problem!
+> [!NOTE]
+> It's worth re-iterating: it's very rarely a good idea to use user agent sniffing. You can almost always find a better, more broadly compatible way to solve your problem!
 
 ## Considerations before using browser detection
 
@@ -271,4 +272,5 @@ The following table summarizes the way common browser vendors indicate that thei
 
 In summary, we recommend looking for the string `Mobi` anywhere in the User Agent to detect a mobile device.
 
-> **Note:** If the device is large enough that it's not marked with `Mobi`, you should serve your desktop site (which, as a best practice, should support touch input anyway, as more desktop machines are appearing with touchscreens).
+> [!NOTE]
+> If the device is large enough that it's not marked with `Mobi`, you should serve your desktop site (which, as a best practice, should support touch input anyway, as more desktop machines are appearing with touchscreens).

--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -264,7 +264,8 @@ The server will return `304 Not Modified` if the value of the `ETag` header it d
 
 But if the server determines the requested resource should now have a different `ETag` value, the server will instead respond with a `200 OK` and the latest version of the resource.
 
-> **Note:** RFC9110 prefers that servers send both `ETag` and `Last-Modified` for a `200` response if possible.
+> [!NOTE]
+> RFC9110 prefers that servers send both `ETag` and `Last-Modified` for a `200` response if possible.
 > During cache revalidation, if both `If-Modified-Since` and `If-None-Match` are present, then `If-None-Match` takes precedence for the validator.
 > If you are only considering caching, you may think that `Last-Modified` is unnecessary.
 > However, `Last-Modified` is not just useful for caching; it is a standard HTTP header that is also used by content-management (CMS) systems to display the last-modified time, by crawlers to adjust crawl frequency, and for other various purposes.
@@ -575,7 +576,8 @@ Note that number `41` has the longest `max-age` (1 year), but with `public`.
 
 The `public` value has the effect of making the response storable even if the `Authorization` header is present.
 
-> **Note:** The `public` directive should only be used if there is a need to store the response when the `Authorization` header is set.
+> [!NOTE]
+> The `public` directive should only be used if there is a need to store the response when the `Authorization` header is set.
 > It is not required otherwise, because a response will be stored in the shared cache as long as `max-age` is given.
 
 So if the response is personalized with basic authentication, the presence of `public` may cause problems. If you are concerned about that, you can choose the second-longest value, `38` (1 month).
@@ -618,7 +620,8 @@ ETag: YsAIAAAA-QG4G6kCMAMBAAAAAAAoK
 
 **Cache busting** is a technique to make a response cacheable over a long period by changing the URL when the content changes. The technique can be applied to all subresources, such as images.
 
-> **Note:** When evaluating the use of `immutable` and QPACK:
+> [!NOTE]
+> When evaluating the use of `immutable` and QPACK:
 > If you're concerned that `immutable` changes the predefined value provided by QPACK, consider that
 > in this case, the `immutable` part can be encoded separately by splitting the `Cache-Control` value into two lines — though this is dependent on the encoding algorithm a particular QPACK implementation uses.
 

--- a/files/en-us/web/http/client_hints/index.md
+++ b/files/en-us/web/http/client_hints/index.md
@@ -27,7 +27,8 @@ It is also relatively "privacy-preserving", in that it is up to the client to de
 
 There is a small set of [low entropy client hint headers](#low_entropy_hints) that may be sent by a client even if not requested.
 
-> **Note:** Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#http-equiv) attribute.
+> [!NOTE]
+> Client hints can also be specified in HTML using the {{HTMLElement("meta")}} element with the [`http-equiv`](/en-US/docs/Web/HTML/Element/meta#http-equiv) attribute.
 >
 > ```html
 > <meta http-equiv="Accept-CH" content="Width, Downlink, Sec-CH-UA" />
@@ -56,7 +57,8 @@ In other words, the request for a specific set of hints does not expire until th
 A server can replace the set of client hints it is interested in receiving by resending the `Accept-CH` response header with a new list.
 For example, to stop requesting any hints it would send `Accept-CH` with an empty list.
 
-> **Note:** The client hints set for a particular origin can also be cleared by sending a {{httpheader("Clear-Site-Data", "Clear-Site-Data: \"clientHints\"")}} response header for a URL inside that origin.
+> [!NOTE]
+> The client hints set for a particular origin can also be cleared by sending a {{httpheader("Clear-Site-Data", "Clear-Site-Data: \"clientHints\"")}} response header for a URL inside that origin.
 
 ## Low entropy hints
 
@@ -89,7 +91,8 @@ Vary: Sec-CH-Prefers-Reduced-Motion
 Critical-CH: Sec-CH-Prefers-Reduced-Motion
 ```
 
-> **Note:** We've also specified `Sec-CH-Prefers-Reduced-Motion` in the {{httpheader("Vary")}} header to indicate to the browser that the served content will differ based on this header value, even if the URL stays the same, so the browser shouldn't just use an existing cached response and instead should cache this response separately. Each header listed in the `Critical-CH` header should also be present in the `Accept-CH` and `Vary` headers.
+> [!NOTE]
+> We've also specified `Sec-CH-Prefers-Reduced-Motion` in the {{httpheader("Vary")}} header to indicate to the browser that the served content will differ based on this header value, even if the URL stays the same, so the browser shouldn't just use an existing cached response and instead should cache this response separately. Each header listed in the `Critical-CH` header should also be present in the `Accept-CH` and `Vary` headers.
 
 As `Sec-CH-Prefers-Reduced-Motion` is a critical hint that was not in the original request, the client automatically retries the request — this time telling the server via `Sec-CH-Prefers-Reduced-Motion` that it has a user preference for reduced-motion animations.
 
@@ -108,12 +111,14 @@ For a list of `Sec-CH-UA-*` headers, see [User agent client hints headers](/en-U
 
 Client hints are available to web page JavaScript via the [User Agent Client Hints API](/en-US/docs/Web/API/User-Agent_Client_Hints_API).
 
-> **Note:** Servers currently get most of the same information by parsing the {{HTTPHeader("User-Agent")}} header.
+> [!NOTE]
+> Servers currently get most of the same information by parsing the {{HTTPHeader("User-Agent")}} header.
 > For historical reasons this header contains a lot of largely irrelevant information, and information that might be used to identify a _particular user_.
 > UA client hints provide a more efficient and privacy preserving way of getting the desired information.
 > They are eventually expected to replace this older approach.
 
-> **Note:** User-agent client hints are not available inside [fenced frames](/en-US/docs/Web/API/Fenced_frame_API) because they rely on [permissions policy](/en-US/docs/Web/HTTP/Permissions_Policy) delegation, which could be used to leak data.
+> [!NOTE]
+> User-agent client hints are not available inside [fenced frames](/en-US/docs/Web/API/Fenced_frame_API) because they rely on [permissions policy](/en-US/docs/Web/HTTP/Permissions_Policy) delegation, which could be used to leak data.
 
 ### User preference media features client hints
 

--- a/files/en-us/web/http/compression/index.md
+++ b/files/en-us/web/http/compression/index.md
@@ -27,7 +27,8 @@ Some formats can be used for both loss-less or lossy compression, like `webp`, a
 
 Lossy compression algorithms are usually more efficient than loss-less ones.
 
-> **Note:** As compression works better on a specific kind of files, it usually provides nothing to compress them a second time. In fact, this is often counterproductive as the cost of the overhead (algorithms usually need a dictionary that adds to the initial size) can be higher than the extra gain in compression resulting in a larger file. Do not use the two following techniques for files in a compressed format.
+> [!NOTE]
+> As compression works better on a specific kind of files, it usually provides nothing to compress them a second time. In fact, this is often counterproductive as the cost of the overhead (algorithms usually need a dictionary that adds to the initial size) can be higher than the extra gain in compression resulting in a larger file. Do not use the two following techniques for files in a compressed format.
 
 ## End-to-end compression
 

--- a/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
+++ b/files/en-us/web/http/configuring_servers_for_ogg_media/index.md
@@ -44,7 +44,8 @@ When the browser seeks through Ogg media to a specified time, it has to seek to 
 
 By default, [`ffmpeg2theora`](https://gitlab.xiph.org/xiph/ffmpeg2theora) uses one key frame every 64 frames (or about every 2 seconds at 30 frames per second), which works pretty well.
 
-> **Note:** Of course, the more key frames you use, the larger your video file is, so you may need to experiment a bit to get the right balance between file size and seek performance.
+> [!NOTE]
+> Of course, the more key frames you use, the larger your video file is, so you may need to experiment a bit to get the right balance between file size and seek performance.
 
 ## Consider using the preload attribute
 
@@ -56,7 +57,8 @@ The HTML {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements provide 
 
 ### Serve X-Content-Duration headers
 
-> **Note:** As of [Firefox 41](/en-US/docs/Mozilla/Firefox/Releases/41), the `X-Content-Duration` header is no longer supported. See [Firefox bug 1160695](https://bugzil.la/1160695) for more details.
+> [!NOTE]
+> As of [Firefox 41](/en-US/docs/Mozilla/Firefox/Releases/41), the `X-Content-Duration` header is no longer supported. See [Firefox bug 1160695](https://bugzil.la/1160695) for more details.
 
 The Ogg format doesn't encapsulate the duration of media, so for the progress bar on the video controls to display the duration of the video, Gecko needs to determine the length of the media using other means.
 

--- a/files/en-us/web/http/connection_management_in_http_1.x/index.md
+++ b/files/en-us/web/http/connection_management_in_http_1.x/index.md
@@ -16,7 +16,8 @@ Two newer models were created in HTTP/1.1. The persistent-connection model keeps
 
 ![Compares the performance of the three HTTP/1.x connection models: short-lived connections, persistent connections, and HTTP pipelining.](http1_x_connections.png)
 
-> **Note:** HTTP/2 adds additional models for connection management.
+> [!NOTE]
+> HTTP/2 adds additional models for connection management.
 
 It's important to note that connection management in HTTP applies to the connection between two consecutive nodes, which is [hop-by-hop](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) and not [end-to-end](/en-US/docs/Web/HTTP/Headers#end-to-end_headers). The model used in connections between a client and its first proxy may differ from the model between a proxy and the destination server (or any intermediate proxies). The HTTP headers involved in defining the connection model, like {{HTTPHeader("Connection")}} and {{HTTPHeader("Keep-Alive")}}, are [hop-by-hop](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) headers with their values able to be changed by intermediary nodes.
 
@@ -30,7 +31,8 @@ The TCP handshake itself is time-consuming, but a TCP connection adapts to its l
 
 This model is the default model used in HTTP/1.0 (if there is no {{HTTPHeader("Connection")}} header, or if its value is set to `close`). In HTTP/1.1, this model is only used when the {{HTTPHeader("Connection")}} header is sent with a value of `close`.
 
-> **Note:** Unless dealing with a very old system, which doesn't support a persistent connection, there is no compelling reason to use this model.
+> [!NOTE]
+> Unless dealing with a very old system, which doesn't support a persistent connection, there is no compelling reason to use this model.
 
 ## Persistent connections
 
@@ -46,7 +48,8 @@ In HTTP/1.1, persistence is the default, and the header is no longer needed (but
 
 ## HTTP pipelining
 
-> **Note:** HTTP pipelining is not activated by default in modern browsers:
+> [!NOTE]
+> HTTP pipelining is not activated by default in modern browsers:
 >
 > - Buggy [proxies](https://en.wikipedia.org/wiki/Proxy_server) are still common and these lead to strange and erratic behaviors that Web developers cannot foresee and diagnose easily.
 > - Pipelining is complex to implement correctly: the size of the resource being transferred, the effective [RTT](https://en.wikipedia.org/wiki/Round-trip_delay_time) that will be used, as well as the effective bandwidth, have a direct incidence on the improvement provided by the pipeline. Without knowing these, important messages may be delayed behind unimportant ones. The notion of important even evolves during page layout! HTTP pipelining therefore brings a marginal improvement in most cases only.
@@ -64,7 +67,8 @@ Today, every HTTP/1.1-compliant proxy and server should support pipelining, thou
 
 ## Domain sharding
 
-> **Note:** Unless you have a very specific immediate need, don't use this deprecated technique; switch to HTTP/2 instead. In HTTP/2, domain sharding is no longer useful: the HTTP/2 connection is able to handle parallel unprioritized requests very well. Domain sharding is even detrimental to performance. Most HTTP/2 implementations use a technique called [connection coalescing](https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/) to revert eventual domain sharding.
+> [!NOTE]
+> Unless you have a very specific immediate need, don't use this deprecated technique; switch to HTTP/2 instead. In HTTP/2, domain sharding is no longer useful: the HTTP/2 connection is able to handle parallel unprioritized requests very well. Domain sharding is even detrimental to performance. Most HTTP/2 implementations use a technique called [connection coalescing](https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/) to revert eventual domain sharding.
 
 As an HTTP/1.x connection is serializing requests, even without any ordering, it can't be optimal without large enough available bandwidth. As a solution, browsers open several connections to each domain, sending parallel requests. Default was once 2 to 3 connections, but this has now increased to a more common use of 6 parallel connections. There is a risk of triggering [DoS](/en-US/docs/Glossary/DOS_attack) protection on the server side if attempting more than this number.
 

--- a/files/en-us/web/http/content_negotiation/index.md
+++ b/files/en-us/web/http/content_negotiation/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 In [HTTP](/en-US/docs/Glossary/HTTP), **_content negotiation_** is the mechanism that is used for serving different {{Glossary("Representation header","representations")}} of a resource to the same URI to help the user agent specify which representation is best suited for the user (for example, which document language, which image format, or which content encoding).
 
-> **Note:** You'll find some disadvantages of HTTP content negotiation in [a wiki page from WHATWG](https://wiki.whatwg.org/wiki/Why_not_conneg). HTML provides alternatives to content negotiation via, for example, the [`<source>` element](/en-US/docs/Web/HTML/Element/source).
+> [!NOTE]
+> You'll find some disadvantages of HTTP content negotiation in [a wiki page from WHATWG](https://wiki.whatwg.org/wiki/Why_not_conneg). HTML provides alternatives to content negotiation via, for example, the [`<source>` element](/en-US/docs/Web/HTML/Element/source).
 
 ## Principles of content negotiation
 
@@ -47,7 +48,8 @@ The `Accept` header is defined by the browser, or any other user agent, and can 
 
 ### The `Accept-CH` header {{experimental_inline}}
 
-> **Note:** This is part of an **experimental** technology called _Client Hints_. Initial support comes in Chrome 46 or later. The Device-Memory value is in Chrome 61 or later.
+> [!NOTE]
+> This is part of an **experimental** technology called _Client Hints_. Initial support comes in Chrome 46 or later. The Device-Memory value is in Chrome 61 or later.
 
 The experimental {{HTTPHeader("Accept-CH")}} lists configuration data that the server can use to select an appropriate response. Valid values are:
 
@@ -74,7 +76,8 @@ Due to the [configuration-based entropy](https://www.eff.org/deeplinks/2010/01/p
 
 ### The `User-Agent` header
 
-> **Note:** Though there are legitimate uses of this header for selecting content, [it's considered bad practice](/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent) to rely on it to define what features are supported by the user agent.
+> [!NOTE]
+> Though there are legitimate uses of this header for selecting content, [it's considered bad practice](/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent) to rely on it to define what features are supported by the user agent.
 
 The {{HTTPHeader("User-Agent")}} header identifies the browser sending the request. This string may contain a space-separated list of _product tokens_ and _comments_.
 

--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -36,7 +36,8 @@ They are designed with storage in mind, never send data to the server, and don't
 - Browsers are generally limited to a maximum number of cookies per domain (varies by browser, generally in the hundreds), and a maximum size per cookie (usually 4KB). Storage APIs can store larger amounts of data.
 - Cookies are sent with every request, so they can worsen performance (for example on slow mobile data connections), especially if you have a lot of cookies set.
 
-> **Note:** To see stored cookies (and other storage that a web page is using) you can use the [Storage Inspector](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) in Firefox Developer Tools, or the [Application panel](https://developer.chrome.com/docs/devtools/progressive-web-apps) in Chrome Developer Tools.
+> [!NOTE]
+> To see stored cookies (and other storage that a web page is using) you can use the [Storage Inspector](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) in Firefox Developer Tools, or the [Application panel](https://developer.chrome.com/docs/devtools/progressive-web-apps) in Chrome Developer Tools.
 
 ## Creating, removing, and updating cookies
 
@@ -57,7 +58,8 @@ Set-Cookie: tasty_cookie=strawberry
 [page content]
 ```
 
-> **Note:** Find out how to use the `Set-Cookie` header in various server-side languages/frameworks: [PHP](https://www.php.net/manual/en/function.setcookie.php), [Node.JS](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value), [Python](https://docs.python.org/3/library/http.cookies.html), [Ruby on Rails](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
+> [!NOTE]
+> Find out how to use the `Set-Cookie` header in various server-side languages/frameworks: [PHP](https://www.php.net/manual/en/function.setcookie.php), [Node.JS](https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_response_setheader_name_value), [Python](https://docs.python.org/3/library/http.cookies.html), [Ruby on Rails](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
 
 When a new request is made, the browser usually sends previously stored cookies for the current domain back to the server within a {{HTTPHeader("Cookie")}} HTTP header:
 
@@ -142,7 +144,8 @@ Set-Cookie: id=a3fWa; Expires=Thu, 21 Oct 2021 07:28:00 GMT; Secure; HttpOnly
 
 - A cookie with the `HttpOnly` attribute can't be modified by JavaScript, for example using {{domxref("Document.cookie")}}; it can only be modified when it reaches the server. Cookies that persist user sessions for example should have the `HttpOnly` attribute set — it would be really insecure to make them available to JavaScript. This precaution helps mitigate cross-site scripting ([XSS](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)) attacks.
 
-> **Note:** Depending on the application, you may want to use an opaque identifier that the server looks up rather than storing sensitive information directly in cookies, or investigate alternative authentication/confidentiality mechanisms such as [JSON Web Tokens](https://jwt.io/).
+> [!NOTE]
+> Depending on the application, you may want to use an opaque identifier that the server looks up rather than storing sensitive information directly in cookies, or investigate alternative authentication/confidentiality mechanisms such as [JSON Web Tokens](https://jwt.io/).
 
 ### Define where cookies are sent
 
@@ -219,7 +222,8 @@ As a [defense-in-depth measure](<https://en.wikipedia.org/wiki/Defense_in_depth_
 
 The browser will reject cookies with these prefixes that don't comply with their restrictions. This ensures that subdomain-created cookies with prefixes are either confined to a subdomain or ignored completely. As the application server only checks for a specific cookie name when determining if the user is authenticated or a CSRF token is correct, this effectively acts as a defense measure against session fixation.
 
-> **Note:** On the server, the web application _must_ check for the full cookie name including the prefix. User agents _do not_ strip the prefix from the cookie before sending it in a request's {{HTTPHeader("Cookie")}} header.
+> [!NOTE]
+> On the server, the web application _must_ check for the full cookie name including the prefix. User agents _do not_ strip the prefix from the cookie before sending it in a request's {{HTTPHeader("Cookie")}} header.
 
 For more information about cookie prefixes and the current state of browser support, see the [Prefixes section of the Set-Cookie reference article](/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes).
 
@@ -233,7 +237,8 @@ However, third-party cookies can also be used to create creepy, invasive user ex
 
 Browser vendors know that users don't like this behavior, and as a result have all started to block third-party cookies by default, or at least made plans to go in that direction. Third-party cookies (or just tracking cookies) may also be blocked by other browser settings or extensions.
 
-> **Note:** Cookie blocking can cause some third-party components (such as social media widgets) not to function as intended. As browsers impose further restrictions on third-party cookies, developers should start to look at ways to reduce their reliance on them.
+> [!NOTE]
+> Cookie blocking can cause some third-party components (such as social media widgets) not to function as intended. As browsers impose further restrictions on third-party cookies, developers should start to look at ways to reduce their reliance on them.
 
 See our [Third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies) article for detailed information on third-party cookies, the issues associated with them, and what alternatives are available. See our [Privacy](/en-US/docs/Web/Privacy) landing page for more information on privacy in general.
 
@@ -255,7 +260,8 @@ These regulations include requirements such as:
 
 There may be other regulations that govern the use of cookies in your locality. The burden is on you to know and comply with these regulations. There are companies that offer "cookie banner" code that helps you comply with these regulations.
 
-> **Note:** Companies should disclose the types of cookies they use on their sites for transparency purposes and to comply with regulations. For example, see [Google's notice on the types of cookies it uses](https://policies.google.com/technologies/types) and Mozilla's [Websites, Communications & Cookies Privacy Notice](https://www.mozilla.org/en-US/privacy/websites/#cookies).
+> [!NOTE]
+> Companies should disclose the types of cookies they use on their sites for transparency purposes and to comply with regulations. For example, see [Google's notice on the types of cookies it uses](https://policies.google.com/technologies/types) and Mozilla's [Websites, Communications & Cookies Privacy Notice](https://www.mozilla.org/en-US/privacy/websites/#cookies).
 
 ## See also
 

--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -27,7 +27,8 @@ configuration is typically found in a `.conf` file (`httpd.conf`
 and `apache.conf` are common names for these), or in an
 `.htaccess` file.
 
-> **Warning:** You must include the HTTPS or HTTP protocol as part of the origin.
+> [!WARNING]
+> You must include the HTTPS or HTTP protocol as part of the origin.
 
 ```apacheconf
 Header set Access-Control-Allow-Origin 'origin'

--- a/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
+++ b/files/en-us/web/http/cors/errors/corsmethodnotfound/index.md
@@ -31,7 +31,8 @@ Trying to use a {{HTTPMethod("PUT")}} request will fail with this error.
 
 Make sure your code only uses the permitted HTTP methods when accessing the service.
 
-> **Note:** If the server includes any unrecognized or undefined method names in its `Access-Control-Allow-methods` header, a different error occurs: [Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Methods'](/en-US/docs/Web/HTTP/CORS/Errors/CORSInvalidAllowMethod).
+> [!NOTE]
+> If the server includes any unrecognized or undefined method names in its `Access-Control-Allow-methods` header, a different error occurs: [Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Methods'](/en-US/docs/Web/HTTP/CORS/Errors/CORSInvalidAllowMethod).
 
 ## See also
 

--- a/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingalloworigin/index.md
@@ -40,7 +40,8 @@ sending credentials like cookies in requests.
 Access-Control-Allow-Origin: *
 ```
 
-> **Warning:** Using the wildcard to allow all sites to access a private
+> [!WARNING]
+> Using the wildcard to allow all sites to access a private
 > API is a bad idea.
 
 To allow any site to make CORS requests _without_ using the `*`

--- a/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
+++ b/files/en-us/web/http/cors/errors/corsrequestnothttp/index.md
@@ -31,7 +31,8 @@ As a result, loading a local file with included local resources will now result 
 Developers who need to perform local testing should now [set up a local server](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server).
 As all files are served from the same scheme and domain (`localhost`) they all have the same origin, and do not trigger cross-origin errors.
 
-> **Note:** This change is in line with the [URL specification](https://url.spec.whatwg.org/#origin), which leaves the origin behavior for files to the implementation, but recommends that file origins are treated as opaque if in doubt.
+> [!NOTE]
+> This change is in line with the [URL specification](https://url.spec.whatwg.org/#origin), which leaves the origin behavior for files to the implementation, but recommends that file origins are treated as opaque if in doubt.
 
 ## See also
 

--- a/files/en-us/web/http/cors/errors/index.md
+++ b/files/en-us/web/http/cors/errors/index.md
@@ -27,7 +27,8 @@ reading the remote resource at https://some-url-here. (Reason:
 additional information here).
 ```
 
-> **Note:** For security reasons, specifics about what went wrong with a CORS request _are not available to JavaScript code_. All the code knows is that an error occurred. The only way to determine what specifically went wrong is to look at the browser's console for details.
+> [!NOTE]
+> For security reasons, specifics about what went wrong with a CORS request _are not available to JavaScript code_. All the code knows is that an error occurred. The only way to determine what specifically went wrong is to look at the browser's console for details.
 
 ## CORS error messages
 

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -72,7 +72,8 @@ A _simple request_ is one that **meets all the following conditions**:
 - If the request is made using an {{domxref("XMLHttpRequest")}} object, no event listeners are registered on the object returned by the {{domxref("XMLHttpRequest.upload")}} property used in the request; that is, given an {{domxref("XMLHttpRequest")}} instance `xhr`, no code has called `xhr.upload.addEventListener()` to add an event listener to monitor the upload.
 - No {{domxref("ReadableStream")}} object is used in the request.
 
-> **Note:** WebKit Nightly and Safari Technology Preview place additional restrictions on the values allowed in the {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}}, and {{HTTPHeader("Content-Language")}} headers. If any of those headers have "nonstandard" values, WebKit/Safari does not consider the request to be a "simple request". What values WebKit/Safari consider "nonstandard" is not documented, except in the following WebKit bugs:
+> [!NOTE]
+> WebKit Nightly and Safari Technology Preview place additional restrictions on the values allowed in the {{HTTPHeader("Accept")}}, {{HTTPHeader("Accept-Language")}}, and {{HTTPHeader("Content-Language")}} headers. If any of those headers have "nonstandard" values, WebKit/Safari does not consider the request to be a "simple request". What values WebKit/Safari consider "nonstandard" is not documented, except in the following WebKit bugs:
 >
 > - [Require preflight for non-standard CORS-safelisted request headers Accept, Accept-Language, and Content-Language](https://webkit.org/b/165178)
 > - [Allow commas in Accept, Accept-Language, and Content-Language request headers for simple CORS](https://webkit.org/b/165566)
@@ -138,7 +139,8 @@ This pattern of the {{HTTPHeader("Origin")}} and {{HTTPHeader("Access-Control-Al
 Access-Control-Allow-Origin: https://foo.example
 ```
 
-> **Note:** When responding to a [credentialed requests](#requests_with_credentials) request, the server **must** specify an origin in the value of the `Access-Control-Allow-Origin` header, instead of specifying the "`*`" wildcard.
+> [!NOTE]
+> When responding to a [credentialed requests](#requests_with_credentials) request, the server **must** specify an origin in the value of the `Access-Control-Allow-Origin` header, instead of specifying the "`*`" wildcard.
 
 ### Preflighted requests
 
@@ -166,7 +168,8 @@ The example above creates an XML body to send with the `POST` request. Also, a n
 
 ![Diagram of a request that is preflighted](https://mdn.github.io/shared-assets/images/diagrams/http/cors/preflight-correct.svg)
 
-> **Note:** As described below, the actual `POST` request does not include the `Access-Control-Request-*` headers; they are needed only for the `OPTIONS` request.
+> [!NOTE]
+> As described below, the actual `POST` request does not include the `Access-Control-Request-*` headers; they are needed only for the `OPTIONS` request.
 
 Let's look at the full exchange between client and server. The first exchange is the _preflight request/response_:
 
@@ -275,7 +278,8 @@ However, if the request is one that triggers a preflight due to the presence of 
 
 ### Requests with credentials
 
-> **Note:** When making credentialed requests to a different domain, third-party cookie policies will still apply. The policy is always enforced regardless of any setup on the server and the client as described in this chapter.
+> [!NOTE]
+> When making credentialed requests to a different domain, third-party cookie policies will still apply. The policy is always enforced regardless of any setup on the server and the client as described in this chapter.
 
 The most interesting capability exposed by both {{domxref("Window/fetch", "fetch()")}} or {{domxref("XMLHttpRequest")}} and CORS is the ability to make "credentialed" requests that are aware of [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) and HTTP Authentication information. By default, in cross-origin `fetch()` or `XMLHttpRequest` calls, browsers will _not_ send credentials.
 
@@ -336,7 +340,8 @@ Although the request's `Cookie` header contains the cookie destined for the cont
 
 CORS-preflight requests must never include credentials. The _response_ to a preflight request must specify `Access-Control-Allow-Credentials: true` to indicate that the actual request can be made with credentials.
 
-> **Note:** Some enterprise authentication services require that TLS client certificates be sent in preflight requests, in contravention of the [Fetch](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials) specification.
+> [!NOTE]
+> Some enterprise authentication services require that TLS client certificates be sent in preflight requests, in contravention of the [Fetch](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials) specification.
 >
 > Firefox 87 allows this non-compliant behavior to be enabled by setting the preference: `network.cors_preflight.allow_client_cert` to `true` ([Firefox bug 1511151](https://bugzil.la/1511151)). Chromium-based browsers currently always send TLS client certificates in CORS preflight requests ([Chrome bug 775438](https://crbug.com/775438)).
 
@@ -457,7 +462,8 @@ Origin: <origin>
 
 The origin is a URL indicating the server from which the request is initiated. It does not include any path information, only the server name.
 
-> **Note:** The `origin` value can be `null`.
+> [!NOTE]
+> The `origin` value can be `null`.
 
 Note that in any access control request, the {{HTTPHeader("Origin")}} header is **always** sent.
 

--- a/files/en-us/web/http/cross-origin_resource_policy/index.md
+++ b/files/en-us/web/http/cross-origin_resource_policy/index.md
@@ -11,13 +11,15 @@ browser-compat: http.headers.Cross-Origin-Resource-Policy
 
 CORP is an additional layer of protection beyond the default {{Glossary("same-origin policy")}}. Cross-Origin Resource Policy complements [Cross-Origin Read Blocking](https://fetch.spec.whatwg.org/#corb) (CORB), which is a mechanism to prevent some cross-origin reads by default.
 
-> **Note:** The policy is only effective for [`no-cors`](https://fetch.spec.whatwg.org/#concept-request-mode) requests, which are issued by default for CORS-safelisted methods/headers.
+> [!NOTE]
+> The policy is only effective for [`no-cors`](https://fetch.spec.whatwg.org/#concept-request-mode) requests, which are issued by default for CORS-safelisted methods/headers.
 
 As this policy is expressed via a _[response header](/en-US/docs/Glossary/Response_header)_, the actual request is not prevented—rather, the browser prevents the _result_ from being leaked by stripping the response body.
 
 ## Usage
 
-> **Note:** Due to a [bug in Chrome](https://crbug.com/1074261), setting Cross-Origin-Resource-Policy can break PDF rendering, preventing visitors from being able to read past the first page of some PDFs. Exercise caution using this header in a production environment.
+> [!NOTE]
+> Due to a [bug in Chrome](https://crbug.com/1074261), setting Cross-Origin-Resource-Policy can break PDF rendering, preventing visitors from being able to read past the first page of some PDFs. Exercise caution using this header in a production environment.
 
 Web applications set a Cross-Origin Resource Policy via the {{HTTPHeader("Cross-Origin-Resource-Policy")}} HTTP response header, which accepts one of three values:
 

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -26,7 +26,8 @@ Alternatively, the {{HTMLElement("meta")}} element can be used to configure a po
   content="default-src 'self'; img-src https://*; child-src 'none';" />
 ```
 
-> **Note:** Some features, such as sending CSP violation reports, are only available when using the HTTP headers.
+> [!NOTE]
+> Some features, such as sending CSP violation reports, are only available when using the HTTP headers.
 
 ## Threats
 
@@ -173,7 +174,7 @@ Reporting-Endpoints: csp-endpoint="https://example.com/csp-reports",
                      hpkp-endpoint="https://example.com/hpkp-reports"
 ```
 
-> **Warning:**
+> [!WARNING]
 > The `report-uri` directive is deprecated and it's recommended to send CSP reports using {{CSP("report-to")}} instead.
 > See the {{CSP("report-uri")}} documentation for details on how to specify both directives for backwards compatibility.
 

--- a/files/en-us/web/http/messages/index.md
+++ b/files/en-us/web/http/messages/index.md
@@ -27,7 +27,8 @@ The start-line and HTTP headers of the HTTP message are collectively known as th
 
 ### Request line
 
-> **Note:** The start-line is called the "request-line" in requests.
+> [!NOTE]
+> The start-line is called the "request-line" in requests.
 
 HTTP requests are messages sent by the client to initiate an action on the server. Their _request-line_ contain three elements:
 
@@ -73,7 +74,8 @@ Bodies can be broadly divided into two categories:
 
 ### Status line
 
-> **Note:** The start-line is called the "status line" in responses.
+> [!NOTE]
+> The start-line is called the "status line" in responses.
 
 The start line of an HTTP response, called the _status line_, contains the following information:
 

--- a/files/en-us/web/http/methods/get/index.md
+++ b/files/en-us/web/http/methods/get/index.md
@@ -9,7 +9,8 @@ browser-compat: http.methods.GET
 
 The **HTTP `GET` method** requests a representation of the specified resource. Requests using `GET` should only be used to request data (they shouldn't include data).
 
-> **Note:** Sending body/payload in a `GET` request may cause some existing implementations to reject the request — while not prohibited by the specification, the semantics are undefined. It is better to just avoid sending payloads in `GET` requests.
+> [!NOTE]
+> Sending body/payload in a `GET` request may cause some existing implementations to reject the request — while not prohibited by the specification, the semantics are undefined. It is better to just avoid sending payloads in `GET` requests.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/methods/head/index.md
+++ b/files/en-us/web/http/methods/head/index.md
@@ -9,7 +9,8 @@ browser-compat: http.methods.HEAD
 
 The **HTTP `HEAD` method** requests the [headers](/en-US/docs/Web/HTTP/Headers) that would be returned if the `HEAD` request's URL was instead requested with the HTTP {{HTTPMethod("GET")}} method. For example, if a URL might produce a large download, a `HEAD` request could read its {{HTTPHeader("Content-Length")}} header to check the filesize without actually downloading the file.
 
-> **Warning:** A response to a `HEAD` method _should not_ have a body. If it has one anyway, that body **must be** ignored: any {{glossary("Representation header", "representation headers")}} that might describe the erroneous body are instead assumed to describe the response which a similar `GET` request would have received.
+> [!WARNING]
+> A response to a `HEAD` method _should not_ have a body. If it has one anyway, that body **must be** ignored: any {{glossary("Representation header", "representation headers")}} that might describe the erroneous body are instead assumed to describe the response which a similar `GET` request would have received.
 
 If the response to a `HEAD` request shows that a cached URL response is now outdated, the cached copy is invalidated even if no `GET` request was made.
 

--- a/files/en-us/web/http/permissions_policy/index.md
+++ b/files/en-us/web/http/permissions_policy/index.md
@@ -18,7 +18,8 @@ Examples of what you can do with Permissions Policy:
 - Allow iframes to use the [Fullscreen API](/en-US/docs/Web/API/Fullscreen_API).
 - Stop items from being scripted if they are not visible in the viewport, to improve performance.
 
-> **Note:** Permissions Policy used to be called Feature Policy. The name has changed, and so has the HTTP header syntax, so bear this in mind if you have used Feature Policy in the past, and check the browser support tables. The `<iframe allow=" ... ">` syntax has stayed the same.
+> [!NOTE]
+> Permissions Policy used to be called Feature Policy. The name has changed, and so has the HTTP header syntax, so bear this in mind if you have used Feature Policy in the past, and check the browser support tables. The `<iframe allow=" ... ">` syntax has stayed the same.
 
 ## Concepts and usage
 
@@ -31,7 +32,8 @@ Some approaches include:
 - APIs are not even exposed, as though they don't exist.
 - Options that control the feature behavior have different default values.
 
-> **Note:** Newly-introduced features may have an explicit API to signal the state. Existing features that later integrate with Permissions Policy will typically use existing mechanisms.
+> [!NOTE]
+> Newly-introduced features may have an explicit API to signal the state. Existing features that later integrate with Permissions Policy will typically use existing mechanisms.
 
 Permissions Policy allows you to control which origins can use which features, both on the top-level page and in embedded {{htmlelement("iframe")}}s. The aim is to enforce best practices for good user experiences and provide granular control over _sensitive_ or _powerful_ features (meaning features that a user is required to give express permission for usage of, before related code can be executed).
 
@@ -42,7 +44,8 @@ Permissions Policy provides two ways to specify policies:
 
 These are separate but related — see [Inheritance of policies for embedded content](#inheritance_of_policies_for_embedded_content) for details.
 
-> **Note:** Scripts can programmatically query information about the permission policy via the {{DOMxRef("FeaturePolicy")}} object located at either {{DOMxRef("Document.featurePolicy")}} or {{DOMxRef("HTMLIFrameElement.featurePolicy")}}.
+> [!NOTE]
+> Scripts can programmatically query information about the permission policy via the {{DOMxRef("FeaturePolicy")}} object located at either {{DOMxRef("Document.featurePolicy")}} or {{DOMxRef("HTMLIFrameElement.featurePolicy")}}.
 
 To control each feature, you write a policy that consists of:
 
@@ -76,7 +79,8 @@ An allowlist is a list of origins that takes one or more of the following values
 
 The values `*` and `()` may only be used on their own, while `self` and `src` may be used in combination with one or more origins.
 
-> **Note:** Directives have a default allowlist, which is always one of `*`, `self`, or `none` for the `Permissions-Policy` HTTP header, and governs the default behavior if they are not explicitly listed in a policy. These are specified on the individual [directive reference pages](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#directives). For `<iframe>` `allow` attributes , the default behavior is always `src`.
+> [!NOTE]
+> Directives have a default allowlist, which is always one of `*`, `self`, or `none` for the `Permissions-Policy` HTTP header, and governs the default behavior if they are not explicitly listed in a policy. These are specified on the individual [directive reference pages](/en-US/docs/Web/HTTP/Headers/Permissions-Policy#directives). For `<iframe>` `allow` attributes , the default behavior is always `src`.
 
 Where supported, you can include wildcards in Permissions Policy origins. This means that instead of having to explicitly specify several different subdomains in an allowlist, you can specify them all in a single origin with a wildcard.
 
@@ -92,7 +96,7 @@ You can specify
 ("https://example.com" "https://*.example.com")
 ```
 
-> **Note:** `"https://*.example.com"` does not match `"https://example.com"`.
+> [!NOTE] > `"https://*.example.com"` does not match `"https://example.com"`.
 
 allowlist examples:
 
@@ -180,7 +184,8 @@ It is worth giving the `src` value a special mention. We mentioned above that us
 ></iframe>
 ```
 
-> **Note:** As you'll have noticed, the syntax for `<iframe>` policies is a bit different to the syntax for `Permissions-Policy` headers. The former still uses the same syntax as the older Feature Policy specification, which was superseded by Permissions Policy.
+> [!NOTE]
+> As you'll have noticed, the syntax for `<iframe>` policies is a bit different to the syntax for `Permissions-Policy` headers. The former still uses the same syntax as the older Feature Policy specification, which was superseded by Permissions Policy.
 
 ### Fenced frames and permissions policy
 

--- a/files/en-us/web/http/permissions_policy/index.md
+++ b/files/en-us/web/http/permissions_policy/index.md
@@ -96,7 +96,7 @@ You can specify
 ("https://example.com" "https://*.example.com")
 ```
 
-> [!NOTE] > `"https://*.example.com"` does not match `"https://example.com"`.
+> **Note:** `"https://*.example.com"` does not match `"https://example.com"`.
 
 allowlist examples:
 

--- a/files/en-us/web/http/protocol_upgrade_mechanism/index.md
+++ b/files/en-us/web/http/protocol_upgrade_mechanism/index.md
@@ -45,7 +45,8 @@ webSocket = new WebSocket("ws://destination.server.ext", "optionalProtocol");
 
 The {{domxref("WebSocket.WebSocket", "WebSocket()")}} constructor does all the work of creating an initial HTTP/1.1 connection then handling the handshaking and upgrade process for you.
 
-> **Note:** You can also use the `"wss://"` URL scheme to open a secure WebSocket connection.
+> [!NOTE]
+> You can also use the `"wss://"` URL scheme to open a secure WebSocket connection.
 
 If you need to create a WebSocket connection from scratch, you'll have to handle the handshaking process yourself. After creating the initial HTTP/1.1 session, you need to request the upgrade by adding to a standard request the {{HTTPHeader("Upgrade")}} and {{HTTPHeader("Connection")}} headers, as follows:
 

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -72,7 +72,7 @@ And the MIME type should be set to `application/x-ns-proxy-autoconfig`.
 
 Next, you should configure your server to map the .pac filename extension to the MIME type.
 
-> **Note:**
+> [!NOTE]
 >
 > - The JavaScript function should always be saved to a file by itself but not be embedded in a HTML file or any other file.
 > - The examples at the end of this document are complete. There is no additional syntax needed to save it into a file and use it. (Of course, the JavaScripts must be edited to reflect your site's domain name and/or subnets.)
@@ -114,7 +114,8 @@ These functions can be used in building the PAC file:
 
   - `ProxyConfig.bindings` {{deprecated_inline}}
 
-> **Note:** pactester (part of the [pacparser](https://github.com/manugarg/pacparser) package) was used to test the following syntax examples.
+> [!NOTE]
+> pactester (part of the [pacparser](https://github.com/manugarg/pacparser) package) was used to test the following syntax examples.
 >
 > - The PAC file is named `proxy.pac`
 > - Command line: `pactester -p ~/pacparser-master/tests/proxy.pac -u https://www.mozilla.org` (passes the `host` parameter `www.mozilla.org` and the `url` parameter `https://www.mozilla.org`)
@@ -307,7 +308,8 @@ myIpAddress()
 
 Returns the server IP address of the machine Firefox is running on, as a string in the dot-separated integer format.
 
-> **Warning:** myIpAddress() returns the same IP address as the server address returned by **`nslookup localhost`** on a Linux machine. It does not return the public IP address.
+> [!WARNING]
+> myIpAddress() returns the same IP address as the server address returned by **`nslookup localhost`** on a Linux machine. It does not return the public IP address.
 
 #### Example
 
@@ -359,7 +361,8 @@ Support for particular glob expression syntax varies across browsers:
 `*` (match any number of characters) and `?` (match one character) are always supported,
 while `[characters]` and `[^characters]` are additionally supported by some implementations (including Firefox).
 
-> **Note:** If supported by the client, JavaScript regular expressions typically provide a more powerful and consistent way to pattern-match URLs (and other strings).
+> [!NOTE]
+> If supported by the client, JavaScript regular expressions typically provide a more powerful and consistent way to pattern-match URLs (and other strings).
 
 #### Examples
 
@@ -376,7 +379,8 @@ shExpMatch("http://home.netscape.com/people/montulli/index.html", "*/ari/*"); //
 weekdayRange(wd1, wd2, [gmt])
 ```
 
-> **Note:** (Before Firefox 49) wd1 must be less than wd2 if you want the function to evaluate these parameters as a range. See the warning below.
+> [!NOTE]
+> (Before Firefox 49) wd1 must be less than wd2 if you want the function to evaluate these parameters as a range. See the warning below.
 
 #### Parameters
 
@@ -391,7 +395,7 @@ If only one parameter is present, the function returns a value of true on the we
 
 If both **wd1** and **wd2** are defined, the condition is true if the current weekday is in between those two _ordered_ weekdays. Bounds are inclusive, _but the bounds are ordered_. If the "GMT" parameter is specified, times are taken to be in GMT. Otherwise, the local timezone is used.
 
-> **Warning:** _The order of the days matters_.
+> [!WARNING] > _The order of the days matters_.
 > Before Firefox 49, `weekdayRange("SUN", "SAT")` will always evaluate to `true`.
 > Now `weekdayRange("WED", "SUN")` will only evaluate to `true`
 > if the current day is Wednesday or Sunday.
@@ -420,7 +424,8 @@ dateRange(<month1>, <year1>, <month2>, <year2>, [gmt])
 dateRange(<day1>, <month1>, <year1>, <day2>, <month2>, <year2>, [gmt])
 ```
 
-> **Note:** (Before Firefox 49) day1 must be less than day2, month1 must be less than month2, and year1 must be less than year2 if you want the function to evaluate these parameters as a range. See the warning below.
+> [!NOTE]
+> (Before Firefox 49) day1 must be less than day2, month1 must be less than month2, and year1 must be less than year2 if you want the function to evaluate these parameters as a range. See the warning below.
 
 #### Parameters
 
@@ -445,7 +450,7 @@ dateRange(<day1>, <month1>, <year1>, <day2>, <month2>, <year2>, [gmt])
 
 If only a single value is specified (from each category: day, month, year), the function returns a true value only on days that match that specification. If both values are specified, the result is true between those times, including bounds, _but the bounds are ordered_.
 
-> **Warning:** **The order of the days, months, and years matter**; Before Firefox 49, `dateRange("JAN", "DEC")` will always evaluate to `true`. Now `dateRange("DEC", "JAN")` will only evaluate true if the current month is December or January.
+> [!WARNING] > **The order of the days, months, and years matter**; Before Firefox 49, `dateRange("JAN", "DEC")` will always evaluate to `true`. Now `dateRange("DEC", "JAN")` will only evaluate true if the current month is December or January.
 
 #### Examples
 
@@ -483,7 +488,8 @@ dateRange(1995, 1997);
 timeRange(<hour1>, <min1>, <sec1>, <hour2>, <min2>, <sec2>, [gmt])
 ```
 
-> **Note:** (Before Firefox 49) the category hour1, min1, sec1 must be less than the category hour2, min2, sec2 if you want the function to evaluate these parameters as a range. See the warning below.
+> [!NOTE]
+> (Before Firefox 49) the category hour1, min1, sec1 must be less than the category hour2, min2, sec2 if you want the function to evaluate these parameters as a range. See the warning below.
 
 #### Parameters
 
@@ -498,7 +504,7 @@ timeRange(<hour1>, <min1>, <sec1>, <hour2>, <min2>, <sec2>, [gmt])
 
 If only a single value is specified (from each category: hour, minute, second), the function returns a true value only at times that match that specification. If both values are specified, the result is true between those times, including bounds, _but the bounds are ordered_.
 
-> **Warning:** **The order of the hour, minute, second matter**; Before Firefox 49, `timeRange(0, 23)` will always evaluate to true. Now `timeRange(23, 0)` will only evaluate true if the current hour is 23:00 or midnight.
+> [!WARNING] > **The order of the hour, minute, second matter**; Before Firefox 49, `timeRange(0, 23)` will always evaluate to true. Now `timeRange(23, 0)` will only evaluate true if the current hour is 23:00 or midnight.
 
 #### Examples
 
@@ -537,7 +543,8 @@ alert("Error: shouldn't reach this clause.") // log a simple message
 
 ### Use proxy for everything except local hosts
 
-> **Note:** Since all of the examples that follow are very specific, they have not been tested.
+> [!NOTE]
+> Since all of the examples that follow are very specific, they have not been tested.
 
 All hosts which aren't fully qualified, or the ones that are in local domain, will be connected to directly. Everything else will go through `w3proxy.mozilla.org:8080`. If the proxy goes down, connections become direct automatically:
 
@@ -551,7 +558,8 @@ function FindProxyForURL(url, host) {
 }
 ```
 
-> **Note:** This is the simplest and most efficient autoconfig file for cases where there's only one proxy.
+> [!NOTE]
+> This is the simplest and most efficient autoconfig file for cases where there's only one proxy.
 
 ## Example 2
 
@@ -575,7 +583,8 @@ function FindProxyForURL(url, host) {
 
 The above example will use the proxy for everything except local hosts in the mozilla.org domain, with the further exception that hosts `www.mozilla.org` and `merchant.mozilla.org` will go through the proxy.
 
-> **Note:** The order of the above exceptions for efficiency: `localHostOrDomainIs()` functions only get executed for URLs that are in local domain, not for every URL. Be careful to note the parentheses around the _or_ expression before the _and_ expression to achieve the above-mentioned efficient behavior.
+> [!NOTE]
+> The order of the above exceptions for efficiency: `localHostOrDomainIs()` functions only get executed for URLs that are in local domain, not for every URL. Be careful to note the parentheses around the _or_ expression before the _and_ expression to achieve the above-mentioned efficient behavior.
 
 ## Example 3
 
@@ -688,7 +697,8 @@ function FindProxyForURL(url, host) {
 }
 ```
 
-> **Note:** The same can be accomplished using the [`shExpMatch()`](#shexpmatch) function described earlier.
+> [!NOTE]
+> The same can be accomplished using the [`shExpMatch()`](#shexpmatch) function described earlier.
 
 For example:
 
@@ -698,7 +708,8 @@ if (shExpMatch(url, "http:*")) {
 }
 ```
 
-> **Note:** The autoconfig file can be output by a CGI script. This is useful, for example, when making the autoconfig file act differently based on the client IP address (the `REMOTE_ADDR` environment variable in CGI).
+> [!NOTE]
+> The autoconfig file can be output by a CGI script. This is useful, for example, when making the autoconfig file act differently based on the client IP address (the `REMOTE_ADDR` environment variable in CGI).
 >
 > Usage of `isInNet()`, `isResolvable()` and `dnsResolve()` functions should be carefully considered, as they require the DNS server to be consulted. All the other autoconfig-related functions are mere string-matching functions that don't require the use of a DNS server. If a proxy is used, the proxy will perform its DNS lookup which would double the impact on the DNS server. Most of the time these functions are not necessary to achieve the desired result.
 

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -395,7 +395,7 @@ If only one parameter is present, the function returns a value of true on the we
 
 If both **wd1** and **wd2** are defined, the condition is true if the current weekday is in between those two _ordered_ weekdays. Bounds are inclusive, _but the bounds are ordered_. If the "GMT" parameter is specified, times are taken to be in GMT. Otherwise, the local timezone is used.
 
-> [!WARNING] > _The order of the days matters_.
+> **Warning:** _The order of the days matters_.
 > Before Firefox 49, `weekdayRange("SUN", "SAT")` will always evaluate to `true`.
 > Now `weekdayRange("WED", "SUN")` will only evaluate to `true`
 > if the current day is Wednesday or Sunday.
@@ -450,7 +450,7 @@ dateRange(<day1>, <month1>, <year1>, <day2>, <month2>, <year2>, [gmt])
 
 If only a single value is specified (from each category: day, month, year), the function returns a true value only on days that match that specification. If both values are specified, the result is true between those times, including bounds, _but the bounds are ordered_.
 
-> [!WARNING] > **The order of the days, months, and years matter**; Before Firefox 49, `dateRange("JAN", "DEC")` will always evaluate to `true`. Now `dateRange("DEC", "JAN")` will only evaluate true if the current month is December or January.
+> **Warning:** **The order of the days, months, and years matter**; Before Firefox 49, `dateRange("JAN", "DEC")` will always evaluate to `true`. Now `dateRange("DEC", "JAN")` will only evaluate true if the current month is December or January.
 
 #### Examples
 
@@ -504,7 +504,7 @@ timeRange(<hour1>, <min1>, <sec1>, <hour2>, <min2>, <sec2>, [gmt])
 
 If only a single value is specified (from each category: hour, minute, second), the function returns a true value only at times that match that specification. If both values are specified, the result is true between those times, including bounds, _but the bounds are ordered_.
 
-> [!WARNING] > **The order of the hour, minute, second matter**; Before Firefox 49, `timeRange(0, 23)` will always evaluate to true. Now `timeRange(23, 0)` will only evaluate true if the current hour is 23:00 or midnight.
+> **Warning:** **The order of the hour, minute, second matter**; Before Firefox 49, `timeRange(0, 23)` will always evaluate to true. Now `timeRange(23, 0)` will only evaluate true if the current hour is 23:00 or midnight.
 
 #### Examples
 

--- a/files/en-us/web/http/redirections/index.md
+++ b/files/en-us/web/http/redirections/index.md
@@ -142,7 +142,8 @@ When you restructure websites, URLs change. Even if you update your site's links
 
 You don't want to break these links, as they bring valuable users and help your SEO, so you set up redirects from the old URLs to the new ones.
 
-> **Note:** This technique does work for internal links, but try to avoid having internal redirects. A redirect has a significant performance cost (as an extra HTTP request occurs). If you can avoid it by correcting internal links, you should fix those links instead.
+> [!NOTE]
+> This technique does work for internal links, but try to avoid having internal redirects. A redirect has a significant performance cost (as an extra HTTP request occurs). If you can avoid it by correcting internal links, you should fix those links instead.
 
 ### Temporary responses to unsafe requests
 

--- a/files/en-us/web/http/session/index.md
+++ b/files/en-us/web/http/session/index.md
@@ -20,7 +20,8 @@ In client-server protocols, it is the client which establishes the connection. O
 
 With TCP the default port, for an HTTP server on a computer, is port 80. Other ports can also be used, like 8000 or 8080. The URL of a page to fetch contains both the domain name, and the port number, though the latter can be omitted if it is 80. See [Identifying resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web) for more details.
 
-> **Note:** The client-server model does not allow the server to send data to the client without an explicit request for it. However, various Web APIs enable this use case, including the [Push API](/en-US/docs/Web/API/Push_API), [Server-sent events](/en-US/docs/Web/API/Server-sent_events), and the [WebSockets API](/en-US/docs/Web/API/WebSockets_API).
+> [!NOTE]
+> The client-server model does not allow the server to send data to the client without an explicit request for it. However, various Web APIs enable this use case, including the [Push API](/en-US/docs/Web/API/Push_API), [Server-sent events](/en-US/docs/Web/API/Server-sent_events), and the [WebSockets API](/en-US/docs/Web/API/WebSockets_API).
 
 ## Sending a client request
 

--- a/files/en-us/web/http/status/102/index.md
+++ b/files/en-us/web/http/status/102/index.md
@@ -11,7 +11,8 @@ The HTTP **`102 Processing`** informational status response code indicates to cl
 
 This status code is only sent if the server expects the request to take significant time. It tells the client that your request is not dead yet.
 
-> **Note:** This status code is deprecated and shouldn't be sent any more. Clients may still accept it, but simply ignore them.
+> [!NOTE]
+> This status code is deprecated and shouldn't be sent any more. Clients may still accept it, but simply ignore them.
 
 ## Status
 

--- a/files/en-us/web/http/status/103/index.md
+++ b/files/en-us/web/http/status/103/index.md
@@ -17,7 +17,8 @@ A server might send multiple `103` responses, for example, following a redirect.
 Browsers only process the first early hint response, and this response must be discarded if the request results in a cross-origin redirect.
 Preloaded resources from the early hint are effectively pre-pended to the `Document`'s head element, and then followed by the resources loaded in the final response.
 
-> **Note:** For compatibility reasons [it is recommended](https://www.rfc-editor.org/rfc/rfc8297#section-3) to only send HTTP `103 Early Hints` responses over HTTP/2 or later, unless the client is known to handle informational responses correctly.
+> [!NOTE]
+> For compatibility reasons [it is recommended](https://www.rfc-editor.org/rfc/rfc8297#section-3) to only send HTTP `103 Early Hints` responses over HTTP/2 or later, unless the client is known to handle informational responses correctly.
 >
 > Most browsers limit support to HTTP/2 or later for this reason. See [browser compatibility](#browser_compatibility) below.
 >

--- a/files/en-us/web/http/status/207/index.md
+++ b/files/en-us/web/http/status/207/index.md
@@ -7,7 +7,8 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.1
 
 {{HTTPSidebar}}
 
-> **Note:** The ability to return a _collection of resources_ is part of the {{Glossary("WebDAV")}} protocol (it may be received by web applications accessing a WebDAV server).
+> [!NOTE]
+> The ability to return a _collection of resources_ is part of the {{Glossary("WebDAV")}} protocol (it may be received by web applications accessing a WebDAV server).
 > Browsers accessing web pages will never encounter this status code.
 
 The HTTP **`207 Multi-Status`** response code indicates that there might be a mixture of responses.

--- a/files/en-us/web/http/status/208/index.md
+++ b/files/en-us/web/http/status/208/index.md
@@ -7,7 +7,8 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc5842.html#section-7.1
 
 {{HTTPSidebar}}
 
-> **Note:** The ability to _bind_ a resource to several paths is an extension to the {{Glossary("WebDAV")}} protocol (it may be received by web applications accessing a WebDAV server).
+> [!NOTE]
+> The ability to _bind_ a resource to several paths is an extension to the {{Glossary("WebDAV")}} protocol (it may be received by web applications accessing a WebDAV server).
 > Browsers accessing web pages will never encounter this status code.
 
 The HTTP **`208 Already Reported`** response code is used in a {{HTTPStatus("207")}} (`207 Multi-Status`) response to save space and avoid conflicts.

--- a/files/en-us/web/http/status/226/index.md
+++ b/files/en-us/web/http/status/226/index.md
@@ -7,7 +7,8 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc3229.html#section-10.4.1
 
 {{HTTPSidebar}}
 
-> **Note:** Browsers don't support _delta encoding_ with HTTP. This status code is sent back by custom servers used by specific clients.
+> [!NOTE]
+> Browsers don't support _delta encoding_ with HTTP. This status code is sent back by custom servers used by specific clients.
 
 In the context of delta encodings, the HTTP **`226 IM Used`** status code is set by the server to indicate that it is returning a _delta_ to the {{HTTPMethod("GET")}} request that it received.
 

--- a/files/en-us/web/http/status/301/index.md
+++ b/files/en-us/web/http/status/301/index.md
@@ -9,7 +9,8 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.301
 
 The HyperText Transfer Protocol (HTTP) **`301 Moved Permanently`** redirect status response code indicates that the requested resource has been definitively moved to the URL given by the {{HTTPHeader("Location")}} headers. A browser redirects to the new URL and search engines update their links to the resource.
 
-> **Note:** Although the [specification](#specifications) requires the method and the body to remain unchanged when the redirection is performed, not all user-agents meet this requirement. Use the `301` code only as a response for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} methods and use the {{HTTPStatus("308", "308 Permanent Redirect")}} for {{HTTPMethod("POST")}} methods instead, as the method change is explicitly prohibited with this status.
+> [!NOTE]
+> Although the [specification](#specifications) requires the method and the body to remain unchanged when the redirection is performed, not all user-agents meet this requirement. Use the `301` code only as a response for {{HTTPMethod("GET")}} or {{HTTPMethod("HEAD")}} methods and use the {{HTTPStatus("308", "308 Permanent Redirect")}} for {{HTTPMethod("POST")}} methods instead, as the method change is explicitly prohibited with this status.
 
 ## Status
 

--- a/files/en-us/web/http/status/304/index.md
+++ b/files/en-us/web/http/status/304/index.md
@@ -17,7 +17,8 @@ have been sent in an equivalent {{HTTPStatus("200")}} `OK` response:
 {{HTTPHeader("Date")}}, {{HTTPHeader("ETag")}}, {{HTTPHeader("Expires")}}, and
 {{HTTPHeader("Vary")}}.
 
-> **Note:** Many [developer tools' network panels](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
+> [!NOTE]
+> Many [developer tools' network panels](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html)
 > of browsers create extraneous requests leading to `304` responses, so that
 > access to the local cache is visible to developers.
 

--- a/files/en-us/web/http/status/308/index.md
+++ b/files/en-us/web/http/status/308/index.md
@@ -17,7 +17,8 @@ engines update their links to the resource (in 'SEO-speak', it is said that the
 The request method and the body will not be altered, whereas {{HTTPStatus("301")}} may
 incorrectly sometimes be changed to a {{HTTPMethod("GET")}} method.
 
-> **Note:** Some Web applications may use the
+> [!NOTE]
+> Some Web applications may use the
 > `308 Permanent Redirect` in a non-standard way and for other purposes. For
 > example, Google Drive uses a `308 Resume Incomplete` response to indicate
 > to the client when an incomplete upload stalled. (See [Perform a resumable download](https://developers.google.com/drive/api/guides/manage-uploads) on Google Drive documentation.)

--- a/files/en-us/web/http/status/404/index.md
+++ b/files/en-us/web/http/status/404/index.md
@@ -64,7 +64,7 @@ The example below uses `notfound.html` as a page to show visitors on 404s, altho
 ErrorDocument 404 /notfound.html
 ```
 
-> **Note:**
+> [!NOTE]
 > Custom 404 page design is a good thing in moderation.
 > Feel free to make your 404 page humorous and human, but don't confuse your visitors as to why they are seeing something unexpected.
 >

--- a/files/en-us/web/http/status/408/index.md
+++ b/files/en-us/web/http/status/408/index.md
@@ -14,7 +14,8 @@ A server should send the {{HTTPHeader("Connection", "Connection: close")}} heade
 
 This response is used much more since some browsers, like Chrome and Firefox, use HTTP pre-connection mechanisms to speed up surfing.
 
-> **Note:** Some servers will shut down a connection without sending this message.
+> [!NOTE]
+> Some servers will shut down a connection without sending this message.
 
 ## Status
 

--- a/files/en-us/web/http/status/411/index.md
+++ b/files/en-us/web/http/status/411/index.md
@@ -9,7 +9,7 @@ spec-urls: https://httpwg.org/specs/rfc9110.html#status.411
 
 The HTTP **`411 Length Required`** [client error response](/en-US/docs/Web/HTTP/Status#client_error_responses) status code indicates that the server refused to accept the request without a defined {{HTTPHeader("Content-Length")}} header.
 
-> **Note:**
+> [!NOTE]
 > When sending data in a series of chunks, the `Content-Length` header is omitted, and at the beginning of each chunk, the length of the current chunk needs to be included in hexadecimal format.
 > See {{HTTPHeader("Transfer-Encoding")}} for more details.
 

--- a/files/en-us/web/http/status/423/index.md
+++ b/files/en-us/web/http/status/423/index.md
@@ -10,7 +10,7 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.3
 The HTTP **`423 Locked`** [client error response](/en-US/docs/Web/HTTP/Status#client_error_responses) status code indicates that a resource is _locked_, meaning it can't be accessed.
 Its response body should contain information in {{glossary("WebDAV")}}'s XML format.
 
-> **Note:**
+> [!NOTE]
 > The ability to _lock_ a resource to prevent conflicts is specific to some {{Glossary("WebDAV")}} servers.
 > Browsers accessing web pages will never encounter this status code; in the erroneous cases it happens, they will handle it as a generic {{HTTPStatus(400)}} status code.
 

--- a/files/en-us/web/http/status/451/index.md
+++ b/files/en-us/web/http/status/451/index.md
@@ -21,7 +21,8 @@ The HTTP **`451 Unavailable For Legal Reasons`** [client error response](/en-US/
 
 This example response is taken from the IETF RFC (see below) and contains a reference to [Monty Python's Life of Brian](https://en.wikipedia.org/wiki/Monty_Python's_Life_of_Brian).
 
-> **Note:** the {{HTTPHeader("Link")}} header might also contain a `rel="blocked-by"` relation identifying the entity implementing the blockage, not any other entity mandating it.
+> [!NOTE]
+> the {{HTTPHeader("Link")}} header might also contain a `rel="blocked-by"` relation identifying the entity implementing the blockage, not any other entity mandating it.
 
 Any attempt to identify the entity ultimately responsible for the resource being unavailable belongs in the response body, not in the `rel="blocked-by"` link. This includes the name of the person or organization that made a legal demand resulting in the content's removal.
 

--- a/files/en-us/web/http/status/501/index.md
+++ b/files/en-us/web/http/status/501/index.md
@@ -15,7 +15,7 @@ This status can also send a {{HTTPHeader("Retry-After")}} header, telling the re
 
 If the server _does_ recognize the method, but intentionally does not support it, the appropriate response is {{HTTPStatus(405, "405 Method Not Allowed")}}.
 
-> **Note:**
+> [!NOTE]
 >
 > - A 501 error is not something you can fix, but requires a fix by the web server you are trying to access.
 > - A 501 response is cacheable by default; that is, unless caching headers instruct otherwise.

--- a/files/en-us/web/http/status/502/index.md
+++ b/files/en-us/web/http/status/502/index.md
@@ -9,7 +9,8 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.502
 
 The HyperText Transfer Protocol (HTTP) **`502 Bad Gateway`** server error response code indicates that the server, while acting as a gateway or proxy, received an invalid response from the upstream server.
 
-> **Note:** A [Gateway](<https://en.wikipedia.org/wiki/Gateway_(telecommunications)>) might refer to different things in networking and a 502 error is usually not something you can fix, but requires a fix by the web server or the proxies you are trying to get access through.
+> [!NOTE]
+> A [Gateway](<https://en.wikipedia.org/wiki/Gateway_(telecommunications)>) might refer to different things in networking and a 502 error is usually not something you can fix, but requires a fix by the web server or the proxies you are trying to get access through.
 
 ## Status
 

--- a/files/en-us/web/http/status/503/index.md
+++ b/files/en-us/web/http/status/503/index.md
@@ -11,7 +11,8 @@ The HyperText Transfer Protocol (HTTP) **`503 Service Unavailable`** server erro
 
 Common causes are a server that is down for maintenance or that is overloaded. This response should be used for temporary conditions and the {{HTTPHeader("Retry-After")}} HTTP header should, if possible, contain the estimated time for the recovery of the service.
 
-> **Note:** together with this response, a user-friendly page explaining the problem should be sent.
+> [!NOTE]
+> together with this response, a user-friendly page explaining the problem should be sent.
 
 Caching-related headers that are sent along with this response should be taken care of, as a 503 status is often a temporary condition and responses shouldn't usually be cached.
 

--- a/files/en-us/web/http/status/504/index.md
+++ b/files/en-us/web/http/status/504/index.md
@@ -9,7 +9,8 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc9110#status.504
 
 The HyperText Transfer Protocol (HTTP) **`504 Gateway Timeout`** server error response code indicates that the server, while acting as a gateway or proxy, did not get a response in time from the upstream server that it needed in order to complete the request.
 
-> **Note:** A [Gateway](<https://en.wikipedia.org/wiki/Gateway_(telecommunications)>) might refer to different things in networking and a 504 error is usually not something you can fix, but requires a fix by the web server or the proxies you are trying to get access through.
+> [!NOTE]
+> A [Gateway](<https://en.wikipedia.org/wiki/Gateway_(telecommunications)>) might refer to different things in networking and a 504 error is usually not something you can fix, but requires a fix by the web server or the proxies you are trying to get access through.
 
 ## Status
 

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -18,7 +18,8 @@ Responses are grouped in five classes:
 
 The status codes listed below are defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes).
 
-> **Note:** If you receive a response that is not in [this list](#information_responses), it is a non-standard response, possibly custom to the server's software.
+> [!NOTE]
+> If you receive a response that is not in [this list](#information_responses), it is a non-standard response, possibly custom to the server's software.
 
 ## Information responses
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/http' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
