### PR TITLE
Convert noteblocks for web/api folder (part 2)

### DIFF
--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -14,7 +14,8 @@ representing the keys of the {{domxref("Cache")}}.
 
 The requests are returned in the same order that they were inserted.
 
-> **Note:** Requests with duplicate URLs but different headers can be
+> [!NOTE]
+> Requests with duplicate URLs but different headers can be
 > returned if their responses have the `VARY` header set on them.
 
 ## Syntax

--- a/files/en-us/web/api/cachestorage/open/index.md
+++ b/files/en-us/web/api/cachestorage/open/index.md
@@ -14,7 +14,8 @@ the {{domxref("Cache")}} object matching the `cacheName`.
 
 You can access `CacheStorage` through the {{domxref("Window.caches")}} property in windows or through the {{domxref("WorkerGlobalScope.caches")}} property in workers.
 
-> **Note:** If the specified {{domxref("Cache")}} does not exist, a new
+> [!NOTE]
+> If the specified {{domxref("Cache")}} does not exist, a new
 > cache is created with that `cacheName` and a {{jsxref("Promise")}} that
 > resolves to this new {{domxref("Cache")}} object is returned.
 

--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -52,7 +52,8 @@ ctx.fillRect(10, 10, 150, 100);
 - {{domxref("Path2D")}} {{experimental_inline}}
 - {{domxref("ImageBitmapRenderingContext")}} {{experimental_inline}}
 
-> **Note:** The interfaces related to the `WebGLRenderingContext` are referenced under [WebGL](/en-US/docs/Web/API/WebGL_API).
+> [!NOTE]
+> The interfaces related to the `WebGLRenderingContext` are referenced under [WebGL](/en-US/docs/Web/API/WebGL_API).
 
 > **Note:** {{domxref("OffscreenCanvas")}} is also available in web workers.
 
@@ -87,7 +88,8 @@ The Canvas API is extremely powerful, but not always simple to use. The librarie
 - The [ZIM](https://zimjs.com) framework provides conveniences, components, and controls for coding creativity on the canvas — includes accessibility and hundreds of colorful tutorials.
 - [Sprig](https://github.com/hackclub/sprig) is a beginner-friendly, open-source, tile-based game development library that uses Canvas.
 
-> **Note:** See the [WebGL API](/en-US/docs/Web/API/WebGL_API) for 2D and 3D libraries that use WebGL.
+> [!NOTE]
+> See the [WebGL API](/en-US/docs/Web/API/WebGL_API) for 2D and 3D libraries that use WebGL.
 
 ## Specifications
 

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 In the chapter about [drawing shapes](/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes), we used only the default line and fill styles. Here we will explore the canvas options we have at our disposal to make our drawings a little more attractive. You will learn how to add different colors, line styles, gradients, patterns and shadows to your drawings.
 
-> **Note:** Canvas content is not accessible to screen readers. If the canvas is purely decorative, include `role="presentation"` on the `<canvas>` opening tag. Otherwise, include descriptive text as the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute directly on the canvas element itself or include fallback content placed within the opening and closing canvas tag. Canvas content is not part of the DOM, but nested fallback content is.
+> [!NOTE]
+> Canvas content is not accessible to screen readers. If the canvas is purely decorative, include `role="presentation"` on the `<canvas>` opening tag. Otherwise, include descriptive text as the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute directly on the canvas element itself or include fallback content placed within the opening and closing canvas tag. Canvas content is not part of the DOM, but nested fallback content is.
 
 ## Colors
 
@@ -21,7 +22,8 @@ Up until now we have only seen methods of the drawing context. If we want to app
 
 `color` is a string representing a CSS {{cssxref("&lt;color&gt;")}}, a gradient object, or a pattern object. We'll look at gradient and pattern objects later. By default, the stroke and fill color are set to black (CSS color value `#000000`).
 
-> **Note:** When you set the `strokeStyle` and/or `fillStyle` property, the new value becomes the default for all shapes being drawn from then on. For every shape you want in a different color, you will need to reassign the `fillStyle` or `strokeStyle` property.
+> [!NOTE]
+> When you set the `strokeStyle` and/or `fillStyle` property, the new value becomes the default for all shapes being drawn from then on. For every shape you want in a different color, you will need to reassign the `fillStyle` or `strokeStyle` property.
 
 The valid strings you can enter should, according to the specification, be CSS {{cssxref("&lt;color&gt;")}} values. Each of the following examples describe the same color.
 
@@ -256,7 +258,8 @@ If you consider a path from (3,1) to (3,5) with a line thickness of `1.0`, you e
 
 To fix this, you have to be very precise in your path creation. Knowing that a `1.0` width line will extend half a unit to either side of the path, creating the path from (3.5,1) to (3.5,5) results in the situation in the third image—the `1.0` line width ends up completely and precisely filling a single pixel vertical line.
 
-> **Note:** Be aware that in our vertical line example, the Y position still referenced an integer gridline position—if it hadn't, we would see pixels with half coverage at the endpoints (but note also that this behavior depends on the current `lineCap` style whose default value is `butt`; you may want to compute consistent strokes with half-pixel coordinates for odd-width lines, by setting the `lineCap` style to `square`, so that the outer border of the stroke around the endpoint will be automatically extended to cover the whole pixel exactly).
+> [!NOTE]
+> Be aware that in our vertical line example, the Y position still referenced an integer gridline position—if it hadn't, we would see pixels with half coverage at the endpoints (but note also that this behavior depends on the current `lineCap` style whose default value is `butt`; you may want to compute consistent strokes with half-pixel coordinates for odd-width lines, by setting the `lineCap` style to `square`, so that the outer border of the stroke around the endpoint will be automatically extended to cover the whole pixel exactly).
 >
 > Note also that only start and final endpoints of a path are affected: if a path is closed with `closePath()`, there's no start and final endpoint; instead, all endpoints in the path are connected to their attached previous and next segment using the current setting of the `lineJoin` style, whose default value is `miter`, with the effect of automatically extending the outer borders of the connected segments to their intersection point, so that the rendered stroke will exactly cover full pixels centered at each endpoint if those connected segments are horizontal and/or vertical. See the next two sections for demonstrations of these additional line styles.
 
@@ -675,7 +678,8 @@ img.src = "someimage.png";
 const ptrn = ctx.createPattern(img, "repeat");
 ```
 
-> **Note:** Like with the `drawImage()` method, you must make sure the image you use is loaded before calling this method or the pattern may be drawn incorrectly.
+> [!NOTE]
+> Like with the `drawImage()` method, you must make sure the image you use is loaded before calling this method or the pattern may be drawn incorrectly.
 
 ### A `createPattern` example
 
@@ -726,7 +730,8 @@ The `shadowBlur` property indicates the size of the blurring effect; this value 
 
 The `shadowColor` property is a standard CSS color value indicating the color of the shadow effect; by default, it is fully-transparent black.
 
-> **Note:** Shadows are only drawn for `source-over` [compositing operations](/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing).
+> [!NOTE]
+> Shadows are only drawn for `source-over` [compositing operations](/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing).
 
 ### A shadowed text example
 

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -42,7 +42,8 @@ First there's the {{domxref("setInterval()")}}, {{domxref("setTimeout()")}}, and
 
 If you don't want any user interaction you can use the `setInterval()` function, which repeatedly executes the supplied code. If we wanted to make a game, we could use keyboard or mouse events to control the animation and use `setTimeout()`. By setting listeners using {{domxref("EventTarget/addEventListener", "addEventListener()")}}, we catch any user interaction and execute our animation functions.
 
-> **Note:** In the examples below, we'll use the {{domxref("window.requestAnimationFrame()")}} method to control the animation. The `requestAnimationFrame` method provides a smoother and more efficient way for animating by calling the animation frame when the system is ready to paint the frame. The number of callbacks is usually 60 times per second and may be reduced to a lower rate when running in background tabs. For more information about the animation loop, especially for games, see the article [Anatomy of a video game](/en-US/docs/Games/Anatomy) in our [Game development zone](/en-US/docs/Games).
+> [!NOTE]
+> In the examples below, we'll use the {{domxref("window.requestAnimationFrame()")}} method to control the animation. The `requestAnimationFrame` method provides a smoother and more efficient way for animating by calling the animation frame when the system is ready to paint the frame. The number of callbacks is usually 60 times per second and may be reduced to a lower rate when running in background tabs. For more information about the animation loop, especially for games, see the article [Anatomy of a video game](/en-US/docs/Games/Anatomy) in our [Game development zone](/en-US/docs/Games).
 
 ## An animated solar system
 
@@ -238,7 +239,8 @@ window.requestAnimationFrame(clock);
 
 ### Result
 
-> **Note:** Although the clock updates only once every second, the animated image is updated at 60 frames per second (or at the display refresh rate of your web browser).
+> [!NOTE]
+> Although the clock updates only once every second, the animated image is updated at 60 frames per second (or at the display refresh rate of your web browser).
 > To display the clock with a sweeping second hand, replace the definition of `const sec` above with the version that has been commented out.
 
 {{EmbedLiveSample("An_animated_clock", "180", "200")}}

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -16,7 +16,8 @@ Let's start this tutorial by looking at the {{HTMLElement("canvas")}} {{Glossary
 
 At first sight a {{HTMLElement("canvas")}} looks like the {{HTMLElement("img")}} element, with the only clear difference being that it doesn't have the `src` and `alt` attributes. Indeed, the `<canvas>` element has only two attributes, [`width`](/en-US/docs/Web/HTML/Element/canvas#width) and [`height`](/en-US/docs/Web/HTML/Element/canvas#height). These are both optional and can also be set using {{Glossary("DOM")}} [properties](/en-US/docs/Web/API/HTMLCanvasElement). When no `width` and `height` attributes are specified, the canvas will initially be **300 pixels** wide and **150 pixels** high. The element can be sized arbitrarily by {{Glossary("CSS")}}, but during rendering the image is scaled to fit its layout size: if the CSS sizing doesn't respect the ratio of the initial canvas, it will appear distorted.
 
-> **Note:** If your renderings seem distorted, try specifying your `width` and `height` attributes explicitly in the `<canvas>` attributes, and not using CSS.
+> [!NOTE]
+> If your renderings seem distorted, try specifying your `width` and `height` attributes explicitly in the `<canvas>` attributes, and not using CSS.
 
 The [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute isn't specific to the `<canvas>` element but is one of the [global HTML attributes](/en-US/docs/Web/HTML/Global_attributes) which can be applied to any HTML element (like [`class`](/en-US/docs/Web/HTML/Global_attributes/class) for instance). It is always a good idea to supply an `id` because this makes it much easier to identify it in a script.
 
@@ -80,7 +81,8 @@ if (canvas.getContext) {
 
 Here is a minimalistic template, which we'll be using as a starting point for later examples.
 
-> **Note:** it is not good practice to embed a script inside HTML. We do it here to keep the example concise.
+> [!NOTE]
+> it is not good practice to embed a script inside HTML. We do it here to keep the example concise.
 
 ```html
 <!doctype html>

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -93,13 +93,15 @@ Here are the functions used to perform these steps:
 
 The first step to create a path is to call the `beginPath()`. Internally, paths are stored as a list of sub-paths (lines, arcs, etc.) which together form a shape. Every time this method is called, the list is reset and we can start drawing new shapes.
 
-> **Note:** When the current path is empty, such as immediately after calling `beginPath()`, or on a newly created canvas, the first path construction command is always treated as a `moveTo()`, regardless of what it actually is. For that reason, you will almost always want to specifically set your starting position after resetting a path.
+> [!NOTE]
+> When the current path is empty, such as immediately after calling `beginPath()`, or on a newly created canvas, the first path construction command is always treated as a `moveTo()`, regardless of what it actually is. For that reason, you will almost always want to specifically set your starting position after resetting a path.
 
 The second step is calling the methods that actually specify the paths to be drawn. We'll see these shortly.
 
 The third, and an optional step, is to call `closePath()`. This method tries to close the shape by drawing a straight line from the current point to the start. If the shape has already been closed or there's only one point in the list, this function does nothing.
 
-> **Note:** When you call `fill()`, any open shapes are closed automatically, so you don't have to call `closePath()`. This is **not** the case when you call `stroke()`.
+> [!NOTE]
+> When you call `fill()`, any open shapes are closed automatically, so you don't have to call `closePath()`. This is **not** the case when you call `stroke()`.
 
 ### Drawing a triangle
 
@@ -184,7 +186,8 @@ The result looks like this:
 
 If you'd like to see the connecting lines, you can remove the lines that call `moveTo()`.
 
-> **Note:** To learn more about the `arc()` function, see the [Arcs](#arcs) section below.
+> [!NOTE]
+> To learn more about the `arc()` function, see the [Arcs](#arcs) section below.
 
 ### Lines
 
@@ -250,7 +253,8 @@ To draw arcs or circles, we use the `arc()` or `arcTo()` methods.
 
 Let's have a more detailed look at the `arc` method, which takes six parameters: `x` and `y` are the coordinates of the center of the circle on which the arc should be drawn. `radius` is self-explanatory. The `startAngle` and `endAngle` parameters define the start and end points of the arc in radians, along the curve of the circle. These are measured from the x axis. The `counterclockwise` parameter is a Boolean value which, when `true`, draws the arc counterclockwise; otherwise, the arc is drawn clockwise.
 
-> **Note:** Angles in the `arc` function are measured in radians, not degrees. To convert degrees to radians you can use the following JavaScript expression: `radians = (Math.PI/180)*degrees`.
+> [!NOTE]
+> Angles in the `arc` function are measured in radians, not degrees. To convert degrees to radians you can use the following JavaScript expression: `radians = (Math.PI/180)*degrees`.
 
 The following example is a little more complex than the ones we've seen above. It draws 12 different arcs all with different angles and fills.
 
@@ -260,7 +264,8 @@ The `x` and `y` coordinates should be clear enough. `radius` and `startAngle` ar
 
 The statement for the `clockwise` parameter results in the first and third row being drawn as clockwise arcs and the second and fourth row as counterclockwise arcs. Finally, the `if` statement makes the top half stroked arcs and the bottom half filled arcs.
 
-> **Note:** This example requires a slightly larger canvas than the others on this page: 150 x 200 pixels.
+> [!NOTE]
+> This example requires a slightly larger canvas than the others on this page: 150 x 200 pixels.
 
 ```html hidden
 <html lang="en">

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -78,7 +78,8 @@ const myImageData = ctx.getImageData(left, top, width, height);
 
 This method returns an `ImageData` object representing the pixel data for the area of the canvas whose corners are represented by the points (`left`, `top`), (`left+width`, `top`), (`left`, `top+height`), and (`left+width`, `top+height`). The coordinates are specified in canvas coordinate space units.
 
-> **Note:** Any pixels outside the canvas are returned as transparent black in the resulting `ImageData` object.
+> [!NOTE]
+> Any pixels outside the canvas are returned as transparent black in the resulting `ImageData` object.
 
 This method is also demonstrated in the article [Manipulating video using canvas](/en-US/docs/Web/API/Canvas_API/Manipulating_video_using_canvas).
 
@@ -283,7 +284,8 @@ Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/mai
 
 The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is useful when saving images. It returns a [data URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)). The returned image is in a resolution of 96 dpi.
 
-> **Note:** Be aware that if the canvas contains any pixels that were obtained from another {{Glossary("origin")}} without using CORS, the canvas is **tainted** and its contents can no longer be read and saved.
+> [!NOTE]
+> Be aware that if the canvas contains any pixels that were obtained from another {{Glossary("origin")}} without using CORS, the canvas is **tainted** and its contents can no longer be read and saved.
 > See [Security and tainted canvases](/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases).
 
 - {{domxref("HTMLCanvasElement.toDataURL", "canvas.toDataURL('image/png')")}}

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
@@ -141,7 +141,8 @@ The rotation center point is always the canvas origin. To change the center poin
 
 In this example, we'll use the `rotate()` method to first rotate a rectangle from the canvas origin and then from the center of the rectangle itself with the help of `translate()`.
 
-> **Note:** Angles are in radians, not degrees. To convert, we are using: `radians = (Math.PI/180)*degrees`.
+> [!NOTE]
+> Angles are in radians, not degrees. To convert, we are using: `radians = (Math.PI/180)*degrees`.
 
 ```js
 function draw() {

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -133,7 +133,8 @@ Once we have a reference to our source image object we can use the `drawImage()`
 - {{domxref("CanvasRenderingContext2D.drawImage", "drawImage(image, x, y)")}}
   - : Draws the image specified by the `image` parameter at the coordinates (`x`, `y`).
 
-> **Note:** SVG images must specify a width and height in the root \<svg> element.
+> [!NOTE]
+> SVG images must specify a width and height in the root \<svg> element.
 
 ### Example: A small line graph
 
@@ -181,7 +182,8 @@ The second variant of the `drawImage()` method adds two new parameters and lets 
 
 In this example, we'll use an image as a wallpaper and repeat it several times on the canvas. This is done by looping and placing the scaled images at different positions. In the code below, the first `for` loop iterates over the rows. The second `for` loop iterates over the columns. The image is scaled to one third of its original size, which is 50x38 pixels.
 
-> **Note:** Images can become blurry when scaling up or grainy if they're scaled down too much. Scaling is probably best not done if you've got some text in it which needs to remain legible.
+> [!NOTE]
+> Images can become blurry when scaling up or grainy if they're scaled down too much. Scaling is probably best not done if you've got some text in it which needs to remain legible.
 
 ```html hidden
 <html lang="en">

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -13,7 +13,8 @@ The arc is automatically connected to the path's latest point with a straight li
 
 This method is commonly used for making rounded corners.
 
-> **Note:** You may get unexpected results when using a
+> [!NOTE]
+> You may get unexpected results when using a
 > relatively large radius: the arc's connecting line will go in whatever direction it
 > must to meet the specified radius.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -13,7 +13,8 @@ The
 method of the Canvas 2D API starts a new path by emptying the list of sub-paths. Call
 this method when you want to create a new path.
 
-> **Note:** To create a new sub-path, i.e., one matching the current
+> [!NOTE]
+> To create a new sub-path, i.e., one matching the current
 > canvas state, you can use {{domxref("CanvasRenderingContext2D.moveTo()")}}.
 
 ## Syntax

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -13,7 +13,8 @@ The
 method of the Canvas 2D API erases the pixels in a rectangular area by setting them to
 transparent black.
 
-> **Note:** Be aware that `clearRect()` may cause unintended
+> [!NOTE]
+> Be aware that `clearRect()` may cause unintended
 > side effects if you're not [using paths properly](/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes#drawing_paths). Make sure to call
 > {{domxref("CanvasRenderingContext2D.beginPath", "beginPath()")}} before starting to
 > draw new items after calling `clearRect()`.

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -20,13 +20,15 @@ drawn.
 
 ![Star-shaped clipping region](canvas_clipping_path.png)
 
-> **Note:** Be aware that the clipping region is only constructed from
+> [!NOTE]
+> Be aware that the clipping region is only constructed from
 > shapes added to the path. It doesn't work with shape primitives drawn directly to the
 > canvas, such as {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
 > Instead, you'd have to use {{domxref("CanvasRenderingContext2D.rect()","rect()")}} to
 > add a rectangular shape to the path before calling `clip()`.
 
-> **Note:** Clip paths cannot be reverted directly. You must save your canvas state using {{domxref("CanvasRenderingContext2D/save", "save()")}} before calling `clip()`, and restore it once you have finished drawing in the clipped area using {{domxref("CanvasRenderingContext2D/restore", "restore()")}}.
+> [!NOTE]
+> Clip paths cannot be reverted directly. You must save your canvas state using {{domxref("CanvasRenderingContext2D/save", "save()")}} before calling `clip()`, and restore it once you have finished drawing in the clipped area using {{domxref("CanvasRenderingContext2D/restore", "restore()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
@@ -71,7 +71,8 @@ ctx.stroke();
 
 This example draws a smiley face consisting of three disconnected sub-paths.
 
-> **Note:** Although `closePath()` is called after all the arcs have been
+> [!NOTE]
+> Although `closePath()` is called after all the arcs have been
 > created, only the last arc (sub-path) gets closed.
 
 #### HTML

--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
@@ -12,7 +12,8 @@ The **`CanvasRenderingContext2D.createConicGradient()`** method of the Canvas 2D
 
 This method returns a conic {{domxref("CanvasGradient")}}. To be applied to a shape, the gradient must first be assigned to the {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} or {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}} properties.
 
-> **Note:** Gradient coordinates are global, i.e., relative to the current coordinate space. When applied to a shape, the coordinates are NOT relative to the shape's coordinates.
+> [!NOTE]
+> Gradient coordinates are global, i.e., relative to the current coordinate space. When applied to a shape, the coordinates are NOT relative to the shape's coordinates.
 
 ## Syntax
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
@@ -20,7 +20,8 @@ the gradient must first be assigned to the
 {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} or
 {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}} properties.
 
-> **Note:** Gradient coordinates are global, i.e., relative to the current
+> [!NOTE]
+> Gradient coordinates are global, i.e., relative to the current
 > coordinate space. When applied to a shape, the coordinates are NOT relative to the
 > shape's coordinates.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
@@ -16,7 +16,8 @@ two circles.
 This method returns a {{domxref("CanvasGradient")}}. To be applied to a shape, the
 gradient must first be assigned to the {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} or {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}} properties.
 
-> **Note:** Gradient coordinates are global, i.e., relative to the current
+> [!NOTE]
+> Gradient coordinates are global, i.e., relative to the current
 > coordinate space. When applied to a shape, the coordinates are NOT relative to the
 > shape's coordinates.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -14,7 +14,8 @@ property of the [Canvas 2D API](/en-US/docs/Web/API/Canvas_API) specifies the
 color, gradient, or pattern to use inside shapes. The default style is `#000`
 (black).
 
-> **Note:** For more examples of fill and stroke styles, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
+> [!NOTE]
+> For more examples of fill and stroke styles, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
 ## Value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
@@ -25,7 +25,8 @@ The text is rendered using the font and text layout configuration as defined by 
 {{domxref("CanvasRenderingContext2D.textBaseline","textBaseline")}}, and
 {{domxref("CanvasRenderingContext2D.direction","direction")}} properties.
 
-> **Note:** To draw the outlines of the characters in a string, call the context's
+> [!NOTE]
+> To draw the outlines of the characters in a string, call the context's
 > {{domxref("CanvasRenderingContext2D.strokeText", "strokeText()")}} method.
 
 ## Syntax

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -17,7 +17,8 @@ This method is not affected by the canvas's transformation matrix. If the specif
 rectangle extends outside the bounds of the canvas, the pixels outside the canvas are
 transparent black in the returned `ImageData` object.
 
-> **Note:** Image data can be painted onto a canvas using the
+> [!NOTE]
+> Image data can be painted onto a canvas using the
 > {{domxref("CanvasRenderingContext2D.putImageData()", "putImageData()")}} method.
 
 You can find more information about `getImageData()` and general

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
@@ -32,7 +32,8 @@ The transformation matrix is described by:
 </math>
 <!-- prettier-ignore-end -->
 
-> **Note:** The returned object is not live, so updating it will not
+> [!NOTE]
+> The returned object is not live, so updating it will not
 > affect the current transformation matrix, and updating the current transformation
 > matrix will not affect an already returned `DOMMatrix`.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
@@ -13,7 +13,8 @@ The
 property of the Canvas 2D API specifies the alpha (transparency) value that is applied
 to shapes and images before they are drawn onto the canvas.
 
-> **Note:** See also the chapter [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas Tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
+> [!NOTE]
+> See also the chapter [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas Tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
 ## Value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -17,7 +17,8 @@ This property is useful for games and other apps that use pixel art. When enlarg
 images, the default resizing algorithm will blur the pixels. Set this property to
 `false` to retain the pixels' sharpness.
 
-> **Note:** You can adjust the smoothing quality with the
+> [!NOTE]
+> You can adjust the smoothing quality with the
 > {{domxref("CanvasRenderingContext2D.imageSmoothingQuality", "imageSmoothingQuality")}}
 > property.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
@@ -12,7 +12,8 @@ The **`imageSmoothingQuality`** property of the
 {{domxref("CanvasRenderingContext2D")}} interface, part of the [Canvas API](/en-US/docs/Web/API/Canvas_API), lets you set the quality of
 image smoothing.
 
-> **Note:** For this property to have an effect,
+> [!NOTE]
+> For this property to have an effect,
 > {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled", "imageSmoothingEnabled")}}
 > must be `true`.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -12,7 +12,8 @@ The
 **`CanvasRenderingContext2D.lineCap`**
 property of the Canvas 2D API determines the shape used to draw the end points of lines.
 
-> **Note:** Lines can be drawn with the
+> [!NOTE]
+> Lines can be drawn with the
 > {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}}, {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}},
 > and {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}} methods.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
@@ -12,7 +12,8 @@ The
 **`CanvasRenderingContext2D.lineDashOffset`**
 property of the Canvas 2D API sets the line dash offset, or "phase."
 
-> **Note:** Lines are drawn by calling the
+> [!NOTE]
+> Lines are drawn by calling the
 > {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}} method.
 
 ## Value

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.md
@@ -18,7 +18,8 @@ because no joining area will be added in this case. Degenerate segments with a l
 zero (i.e., with all endpoints and control points at the exact same position) are also
 ignored.
 
-> **Note:** Lines can be drawn with the
+> [!NOTE]
+> Lines can be drawn with the
 > {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}},
 > {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}},
 > and {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}} methods.

--- a/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.md
@@ -12,7 +12,8 @@ The
 **`CanvasRenderingContext2D.lineWidth`**
 property of the Canvas 2D API sets the thickness of lines.
 
-> **Note:** Lines can be drawn with the
+> [!NOTE]
+> Lines can be drawn with the
 > {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}},
 > {{domxref("CanvasRenderingContext2D.strokeRect()", "strokeRect()")}},
 > and {{domxref("CanvasRenderingContext2D.strokeText()", "strokeText()")}} methods.

--- a/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.md
@@ -11,7 +11,8 @@ browser-compat: api.CanvasRenderingContext2D.miterLimit
 The **`CanvasRenderingContext2D.miterLimit`** property of the
 Canvas 2D API sets the miter limit ratio.
 
-> **Note:** For more info about miters, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
+> [!NOTE]
+> For more info about miters, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
 ## Value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -13,7 +13,8 @@ method of the Canvas 2D API paints data from the given {{domxref("ImageData")}} 
 onto the canvas. If a dirty rectangle is provided, only the pixels from that rectangle
 are painted. This method is not affected by the canvas transformation matrix.
 
-> **Note:** Image data can be retrieved from a canvas using the
+> [!NOTE]
+> Image data can be retrieved from a canvas using the
 > {{domxref("CanvasRenderingContext2D.getImageData()", "getImageData()")}} method.
 
 You can find more information about `putImageData()` and general
@@ -120,7 +121,8 @@ putImageData(ctx, imagedata, 150, 0, 50, 50, 25, 25);
 
 ### Data loss due to browser optimization
 
-> **Warning:** Due to the lossy nature of converting to and from premultiplied alpha color values,
+> [!WARNING]
+> Due to the lossy nature of converting to and from premultiplied alpha color values,
 > pixels that have just been set using `putImageData()` might be returned to
 > an equivalent `getImageData()` as different values.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
@@ -17,7 +17,8 @@ anything. To draw the rectangle onto a canvas, you can use the
 {{domxref("CanvasRenderingContext2D.fill", "fill()")}} or
 {{domxref("CanvasRenderingContext2D.stroke", "stroke()")}} methods.
 
-> **Note:** To both create and render a rectangle in one step, use the
+> [!NOTE]
+> To both create and render a rectangle in one step, use the
 > {{domxref("CanvasRenderingContext2D.fillRect", "fillRect()")}} or
 > {{domxref("CanvasRenderingContext2D.strokeRect", "strokeRect()")}} methods.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
@@ -13,7 +13,8 @@ The **`setLineDash()`** method of the Canvas 2D API's
 stroking lines. It uses an array of values that specify alternating lengths of lines
 and gaps which describe the pattern.
 
-> **Note:** To return to using solid lines, set the line dash list to an
+> [!NOTE]
+> To return to using solid lines, set the line dash list to an
 > empty array.
 
 ## Syntax

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -10,7 +10,8 @@ browser-compat: api.CanvasRenderingContext2D.setTransform
 
 The **`CanvasRenderingContext2D.setTransform()`** method of the Canvas 2D API resets (overrides) the current transformation to the identity matrix, and then invokes a transformation described by the arguments of this method. This lets you scale, rotate, translate (move), and skew the context.
 
-> **Note:** See also the {{domxref("CanvasRenderingContext2D.transform()", "transform()")}} method; instead of overriding the current transform matrix, it
+> [!NOTE]
+> See also the {{domxref("CanvasRenderingContext2D.transform()", "transform()")}} method; instead of overriding the current transform matrix, it
 > multiplies it with a given one.
 
 ## Syntax

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.md
@@ -13,7 +13,8 @@ The
 property of the Canvas 2D API specifies the amount of blur applied to shadows. The
 default is `0` (no blur).
 
-> **Note:** Shadows are only drawn if the
+> [!NOTE]
+> Shadows are only drawn if the
 > {{domxref("CanvasRenderingContext2D.shadowColor", "shadowColor")}} property is set to
 > a non-transparent value. One of the `shadowBlur`,
 > {{domxref("CanvasRenderingContext2D.shadowOffsetX", "shadowOffsetX")}}, or

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.md
@@ -17,7 +17,8 @@ Be aware that the shadow's rendered opacity will be affected by the opacity of t
 of the {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}} color when
 stroking.
 
-> **Note:** Shadows are only drawn if the `shadowColor`
+> [!NOTE]
+> Shadows are only drawn if the `shadowColor`
 > property is set to a non-transparent value. One of the
 > {{domxref("CanvasRenderingContext2D.shadowBlur", "shadowBlur")}},
 > {{domxref("CanvasRenderingContext2D.shadowOffsetX", "shadowOffsetX")}}, or

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.md
@@ -13,7 +13,8 @@ The
 property of the Canvas 2D API specifies the distance that shadows will be offset
 horizontally.
 
-> **Note:** Shadows are only drawn if the
+> [!NOTE]
+> Shadows are only drawn if the
 > {{domxref("CanvasRenderingContext2D.shadowColor", "shadowColor")}} property is set to
 > a non-transparent value. One of the {{domxref("CanvasRenderingContext2D.shadowBlur", "shadowBlur")}}, `shadowOffsetX`, or
 > {{domxref("CanvasRenderingContext2D.shadowOffsetY", "shadowOffsetY")}} properties must

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.md
@@ -13,7 +13,8 @@ The
 property of the Canvas 2D API specifies the distance that shadows will be offset
 vertically.
 
-> **Note:** Shadows are only drawn if the
+> [!NOTE]
+> Shadows are only drawn if the
 > {{domxref("CanvasRenderingContext2D.shadowColor", "shadowColor")}} property is set to
 > a non-transparent value. One of the {{domxref("CanvasRenderingContext2D.shadowBlur", "shadowBlur")}},
 > {{domxref("CanvasRenderingContext2D.shadowOffsetX", "shadowOffsetX")}}, or `shadowOffsetY` properties must be non-zero, as

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -12,7 +12,8 @@ The **`CanvasRenderingContext2D.strokeStyle`** property of the
 Canvas 2D API specifies the color, gradient, or pattern to use for the strokes
 (outlines) around shapes. The default is `#000` (black).
 
-> **Note:** For more examples of stroke and fill styles, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
+> [!NOTE]
+> For more examples of stroke and fill styles, see [Applying styles and color](/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors) in the [Canvas tutorial](/en-US/docs/Web/API/Canvas_API/Tutorial).
 
 ## Value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
@@ -20,7 +20,8 @@ subsequent {{domxref("CanvasRenderingContext2D.fill()", "fill()")}} or
 {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}} calls will have no effect
 on it.
 
-> **Note:** Use the {{domxref('CanvasRenderingContext2D.fillText()', 'fillText()')}} method to
+> [!NOTE]
+> Use the {{domxref('CanvasRenderingContext2D.fillText()', 'fillText()')}} method to
 > fill the text characters rather than having just their outlines drawn.
 
 ## Syntax

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
@@ -14,7 +14,8 @@ method of the Canvas 2D API multiplies the current transformation with the matri
 described by the arguments of this method. This lets you scale, rotate, translate
 (move), and skew the context.
 
-> **Note:** See also the
+> [!NOTE]
+> See also the
 > {{domxref("CanvasRenderingContext2D.setTransform()", "setTransform()")}} method, which
 > resets the current transform to the identity matrix and then invokes
 > `transform()`.

--- a/files/en-us/web/api/cdatasection/index.md
+++ b/files/en-us/web/api/cdatasection/index.md
@@ -29,7 +29,8 @@ For example:
 The only sequence which is not allowed within a CDATA section is the closing sequence
 of a CDATA section itself, `]]>`.
 
-> **Note:** CDATA sections should not be used within HTML they are considered as comments and not displayed.
+> [!NOTE]
+> CDATA sections should not be used within HTML they are considered as comments and not displayed.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
+++ b/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
@@ -19,7 +19,8 @@ Channel messaging is mainly useful in cases where you've got a social site that 
 
 Message channels on the other hand can provide a secure channel that allows you to pass data between different browsing contexts.
 
-> **Note:** For more information and ideas, the [Ports as the basis of an object-capability model on the Web](https://html.spec.whatwg.org/multipage/comms.html#ports-as-the-basis-of-an-object-capability-model-on-the-web) section of the spec is a useful read.
+> [!NOTE]
+> For more information and ideas, the [Ports as the basis of an object-capability model on the Web](https://html.spec.whatwg.org/multipage/comms.html#ports-as-the-basis-of-an-object-capability-model-on-the-web) section of the spec is a useful read.
 
 ## Simple examples
 

--- a/files/en-us/web/api/characterdata/after/index.md
+++ b/files/en-us/web/api/characterdata/after/index.md
@@ -50,7 +50,8 @@ h1TextNode.data;
 // "CharacterData.after()"
 ```
 
-> **Note:** If you rather want to append text to the current node,
+> [!NOTE]
+> If you rather want to append text to the current node,
 > the [`appendData()`](/en-US/docs/Web/API/CharacterData/appendData) method lets you append to the current node's data.
 
 ## Specifications

--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -25,7 +25,8 @@ replaceWith(...nodes)
 - `nodes` {{optional_inline}}
   - : A comma-separated list of {{domxref("Node")}} objects or strings that will replace the current node.
 
-> **Note:** If no arguments are passed in, this method removes the node from the DOM tree.
+> [!NOTE]
+> If no arguments are passed in, this method removes the node from the DOM tree.
 
 ### Return value
 

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -129,7 +129,8 @@ The example will fetch the image data from the clipboard and display the image i
 
 {{EmbedLiveSample("Reading image data from clipboard", "100%", "200")}}
 
-> **Note:** If prompted, grant permission in order to paste the image.
+> [!NOTE]
+> If prompted, grant permission in order to paste the image.
 
 ### Reading data from the clipboard
 

--- a/files/en-us/web/api/clipboard/readtext/index.md
+++ b/files/en-us/web/api/clipboard/readtext/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Clipboard.readText
 
 The **`readText()`** method of the {{domxref("Clipboard")}} interface returns a {{jsxref("Promise")}} which fulfils with a copy of the textual contents of the system clipboard.
 
-> **Note:** To read non-text contents from the clipboard, use the {{domxref("Clipboard.read", "read()")}} method instead.
+> [!NOTE]
+> To read non-text contents from the clipboard, use the {{domxref("Clipboard.read", "read()")}} method instead.
 > You can write text to the clipboard using {{domxref("Clipboard.writeText", "writeText()")}}.
 
 ## Syntax

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -12,9 +12,11 @@ browser-compat:
 
 The **Clipboard API** provides the ability to respond to clipboard commands (cut, copy, and paste), as well as to asynchronously read from and write to the system clipboard.
 
-> **Note:** Use this API in preference to the deprecated {{domxref("document.execCommand()")}} method for accessing the clipboard.
+> [!NOTE]
+> Use this API in preference to the deprecated {{domxref("document.execCommand()")}} method for accessing the clipboard.
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
 ## Concepts and usage
 

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ClipboardItem.ClipboardItem
 
 The **`ClipboardItem()`** constructor creates a new {{domxref("ClipboardItem")}} object, which represents data to be stored or retrieved via the [Clipboard API](/en-US/docs/Web/API/Clipboard_API) {{domxref("clipboard.write()")}} and {{domxref("clipboard.read()")}} methods, respectively.
 
-> **Note:** Image format support varies by browser. See the browser compatibility table for the {{domxref("Clipboard")}} interface.
+> [!NOTE]
+> Image format support varies by browser. See the browser compatibility table for the {{domxref("Clipboard")}} interface.
 
 ## Syntax
 
@@ -30,14 +31,16 @@ new ClipboardItem(data, options)
       - : One of the three strings: `unspecified`, `inline` or `attachment`.
         The default is `unspecified`.
 
-> **Note:** You can also work with text via the {{domxref("Clipboard.readText()")}} and {{domxref("Clipboard.writeText()")}} methods of the {{domxref("Clipboard")}} interface.
+> [!NOTE]
+> You can also work with text via the {{domxref("Clipboard.readText()")}} and {{domxref("Clipboard.writeText()")}} methods of the {{domxref("Clipboard")}} interface.
 
 ## Examples
 
 The below example requests a PNG image using {{domxref("Window/fetch", "fetch()")}}, and in turn, the {{domxref("Response.blob()")}} method, to create a new {{domxref("ClipboardItem")}}.
 This item is then written to the clipboard, using the {{domxref("Clipboard.write()")}} method.
 
-> **Note:** You can only pass in one clipboard item at a time.
+> [!NOTE]
+> You can only pass in one clipboard item at a time.
 
 ```js
 async function writeClipImg() {

--- a/files/en-us/web/api/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/index.md
@@ -11,7 +11,8 @@ The **`ClipboardItem`** interface of the [Clipboard API](/en-US/docs/Web/API/Cli
 
 The benefit of having the **`ClipboardItem`** interface to represent data, is that it enables developers to cope with the varying scope of file types and data.
 
-> **Note:** To work with text see the {{domxref("Clipboard.readText()")}} and {{domxref("Clipboard.writeText()")}} methods of the {{domxref("Clipboard")}} interface.
+> [!NOTE]
+> To work with text see the {{domxref("Clipboard.readText()")}} and {{domxref("Clipboard.writeText()")}} methods of the {{domxref("Clipboard")}} interface.
 
 ## Constructor
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.md
@@ -14,7 +14,8 @@ The **`initCompositionEvent()`**
 method of the {{domxref("CompositionEvent")}} interface initializes the attributes of a
 `CompositionEvent` object instance.
 
-> **Note:** The correct way of creating a {{domxref("CompositionEvent")}} is to use
+> [!NOTE]
+> The correct way of creating a {{domxref("CompositionEvent")}} is to use
 > the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.
 
 ## Syntax

--- a/files/en-us/web/api/compositionevent/locale/index.md
+++ b/files/en-us/web/api/compositionevent/locale/index.md
@@ -15,7 +15,8 @@ The **`locale`** read-only property of the
 {{domxref("CompositionEvent")}} interface returns the locale of current input method
 (for example, the keyboard layout locale if the composition is associated with {{glossary("IME")}}).
 
-> **Warning:** Even for browsers supporting it, don't trust the value contained in this property.
+> [!WARNING]
+> Even for browsers supporting it, don't trust the value contained in this property.
 > Even if technically it is accessible, the way to set it up when creating a {{domxref("CompositionEvent")}}
 > is not guaranteed to be coherent.
 

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -214,9 +214,11 @@ The properties usable along with the `%c` syntax are as follows (at least, in Fi
 - {{cssxref("word-spacing")}} and {{cssxref("word-break")}}
 - {{cssxref("writing-mode")}}
 
-> **Note:** Each console message behaves like an inline element by default. If you want properties such as `padding`, `margin`, and so on to have any effect, you can set the `display` property to `display: inline-block`.
+> [!NOTE]
+> Each console message behaves like an inline element by default. If you want properties such as `padding`, `margin`, and so on to have any effect, you can set the `display` property to `display: inline-block`.
 
-> **Note:** In order to support both light and dark color schemes, {{cssxref("color_value/light-dark")}} can be used when specifying colors; for example: `color: light-dark(#D00000, #FF4040);`
+> [!NOTE]
+> In order to support both light and dark color schemes, {{cssxref("color_value/light-dark")}} can be used when specifying colors; for example: `color: light-dark(#D00000, #FF4040);`
 
 ### Using groups in the console
 

--- a/files/en-us/web/api/console/trace_static/index.md
+++ b/files/en-us/web/api/console/trace_static/index.md
@@ -10,7 +10,8 @@ browser-compat: api.console.trace_static
 
 The **`console.trace()`** static method outputs a stack trace to the console.
 
-> **Note:** In some browsers, `console.trace()` may also output the sequence of calls and asynchronous events leading to the current `console.trace()` which are not on the call stack — to help identify the origin of the current event evaluation loop.
+> [!NOTE]
+> In some browsers, `console.trace()` may also output the sequence of calls and asynchronous events leading to the current `console.trace()` which are not on the call stack — to help identify the origin of the current event evaluation loop.
 
 See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the {{domxref("console")}} documentation for details and examples.
 

--- a/files/en-us/web/api/constantsourcenode/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/constantsourcenode/index.md
@@ -45,7 +45,8 @@ let audioContext = new AudioContext();
 let myConstantSource = new ConstantSourceNode(audioContext, { offset: 0.5 });
 ```
 
-> **Note:** The new `ConstantSourceNode` created by the
+> [!NOTE]
+> The new `ConstantSourceNode` created by the
 > constructor has a
 > [`channelCount`](/en-US/docs/Web/API/AudioNode/channelCount) of
 > 2\.

--- a/files/en-us/web/api/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/index.md
@@ -42,7 +42,8 @@ _Inherits properties from its parent interface, {{domxref("AudioScheduledSourceN
 
 _Inherits events from its parent interface, {{domxref("AudioScheduledSourceNode")}}._
 
-> **Note:** Some browsers' implementations of these events are part of the {{domxref("AudioScheduledSourceNode")}} interface.
+> [!NOTE]
+> Some browsers' implementations of these events are part of the {{domxref("AudioScheduledSourceNode")}} interface.
 
 - {{domxref("AudioScheduledSourceNode.ended_event","ended")}}
   - : Fired whenever the `ConstantSourceNode` data has stopped playing.
@@ -51,7 +52,8 @@ _Inherits events from its parent interface, {{domxref("AudioScheduledSourceNode"
 
 _Inherits methods from its parent interface, {{domxref("AudioScheduledSourceNode")}}._
 
-> **Note:** Some browsers' implementations of these methods are part of the {{domxref("AudioScheduledSourceNode")}} interface.
+> [!NOTE]
+> Some browsers' implementations of these methods are part of the {{domxref("AudioScheduledSourceNode")}} interface.
 
 - {{domxref("AudioScheduledSourceNode.start", "start()")}}
   - : Schedules a sound to playback at an exact time.

--- a/files/en-us/web/api/constantsourcenode/offset/index.md
+++ b/files/en-us/web/api/constantsourcenode/offset/index.md
@@ -12,7 +12,8 @@ The read-only `offset` property of the {{ domxref("ConstantSourceNode") }}
 interface returns a {{domxref("AudioParam")}} object indicating the numeric [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) value which is always returned
 by the source when asked for the next sample.
 
-> **Note:** While the `AudioParam` named `offset` is read-only, the
+> [!NOTE]
+> While the `AudioParam` named `offset` is read-only, the
 > `value` property within is not. So you can change the value of
 > `offset` by setting the value of
 > `ConstantSourceNode.offset.value`:

--- a/files/en-us/web/api/contact_picker_api/index.md
+++ b/files/en-us/web/api/contact_picker_api/index.md
@@ -11,7 +11,8 @@ browser-compat: api.ContactsManager
 
 The Contact Picker API allows users to select entries from their contact list and share limited details of the selected entries with a website or application.
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
 ## Contact Picker API Concepts and Usage
 

--- a/files/en-us/web/api/content_index_api/index.md
+++ b/files/en-us/web/api/content_index_api/index.md
@@ -22,7 +22,8 @@ The Content Index API is an extension to [service workers](/en-US/docs/Web/API/S
 
 Indexed entries do not automatically expire. It's good practice to present an interface for clearing out entries, or periodically remove older entries.
 
-> **Note:** The API supports indexing URLs corresponding to HTML documents. A URL for a cached media file, for example, can't be indexed directly. Instead, you need to provide a URL for a page that displays media, and which works offline.
+> [!NOTE]
+> The API supports indexing URLs corresponding to HTML documents. A URL for a cached media file, for example, can't be indexed directly. Instead, you need to provide a URL for a page that displays media, and which works offline.
 
 ## Interfaces
 

--- a/files/en-us/web/api/contentindex/delete/index.md
+++ b/files/en-us/web/api/contentindex/delete/index.md
@@ -14,7 +14,8 @@ The **`delete()`** method of the
 {{domxref("ContentIndex")}} interface unregisters an item from the currently indexed
 content.
 
-> **Note:** Calling `delete()` only affects the index. It does not delete anything
+> [!NOTE]
+> Calling `delete()` only affects the index. It does not delete anything
 > from the {{domxref('Cache')}}.
 
 ## Syntax

--- a/files/en-us/web/api/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/index.md
@@ -9,7 +9,8 @@ browser-compat: api.ConvolverNode
 
 The `ConvolverNode` interface is an {{domxref("AudioNode")}} that performs a Linear Convolution on a given {{domxref("AudioBuffer")}}, often used to achieve a reverb effect. A `ConvolverNode` always has exactly one input and one output.
 
-> **Note:** For more information on the theory behind Linear Convolution, see the [Convolution article on Wikipedia](https://en.wikipedia.org/wiki/Convolution).
+> [!NOTE]
+> For more information on the theory behind Linear Convolution, see the [Convolution article on Wikipedia](https://en.wikipedia.org/wiki/Convolution).
 
 {{InheritanceDiagram}}
 
@@ -60,7 +61,8 @@ _No specific method; inherits methods from its parent, {{domxref("AudioNode")}}_
 
 The following example shows basic usage of an AudioContext to create a convolver node.
 
-> **Note:** You will need to find an impulse response to complete the example below. See this [Codepen](https://codepen.io/DonKarlssonSan/pen/doVKRE) for an applied example.
+> [!NOTE]
+> You will need to find an impulse response to complete the example below. See this [Codepen](https://codepen.io/DonKarlssonSan/pen/doVKRE) for an applied example.
 
 ```js
 let audioCtx = new window.AudioContext();

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -12,7 +12,8 @@ The **`CookieChangeEvent()`** constructor creates a new {{domxref("CookieChangeE
 which is the event type of the {{domxref("CookieStore/change_event", "change")}} event fired at a {{domxref("CookieStore")}} when any cookie changes occur.
 This constructor is called by the browser when a change event occurs.
 
-> **Note:** This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.
+> [!NOTE]
+> This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.
 
 ## Syntax
 

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -15,7 +15,8 @@ Cookie changes that will cause the `CookieChangeEvent` to be dispatched are:
 - A cookie is newly created and immediately removed. In this case `type` is "deleted".
 - A cookie is removed. In this case `type` is "deleted".
 
-> **Note:** A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
+> [!NOTE]
+> A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -35,7 +35,8 @@ Or
     - `url`
       - : A string with the URL of a cookie.
 
-> **Note:** The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
+> [!NOTE]
+> The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
 
 ### Return value
 

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -33,7 +33,8 @@ Or
     - `url`
       - : A string with the URL of a cookie.
 
-> **Note:** The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
+> [!NOTE]
+> The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
 
 ### Return value
 

--- a/files/en-us/web/api/credential_management_api/credential_types/index.md
+++ b/files/en-us/web/api/credential_management_api/credential_types/index.md
@@ -21,7 +21,8 @@ The credential types are all represented as subclasses of the {{domxref("Credent
 
 In this guide we'll introduce the different credential types and explain at a high level how they are used.
 
-> **Note:** Although we're describing all the credential types together here, the different credential types are defined in several different specifications, which extend the main Credential Management API specification.
+> [!NOTE]
+> Although we're describing all the credential types together here, the different credential types are defined in several different specifications, which extend the main Credential Management API specification.
 >
 > - [Credential Management API](https://w3c.github.io/webappsec-credential-management/) defines passwords and legacy federated credentials.
 > - [Federated Credential Management API](https://fedidcg.github.io/FedCM/) defines the new federated credentials.
@@ -30,7 +31,8 @@ In this guide we'll introduce the different credential types and explain at a hi
 
 ## Passwords
 
-> **Note:** Most browsers do not support this credential type and it is not widely used on the web. Instead, browsers automatically offer to store passwords in a password manager, and can automatically retrieve stored passwords to autofill [password input elements](/en-US/docs/Web/HTML/Element/input/password).
+> [!NOTE]
+> Most browsers do not support this credential type and it is not widely used on the web. Instead, browsers automatically offer to store passwords in a password manager, and can automatically retrieve stored passwords to autofill [password input elements](/en-US/docs/Web/HTML/Element/input/password).
 
 Modern browsers provide users with a password manager, which enables users to store the passwords they enter on websites, and later retrieve them when they need to log in again. Password managers can help with password security by remembering passwords for users and autofilling them, which allows users to choose stronger passwords.
 
@@ -58,7 +60,8 @@ If, in the course of this exchange, the user can be authenticated with the IdP, 
 
 Note that {{domxref("CredentialsContainer.create", "create()")}} and {{domxref("CredentialsContainer.store", "store()")}} are not used when working with the Federated Credential Management API.
 
-> **Note:** Support for federated identity in the Credential Management API was originally provided through the {{domxref("FederatedCredential")}} interface. However, this mechanism depends on technologies such as [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies), which are intrinsically privacy-invasive. These technologies were [deprecated in browsers](/en-US/blog/goodbye-third-party-cookies/), therefore a new approach was needed.
+> [!NOTE]
+> Support for federated identity in the Credential Management API was originally provided through the {{domxref("FederatedCredential")}} interface. However, this mechanism depends on technologies such as [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies), which are intrinsically privacy-invasive. These technologies were [deprecated in browsers](/en-US/blog/goodbye-third-party-cookies/), therefore a new approach was needed.
 
 ## One-time passwords
 

--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -44,7 +44,8 @@ create(options)
 
       - : A {{domxref("PublicKeyCredentialCreationOptions")}} object containing requirements for creating a public key credential. Causes the `create()` call to request that the user agent creates new credentials via an authenticator — either for registering a new account or for associating a new asymmetric key pair with an existing account.
 
-        > **Note:** Usage of `create()` with the `publicKey` parameter may be blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
+        > [!NOTE]
+        > Usage of `create()` with the `publicKey` parameter may be blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
 
 ### Return value
 
@@ -166,7 +167,8 @@ navigator.credentials.create({ publicKey }).then((publicKeyCredential) => {
 
 Some of this data will need to be stored on the server for future authentication operations against this credential — for example the public key, the algorithm used, and the permissible transports.
 
-> **Note:** See [Creating a key pair and registering a user](/en-US/docs/Web/API/Web_Authentication_API#creating_a_key_pair_and_registering_a_user) for more information about how the overall flow works.
+> [!NOTE]
+> See [Creating a key pair and registering a user](/en-US/docs/Web/API/Web_Authentication_API#creating_a_key_pair_and_registering_a_user) for more information about how the overall flow works.
 
 ## Specifications
 

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -44,7 +44,8 @@ get(options)
 
         If `mediation` is omitted, it will default to `"optional"`.
 
-        > **Note:** In the case of a [federated authentication (FedCM API)](/en-US/docs/Web/API/FedCM_API) request, a `mediation` value of `optional` or `silent` may result in attempted [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication). Whether this occurred is communicated to the identity provider (IdP) via the [`is_auto_selected`](/en-US/docs/Web/API/FedCM_API/IDP_integration#is_auto_selected) parameter sent to the IdP's `id_assertion_endpoint` during validation and the relying party (RP) via the {{domxref("IdentityCredential.isAutoSelected")}} property. This is useful for performance evaluation, security requirements (the IdP may wish to reject automatic reauthentication requests and always require user mediation), and general UX (an IdP or RP may wish to present different UX for auto and non-auto login experiences).
+        > [!NOTE]
+        > In the case of a [federated authentication (FedCM API)](/en-US/docs/Web/API/FedCM_API) request, a `mediation` value of `optional` or `silent` may result in attempted [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication). Whether this occurred is communicated to the identity provider (IdP) via the [`is_auto_selected`](/en-US/docs/Web/API/FedCM_API/IDP_integration#is_auto_selected) parameter sent to the IdP's `id_assertion_endpoint` during validation and the relying party (RP) via the {{domxref("IdentityCredential.isAutoSelected")}} property. This is useful for performance evaluation, security requirements (the IdP may wish to reject automatic reauthentication requests and always require user mediation), and general UX (an IdP or RP may wish to present different UX for auto and non-auto login experiences).
 
     - `signal` {{optional_inline}}
 
@@ -110,7 +111,8 @@ The [Federated Credential Management (FedCM) API](/en-US/docs/Web/API/FedCM_API)
 
 An individual can then use an existing IdP account (that they are already signed into on the browser) to sign into a website (a relying party or RP). The RP handles this by calling `get()` with an `identity` option.
 
-> **Note:** Usage of `get()` with the `identity` parameter may be blocked by an {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
+> [!NOTE]
+> Usage of `get()` with the `identity` parameter may be blocked by an {{httpheader("Permissions-Policy/identity-credentials-get", "identity-credentials-get")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
 
 ### `identity` object structure
 
@@ -135,7 +137,8 @@ An individual can then use an existing IdP account (that they are already signed
     - `nonce` {{optional_inline}}
       - : A random string that can be included to ensure the response is issued specifically for this request and prevent {{glossary("replay attack", "replay attacks")}}.
 
-    > **Note:** Currently FedCM only allows the API to be invoked with a single IdP, i.e. the `identity.providers` array has to have a length of 1. Multiple IdPs must be supported via different `get()` calls.
+    > [!NOTE]
+    > Currently FedCM only allows the API to be invoked with a single IdP, i.e. the `identity.providers` array has to have a length of 1. Multiple IdPs must be supported via different `get()` calls.
 
 ### Return value
 
@@ -147,7 +150,8 @@ The RP sends the token to its server to validate the certificate, and on success
 
 If the `get()` method's promise rejects, the RP can direct the user to the IdP login page to sign in or create an account.
 
-> **Note:** The exact nature of the token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
+> [!NOTE]
+> The exact nature of the token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
 
 ### Exceptions
 
@@ -206,7 +210,8 @@ async function signIn() {
 }
 ```
 
-> **Note:** After a user has signed in with an IdP, the IdP can call the static {{domxref("IdentityProvider.getUserInfo_static", "IdentityProvider.getUserInfo()")}} method to retrieve their details. `getUserInfo()` must be called from within an IdP-origin {{htmlelement("iframe")}} to ensure that RP scripts cannot access the data. This information can then be used to display a personalized welcome message and sign-in button. This approach is already common on sites that use identity federation for sign-in. However, `getUserInfo()` offers a way to achieve this without relying on [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies).
+> [!NOTE]
+> After a user has signed in with an IdP, the IdP can call the static {{domxref("IdentityProvider.getUserInfo_static", "IdentityProvider.getUserInfo()")}} method to retrieve their details. `getUserInfo()` must be called from within an IdP-origin {{htmlelement("iframe")}} to ensure that RP scripts cannot access the data. This information can then be used to display a personalized welcome message and sign-in button. This approach is already common on sites that use identity federation for sign-in. However, `getUserInfo()` offers a way to achieve this without relying on [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies).
 
 #### Example including Error API information
 
@@ -279,13 +284,15 @@ navigator.credentials
   });
 ```
 
-> **Note:** For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
+> [!NOTE]
+> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
 
 ## Web Authentication API
 
 The [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) enables strong authentication with public key cryptography, enabling passwordless authentication and/or secure multi-authentication (MFA) without SMS texts. Check out the linked API landing page for more usage information.
 
-> **Note:** Usage of `get()` with the `publicKey` parameter may be blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-get","publickey-credentials-get")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
+> [!NOTE]
+> Usage of `get()` with the `publicKey` parameter may be blocked by a {{HTTPHeader("Permissions-Policy/publickey-credentials-get","publickey-credentials-get")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
 
 ### `publicKey` object structure
 
@@ -303,7 +310,8 @@ The [Web Authentication API](/en-US/docs/Web/API/Web_Authentication_API) enables
 
       - : An array of strings providing hints as to the methods the client could use to communicate with the relevant authenticator of the public key credential to retrieve. Possible transports are: `"ble"`, `"hybrid"`, `"internal"`, `"nfc"`, and `"usb"`.
 
-        > **Note:** This value is mirrored by the return value of the {{domxref("AuthenticatorAttestationResponse.getTransports", "PublicKeyCredential.response.getTransports()")}} method of the {{domxref("PublicKeyCredential")}} object returned by the `create()` call that originally created the credential.
+        > [!NOTE]
+        > This value is mirrored by the return value of the {{domxref("AuthenticatorAttestationResponse.getTransports", "PublicKeyCredential.response.getTransports()")}} method of the {{domxref("PublicKeyCredential")}} object returned by the `create()` call that originally created the credential.
         > At that point, it should be stored by the app for later use.
 
     - `type`
@@ -438,7 +446,8 @@ navigator.credentials.get({ publicKey }).then((publicKeyCredential) => {
 
 Some of this data will need to be stored on the server — for example the `signature` to provide proof that authenticator possesses the genuine private key used to create the credential, and the `userHandle` to link the user with the credential, sign in attempt, and other data.
 
-> **Note:** See [Authenticating a user](/en-US/docs/Web/API/Web_Authentication_API#authenticating_a_user) for more information about how the overall flow works.
+> [!NOTE]
+> See [Authenticating a user](/en-US/docs/Web/API/Web_Authentication_API#authenticating_a_user) for more information about how the overall flow works.
 
 ## Specifications
 

--- a/files/en-us/web/api/credentialscontainer/store/index.md
+++ b/files/en-us/web/api/credentialscontainer/store/index.md
@@ -12,7 +12,8 @@ The **`store()`** method of the
 {{domxref("CredentialsContainer")}} stores a set of credentials for the user inside a
 {{domxref("Credential")}} instance, returning this in a {{jsxref("Promise")}}.
 
-> **Note:** This method is restricted to top-level contexts. Calls to it within an
+> [!NOTE]
+> This method is restricted to top-level contexts. Calls to it within an
 > `<iframe>` element will resolve without effect.
 
 ## Syntax

--- a/files/en-us/web/api/cspviolationreportbody/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/index.md
@@ -9,7 +9,8 @@ browser-compat: api.CSPViolationReportBody
 
 The `CSPViolationReportBody` interface contains the report data for a Content Security Policy (CSP) violation. CSP violations are thrown when the webpage attempts to load a resource that violates the CSP set by the {{HTTPHeader("Content-Security-Policy")}} HTTP header.
 
-> **Note:** this interface is similar, but not identical to, the [JSON objects](/en-US/docs/Web/HTTP/CSP#violation_report_syntax) sent back to the [`report-uri`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri) or [`report-to`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) policy directive of the {{HTTPHeader("Content-Security-Policy")}} header.
+> [!NOTE]
+> this interface is similar, but not identical to, the [JSON objects](/en-US/docs/Web/HTTP/CSP#violation_report_syntax) sent back to the [`report-uri`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri) or [`report-to`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) policy directive of the {{HTTPHeader("Content-Security-Policy")}} header.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -9,7 +9,8 @@ browser-compat: api.FontFace
 
 The CSS Font Loading API provides events and interfaces for dynamically loading font resources.
 
-> **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (`self.fonts` provides access to {{domxref('FontFaceSet')}}).
+> [!NOTE]
+> This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (`self.fonts` provides access to {{domxref('FontFaceSet')}}).
 
 ## Concepts and usage
 
@@ -48,7 +49,8 @@ const font = new FontFace("myfont", "url(myfont.woff)", {
 });
 ```
 
-> **Note:** As with `@font-face`, some descriptors represent the expected data in the font data and are used for font matching, while others actually set/define properties of the generated font face.
+> [!NOTE]
+> As with `@font-face`, some descriptors represent the expected data in the font data and are used for font matching, while others actually set/define properties of the generated font face.
 > For example, setting the `style` to "italic" indicates that the file contains italic fonts; it is up to the author to specify a file for which this is true.
 
 Font faces with a _binary source_ are automatically loaded if the font definition is valid and the font data can be loaded — {{domxref('FontFace.status')}} is set to `loaded` on success and `failed` otherwise.

--- a/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
@@ -133,7 +133,8 @@ And here's the result
   </tbody>
 </table>
 
-> **Note:** The orientation media query actually applies based on the orientation of the browser window (or iframe) not the orientation of the device.
+> [!NOTE]
+> The orientation media query actually applies based on the orientation of the browser window (or iframe) not the orientation of the device.
 
 ## Locking the screen orientation
 
@@ -163,7 +164,8 @@ screen.orientation.lock();
 
 It returns a [promise](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves after the lock succeeds.
 
-> **Note:** A screen lock is web application dependent. If application A is locked to `landscape` and application B is locked to `portrait`, switching from application A to B or B to A will not fire a `change` event on `ScreenOrientation` because both applications will keep the orientation they had.
+> [!NOTE]
+> A screen lock is web application dependent. If application A is locked to `landscape` and application B is locked to `portrait`, switching from application A to B or B to A will not fire a `change` event on `ScreenOrientation` because both applications will keep the orientation they had.
 >
 > However, locking the orientation can fire an `change` event if the orientation had to be changed to satisfy the lock requirements.
 

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -17,7 +17,8 @@ To elaborate over these steps, we're going to start by creating a half-highlight
 
 ![Text reading 'My Cool Header' with a solid yellow background image block on the bottom left two thirds of the header](mycoolheader.png)
 
-> **Note:** The complete source for all the examples in this article can be found at [https://github.com/mdn/dom-examples/tree/main/css-painting](https://github.com/mdn/dom-examples/tree/main/css-painting), and the examples are running live at [https://mdn.github.io/dom-examples/css-painting/](https://mdn.github.io/dom-examples/css-painting/).
+> [!NOTE]
+> The complete source for all the examples in this article can be found at [https://github.com/mdn/dom-examples/tree/main/css-painting](https://github.com/mdn/dom-examples/tree/main/css-painting), and the examples are running live at [https://mdn.github.io/dom-examples/css-painting/](https://mdn.github.io/dom-examples/css-painting/).
 
 ## CSS paint worklet
 
@@ -419,7 +420,8 @@ You could try making the background images above without the CSS Paint API. It i
 
 ## Passing parameters
 
-> **Note:** The following example requires the Experimental Web Platform features flag to be enabled in Chrome or Edge by visiting `about://flags`.
+> [!NOTE]
+> The following example requires the Experimental Web Platform features flag to be enabled in Chrome or Edge by visiting `about://flags`.
 
 With the CSS Paint API, we not only have access to custom properties and regular properties, but we can pass custom arguments to the `paint()` function as well.
 

--- a/files/en-us/web/api/csscontainerrule/index.md
+++ b/files/en-us/web/api/csscontainerrule/index.md
@@ -102,7 +102,8 @@ log(`CSSContainerRule.containerQuery: "${containerRule.containerQuery}"`);
 log(`CSSContainerRule.conditionText: "${containerRule.conditionText}"`);
 ```
 
-> **Note:** The styles for this example are defined in an inline HTML `style` element with an id in order to make it easy for the code to find the correct sheet.
+> [!NOTE]
+> The styles for this example are defined in an inline HTML `style` element with an id in order to make it easy for the code to find the correct sheet.
 > You might also locate the correct sheets for each example from the document by indexing against the length (e.g. `document.styleSheets[document.styleSheets.length-1]` but that makes working out correct sheet for each example more complicated).
 
 The example output is shown below.

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
@@ -16,7 +16,8 @@ value. If this CSS value doesn't contain a counter value, a {{domxref("DOMExcept
 is raised. Modification to the corresponding style property can be achieved using the
 {{domxref("Counter")}} interface.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.md
@@ -15,7 +15,8 @@ The **`getFloatValue()`** method of the
 unit. If this CSS value doesn't contain a float value or can't be converted into the
 specified unit, a {{domxref("DOMException")}} is raised.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
@@ -16,7 +16,8 @@ value doesn't contain a rect value, a {{domxref("DOMException")}} is raised.
 Modification to the corresponding style property can be achieved using the
 {{domxref("Rect")}} interface.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
@@ -16,7 +16,8 @@ CSS value doesn't contain a RGB color value, a {{domxref("DOMException")}} is ra
 Modification to the corresponding style property can be achieved using the
 {{domxref("RGBColor")}} interface.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
@@ -14,7 +14,8 @@ The **`getStringValue()`** method of the
 {{domxref("CSSPrimitiveValue")}} interface is used to get a string value. If this CSS
 value doesn't contain a string value, a {{domxref("DOMException")}} is raised.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/index.md
@@ -11,7 +11,8 @@ browser-compat: api.CSSPrimitiveValue
 
 The **`CSSPrimitiveValue`** interface derives from the {{DOMxRef("CSSValue")}} interface and represents the current computed value of a CSS property.
 
-> **Note:** This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
@@ -13,7 +13,8 @@ browser-compat: api.CSSPrimitiveValue.primitiveType
 The **`primitiveType`** read-only property of the
 {{domxref("CSSPrimitiveValue")}} interface represents the type of a CSS value.
 
-> **Note:** This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.md
@@ -15,7 +15,8 @@ The **`setFloatValue()`** method of the
 attached to this value can't accept the specified unit or the float value, the value
 will be unchanged and a {{domxref("DOMException")}} will be raised.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.md
@@ -15,7 +15,8 @@ The **`setStringValue()`** method of the
 property attached to this value can't accept the specified unit or the string value, the
 value will be unchanged and a {{domxref("DOMException")}} will be raised.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssrule/csstext/index.md
+++ b/files/en-us/web/api/cssrule/csstext/index.md
@@ -11,7 +11,8 @@ browser-compat: api.CSSRule.cssText
 The **`cssText`** property of the {{domxref("CSSRule")}}
 interface returns the actual text of a {{domxref("CSSStyleSheet")}} style-rule.
 
-> **Note:** Do not confuse this property with element-style
+> [!NOTE]
+> Do not confuse this property with element-style
 > {{domxref("CSSStyleDeclaration.cssText")}}.
 
 Be aware that this property can no longer be set directly, as it is [now specified](https://www.w3.org/TR/cssom-1/#changes-from-5-december-2013)

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.md
@@ -15,7 +15,8 @@ method interface returns a {{domxref('CSSValue')}} containing the CSS value for 
 property. Note that it returns `null` if the property name is a
 shorthand property.
 
-> **Note:** This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssstylerule/style/index.md
+++ b/files/en-us/web/api/cssstylerule/style/index.md
@@ -39,7 +39,8 @@ let myRules = document.styleSheets[0].cssRules;
 console.log(myRules[0].style); // a CSSStyleDeclaration representing the declarations on the h1.
 ```
 
-> **Note:** The declaration block is that part of the style rule that appears within the braces and that actually provides the style definitions (for the selector, the part that comes before the braces).
+> [!NOTE]
+> The declaration block is that part of the style rule that appears within the braces and that actually provides the style definitions (for the selector, the part that comes before the braces).
 
 ## Specifications
 

--- a/files/en-us/web/api/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/index.md
@@ -39,7 +39,8 @@ _Inherits properties from its parent, {{domxref("StyleSheet")}}._
 
   - : Returns a live {{domxref("CSSRuleList")}} which maintains an up-to-date list of the {{domxref("CSSRule")}} objects that comprise the stylesheet.
 
-    > **Note:** In some browsers, if a stylesheet is loaded from a different domain, accessing `cssRules` results in a `SecurityError`.
+    > [!NOTE]
+    > In some browsers, if a stylesheet is loaded from a different domain, accessing `cssRules` results in a `SecurityError`.
 
 - {{domxref("CSSStyleSheet.ownerRule")}} {{ReadOnlyInline}}
   - : If this stylesheet is imported into the document using an {{cssxref("@import")}} rule, the `ownerRule` property returns the corresponding {{domxref("CSSImportRule")}}; otherwise, this property's value is `null`.

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -11,7 +11,8 @@ browser-compat: api.CSSStyleSheet.insertRule
 The **`CSSStyleSheet.insertRule()`**
 method inserts a new [CSS rule](/en-US/docs/Web/API/CSSRule) into the [current style sheet](/en-US/docs/Web/API/CSSStyleSheet).
 
-> **Note:** Although `insertRule()` is exclusively a method of
+> [!NOTE]
+> Although `insertRule()` is exclusively a method of
 > {{domxref("CSSStyleSheet")}}, it actually inserts the rule into
 > `{{domxref("CSSStyleSheet", "", "", "1")}}.cssRules` — its internal
 > {{domxref("CSSRuleList")}}.

--- a/files/en-us/web/api/cssstylesheet/removerule/index.md
+++ b/files/en-us/web/api/cssstylesheet/removerule/index.md
@@ -15,7 +15,8 @@ The obsolete {{domxref("CSSStyleSheet")}} method
 object. It is functionally identical to the standard, preferred method
 {{domxref("CSSStyleSheet.deleteRule", "deleteRule()")}}.
 
-> **Note:** This is a _legacy method_ which has been replaced by
+> [!NOTE]
+> This is a _legacy method_ which has been replaced by
 > the standard method {{domxref("CSSStyleSheet.deleteRule", "deleteRule()")}}. You
 > should use that instead.
 

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -24,7 +24,8 @@ replace(text)
 
   - : A string containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.
 
-    > **Note:** If any of the rules passed in `text` are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.
+    > [!NOTE]
+    > If any of the rules passed in `text` are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.
 
 ### Return value
 

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -24,7 +24,8 @@ replaceSync(text)
 
   - : A string containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.
 
-    > **Note:** If any of the rules passed in `text` are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.
+    > [!NOTE]
+    > If any of the rules passed in `text` are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.
 
 ### Return value
 

--- a/files/en-us/web/api/cssstylesheet/rules/index.md
+++ b/files/en-us/web/api/cssstylesheet/rules/index.md
@@ -16,7 +16,8 @@ identical to the preferred {{domxref("CSSStyleSheet.cssRules", "cssRules")}} pro
 it provides access to a live-updating list of the CSS rules comprising the
 stylesheet.
 
-> **Note:** As a legacy property, you should not use `rules` and
+> [!NOTE]
+> As a legacy property, you should not use `rules` and
 > should instead use the preferred {{domxref("CSSStyleSheet.cssRules", "cssRules")}}.
 > While `rules` is unlikely to be removed soon, its availability is not as
 > widespread and using it will result in compatibility problems for your site or app.

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
@@ -14,7 +14,8 @@ object.
 
 All transform functions can be represented mathematically as a 4x4 transformation matrix. This is explained in detail in [Understanding the CSS Transforms matrix](https://dev.opera.com/articles/understanding-the-css-transforms-matrix/).
 
-> **Note:** The `is2D` property affects what transform, and therefore type of matrix that will be returned. CSS 2D and 3D transforms are different for legacy reasons. A brief explanation of 2D vs. 3D transforms can be found in [Using CSS transforms](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms).
+> [!NOTE]
+> The `is2D` property affects what transform, and therefore type of matrix that will be returned. CSS 2D and 3D transforms are different for legacy reasons. A brief explanation of 2D vs. 3D transforms can be found in [Using CSS transforms](/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms).
 
 ## Syntax
 

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -13,7 +13,8 @@ browser-compat: api.CSSValue.cssText
 The **`cssText`** property of the {{domxref("CSSValue")}}
 interface represents the current computed CSS property value.
 
-> **Note:** This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.md
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.md
@@ -14,7 +14,8 @@ The **`cssValueType`** read-only property of the
 {{domxref("CSSValue")}} interface represents the type of the current computed CSS
 property value.
 
-> **Note:** This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssvalue/index.md
+++ b/files/en-us/web/api/cssvalue/index.md
@@ -11,7 +11,8 @@ browser-compat: api.CSSValue
 
 The **`CSSValue`** interface represents the current computed value of a CSS property.
 
-> **Note:** This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssvaluelist/index.md
+++ b/files/en-us/web/api/cssvaluelist/index.md
@@ -11,7 +11,8 @@ browser-compat: api.CSSValueList
 
 The **`CSSValueList`** interface derives from the {{DOMxRef("CSSValue")}} interface and provides the abstraction of an ordered collection of CSS values.
 
-> **Note:** This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This interface was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssvaluelist/item/index.md
+++ b/files/en-us/web/api/cssvaluelist/item/index.md
@@ -17,7 +17,8 @@ The order in this collection represents the order of the values in the CSS style
 property. If the index is greater than or equal to the number of values in the list,
 this method returns `null`.
 
-> **Note:** This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This method was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/cssvaluelist/length/index.md
+++ b/files/en-us/web/api/cssvaluelist/length/index.md
@@ -15,7 +15,8 @@ The **`length`** read-only property of the
 in the list. The range of valid values of the indices is `0` to
 `length-1` inclusive.
 
-> **Note:** This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
+> [!NOTE]
+> This property was part of an attempt to create a typed CSS Object Model. This attempt has been abandoned, and most browsers do
 > not implement it.
 >
 > To achieve your purpose, you can use:

--- a/files/en-us/web/api/customevent/index.md
+++ b/files/en-us/web/api/customevent/index.md
@@ -9,7 +9,8 @@ browser-compat: api.CustomEvent
 
 The **`CustomEvent`** interface represents events initialized by an application for any purpose.
 
-> **Note:** If used to attempt to communicate between a web extension content script and a web page script, a non-string `detail` property throws with "Permission denied to access property" in Firefox. To avoid this issue clone the object. See [Share objects with page scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts) for more information.
+> [!NOTE]
+> If used to attempt to communicate between a web extension content script and a web page script, a non-string `detail` property throws with "Permission denied to access property" in Firefox. To avoid this issue clone the object. See [Share objects with page scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts) for more information.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 2.
