### PR TITLE
Convert noteblocks for web/api folder (part 3)

### DIFF
--- a/files/en-us/web/api/background_tasks_api/index.md
+++ b/files/en-us/web/api/background_tasks_api/index.md
@@ -9,7 +9,8 @@ browser-compat: api.Window.requestIdleCallback
 
 The **Cooperative Scheduling of Background Tasks API** (also referred to as the Background Tasks API or the `requestIdleCallback()` API) provides the ability to queue tasks to be executed automatically by the user agent when it determines that there is free time to do so.
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
 ## Concepts and usage
 

--- a/files/en-us/web/api/barprop/visible/index.md
+++ b/files/en-us/web/api/barprop/visible/index.md
@@ -14,7 +14,8 @@ The **`visible`** read-only property of the {{domxref("BarProp")}} interface ret
 
 A {{jsxref("Boolean")}}, which is true if the top-level window is opened by {{domxref("window.open")}} with the [`popup`](/en-US/docs/Web/API/Window/open#popup) feature enabled.
 
-> **Note:** Historically this represented whether the interface element used is visible
+> [!NOTE]
+> Historically this represented whether the interface element used is visible
 > or not. But for privacy reasons, this no longer represents the actual visibility of each
 > interface element.
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
@@ -12,11 +12,13 @@ The `createAnalyser()` method of the
 {{domxref("BaseAudioContext")}} interface creates an {{domxref("AnalyserNode")}}, which
 can be used to expose audio time and frequency data and create data visualizations.
 
-> **Note:** The {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}} constructor is the
+> [!NOTE]
+> The {{domxref("AnalyserNode.AnalyserNode", "AnalyserNode()")}} constructor is the
 > recommended way to create an {{domxref("AnalyserNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
-> **Note:** For more on using this node, see the
+> [!NOTE]
+> For more on using this node, see the
 > {{domxref("AnalyserNode")}} page.
 
 ## Syntax

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.md
@@ -12,7 +12,8 @@ The `createBiquadFilter()` method of the {{ domxref("BaseAudioContext") }}
 interface creates a {{ domxref("BiquadFilterNode") }}, which represents a second order
 filter configurable as several different common filter types.
 
-> **Note:** The {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}} constructor is the
+> [!NOTE]
+> The {{domxref("BiquadFilterNode.BiquadFilterNode", "BiquadFilterNode()")}} constructor is the
 > recommended way to create a {{domxref("BiquadFilterNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
@@ -32,7 +32,8 @@ createBuffer(numOfChannels, length, sampleRate)
 
 ### Parameters
 
-> **Note:** For an in-depth explanation of how audio buffers work, and
+> [!NOTE]
+> For an in-depth explanation of how audio buffers work, and
 > what these parameters mean, read [Audio buffers: frames, samples and channels](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#audio_buffers_frames_samples_and_channels) from our Basic concepts guide.
 
 - `numOfChannels`
@@ -84,7 +85,8 @@ on an `AudioContext` running at 44100Hz, will be automatically \*resampled\* to
 44100Hz (and therefore yield 44100 frames), and last for 1.0 second: 44100 frames /
 44100Hz = 1 second.
 
-> **Note:** audio resampling is very similar to image resizing: say you've
+> [!NOTE]
+> audio resampling is very similar to image resizing: say you've
 > got a 16 x 16 image, but you want it to fill a 32x32 area: you resize (resample) it.
 > the result has less quality (it can be blurry or edgy, depending on the resizing
 > algorithm), but it works, and the resized image takes up less space. Resampled audio

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
@@ -13,7 +13,8 @@ Interface is used to create a new {{ domxref("AudioBufferSourceNode") }}, which 
 used to play audio data contained within an {{ domxref("AudioBuffer") }} object.
 {{domxref("AudioBuffer")}}s are created using {{domxref("BaseAudioContext.createBuffer")}} or returned by {{domxref("BaseAudioContext.decodeAudioData")}} when it successfully decodes an audio track.
 
-> **Note:** The {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
+> [!NOTE]
+> The {{domxref("AudioBufferSourceNode.AudioBufferSourceNode", "AudioBufferSourceNode()")}}
 > constructor is the recommended way to create a {{domxref("AudioBufferSourceNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
@@ -37,7 +38,8 @@ In this example, we create a two second buffer, fill it with white noise, and th
 it via an {{ domxref("AudioBufferSourceNode") }}. The comments should clearly explain
 what is going on.
 
-> **Note:** You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/),
+> [!NOTE]
+> You can also [run the code live](https://mdn.github.io/webaudio-examples/audio-buffer/),
 > or [view the source](https://github.com/mdn/webaudio-examples/blob/main/audio-buffer/index.html).
 
 ```js

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.md
@@ -11,7 +11,8 @@ browser-compat: api.BaseAudioContext.createChannelMerger
 The `createChannelMerger()` method of the {{domxref("BaseAudioContext")}} interface creates a {{domxref("ChannelMergerNode")}},
 which combines channels from multiple audio streams into a single audio stream.
 
-> **Note:** The {{domxref("ChannelMergerNode.ChannelMergerNode", "ChannelMergerNode()")}} constructor is the
+> [!NOTE]
+> The {{domxref("ChannelMergerNode.ChannelMergerNode", "ChannelMergerNode()")}} constructor is the
 > recommended way to create a {{domxref("ChannelMergerNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
@@ -11,7 +11,8 @@ browser-compat: api.BaseAudioContext.createChannelSplitter
 The `createChannelSplitter()` method of the {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("ChannelSplitterNode")}},
 which is used to access the individual channels of an audio stream and process them separately.
 
-> **Note:** The {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}}
+> [!NOTE]
+> The {{domxref("ChannelSplitterNode.ChannelSplitterNode", "ChannelSplitterNode()")}}
 > constructor is the recommended way to create a {{domxref("ChannelSplitterNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.md
@@ -14,7 +14,8 @@ property of the {{domxref("BaseAudioContext")}} interface creates a
 outputs a monaural (one-channel) sound signal whose samples all have the same
 value.
 
-> **Note:** The {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
+> [!NOTE]
+> The {{domxref("ConstantSourceNode.ConstantSourceNode", "ConstantSourceNode()")}}
 > constructor is the recommended way to create a {{domxref("ConstantSourceNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
@@ -12,7 +12,8 @@ The `createConvolver()` method of the {{ domxref("BaseAudioContext") }}
 interface creates a {{ domxref("ConvolverNode") }}, which is commonly used to apply
 reverb effects to your audio. See the [spec definition of Convolution](https://webaudio.github.io/web-audio-api/#background-3) for more information.
 
-> **Note:** The {{domxref("ConvolverNode.ConvolverNode", "ConvolverNode()")}}
+> [!NOTE]
+> The {{domxref("ConvolverNode.ConvolverNode", "ConvolverNode()")}}
 > constructor is the recommended way to create a {{domxref("ConvolverNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.md
@@ -12,7 +12,8 @@ The `createDelay()` method of the
 {{domxref("BaseAudioContext")}} Interface is used to create a {{domxref("DelayNode")}},
 which is used to delay the incoming audio signal by a certain amount of time.
 
-> **Note:** The {{domxref("DelayNode.DelayNode", "DelayNode()")}}
+> [!NOTE]
+> The {{domxref("DelayNode.DelayNode", "DelayNode()")}}
 > constructor is the recommended way to create a {{domxref("DelayNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
@@ -16,7 +16,8 @@ especially important in games and musical applications where large numbers of in
 sounds are played simultaneously, where you want to control the overall signal level and
 help avoid clipping (distorting) of the audio output.
 
-> **Note:** The {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
+> [!NOTE]
+> The {{domxref("DynamicsCompressorNode.DynamicsCompressorNode", "DynamicsCompressorNode()")}}
 > constructor is the recommended way to create a {{domxref("DynamicsCompressorNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -12,7 +12,8 @@ The `createGain()` method of the {{ domxref("BaseAudioContext") }}
 interface creates a {{ domxref("GainNode") }}, which can be used to control the
 overall gain (or volume) of the audio graph.
 
-> **Note:** The {{domxref("GainNode.GainNode", "GainNode()")}}
+> [!NOTE]
+> The {{domxref("GainNode.GainNode", "GainNode()")}}
 > constructor is the recommended way to create a {{domxref("GainNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.md
@@ -10,7 +10,8 @@ browser-compat: api.BaseAudioContext.createIIRFilter
 
 The **`createIIRFilter()`** method of the {{domxref("BaseAudioContext")}} interface creates an {{ domxref("IIRFilterNode") }}, which represents a general **[infinite impulse response](https://en.wikipedia.org/wiki/Infinite_impulse_response)** (IIR) filter which can be configured to serve as various types of filter.
 
-> **Note:** The {{domxref("IIRFilterNode.IIRFilterNode", "IIRFilterNode()")}}
+> [!NOTE]
+> The {{domxref("IIRFilterNode.IIRFilterNode", "IIRFilterNode()")}}
 > constructor is the recommended way to create a {{domxref("IIRFilterNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
@@ -12,7 +12,8 @@ The `createOscillator()` method of the {{domxref("BaseAudioContext")}}
 interface creates an {{domxref("OscillatorNode")}}, a source representing a periodic
 waveform. It basically generates a constant tone.
 
-> **Note:** The {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
+> [!NOTE]
+> The {{domxref("OscillatorNode.OscillatorNode", "OscillatorNode()")}}
 > constructor is the recommended way to create a {{domxref("OscillatorNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.md
@@ -17,7 +17,8 @@ The panner node is spatialized in relation to the AudioContext's
 attribute), which represents the position and orientation of the person listening to the
 audio.
 
-> **Note:** The {{domxref("PannerNode.PannerNode", "PannerNode()")}}
+> [!NOTE]
+> The {{domxref("PannerNode.PannerNode", "PannerNode()")}}
 > constructor is the recommended way to create a {{domxref("PannerNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
@@ -143,7 +144,8 @@ function positionPanner() {
 }
 ```
 
-> **Note:** In terms of working out what position values to apply to the
+> [!NOTE]
+> In terms of working out what position values to apply to the
 > listener and panner, to make the sound appropriate to what the visuals are doing on
 > screen, there is quite a bit of math involved, but you will soon get used to it with a
 > bit of experimentation.

--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -33,7 +33,8 @@ The `real` and `imag` arrays must have the same length, otherwise an error is th
     - `disableNormalization`
       - : If set to `true`, normalization is disabled for the periodic wave. The default is `false`.
 
-> **Note:** If normalized, the resulting wave will have a maximum absolute peak value of 1.
+> [!NOTE]
+> If normalized, the resulting wave will have a maximum absolute peak value of 1.
 
 ### Return value
 

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -13,7 +13,8 @@ browser-compat: api.BaseAudioContext.createScriptProcessor
 The `createScriptProcessor()` method of the {{domxref("BaseAudioContext")}} interface
 creates a {{domxref("ScriptProcessorNode")}} used for direct audio processing.
 
-> **Note:** This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
+> [!NOTE]
+> This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
 
 ## Syntax
 
@@ -45,10 +46,12 @@ createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)
   - : Integer specifying the number of channels for this node's output, defaults to 2.
     Values of up to 32 are supported.
 
-> **Warning:** Webkit currently (version 31) requires that a valid
+> [!WARNING]
+> Webkit currently (version 31) requires that a valid
 > `bufferSize` be passed when calling this method.
 
-> **Note:** It is invalid for both `numberOfInputChannels` and
+> [!NOTE]
+> It is invalid for both `numberOfInputChannels` and
 > `numberOfOutputChannels` to be zero.
 
 ### Return value
@@ -63,7 +66,8 @@ The following example shows how to use a `ScriptProcessorNode` to take a track l
 
 For each channel and each sample frame, the script node's {{domxref("ScriptProcessorNode.audioprocess_event", "audioprocess")}} event handler uses the associated `audioProcessingEvent` to loop through each channel of the input buffer, and each sample in each channel, and add a small amount of white noise, before setting that result to be the output sample in each case.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/script-processor-node/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/script-processor-node/).
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/script-processor-node/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/script-processor-node/).
 
 ```js
 const myScript = document.querySelector("script");

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
@@ -12,7 +12,8 @@ The `createStereoPanner()` method of the {{ domxref("BaseAudioContext") }} inter
 stereo panning to an audio source.
 It positions an incoming audio stream in a stereo image using a [low-cost panning algorithm](https://webaudio.github.io/web-audio-api/#stereopanner-algorithm).
 
-> **Note:** The {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
+> [!NOTE]
+> The {{domxref("StereoPannerNode.StereoPannerNode", "StereoPannerNode()")}}
 > constructor is the recommended way to create a {{domxref("StereoPannerNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -12,7 +12,8 @@ The `createWaveShaper()` method of the {{ domxref("BaseAudioContext") }}
 interface creates a {{ domxref("WaveShaperNode") }}, which represents a non-linear
 distortion. It is used to apply distortion effects to your audio.
 
-> **Note:** The {{domxref("WaveShaperNode.WaveShaperNode", "WaveShaperNode()")}}
+> [!NOTE]
+> The {{domxref("WaveShaperNode.WaveShaperNode", "WaveShaperNode()")}}
 > constructor is the recommended way to create a {{domxref("WaveShaperNode")}}; see
 > [Creating an AudioNode](/en-US/docs/Web/API/AudioNode#creating_an_audionode).
 
@@ -35,7 +36,8 @@ A {{domxref("WaveShaperNode")}}.
 The following example shows basic usage of an AudioContext to create a wave shaper node.
 For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
-> **Note:** Sigmoid functions are commonly used for distortion curves
+> [!NOTE]
+> Sigmoid functions are commonly used for distortion curves
 > because of their natural properties. Their S-shape, for instance, helps create a
 > smoother sounding result. We found the below distortion curve code on [Stack Overflow](https://stackoverflow.com/questions/22312841/waveshaper-node-in-webaudio-how-to-emulate-distortion).
 

--- a/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.md
+++ b/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.md
@@ -60,7 +60,8 @@ In this section we will first cover the promise-based syntax and then the callba
 
 In this example `loadAudio()` uses {{domxref("Window/fetch", "fetch()")}} to retrieve an audio file and decodes it into an {{domxref("AudioBuffer")}}. It then caches the `audioBuffer` in the global `buffer` variable for later playback.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/promise/).
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/promise/).
 
 ```js
 let audioCtx;
@@ -84,7 +85,8 @@ async function loadAudio() {
 In this example `loadAudio()` uses {{domxref("Window/fetch", "fetch()")}} to retrieve an audio
 file and decodes it into an {{domxref("AudioBuffer")}} using the callback-based version of `decodeAudioData()`. In the callback, it plays the decoded buffer.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/callback/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/callback/).
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/decode-audio-data/callback/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/decode-audio-data/callback/).
 
 ```js
 let audioCtx;

--- a/files/en-us/web/api/baseaudiocontext/destination/index.md
+++ b/files/en-us/web/api/baseaudiocontext/destination/index.md
@@ -19,7 +19,8 @@ An {{ domxref("AudioDestinationNode") }}.
 
 ## Examples
 
-> **Note:** For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
+> [!NOTE]
+> For more complete applied examples/information, check out our [Voice-change-O-matic](https://github.com/mdn/webaudio-examples/tree/main/voice-change-o-matic) demo (see [app.js lines 108–193](https://github.com/mdn/webaudio-examples/blob/main/voice-change-o-matic/scripts/app.js#L108-L193) for relevant code).
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/baseaudiocontext/listener/index.md
+++ b/files/en-us/web/api/baseaudiocontext/listener/index.md
@@ -18,7 +18,8 @@ An {{ domxref("AudioListener") }} object.
 
 ## Examples
 
-> **Note:** for a full Web Audio spatialization example, see our [panner-node](https://github.com/mdn/webaudio-examples/tree/main/panner-node) demo.
+> [!NOTE]
+> for a full Web Audio spatialization example, see our [panner-node](https://github.com/mdn/webaudio-examples/tree/main/panner-node) demo.
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.md
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.md
@@ -18,7 +18,8 @@ second.
 
 ## Examples
 
-> **Note:** for a full Web Audio example implementation, see one of our
+> [!NOTE]
+> for a full Web Audio example implementation, see one of our
 > Web Audio Demos on the [MDN GitHub repo](https://github.com/mdn/webaudio-examples). Try entering
 > `audioCtx.sampleRate` into your browser console.
 

--- a/files/en-us/web/api/battery_status_api/index.md
+++ b/files/en-us/web/api/battery_status_api/index.md
@@ -12,7 +12,8 @@ spec-urls: https://w3c.github.io/battery/
 
 The **Battery Status API**, more often referred to as the **Battery API**, provides information about the system's battery charge level and lets you be notified by events that are sent when the battery level or charging status change. This can be used to adjust your app's resource usage to reduce battery drain when the battery is low, or to save changes before the battery runs out in order to prevent data loss.
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
 ## Interfaces
 

--- a/files/en-us/web/api/batterymanager/chargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.md
@@ -12,7 +12,8 @@ The **`chargingTime`** read-only property of the {{domxref("BatteryManager")}} i
 If the battery is currently discharging, its value is {{jsxref("Infinity")}}.
 When its value changes, the {{domxref("BatteryManager/chargingtimechange_event", "chargingtimechange")}} event is fired.
 
-> **Note:** Even if the time returned is precise to the second,
+> [!NOTE]
+> Even if the time returned is precise to the second,
 > browsers round them to a higher interval
 > (typically to the closest 15 minutes) for privacy reasons.
 

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.md
@@ -12,7 +12,8 @@ The **`dischargingTime`** read-only property of the {{domxref("BatteryManager")}
 or {{jsxref("Infinity")}} if the battery is currently charging rather than discharging or the user agent is unable to report the battery status information.
 When its value changes, the {{domxref("BatteryManager/dischargingtimechange_event", "dischargingtimechange")}} event is fired.
 
-> **Note:** Even if the time returned is precise to the second, browsers round them to a higher
+> [!NOTE]
+> Even if the time returned is precise to the second, browsers round them to a higher
 > interval (typically to the closest 15 minutes) for privacy reasons.
 
 ## Value

--- a/files/en-us/web/api/beacon_api/index.md
+++ b/files/en-us/web/api/beacon_api/index.md
@@ -13,7 +13,8 @@ The main use case for the Beacon API is to send analytics such as client-side ev
 
 For more details about the motivation for and usage of this API, see the documentation for the {{domxref("navigator.sendBeacon()")}} method.
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
 ## Interfaces
 

--- a/files/en-us/web/api/beforeunloadevent/returnvalue/index.md
+++ b/files/en-us/web/api/beforeunloadevent/returnvalue/index.md
@@ -21,7 +21,8 @@ The **`returnValue`** property of the
 
 Setting it to just about any [truthy](/en-US/docs/Glossary/Truthy) value will cause the dialog to be triggered on page close/reload, however note that it also requires [sticky activation](/en-US/docs/Glossary/Sticky_activation). In other words, the browser will only show the dialog if the frame or any embedded frame receives a user gesture or user interaction. If the user has never interacted with the page, then there is no user data to save, so no legitimate use case for the dialog.
 
-> **Note:** A generic browser-specified string is displayed in the dialog. This cannot be controlled by the webpage code.
+> [!NOTE]
+> A generic browser-specified string is displayed in the dialog. This cannot be controlled by the webpage code.
 
 ## Examples
 

--- a/files/en-us/web/api/biquadfilternode/detune/index.md
+++ b/files/en-us/web/api/biquadfilternode/detune/index.md
@@ -14,7 +14,8 @@ The `detune` property of the {{ domxref("BiquadFilterNode") }} interface is an [
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}.
 
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/biquadfilternode/frequency/index.md
+++ b/files/en-us/web/api/biquadfilternode/frequency/index.md
@@ -16,7 +16,8 @@ Its default value is `350`, with a nominal range of `10` to the [Nyquist frequen
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/biquadfilternode/gain/index.md
+++ b/files/en-us/web/api/biquadfilternode/gain/index.md
@@ -18,7 +18,8 @@ It is expressed in dB, has a default value of `0`, and can take a value in a nom
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/biquadfilternode/index.md
+++ b/files/en-us/web/api/biquadfilternode/index.md
@@ -45,7 +45,8 @@ The `BiquadFilterNode` interface represents a simple low-order filter, and is cr
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
-> **Note:** Though the `AudioParam` objects returned are read-only, the values they represent are not.
+> [!NOTE]
+> Though the `AudioParam` objects returned are read-only, the values they represent are not.
 
 - {{domxref("BiquadFilterNode.frequency")}} {{ReadOnlyInline}}
   - : An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}}, a double representing a frequency in the current filtering algorithm measured in hertz (Hz).

--- a/files/en-us/web/api/biquadfilternode/q/index.md
+++ b/files/en-us/web/api/biquadfilternode/q/index.md
@@ -16,7 +16,8 @@ It is a dimensionless value with a default value of `1` and a nominal range of `
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/blob/type/index.md
+++ b/files/en-us/web/api/blob/type/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Blob.type
 
 The **`type`** read-only property of the {{domxref("Blob")}} interface returns the {{Glossary("MIME type")}} of the file.
 
-> **Note:** Based on the current implementation, browsers won't actually read the bytestream of a file to determine its media type.
+> [!NOTE]
+> Based on the current implementation, browsers won't actually read the bytestream of a file to determine its media type.
 > It is assumed based on the file extension; a PNG image file renamed to .txt would give "_text/plain_" and not "_image/png_". Moreover, `blob.type` is generally reliable only for common file types like images, HTML documents, audio and video.
 > Uncommon file extensions would return an empty string.
 > Client configuration (for instance, the Windows Registry) may result in unexpected values even for common types. **Developers are advised not to rely on this property as a sole validation scheme.**

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -104,7 +104,8 @@ After the user selects a device to pair in the current origin, it is only allowe
 It is therefore important to list the required services.
 In particular, when filtering with just [`name`](#name) you must remember to also specify the desired services in [`optionalServices`](#optionalservices).
 
-> **Note:** Even though the `options` argument is technically optional, in order to return any results you must either set a value for `filters` or set `acceptAllDevices` to `true`.
+> [!NOTE]
+> Even though the `options` argument is technically optional, in order to return any results you must either set a value for `filters` or set `acceptAllDevices` to `true`.
 
 ### Return value
 

--- a/files/en-us/web/api/broadcast_channel_api/index.md
+++ b/files/en-us/web/api/broadcast_channel_api/index.md
@@ -9,7 +9,8 @@ browser-compat: api.BroadcastChannel
 
 The **Broadcast Channel API** allows basic communication between {{glossary("browsing context", "browsing contexts")}} (that is, _windows_, _tabs_, _frames_, or _iframes_) and workers on the same {{glossary("origin")}}.
 
-> **Note:** To be exact, communication is allowed between browsing contexts using the same [storage partition](/en-US/docs/Web/Privacy/State_Partitioning). Storage is first partitioned according to top-level sites—so for example, if you have one opened page at `a.com` that embeds an iframe from `b.com`, and another page opened to `b.com`, then the iframe cannot communicate with the second page despite them being technically same-origin. However, if the first page is also on `b.com`, then the iframe can communicate with the second page.
+> [!NOTE]
+> To be exact, communication is allowed between browsing contexts using the same [storage partition](/en-US/docs/Web/Privacy/State_Partitioning). Storage is first partitioned according to top-level sites—so for example, if you have one opened page at `a.com` that embeds an iframe from `b.com`, and another page opened to `b.com`, then the iframe cannot communicate with the second page despite them being technically same-origin. However, if the first page is also on `b.com`, then the iframe can communicate with the second page.
 
 By creating a {{domxref("BroadcastChannel")}} object, you can receive any messages that are posted to it. You don't have to maintain a reference to the frames or workers you wish to communicate with: they can "subscribe" to a particular channel by constructing their own {{domxref("BroadcastChannel")}} with the same name, and have bi-directional communication between all of them.
 

--- a/files/en-us/web/api/bytelengthqueuingstrategy/highwatermark/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/highwatermark/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ByteLengthQueuingStrategy.highWaterMark
 
 The read-only **`ByteLengthQueuingStrategy.highWaterMark`** property returns the total number of bytes that can be contained in the internal queue before [backpressure](/en-US/docs/Web/API/Streams_API/Concepts#backpressure) is applied.
 
-> **Note:** Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` property specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
+> [!NOTE]
+> Unlike [`CountQueuingStrategy()`](/en-US/docs/Web/API/CountQueuingStrategy/CountQueuingStrategy) where the `highWaterMark` property specifies a simple count of the number of chunks, with `ByteLengthQueuingStrategy()`, the `highWaterMark` parameter specifies a number of _bytes_ — specifically, given a stream of chunks, how many bytes worth of those chunks (rather than a count of how many of those chunks) can be contained in the internal queue before backpressure is applied.
 
 ## Values
 

--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -13,9 +13,11 @@ An origin can have multiple, named `Cache` objects. You are responsible for impl
 
 You are also responsible for periodically purging cache entries. Each browser has a hard limit on the amount of cache storage that a given origin can use. `Cache` quota usage estimates are available via the {{domxref("StorageManager.estimate()")}} method. The browser does its best to manage disk space, but it may delete the `Cache` storage for an origin. The browser will generally delete all of the data for an origin or none of the data for an origin. Make sure to version caches by name and use the caches only from the version of the script that they can safely operate on. See [Deleting old caches](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#deleting_old_caches) for more information.
 
-> **Note:** The key matching algorithm depends on the [VARY header](https://www.fastly.com/blog/best-practices-using-vary-header) in the value. So matching a new key requires looking at both key and value for entries in the `Cache` object.
+> [!NOTE]
+> The key matching algorithm depends on the [VARY header](https://www.fastly.com/blog/best-practices-using-vary-header) in the value. So matching a new key requires looking at both key and value for entries in the `Cache` object.
 
-> **Note:** The caching API doesn't honor HTTP caching headers.
+> [!NOTE]
+> The caching API doesn't honor HTTP caching headers.
 
 ## Instance methods
 
@@ -46,7 +48,8 @@ The code snippet also shows a best practice for versioning caches used by the se
 
 In the code example, `caches` is a property of the {{domxref("ServiceWorkerGlobalScope")}}. It holds the `CacheStorage` object, by which it can access the {{domxref("CacheStorage")}} interface.
 
-> **Note:** In Chrome, visit `chrome://inspect/#service-workers` and click on the "inspect" link below the registered service worker to view logging statements for the various actions the [`service-worker.js`](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js) script is performing.
+> [!NOTE]
+> In Chrome, visit `chrome://inspect/#service-workers` and click on the "inspect" link below the registered service worker to view logging statements for the various actions the [`service-worker.js`](https://github.com/GoogleChrome/samples/blob/gh-pages/service-worker/selective-caching/service-worker.js) script is performing.
 
 ```js
 const CACHE_VERSION = 1;

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -77,7 +77,8 @@ CSS can also be used to match a custom state [within a custom element's shadow D
 
 Additionally, the `:state()` pseudo-class can be used after the [`::part()`](/en-US/docs/Web/CSS/::part) pseudo-element to match the [shadow parts](/en-US/docs/Web/CSS/CSS_shadow_parts) of a custom element that are in a particular state.
 
-> **Warning:** Browsers that do not yet support [`:state()`](/en-US/docs/Web/CSS/:state) will use a CSS `<dashed-ident>` for selecting custom states, which is now deprecated.
+> [!WARNING]
+> Browsers that do not yet support [`:state()`](/en-US/docs/Web/CSS/:state) will use a CSS `<dashed-ident>` for selecting custom states, which is now deprecated.
 > For information about how to support both approaches see the [Compatibility with `<dashed-ident>` syntax](#compability_with_dashed-ident_syntax) section below.
 
 ## Examples

--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -16,7 +16,8 @@ to the given element. This element will be the element to which {{domxref("HTMLE
 {{domxref("HTMLElement/dragend_event", "dragend")}} events are fired, and not the default target (the node that was
 dragged).
 
-> **Note:** This method is Firefox-specific.
+> [!NOTE]
+> This method is Firefox-specific.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -19,7 +19,8 @@ This method does _not_ remove files from the drag operation, so it's possible
 for there still to be an entry with the type `"Files"` left in the object's
 {{domxref("DataTransfer.types")}} list if there are any files included in the drag.
 
-> **Note:** This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
+> [!NOTE]
+> This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
 > because that's the only time the drag operation's data store is writable.
 
 ## Syntax

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -12,7 +12,8 @@ The **`files`** read-only property of [`DataTransfer`](/en-US/docs/Web/API/DataT
 
 This feature can be used to drag files from a user's desktop to the browser.
 
-> **Note:** The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the `drop` event. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store).
+> [!NOTE]
+> The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the `drop` event. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store).
 
 ## Value
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -10,7 +10,8 @@ browser-compat: api.DataTransferItem.webkitGetAsEntry
 
 If the item described by the {{domxref("DataTransferItem")}} is a file, `webkitGetAsEntry()` returns a {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file, `null` is returned.
 
-> **Note:** This function is implemented as `webkitGetAsEntry()` in non-WebKit browsers including Firefox at this time; it may be renamed to
+> [!NOTE]
+> This function is implemented as `webkitGetAsEntry()` in non-WebKit browsers including Firefox at this time; it may be renamed to
 > `getAsEntry()` in the future, so you should code defensively, looking for both.
 
 ## Syntax
@@ -90,7 +91,8 @@ body {
 First, let's look at the recursive `scanFiles()` function.
 This function takes as input a {{domxref("FileSystemEntry")}} representing an entry in the file system to be scanned and processed (the `item` parameter), and an element into which to insert the list of contents (the `container` parameter).
 
-> **Note:** To read all files in a directory, `readEntries` needs to be called repeatedly until it returns an empty array.
+> [!NOTE]
+> To read all files in a directory, `readEntries` needs to be called repeatedly until it returns an empty array.
 > In Chromium-based browsers, the following example will only return a max of 100 entries.
 
 ```js

--- a/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
@@ -34,7 +34,8 @@ close();
 
 `close()` and `self.close()` are effectively equivalent — both represent `close()` being called from inside the worker's inner scope.
 
-> **Note:** There is also a way to stop the worker from the main thread: the {{domxref("Worker.terminate")}} method.
+> [!NOTE]
+> There is also a way to stop the worker from the main thread: the {{domxref("Worker.terminate")}} method.
 
 ## Specifications
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/requestanimationframe/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/requestanimationframe/index.md
@@ -14,7 +14,8 @@ The frequency of calls to the callback function will generally match the display
 
 A call to the `requestAnimationFrame()` method schedules only one single call to the callback function. If you want to animate another frame, your callback function must call `requestAnimationFrame()` again.
 
-> **Warning:** Be sure always to use the first argument (or some other method for getting the current time) to calculate how much the animation will progress in a frame — **otherwise, the animation will run faster on high refresh-rate screens**. For ways to do that, see the examples below.
+> [!WARNING]
+> Be sure always to use the first argument (or some other method for getting the current time) to calculate how much the animation will progress in a frame — **otherwise, the animation will run faster on high refresh-rate screens**. For ways to do that, see the examples below.
 
 Calling the `requestAnimationFrame()` method requires the current worker to have an associated owner {{domxref("Window", "window")}}. That means that the current worker must be created by {{domxref("Window", "window")}} or by a dedicated worker that also has an associated owner {{domxref("Window", "window")}}.
 

--- a/files/en-us/web/api/delaynode/delaytime/index.md
+++ b/files/en-us/web/api/delaynode/delaytime/index.md
@@ -12,7 +12,8 @@ The `delayTime` property of the {{ domxref("DelayNode") }} interface is an [a-ra
 
 `delayTime` is expressed in seconds, its minimal value is `0`, and its maximum value is defined by the `maxDelayTime` argument of the {{domxref("BaseAudioContext.createDelay")}} method that created it.
 
-> **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Value
 

--- a/files/en-us/web/api/deprecationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/deprecationreportbody/columnnumber/index.md
@@ -12,7 +12,8 @@ browser-compat: api.DeprecationReportBody.columnNumber
 
 The **`columnNumber`** read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.
 
-> **Note:** This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} and {{domxref("DeprecationReportBody.lineNumber")}} as it enables the location of the column in that file and line where the error occurred.
+> [!NOTE]
+> This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} and {{domxref("DeprecationReportBody.lineNumber")}} as it enables the location of the column in that file and line where the error occurred.
 
 ## Value
 

--- a/files/en-us/web/api/deprecationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/deprecationreportbody/linenumber/index.md
@@ -12,7 +12,8 @@ browser-compat: api.DeprecationReportBody.lineNumber
 
 The **`lineNumber`** read-only property of the {{domxref("DeprecationReportBody")}} interface returns the line in the source file in which the deprecated feature was used.
 
-> **Note:** This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} as it enables the location of the line in that file where the error occurred.
+> [!NOTE]
+> This property is most useful alongside {{domxref("DeprecationReportBody.sourceFile")}} as it enables the location of the line in that file where the error occurred.
 
 ## Value
 

--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
@@ -12,7 +12,8 @@ browser-compat: api.DeprecationReportBody.sourceFile
 
 The **`sourceFile`** read-only property of the {{domxref("DeprecationReportBody")}} interface returns the path to the source file where the deprecated feature was used.
 
-> **Note:** This property can be used with {{domxref("DeprecationReportBody.lineNumber")}} and {{domxref("DeprecationReportBody.columnNumber")}} to locate the column and line in the file where the error occurred.
+> [!NOTE]
+> This property can be used with {{domxref("DeprecationReportBody.lineNumber")}} and {{domxref("DeprecationReportBody.columnNumber")}} to locate the column and line in the file where the error occurred.
 
 ## Value
 

--- a/files/en-us/web/api/device_orientation_events/index.md
+++ b/files/en-us/web/api/device_orientation_events/index.md
@@ -31,7 +31,8 @@ Some typical features for which you might want to use the device orientation eve
 
 - for gesture recognition — for example, recognizing a "shake" gesture and using it to perform some action such as clearing an input area when the user shakes the device
 
-> **Note:** This API is widely supported on mobile browsers. While some desktop-only browsers may have limitations due to hardware differences, these constraints are rarely significant given the API's primary usage on sensor-equipped devices.
+> [!NOTE]
+> This API is widely supported on mobile browsers. While some desktop-only browsers may have limitations due to hardware differences, these constraints are rarely significant given the API's primary usage on sensor-equipped devices.
 
 ## Interfaces
 

--- a/files/en-us/web/api/device_orientation_events/orientation_and_motion_data_explained/index.md
+++ b/files/en-us/web/api/device_orientation_events/orientation_and_motion_data_explained/index.md
@@ -30,7 +30,8 @@ The device coordinate frame is the coordination frame fixed on the center of the
 - The **y** axis is in the plane of the screen and is positive toward the top and negative toward the bottom.
 - The **z** axis is perpendicular to the screen or keyboard, and is positive extending outward from the screen.
 
-> **Note:** On a phone or tablet, the orientation of the device is always considered in relation to the standard orientation of the screen; this is the "portrait" orientation on most devices. On a laptop computer, the orientation is considered in relation to the keyboard. If you want to detect changes in device orientation in order to compensate, you can use the [`change`](/en-US/docs/Web/API/ScreenOrientation/change_event) event.
+> [!NOTE]
+> On a phone or tablet, the orientation of the device is always considered in relation to the standard orientation of the screen; this is the "portrait" orientation on most devices. On a laptop computer, the orientation is considered in relation to the keyboard. If you want to detect changes in device orientation in order to compensate, you can use the [`change`](/en-US/docs/Web/API/ScreenOrientation/change_event) event.
 
 ## About rotation
 

--- a/files/en-us/web/api/devicemotionevent/acceleration/index.md
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.md
@@ -13,7 +13,8 @@ the device, in [meters per second squared (m/s²)](https://en.wikipedia.org/wiki
 The acceleration value does not include the effect of
 the gravity force, in contrast to {{DOMxRef("DeviceMotionEvent.accelerationIncludingGravity")}}.
 
-> **Note:** If the hardware doesn't know how to remove gravity from the
+> [!NOTE]
+> If the hardware doesn't know how to remove gravity from the
 > acceleration data, this value may not be present in the
 > {{DOMxRef("DeviceMotionEvent")}}. In this situation, you'll need to use
 > {{DOMxRef("DeviceMotionEvent.accelerationIncludingGravity")}} instead.

--- a/files/en-us/web/api/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/index.md
@@ -9,7 +9,8 @@ browser-compat: api.DeviceMotionEvent
 
 The **`DeviceMotionEvent`** interface of the {{domxref("Device Orientation Events", "", "", "nocode")}} provides web developers with information about the speed of changes for the device's position and orientation.
 
-> **Warning:** Currently, Firefox and Chrome do not handle the coordinates the same way. Take care about this while using them.
+> [!WARNING]
+> Currently, Firefox and Chrome do not handle the coordinates the same way. Take care about this while using them.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.md
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.md
@@ -11,7 +11,8 @@ browser-compat: api.DeviceMotionEvent.rotationRate
 The **`rotationRate`** read-only property of the {{domxref("DeviceMotionEvent")}} interface returns the rate at which the device is rotating around each of its axes in degrees per
 second.
 
-> **Note:** If the hardware isn't capable of providing this
+> [!NOTE]
+> If the hardware isn't capable of providing this
 > information, this property returns `null`.
 
 ## Value

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -12,7 +12,8 @@ browser-compat: api.DirectoryEntrySync
 
 The `DirectoryEntrySync` interface represents a directory in a file system. It includes methods for creating, reading, looking up, and recursively removing files in a directory.
 
-> **Warning:** This interface is deprecated and is no more on the standard track.
+> [!WARNING]
+> This interface is deprecated and is no more on the standard track.
 > _Do not use it anymore._ Use the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Basic concepts

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -12,7 +12,8 @@ browser-compat: api.DirectoryReaderSync
 
 The `DirectoryReaderSync` interface lets you read the entries in a directory.
 
-> **Warning:** This interface is deprecated and is no more on the standard track.
+> [!WARNING]
+> This interface is deprecated and is no more on the standard track.
 > _Do not use it anymore._ Use the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Basic concepts

--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -23,7 +23,8 @@ toggle a radio button). Which elements are focusable varies depending on the pla
 and the browser's current configuration. For example, on macOS systems, elements that
 aren't text input elements are not typically focusable by default.
 
-> **Note:** Focus (which element is receiving user input events) is not
+> [!NOTE]
+> Focus (which element is receiving user input events) is not
 > the same thing as selection (the currently highlighted part of the document). You can
 > get the current selection using {{domxref("window.getSelection()")}}.
 

--- a/files/en-us/web/api/document/adoptedstylesheets/index.md
+++ b/files/en-us/web/api/document/adoptedstylesheets/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Document.adoptedStyleSheets
 
 The **`adoptedStyleSheets`** property of the {{domxref("Document")}} interface is used for setting an array of constructed stylesheets to be used by the document.
 
-> **Note:** A constructed stylesheet is a stylesheet created programmatically using the [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) (as compared to one created by a user-agent when importing a stylesheet from a script, imported using {{HTMLElement('style')}} and {{CSSXref('@import')}}, or linked to via {{HTMLElement('link')}}).
+> [!NOTE]
+> A constructed stylesheet is a stylesheet created programmatically using the [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) (as compared to one created by a user-agent when importing a stylesheet from a script, imported using {{HTMLElement('style')}} and {{CSSXref('@import')}}, or linked to via {{HTMLElement('link')}}).
 
 The same constructed stylesheets can also be shared with one or more {{domxref("ShadowRoot")}} instances using the [`ShadowRoot.adoptedStyleSheets`](/en-US/docs/Web/API/ShadowRoot/adoptedStyleSheets) property.
 Changing an adopted stylesheet will affect all the objects that adopt it.

--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -12,7 +12,8 @@ browser-compat: api.Document.applets
 
 The **`applets`** property of the {{domxref("Document")}} returns an empty {{domxref("HTMLCollection")}}. This property is kept only for compatibility reasons; in older versions of browsers, it returned a list of the applets within a document.
 
-> **Note:** Support for the `<applet>` element has been removed by all browsers. Therefore, calling `document.applets` always
+> [!NOTE]
+> Support for the `<applet>` element has been removed by all browsers. Therefore, calling `document.applets` always
 > returns an empty collection.
 
 ## Value

--- a/files/en-us/web/api/document/browsingtopics/index.md
+++ b/files/en-us/web/api/document/browsingtopics/index.md
@@ -11,9 +11,11 @@ browser-compat: api.Document.browsingTopics
 
 {{APIRef("Topics API")}}{{SeeCompatTable}}{{non-standard_header}}
 
-> **Warning:** This feature is currently opposed by two browser vendors. See the [Standards positions](/en-US/docs/Web/API/Topics_API#standards_positions) section below for details of opposition.
+> [!WARNING]
+> This feature is currently opposed by two browser vendors. See the [Standards positions](/en-US/docs/Web/API/Topics_API#standards_positions) section below for details of opposition.
 
-> **Note:** An [Enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment) is required to use this feature in your applications.
+> [!NOTE]
+> An [Enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment) is required to use this feature in your applications.
 
 The `browsingTopics()` method of the {{domxref("Document")}} interface returns a promise that fulfills with an array of objects representing the top topics for the user, one from each of the last three epochs. These topics could then be returned to the ad tech platform in a subsequent fetch request. By default, the method also causes the browser to record the current page visit as observed by the caller, so the page's hostname can later be used in topics calculation.
 

--- a/files/en-us/web/api/document/characterset/index.md
+++ b/files/en-us/web/api/document/characterset/index.md
@@ -12,7 +12,8 @@ The **`Document.characterSet`**
 read-only property returns the [character encoding](/en-US/docs/Glossary/Character_encoding) of the
 document that it's currently rendered with.
 
-> **Note:** A "character set" and a "character encoding" are related, but different. Despite the
+> [!NOTE]
+> A "character set" and a "character encoding" are related, but different. Despite the
 > name of this property, it returns the _encoding_.
 
 ## Value

--- a/files/en-us/web/api/document/compatmode/index.md
+++ b/files/en-us/web/api/document/compatmode/index.md
@@ -20,7 +20,8 @@ An enumerated value that can be:
 - "`CSS1Compat`" if the document is in no-quirks (also known as
   "standards") mode or limited-quirks (also known as "almost standards") mode.
 
-> **Note:** All these modes are now standardized, so the older "standards"
+> [!NOTE]
+> All these modes are now standardized, so the older "standards"
 > and "almost standards" names are nonsensical and no longer used in standards.
 
 ## Examples

--- a/files/en-us/web/api/document/contenttype/index.md
+++ b/files/en-us/web/api/document/contenttype/index.md
@@ -13,7 +13,8 @@ MIME type that the document is being rendered as. This may come from HTTP header
 other sources of MIME information, and might be affected by automatic type conversions
 performed by either the browser or extensions.
 
-> **Note:** This property is unaffected by {{HTMLElement("meta")}}
+> [!NOTE]
+> This property is unaffected by {{HTMLElement("meta")}}
 > elements.
 
 ## Value

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -37,12 +37,14 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
     If a domain is specified, subdomains are always included.
     Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots.
 
-    > **Note:** The domain _must_ match the domain of the JavaScript origin.
+    > [!NOTE]
+    > The domain _must_ match the domain of the JavaScript origin.
     > Setting cookies to foreign domains will be silently ignored.
 
   - `;expires=date-in-UTCString-format`: The expiry date of the cookie. If neither `expires` nor `max-age` is specified, it will expire at the end of session.
 
-    > **Warning:** When user privacy is a concern, it's important that any web app implementation invalidate cookie data after a certain timeout instead of relying on the browser to do it.
+    > [!WARNING]
+    > When user privacy is a concern, it's important that any web app implementation invalidate cookie data after a certain timeout instead of relying on the browser to do it.
     > Many browsers let users specify that cookies should never expire, which is not necessarily safe.
 
     See {{jsxref("Date.toUTCString()")}} for help formatting this value.
@@ -73,11 +75,14 @@ In the code above, `newCookie` is a string of form `key=value`, specifying the c
     It also signals that the domain attribute must not be present, which prevents the cookie from being sent to other domains.
     For Chrome the path attribute must always be the origin.
 
-  > **Note:** The dash is considered part of the prefix.
+  > [!NOTE]
+  > The dash is considered part of the prefix.
 
-  > **Note:** These flags are only settable with the `secure` attribute.
+  > [!NOTE]
+  > These flags are only settable with the `secure` attribute.
 
-> **Note:** As you can see from the code above, `document.cookie` is an [accessor property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with native _setter_ and _getter_ functions, and consequently is _not_ a [data property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with a value: what you write is not the same as what you read, everything is always mediated by the JavaScript interpreter.
+> [!NOTE]
+> As you can see from the code above, `document.cookie` is an [accessor property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with native _setter_ and _getter_ functions, and consequently is _not_ a [data property](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description) with a value: what you write is not the same as what you read, everything is always mediated by the JavaScript interpreter.
 
 ## Examples
 

--- a/files/en-us/web/api/document/createattribute/index.md
+++ b/files/en-us/web/api/document/createattribute/index.md
@@ -13,7 +13,8 @@ attribute node, and returns it. The object created is a node implementing the
 {{domxref("Attr")}} interface. The DOM does not enforce what sort of attributes can be
 added to a particular element in this manner.
 
-> **Note:** The string given in parameter is converted to lowercase.
+> [!NOTE]
+> The string given in parameter is converted to lowercase.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/createelement/index.md
+++ b/files/en-us/web/api/document/createelement/index.md
@@ -31,7 +31,8 @@ createElement(tagName, options)
 
 The new {{domxref("Element")}}.
 
-> **Note:** A new {{domxref("HTMLElement", "HTMLElement", "", "1")}} is returned if the document is an {{domxref("HTMLDocument", "HTMLDocument", "", "1")}}, which is the most common case. Otherwise a new {{domxref("Element","Element","","1")}} is returned.
+> [!NOTE]
+> A new {{domxref("HTMLElement", "HTMLElement", "", "1")}} is returned if the document is an {{domxref("HTMLDocument", "HTMLDocument", "", "1")}}, which is the most common case. Otherwise a new {{domxref("Element","Element","","1")}} is returned.
 
 ## Examples
 
@@ -81,7 +82,8 @@ function addElement() {
 
 ### Web component example
 
-> **Note:** Check the [browser compatibility](#browser_compatibility) section for support, and the [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute reference for caveats on implementation reality of custom built-in elements.
+> [!NOTE]
+> Check the [browser compatibility](#browser_compatibility) section for support, and the [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute reference for caveats on implementation reality of custom built-in elements.
 
 The following example snippet is taken from our [expanding-list-web-component](https://github.com/mdn/web-components-examples/tree/main/expanding-list-web-component) example ([see it live also](https://mdn.github.io/web-components-examples/expanding-list-web-component/)). In this case, our custom element extends the {{domxref("HTMLUListElement")}}, which represents the {{htmlelement("ul")}} element.
 
@@ -109,7 +111,8 @@ let expandingList = document.createElement("ul", { is: "expanding-list" });
 
 The new element will be given an [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute whose value is the custom element's tag name.
 
-> **Note:** For backwards compatibility with previous versions of the [Custom Elements specification](https://www.w3.org/TR/custom-elements/), some browsers will allow you to pass a string here instead of an object, where the string's value is the custom element's tag name.
+> [!NOTE]
+> For backwards compatibility with previous versions of the [Custom Elements specification](https://www.w3.org/TR/custom-elements/), some browsers will allow you to pass a string here instead of an object, where the string's value is the custom element's tag name.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/createelementns/index.md
+++ b/files/en-us/web/api/document/createelementns/index.md
@@ -95,7 +95,8 @@ elements from two different namespaces within a single document:
 </page>
 ```
 
-> **Note:** The example given above uses inline script which is not recommended in XHTML
+> [!NOTE]
+> The example given above uses inline script which is not recommended in XHTML
 > documents. This particular example is actually an XUL document with embedded XHTML,
 > however, the recommendation still applies.
 

--- a/files/en-us/web/api/document/createevent/index.md
+++ b/files/en-us/web/api/document/createevent/index.md
@@ -8,7 +8,8 @@ browser-compat: api.Document.createEvent
 
 {{APIRef("DOM")}}
 
-> **Warning:** Many methods used with `createEvent`, such as `initCustomEvent`, are deprecated.
+> [!WARNING]
+> Many methods used with `createEvent`, such as `initCustomEvent`, are deprecated.
 > Use [event constructors](/en-US/docs/Web/API/CustomEvent) instead.
 
 Creates an [event](/en-US/docs/Web/API/Event) of the type specified. The

--- a/files/en-us/web/api/document/createtouch/index.md
+++ b/files/en-us/web/api/document/createtouch/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Document.createTouch
 
 The **`Document.createTouch()`** method creates and returns a new {{DOMxRef("Touch")}} object.
 
-> **Note:** Use the {{domxref("TouchEvent.TouchEvent", "TouchEvent()")}} constructor.
+> [!NOTE]
+> Use the {{domxref("TouchEvent.TouchEvent", "TouchEvent()")}} constructor.
 
 ## Syntax
 
@@ -23,7 +24,8 @@ createTouch(view, target, identifier, pageX, pageY, screenX, screenY)
 
 ### Parameters
 
-> **Note:** All parameters are optional.
+> [!NOTE]
+> All parameters are optional.
 
 - `view`
   - : The {{DOMxRef("window")}} in which the touch occurred.
@@ -40,7 +42,8 @@ createTouch(view, target, identifier, pageX, pageY, screenX, screenY)
 - `screenY`
   - : The value for {{DOMxRef("Touch.screenY")}}.
 
-> **Note:** Previous versions of this method included the
+> [!NOTE]
+> Previous versions of this method included the
 > following additional parameters but those parameters are not included in either of the
 > standards listed below. Consequently, these parameters should be considered deprecated
 > and not used.

--- a/files/en-us/web/api/document/createtreewalker/index.md
+++ b/files/en-us/web/api/document/createtreewalker/index.md
@@ -44,7 +44,8 @@ createTreeWalker(root, whatToShow, filter)
     | `NodeFilter.SHOW_PROCESSING_INSTRUCTION`                 | `0x40`          | Shows {{domxref("ProcessingInstruction")}} nodes. |
     | `NodeFilter.SHOW_TEXT`                                   | `0x4`           | Shows {{domxref("Text")}} nodes.                  |
 
-    > **Note:** Since the parent of any `Attr` node is always `null`, {{DOMXref("TreeWalker.nextNode()")}} and {{DOMXref("TreeWalker.previousNode()")}} will never return an `Attr` node. To traverse `Attr` nodes, use {{DOMXref("Element.attributes")}} instead.
+    > [!NOTE]
+    > Since the parent of any `Attr` node is always `null`, {{DOMXref("TreeWalker.nextNode()")}} and {{DOMXref("TreeWalker.previousNode()")}} will never return an `Attr` node. To traverse `Attr` nodes, use {{DOMXref("Element.attributes")}} instead.
 
 - `filter` {{optional_inline}}
 

--- a/files/en-us/web/api/document/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.md
@@ -70,7 +70,8 @@ if (document.readyState === "loading") {
 }
 ```
 
-> **Note:** There's no race condition here — it's not possible for the document to be loaded between the `if` check and the `addEventListener()` call. JavaScript has run-to-completion semantics, which means if the document is loading at one particular tick of the event loop, it can't become loaded until the next cycle, at which time the `doSomething` handler is already attached and will be fired.
+> [!NOTE]
+> There's no race condition here — it's not possible for the document to be loaded between the `if` check and the `addEventListener()` call. JavaScript has run-to-completion semantics, which means if the document is loading at one particular tick of the event loop, it can't become loaded until the next cycle, at which time the `doSomething` handler is already attached and will be fired.
 
 ### Live example
 

--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -50,20 +50,23 @@ evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result)
       - : A result set containing all the nodes matching the expression. The nodes
         in the result set are not necessarily in the same order they appear in
         the document.
-        > **Note:** Results of this type contain references to nodes in the document.
+        > [!NOTE]
+        > Results of this type contain references to nodes in the document.
         > Modifying a node will invalidate the iterator.
         > After modifying a node, attempting to iterate through the results will result in an error.
     - `ORDERED_NODE_ITERATOR_TYPE` (`5`)
       - : A result set containing all the nodes matching the expression. The nodes
         in the result set are in the same order they appear in the document.
-        > **Note:** Results of this type contain references to nodes in the document.
+        > [!NOTE]
+        > Results of this type contain references to nodes in the document.
         > Modifying a node will invalidate the iterator.
         > After modifying a node, attempting to iterate through the results will result in an error.
     - `UNORDERED_NODE_SNAPSHOT_TYPE` (`6`)
       - : A result set containing snapshots of all the nodes matching the
         expression. The nodes in the result set are not necessarily in the same
         order they appear in the document.
-        > **Note:** Results of this type are snapshots, which are essentially lists of matched nodes.
+        > [!NOTE]
+        > Results of this type are snapshots, which are essentially lists of matched nodes.
         > You can make changes to the document by altering snapshot nodes.
         > Modifying the document doesn't invalidate the snapshot;
         > however, if the document is changed, the snapshot may not correspond to the current state of the document,
@@ -72,7 +75,8 @@ evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result)
       - : A result set containing snapshots of all the nodes matching the
         expression. The nodes in the result set are in the same order they
         appear in the document.
-        > **Note:** Results of this type are snapshots, which are essentially lists of matched nodes.
+        > [!NOTE]
+        > Results of this type are snapshots, which are essentially lists of matched nodes.
         > You can make changes to the document by altering snapshot nodes.
         > Modifying the document doesn't invalidate the snapshot;
         > however, if the document is changed, the snapshot may not correspond to the current state of the document,

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -16,7 +16,8 @@ To access the clipboard, the newer [Clipboard API](/en-US/docs/Web/API/Clipboard
 
 Most commands affect the document's [selection](/en-US/docs/Web/API/Selection). For example, some commands (bold, italics, etc.) format the currently selected text, while others delete the selection, insert new elements (replacing the selection) or affect an entire line (indenting). Only the currently active editable element can be modified, but some commands (e.g. `copy`) can work without an editable element.
 
-> **Note:** Modifications performed by `execCommand()` may or may not trigger {{domxref("Element/beforeinput_event", "beforeinput")}} and {{domxref("Element/input_event", "input")}} events, depending on the browser and configuration. If triggered, the handlers for the events will run before `execCommand()` returns. Authors need to be careful about such recursive calls, especially if they call `execCommand()` in response to these events. From Firefox 82, nested `execCommand()` calls will always fail, see [bug 1634262](https://bugzil.la/1634262).
+> [!NOTE]
+> Modifications performed by `execCommand()` may or may not trigger {{domxref("Element/beforeinput_event", "beforeinput")}} and {{domxref("Element/input_event", "input")}} events, depending on the browser and configuration. If triggered, the handlers for the events will run before `execCommand()` returns. Authors need to be careful about such recursive calls, especially if they call `execCommand()` in response to these events. From Firefox 82, nested `execCommand()` calls will always fail, see [bug 1634262](https://bugzil.la/1634262).
 
 ## Syntax
 
@@ -121,7 +122,8 @@ execCommand(aCommandName, aShowDefaultUI, aValueArgument)
       - : Removes the [anchor element](/en-US/docs/Web/HTML/Element/a) from a selected hyperlink.
     - `useCSS` {{Deprecated_inline}}
       - : Toggles the use of HTML tags or CSS for the generated markup. Requires a boolean true/false as a value argument.
-        > **Note:** This argument is logically backwards (i.e., use `false` to use CSS,
+        > [!NOTE]
+        > This argument is logically backwards (i.e., use `false` to use CSS,
         > `true` to use HTML). This has been deprecated in favor of `styleWithCSS`.
     - `styleWithCSS`
       - : Replaces the `useCSS` command. `true` modifies/generates `style` attributes in markup, false generates presentational elements.

--- a/files/en-us/web/api/document/exitfullscreen/index.md
+++ b/files/en-us/web/api/document/exitfullscreen/index.md
@@ -48,7 +48,8 @@ document.onclick = (event) => {
 };
 ```
 
-> **Note:** For a more complete example, see the
+> [!NOTE]
+> For a more complete example, see the
 > [`Element.requestFullscreen()` examples](/en-US/docs/Web/API/Element/requestFullscreen#examples).
 
 ## Specifications

--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Document.exitPointerLock
 
 The **`exitPointerLock()`** method of the {{domxref("Document")}} interface asynchronously releases a pointer lock previously requested through {{domxref("Element.requestPointerLock")}}.
 
-> **Note:** While the **`exitPointerLock()`** method is called on the document, the **`requestPointerLock()`** method is called on an element.
+> [!NOTE]
+> While the **`exitPointerLock()`** method is called on the document, the **`requestPointerLock()`** method is called on an element.
 
 To track the success or failure of the request, it is necessary to listen for the {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} and {{domxref("Document/pointerlockerror_event", "pointerlockerror")}} events.
 

--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -12,7 +12,8 @@ The **`forms`** read-only property of
 the {{domxref("Document")}} interface returns an {{domxref("HTMLCollection")}} listing
 all the {{HTMLElement("form")}} elements contained in the document.
 
-> **Note:** Similarly, you can access a list of a form's component user
+> [!NOTE]
+> Similarly, you can access a list of a form's component user
 > input elements using the {{domxref("HTMLFormElement.elements")}} property.
 
 ## Value

--- a/files/en-us/web/api/document/fullscreen/index.md
+++ b/files/en-us/web/api/document/fullscreen/index.md
@@ -14,7 +14,8 @@ The obsolete {{domxref("Document")}} interface's **`fullscreen`** read-only prop
 
 Although this property is read-only, it will not throw if it is modified (even in strict mode); the setter is a no-operation and it will be ignored.
 
-> **Note:** Since this property is deprecated, you can determine if fullscreen mode is active on the document by checking to see if {{DOMxRef("Document.fullscreenElement")}} is not `null`.
+> [!NOTE]
+> Since this property is deprecated, you can determine if fullscreen mode is active on the document by checking to see if {{DOMxRef("Document.fullscreenElement")}} is not `null`.
 
 ## Value
 

--- a/files/en-us/web/api/document/getelementbyid/index.md
+++ b/files/en-us/web/api/document/getelementbyid/index.md
@@ -12,7 +12,8 @@ The **`getElementById()`** method of the {{domxref("Document")}} interface retur
 
 If you need to get access to an element which doesn't have an ID, you can use {{domxref("Document.querySelector", "querySelector()")}} to find the element using any {{Glossary("CSS selector", "selector")}}.
 
-> **Note:** IDs should be unique inside a document. If two or more elements in a document have the same ID, this method returns the first element found.
+> [!NOTE]
+> IDs should be unique inside a document. If two or more elements in a document have the same ID, this method returns the first element found.
 
 ## Syntax
 
@@ -20,7 +21,8 @@ If you need to get access to an element which doesn't have an ID, you can use {{
 getElementById(id)
 ```
 
-> **Note:** The capitalization of `"Id"` in the name of this method _must_ be correct for the code to function; `getElementByID()` is _not_ valid and will not work, however natural it may seem.
+> [!NOTE]
+> The capitalization of `"Id"` in the name of this method _must_ be correct for the code to function; `getElementByID()` is _not_ valid and will not work, however natural it may seem.
 
 ### Parameters
 

--- a/files/en-us/web/api/document/getelementsbyclassname/index.md
+++ b/files/en-us/web/api/document/getelementsbyclassname/index.md
@@ -16,7 +16,8 @@ When called on
 the {{domxref("document")}} object, the complete document is searched, including the
 root node. You may also call {{domxref("Element.getElementsByClassName", "getElementsByClassName()")}} on any element; it will return only elements which are descendants of the specified root element with the given class name(s).
 
-> **Warning:** This is a live {{domxref("HTMLCollection")}}. Changes in the DOM will
+> [!WARNING]
+> This is a live {{domxref("HTMLCollection")}}. Changes in the DOM will
 > reflect in the array as the changes occur. If an element selected by this array no
 > longer qualifies for the selector, it will automatically be removed. Be aware of this
 > for iteration purposes.

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -31,11 +31,13 @@ getElementsByTagNameNS(namespace, name)
 A live {{DOMxRef("NodeList")}} (but see the note below) of
 found elements in the order they appear in the tree.
 
-> **Note:** While the W3C specification says returned value is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} in Firefox.
+> [!NOTE]
+> While the W3C specification says returned value is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} in Firefox.
 > Opera returns a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. As of January 2012, only in WebKit browsers is the returned value a pure `NodeList`.
 > See [bug 14869](https://bugzil.la/14869) for details.
 
-> **Note:** Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.
+> [!NOTE]
+> Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.
 > See the [developer release note for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6#dom) and a note in Browser compatibility section in {{domxref("Element.getElementsByTagNameNS")}} for details.
 
 ## Examples

--- a/files/en-us/web/api/document/hasfocus/index.md
+++ b/files/en-us/web/api/document/hasfocus/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Document.hasFocus
 The **`hasFocus()`** method of the {{domxref("Document")}} interface returns a boolean value indicating whether the document or any element inside the document has focus.
 This method can be used to determine whether the active element in a document has focus.
 
-> **Note:** When viewing a document, an element with focus is always the [active element](/en-US/docs/Web/API/Document/activeElement) in the document, but an active element does not necessarily have focus.
+> [!NOTE]
+> When viewing a document, an element with focus is always the [active element](/en-US/docs/Web/API/Document/activeElement) in the document, but an active element does not necessarily have focus.
 > For example, an active element within a popup window that is not the foreground doesn't have focus.
 
 ## Syntax

--- a/files/en-us/web/api/document/hasstorageaccess/index.md
+++ b/files/en-us/web/api/document/hasstorageaccess/index.md
@@ -12,7 +12,8 @@ The **`hasStorageAccess()`** method of the {{domxref("Document")}} interface ret
 
 This method is part of the [Storage Access API](/en-US/docs/Web/API/Storage_Access_API).
 
-> **Note:** This method is another name for {{DOMxRef("Document.hasUnpartitionedCookieAccess()")}}. There are no current plans to remove this method in favor of {{DOMxRef("Document.hasUnpartitionedCookieAccess()")}}.
+> [!NOTE]
+> This method is another name for {{DOMxRef("Document.hasUnpartitionedCookieAccess()")}}. There are no current plans to remove this method in favor of {{DOMxRef("Document.hasUnpartitionedCookieAccess()")}}.
 
 ## Syntax
 
@@ -33,7 +34,8 @@ The result returned by this method can be inaccurate in a couple of circumstance
 1. The user may have active browser settings that block third-party cookies; in this case, `true` may be returned even though third-party cookies are still inaccessible. To handle such a situation, you should gracefully handle any errors resulting in cookie values being unretrievable; for example, inform the user that access to their personalized settings is blocked and invite them to sign in again to use them.
 2. The browser might not block third-party cookie access by default; in this case, `false` may be returned even though third-party cookies are accessible, and storage access wouldn't need to be requested (i.e., via {{domxref("Document.requestStorageAccess()")}}). To get around this issue, you could query {{domxref("Document.cookie")}} to find out whether your cookies are accessible, and call {{domxref("Document.requestStorageAccess()")}} if they are not.
 
-> **Note:** If the promise gets resolved and a user gesture event was being processed when the function was originally called, the resolve handler will run as if a user gesture was being processed, so it will be able to call APIs that require user activation.
+> [!NOTE]
+> If the promise gets resolved and a user gesture event was being processed when the function was originally called, the resolve handler will run as if a user gesture was being processed, so it will be able to call APIs that require user activation.
 
 ### Exceptions
 
@@ -55,7 +57,8 @@ document.hasStorageAccess().then((hasAccess) => {
 });
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/hasunpartitionedcookieaccess/index.md
+++ b/files/en-us/web/api/document/hasunpartitionedcookieaccess/index.md
@@ -50,7 +50,8 @@ document.hasUnpartitionedCookieAccess().then((hasAccess) => {
 });
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/implementation/index.md
+++ b/files/en-us/web/api/document/implementation/index.md
@@ -27,7 +27,8 @@ console.log(`DOM ${modName} ${modVer} supported?: ${conformTest}`);
 // Log: "DOM HTML 2.0 supported?: true" (hasFeature always returns true)
 ```
 
-> **Warning:** Do not use this for feature detection. The `hasFeature()` method always returns true.
+> [!WARNING]
+> Do not use this for feature detection. The `hasFeature()` method always returns true.
 
 ## Notes
 

--- a/files/en-us/web/api/document/importnode/index.md
+++ b/files/en-us/web/api/document/importnode/index.md
@@ -65,7 +65,8 @@ Before they can be inserted into the current document, nodes from external docum
 - cloned using `document.importNode()`; or
 - adopted using {{domXref("document.adoptNode()")}}.
 
-> **Note:** Although Firefox doesn't currently enforce this rule, we encourage you to follow this rule for improved future compatibility.
+> [!NOTE]
+> Although Firefox doesn't currently enforce this rule, we encourage you to follow this rule for improved future compatibility.
 
 For more on the {{domXref("Node.ownerDocument")}} issues, see the W3C DOM FAQ.
 

--- a/files/en-us/web/api/document/laststylesheetset/index.md
+++ b/files/en-us/web/api/document/laststylesheetset/index.md
@@ -19,7 +19,8 @@ changed.
 
 The style sheet set that was most recently set. If the current style sheet set has not been changed by setting {{domxref("document.selectedStyleSheetSet")}}, the returned value is `null`.
 
-> **Note:** This value doesn't change when
+> [!NOTE]
+> This value doesn't change when
 > {{domxref("document.enableStyleSheetsForSet()")}} is called.
 
 ## Examples

--- a/files/en-us/web/api/document/plugins/index.md
+++ b/files/en-us/web/api/document/plugins/index.md
@@ -13,7 +13,8 @@ The **`plugins`** read-only property of the
 containing one or more {{domxref("HTMLEmbedElement")}}s representing the
 {{HTMLElement("embed")}} elements in the current document.
 
-> **Note:** For a list of installed plugins, use [Navigator.plugins](/en-US/docs/Web/API/Navigator/plugins)
+> [!NOTE]
+> For a list of installed plugins, use [Navigator.plugins](/en-US/docs/Web/API/Navigator/plugins)
 > instead.
 
 ## Value

--- a/files/en-us/web/api/document/prerendering/index.md
+++ b/files/en-us/web/api/document/prerendering/index.md
@@ -49,7 +49,8 @@ if (document.prerendering) {
 }
 ```
 
-> **Note:** See the [Speculation Rules API](/en-US/docs/Web/API/Speculation_Rules_API) landing page and particularly the [Unsafe speculative loading conditions](/en-US/docs/Web/API/Speculation_Rules_API#unsafe_speculative_loading_conditions) section for more information on the kinds of activities you might wish to delay.
+> [!NOTE]
+> See the [Speculation Rules API](/en-US/docs/Web/API/Speculation_Rules_API) landing page and particularly the [Unsafe speculative loading conditions](/en-US/docs/Web/API/Speculation_Rules_API#unsafe_speculative_loading_conditions) section for more information on the kinds of activities you might wish to delay.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/prerenderingchange_event/index.md
+++ b/files/en-us/web/api/document/prerenderingchange_event/index.md
@@ -40,7 +40,8 @@ if (document.prerendering) {
 }
 ```
 
-> **Note:** See the [Speculation Rules API](/en-US/docs/Web/API/Speculation_Rules_API) landing page and particularly the [Unsafe speculative loading conditions](/en-US/docs/Web/API/Speculation_Rules_API#unsafe_speculative_loading_conditions) section for more information on the kinds of activities you might wish to delay until after prerendering has finished.
+> [!NOTE]
+> See the [Speculation Rules API](/en-US/docs/Web/API/Speculation_Rules_API) landing page and particularly the [Unsafe speculative loading conditions](/en-US/docs/Web/API/Speculation_Rules_API#unsafe_speculative_loading_conditions) section for more information on the kinds of activities you might wish to delay until after prerendering has finished.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/queryselectorall/index.md
+++ b/files/en-us/web/api/document/queryselectorall/index.md
@@ -34,7 +34,8 @@ A non-live {{domxref("NodeList")}} containing one {{domxref("Element")}} object 
 each element that matches at least one of the specified selectors or an empty
 {{domxref("NodeList")}} in case of no matches.
 
-> **Note:** If the specified `selectors` include a [CSS pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), the returned list
+> [!NOTE]
+> If the specified `selectors` include a [CSS pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), the returned list
 > is always empty.
 
 ### Exceptions

--- a/files/en-us/web/api/document/requeststorageaccess/index.md
+++ b/files/en-us/web/api/document/requeststorageaccess/index.md
@@ -12,7 +12,8 @@ The **`requestStorageAccess()`** method of the {{domxref("Document")}} interface
 
 To check whether permission to access third-party cookies has already been granted, you can call {{domxref("Permissions.query()")}}, specifying the feature name `"storage-access"`.
 
-> **Note:** Usage of this feature may be blocked by a {{httpheader("Permissions-Policy/storage-access", "storage-access")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server. In addition, the document must pass additional browser-specific checks such as allowlists, blocklists, on-device classification, user settings, anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics, or prompting the user for explicit permission.
+> [!NOTE]
+> Usage of this feature may be blocked by a {{httpheader("Permissions-Policy/storage-access", "storage-access")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server. In addition, the document must pass additional browser-specific checks such as allowlists, blocklists, on-device classification, user settings, anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics, or prompting the user for explicit permission.
 
 ## Syntax
 
@@ -100,7 +101,8 @@ document.requestStorageAccess({ localStorage: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/requeststorageaccessfor/index.md
+++ b/files/en-us/web/api/document/requeststorageaccessfor/index.md
@@ -66,7 +66,8 @@ navigator.permissions.query({
 });
 ```
 
-> **Note:** Usage of this feature may be blocked by a {{httpheader("Permissions-Policy/storage-access", "storage-access")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server (the same one that controls the rest of the Storage Access API). In addition, the document must pass additional browser-specific checks such as allowlists, blocklists, on-device classification, user settings, or anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics.
+> [!NOTE]
+> Usage of this feature may be blocked by a {{httpheader("Permissions-Policy/storage-access", "storage-access")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server (the same one that controls the rest of the Storage Access API). In addition, the document must pass additional browser-specific checks such as allowlists, blocklists, on-device classification, user settings, or anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics.
 
 ## Examples
 
@@ -103,7 +104,8 @@ function checkCookie() {
 }
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/document/securitypolicyviolation_event/index.md
@@ -14,7 +14,8 @@ The event is fired on the global scope when violates the policy and will bubble 
 
 The handler can be assigned using the `onsecuritypolicyviolation` event handler property or using {{domxref("EventTarget.addEventListener()")}}.
 
-> **Note:** It is recommended to add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}). While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.
+> [!NOTE]
+> It is recommended to add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}). While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/selectedstylesheetset/index.md
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.md
@@ -22,7 +22,8 @@ Setting the value of this property is equivalent to calling
 `currentStyleSheetSet`, then setting the value of
 `lastStyleSheetSet` to that value as well.
 
-> **Note:** This attribute's value is live; directly changing
+> [!NOTE]
+> This attribute's value is live; directly changing
 > the `disabled` attribute on style sheets will affect the value of this
 > attribute.
 

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -14,7 +14,8 @@ This event is not cancelable and does not bubble.
 
 The event can be handled by adding an event listener for `selectionchange` or using the `onselectionchange` event handler.
 
-> **Note:** This event is not quite the same as the `selectionchange` events fired when the text selection in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is changed. See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` for more details.
+> [!NOTE]
+> This event is not quite the same as the `selectionchange` events fired when the text selection in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is changed. See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` for more details.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -15,7 +15,8 @@ This timeline is unique to each `document` and persists for the lifetime of the 
 This timeline expresses the time in milliseconds since {{domxref("Performance.timeOrigin")}}.
 Prior to the time origin, the timeline is inactive, and its {{domxref("AnimationTimeline.currentTime","currentTime")}} is `null`.
 
-> **Note:** A document timeline that is associated with a non-active document (a {{domxref("Document")}} not associated with a {{domxref("Window")}}, {{htmlelement("iframe")}}, or {{htmlelement("frame")}}) is also considered to be inactive.
+> [!NOTE]
+> A document timeline that is associated with a non-active document (a {{domxref("Document")}} not associated with a {{domxref("Window")}}, {{htmlelement("iframe")}}, or {{htmlelement("frame")}}) is also considered to be inactive.
 
 ## Value
 

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -8,7 +8,8 @@ browser-compat: api.Document.write
 
 {{ApiRef("DOM")}}
 
-> **Warning:** Use of the `document.write()` method is strongly discouraged.
+> [!WARNING]
+> Use of the `document.write()` method is strongly discouraged.
 >
 > As [the HTML spec itself warns](<https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.write()>):
 >
@@ -17,7 +18,8 @@ browser-compat: api.Document.write
 
 The **`document.write()`** method writes a string of text to a document stream opened by {{domxref("document.open()")}}.
 
-> **Note:** Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document automatically calls `document.open()`, [which will clear the document](/en-US/docs/Web/API/Document/open#notes).
+> [!NOTE]
+> Because `document.write()` writes to the document **stream**, calling `document.write()` on a closed (loaded) document automatically calls `document.open()`, [which will clear the document](/en-US/docs/Web/API/Document/open#notes).
 
 ## Syntax
 

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -8,7 +8,8 @@ browser-compat: api.Document.writeln
 
 {{ ApiRef("DOM") }}
 
-> **Warning:** Use of the `document.writeln()` method is strongly discouraged.
+> [!WARNING]
+> Use of the `document.writeln()` method is strongly discouraged.
 >
 > As [the HTML spec itself warns](<https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.write()>):
 >

--- a/files/en-us/web/api/document/xmlencoding/index.md
+++ b/files/en-us/web/api/document/xmlencoding/index.md
@@ -12,7 +12,8 @@ browser-compat: api.Document.xmlEncoding
 
 Returns the encoding as determined by the XML declaration. Should be `null` if unspecified or unknown.
 
-> **Warning:** Do not use this attribute; it has been removed from the DOM Level 4 specification and is no longer supported in Firefox 10.0.
+> [!WARNING]
+> Do not use this attribute; it has been removed from the DOM Level 4 specification and is no longer supported in Firefox 10.0.
 
 Consider the following XML Declaration:
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 3.
