### PR TITLE
Convert noteblocks for web/javascript/reference folder

### DIFF
--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -9,7 +9,8 @@ browser-compat: javascript.classes.constructor
 
 The **`constructor`** method is a special method of a [class](/en-US/docs/Web/JavaScript/Reference/Classes) for creating and initializing an object instance of that class.
 
-> **Note:** This page introduces the `constructor` syntax. For the `constructor` property present on all objects, see {{jsxref("Object.prototype.constructor")}}.
+> [!NOTE]
+> This page introduces the `constructor` syntax. For the `constructor` property present on all objects, see {{jsxref("Object.prototype.constructor")}}.
 
 {{EmbedInteractiveExample("pages/js/classes-constructor.html")}}
 
@@ -62,7 +63,8 @@ constructor(...args) {
 }
 ```
 
-> **Note:** The difference between an explicit constructor like the one above and the default constructor is that the latter doesn't actually invoke [the array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Symbol.iterator) through [argument spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).
+> [!NOTE]
+> The difference between an explicit constructor like the one above and the default constructor is that the latter doesn't actually invoke [the array iterator](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Symbol.iterator) through [argument spreading](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).
 
 That enables code like this to work:
 

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -120,7 +120,8 @@ If the parent class constructor returns an object, that object will be used as t
 
 ### Subclassing built-ins
 
-> **Warning:** The standard committee now holds the position that the built-in subclassing mechanism in previous spec versions is over-engineered and causes non-negligible performance and security impacts. New built-in methods consider less about subclasses, and engine implementers are [investigating whether to remove certain subclassing mechanisms](https://github.com/tc39/proposal-rm-builtin-subclassing). Consider using composition instead of inheritance when enhancing built-ins.
+> [!WARNING]
+> The standard committee now holds the position that the built-in subclassing mechanism in previous spec versions is over-engineered and causes non-negligible performance and security impacts. New built-in methods consider less about subclasses, and engine implementers are [investigating whether to remove certain subclassing mechanisms](https://github.com/tc39/proposal-rm-builtin-subclassing). Consider using composition instead of inheritance when enhancing built-ins.
 
 Here are some things you may expect when extending a class:
 

--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -72,7 +72,8 @@ Together, they add up to 16 possible combinations. To divide the reference more 
 - [Private properties](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties)
   - : Everything that's private
 
-> **Note:** Private properties have the restriction that all property names declared in the same class must be unique. All other public properties do not have this restriction — you can have multiple public properties with the same name, and the last one overwrites the others. This is the same behavior as in [object initializers](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#duplicate_property_names).
+> [!NOTE]
+> Private properties have the restriction that all property names declared in the same class must be unique. All other public properties do not have this restriction — you can have multiple public properties with the same name, and the last one overwrites the others. This is the same behavior as in [object initializers](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#duplicate_property_names).
 
 In addition, there are two special class element syntaxes: [`constructor`](#constructor) and [static initialization blocks](#static_initialization_blocks), with their own references.
 

--- a/files/en-us/web/javascript/reference/classes/private_properties/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_properties/index.md
@@ -74,7 +74,8 @@ instance.#privateField; // Syntax error
 
 JavaScript, being a dynamic language, is able to perform this compile-time check because of the special hash identifier syntax, making it different from normal properties on the syntax level.
 
-> **Note:** Code run in the Chrome console can access private properties outside the class. This is a DevTools-only relaxation of the JavaScript syntax restriction.
+> [!NOTE]
+> Code run in the Chrome console can access private properties outside the class. This is a DevTools-only relaxation of the JavaScript syntax restriction.
 
 If you access a private property from an object that doesn't have the property, a {{jsxref("TypeError")}} is thrown, instead of returning `undefined` as normal properties do.
 
@@ -153,7 +154,7 @@ class Subclass extends ClassWithPrivateField {
 new Subclass(); // In some dev tools, it shows Subclass {#privateField: 42, #subPrivateField: 23}
 ```
 
-> **Note:** `#privateField` from the `ClassWithPrivateField` base class is private to `ClassWithPrivateField` and is not accessible from the derived `Subclass`.
+> [!NOTE] > `#privateField` from the `ClassWithPrivateField` base class is private to `ClassWithPrivateField` and is not accessible from the derived `Subclass`.
 
 #### Returning overriding object
 
@@ -187,7 +188,8 @@ console.log(obj instanceof Stamper); // false
 new Stamper(obj); // Error: Initializing an object twice is an error with private fields
 ```
 
-> **Warning:** This is a potentially very confusing thing to do. You are generally advised to avoid returning anything from the constructor — especially something unrelated to `this`.
+> [!WARNING]
+> This is a potentially very confusing thing to do. You are generally advised to avoid returning anything from the constructor — especially something unrelated to `this`.
 
 #### Private static fields
 

--- a/files/en-us/web/javascript/reference/classes/private_properties/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_properties/index.md
@@ -154,7 +154,7 @@ class Subclass extends ClassWithPrivateField {
 new Subclass(); // In some dev tools, it shows Subclass {#privateField: 42, #subPrivateField: 23}
 ```
 
-> [!NOTE] > `#privateField` from the `ClassWithPrivateField` base class is private to `ClassWithPrivateField` and is not accessible from the derived `Subclass`.
+> **Note:** `#privateField` from the `ClassWithPrivateField` base class is private to `ClassWithPrivateField` and is not accessible from the derived `Subclass`.
 
 #### Returning overriding object
 

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -142,7 +142,8 @@ console.log(instance.d); // 3
 console.log(instance.b); // undefined
 ```
 
-> **Note:** This is more important with [private fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), because accessing a non-initialized private field throws a {{jsxref("TypeError")}}, even if the private field is declared below. (If the private field is not declared, it would be an early {{jsxref("SyntaxError")}}.)
+> [!NOTE]
+> This is more important with [private fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), because accessing a non-initialized private field throws a {{jsxref("TypeError")}}, even if the private field is declared below. (If the private field is not declared, it would be an early {{jsxref("SyntaxError")}}.)
 
 Because class fields are added using the [`[[DefineOwnProperty]]`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty) semantic (which is essentially {{jsxref("Object.defineProperty()")}}), field declarations in derived classes do not invoke setters in the base class. This behavior differs from using `this.field = …` in the constructor.
 
@@ -169,7 +170,8 @@ class DerivedWithConstructor extends Base {
 const instance2 = new DerivedWithConstructor(); // Logs 1
 ```
 
-> **Note:** Before the class fields specification was finalized with the `[[DefineOwnProperty]]` semantic, most transpilers, including [Babel](https://babeljs.io/) and [tsc](https://www.typescriptlang.org/), transformed class fields to the `DerivedWithConstructor` form, which has caused subtle bugs after class fields were standardized.
+> [!NOTE]
+> Before the class fields specification was finalized with the `[[DefineOwnProperty]]` semantic, most transpilers, including [Babel](https://babeljs.io/) and [tsc](https://www.typescriptlang.org/), transformed class fields to the `DerivedWithConstructor` form, which has caused subtle bugs after class fields were standardized.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -11,7 +11,8 @@ The **`static`** keyword defines a [static method or field](/en-US/docs/Web/Java
 
 Static methods are often utility functions, such as functions to create or clone objects, whereas static properties are useful for caches, fixed-configuration, or any other data you don't need to be replicated across instances.
 
-> **Note:** In the context of classes, MDN Web Docs content uses the terms properties and [fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) interchangeably.
+> [!NOTE]
+> In the context of classes, MDN Web Docs content uses the terms properties and [fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) interchangeably.
 
 {{EmbedInteractiveExample("pages/js/classes-static.html", "taller")}}
 
@@ -88,7 +89,8 @@ The expression is evaluated synchronously. You cannot use {{jsxref("Operators/aw
 
 Static field initializers and [static initialization blocks](/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) are evaluated one-by-one. Field initializers can refer to field values above it, but not below it. All static methods are added beforehand and can be accessed, although calling them may not behave as expected if they refer to fields below the one being initialized.
 
-> **Note:** This is more important with [private static fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), because accessing a non-initialized private field throws a {{jsxref("TypeError")}}, even if the private field is declared below. (If the private field is not declared, it would be an early {{jsxref("SyntaxError")}}.)
+> [!NOTE]
+> This is more important with [private static fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), because accessing a non-initialized private field throws a {{jsxref("TypeError")}}, even if the private field is declared below. (If the private field is not declared, it would be an early {{jsxref("SyntaxError")}}.)
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -67,7 +67,8 @@ The scope of the static block is nested _within_ the lexical scope of the class 
 
 [Static field](/en-US/docs/Web/JavaScript/Reference/Classes/static) initializers and static initialization blocks are evaluated one-by-one. The initialization block can refer to field values above it, but not below it. All static methods are added beforehand and can be accessed, although calling them may not behave as expected if they refer to fields below the current block.
 
-> **Note:** This is more important with [private static fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), because accessing a non-initialized private field throws a {{jsxref("TypeError")}}, even if the private field is declared below. (If the private field is not declared, it would be an early {{jsxref("SyntaxError")}}.)
+> [!NOTE]
+> This is more important with [private static fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties), because accessing a non-initialized private field throws a {{jsxref("TypeError")}}, even if the private field is declared below. (If the private field is not declared, it would be an early {{jsxref("SyntaxError")}}.)
 
 A static initialization block may not have decorators (the class itself may).
 

--- a/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
+++ b/files/en-us/web/javascript/reference/deprecated_and_obsolete_features/index.md
@@ -53,7 +53,8 @@ The following properties are deprecated. This does not affect their use in [repl
 - [`rightContext`, `$'`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext)
   - : The substring following the most recent match.
 
-> **Warning:** Avoid using these static properties, as they can cause [issues when interacting with external code](https://github.com/tc39/proposal-regexp-legacy-features/blob/master/subclass-restriction-motivation.md#legacy-static-properties-regexp1-etc)!
+> [!WARNING]
+> Avoid using these static properties, as they can cause [issues when interacting with external code](https://github.com/tc39/proposal-regexp-legacy-features/blob/master/subclass-restriction-motivation.md#legacy-static-properties-regexp1-etc)!
 
 The {{jsxref("RegExp/compile", "compile()")}} method is deprecated. Construct a new `RegExp` instance instead.
 

--- a/files/en-us/web/javascript/reference/errors/await_yield_in_parameter/index.md
+++ b/files/en-us/web/javascript/reference/errors/await_yield_in_parameter/index.md
@@ -28,7 +28,8 @@ SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression within para
 
 The default expression must be able to evaluate _synchronously_. If it contains an `await` or `yield` expression, it will pause the evaluation of the default expression, which is not allowed.
 
-> **Note:** This error is only generated when `await` or `yield` are valid operators in this function context. Otherwise, `await` or `yield` would be parsed as an identifier, and either not cause an error, or cause an error like "reserved identifier", or "unexpected token" if there's an expression following it.
+> [!NOTE]
+> This error is only generated when `await` or `yield` are valid operators in this function context. Otherwise, `await` or `yield` would be parsed as an identifier, and either not cause an error, or cause an error like "reserved identifier", or "unexpected token" if there's an expression following it.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
@@ -46,7 +46,8 @@ const c = BigInt("1");
 const d = BigInt(Symbol("1").description);
 ```
 
-> **Note:** Simply coercing the value to a string or number using [`String()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String) or [`Number()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number) before passing it to `BigInt()` is usually not sufficient to avoid all errors. If the string is not a valid integer number string, a [SyntaxError](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_BigInt_syntax) is thrown; if the number is not an integer (most notably, {{jsxref("NaN")}}), a [RangeError](/en-US/docs/Web/JavaScript/Reference/Errors/Cant_be_converted_to_BigInt_because_it_isnt_an_integer) is thrown. If the range of input is unknown, properly validate it before using `BigInt()`.
+> [!NOTE]
+> Simply coercing the value to a string or number using [`String()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String) or [`Number()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/Number) before passing it to `BigInt()` is usually not sufficient to avoid all errors. If the string is not a valid integer number string, a [SyntaxError](/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_BigInt_syntax) is thrown; if the number is not an integer (most notably, {{jsxref("NaN")}}), a [RangeError](/en-US/docs/Web/JavaScript/Reference/Errors/Cant_be_converted_to_BigInt_because_it_isnt_an_integer) is thrown. If the range of input is unknown, properly validate it before using `BigInt()`.
 
 ### Passing a number to a function expecting a BigInt
 

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -13,7 +13,7 @@ For {{jsxref("Array")}} the maximum length is 2<sup>32</sup>-1.
 For {{jsxref("ArrayBuffer")}} the maximum is 2<sup>31</sup>-1 (2GiB-1) on 32-bit systems.
 From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 2<sup>33</sup> (8GiB) on 64-bit systems.
 
-> **Note:** `Array` and `ArrayBuffer` are independent data structures (the implementation of one does not affect the other).
+> [!NOTE] > `Array` and `ArrayBuffer` are independent data structures (the implementation of one does not affect the other).
 
 ## Message
 

--- a/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_array_length/index.md
@@ -13,7 +13,7 @@ For {{jsxref("Array")}} the maximum length is 2<sup>32</sup>-1.
 For {{jsxref("ArrayBuffer")}} the maximum is 2<sup>31</sup>-1 (2GiB-1) on 32-bit systems.
 From Firefox version 89 the maximum value of {{jsxref("ArrayBuffer")}} is 2<sup>33</sup> (8GiB) on 64-bit systems.
 
-> [!NOTE] > `Array` and `ArrayBuffer` are independent data structures (the implementation of one does not affect the other).
+> **Note:** `Array` and `ArrayBuffer` are independent data structures (the implementation of one does not affect the other).
 
 ## Message
 

--- a/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_assignment_left-hand_side/index.md
@@ -76,7 +76,8 @@ function foo() {
 foo().a = 1;
 ```
 
-> **Note:** In Firefox and Safari, the first example produces a `ReferenceError` in non-strict mode, and a `SyntaxError` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode). Chrome throws a runtime `ReferenceError` for both strict and non-strict modes.
+> [!NOTE]
+> In Firefox and Safari, the first example produces a `ReferenceError` in non-strict mode, and a `SyntaxError` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode). Chrome throws a runtime `ReferenceError` for both strict and non-strict modes.
 
 ### Using optional chaining as assignment target
 

--- a/files/en-us/web/javascript/reference/errors/not_defined/index.md
+++ b/files/en-us/web/javascript/reference/errors/not_defined/index.md
@@ -25,7 +25,8 @@ ReferenceError: Can't find variable: x (Safari)
 There is a non-existent variable referenced somewhere. This variable needs to be
 declared, or you need to make sure it is available in your current script or [scope](/en-US/docs/Glossary/Scope).
 
-> **Note:** When loading a library (such as jQuery), make sure it is
+> [!NOTE]
+> When loading a library (such as jQuery), make sure it is
 > loaded before you access library variables, such as "$". Put the
 > {{HTMLElement("script")}} element that loads the library before your code that uses
 > it.

--- a/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
@@ -20,7 +20,7 @@ A reference to the currently executing function.
 
 {{js_property_attributes(1, 0, 1)}}
 
-> [!NOTE] > `callee` is a data property only in non-strict functions with simple parameters (in which case the `arguments` object is also [auto-syncing](/en-US/docs/Web/JavaScript/Reference/Functions/arguments#assigning_to_indices)). Otherwise, it is an accessor property whose getter and setter both throw a {{jsxref("TypeError")}}.
+> **Note:** `callee` is a data property only in non-strict functions with simple parameters (in which case the `arguments` object is also [auto-syncing](/en-US/docs/Web/JavaScript/Reference/Functions/arguments#assigning_to_indices)). Otherwise, it is an accessor property whose getter and setter both throw a {{jsxref("TypeError")}}.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
@@ -9,7 +9,8 @@ browser-compat: javascript.functions.arguments.callee
 
 {{jsSidebar("Functions")}}{{Deprecated_Header}}
 
-> **Note:** Accessing `arguments.callee` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) will throw a {{jsxref("TypeError")}}. If a function must reference itself, either give the [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) a name or use a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function).
+> [!NOTE]
+> Accessing `arguments.callee` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) will throw a {{jsxref("TypeError")}}. If a function must reference itself, either give the [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function) a name or use a [function declaration](/en-US/docs/Web/JavaScript/Reference/Statements/function).
 
 The **`arguments.callee`** data property contains the currently executing function that the arguments belong to.
 
@@ -19,7 +20,7 @@ A reference to the currently executing function.
 
 {{js_property_attributes(1, 0, 1)}}
 
-> **Note:** `callee` is a data property only in non-strict functions with simple parameters (in which case the `arguments` object is also [auto-syncing](/en-US/docs/Web/JavaScript/Reference/Functions/arguments#assigning_to_indices)). Otherwise, it is an accessor property whose getter and setter both throw a {{jsxref("TypeError")}}.
+> [!NOTE] > `callee` is a data property only in non-strict functions with simple parameters (in which case the `arguments` object is also [auto-syncing](/en-US/docs/Web/JavaScript/Reference/Functions/arguments#assigning_to_indices)). Otherwise, it is an accessor property whose getter and setter both throw a {{jsxref("TypeError")}}.
 
 ## Description
 
@@ -142,7 +143,8 @@ console.log(
 // [ 1, 2, 6, 24, 120 ]
 ```
 
-> **Note:** This method allocates a new closure for every iteration, which may significantly increase memory usage. It's only here to demonstrate the possibility, but should be avoided in production. Use a temporary variable or a named function expression instead.
+> [!NOTE]
+> This method allocates a new closure for every iteration, which may significantly increase memory usage. It's only here to demonstrate the possibility, but should be avoided in production. Use a temporary variable or a named function expression instead.
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/functions/arguments/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/index.md
@@ -13,7 +13,8 @@ browser-compat: javascript.functions.arguments
 
 ## Description
 
-> **Note:** In modern code, [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) should be preferred.
+> [!NOTE]
+> In modern code, [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) should be preferred.
 
 The `arguments` object is a local variable available within all non-[arrow](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) functions. You can refer to a function's arguments inside that function by using its `arguments` object. It has entries for each argument the function was called with, with the first entry's index at `0`.
 
@@ -90,7 +91,8 @@ funcWithDefault3(); // undefined; 0
 
 This is the same behavior exhibited by all [strict-mode functions](/en-US/docs/Web/JavaScript/Reference/Strict_mode#making_eval_and_arguments_simpler), regardless of the type of parameters they are passed. That is, assigning new values to parameters in the body of the function never affects the `arguments` object, nor will assigning new values to the `arguments` indices affect the value of parameters, even when the function only has simple parameters.
 
-> **Note:** You cannot write a `"use strict";` directive in the body of a function definition that accepts rest, default, or destructured parameters. Doing so will throw [a syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Strict_non_simple_params).
+> [!NOTE]
+> You cannot write a `"use strict";` directive in the body of a function definition that accepts rest, default, or destructured parameters. Doing so will throw [a syntax error](/en-US/docs/Web/JavaScript/Reference/Errors/Strict_non_simple_params).
 
 ### arguments is an array-like object
 

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -61,7 +61,8 @@ async (param1, param2, ...paramN) => {
 
 Let's decompose a traditional anonymous function down to the simplest arrow function step-by-step. Each step along the way is a valid arrow function.
 
-> **Note:** Traditional function expressions and arrow functions have more differences than their syntax. We will introduce their behavior differences in more detail in the next few subsections.
+> [!NOTE]
+> Traditional function expressions and arrow functions have more differences than their syntax. We will introduce their behavior differences in more detail in the next few subsections.
 
 ```js-nolint
 // Traditional anonymous function
@@ -238,7 +239,8 @@ class C {
 }
 ```
 
-> **Note:** Class fields are defined on the _instance_, not on the _prototype_, so every instance creation would create a new function reference and allocate a new closure, potentially leading to more memory usage than a normal unbound method.
+> [!NOTE]
+> Class fields are defined on the _instance_, not on the _prototype_, so every instance creation would create a new function reference and allocate a new closure, potentially leading to more memory usage than a normal unbound method.
 
 For similar reasons, the [`call()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call), [`apply()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), and [`bind()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) methods are not useful when called on arrow functions, because arrow functions establish `this` based on the scope the arrow function is defined within, and the `this` value does not change based on how the function is invoked.
 
@@ -255,7 +257,8 @@ function foo(n) {
 foo(3); // 3 + 3 = 6
 ```
 
-> **Note:** You cannot declare a variable called `arguments` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode#making_eval_and_arguments_simpler), so the code above would be a syntax error. This makes the scoping effect of `arguments` much easier to comprehend.
+> [!NOTE]
+> You cannot declare a variable called `arguments` in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode#making_eval_and_arguments_simpler), so the code above would be a syntax error. This makes the scoping effect of `arguments` much easier to comprehend.
 
 In most cases, using [rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
 is a good alternative to using an `arguments` object.

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -69,7 +69,8 @@ f(); // [1, undefined]
 f(2); // [2, undefined]
 ```
 
-> **Note:** The first default parameter and all parameters after it will not contribute to the function's [`length`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length).
+> [!NOTE]
+> The first default parameter and all parameters after it will not contribute to the function's [`length`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length).
 
 The default parameter initializers live in their own scope, which is a parent of the scope created for the function body.
 
@@ -107,7 +108,8 @@ async function f(a = await Promise.resolve(1)) {
 }
 ```
 
-> **Note:** Because the default parameter is evaluated when the function is called, not when the function is defined, the validity of the `await` and `yield` operators depends on the function itself, not its surrounding function. For example, if the current function is not `async`, `await` will be parsed as an identifier and follow normal [identifier syntax rules](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), even when this function is nested in an `async` function.
+> [!NOTE]
+> Because the default parameter is evaluated when the function is called, not when the function is defined, the validity of the `await` and `yield` operators depends on the function itself, not its surrounding function. For example, if the current function is not `async`, `await` will be parsed as an identifier and follow normal [identifier syntax rules](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers), even when this function is nested in an `async` function.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -165,7 +165,8 @@ the following situations:
 - If it's used, it will be accessed several times, and there is no need to
   re-calculate that value will never be changed or shouldn't be re-calculated.
 
-> **Note:** This means that you shouldn't write a lazy getter for a property whose value you
+> [!NOTE]
+> This means that you shouldn't write a lazy getter for a property whose value you
 > expect to change, because if the getter is lazy, then it will not recalculate the
 > value.
 >

--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -17,13 +17,15 @@ For more examples and explanations, see the [JavaScript guide about functions](/
 
 Function values are typically instances of [`Function`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function). See {{jsxref("Function")}} for information on properties and methods of `Function` objects. Callable values cause [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) to return `"function"` instead of `"object"`.
 
-> **Note:** Not all callable values are `instanceof Function`. For example, the `Function.prototype` object is callable but not an instance of `Function`. You can also manually set the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) of your function so it no longer inherits from `Function.prototype`. However, such cases are extremely rare.
+> [!NOTE]
+> Not all callable values are `instanceof Function`. For example, the `Function.prototype` object is callable but not an instance of `Function`. You can also manually set the [prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain) of your function so it no longer inherits from `Function.prototype`. However, such cases are extremely rare.
 
 ### Return value
 
 By default, if a function's execution doesn't end at a [`return`](/en-US/docs/Web/JavaScript/Reference/Statements/return) statement, or if the `return` keyword doesn't have an expression after it, then the return value is {{jsxref("undefined")}}. The `return` statement allows you to return an arbitrary value from the function. One function call can only return one value, but you can simulate the effect of returning multiple values by returning an object or array and [destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) the result.
 
-> **Note:** Constructors called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) have a different set of logic to determine their return values.
+> [!NOTE]
+> Constructors called with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new) have a different set of logic to determine their return values.
 
 ### Passing arguments
 

--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -59,7 +59,8 @@ Optionally, the iterator can also implement the **`return(value)`** and **`throw
 - `throw(exception)` {{optional_inline}}
   - : A function that accepts zero or one argument and returns an object conforming to the `IteratorResult` interface, typically with `done` equal to `true`. Calling this method tells the iterator that the caller detects an error condition, and `exception` is typically an {{jsxref("Error")}} instance. No built-in language feature calls `throw()` for cleanup purposes — it's a special feature of generators for the symmetry of `return`/`throw`.
 
-> **Note:** It is not possible to know reflectively (i.e. without actually calling `next()` and validating the returned result) whether a particular object implements the iterator protocol.
+> [!NOTE]
+> It is not possible to know reflectively (i.e. without actually calling `next()` and validating the returned result) whether a particular object implements the iterator protocol.
 
 It is very easy to make an iterator also iterable: just implement an `[Symbol.iterator]()` method that returns `this`.
 

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -38,9 +38,11 @@ In JavaScript source text, \<ZWNJ> and \<ZWJ> are treated as [identifier](#ident
 
 [space separator set]: https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BGeneral_Category%3DSpace_Separator%7D
 
-> **Note:** Of those [characters with the "White_Space" property but are not in the "Space_Separator" general category](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BWhite_Space%7D%26%5CP%7BGeneral_Category%3DSpace_Separator%7D), U+0009, U+000B, and U+000C are still treated as white space in JavaScript; U+0085 NEXT LINE has no special role; others become the set of [line terminators](#line_terminators).
+> [!NOTE]
+> Of those [characters with the "White_Space" property but are not in the "Space_Separator" general category](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BWhite_Space%7D%26%5CP%7BGeneral_Category%3DSpace_Separator%7D), U+0009, U+000B, and U+000C are still treated as white space in JavaScript; U+0085 NEXT LINE has no special role; others become the set of [line terminators](#line_terminators).
 
-> **Note:** Changes to the Unicode standard used by the JavaScript engine may affect programs' behavior. For example, ES2016 upgraded the reference Unicode standard from 5.1 to 8.0.0, which caused U+180E MONGOLIAN VOWEL SEPARATOR to be moved from the "Space_Separator" category to the "Format (Cf)" category, and made it a non-whitespace. Subsequently, the result of [`"\u180E".trim().length`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) changed from `0` to `1`.
+> [!NOTE]
+> Changes to the Unicode standard used by the JavaScript engine may affect programs' behavior. For example, ES2016 upgraded the reference Unicode standard from 5.1 to 8.0.0, which caused U+180E MONGOLIAN VOWEL SEPARATOR to be moved from the "Space_Separator" category to the "Format (Cf)" category, and made it a non-whitespace. Subsequently, the result of [`"\u180E".trim().length`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) changed from `0` to `1`.
 
 ## Line terminators
 
@@ -136,7 +138,8 @@ console.log("Hello world");
 
 The JavaScript interpreter will treat it as a normal comment — it only has semantic meaning to the shell if the script is directly run in a shell.
 
-> **Warning:** If you want scripts to be runnable directly in a shell environment, encode them in UTF-8 without a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark). Although a BOM will not cause any problems for code running in a browser — because it's stripped during UTF-8 decoding, before the source text is analyzed — a Unix/Linux shell will not recognize the hashbang if it's preceded by a BOM character.
+> [!WARNING]
+> If you want scripts to be runnable directly in a shell environment, encode them in UTF-8 without a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark). Although a BOM will not cause any problems for code running in a browser — because it's stripped during UTF-8 decoding, before the source text is analyzed — a Unix/Linux shell will not recognize the hashbang if it's preceded by a BOM character.
 
 You must only use the `#!` comment style to specify a JavaScript interpreter. In all other cases just use a `//` comment (or multiline comment).
 
@@ -157,7 +160,8 @@ lbl: console.log(1); // Label
 
 In JavaScript, identifiers are commonly made of alphanumeric characters, underscores (`_`), and dollar signs (`$`). Identifiers are not allowed to start with numbers. However, JavaScript identifiers are not only limited to {{Glossary("ASCII")}} — many Unicode code points are allowed as well. Namely, any character in the [ID_Start](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Start%7D) category can start an identifier, while any character in the [ID_Continue](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BID_Continue%7D) category can appear after the first character.
 
-> **Note:** If, for some reason, you need to parse some JavaScript source yourself, do not assume all identifiers follow the pattern `/[A-Za-z_$][\w$]*/` (i.e. ASCII-only)! The range of identifiers can be described by the regex `/[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*/u` (excluding unicode escape sequences).
+> [!NOTE]
+> If, for some reason, you need to parse some JavaScript source yourself, do not assume all identifiers follow the pattern `/[A-Za-z_$][\w$]*/` (i.e. ASCII-only)! The range of identifiers can be described by the regex `/[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*/u` (excluding unicode escape sequences).
 
 In addition, JavaScript allows using [Unicode escape sequences](#unicode_escape_sequences) in the form of `\u0000` or `\u{000000}` in identifiers, which encode the same string value as the actual Unicode characters. For example, `你好` and `\u4f60\u597d` are the same identifiers:
 
@@ -297,7 +301,8 @@ A few identifiers have a special meaning in some contexts without being reserved
 
 ## Literals
 
-> **Note:** This section discusses literals that are atomic tokens. [Object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) and [array literals](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array#array_literal_notation) are [expressions](/en-US/docs/Web/JavaScript/Reference/Operators) that consist of a series of tokens.
+> [!NOTE]
+> This section discusses literals that are atomic tokens. [Object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) and [array literals](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array#array_literal_notation) are [expressions](/en-US/docs/Web/JavaScript/Reference/Operators) that consist of a series of tokens.
 
 ### Null literal
 

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -7,7 +7,8 @@ spec-urls: https://tc39.es/ecma262/multipage/strict-mode-of-ecmascript.html
 
 {{jsSidebar("More")}}
 
-> **Note:** Sometimes you'll see the default, non-strict mode referred to as _[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)_. This isn't an official term, but be aware of it, just in case.
+> [!NOTE]
+> Sometimes you'll see the default, non-strict mode referred to as _[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)_. This isn't an official term, but be aware of it, just in case.
 
 JavaScript's strict mode is a way to _opt in_ to a restricted variant of JavaScript, thereby implicitly opting-out of "[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)". Strict mode isn't just a subset: it _intentionally_ has different semantics from normal code. Browsers not supporting strict mode will run strict mode code with different behavior from browsers that do, so don't rely on strict mode without feature-testing for support for the relevant aspects of strict mode. Strict mode code and non-strict mode code can coexist, so scripts can opt into strict mode incrementally.
 
@@ -238,7 +239,8 @@ Duplicate property names used to be considered a {{jsxref("SyntaxError")}} in st
 const o = { p: 1, p: 2 }; // syntax error prior to ECMAScript 2015
 ```
 
-> **Note:** Making code that used to error become non-errors is always considered backwards-compatible. This is a good part of the language being strict about throwing errors: it leaves room for future semantic changes.
+> [!NOTE]
+> Making code that used to error become non-errors is always considered backwards-compatible. This is a good part of the language being strict about throwing errors: it leaves room for future semantic changes.
 
 ### Simplifying scope management
 

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -314,7 +314,7 @@ In normal template literals, [the escape sequences in string literals](/en-US/do
 - `\u` not followed by `{` and followed by fewer than four hex digits (including none); for example `\uz`
 - `\u{}` enclosing an invalid Unicode code point — it contains a non-hex digit, or its value is greater than `10FFFF`; for example `\u{110000}` and `\u{z}`
 
-> **Note:** `\` followed by other characters, while they may be useless since nothing is escaped, are not syntax errors.
+> [!NOTE] > `\` followed by other characters, while they may be useless since nothing is escaped, are not syntax errors.
 
 However, this is problematic for tagged templates, which, in addition to the "cooked" literal, also have access to the raw literals (escape sequences are preserved as-is).
 

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -314,7 +314,7 @@ In normal template literals, [the escape sequences in string literals](/en-US/do
 - `\u` not followed by `{` and followed by fewer than four hex digits (including none); for example `\uz`
 - `\u{}` enclosing an invalid Unicode code point — it contains a non-hex digit, or its value is greater than `10FFFF`; for example `\u{110000}` and `\u{z}`
 
-> [!NOTE] > `\` followed by other characters, while they may be useless since nothing is escaped, are not syntax errors.
+> **Note:** `\` followed by other characters, while they may be useless since nothing is escaped, are not syntax errors.
 
 However, this is problematic for tagged templates, which, in addition to the "cooked" literal, also have access to the raw literals (escape sequences are preserved as-is).
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.md
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.md
@@ -208,7 +208,8 @@ export { A as B, C as D, E as F, };
 
 ### Quantifier prefix
 
-> **Note:** The trailing comma in a [quantifier](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers) actually changes its semantics from matching "exactly `n`" to matching "at least `n`".
+> [!NOTE]
+> The trailing comma in a [quantifier](/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Quantifiers) actually changes its semantics from matching "exactly `n`" to matching "at least `n`".
 
 ```js
 /x{2}/; // Exactly 2 occurrences of "x"; equivalent to /xx/


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/javascript/reference' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
