### PR TITLE
Convert noteblocks for web folder

### DIFF
--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/index.md
@@ -73,7 +73,7 @@ Linking via absolute URLs is not recommended, however. You should host the image
 
 If you did not create the images, you should make sure you have the permission to use them under the conditions of the license they are published under (see [Media assets and licensing](#media_assets_and_licensing) below for more information).
 
-> [!WARNING] > _Never_ point the `src` attribute at an image hosted on someone else's website _without permission_. This is called "hotlinking". It is considered unethical, since someone else would be paying the bandwidth costs for delivering the image when someone visits your page. It also leaves you with no control over the image being removed or replaced with something embarrassing.
+> **Warning:** _Never_ point the `src` attribute at an image hosted on someone else's website _without permission_. This is called "hotlinking". It is considered unethical, since someone else would be paying the bandwidth costs for delivering the image when someone visits your page. It also leaves you with no control over the image being removed or replaced with something embarrassing.
 
 The previous code snippet, either with the absolute or the relative URL, will give us the following result:
 

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -18,7 +18,8 @@ You can use the [Event reference](/en-US/docs/Web/Events#event_index) to find ou
 
 There are two recommended approaches for registering handlers. Event handler code can be made to run when an event is triggered by assigning it to the target element's corresponding _onevent_ property, or by registering the handler as a listener for the element using the {{domxref("EventTarget.addEventListener", "addEventListener()")}} method. In either case the handler will receive an object that conforms to the [`Event` interface](/en-US/docs/Web/API/Event) (or a [derived interface](/en-US/docs/Web/API/Event#introduction)). The main difference is that multiple event handlers can be added (or removed) using the event listener methods.
 
-> **Warning:** A third approach for setting event handlers using HTML onevent attributes is not recommended! They inflate the markup and make it less readable and harder to debug. For more information see [Inline event handlers](/en-US/docs/Learn/JavaScript/Building_blocks/Events#inline_event_handlers_—_dont_use_these).
+> [!WARNING]
+> A third approach for setting event handlers using HTML onevent attributes is not recommended! They inflate the markup and make it less readable and harder to debug. For more information see [Inline event handlers](/en-US/docs/Learn/JavaScript/Building_blocks/Events#inline_event_handlers_—_dont_use_these).
 
 ### Using onevent properties
 
@@ -44,7 +45,8 @@ Note that an object representing the event is passed as the first argument to th
 
 The most flexible way to set an event handler on an element is to use the {{domxref("EventTarget.addEventListener")}} method. This approach allows multiple listeners to be assigned to an element, and for listeners to be _removed_ if needed (using {{domxref("EventTarget.removeEventListener")}}).
 
-> **Note:** The ability to add and remove event handlers allows you to, for example, have the same button performing different actions in different circumstances. In addition, in more complex programs cleaning up old/unused event handlers can improve efficiency.
+> [!NOTE]
+> The ability to add and remove event handlers allows you to, for example, have the same button performing different actions in different circumstances. In addition, in more complex programs cleaning up old/unused event handlers can improve efficiency.
 
 Below we show how a simple `greet()` function can be set as a listener/event handler for the `click` event (you could use a lambda function instead of a named function if desired). Note again that the event is passed as the first argument to the event handler.
 

--- a/files/en-us/web/exslt/exsl/object-type/index.md
+++ b/files/en-us/web/exslt/exsl/object-type/index.md
@@ -8,7 +8,8 @@ page-type: exslt-function
 
 `exsl:object-type()` returns a string that indicates the type of the specified object.
 
-> **Note:** Most [XSLT](/en-US/docs/Web/XSLT) object types can be coerced into each other safely; however, certain coercions to raise error conditions. In particular, treating something that's not a node-set as a node-set will do so. This function lets authors of named templates and extension functions easily provide flexibility in parameter values.
+> [!NOTE]
+> Most [XSLT](/en-US/docs/Web/XSLT) object types can be coerced into each other safely; however, certain coercions to raise error conditions. In particular, treating something that's not a node-set as a node-set will do so. This function lets authors of named templates and extension functions easily provide flexibility in parameter values.
 
 ## Syntax
 

--- a/files/en-us/web/exslt/set/leading/index.md
+++ b/files/en-us/web/exslt/set/leading/index.md
@@ -25,7 +25,8 @@ set:leading(nodeSet1, nodeSet2)
 
 A node-set containing the nodes from `nodeSet1` whose values precede the first node in `nodeSet2`.
 
-> **Note:** If the first node in `nodeSet2` isn't contained in `nodeSet1`, an empty set is returned. If `nodeSet2` is empty, then the result is `nodeSet1`.
+> [!NOTE]
+> If the first node in `nodeSet2` isn't contained in `nodeSet1`, an empty set is returned. If `nodeSet2` is empty, then the result is `nodeSet1`.
 
 ## Specifications
 

--- a/files/en-us/web/exslt/set/trailing/index.md
+++ b/files/en-us/web/exslt/set/trailing/index.md
@@ -25,7 +25,8 @@ set:trailing(nodeSet1, nodeSet2)
 
 A node-set containing the nodes from `nodeSet1` whose values follow the first node in `nodeSet2`.
 
-> **Note:** If the first node in `nodeSet2` isn't contained in `nodeSet1`, an empty set is returned. If `nodeSet2` is empty, then the result is `nodeSet1`.
+> [!NOTE]
+> If the first node in `nodeSet2` isn't contained in `nodeSet1`, an empty set is returned. If `nodeSet2` is empty, then the result is `nodeSet1`.
 
 ## Specifications
 

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -12,7 +12,8 @@ Firefox also supports additional features not in the OpenSearch standard, such a
 
 OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins).
 
-> **Warning:** OpenSearch plugins can't be uploaded anymore on [addons.mozilla.org](https://addons.mozilla.org) (AMO). Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
+> [!WARNING]
+> OpenSearch plugins can't be uploaded anymore on [addons.mozilla.org](https://addons.mozilla.org) (AMO). Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
 
 ## OpenSearch description file
 
@@ -108,7 +109,8 @@ If your site offers multiple search plugins, you can support autodiscovery for t
 
 This way, your site can offer plugins to search by author, or by title.
 
-> **Note:** In Firefox, an icon change in the search box indicates there's a provided search plugin. (See image, the green plus sign.) Thus if a search box is not shown in the user's UI, they will receive _no_ indication. _In general, behavior varies among browsers_.
+> [!NOTE]
+> In Firefox, an icon change in the search box indicates there's a provided search plugin. (See image, the green plus sign.) Thus if a search box is not shown in the user's UI, they will receive _no_ indication. _In general, behavior varies among browsers_.
 
 ## Supporting automatic updates for OpenSearch plugins
 
@@ -122,7 +124,8 @@ For example:
      template="https://example.com/mysearchdescription.xml" />
 ```
 
-> **Note:** At this time, [addons.mozilla.org](https://addons.mozilla.org) (AMO) doesn't support automatic updating of OpenSearch plugins. If you want to put your search plugin on AMO, remove the auto-updating feature before submitting it.
+> [!NOTE]
+> At this time, [addons.mozilla.org](https://addons.mozilla.org) (AMO) doesn't support automatic updating of OpenSearch plugins. If you want to put your search plugin on AMO, remove the auto-updating feature before submitting it.
 
 ## Troubleshooting Tips
 

--- a/files/en-us/web/performance/css_javascript_animation_performance/index.md
+++ b/files/en-us/web/performance/css_javascript_animation_performance/index.md
@@ -21,7 +21,8 @@ In terms of performance, there is no difference between implementing an animatio
 
 The {{domxref("Window.requestAnimationFrame","requestAnimationFrame()")}} API provides an efficient way to make animations in JavaScript. The callback function of the method is called by the browser before the next repaint on each frame. Compared to {{domxref("setTimeout()")}}/{{domxref("setInterval()")}}, which need a specific delay parameter, `requestAnimationFrame()` is much more efficient. Developers can create an animation by changing an element's style each time the loop is called (or updating the Canvas draw, or whatever.)
 
-> **Note:** Like CSS transitions and animations, `requestAnimationFrame()` pauses when the current tab is pushed into the background.
+> [!NOTE]
+> Like CSS transitions and animations, `requestAnimationFrame()` pauses when the current tab is pushed into the background.
 
 For more details read [animating with JavaScript from setInterval to requestAnimationFrame](https://hacks.mozilla.org/2011/08/animating-with-javascript-from-setinterval-to-requestanimationframe/).
 
@@ -176,7 +177,8 @@ To enable the OMTA (Off Main Thread Animation) in Firefox, you can go to _about:
 
 After enabling OMTA, try running the above test again. You should see that the FPS of the CSS animations will now be significantly higher.
 
-> **Note:** In Nightly/Developer Edition, you should see that OMTA is enabled by default, so you might have to do the tests the other way around (test with it enabled first, then disable to test without OMTA.)
+> [!NOTE]
+> In Nightly/Developer Edition, you should see that OMTA is enabled by default, so you might have to do the tests the other way around (test with it enabled first, then disable to test without OMTA.)
 
 ## Summary
 

--- a/files/en-us/web/performance/dns-prefetch/index.md
+++ b/files/en-us/web/performance/dns-prefetch/index.md
@@ -62,7 +62,8 @@ or via the [HTML `<link>` element](/en-US/docs/Web/HTML/Element/link):
 <link rel="preconnect" href="https://fonts.googleapis.com/" crossorigin />
 ```
 
-> **Note:** If a page needs to make connections to many third-party domains, preconnecting them all is counterproductive. The `preconnect` hint is best used for only the most critical connections. For the others, just use `<link rel="dns-prefetch">` to save time on the first step — the DNS lookup.
+> [!NOTE]
+> If a page needs to make connections to many third-party domains, preconnecting them all is counterproductive. The `preconnect` hint is best used for only the most critical connections. For the others, just use `<link rel="dns-prefetch">` to save time on the first step — the DNS lookup.
 
 The logic behind pairing these hints is because support for dns-prefetch is better than support for preconnect. Browsers that don't support preconnect will still get some added benefit by falling back to dns-prefetch. Because this is an HTML feature, it is very fault-tolerant. If a non-supporting browser encounters a dns-prefetch hint—or any other resource hint—your site won't break. You just won't receive the benefits it provides.
 

--- a/files/en-us/web/performance/fundamentals/index.md
+++ b/files/en-us/web/performance/fundamentals/index.md
@@ -32,7 +32,8 @@ Frame rate is important as a "quality of service" metric. Computer displays are 
 
 As your brain infers, motion is not jerky and discrete, but rather "updates" smoothly and continuously. (Strobe lights are fun because they turn that upside down, starving your brain of inputs to create the illusion of discrete reality). On a computer display, a higher frame rate makes for a more faithful imitation of reality.
 
-> **Note:** Humans usually cannot perceive differences in frame rate above 60Hz. That's why most modern electronic displays are designed to refresh at that rate. A television probably looks choppy and unrealistic to a hummingbird, for example.
+> [!NOTE]
+> Humans usually cannot perceive differences in frame rate above 60Hz. That's why most modern electronic displays are designed to refresh at that rate. A television probably looks choppy and unrealistic to a hummingbird, for example.
 
 ### Memory usage
 
@@ -100,7 +101,8 @@ The Web platform is highly dynamic. JavaScript is a dynamically-typed language, 
 
 Another problem that can delay startup is idle time, caused by waiting for responses to requests (like database loads). To avoid this problem, applications should issue requests as early as possible in startup (this is called "front-loading"). Then when the data is needed later, hopefully it's already available and the application doesn't have to wait.
 
-> **Note:** For much more information on improving startup performance, read [Optimizing startup performance](/en-US/docs/Web/Performance/Optimizing_startup_performance).
+> [!NOTE]
+> For much more information on improving startup performance, read [Optimizing startup performance](/en-US/docs/Web/Performance/Optimizing_startup_performance).
 
 On the same note, notice that locally-cached, static resources can be loaded much faster than dynamic data fetched over high-latency, low-bandwidth mobile networks. Network requests should never be on the critical path to early application startup. Local caching/offline apps can be achieved via [Service Workers](/en-US/docs/Web/API/Service_Worker_API). See [Offline and background operation](/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation) for a guide about using service workers for offline and background sync capabilities.
 
@@ -145,7 +147,8 @@ Instead of tweaking absolute positioning and fiddling with all that math yoursel
 
 In addition, transforms give you capabilities you might not otherwise have. Not only can you translate elements in 2D space, but you can transform in three dimensions, skew and rotate, and so forth. Paul Irish has an [in-depth analysis of the benefits of `translate()`](https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/) (2012) from a performance point of view. In general, however, you have the same benefits you get from using CSS animations: you use the right tool for the job and leave the optimization to the browser. You also use an easily extensible way of positioning elements — something that needs a lot of extra code if you simulate translation with `top` and `left` positioning. Another bonus is that this is just like working in a `canvas` element.
 
-> **Note:** You may need to attach a `translateZ(0.1)` transform if you wish to get hardware acceleration on your CSS animations, depending on platform. As noted above, this can improve performance. When overused, it can have memory consumption issues. What you do in this regard is up to you — do some testing and find out what's best for your particular app.
+> [!NOTE]
+> You may need to attach a `translateZ(0.1)` transform if you wish to get hardware acceleration on your CSS animations, depending on platform. As noted above, this can improve performance. When overused, it can have memory consumption issues. What you do in this regard is up to you — do some testing and find out what's best for your particular app.
 
 #### Use `requestAnimationFrame()` instead of `setInterval()`
 
@@ -177,7 +180,8 @@ The [Built-in Gecko Profiler](https://firefox-source-docs.mozilla.org/tools/prof
 
 ![A built-in Gecko profiler windows showing a lot of network information.](gecko-profiler.png)
 
-> **Note:** You can use these tools with the Android browser by running Firefox and enabling [about:debugging](https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/index.html).
+> [!NOTE]
+> You can use these tools with the Android browser by running Firefox and enabling [about:debugging](https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/index.html).
 
 In particular, making dozens or hundreds of network requests takes longer in mobile browsers. Rendering large images and CSS gradients can also take longer. Downloading large files can take longer, even over a fast network, because mobile hardware is sometimes too slow to take advantage of all the available bandwidth. For useful general tips on mobile Web performance, have a look at Maximiliano Firtman's [Mobile Web High Performance](https://www.slideshare.net/firt/mobile-web-high-performance) talk.
 

--- a/files/en-us/web/performance/speculative_loading/index.md
+++ b/files/en-us/web/performance/speculative_loading/index.md
@@ -20,7 +20,8 @@ There are several mechanisms for speculative loading:
 - **Prerendering** goes a step further, and actually renders the content ready to be shown when required. Depending on how this is done, this can result in an instant navigation from old page to new page.
 - **Preconnecting** involves speeding up future loads from a given origin by preemptively performing part or all of the connection handshake (i.e. DNS + TCP + TLS).
 
-> **Note:** The above descriptions are high-level and general. Exactly what browsers will do to achieve prefetching and prerendering depends on the features used. More exact feature descriptions are provided in the [Speculative loading features](#speculative_loading_features) section below.
+> [!NOTE]
+> The above descriptions are high-level and general. Exactly what browsers will do to achieve prefetching and prerendering depends on the features used. More exact feature descriptions are provided in the [Speculative loading features](#speculative_loading_features) section below.
 
 ## How is speculative loading achieved?
 
@@ -64,7 +65,8 @@ For example:
 <link rel="dns-prefetch" href="https://example.com" />
 ```
 
-> **Note:** See [Using dns-prefetch](/en-US/docs/Web/Performance/dns-prefetch) for more details.
+> [!NOTE]
+> See [Using dns-prefetch](/en-US/docs/Web/Performance/dns-prefetch) for more details.
 
 ### `<link rel="preload">`
 
@@ -138,14 +140,16 @@ Would not be accessible from `https://aggregator.example/`.
 
 > **Note:** `<link rel="prefetch">` is functionally equivalent to a {{domxref("Window/fetch", "fetch()")}} call with a `priority: "low"` option set on it, except that the former will generally have an even lower priority, and it will have a [`Sec-Purpose: prefetch`](/en-US/docs/Web/HTTP/Headers/Sec-Purpose) header set on the request.
 
-> **Note:** The fetch request for a `prefetch` operation results in an HTTP Request that includes the HTTP header [`Sec-Purpose: prefetch`](/en-US/docs/Web/HTTP/Headers/Sec-Purpose). A server might use this header to change the cache timeouts for the resources, or perform other special handling.
+> [!NOTE]
+> The fetch request for a `prefetch` operation results in an HTTP Request that includes the HTTP header [`Sec-Purpose: prefetch`](/en-US/docs/Web/HTTP/Headers/Sec-Purpose). A server might use this header to change the cache timeouts for the resources, or perform other special handling.
 > The request will also include the {{HTTPHeader("Sec-Fetch-Dest")}} header with the value set to `empty`.
 > The {{HTTPHeader("Accept")}} header in the request will match the value used for normal navigation requests. This allows the browser to find the matching cached resources following navigation.
 > If a response is returned, it gets cached with the request in the HTTP cache.
 
 ### `<link rel="prerender">` {{deprecated_inline}}{{non-standard_inline}}
 
-> **Note:** This technology was only ever available in Chrome, and is now deprecated. You should use the [Speculation Rules API](/en-US/docs/Web/API/Speculation_Rules_API) instead, which supercedes this.
+> [!NOTE]
+> This technology was only ever available in Chrome, and is now deprecated. You should use the [Speculation Rules API](/en-US/docs/Web/API/Speculation_Rules_API) instead, which supercedes this.
 
 [`<link rel="prerender">`](/en-US/docs/Web/HTML/Attributes/rel/prerender) provides a hint to browsers that the user might need the target resource for the next navigation, and therefore the browser can likely improve performance by prerendering the resource. `prerender` is used for future navigations, same-site only, and as such makes sense for multi-page applications (MPAs), not single-page applications (SPAs).
 

--- a/files/en-us/web/privacy/firefox_tracking_protection/index.md
+++ b/files/en-us/web/privacy/firefox_tracking_protection/index.md
@@ -97,7 +97,8 @@ Instead, you should account for the case when Google Analytics is missing by che
 
 More information about this technique is available at [Google Analytics, Privacy, and Event Tracking](https://hacks.mozilla.org/2016/01/google-analytics-privacy-and-event-tracking/).
 
-> **Note:** Depending on a third party in this way is not a good practice anyway, because then your site can be broken if the third party is slow or unavailable, or if the tracker has been blocked by an add-on.
+> [!NOTE]
+> Depending on a third party in this way is not a good practice anyway, because then your site can be broken if the third party is slow or unavailable, or if the tracker has been blocked by an add-on.
 
 <section id="Quick_links">
 {{ListSubpages("/en-US/docs/Web/Privacy", "2", "0", "0")}}

--- a/files/en-us/web/privacy/index.md
+++ b/files/en-us/web/privacy/index.md
@@ -67,7 +67,8 @@ Modern browsers take steps to help prevent fingerprinting-based attacks by eithe
 
 For example, if a website queries a user's browser for the elapsed time, a comparison of that time to the time reported by the server might be useful as a factor in fingerprinting. Because of this, browsers typically introduce a small amount of variability to timers to make them less useful for identifying the user's system.
 
-> **Note:** See [Fingerprinting](https://web.dev/learn/privacy/fingerprinting/) on web.dev for additional useful information.
+> [!NOTE]
+> See [Fingerprinting](https://web.dev/learn/privacy/fingerprinting/) on web.dev for additional useful information.
 
 ## Privacy features provided by browsers
 
@@ -124,7 +125,8 @@ The ethics of data collection can be broken down into three simple principles:
 - Communicate clearly how you are going to use the data you collect
 - Delete the data once you have finished with it
 
-> **Note:** The tips provided below make for a better, more privacy-aware user experience, but many of them are required by law to comply with regulations, for example the [GDPR](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679&from=EN) in the EU. You should make sure to find out what regulations apply to you in your locale, and what you need to do to comply with them.
+> [!NOTE]
+> The tips provided below make for a better, more privacy-aware user experience, but many of them are required by law to comply with regulations, for example the [GDPR](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679&from=EN) in the EU. You should make sure to find out what regulations apply to you in your locale, and what you need to do to comply with them.
 
 ### Don't collect more data than you need
 
@@ -154,7 +156,8 @@ Earlier on, we mentioned giving users a way to see what data of theirs you have 
 
 Allowing the user to choose when significant portions of data get deleted is very empowering, and builds trust, but there may be some bits of data that you will want to handle deletion of yourself. For example, some data might only be used for a few hours or minutes and then deleted, like data that is used during the administration of a user's session while they are logged in.
 
-> **Note:** The {{httpheader("Clear-Site-Data")}} HTTP response header is very useful for clearing short-lived user data — it instructs the browser to clear out its cache and/or cookies and/or storage (e.g. [Web Storage](/en-US/docs/Web/API/Web_Storage_API) or [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) data). For example, you might get your server to send it along with a "logged out confirmation" page so that once the user is logged out, their data is safely removed.
+> [!NOTE]
+> The {{httpheader("Clear-Site-Data")}} HTTP response header is very useful for clearing short-lived user data — it instructs the browser to clear out its cache and/or cookies and/or storage (e.g. [Web Storage](/en-US/docs/Web/API/Web_Storage_API) or [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) data). For example, you might get your server to send it along with a "logged out confirmation" page so that once the user is logged out, their data is safely removed.
 
 ## Cut down on tracking
 
@@ -173,7 +176,8 @@ Third-party resources are an essential part of modern web development, they prov
 
 It is important to audit all of the third-party resources you use on your site. Make sure you know what data they collect, what requests they make and to whom, and what their privacy policies are. Your carefully designed privacy policy is useless if you use a third-party script that violates it.
 
-> **Note:** There are various tools out there that can help you build up a picture of what requests a site is making, for example the [Request Map Generator](https://requestmap.webperf.tools/).
+> [!NOTE]
+> There are various tools out there that can help you build up a picture of what requests a site is making, for example the [Request Map Generator](https://requestmap.webperf.tools/).
 
 Once you have audited your third-party resources and understand what they are doing, you should then consider their negatives as a trade-off for the value they bring. If a third-party script is free and really useful but collects quite a lot of user data, you could:
 
@@ -194,7 +198,8 @@ The following list provides some tips on how to mitigate privacy risks inherent 
 
 - Use the {{htmlelement("iframe")}} `sandbox` attribute to allow or disallow usage of certain features inside the content embedded in the `<iframe>` — this includes things like downloads, form submissions, modals, and scripting.
 
-> **Note:** See [Third parties](https://web.dev/learn/privacy/third-parties/) over on web.dev for additional useful information on auditing and more.
+> [!NOTE]
+> See [Third parties](https://web.dev/learn/privacy/third-parties/) over on web.dev for additional useful information on auditing and more.
 
 ## Protect user data
 

--- a/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
+++ b/files/en-us/web/privacy/privacy_sandbox/partitioned_cookies/index.md
@@ -32,7 +32,8 @@ Browsers with CHIPS support provide a new attribute for the {{httpheader("Set-Co
 Set-Cookie: __Host-example=34d8g; SameSite=None; Secure; Path=/; Partitioned;
 ```
 
-> **Note:** Partitioned cookies must be set with `Secure`. In addition, you can use the `__Host` prefix when setting partitioned cookies to bind them only to the current domain or subdomain, and this is recommended if you don't need to share cookies between subdomains.
+> [!NOTE]
+> Partitioned cookies must be set with `Secure`. In addition, you can use the `__Host` prefix when setting partitioned cookies to bind them only to the current domain or subdomain, and this is recommended if you don't need to share cookies between subdomains.
 
 With `Partitioned` set, third-party cookies are stored using two keys, the host key and a new **partition key**. The partition key is based on the scheme and {{Glossary("eTLD", "eTLD+1")}} of the top-level URL the browser was visiting when the request was made to the URL endpoint that set the cookie.
 
@@ -42,7 +43,8 @@ Revisiting our example:
 2. The storage key for the cookie would now be `{("https://site-a.example"), ("3rd-party.example")}`.
 3. When the user visits `https://site-b.example`, which also embeds `https://3rd-party.example`, this new embedded instance is no longer able to access the cookie because the partition key doesn't match.
 
-> **Note:** CHIPS is similar to the [state partitioning mechanism](/en-US/docs/Web/Privacy/State_Partitioning) implemented by Firefox. The difference is that state partitioning partitions cookie storage and retrieval into separate cookie jars for each top-level site, without a mechanism to allow opt-in to third-party cookies if desired. As browsers start to phase out third-party cookie usage, there are still valid, non-tracking uses of third-party cookies that need to be permitted while developers begin to handle this change.
+> [!NOTE]
+> CHIPS is similar to the [state partitioning mechanism](/en-US/docs/Web/Privacy/State_Partitioning) implemented by Firefox. The difference is that state partitioning partitions cookie storage and retrieval into separate cookie jars for each top-level site, without a mechanism to allow opt-in to third-party cookies if desired. As browsers start to phase out third-party cookie usage, there are still valid, non-tracking uses of third-party cookies that need to be permitted while developers begin to handle this change.
 
 ## CHIPS and subdomains
 

--- a/files/en-us/web/privacy/redirect_tracking_protection/index.md
+++ b/files/en-us/web/privacy/redirect_tracking_protection/index.md
@@ -45,7 +45,8 @@ Firefox will clear the [following data](https://searchfox.org/mozilla-central/re
 - HTTP Authentication Tokens
 - HTTP Authentication Cache
 
-> **Note:** Even though we're clearing all of this data, we currently only flag origins for clearing when they use cookies or other site storage.
+> [!NOTE]
+> Even though we're clearing all of this data, we currently only flag origins for clearing when they use cookies or other site storage.
 
 Storage clearing ignores origin attributes. This means that storage will be cleared across [containers](https://wiki.mozilla.org/Security/Contextual_Identity_Project/Containers) and isolated storage (i.e. from [First-Party Isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation)).
 

--- a/files/en-us/web/privacy/state_partitioning/index.md
+++ b/files/en-us/web/privacy/state_partitioning/index.md
@@ -107,7 +107,8 @@ data, but they can be
 for cross-site tracking. As such, the following network APIs and caches are
 **permanently** partitioned by the top-level site.
 
-> **Note:** Network Partitioning is permanent. Websites can't
+> [!NOTE]
+> Network Partitioning is permanent. Websites can't
 > control or relax these restrictions.
 
 ### Network APIs
@@ -154,7 +155,8 @@ grant unpartitioned access to cookies automatically to third parties that
 receive user interaction. These heuristics are intended to allow some
 third-party integrations that are common on the web to continue to function.
 
-> **Warning:** Storage access heuristics are a transitional
+> [!WARNING]
+> Storage access heuristics are a transitional
 > feature meant to prevent website breakage. They should not be relied upon
 > for current and future web development.
 
@@ -168,7 +170,8 @@ third-party integrations that are common on the web to continue to function.
   `b.example`, `b.example` is granted
   third-party storage access to `a.example` for 30 days.
 
-> **Note:** For third-parties which abuse these heuristic for
+> [!NOTE]
+> For third-parties which abuse these heuristic for
 > tracking purposes, we may require user interaction with the popup before
 > storage access is granted.
 
@@ -193,7 +196,8 @@ Third-party frames may use
 [Storage Access API](/en-US/docs/Web/API/Storage_Access_API). Once
 granted, the requesting party will gain access to its entire first-party cookies (i.e., the cookies it would have access to if visited as a first-party).
 
-> **Warning:** When storage access is granted there may still
+> [!WARNING]
+> When storage access is granted there may still
 > be references to the partitioned storage. However, sites shouldn't rely on
 > being able to use partitioned and unpartitioned cookies at the same
 > time.
@@ -225,7 +229,8 @@ the [Site Information Panel](https://support.mozilla.org/en-US/kb/site-informati
 
 ### Test Preferences
 
-> **Warning:** Make sure to set these preferences in a separate
+> [!WARNING]
+> Make sure to set these preferences in a separate
 > Firefox profile or reset them after testing.
 
 #### Disable Web Compatibility Features

--- a/files/en-us/web/privacy/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/index.md
@@ -141,7 +141,8 @@ Curious how things will work if a third-party domain on your site were classifie
 4. If the preference does not exist, click "String" and then "+" to create a new preference.
 5. For the preference value enter comma separated origins that you'd like to have classified as trackers. E.g. "example.net,example.org".
 
-> **Warning:** Be sure to remove these entries after you have finished testing.
+> [!WARNING]
+> Be sure to remove these entries after you have finished testing.
 
 ## FAQ
 

--- a/files/en-us/web/privacy/third-party_cookies/index.md
+++ b/files/en-us/web/privacy/third-party_cookies/index.md
@@ -15,7 +15,8 @@ A [cookie](/en-US/docs/Web/HTTP/Cookies) is associated with a particular domain 
 - If the cookie domain and scheme match the current page the user is looking at (the URL shown in the browser's address bar), the cookie is considered to be from the same site as the page, and is referred to as a _first-party cookie_.
 - If the domain and scheme are different, the cookie is not considered to be from the same site, and is referred to as a _third-party cookie_.
 
-> **Note:** Third-party cookies are sometimes referred to as _cross-site cookies_. This is arguably a more accurate name, as _third-party cookies_ imply ownership by a third-party company or organization. However, the behavior and potential issues are the same whether or not you own all the involved sites. For example, a site might access resources such as images from a different domain that they own.
+> [!NOTE]
+> Third-party cookies are sometimes referred to as _cross-site cookies_. This is arguably a more accurate name, as _third-party cookies_ imply ownership by a third-party company or organization. However, the behavior and potential issues are the same whether or not you own all the involved sites. For example, a site might access resources such as images from a different domain that they own.
 
 A first-party cookie may be set when a user first visits a page, follows an internal link to another page on the same site, or requests a resource residing on the same site (for example, an embedded image, web font, or JavaScript file).
 
@@ -56,7 +57,8 @@ Individually, such cases are bad enough, but it gets worse. Third-party servers 
 
 In such cases, third-party cookies are referred to as _tracking cookies_.
 
-> **Note:** User information gained through illegitimate means is also often sold to other third parties, multiplying the problem further.
+> [!NOTE]
+> User information gained through illegitimate means is also often sold to other third parties, multiplying the problem further.
 
 Legislation such as the [General Data Privacy Regulation](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) (GDPR) in the European Union and the [California Consumer Privacy Act](https://www.oag.ca.gov/privacy/ccpa) (CCPA) have helped by making it a legal requirement for companies to be transparent about the cookies they set and the information they collect. Examples include asking customers to opt into such data collection, allowing them to see what data a company holds on them, and delete the data if they wish. However, it is still not always clear to customers how their data is used.
 
@@ -72,7 +74,8 @@ Browser vendors know that users don't like the behavior described above, and as 
 
 It is possible to allow usage of third-party cookies on a case-by-case basis in Firefox via browser settings. In Safari however, control is more limited — you can turn off cross-site tracking prevention, but allowing access to third-party cookies per frame can only be done at the code level, via the [Storage Access API](/en-US/docs/Web/API/Storage_Access_API).
 
-> **Note:** Third-party cookies (or just tracking cookies) may also be blocked by browser extensions.
+> [!NOTE]
+> Third-party cookies (or just tracking cookies) may also be blocked by browser extensions.
 
 Cookie blocking can cause some third-party components (such as social media widgets) not to function as intended. As browsers impose further restrictions on third-party cookies, developers should start to look at ways to reduce their reliance on them: see [Replacing third-party cookies](#replacing_third-party_cookies).
 
@@ -90,7 +93,8 @@ Set-Cookie: widget_session=7yjgj57e4n3d; SameSite=None; Secure; HttpOnly
 
 Note that if `SameSite=None` is set then the `Secure` attribute must also be set — `SameSite=None` requires a _secure context_. In the above example we have also set the `HttpOnly` attribute, to disable JavaScript access to the cookie (e.g. via {{domxref("Document.cookie")}}). Cookies that persist sensitive information should always have the `HttpOnly` attribute set — it would be really insecure to make them available to JavaScript. This precaution helps mitigate cross-site scripting ([XSS](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)) attacks.
 
-> **Note:** Cookies that are used for sensitive information should also have a short [lifetime](/en-US/docs/Web/HTTP/Cookies#removal_defining_the_lifetime_of_a_cookie).
+> [!NOTE]
+> Cookies that are used for sensitive information should also have a short [lifetime](/en-US/docs/Web/HTTP/Cookies#removal_defining_the_lifetime_of_a_cookie).
 
 ### Transitioning from third-party cookies
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -21,7 +21,8 @@ We'll discuss each of these features in this guide. First, though, we'll discuss
 
 For a web app to be promoted for installation by a supporting browser, it needs to meet some technical requirements. We can consider these the minimum requirements for a web app to be a PWA.
 
-> **Note:** While not a requirement for a PWA to be installable, many PWAs use [service workers](/en-US/docs/Web/API/Service_Worker_API) to provide an offline experience.
+> [!NOTE]
+> While not a requirement for a PWA to be installable, many PWAs use [service workers](/en-US/docs/Web/API/Service_Worker_API) to provide an offline experience.
 > See the [CycleTracker: Service workers](/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/Service_workers) tutorial for more information.
 
 ### The web app manifest

--- a/files/en-us/web/progressive_web_apps/guides/offline_and_background_operation/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/offline_and_background_operation/index.md
@@ -120,7 +120,8 @@ self.addEventListener("fetch", (event) => {
 
 This means that in many situations, the web app will function well even if network connectivity is intermittent. From the point of view of the main app code, it is completely transparent: the app just makes network requests and gets responses. Also, because the service worker is in a separate thread, the main app code can stay responsive to user input while resources are fetched and cached.
 
-> **Note:** The strategy described here is just one way a service worker could implement caching. Specifically, in a cache first strategy, we check the cache first before the network, meaning that we are more likely to return a quick response without incurring a network cost, but are more likely to return a stale response.
+> [!NOTE]
+> The strategy described here is just one way a service worker could implement caching. Specifically, in a cache first strategy, we check the cache first before the network, meaning that we are more likely to return a quick response without incurring a network cost, but are more likely to return a stale response.
 >
 > An alternative would be a _network first_ strategy, in which we try to fetch the resource from the server first, and fall back to the cache if the device is offline.
 >

--- a/files/en-us/web/progressive_web_apps/how_to/associate_files_with_your_pwa/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/associate_files_with_your_pwa/index.md
@@ -15,7 +15,8 @@ There are two parts to adding support for file handling:
 - Declare support for certain file types using the [`file_handlers`](/en-US/docs/Web/Manifest/file_handlers) web app manifest member.
 - Handling files using the {{domxref("LaunchQueue")}} interface.
 
-> **Note:** At present this feature is only available on Chromium-based browsers, and only on desktop operating systems.
+> [!NOTE]
+> At present this feature is only available on Chromium-based browsers, and only on desktop operating systems.
 
 ## Declaring support for file types
 

--- a/files/en-us/web/progressive_web_apps/how_to/define_app_icons/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/define_app_icons/index.md
@@ -14,7 +14,8 @@ For example, on Windows, the taskbar can contain icons for both native and PWA a
 
 When creating a PWA, you can define your own set of icons to be used when the app is installed on a device. This article explains how to define your own app icons, which icon sizes to create, and how to make your icons support masking.
 
-> **Note:** The PWA app icon is not the same as the {{glossary("favicon")}} image, which is displayed in places like the browser's address bar. PWAs can have both a favicon and an app icon. To learn more about favicons, see [Adding custom icons to your site](/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_custom_icons_to_your_site).
+> [!NOTE]
+> The PWA app icon is not the same as the {{glossary("favicon")}} image, which is displayed in places like the browser's address bar. PWAs can have both a favicon and an app icon. To learn more about favicons, see [Adding custom icons to your site](/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_custom_icons_to_your_site).
 
 ## Design your icon
 

--- a/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/display_badge_on_app_icon/index.md
@@ -20,7 +20,8 @@ Displaying and updating a badge is done by using the [Badging API](/en-US/docs/W
 
 App badges are only supported when a PWA is installed on its host operating system. Badges appear on the app icon which only exists after the app has been installed.
 
-> **Note:** This article focuses on the {{domxref("Navigator.setAppBadge()")}} and {{domxref("Navigator.clearAppBadge()")}} methods from the Badging API and ignores the `Navigator.setClientBadge` and `Navigator.clearClientBadge`. Although these methods are defined in the [Badging API specification](https://w3c.github.io/badging/) too, they are for displaying badges on documents, not on application icons.
+> [!NOTE]
+> This article focuses on the {{domxref("Navigator.setAppBadge()")}} and {{domxref("Navigator.clearAppBadge()")}} methods from the Badging API and ignores the `Navigator.setClientBadge` and `Navigator.clearClientBadge`. Although these methods are defined in the [Badging API specification](https://w3c.github.io/badging/) too, they are for displaying badges on documents, not on application icons.
 
 ### Desktop support
 

--- a/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
+++ b/files/en-us/web/progressive_web_apps/how_to/trigger_install_prompt/index.md
@@ -6,7 +6,8 @@ page-type: how-to
 
 {{PWASidebar}}
 
-> **Warning:** The technique described here depends on the {{domxref("Window.beforeinstallprompt_event", "beforeinstallprompt")}} event, which is non-standard and currently only implemented in Chromium-based browsers.
+> [!WARNING]
+> The technique described here depends on the {{domxref("Window.beforeinstallprompt_event", "beforeinstallprompt")}} event, which is non-standard and currently only implemented in Chromium-based browsers.
 
 By default, if the user visits your website, and the browser determines that the site is [installable as a PWA](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#installability), then the browser will display some built-in UI — an icon in the URL bar, for example — to install the site. If the user clicks the icon, then the browser shows an install prompt containing, at a minimum, the app's [name](/en-US/docs/Web/Manifest/name) and [icon](/en-US/docs/Web/Manifest/icons). If the user agrees to install the app, then it will be installed.
 

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/secure_connection/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/secure_connection/index.md
@@ -25,7 +25,8 @@ With the `index.html` updated, and the `style.css` housed in the same directory,
 We are viewing our page using the `file://` protocol, which provides a [secure context](/en-US/docs/Web/Security/Secure_Contexts).
 This ensures that the pages can be viewed with the current state of our codebase, and will continue to work as we [add JavaScript functionality](/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/JavaScript_functionality) that requires a secure context.
 
-> **Note:** Serving your app over `https` isn't only good for PWAs, but for all websites as it ensures the information that transits between your web server and the user's browser is encrypted end to end. Several [Web APIs require secure contexts](/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts). Even if you aren't creating installable PWAs, as you add features to any web app, you may run into cases where a secure context is required.
+> [!NOTE]
+> Serving your app over `https` isn't only good for PWAs, but for all websites as it ensures the information that transits between your web server and the user's browser is encrypted end to end. Several [Web APIs require secure contexts](/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts). Even if you aren't creating installable PWAs, as you add features to any web app, you may run into cases where a secure context is required.
 
 While we can view and test most application functionality using the `file://` protocol, we can't use it to test application installation using our [manifest file](/en-US/docs/Web/Progressive_web_apps/Tutorials/CycleTracker/Manifest_file).
 
@@ -45,7 +46,8 @@ There are several {{glossary("IDE")}} extensions and programming-language specif
 
 You can run a local HTTP server using a [VSCode plugin](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server#using_an_extension_in_your_code_editor), which enables running a local server on a single or different port. The [Preview on Web Server extension](https://marketplace.visualstudio.com/items?itemName=yuichinukiyama.vscode-preview-server) for the [VSCode](https://code.visualstudio.com/download) IDE creates a server at the root of the directory currently opened by the editor, with a default port of `8080`. VS Code extensions are configurable. The `previewServer.port` setting is the port number of the web server. The extensions default setting of `8080` can be edited and changed. By default, entering `localhost:8080` in the browser URL bar will load the page.
 
-> **Note:** that the Preview on Web Server extension uses Browsersync. When your development environment is started by this extension, `localhost:3001` provides a user interface for Browsersync, providing an overview of the current server environment.
+> [!NOTE]
+> that the Preview on Web Server extension uses Browsersync. When your development environment is started by this extension, `localhost:3001` provides a user interface for Browsersync, providing an overview of the current server environment.
 
 Learn how to [set up a local testing server](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server) using [Python](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server#using_python) or [local server side language](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server#running_server-side_languages_locally) like PHP.
 
@@ -67,7 +69,8 @@ ws --https
 
 In the above, you may need to prefix the install with `sudo`.
 
-> **Note:** If you are seeking privacy, realize you are building this PWA yourself and it can be installed on your own machine from your own development environment, without ever accessing the Internet. This app has no tracking. It's as private an app as you get.
+> [!NOTE]
+> If you are seeking privacy, realize you are building this PWA yourself and it can be installed on your own machine from your own development environment, without ever accessing the Internet. This app has no tracking. It's as private an app as you get.
 
 ## Secure external server
 

--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/installable_pwas/index.md
@@ -34,7 +34,8 @@ The `js13kpwa.webmanifest` file of the [js13kPWA](https://mdn.github.io/pwa-exam
 <link rel="manifest" href="js13kpwa.webmanifest" />
 ```
 
-> **Note:** many use `manifest.json` for web app manifests as the contents are organized in a JSON structure. However, the `.webmanifest` file format is explicitly mentioned in the [W3C manifest specification](https://w3c.github.io/manifest/), so that's what we'll use here.
+> [!NOTE]
+> Many use `manifest.json` for web app manifests as the contents are organized in a JSON structure. However, the `.webmanifest` file format is explicitly mentioned in the [W3C manifest specification](https://w3c.github.io/manifest/), so that's what we'll use here.
 
 The content of the file looks like this:
 

--- a/files/en-us/web/security/iframe_credentialless/index.md
+++ b/files/en-us/web/security/iframe_credentialless/index.md
@@ -50,7 +50,8 @@ iframeElem.src =
   "https://en.wikipedia.org/wiki/Spectre_(security_vulnerability)";
 ```
 
-> **Note:** The {{domxref("window.credentialless")}} property can be queried by a document embedded in an `<iframe>` to test whether it is being run in a credentialless context. A value of `true` means the embedding `<iframe>` is credentialless.
+> [!NOTE]
+> The {{domxref("window.credentialless")}} property can be queried by a document embedded in an `<iframe>` to test whether it is being run in a credentialless context. A value of `true` means the embedding `<iframe>` is credentialless.
 
 This results in the documents inside the credentialless `<iframe>` being loaded using new, ephemeral contexts — those contexts don't have access to the data associated with their origins; for example [cookies](/en-US/docs/Web/HTTP/Cookies) and [localStorage](/en-US/docs/Web/API/Window/localStorage). The credentialless storage is partitioned out separately with storage keys modified by a nonce ("number used once") value, set once per top-level document. So a cookie set in one credentialless `<iframe>` will be accessible only from other same-origin credentialless `<iframe>`s embedded below the same top-level document.
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -110,7 +110,8 @@ As a general rule, you shouldn't [include sensitive data in URL query strings](h
 
 Use `POST` requests rather than `GET` requests to avoid these issues. Our article [Referer header policy: Privacy and security concerns](/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns) describes in more detail the privacy and security risks associated with the `Referer` header, and offers advice on mitigating those risks.
 
-> **Note:** Steering away from transmitting sensitive data in URLs via `GET` requests can also help protect against {{glossary("CSRF", "cross-site request forgery")}} and [replay attacks](https://en.wikipedia.org/wiki/Replay_attack).
+> [!NOTE]
+> Steering away from transmitting sensitive data in URLs via `GET` requests can also help protect against {{glossary("CSRF", "cross-site request forgery")}} and [replay attacks](https://en.wikipedia.org/wiki/Replay_attack).
 
 ### Enforce usage policies
 
@@ -120,7 +121,8 @@ CSP allows you to add a layer of security by, for example, allowing images or sc
 
 Permissions policy works in a similar way, except that it is more concerned with allowing or blocking access to specific "powerful features" ([as mentioned earlier](#secure_contexts_and_feature_permissions)).
 
-> **Note:** Such policies are very useful to help keep sites secure, especially when you are using a lot of third-party code on your site. However, keep in mind that if you block usage of a feature that a third-party script relies on to work, you may end up breaking your site's functionality.
+> [!NOTE]
+> Such policies are very useful to help keep sites secure, especially when you are using a lot of third-party code on your site. However, keep in mind that if you block usage of a feature that a third-party script relies on to work, you may end up breaking your site's functionality.
 
 ### Maintain data integrity
 

--- a/files/en-us/web/security/mixed_content/index.md
+++ b/files/en-us/web/security/mixed_content/index.md
@@ -29,7 +29,8 @@ Browsers should automatically upgrade requests for upgradable content from HTTP 
 
 This approach ensures that all content in a secure context is either loaded via a secure channel or blocked, which is safer for users than displaying a mix of secure and insecure content, and less disruptive than breaking web pages by blocking absolutely all insecure content.
 
-> **Note:** Earlier versions of the specification divided mixed content into "blockable" and "optionally blockable" categories:
+> [!NOTE]
+> Earlier versions of the specification divided mixed content into "blockable" and "optionally blockable" categories:
 >
 > - Blockable content types, also referred to as "active mixed content", were those that could modify other parts of the web page, such as scripts and stylesheets.
 >   The potential risk if these files are modified is very high, and browsers were required to block them.
@@ -115,7 +116,8 @@ If this code is in a page that is served over HTTPS, saving the link results in 
 
 Browsers are expected to block mixed downloads, and secure sites should not include them.
 
-> **Note:** Browsers commonly block mixed downloads by default, but inform users of the risk and allow them to keep or discard the download.
+> [!NOTE]
+> Browsers commonly block mixed downloads by default, but inform users of the risk and allow them to keep or discard the download.
 
 ## Developer console
 

--- a/files/en-us/web/security/practical_implementation_guides/clickjacking/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/clickjacking/index.md
@@ -31,9 +31,11 @@ The equivalent options for each setting are as follows:
 | `frame-ancestors 'self'`              | `SAMEORIGIN`                    | Allow only same-origin embedding attempts.          |
 | `frame-ancestors https://example.org` | `ALLOWFROM https://example.org` | Allow embedding attempts from the specified domain. |
 
-> **Note:** The `X-Frame-Options: ALLOWFROM https://example.org` syntax is deprecated, and most browsers ignore it. You are recommend to set `DENY` in such cases instead, and/or rely on the CSP equivalent.
+> [!NOTE]
+> The `X-Frame-Options: ALLOWFROM https://example.org` syntax is deprecated, and most browsers ignore it. You are recommend to set `DENY` in such cases instead, and/or rely on the CSP equivalent.
 
-> **Note:** Setting cookies with the [`SameSite`](/en-US/docs/Web/Security/Practical_implementation_guides/Cookies#samesite) directive is also useful in clickjacking cases that rely on the user being authenticated.
+> [!NOTE]
+> Setting cookies with the [`SameSite`](/en-US/docs/Web/Security/Practical_implementation_guides/Cookies#samesite) directive is also useful in clickjacking cases that rely on the user being authenticated.
 
 ## Examples
 

--- a/files/en-us/web/security/practical_implementation_guides/cors/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/cors/index.md
@@ -30,7 +30,8 @@ Allow any site to read the contents of a JavaScript library:
 Access-Control-Allow-Origin: *
 ```
 
-> **Note:** This setting is required for [Subresource integrity](/en-US/docs/Web/Security/Practical_implementation_guides/SRI) to work.
+> [!NOTE]
+> This setting is required for [Subresource integrity](/en-US/docs/Web/Security/Practical_implementation_guides/SRI) to work.
 
 Allow `https://random-dashboard.example.org` to read the returned results of an API:
 

--- a/files/en-us/web/security/practical_implementation_guides/csp/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/csp/index.md
@@ -36,7 +36,8 @@ CSP can also be used to provide granular control over:
 
 ### Steps for implementing CSP
 
-> **Note:** Before implementing any actual CSP with the `Content-Security-Policy` header, you are advised to first test it out using the [`Content-Security-Policy-Report-Only`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only) HTTP header. This allows you to see if any violations would have occurred with that policy. This test requires the use of `report-to`/`report-uri`, as explained below.
+> [!NOTE]
+> Before implementing any actual CSP with the `Content-Security-Policy` header, you are advised to first test it out using the [`Content-Security-Policy-Report-Only`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only) HTTP header. This allows you to see if any violations would have occurred with that policy. This test requires the use of `report-to`/`report-uri`, as explained below.
 
 1. Begin by trying out a policy of `default-src https:`. This is a great first goal because it disables inline code and requires browsers to use HTTPS when loading resources. It will also allow you to start to pinpoint the resources that are failing to load as a result of the policy. [`default-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src) serves as a fallback for the other CSP fetch directives.
 2. Next, start to make the policy more specific, to allow the items you need, while blocking any unwanted items. You could first widen the policy remit with a reasonably locked-down policy such as `default-src 'none'; form-action 'self'; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self';`.

--- a/files/en-us/web/security/practical_implementation_guides/csrf_prevention/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/csrf_prevention/index.md
@@ -23,7 +23,8 @@ When a user visits a page containing the above HTML, the browser will attempt to
 
 There are a variety of CSRF mitigation strategies available. The most common and transparent methods of CSRF mitigation are [`SameSite`](/en-US/docs/Web/HTTP/Cookies#controlling_third-party_cookies_with_samesite) cookies and anti-CSRF tokens.
 
-> **Note:** A Cross-Site Scripting ({{Glossary("Cross-site_scripting", "XSS")}}) vulnerability could overcome any CSRF mitigation techniques you put in place. Make sure to harden your site against both types of attack in tandem. XSS can be guarded against using features such as [Content Security Policy](/en-US/docs/Web/Security/Practical_implementation_guides/CSP) (CSP).
+> [!NOTE]
+> A Cross-Site Scripting ({{Glossary("Cross-site_scripting", "XSS")}}) vulnerability could overcome any CSRF mitigation techniques you put in place. Make sure to harden your site against both types of attack in tandem. XSS can be guarded against using features such as [Content Security Policy](/en-US/docs/Web/Security/Practical_implementation_guides/CSP) (CSP).
 
 ### `SameSite` cookies
 

--- a/files/en-us/web/security/same-origin_policy/index.md
+++ b/files/en-us/web/security/same-origin_policy/index.md
@@ -41,7 +41,8 @@ Note that the [URL specification](https://url.spec.whatwg.org/#origin) states th
 
 ## Changing origin
 
-> **Warning:** The approach described here (using the {{domxref("document.domain")}} setter) is deprecated because it undermines the security protections provided by the same origin policy, and complicates the origin model in browsers, leading to interoperability problems and security bugs.
+> [!WARNING]
+> The approach described here (using the {{domxref("document.domain")}} setter) is deprecated because it undermines the security protections provided by the same origin policy, and complicates the origin model in browsers, leading to interoperability problems and security bugs.
 
 A page may change its own origin, with some limitations. A script can set the value of {{domxref("document.domain")}} to its current domain or a superdomain of its current domain. If set to a superdomain of the current domain, the shorter superdomain is used for same-origin checks.
 
@@ -57,7 +58,8 @@ The port number is checked separately by the browser. Any call to `document.doma
 
 The mechanism has some limitations. For example, it will throw a "`SecurityError`" [`DOMException`](/en-US/docs/Web/API/DOMException) if the [`document-domain`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/document-domain) [`Permissions-Policy`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) is enabled or the document is in a sandboxed [`<iframe>`](/en-US/docs/Web/HTML/Element/iframe), and changing the origin in this way does not affect the origin checks used by many Web APIs (e.g. [`localStorage`](/en-US/docs/Web/API/Window/localStorage), [`indexedDB`](/en-US/docs/Web/API/IndexedDB_API), [`BroadcastChannel`](/en-US/docs/Web/API/BroadcastChannel), [`SharedWorker`](/en-US/docs/Web/API/SharedWorker)). A more exhaustive list of failure cases can be found in [Document.domain > Failures](/en-US/docs/Web/API/Document/domain#failures).
 
-> **Note:** When using `document.domain` to allow a subdomain to access its parent, you need to set `document.domain` to the _same value_ in both the parent domain and the subdomain. This is necessary even if doing so is setting the parent domain back to its original value. Failure to do this may result in permission errors.
+> [!NOTE]
+> When using `document.domain` to allow a subdomain to access its parent, you need to set `document.domain` to the _same value_ in both the parent domain and the subdomain. This is necessary even if doing so is setting the parent domain back to its original value. Failure to do this may result in permission errors.
 
 ## Cross-origin network access
 

--- a/files/en-us/web/security/secure_contexts/index.md
+++ b/files/en-us/web/security/secure_contexts/index.md
@@ -27,7 +27,8 @@ However, it's important to note that if a non-secure context causes a new window
 
 Locally-delivered resources such as those with `http://127.0.0.1` URLs, `http://localhost` and `http://*.localhost` URLs (e.g. `http://dev.whatever.localhost/`), and `file://` URLs are also considered to have been delivered securely.
 
-> **Note:** Firefox 84 and later support `http://localhost` and `http://*.localhost` URLs as trustworthy origins (earlier versions did not, because `localhost` was not guaranteed to map to a local/loopback address).
+> [!NOTE]
+> Firefox 84 and later support `http://localhost` and `http://*.localhost` URLs as trustworthy origins (earlier versions did not, because `localhost` was not guaranteed to map to a local/loopback address).
 
 Resources that are not local, to be considered secure, must meet the following criteria:
 

--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -11,7 +11,8 @@ browser-compat:
 
 **Subresource Integrity** (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a [CDN](/en-US/docs/Glossary/CDN)) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.
 
-> **Note:** For subresource-integrity verification of a resource served from an origin other than the document in which it's embedded, browsers additionally check the resource using [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS), to ensure the origin serving the resource allows it to be shared with the requesting origin.
+> [!NOTE]
+> For subresource-integrity verification of a resource served from an origin other than the document in which it's embedded, browsers additionally check the resource using [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS), to ensure the origin serving the resource allows it to be shared with the requesting origin.
 
 ## How Subresource Integrity helps
 
@@ -25,7 +26,8 @@ You use the Subresource Integrity feature by specifying a base64-encoded cryptog
 
 An `integrity` value begins with at least one string, with each string including a prefix indicating a particular hash algorithm (currently the allowed prefixes are `sha256`, `sha384`, and `sha512`), followed by a dash, and ending with the actual base64-encoded hash.
 
-> **Note:** An **integrity** value may contain multiple hashes separated by whitespace. A resource will be loaded if it matches one of those hashes.
+> [!NOTE]
+> An **integrity** value may contain multiple hashes separated by whitespace. A resource will be loaded if it matches one of those hashes.
 
 Example `integrity` string with base64-encoded sha384 hash:
 
@@ -35,7 +37,8 @@ sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC
 
 So `oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC` is the "hash" part, and the prefix `sha384` indicates that it's a sha384 hash.
 
-> **Note:** An `integrity` value's "hash" part is, strictly speaking, a **_cryptographic_ _digest_** formed by applying a particular hash function to some input (for example, a script or stylesheet file). But it's common to use the shorthand "hash" to mean _cryptographic_ _digest_, so that's what's used in this article.
+> [!NOTE]
+> An `integrity` value's "hash" part is, strictly speaking, a **_cryptographic_ _digest_** formed by applying a particular hash function to some input (for example, a script or stylesheet file). But it's common to use the shorthand "hash" to mean _cryptographic_ _digest_, so that's what's used in this article.
 
 ### Tools for generating SRI hashes
 
@@ -70,7 +73,8 @@ To use that code:
 3. Select the integrity value and right-click to copy it to the Clipboard.
 4. Press any key to dismiss the command box.
 
-> **Note:** If OpenSSL is not installed on your system, visit the [OpenSSL project website](https://www.openssl.org) for information about downloading and installing it. The OpenSSL project does not itself host binary distributions of OpenSSL, but does maintain an informal list of third-party distributions: https://wiki.openssl.org/index.php/Binaries.
+> [!NOTE]
+> If OpenSSL is not installed on your system, visit the [OpenSSL project website](https://www.openssl.org) for information about downloading and installing it. The OpenSSL project does not itself host binary distributions of OpenSSL, but does maintain an informal list of third-party distributions: https://wiki.openssl.org/index.php/Binaries.
 
 #### Using shasum
 
@@ -106,7 +110,8 @@ You can use the following {{HTMLElement("script")}} element to tell a browser th
   crossorigin="anonymous"></script>
 ```
 
-> **Note:** For more details on the purpose of the `crossorigin` attribute, see [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin).
+> [!NOTE]
+> For more details on the purpose of the `crossorigin` attribute, see [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin).
 
 ## How browsers handle Subresource Integrity
 

--- a/files/en-us/web/text_fragments/index.md
+++ b/files/en-us/web/text_fragments/index.md
@@ -70,7 +70,8 @@ Supporting browsers will scroll to and highlight the first text fragment in the 
   Document-Policy: force-load-at-top
   ```
 
-> **Note:** If the provided text fragment does not match any text in the linked document, or if the browser does not support text fragments, the whole text fragment is ignored and the top of the document is linked.
+> [!NOTE]
+> If the provided text fragment does not match any text in the linked document, or if the browser does not support text fragments, the whole text fragment is ignored and the top of the document is linked.
 
 ## Examples
 

--- a/files/en-us/web/xml/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/xml/parsing_and_serializing_xml/index.md
@@ -60,7 +60,8 @@ This code fetches the resource as a text string, then uses {{domxref("DOMParser.
 
 If the document is {{Glossary("HTML")}}, the code shown above will return a {{domxref("Document")}}. If the document is XML, the resulting object is actually an `XMLDocument`. The two types are essentially the same; the difference is largely historical, although differentiating has some practical benefits as well.
 
-> **Note:** There is in fact an {{domxref("HTMLDocument")}} interface as well, but it is not necessarily an independent type. In some browsers it is, while in others it is an alias for the `Document` interface.
+> [!NOTE]
+> There is in fact an {{domxref("HTMLDocument")}} interface as well, but it is not necessarily an independent type. In some browsers it is, while in others it is an alias for the `Document` interface.
 
 ## Serializing an XML document
 

--- a/files/en-us/web/xpath/functions/choose/index.md
+++ b/files/en-us/web/xpath/functions/choose/index.md
@@ -8,7 +8,8 @@ page-type: xpath-function
 
 The `choose` function returns one of the specified objects based on a boolean parameter.
 
-> **Note:** This method should be used instead of `if ()`, which has been deprecated.
+> [!NOTE]
+> This method should be used instead of `if ()`, which has been deprecated.
 
 ## Syntax
 
@@ -29,7 +30,8 @@ choose( boolean, object1, object2 )
 
 If the boolean parameter is true, the first object is returned; otherwise, the second object is returned.
 
-> **Note:** All parameters are evaluated, even the one that's not returned.
+> [!NOTE]
+> All parameters are evaluated, even the one that's not returned.
 
 ## Specifications
 

--- a/files/en-us/web/xpath/index.md
+++ b/files/en-us/web/xpath/index.md
@@ -12,7 +12,8 @@ XPath is mainly used in [XSLT](/en-US/docs/Web/XSLT), but can also be used as a 
 
 XPath uses a path notation (as in URLs) for navigating through the hierarchical structure of an XML document. It uses a non-XML syntax so that it can be used in URIs and XML attribute values.
 
-> **Note:** Support for XPath varies widely; it's supported reasonably well in Firefox (although there are no plans to improve support further), while other browsers implement it to a lesser extent, if at all. If you need a polyfill, you may consider [js-xpath](https://sourceforge.net/projects/js-xpath/files/js-xpath/1.0.0/xpath.js/download) or [wicked-good-xpath](https://github.com/google/wicked-good-xpath).
+> [!NOTE]
+> Support for XPath varies widely; it's supported reasonably well in Firefox (although there are no plans to improve support further), while other browsers implement it to a lesser extent, if at all. If you need a polyfill, you may consider [js-xpath](https://sourceforge.net/projects/js-xpath/files/js-xpath/1.0.0/xpath.js/download) or [wicked-good-xpath](https://github.com/google/wicked-good-xpath).
 
 ## Documentation
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
