### PR TITLE
Convert noteblocks for web/http folder

### DIFF
--- a/files/en-us/web/http/cookies/index.md
+++ b/files/en-us/web/http/cookies/index.md
@@ -89,7 +89,8 @@ You can specify an expiration date or time period after which the cookie should 
 
 - _Session_ cookies — cookies without a `Max-Age` or `Expires` attribute – are deleted when the current session ends. The browser defines when the "current session" ends, and some browsers use _session restoring_ when restarting. This can cause session cookies to last indefinitely.
 
-  > **Note:** If your site authenticates users, it should regenerate and resend session cookies, even ones that already exist, whenever a user authenticates. This approach helps prevent [session fixation attacks](/en-US/docs/Web/Security/Types_of_attacks#session_fixation), where a third-party can reuse a user's session.
+  > [!NOTE]
+  > If your site authenticates users, it should regenerate and resend session cookies, even ones that already exist, whenever a user authenticates. This approach helps prevent [session fixation attacks](/en-US/docs/Web/Security/Types_of_attacks#session_fixation), where a third-party can reuse a user's session.
 
 There are some techniques designed to recreate cookies after they're deleted. These are known as "zombie" cookies. These techniques violate the principles of user [privacy](#privacy_and_tracking) and control, may violate [data privacy regulations](#cookie-related_regulations), and could expose a website using them to legal liability.
 
@@ -193,7 +194,8 @@ The [`SameSite`](/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value)
   Set-Cookie: cart=110045_77895_53420; SameSite=Strict
   ```
 
-  > **Note:** Cookies that are used for sensitive information should also have a short [lifetime](#removal_defining_the_lifetime_of_a_cookie).
+  > [!NOTE]
+  > Cookies that are used for sensitive information should also have a short [lifetime](#removal_defining_the_lifetime_of_a_cookie).
 
 - `Lax` is similar, except the browser also sends the cookie when the user _navigates_ to the cookie's origin site (even if the user is coming from a different site). This is useful for cookies affecting the display of a site — for example you might have partner product information along with an affiliate link on your website. When that link is followed to the partner website, they might want to set a cookie stating that the affiliate link was followed, which displays a reward banner and provides a discount if the product is purchased.
 

--- a/files/en-us/web/http/cross-origin_resource_policy/index.md
+++ b/files/en-us/web/http/cross-origin_resource_policy/index.md
@@ -27,7 +27,8 @@ Web applications set a Cross-Origin Resource Policy via the {{HTTPHeader("Cross-
 
   - : Only requests from the same _{{Glossary("Site")}}_ can read the resource.
 
-    > **Warning:** This is less secure than an {{Glossary("origin")}}. The [algorithm for checking if two origins are same site](https://html.spec.whatwg.org/multipage/origin.html#same-site) is defined in the HTML standard and involves checking the _registrable domain_.
+    > [!WARNING]
+    > This is less secure than an {{Glossary("origin")}}. The [algorithm for checking if two origins are same site](https://html.spec.whatwg.org/multipage/origin.html#same-site) is defined in the HTML standard and involves checking the _registrable domain_.
 
 - `same-origin`
   - : Only requests from the same _{{Glossary("origin")}}_ (i.e. scheme + host + port) can read the resource.

--- a/files/en-us/web/http/headers/attribution-reporting-register-source/index.md
+++ b/files/en-us/web/http/headers/attribution-reporting-register-source/index.md
@@ -63,12 +63,14 @@ Attribution-Reporting-Register-Source: <json-string>
       - : A number equal to or greater than `0`, which controls the amount of [noise added to reports](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports#adding_noise_to_reports). Lower values of epsilon result in more noise and therefore provide greater privacy protection. The maximum and default values will vary across implementations; Chrome for example has a maximum and default value of `14`.
     - `"event_report_window"` {{optional_inline}}
       - : A string representing a time in seconds, after which subsequent triggers won't be attributable to this source for the purpose of producing event-level reports (this is called a **report window**). If not set, the event report window falls back to the `"expiry"` value.
-        > **Note:** If `"event_report_window"` is specified, `"event_report_windows"` cannot be specified, otherwise the source registration will fail.
+        > [!NOTE]
+        > If `"event_report_window"` is specified, `"event_report_windows"` cannot be specified, otherwise the source registration will fail.
     - `"event_report_windows"` {{optional_inline}}
       - : An object representing a series of report windows, starting at `"start_time"`, with reports for this source being delivered after each specified end time in `"end_times"`. This can be used to vary the time of report delivery across multiple reports. If not set, the event report window falls back to the `"expiry"` value. Properties are as follows:
         - `"start_time"` {{optional_inline}}: A non-negative number specifying the start time for the reporting windows. If not specified, it defaults to `0`.
         - `"end_times"`: An array of positive numbers specifying end times for subsequent report windows. The values must be increasing, and greater than `"start_time"`.
-          > **Note:** If `"event_report_windows"` is specified, `"event_report_window"` cannot be specified, otherwise the source registration will fail.
+          > [!NOTE]
+          > If `"event_report_windows"` is specified, `"event_report_window"` cannot be specified, otherwise the source registration will fail.
     - `"expiry"` {{optional_inline}}
       - : A string representing an expiry time in seconds for the attribution source, after which it will no longer be active (i.e. subsequent triggers won't be attributable to this source). The maximum allowable expiry time is 2592000 seconds (30 days), which is also the default value if `"expiry"` is not explicitly set.
     - `"filter_data"` {{optional_inline}}
@@ -81,7 +83,8 @@ Attribution-Reporting-Register-Source: <json-string>
 
       - : An array of 32-bit unsigned integers representing data that describes the different trigger events that could match this source. For example, "user added item to shopping cart" or "user signed up to mailing list" could be actions happening at the trigger site that could match this source and indicate a conversion of some kind that the advertiser is trying to measure. These must be matched against `"trigger_data"` specified in [triggers](/en-US/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Trigger#trigger_data) for event-level attribution to take place. If omitted, `"trigger_data"` defaults to `[0, 1, 2, 3, 4, 5, 6, 7]` for navigation-based sources and `[0, 1]` for event-based (image- or script-based) sources.
 
-        > **Note:** The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
+        > [!NOTE]
+        > The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
 
     - `"trigger_data_matching"` {{optional_inline}}
 
@@ -92,7 +95,8 @@ Attribution-Reporting-Register-Source: <json-string>
 
         `"modulus"` mode exists primarily for backwards compatibility with the API's behavior before `"exact"` was introduced, and as such, you'd be unlikely to use it. It is still useful in particular cases that require a very specific kind of compression resulting in smaller registration headers. This can be required when using complex filtering logic that needs to set different trigger data based on the source type according to the maximum number of source `"trigger_data"` items.
 
-        > **Note:** If `"modulus"` is used, the source's `"trigger_data"` must form a contiguous sequence of integers starting at 0. If the trigger data does not form such a sequence, an error occurs.
+        > [!NOTE]
+        > If `"modulus"` is used, the source's `"trigger_data"` must form a contiguous sequence of integers starting at 0. If the trigger data does not form such a sequence, an error occurs.
 
         If not specified, `"trigger_data_matching"` defaults to `"modulus"`. Again, the reason for this is backwards compatibility: omitting the `"trigger_data_matching"` field needs to result in the same behavior observed before this field was introduced.
 

--- a/files/en-us/web/http/headers/attribution-reporting-register-trigger/index.md
+++ b/files/en-us/web/http/headers/attribution-reporting-register-trigger/index.md
@@ -69,7 +69,8 @@ Attribution-Reporting-Register-Trigger: <json-string>
 
           - : A string representing data that describes the trigger, which is typically used to indicate events such as "user added item to shopping cart" or "user signed up to mailing list". This value will be included in the generated event-level report, if any, although it will be subject to modification based on the attributed source's [`"trigger_data_matching"`](/en-US/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Source#trigger_data_matching) field.
 
-            > **Note:** The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
+            > [!NOTE]
+            > The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
 
         - `"priority"` {{optional_inline}}
           - : A string representing a priority value for the attribution trigger. By default, triggers are attributed to the most recent matching source. For both event-level and summary reports you set a higher priority number to make the trigger match older sources. For example, a value of `2` takes priority over the default value of `1`. See [Report priorities and limits](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports#report_priorities_and_limits) for more information.

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -67,7 +67,8 @@ Authorization: Digest username=<username>,
   - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes) that defines how the credentials are encoded.
     Some of the more common types are (case-insensitive): [`Basic`](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme), `Digest`, `Negotiate` and `AWS4-HMAC-SHA256`.
 
-    > **Note:** For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
+    > [!NOTE]
+    > For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
 
 Other than `<auth-scheme>` the remaining directives are specific to each [authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes).
 Generally you will need to check the relevant specifications for these (keys for a small subset of schemes are listed below).
@@ -78,7 +79,8 @@ Generally you will need to check the relevant specifications for these (keys for
 
   - : The credentials, encoded according to the specified scheme.
 
-    > **Note:** For information about the encoding algorithm, see the examples: below, in {{HTTPHeader("WWW-Authenticate")}}, in [HTTP Authentication](/en-US/docs/Web/HTTP/Authentication), and in the relevant specifications.
+    > [!NOTE]
+    > For information about the encoding algorithm, see the examples: below, in {{HTTPHeader("WWW-Authenticate")}}, in [HTTP Authentication](/en-US/docs/Web/HTTP/Authentication), and in the relevant specifications.
 
 ### Digest
 

--- a/files/en-us/web/http/headers/clear-site-data/index.md
+++ b/files/en-us/web/http/headers/clear-site-data/index.md
@@ -50,7 +50,8 @@ Clear-Site-Data: "*"
 
   - : Indicates that the server wishes to remove all [client hints](/en-US/docs/Web/HTTP/Client_hints) (requested via {{httpheader("Accept-CH")}}) stored for the origin of the response URL.
 
-    > **Note:** In browsers that support the `"clientHints"` data type, client hints are also cleared when the `"cache"`, `"cookies"`, or `"*"` types are specified. `"clientHints"` is therefore only needed when none of those other types are specified.
+    > [!NOTE]
+    > In browsers that support the `"clientHints"` data type, client hints are also cleared when the `"cache"`, `"cookies"`, or `"*"` types are specified. `"clientHints"` is therefore only needed when none of those other types are specified.
 
 - `"cookies"`
   - : Indicates that the server wishes to remove all cookies for the origin of the response URL. HTTP authentication credentials are also cleared out. This affects the entire registered domain, including subdomains. So `https://example.com` as well as `https://stage.example.com`, will have cookies cleared.

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -62,7 +62,8 @@ Content-Security-Policy: frame-ancestors <space separated list of sources>;
     - `mail.example.com:443`: Matches all attempts to access port 443 on mail.example.com.
     - `https://store.example.com`: Matches all attempts to access store.example.com using `https:`.
 
-    > **Warning:** If no URL scheme is specified for a `host-source` and the iframe is loaded from an `https` URL, the URL for the page loading the iframe must also be `https`, per the [Does URL match expression in origin with redirect count?](https://w3c.github.io/webappsec-csp/#match-url-to-source-expression) section of the CSP spec.
+    > [!WARNING]
+    > If no URL scheme is specified for a `host-source` and the iframe is loaded from an `https` URL, the URL for the page loading the iframe must also be `https`, per the [Does URL match expression in origin with redirect count?](https://w3c.github.io/webappsec-csp/#match-url-to-source-expression) section of the CSP spec.
 
 - \<scheme-source>
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -48,7 +48,8 @@ where `<policy-directive>` consists of:
   - : Defines the valid sources for [web workers](/en-US/docs/Web/API/Web_Workers_API) and nested browsing contexts loaded using elements such as
     {{HTMLElement("frame")}} and {{HTMLElement("iframe")}}.
 
-    > **Warning:** Instead of **`child-src`**,
+    > [!WARNING]
+    > Instead of **`child-src`**,
     > if you want to regulate nested browsing contexts and workers,
     > you should use the {{CSP("frame-src")}} and {{CSP("worker-src")}} directives, respectively.
 
@@ -74,7 +75,8 @@ where `<policy-directive>` consists of:
 
   - : Specifies valid sources for the {{HTMLElement("object")}} and {{HTMLElement("embed")}} elements.
 
-    > **Note:** Elements controlled by `object-src` are perhaps
+    > [!NOTE]
+    > Elements controlled by `object-src` are perhaps
     > coincidentally considered legacy HTML elements and are not receiving new standardized
     > features (such as the security attributes `sandbox` or `allow`
     > for `<iframe>`). Therefore it is **recommended** to
@@ -135,7 +137,8 @@ Reporting directives control the reporting process of CSP violations. See also t
     These violation reports consist of {{Glossary("JSON")}} documents sent via an HTTP
     `POST` request to the specified URI.
 
-    > **Warning:** Though the {{CSP("report-to")}} directive is intended
+    > [!WARNING]
+    > Though the {{CSP("report-to")}} directive is intended
     > to replace the deprecated **`report-uri`** directive,
     > {{CSP("report-to")}} is not supported in most browsers yet.
     > So for compatibility with current browsers

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -43,7 +43,8 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
     - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
     - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.
 
-    > **Note:** if a scheme source is missing, the document origin's scheme is used.
+    > [!NOTE]
+    > if a scheme source is missing, the document origin's scheme is used.
     > Secure upgrades are allowed, so if the document is loaded using `https:`, then `example.com` will match `https://example.com` but not `http://example.com`.
     > For more information, see [CSP Level 3](https://www.w3.org/TR/CSP3/#match-url-to-source-list).
 
@@ -74,7 +75,8 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
     See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example.
     Specifying nonce makes a modern browser ignore `'unsafe-inline'` which could still be set for older browsers without nonce support.
 
-    > **Note:** The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
+    > [!NOTE]
+    > The CSP `nonce` source can only be applied to _nonceable_ elements (e.g., as the {{HTMLElement("img")}} element has no `nonce` attribute, there is no way to associate it with this CSP source).
 
 - `'<hash-algorithm>-<base64-value>'`
   - : A sha256, sha384 or sha512 hash of scripts or styles.

--- a/files/en-us/web/http/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/headers/permissions-policy/index.md
@@ -44,7 +44,8 @@ Permissions-Policy: <directive>=<allowlist>
 
     The values `*` and `()` may only be used on their own, while `self` and `src` may be used in combination with one or more origins.
 
-    > **Note:** Directives have a default allowlist, which is always one of `*`, `self`, or `none` for the `Permissions-Policy` HTTP header, and governs the default behavior if they are not explicitly listed in a policy. These are specified on the individual [directive reference pages](#directives). For `<iframe>` `allow` attributes , the default behavior is always `src`.
+    > [!NOTE]
+    > Directives have a default allowlist, which is always one of `*`, `self`, or `none` for the `Permissions-Policy` HTTP header, and governs the default behavior if they are not explicitly listed in a policy. These are specified on the individual [directive reference pages](#directives). For `<iframe>` `allow` attributes , the default behavior is always `src`.
 
 Where supported, you can include wildcards in Permissions Policy origins. This means that instead of having to explicitly specify several different subdomains in an allowlist, you can specify them all in a single origin with a wildcard.
 

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -45,7 +45,8 @@ Proxy-Authorization: <type> <credentials>
     - The resulting string is [base64](/en-US/docs/Glossary/Base64)
       encoded (`YWxhZGRpbjpvcGVuc2VzYW1l`).
 
-    > **Note:** Base64 encoding does not mean encryption or hashing! This
+    > [!NOTE]
+    > Base64 encoding does not mean encryption or hashing! This
     > method is as secure as sending the credentials in clear text (base64 is a
     > reversible encoding). It is preferable to use HTTPS in conjunction with Basic
     > Authentication.

--- a/files/en-us/web/http/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/headers/referrer-policy/index.md
@@ -57,13 +57,15 @@ Referrer-Policy: unsafe-url
 
   - : Send the origin, path, and querystring when performing a same-origin request. For cross-origin requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).
 
-    > **Note:** This is the default policy if no policy is specified, or if the provided value is invalid (see spec revision [November 2020](https://github.com/whatwg/fetch/pull/1066)). Previously the default was `no-referrer-when-downgrade`.
+    > [!NOTE]
+    > This is the default policy if no policy is specified, or if the provided value is invalid (see spec revision [November 2020](https://github.com/whatwg/fetch/pull/1066)). Previously the default was `no-referrer-when-downgrade`.
 
 - `unsafe-url`
 
   - : Send the origin, path, and query string when performing any request, regardless of security.
 
-    > **Warning:** This policy will leak potentially-private information from HTTPS resource URLs to insecure origins. Carefully consider the impact of this setting.
+    > [!WARNING]
+    > This policy will leak potentially-private information from HTTPS resource URLs to insecure origins. Carefully consider the impact of this setting.
 
 ## Integration with HTML
 

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -67,7 +67,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     However, this is not required by the RFC specification.
     The percent-encoding does help to satisfy the requirements of the characters allowed for `<cookie-value>`.
 
-    > **Note:** Some `<cookie-name>` have a specific semantic:
+    > [!NOTE]
+    > Some `<cookie-name>` have a specific semantic:
     >
     > **`__Secure-` prefix**: Cookies with names starting with `__Secure-` (dash is part of the prefix) must be set with the `secure` flag from a secure page (HTTPS).
     >
@@ -95,7 +96,8 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     A session finishes when the client shuts down, after which
     the session cookie is removed.
 
-    > **Warning:** Many web browsers have a _session restore_ feature that will save all tabs and restore them the next time the browser is used. Session cookies will also be restored, as if the browser was never closed.
+    > [!WARNING]
+    > Many web browsers have a _session restore_ feature that will save all tabs and restore them the next time the browser is used. Session cookies will also be restored, as if the browser was never closed.
 
     When an `Expires` date is set, the deadline is relative to the _client_ the cookie is being set on, not the server.
 
@@ -150,15 +152,18 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
         This Set-Cookie was blocked because it had the "SameSite=None" attribute but did not have the "Secure" attribute, which is required in order to use "SameSite=None".
         ```
 
-        > **Note:** A [`Secure`](#secure) cookie is only sent to the server with an encrypted request over the HTTPS protocol. Note that insecure sites (`http:`) can't set cookies with the `Secure` directive, and therefore can't use `SameSite=None`.
+        > [!NOTE]
+        > A [`Secure`](#secure) cookie is only sent to the server with an encrypted request over the HTTPS protocol. Note that insecure sites (`http:`) can't set cookies with the `Secure` directive, and therefore can't use `SameSite=None`.
 
-        > **Warning:** Cookies with the `SameSite=None; Secure` that do not also have the [`Partitioned`](#partitioned) attribute may be blocked in cross-site contexts on future browser versions. This behavior protects user data from cross-site tracking. See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies) and [Third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies).
+        > [!WARNING]
+        > Cookies with the `SameSite=None; Secure` that do not also have the [`Partitioned`](#partitioned) attribute may be blocked in cross-site contexts on future browser versions. This behavior protects user data from cross-site tracking. See [Cookies Having Independent Partitioned State (CHIPS)](/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies) and [Third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies).
 
 - `Secure` {{optional_inline}}
 
   - : Indicates that the cookie is sent to the server only when a request is made with the `https:` scheme (except on localhost), and therefore, is more resistant to [man-in-the-middle](/en-US/docs/Glossary/MitM) attacks.
 
-    > **Note:** Do not assume that `Secure` prevents all access to sensitive information in cookies (session keys, login details, etc.). Cookies with this attribute can still be read/modified either with access to the client's hard disk or from JavaScript if the `HttpOnly` cookie attribute is not set.
+    > [!NOTE]
+    > Do not assume that `Secure` prevents all access to sensitive information in cookies (session keys, login details, etc.). Cookies with this attribute can still be read/modified either with access to the client's hard disk or from JavaScript if the `HttpOnly` cookie attribute is not set.
     >
     > Insecure sites (`http:`) cannot set cookies with the `Secure` attribute (since Chrome 52 and Firefox 52). The `https:` requirements are ignored when the `Secure` attribute is set by localhost (since Chrome 89 and Firefox 75).
 

--- a/files/en-us/web/http/headers/set-login/index.md
+++ b/files/en-us/web/http/headers/set-login/index.md
@@ -43,7 +43,8 @@ Set-Login: status
     - `"logged-in"`: The IdP has at least one user account signed in.
     - `"logged-out"`: All IdP user accounts are currently signed out.
 
-    > **Note:** Browsers should ignore this header if it contains any other value.
+    > [!NOTE]
+    > Browsers should ignore this header if it contains any other value.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -79,7 +79,8 @@ WWW-Authenticate: Basic realm=<realm>, charset="UTF-8"
 
   - : The [Authentication scheme](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). Some of the more common types are (case-insensitive): [`Basic`](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme), `Digest`, `Negotiate` and `AWS4-HMAC-SHA256`.
 
-    > **Note:** For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
+    > [!NOTE]
+    > For more information/options see [HTTP Authentication > Authentication schemes](/en-US/docs/Web/HTTP/Authentication#authentication_schemes)
 
 - **realm=**\<realm> {{optional_inline}}
   - : A string describing a protected area.


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/http' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js).
