### PR TITLE
Convert noteblocks for web/svg folder

### DIFF
--- a/files/en-us/web/svg/applying_svg_effects_to_html_content/index.md
+++ b/files/en-us/web/svg/applying_svg_effects_to_html_content/index.md
@@ -10,7 +10,8 @@ Modern browsers support using [SVG](/en-US/docs/Web/SVG) within [CSS](/en-US/doc
 
 You may specify SVG in styles either within the same document or an external style sheet. There are 3 properties you can use: [`mask`](/en-US/docs/Web/CSS/mask), [`clip-path`](/en-US/docs/Web/CSS/clip-path), and [`filter`](/en-US/docs/Web/CSS/filter).
 
-> **Note:** References to SVG in external files must be to the [same origin](/en-US/docs/Web/Security/Same-origin_policy) as the referencing document.
+> [!NOTE]
+> References to SVG in external files must be to the [same origin](/en-US/docs/Web/Security/Same-origin_policy) as the referencing document.
 
 ## Using embedded SVG
 

--- a/files/en-us/web/svg/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/index.md
@@ -88,7 +88,8 @@ As an aside, it's useful to know that namespace prefixes can also be used for el
 </html>
 ```
 
-> **Note:** This is an {{Glossary("XHTML")}} file, not an HTML file. XML namespaces are not valid in HTML. To try this example, you have to save your file as `.xhtml`.
+> [!NOTE]
+> This is an {{Glossary("XHTML")}} file, not an HTML file. XML namespaces are not valid in HTML. To try this example, you have to save your file as `.xhtml`.
 
 Note that because a namespace prefix is used for the `<svg:svg>` element and its child `<svg:circle>`, it wasn't necessary to redeclare the default namespace. In general, it is better to redeclare the default namespace rather than prefix lots of elements in this way.
 

--- a/files/en-us/web/svg/scripting/index.md
+++ b/files/en-us/web/svg/scripting/index.md
@@ -59,13 +59,15 @@ In addition, the {{HTMLElement("iframe")}}, {{HTMLElement("embed")}}, and {{HTML
 
 You can also use `document.getElementById("svg_elem_name").getSVGDocument()`, which gives the same result.
 
-> **Note:** You may find documentation referring to an `SVGDocument` interface. Prior to SVG 2, SVG documents were represented using that interface. However, SVG documents are now represented using the {{domxref("XMLDocument")}} interface instead.
+> [!NOTE]
+> You may find documentation referring to an `SVGDocument` interface. Prior to SVG 2, SVG documents were represented using that interface. However, SVG documents are now represented using the {{domxref("XMLDocument")}} interface instead.
 
 ### Inter-document scripting: calling JavaScript functions
 
 When calling a JavaScript function that resides in the HTML file from an SVG file that is embedded in an HTML document, you should use `parent.functionname()` to reference the function. Although the Adobe SVG viewer plugin allows the use of `functionname()`, it's not the preferred way to do things.
 
-> **Note:** According to the [SVG wiki](https://web.archive.org/web/20100223210744/http://wiki.svg.org/Inter-Document_Communication) the `"parent"` JS variable is broken in Adobe's SVG version 6 preview plugin. The suggested workaround is to use `"top"` instead of `"parent"`. Since it is a beta version of their plugin, we can probably safely ignore this.
+> [!NOTE]
+> According to the [SVG wiki](https://web.archive.org/web/20100223210744/http://wiki.svg.org/Inter-Document_Communication) the `"parent"` JS variable is broken in Adobe's SVG version 6 preview plugin. The suggested workaround is to use `"top"` instead of `"parent"`. Since it is a beta version of their plugin, we can probably safely ignore this.
 
 More information and some examples can be found on the [SVG wiki inter-document scripting page](https://web.archive.org/web/20100223210744/http://wiki.svg.org/Inter-Document_Communication).
 

--- a/files/en-us/web/svg/tutorial/basic_shapes/index.md
+++ b/files/en-us/web/svg/tutorial/basic_shapes/index.md
@@ -37,7 +37,8 @@ The code to generate that image looks something like this:
 </svg>
 ```
 
-> **Note:** The `stroke`, `stroke-width`, and `fill` attributes are explained later in the tutorial.
+> [!NOTE]
+> The `stroke`, `stroke-width`, and `fill` attributes are explained later in the tutorial.
 
 ## Rectangle
 
@@ -125,7 +126,8 @@ A {{SVGElement("polyline")}} is a group of connected straight lines. Since the l
 
 A {{SVGElement("polygon")}} is similar to a {{SVGElement("polyline")}}, in that it is composed of straight line segments connecting a list of points. For polygons though, the path automatically connects the last point with the first, creating a closed shape.
 
-> **Note:** A rectangle is a type of polygon, so a polygon can be used to create a `<rect/>` element that does not have rounded corners.
+> [!NOTE]
+> A rectangle is a type of polygon, so a polygon can be used to create a `<rect/>` element that does not have rounded corners.
 
 ```xml
 <polygon points="50, 160 55, 180 70, 180 60, 190 65, 205 50, 195 35, 205 40, 190 30, 180 45, 180"/>

--- a/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
+++ b/files/en-us/web/svg/tutorial/fills_and_strokes/index.md
@@ -133,7 +133,8 @@ In case of second shape, stroke has been rendered before fill.
 
 In addition to setting attributes on objects, you can also use CSS to style fills and strokes. Not all attributes can be set via CSS. Attributes that deal with painting and filling are usually available, so `fill`, `stroke`, `stroke-dasharray`, etc. can all be set this way, in addition to the gradient and pattern versions of those shown below. Attributes like `width`, `height`, or {{SVGElement("path")}} commands cannot be set through CSS. It's easiest just to test and find out what is available and what isn't.
 
-> **Note:** The [SVG specification](https://www.w3.org/TR/SVG/propidx.html) decides strictly between attributes that are _properties_ and other attributes. The former can be modified with CSS, the latter not.
+> [!NOTE]
+> The [SVG specification](https://www.w3.org/TR/SVG/propidx.html) decides strictly between attributes that are _properties_ and other attributes. The former can be modified with CSS, the latter not.
 
 CSS can be inserted inline with the element via the `style` attribute:
 

--- a/files/en-us/web/svg/tutorial/gradients/index.md
+++ b/files/en-us/web/svg/tutorial/gradients/index.md
@@ -82,7 +82,8 @@ The `<linearGradient>` element also takes several other attributes, which specif
 <linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1"></linearGradient>
 ```
 
-> **Note:** You can also use the `href` attribute on gradients too. When it is used, attributes and stops from one gradient can be included on another. In the above example, you wouldn't have to recreate all the stops in Gradient2.
+> [!NOTE]
+> You can also use the `href` attribute on gradients too. When it is used, attributes and stops from one gradient can be included on another. In the above example, you wouldn't have to recreate all the stops in Gradient2.
 >
 > ```html
 > <linearGradient id="Gradient1">

--- a/files/en-us/web/svg/tutorial/other_content_in_svg/index.md
+++ b/files/en-us/web/svg/tutorial/other_content_in_svg/index.md
@@ -41,7 +41,8 @@ Since SVG is an XML application, you can of course _always_ embed arbitrary XML 
 
 The `foreignObject` element is a good way to embed XHTML in SVG. If you have longer texts, the HTML layout is more suitable and comfortable than the SVG `text` element. Another often cited use case is the embedding of formulas with MathML. For scientific applications of SVG this is a very good way to join both worlds.
 
-> **Note:** Please keep in mind, that the content of the `foreignObject` must be processable by the viewer. A standalone SVG viewer is unlikely to be able to render HTML or MathML.
+> [!NOTE]
+> Please keep in mind, that the content of the `foreignObject` must be processable by the viewer. A standalone SVG viewer is unlikely to be able to render HTML or MathML.
 
 Since the `foreignObject` is an SVG element, you can, like in the case of `image`, use any SVG goodness with it, which then will be applied to its content.
 

--- a/files/en-us/web/svg/tutorial/paths/index.md
+++ b/files/en-us/web/svg/tutorial/paths/index.md
@@ -167,7 +167,8 @@ An example of this syntax is shown below, and in the figure to the left the spec
 
 The other type of Bézier curve, the quadratic curve called with `Q`, is actually a simpler curve than the cubic one. It requires one control point which determines the slope of the curve at both the start point and the end point. It takes two parameters: the control point and the end point of the curve.
 
-> **Note:** The co-ordinate deltas for `q` are both relative to the previous point (that is, `dx` and `dy` are not relative to `dx1` and `dy1`).
+> [!NOTE]
+> The co-ordinate deltas for `q` are both relative to the previous point (that is, `dx` and `dy` are not relative to `dx1` and `dy1`).
 
 ```plain
 Q x1 y1, x y

--- a/files/en-us/web/svg/tutorial/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorial/svg_and_css/index.md
@@ -12,7 +12,8 @@ This page illustrates the application of CSS to the specialized language for cre
 
 Below you'll create a simple demonstration that runs in your SVG-enabled browser.
 
-> **Note:** Elements referenced by {{SVGElement("use")}} elements inherit the styles from that element. So to apply different styles to them you should use [CSS custom properties](/en-US/docs/Web/CSS/CSS_cascading_variables).
+> [!NOTE]
+> Elements referenced by {{SVGElement("use")}} elements inherit the styles from that element. So to apply different styles to them you should use [CSS custom properties](/en-US/docs/Web/CSS/CSS_cascading_variables).
 
 ## Example
 

--- a/files/en-us/web/svg/tutorial/svg_fonts/index.md
+++ b/files/en-us/web/svg/tutorial/svg_fonts/index.md
@@ -10,7 +10,8 @@ page-type: guide
 
 When SVG was specified, support for web fonts was not widespread in browsers. Since accessing the correct font file is, however, crucial for rendering text correctly, a font description technology was added to SVG to provide this ability. It was not meant for compatibility with other formats like [PostScript](https://www.adobe.com/products/postscript.html) or [OTF](https://fonts.google.com/knowledge/glossary/open_type), but rather as a simple means of embedding glyph information into SVG when rendered.
 
-> **Note:** SVG Fonts are currently supported only in Safari and Android Browser.
+> [!NOTE]
+> SVG Fonts are currently supported only in Safari and Android Browser.
 >
 > The functionality was [removed from Chrome 38](https://chromestatus.com/feature/5930075908210688) (and Opera 25) and Firefox [postponed its implementation indefinitely](https://bugzil.la/119490) to concentrate on [WOFF](/en-US/docs/Web/CSS/CSS_fonts/WOFF). Other tools, however, like Batik and parts of Inkscape support SVG font embedding.
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/svg' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
