### PR TITLE
Convert noteblocks for web/media folder

### DIFF
--- a/files/en-us/web/media/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -14,7 +14,8 @@ In this article, we will refer to the Video player with captions example. This e
 
 ![Video player with stand controls such as play, stop, volume, and captions on and off. The video playing shows a scene of a man holding a spear-like weapon, and a caption reads "Esta hoja tiene pasado oscuro."](video-player-with-captions.png)
 
-> **Note:** You can find the [source on GitHub](https://github.com/iandevlin/iandevlin.github.io/tree/master/mdn/video-player-with-captions), and also [view the example live](https://iandevlin.github.io/mdn/video-player-with-captions/).
+> [!NOTE]
+> You can find the [source on GitHub](https://github.com/iandevlin/iandevlin.github.io/tree/master/mdn/video-player-with-captions), and also [view the example live](https://iandevlin.github.io/mdn/video-player-with-captions/).
 
 ## HTML and Video Captions
 
@@ -299,7 +300,8 @@ Then this specific 'voice' will be stylable like so:
 }
 ```
 
-> **Note:** Some of the styling of cues with ::cue currently works on Chrome, Opera, and Safari, but not yet on Firefox.
+> [!NOTE]
+> Some of the styling of cues with ::cue currently works on Chrome, Opera, and Safari, but not yet on Firefox.
 
 ## Browser compatibility
 

--- a/files/en-us/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -122,7 +122,7 @@ If we wish to create our own custom player, we may want to provide feedback on h
 const seekableEnd = audio.seekable.end(audio.seekable.length - 1);
 ```
 
-> [!NOTE] > `audio.seekable.end(audio.seekable.length - 1)` actually tells us the end point of the last time range that is seekable (not all seekable media). In practice this is good enough as the browser either enables range requests or it doesn't. If it doesn't then `audio.seekable` will be equivalent to `audio.buffered`, which will give a valid indication of the end of seekable media. If range requests are enabled this value usually becomes the duration of the media almost instantly.
+> **Note:** `audio.seekable.end(audio.seekable.length - 1)` actually tells us the end point of the last time range that is seekable (not all seekable media). In practice this is good enough as the browser either enables range requests or it doesn't. If it doesn't then `audio.seekable` will be equivalent to `audio.buffered`, which will give a valid indication of the end of seekable media. If range requests are enabled this value usually becomes the duration of the media almost instantly.
 
 It is better perhaps to give an indication of how much media has actually downloaded — this what the browser's native players seem to display.
 

--- a/files/en-us/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -102,7 +102,8 @@ This works better with longer pieces of audio or video, but press play and click
 
 ![A simple audio player with play button, seek bar and volume control, with a series of red rectangles beneath it representing time ranges.](bufferedtimeranges.png)
 
-> **Note:** You can see the [timerange code running live on JS Bin](https://jsbin.com/memazaro/1/edit).
+> [!NOTE]
+> You can see the [timerange code running live on JS Bin](https://jsbin.com/memazaro/1/edit).
 
 ## Seekable
 
@@ -121,7 +122,7 @@ If we wish to create our own custom player, we may want to provide feedback on h
 const seekableEnd = audio.seekable.end(audio.seekable.length - 1);
 ```
 
-> **Note:** `audio.seekable.end(audio.seekable.length - 1)` actually tells us the end point of the last time range that is seekable (not all seekable media). In practice this is good enough as the browser either enables range requests or it doesn't. If it doesn't then `audio.seekable` will be equivalent to `audio.buffered`, which will give a valid indication of the end of seekable media. If range requests are enabled this value usually becomes the duration of the media almost instantly.
+> [!NOTE] > `audio.seekable.end(audio.seekable.length - 1)` actually tells us the end point of the last time range that is seekable (not all seekable media). In practice this is good enough as the browser either enables range requests or it doesn't. If it doesn't then `audio.seekable` will be equivalent to `audio.buffered`, which will give a valid indication of the end of seekable media. If range requests are enabled this value usually becomes the duration of the media almost instantly.
 
 It is better perhaps to give an indication of how much media has actually downloaded — this what the browser's native players seem to display.
 
@@ -213,7 +214,8 @@ This should give you results similar to the following, where the light grey bar 
 
 ![A simple audio player with play button, seek bar, and volume control, and a progress bar below the controls. The progress bar has a green portion to show played video and a light grey portion to show how much has been buffered.](bufferedprogress.png)
 
-> **Note:** You can see the [buffering code running live on JS Bin](https://jsbin.com/badimipi/1/edit).
+> [!NOTE]
+> You can see the [buffering code running live on JS Bin](https://jsbin.com/badimipi/1/edit).
 
 ## A quick word about Played
 

--- a/files/en-us/web/media/audio_and_video_delivery/cross-browser_audio_basics/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/cross-browser_audio_basics/index.md
@@ -27,7 +27,8 @@ The code below is an example of a basic audio implementation using HTML5:
 </audio>
 ```
 
-> **Note:** You can also use an MP4 file instead of MP3. MP4 files typically contain [AAC](https://en.wikipedia.org/wiki/Advanced_Audio_Coding) encoded audio. You can use `type="audio/mp4"`. (Currently, browsers that support mp3 also support mp4 audio).
+> [!NOTE]
+> You can also use an MP4 file instead of MP3. MP4 files typically contain [AAC](https://en.wikipedia.org/wiki/Advanced_Audio_Coding) encoded audio. You can use `type="audio/mp4"`. (Currently, browsers that support mp3 also support mp4 audio).
 
 - Here we define an {{ htmlelement("audio") }} element with multiple sources — we do this as not all browsers support the same audio formats. To ensure reasonable coverage, we should specify at least two different formats. The two formats that will give maximum coverage are mp3 and ogg vorbis.
 - We do this using the {{ htmlelement("source") }} element, which takes the attributes `src` and `type`.
@@ -54,7 +55,8 @@ Specifying `autoplay` will cause the audio to start playing as soon as possible 
 <audio autoplay>…</audio>
 ```
 
-> **Note:** This value is often ignored on mobile platforms, and its use is not recommended unless really necessary. Autoplaying audio (and video) is usually really annoying. Plus browsers have policies that will block autoplay entirely in many situations. See the [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) for details.
+> [!NOTE]
+> This value is often ignored on mobile platforms, and its use is not recommended unless really necessary. Autoplaying audio (and video) is usually really annoying. Plus browsers have policies that will block autoplay entirely in many situations. See the [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) for details.
 
 #### loop
 
@@ -72,7 +74,8 @@ If you want the audio to start muted (no volume), add the `muted` attribute.
 <audio muted>…</audio>
 ```
 
-> **Note:** This value is often ignored on mobile platforms.
+> [!NOTE]
+> This value is often ignored on mobile platforms.
 
 #### preload
 
@@ -84,7 +87,8 @@ The `preload` attribute allows you to specify a preference for how the browser p
 2. `metadata`: Download the audio metadata; this is usually the best option, as it allows you to access and display information such as audio length, and allow the browser to work out which audio file it should use.
 3. `auto`: Download the whole audio file as soon as possible. This is generally not a good option unless you can guarantee your users will have a fast network connection.
 
-> **Note:** This value is often ignored on mobile platforms.
+> [!NOTE]
+> This value is often ignored on mobile platforms.
 
 ```html
 <audio preload="auto">…</audio>
@@ -175,7 +179,8 @@ The `pause()` method is used to tell the audio to pause. It takes no parameters.
 audio.pause();
 ```
 
-> **Note:** There is no stop method — to implement a stop function, you'd have to pause the media then set the [`currentTime`](#currenttime) property value to 0.
+> [!NOTE]
+> There is no stop method — to implement a stop function, you'd have to pause the media then set the [`currentTime`](#currenttime) property value to 0.
 
 #### canPlayType
 
@@ -196,7 +201,8 @@ if (audio.canPlayType("audio/mpeg")) {
 
 In practice, we usually check if the result is true or false. Non-empty strings are true.
 
-> **Note:** A very early spec specified that the browser should return `no` instead of an empty string, but thankfully the number of people using older browsers that implement this version of the spec are few and far between.
+> [!NOTE]
+> A very early spec specified that the browser should return `no` instead of an empty string, but thankfully the number of people using older browsers that implement this version of the spec are few and far between.
 
 #### currentTime
 
@@ -556,7 +562,8 @@ There are also a couple of events related to buffering:
 - `seeked`
   - : `seeked` occurs when the `seeking` attribute changes to `false`.
 
-> **Note:** You can read more on [Buffering, Seeking and Time Ranges](/en-US/docs/Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges) elsewhere.
+> [!NOTE]
+> You can read more on [Buffering, Seeking and Time Ranges](/en-US/docs/Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges) elsewhere.
 
 ## See also
 

--- a/files/en-us/web/media/audio_and_video_delivery/cross_browser_video_player/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/cross_browser_video_player/index.md
@@ -233,7 +233,8 @@ video.addEventListener("timeupdate", () => {
 });
 ```
 
-> **Note:** for more information and ideas on progress bars and buffering feedback, read [Media buffering, seeking, and time ranges](/en-US/docs/Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges).
+> [!NOTE]
+> for more information and ideas on progress bars and buffering feedback, read [Media buffering, seeking, and time ranges](/en-US/docs/Web/Media/Audio_and_video_delivery/buffering_seeking_time_ranges).
 
 ### Skip Ahead
 

--- a/files/en-us/web/media/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/index.md
@@ -35,7 +35,8 @@ To deliver video and audio, the general workflow is usually something like this:
 
 The code above will create an audio player that attempts to preload as much audio as possible for smooth playback.
 
-> **Note:** The `preload` attribute may be ignored by some mobile browsers.
+> [!NOTE]
+> The `preload` attribute may be ignored by some mobile browsers.
 
 For further info see [Cross Browser Audio Basics (HTML Audio In Detail)](/en-US/docs/Web/Media/Audio_and_video_delivery/Cross-browser_audio_basics#html_audio_in_detail)
 
@@ -69,7 +70,8 @@ For further info see [Cross Browser Audio Basics (HTML Audio In Detail)](/en-US/
 
 The code above creates a video player of dimensions 640x480 pixels, displaying a poster image until the video is played. We instruct the video to autoplay but to be muted by default.
 
-> **Note:** The `autoplay` attribute may be ignored by some mobile browsers. Also, the autoplay feature can be controversial when misused. It's strongly recommended that you read the [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) to learn how to use autoplay wisely.
+> [!NOTE]
+> The `autoplay` attribute may be ignored by some mobile browsers. Also, the autoplay feature can be controversial when misused. It's strongly recommended that you read the [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) to learn how to use autoplay wisely.
 
 For further info see [\<video> element](/en-US/docs/Web/HTML/Element/video) and [Creating a cross-browser video player](/en-US/docs/Web/Media/Audio_and_video_delivery/cross_browser_video_player).
 
@@ -90,7 +92,8 @@ myAudio.play();
 
 We set the source of the audio depending on the type of audio file the browser supports, then set the play-head 5 seconds in and attempt to play it.
 
-> **Note:** Play will be ignored by most browsers unless issued by a user-initiated event.
+> [!NOTE]
+> Play will be ignored by most browsers unless issued by a user-initiated event.
 
 It's also possible to feed an {{ htmlelement("audio") }} element a base64 encoded WAV file, allowing to generate audio on the fly:
 
@@ -241,7 +244,8 @@ New formats and protocols are being rolled out to facilitate adaptive streaming.
 
 The main formats used for adaptive streaming are [HLS](/en-US/docs/Web/Media/Audio_and_video_delivery/Live_streaming_web_audio_and_video#hls) and [MPEG-DASH](/en-US/docs/Web/Media/Audio_and_video_delivery/Live_streaming_web_audio_and_video#mpeg-dash). MSE has been designed with DASH in mind. MSE defines byte streams according to [ISOBMFF](https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/isobmff-byte-stream-format.html) and [M2TS](https://en.wikipedia.org/wiki/M2ts) (both supported in DASH, the latter supported in HLS). Generally speaking, if you are interested in standards, are looking for flexibility, or wish to support most modern browsers, you are probably better off with DASH.
 
-> **Note:** Currently Safari does not support DASH although dash.js will work on newer versions of Safari scheduled for release with OSX Yosemite.
+> [!NOTE]
+> Currently Safari does not support DASH although dash.js will work on newer versions of Safari scheduled for release with OSX Yosemite.
 
 DASH also provides a number of profiles including simple onDemand profiles that require no preprocessing and splitting up of media files. There are also a number of cloud based services that will convert your media to both HLS and DASH.
 
@@ -523,7 +527,8 @@ A number of audio and video JavaScript libraries exist. The most popular librari
 - [Easy audio capture with the MediaRecorder API](https://hacks.mozilla.org/2014/06/easy-audio-capture-with-the-mediarecorder-api/)
   - : Explains the basics of using the MediaStream Recording API to directly record a media stream.
 
-> **Note:** Firefox OS versions 1.3 and above support the [RTSP](https://en.wikipedia.org/wiki/Real_Time_Streaming_Protocol) protocol for streaming video delivery. A fallback solution for older versions would be to use `<video>` along with a suitable format for Gecko (such as WebM) to serve fallback content. More information will be published on this in good time.
+> [!NOTE]
+> Firefox OS versions 1.3 and above support the [RTSP](https://en.wikipedia.org/wiki/Real_Time_Streaming_Protocol) protocol for streaming video delivery. A fallback solution for older versions would be to use `<video>` along with a suitable format for Gecko (such as WebM) to serve fallback content. More information will be published on this in good time.
 
 ## References
 

--- a/files/en-us/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -109,7 +109,7 @@ Opus is a royalty-free and open format that manages to optimize quality at vario
 
 Currently, Opus is supported by Firefox desktop and mobile as well as the latest versions of desktop Chrome and Opera.
 
-> [!NOTE] > [Opus is a mandatory format](https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-audio-05) for WebRTC browser implementations.
+> **Note:** [Opus is a mandatory format](https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-audio-05) for WebRTC browser implementations.
 
 ### MP3, AAC, Ogg Vorbis
 
@@ -133,7 +133,7 @@ For RTMP transfer you can use the [Nginx RTMP Module](https://github.com/arut/ng
 
 [SHOUTcast](https://en.wikipedia.org/wiki/SHOUTcast) is a cross-platform proprietary technology for streaming media. Developed by Nullsoft, it allows digital audio content in MP3 or AAC format to be broadcast. For web use, SHOUTcast streams are transmitted over HTTP.
 
-> [!NOTE] > [SHOUTcast URLs may require a semicolon to be appended to them](https://stackoverflow.com/questions/2743279/how-could-i-play-a-shoutcast-icecast-stream-using-html5).
+> **Note:** [SHOUTcast URLs may require a semicolon to be appended to them](https://stackoverflow.com/questions/2743279/how-could-i-play-a-shoutcast-icecast-stream-using-html5).
 
 ### Icecast
 

--- a/files/en-us/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -44,7 +44,8 @@ Real Time Messaging Protocol (RTMP) is a proprietary protocol developed by Macro
 
 ### RTSP
 
-> **Note:** Real Time Streaming Protocol (RTSP) controls media sessions between endpoints and is often used together with Real-time Transport Protocol (RTP) and with Real-time Control Protocol (RTCP) for media stream delivery. Using RTP with RTCP allows for adaptive streaming. This is not yet supported natively in most browsers.
+> [!NOTE]
+> Real Time Streaming Protocol (RTSP) controls media sessions between endpoints and is often used together with Real-time Transport Protocol (RTP) and with Real-time Control Protocol (RTCP) for media stream delivery. Using RTP with RTCP allows for adaptive streaming. This is not yet supported natively in most browsers.
 >
 > Some vendors implement propriety transport protocols, such as RealNetworks and their Real Data Transport (RDT).
 
@@ -52,7 +53,8 @@ Real Time Messaging Protocol (RTMP) is a proprietary protocol developed by Macro
 
 RTSP 2.0 is currently in development and is not backward compatible with RTSP 1.0.
 
-> **Warning:** Although the {{ htmlelement("audio") }} and {{ htmlelement("video") }} tags are protocol agnostic, no browser currently supports anything other than HTTP without requiring plugins, although this looks set to change. Protocols other than HTTP may also be subject to blocking from firewalls or proxy servers.
+> [!WARNING]
+> Although the {{ htmlelement("audio") }} and {{ htmlelement("video") }} tags are protocol agnostic, no browser currently supports anything other than HTTP without requiring plugins, although this looks set to change. Protocols other than HTTP may also be subject to blocking from firewalls or proxy servers.
 
 ## Using streaming protocols
 
@@ -72,19 +74,22 @@ For example:
 
 For example, [you could implement MPEG-DASH using JavaScript while offloading the decoding to MSE](https://web.archive.org/web/20170504035455/https://msopentech.com/blog/2014/01/03/streaming_video_player/).
 
-> **Note:** Time Shifting is the process of consuming a live stream sometime after it happened.
+> [!NOTE]
+> Time Shifting is the process of consuming a live stream sometime after it happened.
 
 ## Video Streaming File Formats
 
 A couple of HTTP-based livestreaming video formats are beginning to see support across browsers.
 
-> **Note:** You can find a guide to encoding HLS and MPEG-DASH for use on the web at [Setting up adaptive streaming media sources](/en-US/docs/Web/Media/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources).
+> [!NOTE]
+> You can find a guide to encoding HLS and MPEG-DASH for use on the web at [Setting up adaptive streaming media sources](/en-US/docs/Web/Media/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources).
 
 ### MPEG-DASH
 
 DASH stands for Dynamic Adaptive Streaming over HTTP. It is supported via Media Source Extensions which are used by JavaScript libraries such as [DASH.js](https://github.com/Dash-Industry-Forum/dash.js/). This approach allows us to download chunks of the video stream using XHR and "append" the chunks to the stream that's played by the {{ htmlelement("video") }} element. So for example, if we detect that the network is slow, we can start requesting lower quality (smaller) chunks for the next segment. This technology also allows an advertising segment to be appended/inserted into the stream.
 
-> **Note:** You can also [use WebM with the MPEG DASH adaptive streaming system](https://wiki.webmproject.org/adaptive-streaming/webm-dash-specification).
+> [!NOTE]
+> You can also [use WebM with the MPEG DASH adaptive streaming system](https://wiki.webmproject.org/adaptive-streaming/webm-dash-specification).
 
 ### HLS
 
@@ -104,7 +109,7 @@ Opus is a royalty-free and open format that manages to optimize quality at vario
 
 Currently, Opus is supported by Firefox desktop and mobile as well as the latest versions of desktop Chrome and Opera.
 
-> **Note:** [Opus is a mandatory format](https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-audio-05) for WebRTC browser implementations.
+> [!NOTE] > [Opus is a mandatory format](https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-audio-05) for WebRTC browser implementations.
 
 ### MP3, AAC, Ogg Vorbis
 
@@ -128,13 +133,14 @@ For RTMP transfer you can use the [Nginx RTMP Module](https://github.com/arut/ng
 
 [SHOUTcast](https://en.wikipedia.org/wiki/SHOUTcast) is a cross-platform proprietary technology for streaming media. Developed by Nullsoft, it allows digital audio content in MP3 or AAC format to be broadcast. For web use, SHOUTcast streams are transmitted over HTTP.
 
-> **Note:** [SHOUTcast URLs may require a semicolon to be appended to them](https://stackoverflow.com/questions/2743279/how-could-i-play-a-shoutcast-icecast-stream-using-html5).
+> [!NOTE] > [SHOUTcast URLs may require a semicolon to be appended to them](https://stackoverflow.com/questions/2743279/how-could-i-play-a-shoutcast-icecast-stream-using-html5).
 
 ### Icecast
 
 The [Icecast](https://www.icecast.org/) server is an open source technology for streaming media. Maintained by the [Xiph.org Foundation](https://www.xiph.org/), it streams Ogg Vorbis/Theora as well as MP3 and AAC format via the SHOUTcast protocol.
 
-> **Note:** SHOUTcast and Icecast are among the most established and popular technologies, but there are many [more streaming media systems available](https://en.wikipedia.org/wiki/List_of_streaming_media_systems#Servers).
+> [!NOTE]
+> SHOUTcast and Icecast are among the most established and popular technologies, but there are many [more streaming media systems available](https://en.wikipedia.org/wiki/List_of_streaming_media_systems#Servers).
 
 ### Streaming Services
 

--- a/files/en-us/web/media/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/setting_up_adaptive_streaming_media_sources/index.md
@@ -108,11 +108,14 @@ it might be wise to provide a fallback for browsers that don't yet support MPEG-
 
 A useful piece of software when dealing with MPEG-DASH is [Dash Encoder](https://github.com/slederer/DASHEncoder). This uses [MP4Box](https://github.com/gpac/gpac/wiki/mp4box-dash-opts) to encode media into MPEG-DASH format.
 
-> **Note:** You will need to be comfortable with make files and installing dependencies to get this software up and running.
+> [!NOTE]
+> You will need to be comfortable with make files and installing dependencies to get this software up and running.
 
-> **Note:** Since MPEG-DASH decoding is done partially using JavaScript and MSE files are often grabbed using XHR, keep same origin rules in mind.
+> [!NOTE]
+> Since MPEG-DASH decoding is done partially using JavaScript and MSE files are often grabbed using XHR, keep same origin rules in mind.
 
-> **Note:** If you use WebM you can use the methods shown in this tutorial [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video).
+> [!NOTE]
+> If you use WebM you can use the methods shown in this tutorial [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/Media/DASH_Adaptive_Streaming_for_HTML_5_Video).
 
 Once encoded your file structure may look something like this:
 
@@ -183,7 +186,8 @@ The playlist or `.mpd` file contains XML that explicitly lists where all the var
 
 The MPD file tells the browser where the various pieces of media are located, it also includes metadata such as mimeType and codecs and there are other details such as byte-ranges in there too. Generally these files will be generated for you.
 
-> **Note:** You can also split out your audio and video streams into separate files, which can then be prioritized and served separately depending on bandwidth.
+> [!NOTE]
+> You can also split out your audio and video streams into separate files, which can then be prioritized and served separately depending on bandwidth.
 
 Once you have generated your MPD file you can reference as expected it from within the {{ htmlelement("video") }} element:
 
@@ -202,7 +206,8 @@ it might be wise to provide a fallback:
 </video>
 ```
 
-> **Note:** MPEG-DASH playback relies on [dash.js](https://github.com/Dash-Industry-Forum/dash.js/) and browser support for [Media Source Extensions](https://w3c.github.io/media-source/), see the latest [dash.js reference player](https://reference.dashif.org/dash.js/v4.4.0/samples/dash-if-reference-player/index.html).
+> [!NOTE]
+> MPEG-DASH playback relies on [dash.js](https://github.com/Dash-Industry-Forum/dash.js/) and browser support for [Media Source Extensions](https://w3c.github.io/media-source/), see the latest [dash.js reference player](https://reference.dashif.org/dash.js/v4.4.0/samples/dash-if-reference-player/index.html).
 
 ## HLS Encoding
 
@@ -217,7 +222,8 @@ There are a number of useful tools available for HLS encoding
 - The Stream Segmenter — provided by Apple for Mac platforms — takes a media stream from a local network and splits media into equally sized media files together with an index file.
 - Apple also provides a File Segmenter for Mac — which takes a suitably encoded file, splits it up and produces an index file, in a similar fashion to the Stream Segmenter.
 
-> **Note:** You can find more details about these tools at [Using HTTP Live Streaming](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/UsingHTTPLiveStreaming/UsingHTTPLiveStreaming.html).
+> [!NOTE]
+> You can find more details about these tools at [Using HTTP Live Streaming](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/UsingHTTPLiveStreaming/UsingHTTPLiveStreaming.html).
 
 ### Index Files (Playlists)
 
@@ -241,7 +247,8 @@ http://media.example.com/segment2.ts
 #EXT-X-ENDLIST
 ```
 
-> **Note:** Comprehensive information on how to encode media for Apple's HLS format can be found on [Apple's Developer Pages](https://developer.apple.com/streaming/).
+> [!NOTE]
+> Comprehensive information on how to encode media for Apple's HLS format can be found on [Apple's Developer Pages](https://developer.apple.com/streaming/).
 
 ## See also
 

--- a/files/en-us/web/media/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -54,7 +54,8 @@ As mentioned above, a `data-state` attribute is used in various places for styli
 
 The resultant video player style used here is rather basic — this is intentional, as the purpose is to show how such a video player could be styled and be made responsive.
 
-> **Note:** in some cases some basic CSS is omitted from the code examples here as its use is either obvious or not specifically relevant to styling the video player.
+> [!NOTE]
+> in some cases some basic CSS is omitted from the code examples here as its use is either obvious or not specifically relevant to styling the video player.
 
 ### Basic styling
 

--- a/files/en-us/web/media/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
@@ -61,7 +61,7 @@ window.onload = () => {
 
 Finally, we listen for the `input` event firing on the {{ htmlelement("input") }} element, allowing us to react to the playback rate control being changed.
 
-> [!NOTE] > [Try out this example live](https://jsbin.com/UGIxoJis/1/edit), and try adjusting the playback rate control to see the effect.
+> **Note:** [Try out this example live](https://jsbin.com/UGIxoJis/1/edit), and try adjusting the playback rate control to see the effect.
 
 ## defaultPlaybackRate and ratechange
 

--- a/files/en-us/web/media/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
+++ b/files/en-us/web/media/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
@@ -61,7 +61,7 @@ window.onload = () => {
 
 Finally, we listen for the `input` event firing on the {{ htmlelement("input") }} element, allowing us to react to the playback rate control being changed.
 
-> **Note:** [Try out this example live](https://jsbin.com/UGIxoJis/1/edit), and try adjusting the playback rate control to see the effect.
+> [!NOTE] > [Try out this example live](https://jsbin.com/UGIxoJis/1/edit), and try adjusting the playback rate control to see the effect.
 
 ## defaultPlaybackRate and ratechange
 

--- a/files/en-us/web/media/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/media/audio_and_video_manipulation/index.md
@@ -111,7 +111,8 @@ This is a pretty simple example showing how to manipulate video frames using a c
 
 You can achieve the same result by applying the {{cssxref("filter-function/grayscale", "grayscale()")}} CSS function to the source `<video>` element.
 
-> **Note:** Due to potential security issues if your video is on a different domain than your code, you'll need to enable [CORS (Cross Origin Resource Sharing)](/en-US/docs/Web/HTTP/CORS) on your video server.
+> [!NOTE]
+> Due to potential security issues if your video is on a different domain than your code, you'll need to enable [CORS (Cross Origin Resource Sharing)](/en-US/docs/Web/HTTP/CORS) on your video server.
 
 ### Video and WebGL
 
@@ -119,7 +120,8 @@ You can achieve the same result by applying the {{cssxref("filter-function/grays
 
 {{EmbedGHLiveSample('dom-examples/webgl-examples/tutorial/sample8/index.html', 670, 510) }}
 
-> **Note:** You can find the [source code of this demo on GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) ([see it live](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/) also).
+> [!NOTE]
+> You can find the [source code of this demo on GitHub](https://github.com/mdn/dom-examples/tree/main/webgl-examples/tutorial/sample8) ([see it live](https://mdn.github.io/dom-examples/webgl-examples/tutorial/sample8/) also).
 
 ### Playback rate
 
@@ -189,7 +191,8 @@ window.addEventListener("load", setPlaybackRate);
 
 {{ EmbedLiveSample('Editable_example', 700, 450) }}
 
-> **Note:** Try the [playbackRate example](https://jsbin.com/qomuvefu/2/edit) live.
+> [!NOTE]
+> Try the [playbackRate example](https://jsbin.com/qomuvefu/2/edit) live.
 
 ## Audio manipulation
 
@@ -288,7 +291,8 @@ window.addEventListener("load", setFilter);
 
 {{ EmbedLiveSample('Editable_example_2', 700, 450) }}
 
-> **Note:** unless you have [CORS](/en-US/docs/Web/HTTP/CORS) enabled, to avoid security issues your video should be on the same domain as your code.
+> [!NOTE]
+> unless you have [CORS](/en-US/docs/Web/HTTP/CORS) enabled, to avoid security issues your video should be on the same domain as your code.
 
 #### Common audio filters
 
@@ -303,7 +307,8 @@ These are some common types of audio filter you can apply:
 - Notch: Allows all frequencies through, except for a set of frequencies.
 - All Pass: Allows all frequencies through, but changes the phase relationship between the various frequencies.
 
-> **Note:** See {{domxref("BiquadFilterNode")}} for more information.
+> [!NOTE]
+> See {{domxref("BiquadFilterNode")}} for more information.
 
 ### Convolutions and impulses
 
@@ -341,7 +346,8 @@ source.start(0);
 context.listener.setPosition(0, 0, 0);
 ```
 
-> **Note:** You can find an [example on our GitHub repository](https://github.com/mdn/webaudio-examples/tree/main/panner-node) ([see it live](https://mdn.github.io/webaudio-examples/panner-node/) also).
+> [!NOTE]
+> You can find an [example on our GitHub repository](https://github.com/mdn/webaudio-examples/tree/main/panner-node) ([see it live](https://mdn.github.io/webaudio-examples/panner-node/) also).
 
 ### JavaScript codecs
 
@@ -356,7 +362,8 @@ Libraries currently exist for the following formats:
 - Opus: [Opus.js](https://github.com/audiocogs/opus.js)
 - Vorbis: [vorbis.js](https://github.com/audiocogs/vorbis.js)
 
-> **Note:** At Audiocogs, you can [Try out a few demos](http://audiocogs.org/codecs/); Audiocogs also provides a framework, [Aurora.js](http://audiocogs.org/codecs/), which is intended to help you author your own codecs in JavaScript.
+> [!NOTE]
+> At Audiocogs, you can [Try out a few demos](http://audiocogs.org/codecs/); Audiocogs also provides a framework, [Aurora.js](http://audiocogs.org/codecs/), which is intended to help you author your own codecs in JavaScript.
 
 ## Examples
 

--- a/files/en-us/web/media/autoplay_guide/index.md
+++ b/files/en-us/web/media/autoplay_guide/index.md
@@ -47,7 +47,8 @@ The exact situations that result in blocking, and the specifics of how sites bec
 
 For details, see the autoplay policies for [Google Chrome](https://developer.chrome.com/blog/autoplay/) and [WebKit](https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/).
 
-> **Note:** Put another way, playback of any media that includes audio is generally blocked if the playback is programmatically initiated in a tab which has not yet had any user interaction. Browsers may additionally choose to block under other circumstances.
+> [!NOTE]
+> Put another way, playback of any media that includes audio is generally blocked if the playback is programmatically initiated in a tab which has not yet had any user interaction. Browsers may additionally choose to block under other circumstances.
 
 ## Autoplay of media elements
 
@@ -160,7 +161,8 @@ At this point, your site or app can begin whatever it needs to do that relies up
 
 The term "autoplay" also refers to scenarios in which a script tries to trigger the playback of media that includes audio, outside the context of handling a user input event. This is done by calling the media element's {{domxref("HTMLMediaElement.play", "play()")}} method.
 
-> **Note:** It is strongly recommended that you use the `autoplay` attribute whenever possible, because support for autoplay preferences are more widespread for the `autoplay` attribute than for other means of playing media automatically. It also lets the browser take responsibility for starting playback, letting it optimize the timing of that taking place.
+> [!NOTE]
+> It is strongly recommended that you use the `autoplay` attribute whenever possible, because support for autoplay preferences are more widespread for the `autoplay` attribute than for other means of playing media automatically. It also lets the browser take responsibility for starting playback, letting it optimize the timing of that taking place.
 
 #### Example: Playing video
 
@@ -228,7 +230,8 @@ In addition to the browser-side management and control over autoplay functionali
 
 You can also specify an empty allowlist (`()`) to disable autoplay entirely, `*` to allow autoplay from all domains, or one or more specific origins from which media can be automatically played. These origins are separated by space characters.
 
-> **Note:** The specified Permissions Policy applies to the document and every {{HTMLElement("iframe")}} nested within it, unless those frames include an [`allow`](/en-US/docs/Web/HTML/Element/iframe#allow), which sets a new Permissions Policy for that frame and all frames nested within it.
+> [!NOTE]
+> The specified Permissions Policy applies to the document and every {{HTMLElement("iframe")}} nested within it, unless those frames include an [`allow`](/en-US/docs/Web/HTML/Element/iframe#allow), which sets a new Permissions Policy for that frame and all frames nested within it.
 
 When using the [`allow`](/en-US/docs/Web/HTML/Element/iframe#allow) attribute on an `<iframe>` to specify a Permissions Policy for that frame and its nested frames, you can also specify the value `'src'` to allow autoplay of media only from the same domain as that specified by the frame's [`src`](/en-US/docs/Web/HTML/Element/iframe#src) attribute.
 

--- a/files/en-us/web/media/formats/audio_codecs/index.md
+++ b/files/en-us/web/media/formats/audio_codecs/index.md
@@ -1364,7 +1364,8 @@ For general music playback, the three most likely candidates are MP3, AAC, and V
 
 If you need to minimize latency during music playback, you should strongly consider Opus, which has the lowest range of latencies of the general-purpose codecs (5 ms to 66.5 ms, compared to at least 100 ms for the others).
 
-> **Note:** Compatibility information described here is generally correct as of the time this article was written; however, there may be caveats and exceptions. Be sure to refer to the compatibility tables before committing to a given media format.
+> [!NOTE]
+> Compatibility information described here is generally correct as of the time this article was written; however, there may be caveats and exceptions. Be sure to refer to the compatibility tables before committing to a given media format.
 
 Based on this, AAC is likely your best choice if you can only support one audio format. Of course, if you can provide multiple formats (for example, by using the {{HTMLElement("source")}} element within your {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements), you can avoid many or all of those exceptions.
 
@@ -1384,7 +1385,8 @@ The voice-specific codecs are all inherently very lossy, however, and any sound 
 
 Voice recording and playback usually needs to be low-latency in order to synchronize with video tracks, or in order to avoid cross-talk or other problems. Fortunately, the characteristics that lead to speech codecs being so efficient storage space-wise also make them tend to be very low latency. If you're working with WebRTC, [G.722](#g.722_64_kbps_7_khz_audio_coding), for example, has 4 ms latency (compared with over 100 ms for MP3), and [AMR](#amr_adaptive_multi-rate)'s latency is around 25 ms.
 
-> **Note:** For more about WebRTC and the codecs it can use, see [Codecs used by WebRTC](/en-US/docs/Web/Media/Formats/WebRTC_codecs).
+> [!NOTE]
+> For more about WebRTC and the codecs it can use, see [Codecs used by WebRTC](/en-US/docs/Web/Media/Formats/WebRTC_codecs).
 
 The codecs generally used on the web that are used for voice-only encoding are G.722 and AMR. AMR is a narrowband codec, encoding only the frequencies between 200 Hz and 3,400 Hz at bit rates typically around 7.4 kbps, while G.722 is a wideband codec that expands the audio bandwidth to 50 Hz to 7,000 Hz at much higher bit rates—usually 64 kbps.
 

--- a/files/en-us/web/media/formats/audio_concepts/index.md
+++ b/files/en-us/web/media/formats/audio_concepts/index.md
@@ -52,7 +52,8 @@ There are two types of audio channel. Standard audio channels are used to presen
 
 Monophonic audio has one channel, stereo sound has two channels, 5.1 surround sound has 6 channels (five standard and one LFE), and so forth. Each audio frame is a data record that contains the samples for all of the channels available in an audio signal. The size of an audio frame is calculated by multiplying the sample size in bytes by the number of channels, so a single frame of stereo 16-bit audio is 4 bytes long and a single frame of 5.1 floating-point audio is 24 (4 bytes per sample multiplied by 6 channels).
 
-> **Note:** Some codecs will actually separate the left and right channels, storing them in separate blocks within their data structure. However, an audio frame is always comprised of all of the data for all available channels.
+> [!NOTE]
+> Some codecs will actually separate the left and right channels, storing them in separate blocks within their data structure. However, an audio frame is always comprised of all of the data for all available channels.
 
 The number of frames that comprise a single second of audio varies depending on the sample rate used when recording the sound. Since the sample rate corresponds to the number of "slices" a sound wave is divided into for each second of time, it's sometimes thought of as a frequency (in the sense that it's a description of something that repeats periodically, not in terms of actual audio frequency), and the samples per second measurement therefore uses the [Hertz](https://en.wikipedia.org/wiki/Hertz) as its unit.
 
@@ -91,7 +92,8 @@ At 192 kBps, lower-end networks are already going to be strained just by a singl
 
 To solve this problem, the audio must be made smaller using compression.
 
-> **Note:** Network bandwidth is obviously not the same thing as audio bandwidth, which is discussed in [Sampling audio](#sampling_audio), above.
+> [!NOTE]
+> Network bandwidth is obviously not the same thing as audio bandwidth, which is discussed in [Sampling audio](#sampling_audio), above.
 
 ## Audio compression basics
 
@@ -117,7 +119,8 @@ All of this means there is a fundamental question that has to be asked and answe
 
 If loss of detail and potentially fidelity is unacceptable or undesirable, a **lossless** codec is preferred. On the other hand, if some degree of reduction of audio fidelity is okay, a **lossy** codec can be used. Generally, lossy compression results in significantly smaller output than lossless compression methods; also, many lossy codecs are excellent, with the loss in quality and detail being difficult or even impossible for the average listener to discern.
 
-> **Note:** While a high-quality lossy compression algorithm's effect on sound quality may be difficult for the average person to detect, certain people have exceptionally good hearing, or are particularly adept at noticing the kinds of changes introduced to music by lossy compression techniques.
+> [!NOTE]
+> While a high-quality lossy compression algorithm's effect on sound quality may be difficult for the average person to detect, certain people have exceptionally good hearing, or are particularly adept at noticing the kinds of changes introduced to music by lossy compression techniques.
 
 The majority of audio codecs use some form of lossy compression, because of the better compression ratio those algorithms offer. Whereas lossless compression algorithms usually manage no better than a 40-50% of the size of the original, uncompressed sound data, modern lossy compression algorithms can reduce the size of the audio to between 5-20% of the original size, depending on the complexity of the audio. The vastly superior compression ratios possible with lossy compression usually make it a compelling choice, and adequate or excellent audio quality is possible with well-chosen codec configurations.
 
@@ -143,7 +146,8 @@ Lossy compression algorithms generally use psychoacoustics to determine which co
 
 The type of content being encoded can affect the choice of codec. In particular, the waveform for music is almost always more complex than that of an audio sample that contains only human voices. In addition, the human voice uses a small portion of the range of audio frequencies the human ear can detect.
 
-> **Note:** Telephone networks, which were originally designed specifically to transmit human voices, can only carry audio (or any other kind of signal) in the frequency band from 300 Hz to 3,000 Hz. This doesn't quite cover the entire range of human speech at the low end, but enough of the waveform is available that the human ear and brain compensate easily. This also means that humans are generally acclimated to hearing speech constrained to so narrow an audio bandwidth.
+> [!NOTE]
+> Telephone networks, which were originally designed specifically to transmit human voices, can only carry audio (or any other kind of signal) in the frequency band from 300 Hz to 3,000 Hz. This doesn't quite cover the entire range of human speech at the low end, but enough of the waveform is available that the human ear and brain compensate easily. This also means that humans are generally acclimated to hearing speech constrained to so narrow an audio bandwidth.
 
 Human speech uses a relatively narrow frequency band (around 300 Hz to 18,000 Hz, though the exact range varies from person to person due to factors including gender). In addition, the vast majority of human speech sounds tend to lie between 500 Hz and 3,000 Hz or so, making it possible to drop substantial portions of the overall waveform without compromising the listener's ability to understand the words being said. You can even adjust the audio bandwidth to factor in the pitch of the individual speaker's voice.
 
@@ -163,7 +167,8 @@ On top of simplifying the sound through psychoacoustic analysis, codecs use othe
 
 Importantly, codecs do all the hard work for you. It's why so much engineering and scientific study goes into the creation of new algorithms and codecs. All you need to do is consider the options and your use case, then choose the appropriate codec for your needs.
 
-> **Note:** For a more detailed guide to choosing audio codecs, see [Choosing an audio codec](/en-US/docs/Web/Media/Formats/Audio_codecs#choosing_an_audio_codec).
+> [!NOTE]
+> For a more detailed guide to choosing audio codecs, see [Choosing an audio codec](/en-US/docs/Web/Media/Formats/Audio_codecs#choosing_an_audio_codec).
 
 ## Lossless encoder parameters
 

--- a/files/en-us/web/media/formats/codecs_parameter/index.md
+++ b/files/en-us/web/media/formats/codecs_parameter/index.md
@@ -40,7 +40,8 @@ You can add the `codecs` parameter to the media type. To do so, append a semicol
 
 As is the case with any MIME type parameter, `codecs` must be changed to `codecs*` (note the asterisk character, `*`) if any of the properties of the codec use special characters which must be percent-encoded per {{RFC(2231, "MIME Parameter Value and Encoded Word Extensions", 4)}}. You can use the JavaScript {{jsxref("Global_Objects/encodeURI", "encodeURI()")}} function to encode the parameter list; similarly, you can use {{jsxref("Global_Objects/decodeURI", "decodeURI()")}} to decode a previously encoded parameter list.
 
-> **Note:** When the `codecs` parameter is used, the specified list of codecs must include every codec used for the contents of the file. The list may also contain codecs not present in the file.
+> [!NOTE]
+> When the `codecs` parameter is used, the specified list of codecs must include every codec used for the contents of the file. The list may also contain codecs not present in the file.
 
 ## Codec options by container
 
@@ -63,7 +64,8 @@ The syntax of the `codecs` parameter for AV1 is defined the [AV1 Codec ISO Media
 av01.P.LLT.DD[.M.CCC.cp.tc.mc.F]
 ```
 
-> **Note:** Chromium-based browsers will accept any subset of the optional parameters (rather than all or none, as required by the specification).
+> [!NOTE]
+> Chromium-based browsers will accept any subset of the optional parameters (rather than all or none, as required by the specification).
 
 This codec parameter string's components are described in more detail in the table below. Each component is a fixed number of characters long; if the value is less than that length, it must be padded with leading zeros.
 
@@ -637,7 +639,8 @@ The Audio Object Type is specified as a one or two digit _decimal_ value (unlike
 
 Thus, ER AAC LC, whose Audio Object Type is 17, can be represented using the full `codecs` value `mp4a.40.17`. Single digit values can be given either as one digit (which is the best choice, since it will be the most broadly compatible) or with a leading zero padding it to two digits, such as `mp4a.40.02`.
 
-> **Note:** The specification originally mandated that the Audio Object Type number in the third component be only one decimal digit. However, amendments to the specification over time extended the range of these values well beyond one decimal digit, so now the third parameter may be either one or two digits. Padding values below 10 with a leading `0` is optional. Older implementations of MPEG-4 codecs may not support two-digit values, however, so using a single digit when possible will maximize compatibility.
+> [!NOTE]
+> The specification originally mandated that the Audio Object Type number in the third component be only one decimal digit. However, amendments to the specification over time extended the range of these values well beyond one decimal digit, so now the third parameter may be either one or two digits. Padding values below 10 with a leading `0` is optional. Older implementations of MPEG-4 codecs may not support two-digit values, however, so using a single digit when possible will maximize compatibility.
 
 The Audio Object Types are defined in ISO/IEC 14496-3 subpart 1, section 1.5.1. The table below provides a basic list of the Audio Object Types and in the case of the more common object types provides a list of the profiles supporting it, but you should refer to the specification for details if you need to know more about the inner workings of any given MPEG-4 audio type.
 

--- a/files/en-us/web/media/formats/containers/index.md
+++ b/files/en-us/web/media/formats/containers/index.md
@@ -659,7 +659,7 @@ You can also [add the `codecs` parameter](/en-US/docs/Web/Media/Formats/codecs_p
   </tbody>
 </table>
 
-> **Warning:**
+> [!WARNING]
 > Ogg Opus audio files longer than 12h 35m 39s are truncated and exhibit seeking issues when played on Firefox Linux 64 bit ([Firefox bug 1810378](https://bugzilla.mozilla.org/show_bug.cgi?id=1810378)).
 
 ### QuickTime

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -119,7 +119,8 @@ The image file formats that are most commonly used on the web are listed below.
   </tbody>
 </table>
 
-> **Note:** The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).
+> [!NOTE]
+> The older formats like PNG, JPEG, GIF have poor performance compared to newer formats like WebP and AVIF, but enjoy broader "historical" browser support. The newer image formats are seeing increasing popularity as browsers without support become increasingly irrelevant (i.e. have virtually zero market share).
 
 The following list includes image formats that appear on the web, but which should be avoided for web content (generally this is because either they do not have wide browser support, or because there are better alternatives).
 
@@ -158,9 +159,11 @@ The following list includes image formats that appear on the web, but which shou
   </tbody>
 </table>
 
-> **Note:** The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).
+> [!NOTE]
+> The abbreviation for each image format links to a longer description of the format, its capabilities, and detailed browser compatibility information (including which versions introduced support and specific special features that may have been introduced later).
 
-> **Note:** Safari 11.1 added the ability to use a video format, as an animated gif replacement.
+> [!NOTE]
+> Safari 11.1 added the ability to use a video format, as an animated gif replacement.
 > No other browser supports this.
 > See the [Chromium bug](https://crbug.com/791658), and [Firefox bug](https://bugzil.la/895131) for more information.
 
@@ -279,7 +282,8 @@ They're also commonly used for the animated portions of web browsers' user inter
 
 AV1 Image File Format (AVIF) is a powerful, open source, royalty-free file format that encodes _AV1 bitstreams in the High Efficiency Image File Format (HEIF) container._
 
-> **Note:** AVIF has potential to become the "next big thing" for sharing images in web content.
+> [!NOTE]
+> AVIF has potential to become the "next big thing" for sharing images in web content.
 > It offers state-of-the-art features and performance, without the encumbrance of complicated licensing and patent royalties that have hampered comparable alternatives.
 
 AV1 is a coding format that was originally designed for video transmission over the Internet.
@@ -379,7 +383,8 @@ As support is not yet comprehensive (and has little historical depth) you should
 
 The **BMP** (**Bitmap image**) file type is most prevalent on Windows computers, and is generally used only for special cases in web apps and content.
 
-> **Warning:** You should typically avoid using BMP files for website content.
+> [!WARNING]
+> You should typically avoid using BMP files for website content.
 > The most common form of BMP file represents the data as an uncompressed raster image, resulting in large file sizes compared to png or jpg image types.
 > More efficient BMP formats exist but are not widely used, and rarely supported in web browsers.
 
@@ -603,7 +608,8 @@ Following the directory comes the data for the icons.
 Each icon's data can be either a [BMP](#bmp_bitmap_file) image without the file header, or a complete [PNG](#png_portable_network_graphics) image (including the file header).
 If you use ICO files, you should use the BMP format, as support for PNG inside ICO files wasn't added until Windows Vista and may not be well supported.
 
-> **Warning:** ICO files _should not_ be used in web content.
+> [!WARNING]
+> ICO files _should not_ be used in web content.
 > Additionally, their use for favicons has subsided in favor of using a PNG file and the {{HTMLElement("link")}} element, as described in [Providing icons for different usage contexts](/en-US/docs/Web/HTML/Element/link#providing_icons_for_different_usage_contexts).
 
 <table class="standard-table">
@@ -1225,7 +1231,8 @@ Provide a fallback in either [JPEG](#jpeg_joint_photographic_experts_group_image
   </tbody>
 </table>
 
-> **Note:** On Safari for macOS, WebP support depends on both Safari and macOS versions. You need Safari 14 or later as well as macOS Big Sur (11) or a more recent version.
+> [!NOTE]
+> On Safari for macOS, WebP support depends on both Safari and macOS versions. You need Safari 14 or later as well as macOS Big Sur (11) or a more recent version.
 
 ### XBM (X Window System Bitmap file)
 

--- a/files/en-us/web/media/formats/support_issues/index.md
+++ b/files/en-us/web/media/formats/support_issues/index.md
@@ -34,7 +34,8 @@ Once your image has been converted to progressive form, you can use it as usual.
 
 When using a progressive image, the data is stored in such a way that the browser is able to render a low-quality representation of the image as soon as possible, then update the image as it loads—or after it's finished loading—to present it in full quality.
 
-> **Note:** Progressive (or interlaced) images are inherently slightly larger than the non-progressive versions of the same images. Whether the interlacing will benefit your users is up to you to determine.
+> [!NOTE]
+> Progressive (or interlaced) images are inherently slightly larger than the non-progressive versions of the same images. Whether the interlacing will benefit your users is up to you to determine.
 
 ## Specifying multiple sources
 

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -1880,7 +1880,8 @@ First, let's look at the best options for videos presented on a typical website 
    </video>
    ```
 
-> **Note:** The {{HTMLElement("video")}} element requires a closing `</video>` tag, whether or not you have any {{HTMLElement("source")}} elements inside it.
+> [!NOTE]
+> The {{HTMLElement("video")}} element requires a closing `</video>` tag, whether or not you have any {{HTMLElement("source")}} elements inside it.
 
 ### Recommendations for high-quality video presentation
 

--- a/files/en-us/web/media/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/formats/webrtc_codecs/index.md
@@ -72,7 +72,8 @@ For details on WebRTC-related considerations for each codec, see the sub-section
 
 Complete details of what video codecs and configurations WebRTC is required to support can be found in {{RFC(7742, "WebRTC Video Processing and Codec Requirements")}}. It's worth noting that the RFC covers a variety of video-related requirements, including color spaces (sRGB is the preferred, but not required, default color space), recommendations for webcam processing features (automatic focus, automatic white balance, automatic light level), and so on.
 
-> **Note:** These requirements are for web browsers and other fully-WebRTC compliant products. Non-WebRTC products that are able to communicate with WebRTC to some extent may or may not support these codecs, although they're encouraged to by the specification documents.
+> [!NOTE]
+> These requirements are for web browsers and other fully-WebRTC compliant products. Non-WebRTC products that are able to communicate with WebRTC to some extent may or may not support these codecs, although they're encouraged to by the specification documents.
 
 In addition to the mandatory codecs, some browsers support additional codecs as well. Those are listed in the following table.
 
@@ -205,7 +206,8 @@ See below for more details about any WebRTC-specific considerations that exist f
 
 It's useful to note that {{RFC(7874)}} defines more than a list of audio codecs that a WebRTC-compliant browser must support; it also provides recommendations and requirements for special audio features such as echo cancellation, noise reduction, and audio leveling.
 
-> **Note:** The list above indicates the minimum required set of codecs that all WebRTC-compatible endpoints are required to implement. A given browser may also support other codecs; however, cross-platform and cross-device compatibility may be at risk if you use other codecs without carefully ensuring that support exists in all browsers your users might choose.
+> [!NOTE]
+> The list above indicates the minimum required set of codecs that all WebRTC-compatible endpoints are required to implement. A given browser may also support other codecs; however, cross-platform and cross-device compatibility may be at risk if you use other codecs without carefully ensuring that support exists in all browsers your users might choose.
 
 In addition to the mandatory audio codecs, some browsers support additional codecs as well. Those are listed in the following table.
 
@@ -322,7 +324,8 @@ If no video track is found, we set `codecList` to `null`.
 
 On return, then, `codecList` is either `null` to indicate that no video tracks were found or it's an array of {{domxref("RTCRtpCodecParameters")}} objects, each describing one permitted codec configuration. Of special importance in these objects: the {{domxref("RTCRtpCodecParameters.payloadType", "payloadType")}} property, which is a one-byte value which uniquely identifies the described configuration.
 
-> **Note:** The two methods for obtaining lists of codecs shown here use different output types in their codec lists. Be aware of this when using the results.
+> [!NOTE]
+> The two methods for obtaining lists of codecs shown here use different output types in their codec lists. Be aware of this when using the results.
 
 ### Customizing the codec list
 
@@ -442,7 +445,8 @@ There are a number of factors that come into play when deciding upon a video cod
 
 Before choosing a video codec, make sure you're aware of any licensing requirements around the codec you select; you can find information about possible licensing concerns in our main [guide to video codecs used on the web](/en-US/docs/Web/Media/Formats/Video_codecs). Of the two mandatory codecs for video—VP8 and AVC/H.264—only VP8 is completely free of licensing requirements. If you select AVC, make sure you're; aware of any potential fees you may need to pay; that said, the patent holders have generally said that most typical website developers shouldn't need to worry about paying the license fees, which are typically focused more on the developers of the encoding and decoding software.
 
-> **Warning:** The information here does _not_ constitute legal advice! Be sure to confirm your exposure to liability before making any final decisions where potential exists for licensing issues.
+> [!WARNING]
+> The information here does _not_ constitute legal advice! Be sure to confirm your exposure to liability before making any final decisions where potential exists for licensing issues.
 
 #### Power needs and battery life
 

--- a/files/en-us/web/media/html_media/index.md
+++ b/files/en-us/web/media/html_media/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 The {{Glossary("HTML")}} {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements let you embed audio and video content into a web page. More than that, their underlying interfaces are the key to manipulating and playing back media in general, even offscreen. In this guide, we'll review the media elements and how to use them in HTML content.
 
-> **Note:** This guide is a planned update to integrate content from various scattered places on MDN into one cohesive document or document set. The work is not yet scheduled but hopefully will come soon. For now, some of the key information you may be looking for can be found in our [Learning Area article](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content) on the topic.
+> [!NOTE]
+> This guide is a planned update to integrate content from various scattered places on MDN into one cohesive document or document set. The work is not yet scheduled but hopefully will come soon. For now, some of the key information you may be looking for can be found in our [Learning Area article](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content) on the topic.
 
 We don't have a particularly good guide to using these objects offscreen at this time, although [Audio and video manipulation](/en-US/docs/Web/Media/Audio_and_video_manipulation) may be a good start.
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/media' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
