### PR TITLE
Convert noteblocks for web/api folder (part 1)

### DIFF
--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -62,7 +62,8 @@ function fetchVideo() {
 }
 ```
 
-> **Note:** When `abort()` is called, the `fetch()` promise rejects with an `Error` of type `DOMException`, with name `AbortError`.
+> [!NOTE]
+> When `abort()` is called, the `fetch()` promise rejects with an `Error` of type `DOMException`, with name `AbortError`.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -54,7 +54,8 @@ function fetchVideo() {
 }
 ```
 
-> **Note:** When `abort()` is called, the `fetch()` promise rejects with an `AbortError`.
+> [!NOTE]
+> When `abort()` is called, the `fetch()` promise rejects with an `AbortError`.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -28,7 +28,8 @@ You can create a new `AbortController` object using the {{domxref("AbortControll
 
 ## Examples
 
-> **Note:** There are additional examples in the {{domxref("AbortSignal")}} reference.
+> [!NOTE]
+> There are additional examples in the {{domxref("AbortSignal")}} reference.
 
 In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 

--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -48,7 +48,8 @@ function fetchVideo() {
 }
 ```
 
-> **Note:** When `abort()` is called, the `fetch()` promise rejects with an `AbortError`.
+> [!NOTE]
+> When `abort()` is called, the `fetch()` promise rejects with an `AbortError`.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/main/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
 

--- a/files/en-us/web/api/abortsignal/abort_static/index.md
+++ b/files/en-us/web/api/abortsignal/abort_static/index.md
@@ -20,7 +20,8 @@ return controller.signal;
 
 This could, for example, be passed to a fetch method in order to run its abort logic (i.e. it may be that code is organized such that the abort logic should be run even if the intended fetch operation has not been started).
 
-> **Note:** The method is similar in purpose to {{JSxRef("Promise.reject")}}.
+> [!NOTE]
+> The method is similar in purpose to {{JSxRef("Promise.reject")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -167,7 +167,8 @@ try {
 }
 ```
 
-> **Note:** Unlike when using {{domxref("AbortSignal/timeout_static", "AbortSignal.timeout()")}}, there is no way to tell whether the final abort was caused by a timeout.
+> [!NOTE]
+> Unlike when using {{domxref("AbortSignal/timeout_static", "AbortSignal.timeout()")}}, there is no way to tell whether the final abort was caused by a timeout.
 
 ### Implementing an abortable API
 

--- a/files/en-us/web/api/abstractrange/index.md
+++ b/files/en-us/web/api/abstractrange/index.md
@@ -9,7 +9,8 @@ browser-compat: api.AbstractRange
 
 The **`AbstractRange`** abstract interface is the base class upon which all {{Glossary("DOM")}} range types are defined. A **range** is an object that indicates the start and end points of a section of content within the document.
 
-> **Note:** As an abstract interface, you will not directly instantiate an object of type `AbstractRange`. Instead, you will use the {{domxref("Range")}} or {{domxref("StaticRange")}} interfaces. To understand the difference between those two interfaces, and how to choose which is appropriate for your needs, consult each interface's documentation.
+> [!NOTE]
+> As an abstract interface, you will not directly instantiate an object of type `AbstractRange`. Instead, you will use the {{domxref("Range")}} or {{domxref("StaticRange")}} interfaces. To understand the difference between those two interfaces, and how to choose which is appropriate for your needs, consult each interface's documentation.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/aesctrparams/index.md
+++ b/files/en-us/web/api/aesctrparams/index.md
@@ -23,7 +23,8 @@ Typically this is achieved by splitting the initial counter block value into two
 
 Essentially: the nonce should ensure that counter blocks are not reused from one message to the next, while the counter should ensure that counter blocks are not reused within a single message.
 
-> **Note:** See [Appendix B of the NIST SP800-38A standard](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf#%5B%7B%22num%22%3A70%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22Fit%22%7D%5D) for more information.
+> [!NOTE]
+> See [Appendix B of the NIST SP800-38A standard](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf#%5B%7B%22num%22%3A70%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22Fit%22%7D%5D) for more information.
 
 ## Instance properties
 

--- a/files/en-us/web/api/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/index.md
@@ -75,7 +75,8 @@ _Inherits methods from its parent, {{domxref("AudioNode")}}_.
 
 ## Examples
 
-> **Note:** See the guide [Visualizations with Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API) for more information on creating audio visualizations.
+> [!NOTE]
+> See the guide [Visualizations with Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API) for more information on creating audio visualizations.
 
 ### Basic usage
 

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -16,7 +16,8 @@ A double, representing the minimum [decibel](https://en.wikipedia.org/wiki/Decib
 
 When getting data from `getByteFrequencyData()`, any frequencies with an amplitude of `minDecibels` or lower will be returned as `0`.
 
-> **Note:** If a value greater than `AnalyserNode.maxDecibels` is set, an `INDEX_SIZE_ERR` exception is thrown.
+> [!NOTE]
+> If a value greater than `AnalyserNode.maxDecibels` is set, an `INDEX_SIZE_ERR` exception is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -18,7 +18,8 @@ If 0 is set, there is no averaging done, whereas a value of 1 means "overlap the
 
 In technical terms, we apply a [Blackman window](https://webaudio.github.io/web-audio-api/#blackman-window) and smooth the values over time. The default value is good enough for most cases.
 
-> **Note:** If a value outside the range 0–1 is set, an `INDEX_SIZE_ERR` exception is thrown.
+> [!NOTE]
+> If a value outside the range 0–1 is set, an `INDEX_SIZE_ERR` exception is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ANGLE_instanced_arrays.drawArraysInstancedANGLE
 
 The **`ANGLE_instanced_arrays.drawArraysInstancedANGLE()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) renders primitives from array data like the {{domxref("WebGLRenderingContext.drawArrays()", "gl.drawArrays()")}} method. In addition, it can execute multiple instances of the range of elements.
 
-> **Note:** When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.drawArraysInstanced()", "gl.drawArraysInstanced()")}} by default.
+> [!NOTE]
+> When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.drawArraysInstanced()", "gl.drawArraysInstanced()")}} by default.
 
 ## Syntax
 

--- a/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ANGLE_instanced_arrays.drawElementsInstancedANGLE
 
 The **`ANGLE_instanced_arrays.drawElementsInstancedANGLE()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) renders primitives from array data like the {{domxref("WebGLRenderingContext.drawElements()", "gl.drawElements()")}} method. In addition, it can execute multiple instances of a set of elements.
 
-> **Note:** When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.drawElementsInstanced()", "gl.drawElementsInstanced()")}} by default.
+> [!NOTE]
+> When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.drawElementsInstanced()", "gl.drawElementsInstanced()")}} by default.
 
 ## Syntax
 

--- a/files/en-us/web/api/angle_instanced_arrays/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/index.md
@@ -11,7 +11,8 @@ The **`ANGLE_instanced_arrays`** extension is part of the [WebGL API](/en-US/doc
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "`ANGLE`" suffix.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "`ANGLE`" suffix.
 >
 > Despite the name "ANGLE", this extension works on any device if the hardware supports it and not just on Windows when using the ANGLE library. "ANGLE" just indicates that this extension has been written by the ANGLE library authors.
 
@@ -37,7 +38,8 @@ This extension exposes three new methods.
 
 The following example shows how to draw a given geometry multiple times with a single draw call.
 
-> **Warning:** The following is educational, not production level code. It should generally be avoided to construct data / buffers within the rendering loop or right before use.
+> [!WARNING]
+> The following is educational, not production level code. It should generally be avoided to construct data / buffers within the rendering loop or right before use.
 
 ```js
 // enable the extension

--- a/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ANGLE_instanced_arrays.vertexAttribDivisorANGLE
 
 The **ANGLE_instanced_arrays.vertexAttribDivisorANGLE()** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) modifies the rate at which generic vertex attributes advance when rendering multiple instances of primitives with {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()", "ext.drawArraysInstancedANGLE()")}} and {{domxref("ANGLE_instanced_arrays.drawElementsInstancedANGLE()", "ext.drawElementsInstancedANGLE()")}}.
 
-> **Note:** When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.vertexAttribDivisor()", "gl.vertexAttribDivisor()")}} by default.
+> [!NOTE]
+> When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.vertexAttribDivisor()", "gl.vertexAttribDivisor()")}} by default.
 
 ## Syntax
 

--- a/files/en-us/web/api/animation/cancel/index.md
+++ b/files/en-us/web/api/animation/cancel/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Animation.cancel
 
 The Web Animations API's **`cancel()`** method of the {{domxref("Animation")}} interface clears all {{domxref("KeyframeEffect")}}s caused by this animation and aborts its playback.
 
-> **Note:** When an animation is cancelled, its {{domxref("Animation.startTime", "startTime")}} and {{domxref("Animation.currentTime", "currentTime")}} are set to `null`.
+> [!NOTE]
+> When an animation is cancelled, its {{domxref("Animation.startTime", "startTime")}} and {{domxref("Animation.currentTime", "currentTime")}} are set to `null`.
 
 ## Syntax
 

--- a/files/en-us/web/api/animation/cancel_event/index.md
+++ b/files/en-us/web/api/animation/cancel_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Animation.cancel_event
 
 The **`cancel`** event of the {{domxref("Animation")}} interface is fired when the {{domxref("Animation.cancel()")}} method is called or when the animation enters the `"idle"` play state from another state, such as when the animation is removed from an element before it finishes playing.
 
-> **Note:** Creating a new animation that is initially idle does not trigger a `cancel` event on the new animation.
+> [!NOTE]
+> Creating a new animation that is initially idle does not trigger a `cancel` event on the new animation.
 
 ## Syntax
 

--- a/files/en-us/web/api/animation/finish_event/index.md
+++ b/files/en-us/web/api/animation/finish_event/index.md
@@ -12,7 +12,8 @@ The **`finish`** event of the {{domxref("Animation")}} interface is fired when t
 when the {{domxref("Animation.finish()")}} method is called to immediately cause the
 animation to finish up.
 
-> **Note:** The `"paused"` play state supersedes the `"finished"` play
+> [!NOTE]
+> The `"paused"` play state supersedes the `"finished"` play
 > state; if the animation is both paused and finished, the `"paused"` state
 > is the one that will be reported. You can force the animation into the
 > `"finished"` state by setting its {{domxref("Animation.startTime", "startTime")}} to

--- a/files/en-us/web/api/animation/finished/index.md
+++ b/files/en-us/web/api/animation/finished/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Animation.finished
 
 The **`Animation.finished`** read-only property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns a {{jsxref("Promise")}} which resolves once the animation has finished playing.
 
-> **Note:** Every time the animation leaves the `finished` play state (that is, when it starts playing again), a new `Promise` is created for this property. The new `Promise` will resolve once the new animation sequence has completed.
+> [!NOTE]
+> Every time the animation leaves the `finished` play state (that is, when it starts playing again), a new `Promise` is created for this property. The new `Promise` will resolve once the new animation sequence has completed.
 
 ## Value
 

--- a/files/en-us/web/api/animation/playbackrate/index.md
+++ b/files/en-us/web/api/animation/playbackrate/index.md
@@ -16,7 +16,8 @@ Animations have a **playback rate** that provides a scaling factor from the rate
 
 Takes a number that can be 0, negative, or positive. Negative values reverse the animation. The value is a scaling factor, so for example a value of 2 would double the playback rate.
 
-> **Note:** Setting an animation's `playbackRate` to `0` effectively pauses the animation (however, its {{domxref("Animation.playstate", "playstate")}} does not necessarily become `paused`).
+> [!NOTE]
+> Setting an animation's `playbackRate` to `0` effectively pauses the animation (however, its {{domxref("Animation.playstate", "playstate")}} does not necessarily become `paused`).
 
 ## Examples
 

--- a/files/en-us/web/api/animation/ready/index.md
+++ b/files/en-us/web/api/animation/ready/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Animation.ready
 
 The read-only **`Animation.ready`** property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) returns a {{jsxref("Promise")}} which resolves when the animation is ready to play. A new promise is created every time the animation enters the `"pending"` [play state](/en-US/docs/Web/API/Animation/playState) as well as when the animation is canceled, since in both of those scenarios, the animation is ready to be started again.
 
-> **Note:** Since the same {{jsxref("Promise")}} is used for both pending `play` and pending `pause` requests, authors are advised to check the state of the animation when the promise is resolved.
+> [!NOTE]
+> Since the same {{jsxref("Promise")}} is used for both pending `play` and pending `pause` requests, authors are advised to check the state of the animation when the promise is resolved.
 
 ## Value
 

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AnimationEffect.getComputedTiming
 
 The `getComputedTiming()` method of the {{domxref("AnimationEffect")}} interface returns the calculated timing properties for this animation effect.
 
-> **Note:** These values are comparable to the computed styles of an Element returned using `window.getComputedStyle(elem)`.
+> [!NOTE]
+> These values are comparable to the computed styles of an Element returned using `window.getComputedStyle(elem)`.
 
 ## Syntax
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AnimationEffect.getTiming
 
 The `AnimationEffect.getTiming()` method of the {{domxref("AnimationEffect")}} interface returns an object containing the timing properties for the Animation Effect.
 
-> **Note:** Several of the timing properties returned by `getTiming()` may take on the placeholder value `"auto"`. To obtain resolved values for use in timing computations, instead use {{domxref("AnimationEffect.getComputedTiming()")}}.
+> [!NOTE]
+> Several of the timing properties returned by `getTiming()` may take on the placeholder value `"auto"`. To obtain resolved values for use in timing computations, instead use {{domxref("AnimationEffect.getComputedTiming()")}}.
 >
 > In the future, `"auto"` or similar values might be added to the types of more timing properties, and new types of {{domxref("AnimationEffect")}} might resolve `"auto"` to different values.
 

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -21,7 +21,8 @@ The name is deemed _local_ when it ignores the eventual namespace prefix and dee
 | `myAttr`  | `mynamespace`  | _none_           | `myAttr`             | `myAttr`                 |
 | `myAttr`  | `mynamespace`  | `myns`           | `myAttr`             | `myns:myAttr`            |
 
-> **Note:** This interface represents only attributes present in the tree representation of the {{domxref("Element")}}, being a SVG, an HTML or a MathML element. It doesn't represent the _property_ of an interface associated with such element, such as {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
+> [!NOTE]
+> This interface represents only attributes present in the tree representation of the {{domxref("Element")}}, being a SVG, an HTML or a MathML element. It doesn't represent the _property_ of an interface associated with such element, such as {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
 
 ## Instance properties
 

--- a/files/en-us/web/api/attr/localname/index.md
+++ b/files/en-us/web/api/attr/localname/index.md
@@ -12,7 +12,8 @@ The read-only **`localName`** property of the {{domxref("Attr")}} interface retu
 
 The local name is always in lower case, whatever case at the attribute creation.
 
-> **Note:** HTML only supports a fixed set of namespaces on SVG and MathML elements. These are `xml` (for the `xml:lang` attribute), `xlink` (for the `xlink:href`, `xlink:show`, `xlink:target` and `xlink:title` attributes) and `xpath`.
+> [!NOTE]
+> HTML only supports a fixed set of namespaces on SVG and MathML elements. These are `xml` (for the `xml:lang` attribute), `xlink` (for the `xlink:href`, `xlink:show`, `xlink:target` and `xlink:title` attributes) and `xpath`.
 >
 > That means that the local name of an attribute of an HTML element is always be equal to its qualified name: Colons are treated as regular characters. In XML, like in SVG or MathML, the colon denotes the end of the prefix and what is before is the namespace; the local name may be different from the qualified name.
 

--- a/files/en-us/web/api/attr/namespaceuri/index.md
+++ b/files/en-us/web/api/attr/namespaceuri/index.md
@@ -14,7 +14,8 @@ or `null` if the element is not in a namespace.
 The namespace URI is set at the {{domxref("Attr")}} creation and cannot be changed.
 An attribute with a namespace can be created using {{domxref("Element.setAttributeNS()")}}.
 
-> **Note:** an attribute does not inherit its namespace from the element it is attached to.
+> [!NOTE]
+> an attribute does not inherit its namespace from the element it is attached to.
 > If an attribute is not explicitly given a namespace, it has no namespace.
 
 The browser does not handle or enforce namespace validation per se. It is up to the JavaScript

--- a/files/en-us/web/api/attr/prefix/index.md
+++ b/files/en-us/web/api/attr/prefix/index.md
@@ -12,7 +12,8 @@ The read-only **`prefix`** property of the {{domxref("Attr")}} returns the names
 
 The prefix is always in lower case, whatever case is used at the attribute creation.
 
-> **Note:** Only XML supports namespaces. HTML does not. That means that the prefix of an attribute of an HTML element will always be `null`.
+> [!NOTE]
+> Only XML supports namespaces. HTML does not. That means that the prefix of an attribute of an HTML element will always be `null`.
 
 Also, only the `xml` (for the `xml:lang` attribute), `xlink` (for the `xlink:href`, `xlink:show`, `xlink:target` and `xlink:title` attributes) and `xpath` namespaces are supported, and only on SVG and MathML elements.
 

--- a/files/en-us/web/api/attribution_reporting_api/generating_reports/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/generating_reports/index.md
@@ -77,7 +77,8 @@ An aggregatable report by default is generated and scheduled to be sent after a 
 
 The expiry time is defined by the `expiry` value set in the associated {{httpheader("Attribution-Reporting-Register-Source")}} header, which defaults to 30 days after registration if not explicitly set. Bear in mind that the length of the report window can be further modified by setting an `aggregatable_report_window` value in the `Attribution-Reporting-Register-Source` header. See [Custom report windows](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting/custom-report-windows) for more details.
 
-> **Note:** To further protect user privacy, the summary report values associated with each attribution source have a finite total value — this is called the **contribution budget**. This value may very across different implementations of the API; in Chrome it is 65,536. Any conversions that would generate reports adding values over that limit are not recorded. Make sure you keep track of the budget and share it between the different metrics you are trying to measure.
+> [!NOTE]
+> To further protect user privacy, the summary report values associated with each attribution source have a finite total value — this is called the **contribution budget**. This value may very across different implementations of the API; in Chrome it is 65,536. Any conversions that would generate reports adding values over that limit are not recorded. Make sure you keep track of the budget and share it between the different metrics you are trying to measure.
 
 A typical aggregatable report might look like this:
 
@@ -205,7 +206,8 @@ Different source types have different default limits:
 - [Navigation-based attribution sources](/en-US/docs/Web/API/Attribution_Reporting_API/Registering_sources#navigation-based_attribution_sources) have a three-report limit by default. For example, say a user clicks an ad and converts four times: they visit the advertiser site homepage, then visit a product page, sign up to the newsletter, and finally make a purchase. The purchase report would be dropped, as it comes from the fourth conversion.
 - [Event-based attribution sources](/en-US/docs/Web/API/Attribution_Reporting_API/Registering_sources#event-based_attribution_sources) have a one-report limit by default.
 
-> **Note:** The report limit can be adjusted by setting a different number of `"end_times"` in the [`"event_report_windows"`](/en-US/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Source#event_report_windows) fields of the associated `Attribution-Reporting-Register-Source` header.
+> [!NOTE]
+> The report limit can be adjusted by setting a different number of `"end_times"` in the [`"event_report_windows"`](/en-US/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Source#event_report_windows) fields of the associated `Attribution-Reporting-Register-Source` header.
 
 When an attribution is triggered for a given source event, if the maximum number of attributions (three for clicks, one for images/scripts) has been reached for this source the browser will:
 
@@ -298,7 +300,8 @@ There are two different types of debug report:
 - **Success debug reports** track successful generation of a specific attribution report. Success debug reports are generated and sent as soon as the corresponding trigger is registered.
 - **Verbose debug reports** give you more visibility into the attribution source and attribution trigger events associated with an attribution report. They enable you to ensure that sources were registered successfully, or track missing reports and determine why they're missing (for example due to failure in source or trigger event registration or failure when sending or generating the report). Verbose debug reports are sent immediately upon source or trigger registration.
 
-> **Note:** To use debug reports, the reporting origin needs to set a cookie. If the origin configured to receive reports is a third party, this cookie will be a [third-party cookie](/en-US/docs/Web/Privacy/Third-party_cookies), which means that debug reports will not be available in browsers where third-party cookies are disabled/not available.
+> [!NOTE]
+> To use debug reports, the reporting origin needs to set a cookie. If the origin configured to receive reports is a third party, this cookie will be a [third-party cookie](/en-US/docs/Web/Privacy/Third-party_cookies), which means that debug reports will not be available in browsers where third-party cookies are disabled/not available.
 
 ### Using debug reports
 
@@ -318,7 +321,8 @@ To use debug reports, you need to:
    }
    ```
 
-   > **Note:** Make the source-side debug key different from the `source_event_id`, so that you can differentiate individual reports that have the same source event ID.
+   > [!NOTE]
+   > Make the source-side debug key different from the `source_event_id`, so that you can differentiate individual reports that have the same source event ID.
 
 3. Optionally, set the `debug_reporting` field to `true`, in both the `Attribution-Reporting-Register-Source` and `Attribution-Reporting-Register-Trigger` headers. If you do this, a verbose debug report will be generated. If you don't do this, a success debug report will be generated that mirrors the type of attribution report you are generating (event-level or aggregatable).
 

--- a/files/en-us/web/api/attribution_reporting_api/registering_sources/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/registering_sources/index.md
@@ -49,7 +49,8 @@ What happens behind the scenes to register sources and retrieve and store the so
 
      - `"source_event_id"`: A string representing an ID for the attribution source, which can be used to map it to other information when the attribution source is interacted with, or aggregate information at the reporting endpoint (see [Generating reports > Basic process](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports#basic_process) for endpoint information).
      - `"trigger_data"`: An array of 32-bit unsigned integers representing data that describes the different trigger events that could match this source. For example, "user added item to shopping cart" or "user signed up to mailing list" could be actions happening at the trigger site that could match this source and indicate a conversion of some kind that the advertiser is trying to measure. These must be matched against `"trigger_data"` specified in [triggers](/en-US/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Trigger#trigger_data) for event-level attribution to take place.
-       > **Note:** The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
+       > [!NOTE]
+       > The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
      - `"trigger_data_matching"`: A string that specifies how the `"trigger_data"` from the trigger is matched against the source's `"trigger_data"`. `"exact"` is the value you'll nearly always use, which matches exact values.
      - `"expiry"`: A string representing an expiry time in seconds for the attribution source, after which it will no longer be active (i.e. subsequent triggers won't be attributable to this source).
      - `"priority"`: A string representing a priority value for the attribution source. See [Report priorities and limits](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports#report_priorities_and_limits) for more information.
@@ -132,9 +133,11 @@ elem.addEventListener("click", () => {
 
 In this case, the interaction occurs and the browser stores the source data when `Window.open()` is invoked, and the browser receives the response.
 
-> **Note:** When setting up a [`click`](/en-US/docs/Web/API/Element/click_event) event like in the above example, it is advisable to set it on a control where a click is expected, such as a {{htmlelement("button")}} or {{htmlelement("a")}} element. This makes more sense semantically, and is more accessible to both screenreader and keyboard users.
+> [!NOTE]
+> When setting up a [`click`](/en-US/docs/Web/API/Element/click_event) event like in the above example, it is advisable to set it on a control where a click is expected, such as a {{htmlelement("button")}} or {{htmlelement("a")}} element. This makes more sense semantically, and is more accessible to both screenreader and keyboard users.
 
-> **Note:** To register an attribution source via `open()`, it must be called with [transient activation](/en-US/docs/Glossary/Transient_activation) (i.e. inside a user interaction event handler such as `click`) within five seconds of user interaction.
+> [!NOTE]
+> To register an attribution source via `open()`, it must be called with [transient activation](/en-US/docs/Glossary/Transient_activation) (i.e. inside a user interaction event handler such as `click`) within five seconds of user interaction.
 
 ## Event-based attribution sources
 
@@ -233,7 +236,8 @@ To set up a script-based attribution source, you can either:
 
 In this case, the interaction occurs and the browser stores the source data when the browser receives the response from the fetch request.
 
-> **Note:** The request can be for any resource. It doesn't need to have anything directly to do with the Attribution Reporting API, and can be a request for JSON, plain text, an image blob, or whatever else makes sense for your app.
+> [!NOTE]
+> The request can be for any resource. It doesn't need to have anything directly to do with the Attribution Reporting API, and can be a request for JSON, plain text, an image blob, or whatever else makes sense for your app.
 
 ## Specifying URLs inside attributionsrc
 
@@ -280,7 +284,8 @@ elem.addEventListener("click", () => {
 });
 ```
 
-> **Note:** Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data.
+> [!NOTE]
+> Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data.
 
 ## See also
 

--- a/files/en-us/web/api/attribution_reporting_api/registering_triggers/index.md
+++ b/files/en-us/web/api/attribution_reporting_api/registering_triggers/index.md
@@ -48,7 +48,8 @@ However, what happens behind the scenes to register triggers, look for matches, 
 
    - `"event_trigger_data"`: An object representing data about the trigger. This includes:
      - `"trigger_data"`: The data associated with the trigger, which is typically used to indicate events such as "user added item to shopping cart" or "user signed up to mailing list". This value will be included in the generated report, if any, although it will be subject to modification based on the attributed source's [`"trigger_data_matching"`](/en-US/docs/Web/HTTP/Headers/Attribution-Reporting-Register-Source#trigger_data_matching) field.
-       > **Note:** The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
+       > [!NOTE]
+       > The values used to represent each event, and the number of elements in the array, are completely arbitrary and defined by you as the developer. The array may contain values that are not used, but values must be present in the array to be attributed to the source by the browser when a trigger is registered.
      - `"priority"`: A string representing a priority value for the attribution trigger. See [Report priorities and limits](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports#report_priorities_and_limits) for more information.
      - `"deduplication_key"`: A string representing a unique key that can be used to prevent attributions from being duplicated — for example if a user were to add the same item to a shopping cart multiple times. See [Prevent duplication in reports](https://developer.chrome.com/docs/privacy-sandbox/attribution-reporting/prevent-duplication/) for more information.
    - `"debug_key"`: A number representing a debug key. Set this if you want to generate a [debug report](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports#debug_reports) alongside the associated attribution report.
@@ -92,7 +93,8 @@ However, what happens behind the scenes to register triggers, look for matches, 
    - match the site of at least one of the `destination`s specified in the source's associated data.
    - be same-origin with the request that specified the source registration.
 
-   > **Note:** These requirements provide privacy protection, but also flexibility — the source _and_ trigger can potentially be embedded in an {{htmlelement("iframe")}} or situated in the top-level site.
+   > [!NOTE]
+   > These requirements provide privacy protection, but also flexibility — the source _and_ trigger can potentially be embedded in an {{htmlelement("iframe")}} or situated in the top-level site.
 
    There are many other factors that will prevent a successful match outcome; for example:
 
@@ -103,7 +105,8 @@ However, what happens behind the scenes to register triggers, look for matches, 
 
 4. If a successful match is found, the browser [generates a report](/en-US/docs/Web/API/Attribution_Reporting_API/Generating_reports) based on the source and trigger data, and sends it to a reporting endpoint.
 
-> **Note:** Attribution triggers cannot be registered on {{htmlelement("a")}} elements or {{domxref("Window.open()")}} calls like attribution sources can.
+> [!NOTE]
+> Attribution triggers cannot be registered on {{htmlelement("a")}} elements or {{domxref("Window.open()")}} calls like attribution sources can.
 
 ## HTML-based attribution triggers
 
@@ -200,7 +203,8 @@ To register a script-based attribution trigger, you can either:
 
 In this case, the browser will attempt to match the trigger with a stored attribution source when the browser receives the response from the fetch request.
 
-> **Note:** The request can be for any resource. It doesn't need to have anything directly to do with the Attribution Reporting API, and can be a request for JSON, plain text, an image blob, or whatever else makes sense for your app.
+> [!NOTE]
+> The request can be for any resource. It doesn't need to have anything directly to do with the Attribution Reporting API, and can be a request for JSON, plain text, an image blob, or whatever else makes sense for your app.
 
 ## Specifying a URL inside attributionsrc
 

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -20,7 +20,8 @@ node will play.
 
 ## Examples
 
-> **Note:** For a full working example, see [this code running live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
+> [!NOTE]
+> For a full working example, see [this code running live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
 const myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.md
@@ -20,7 +20,8 @@ while +1200 and -1200 detune it up or down by one octave.
 A [k-rate](/en-US/docs/Web/API/AudioParam#k-rate) {{domxref("AudioParam")}}
 whose value indicates the detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).
 
-> **Note:** Though the `AudioParam` returned is read-only, the
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the
 > value it represents is not.
 
 ## Examples

--- a/files/en-us/web/api/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/index.md
@@ -71,7 +71,8 @@ _Inherits methods from its parent, {{domxref("AudioScheduledSourceNode")}}, and 
 
 In this example, we create a two-second buffer, fill it with white noise, and then play it using an `AudioBufferSourceNode`. The comments should clearly explain what is going on.
 
-> **Note:** You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
+> [!NOTE]
+> You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js
 const audioCtx = new AudioContext();
@@ -107,7 +108,8 @@ source.connect(audioCtx.destination);
 source.start();
 ```
 
-> **Note:** For a `decodeAudioData()` example, see the {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} page.
+> [!NOTE]
+> For a `decodeAudioData()` example, see the {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} page.
 
 ## Specifications
 

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.md
@@ -35,7 +35,8 @@ The example then sets the `loop` property to `true`, so the track loops, and pla
 
 The user can set the `loopStart` and `loopEnd` properties using [range controls](/en-US/docs/Web/HTML/Element/input/range).
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/loop/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/loop).)
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/loop/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/loop).)
 
 ```js
 let audioCtx;

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
@@ -35,7 +35,8 @@ The example then sets the `loop` property to `true`, so the track loops, and pla
 
 The user can set the `loopStart` and `loopEnd` properties using [range controls](/en-US/docs/Web/HTML/Element/input/range).
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/loop/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/loop).)
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/loop/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/loop).)
 
 ```js
 let audioCtx;

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
@@ -28,7 +28,8 @@ The example then sets the `loop` property to `true`, so the track loops, and pla
 
 The user can set the `loopStart` and `loopEnd` properties using [range controls](/en-US/docs/Web/HTML/Element/input/range).
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/loop/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/loop).)
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/loop/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/loop).)
 
 ```js
 let audioCtx;

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
@@ -41,7 +41,8 @@ The example then sets the `loop` property to `true`, so the track loops, and pla
 
 The user can set the `playbackRate` property using a [range control](/en-US/docs/Web/HTML/Element/input/range).
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/playbackrate/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/playbackrate).)
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/audio-buffer-source-node/playbackrate/) (or [view the source](https://github.com/mdn/webaudio-examples/tree/main/audio-buffer-source-node/playbackrate).)
 
 ```js
 let audioCtx;

--- a/files/en-us/web/api/audiobuffersourcenode/start/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.md
@@ -75,7 +75,8 @@ worth of sound starting 3 seconds into the audio buffer.
 source.start(audioCtx.currentTime + 1, 3, 10);
 ```
 
-> **Note:** For a more complete example showing `start()` in use, check out our {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} example. You can also [try the example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), and have a look at [the example source](https://github.com/mdn/webaudio-examples/tree/main/decode-audio-data).
+> [!NOTE]
+> For a more complete example showing `start()` in use, check out our {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}} example. You can also [try the example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), and have a look at [the example source](https://github.com/mdn/webaudio-examples/tree/main/decode-audio-data).
 
 ## Specifications
 

--- a/files/en-us/web/api/audiocontext/baselatency/index.md
+++ b/files/en-us/web/api/audiocontext/baselatency/index.md
@@ -14,7 +14,8 @@ seconds of processing latency incurred by the `AudioContext` passing an audio
 buffer from the {{domxref("AudioDestinationNode")}} — i.e. the end of the audio graph —
 into the host system's audio subsystem ready for playing.
 
-> **Note:** You can request a certain latency during
+> [!NOTE]
+> You can request a certain latency during
 > {{domxref("AudioContext.AudioContext()", "construction time", "", "true")}} with the
 > `latencyHint` option, but the browser may ignore the option.
 

--- a/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
@@ -31,7 +31,8 @@ A {{domxref("MediaElementAudioSourceNode")}}.
 
 This simple example creates a source from an {{htmlelement("audio") }} element using `createMediaElementSource()`, then passes the audio through a {{ domxref("GainNode") }} before feeding it into the {{ domxref("AudioDestinationNode") }} for playback. When the mouse pointer is moved, the `updatePage()` function is invoked, which calculates the current gain as a ratio of mouse Y position divided by overall window height. You can therefore increase and decrease the volume of the playing music by moving the mouse pointer up and down.
 
-> **Note:** You can also [view this example running live](https://mdn.github.io/webaudio-examples/media-source-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/tree/main/media-source-buffer).
+> [!NOTE]
+> You can also [view this example running live](https://mdn.github.io/webaudio-examples/media-source-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/tree/main/media-source-buffer).
 
 ```js
 const audioCtx = new AudioContext();
@@ -65,7 +66,8 @@ source.connect(gainNode);
 gainNode.connect(audioCtx.destination);
 ```
 
-> **Note:** As a consequence of calling `createMediaElementSource()`, audio playback from the {{domxref("HTMLMediaElement")}} will be re-routed into the processing graph of the AudioContext. So playing/pausing the media can still be done through the media element API and the player controls.
+> [!NOTE]
+> As a consequence of calling `createMediaElementSource()`, audio playback from the {{domxref("HTMLMediaElement")}} will be re-routed into the processing graph of the AudioContext. So playing/pausing the media can still be done through the media element API and the player controls.
 
 ## Specifications
 

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
@@ -87,7 +87,8 @@ From here, you can play and save the opus file.
 </html>
 ```
 
-> **Note:** You can [view this example live](https://mdn.github.io/webaudio-examples/create-media-stream-destination/index.html), or [study the source code](https://github.com/mdn/webaudio-examples/blob/main/create-media-stream-destination/index.html), on GitHub.
+> [!NOTE]
+> You can [view this example live](https://mdn.github.io/webaudio-examples/create-media-stream-destination/index.html), or [study the source code](https://github.com/mdn/webaudio-examples/blob/main/create-media-stream-destination/index.html), on GitHub.
 
 ## Specifications
 

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
@@ -42,7 +42,8 @@ The range slider below the {{ htmlelement("video") }} element controls the amoun
 gain given to the lowpass filter — increase the value of the slider to make the audio
 sound more bass heavy!
 
-> **Note:** You can see this [example running live](https://mdn.github.io/webaudio-examples/stream-source-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/tree/main/stream-source-buffer).
+> [!NOTE]
+> You can see this [example running live](https://mdn.github.io/webaudio-examples/stream-source-buffer/), or [view the source](https://github.com/mdn/webaudio-examples/tree/main/stream-source-buffer).
 
 ```js
 const pre = document.querySelector("pre");
@@ -101,7 +102,8 @@ if (navigator.mediaDevices) {
 pre.textContent = myScript.textContent;
 ```
 
-> **Note:** As a consequence of calling
+> [!NOTE]
+> As a consequence of calling
 > `createMediaStreamSource()`, audio playback from the media stream will
 > be re-routed into the processing graph of the {{domxref("AudioContext")}}. So
 > playing/pausing the stream can still be done through the media element API and the

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -17,7 +17,8 @@ The **`AudioData`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCode
 
 An audio track consists of a stream of audio samples, each sample representing a captured moment of sound. An `AudioData` object is a representation of such a sample. Working alongside the interfaces of the [Insertable Streams API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API), you can break a stream into individual `AudioData` objects with {{domxref("MediaStreamTrackProcessor")}}, or construct an audio track from a stream of frames with {{domxref("MediaStreamTrackGenerator")}}.
 
-> **Note:** Find out more about audio on the web in [Digital audio concepts](/en-US/docs/Web/Media/Formats/Audio_concepts).
+> [!NOTE]
+> Find out more about audio on the web in [Digital audio concepts](/en-US/docs/Web/Media/Formats/Audio_concepts).
 
 ### The media resource
 

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -31,7 +31,8 @@ configure(config)
     - `description` {{optional_inline}}
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing a sequence of codec specific bytes, commonly known as extradata.
 
-> **Note:** The registrations in the [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry) link to a specification detailing whether and how to populate the optional `description` member.
+> [!NOTE]
+> The registrations in the [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry) link to a specification detailing whether and how to populate the optional `description` member.
 
 ### Return value
 

--- a/files/en-us/web/api/audiolistener/forwardx/index.md
+++ b/files/en-us/web/api/audiolistener/forwardx/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.forwardX
 
 The `forwardX` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x value of the direction vector defining the forward direction the listener is pointing in.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
+> [!NOTE]
+> The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/forwardy/index.md
+++ b/files/en-us/web/api/audiolistener/forwardy/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.forwardY
 
 The `forwardY` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y value of the direction vector defining the forward direction the listener is pointing in.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
+> [!NOTE]
+> The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/forwardz/index.md
+++ b/files/en-us/web/api/audiolistener/forwardz/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.forwardZ
 
 The `forwardZ` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z value of the direction vector defining the forward direction the listener is pointing in.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
+> [!NOTE]
+> The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "panningModel")}} is set to equalpower, or _k-rate_ otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/index.md
+++ b/files/en-us/web/api/audiolistener/index.md
@@ -15,7 +15,8 @@ It is important to note that there is only one listener per context and that it 
 
 ## Instance properties
 
-> **Note:** The position, forward, and up value are set and retrieved using different syntaxes. Retrieval is done by accessing, for example, `AudioListener.positionX`, while setting the same property is done with `AudioListener.positionX.value`. This is why these values are not marked read only, which is how they appear in the specification's IDL.
+> [!NOTE]
+> The position, forward, and up value are set and retrieved using different syntaxes. Retrieval is done by accessing, for example, `AudioListener.positionX`, while setting the same property is done with `AudioListener.positionX.value`. This is why these values are not marked read only, which is how they appear in the specification's IDL.
 
 - {{domxref("AudioListener.positionX")}}
   - : Represents the horizontal position of the listener in a right-hand cartesian coordinate system. The default is 0.
@@ -43,7 +44,8 @@ It is important to note that there is only one listener per context and that it 
 - {{domxref("AudioListener.setPosition()")}} {{deprecated_inline}}
   - : Sets the position of the listener.
 
-> **Note:** Although these methods are deprecated they are currently the only way to set the orientation and position in Firefox (see [Firefox bug 1283029](https://bugzilla.mozilla.org/show_bug.cgi?id=1283029)).
+> [!NOTE]
+> Although these methods are deprecated they are currently the only way to set the orientation and position in Firefox (see [Firefox bug 1283029](https://bugzilla.mozilla.org/show_bug.cgi?id=1283029)).
 
 ## Deprecated features
 

--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.positionX
 
 The `positionX` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
+> [!NOTE]
+> The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.positionY
 
 The `positionY` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
+> [!NOTE]
+> The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.positionZ
 
 The `positionZ` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z position of the listener in 3D cartesian space.
 
-> **Note:** The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
+> [!NOTE]
+> The parameter is [_a-rate_](/en-US/docs/Web/API/AudioParam#a-rate) when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or [_k-rate_](/en-US/docs/Web/API/AudioParam#k-rate) otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/setposition/index.md
+++ b/files/en-us/web/api/audiolistener/setposition/index.md
@@ -16,7 +16,8 @@ The three parameters `x`, `y` and `z` are unitless and describe the listener's p
 
 The default value of the position vector is `(0, 0, 0)`.
 
-> **Note:** As this method is deprecated, use the three {{domxref("AudioListener.positionX", "positionX")}}, {{domxref("AudioListener.positionY", "positionY")}}, and {{domxref("AudioListener.positionZ", "positionZ")}} properties instead.
+> [!NOTE]
+> As this method is deprecated, use the three {{domxref("AudioListener.positionX", "positionX")}}, {{domxref("AudioListener.positionY", "positionY")}}, and {{domxref("AudioListener.positionZ", "positionZ")}} properties instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/audiolistener/upx/index.md
+++ b/files/en-us/web/api/audiolistener/upx/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.upX
 
 The `upX` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the x value of the direction vector defining the up direction the listener is pointing in.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
+> [!NOTE]
+> The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/upy/index.md
+++ b/files/en-us/web/api/audiolistener/upy/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.upY
 
 The `upY` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the y value of the direction vector defining the up direction the listener is pointing in.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
+> [!NOTE]
+> The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audiolistener/upz/index.md
+++ b/files/en-us/web/api/audiolistener/upz/index.md
@@ -10,7 +10,8 @@ browser-compat: api.AudioListener.upZ
 
 The `upZ` read-only property of the {{ domxref("AudioListener") }} interface is an {{domxref("AudioParam")}} representing the z value of the direction vector defining the up direction the listener is pointing in.
 
-> **Note:** The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
+> [!NOTE]
+> The parameter is _a-rate_ when used with a {{domxref("PannerNode")}} whose {{domxref("PannerNode.panningModel", "PannerNode")}} is set to equalpower, or _k-rate_ otherwise.
 
 ## Value
 

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -33,7 +33,8 @@ The possible values of the `channelCountMode` enumerated value, and their meanin
 
     The following AudioNode children default to this value: {{domxref("AudioDestinationNode")}}, {{domxref("AnalyserNode")}}, {{domxref("ChannelSplitterNode")}}, {{domxref("ChannelMergerNode")}}
 
-> **Note:** In older versions of the spec, the default for a {{domxref("ChannelSplitterNode")}} was `max`.
+> [!NOTE]
+> In older versions of the spec, the default for a {{domxref("ChannelSplitterNode")}} was `max`.
 
 ## Examples
 

--- a/files/en-us/web/api/audionode/index.md
+++ b/files/en-us/web/api/audionode/index.md
@@ -18,7 +18,8 @@ Examples include:
 
 {{InheritanceDiagram}}
 
-> **Note:** An `AudioNode` can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.
+> [!NOTE]
+> An `AudioNode` can be target of events, therefore it implements the {{domxref("EventTarget")}} interface.
 
 ## Instance properties
 

--- a/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
@@ -12,7 +12,8 @@ The **`exponentialRampToValueAtTime()`** method of the {{domxref("AudioParam")}}
 The change starts at the time specified for the _previous_ event, follows an exponential ramp to the new value given in the `value` parameter, and reaches the new value at the time given in the
 `endTime` parameter.
 
-> **Note:** Exponential ramps are considered more useful when changing
+> [!NOTE]
+> Exponential ramps are considered more useful when changing
 > frequencies or playback rates than linear ramps because of the way the human ear
 > works.
 
@@ -75,7 +76,8 @@ expRampMinus.onclick = () => {
 };
 ```
 
-> **Note:** A value of 0.01 was used for the value to ramp down to in the
+> [!NOTE]
+> A value of 0.01 was used for the value to ramp down to in the
 > last function rather than 0, as an _invalid or illegal string_ error is thrown
 > if 0 is used — the value needs to be positive.
 

--- a/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
+++ b/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
@@ -62,7 +62,8 @@ When the parameter's value finishes following the curve, its value is guaranteed
 match the last value in the set of values specified in the `values`
 parameter.
 
-> **Note:** Some early implementations of the Web Audio API did not ensure
+> [!NOTE]
+> Some early implementations of the Web Audio API did not ensure
 > this to be the case, causing unexpected results.
 
 ## Examples

--- a/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/audioprocessingevent/index.md
@@ -12,7 +12,8 @@ browser-compat: api.AudioProcessingEvent.AudioProcessingEvent
 
 The **`AudioProcessingEvent()`** constructor creates a new {{domxref("AudioProcessingEvent")}} object.
 
-> **Note:** Usually, this constructor is not directly called by your code, as the browser creates these objects itself and provides them to the event handler.
+> [!NOTE]
+> Usually, this constructor is not directly called by your code, as the browser creates these objects itself and provides them to the event handler.
 
 ## Syntax
 

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -13,7 +13,8 @@ The `AudioProcessingEvent` interface of the [Web Audio API](/en-US/docs/Web/API/
 
 An `audioprocess` event with this interface is fired on a {{domxref("ScriptProcessorNode")}} when audio processing is required. During audio processing, the input buffer is read and processed to produce output audio data, which is then written to the output buffer.
 
-> **Warning:** This feature has been deprecated and should be replaced by an [`AudioWorklet`](/en-US/docs/Web/API/AudioWorklet).
+> [!WARNING]
+> This feature has been deprecated and should be replaced by an [`AudioWorklet`](/en-US/docs/Web/API/AudioWorklet).
 
 {{InheritanceDiagram}}
 
@@ -53,7 +54,8 @@ of white noise to each audio sample of the input track (buffer) and play it thro
 buffer, and each sample in each channel, and add a small amount of white noise, before
 setting that result to be the output sample in each case.
 
-> **Note:** For a full working example, see our [script-processor-node](https://mdn.github.io/webaudio-examples/script-processor-node/)
+> [!NOTE]
+> For a full working example, see our [script-processor-node](https://mdn.github.io/webaudio-examples/script-processor-node/)
 > GitHub repo. (You can also access the [source code](https://github.com/mdn/webaudio-examples/tree/main/script-processor-node).)
 
 ```js

--- a/files/en-us/web/api/audioscheduledsourcenode/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/index.md
@@ -9,7 +9,8 @@ browser-compat: api.AudioScheduledSourceNode
 
 The `AudioScheduledSourceNode` interface—part of the Web Audio API—is a parent interface for several types of audio source node interfaces which share the ability to be started and stopped, optionally at specified times. Specifically, this interface defines the {{domxref("AudioScheduledSourceNode.start", "start()")}} and {{domxref("AudioScheduledSourceNode.stop", "stop()")}} methods, as well as the {{domxref("AudioScheduledSourceNode.ended_event", "ended")}} event.
 
-> **Note:** You can't create an `AudioScheduledSourceNode` object directly. Instead, use an interface which extends it, such as {{domxref("AudioBufferSourceNode")}}, {{domxref("OscillatorNode")}} or {{domxref("ConstantSourceNode")}}.
+> [!NOTE]
+> You can't create an `AudioScheduledSourceNode` object directly. Instead, use an interface which extends it, such as {{domxref("AudioBufferSourceNode")}}, {{domxref("OscillatorNode")}} or {{domxref("ConstantSourceNode")}}.
 
 Unless stated otherwise, nodes based upon `AudioScheduledSourceNode` output silence when not playing (that is, before `start()` is called and after `stop()` is called). Silence is represented, as always, by a stream of samples with the value zero (0).
 

--- a/files/en-us/web/api/audioscheduledsourcenode/stop/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/stop/index.md
@@ -16,7 +16,8 @@ Each time you call `stop()` on the same node, the specified time replaces
 any previously-scheduled stop time that hasn't occurred yet. If the node has already
 stopped, this method has no effect.
 
-> **Note:** If a scheduled stop time occurs before the node's scheduled
+> [!NOTE]
+> If a scheduled stop time occurs before the node's scheduled
 > start time, the node never starts to play.
 
 ## Syntax

--- a/files/en-us/web/api/audiotrack/enabled/index.md
+++ b/files/en-us/web/api/audiotrack/enabled/index.md
@@ -53,7 +53,8 @@ the {{HTMLElement("video")}} element `"main-video"` the audio tracks whose
 `"commentary"`. These represent the primary audio track and the commentary
 track.
 
-> **Note:** This example assumes that there is only one of each kind of
+> [!NOTE]
+> This example assumes that there is only one of each kind of
 > track in the video, but this is not necessarily the case.
 
 The element's audio tracks are then scanned through using the JavaScript

--- a/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.md
@@ -25,7 +25,8 @@ registerProcessor(name, processorCtor)
 - `processorCtor`
   - : The constructor of a class derived from {{domxref("AudioWorkletProcessor")}}.
 
-> **Note:** A key-value pair `{ name: constructor }`
+> [!NOTE]
+> A key-value pair `{ name: constructor }`
 > is saved internally in the {{domxref("AudioWorkletGlobalScope")}} once the processor
 > is registered. The _name_ is to be referred to when creating an
 > {{domxref("AudioWorkletNode")}} based on the registered processor. A new processor by

--- a/files/en-us/web/api/audioworkletnode/audioworkletnode/index.md
+++ b/files/en-us/web/api/audioworkletnode/audioworkletnode/index.md
@@ -34,7 +34,8 @@ new AudioWorkletNode(context, name, options)
 
     <!-- The specification refers to this object as: AudioWorkletNodeOptions -->
 
-    > **Note:** The result of [the structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
+    > [!NOTE]
+    > The result of [the structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
     > applied to the object is also internally passed into the associated {{domxref("AudioWorkletProcessor.AudioWorkletProcessor", "AudioWorkletProcessor()")}} constructor
     > — this allows custom initialization of an underlying user-defined {{domxref("AudioWorkletProcessor")}}.
 

--- a/files/en-us/web/api/audioworkletnode/index.md
+++ b/files/en-us/web/api/audioworkletnode/index.md
@@ -7,7 +7,8 @@ browser-compat: api.AudioWorkletNode
 
 {{APIRef("Web Audio API")}}{{SecureContext_Header}}
 
-> **Note:** Although the interface is available outside [secure contexts](/en-US/docs/Web/Security/Secure_Contexts), the {{domxref("BaseAudioContext.audioWorklet")}} property is not, thus custom {{domxref("AudioWorkletProcessor")}}s cannot be defined outside them.
+> [!NOTE]
+> Although the interface is available outside [secure contexts](/en-US/docs/Web/Security/Secure_Contexts), the {{domxref("BaseAudioContext.audioWorklet")}} property is not, thus custom {{domxref("AudioWorkletProcessor")}}s cannot be defined outside them.
 
 The **`AudioWorkletNode`** interface of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) represents a base class for a user-defined {{domxref("AudioNode")}}, which can be connected to an audio routing graph along with other nodes. It has an associated {{domxref("AudioWorkletProcessor")}}, which does the actual audio processing in a Web Audio rendering thread.
 

--- a/files/en-us/web/api/audioworkletnode/port/index.md
+++ b/files/en-us/web/api/audioworkletnode/port/index.md
@@ -13,7 +13,8 @@ The read-only **`port`** property of the
 {{domxref("MessagePort")}}. It can be used to communicate between the node and its
 associated {{domxref("AudioWorkletProcessor")}}.
 
-> **Note:** The port at the other end of the channel is
+> [!NOTE]
+> The port at the other end of the channel is
 > available under the {{domxref("AudioWorkletProcessor.port", "port")}} property of the
 > processor.
 

--- a/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.md
@@ -15,7 +15,8 @@ represents an underlying audio processing mechanism of an
 
 ## Syntax
 
-> **Note:** The `AudioWorkletProcessor` and classes that derive from it
+> [!NOTE]
+> The `AudioWorkletProcessor` and classes that derive from it
 > cannot be instantiated directly from a user-supplied code. Instead, they are created
 > only internally by the creation of an associated {{domxref("AudioWorkletNode")}}s.
 

--- a/files/en-us/web/api/audioworkletprocessor/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/index.md
@@ -11,7 +11,8 @@ The **`AudioWorkletProcessor`** interface of the [Web Audio API](/en-US/docs/Web
 
 ## Constructor
 
-> **Note:** The `AudioWorkletProcessor` and classes that derive from it cannot be instantiated directly from a user-supplied code. Instead, they are created only internally by the creation of an associated {{domxref("AudioWorkletNode")}}s. The constructor of the deriving class is getting called with an options object, so you can perform a custom initialization procedures — see constructor page for details.
+> [!NOTE]
+> The `AudioWorkletProcessor` and classes that derive from it cannot be instantiated directly from a user-supplied code. Instead, they are created only internally by the creation of an associated {{domxref("AudioWorkletNode")}}s. The constructor of the deriving class is getting called with an options object, so you can perform a custom initialization procedures — see constructor page for details.
 
 - {{domxref("AudioWorkletProcessor.AudioWorkletProcessor", "AudioWorkletProcessor()")}}
   - : Creates a new instance of an `AudioWorkletProcessor` object.

--- a/files/en-us/web/api/audioworkletprocessor/port/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/port/index.md
@@ -13,7 +13,8 @@ The read-only **`port`** property of the
 {{domxref("MessagePort")}}. It can be used to communicate between the processor and the
 {{domxref("AudioWorkletNode")}} to which it belongs.
 
-> **Note:** The port at the other end of the channel is
+> [!NOTE]
+> The port at the other end of the channel is
 > available under the {{domxref("AudioWorkletNode.port", "port")}} property of the node.
 
 ## Value

--- a/files/en-us/web/api/audioworkletprocessor/process/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.md
@@ -24,7 +24,8 @@ corresponding {{domxref("AudioWorkletNode")}}. In other words, every time a new 
 audio is ready for your processor to manipulate, your `process()` function is
 invoked to do so.
 
-> **Note:** Currently, audio data blocks are always 128 frames
+> [!NOTE]
+> Currently, audio data blocks are always 128 frames
 > long—that is, they contain 128 32-bit floating-point samples for each of the inputs'
 > channels. However, plans are already in place to revise the specification to allow the
 > size of the audio blocks to be changed depending on circumstances (for example, if the
@@ -130,7 +131,8 @@ The 3 most common types of audio node are:
    _tail-time_ equal to its {{domxref("DelayNode.delayTime", "delayTime")}}
    property.
 
-> **Note:** An absence of the `return` statement means that the method returns `undefined`, and as this is a falsy value, it is like returning `false`.
+> [!NOTE]
+> An absence of the `return` statement means that the method returns `undefined`, and as this is a falsy value, it is like returning `false`.
 > Omitting an explicit `return` statement may cause hard-to-detect problems for your nodes.
 
 ### Exceptions

--- a/files/en-us/web/api/authenticatorassertionresponse/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/index.md
@@ -15,7 +15,8 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 {{InheritanceDiagram}}
 
-> **Note:** This interface is restricted to top-level contexts. Use from within an {{HTMLElement("iframe")}} element will not have any effect.
+> [!NOTE]
+> This interface is restricted to top-level contexts. Use from within an {{HTMLElement("iframe")}} element will not have any effect.
 
 ## Instance properties
 

--- a/files/en-us/web/api/authenticatorattestationresponse/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/index.md
@@ -15,7 +15,8 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 {{InheritanceDiagram}}
 
-> **Note:** This interface is restricted to top-level contexts. Use of its features from within an {{HTMLElement("iframe")}} element will not have any effect.
+> [!NOTE]
+> This interface is restricted to top-level contexts. Use of its features from within an {{HTMLElement("iframe")}} element will not have any effect.
 
 ## Instance properties
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 1.
