### PR TITLE
Convert noteblocks for web/api folder (part 4)

### DIFF
--- a/files/en-us/web/api/document_object_model/introduction/index.md
+++ b/files/en-us/web/api/document_object_model/introduction/index.md
@@ -108,7 +108,8 @@ and then adds it to the tree for the document:
 
 This page tries to describe the various objects and types in simple terms. But there are a number of different data types being passed around the API that you should be aware of.
 
-> **Note:** Because the vast majority of code that uses the DOM revolves around manipulating HTML documents, it's common to refer to the nodes in the DOM as **elements**, although strictly speaking not every node is an element.
+> [!NOTE]
+> Because the vast majority of code that uses the DOM revolves around manipulating HTML documents, it's common to refer to the nodes in the DOM as **elements**, although strictly speaking not every node is an element.
 
 The following table briefly describes these data types.
 

--- a/files/en-us/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/en-us/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -17,7 +17,8 @@ This specification adds two new methods to any objects implementing the {{domxre
 - {{domxref("Element.querySelectorAll", "querySelectorAll()")}}
   - : Returns a {{domxref("NodeList")}} containing all matching `Element` nodes within the node's subtree, or an empty `NodeList` if no matches are found.
 
-> **Note:** The {{domxref("NodeList")}} returned by {{domxref("Element.querySelectorAll()", "querySelectorAll()")}} is not live, which means that changes in the DOM are not reflected in the collection. This is different from other DOM querying methods that return live node lists.
+> [!NOTE]
+> The {{domxref("NodeList")}} returned by {{domxref("Element.querySelectorAll()", "querySelectorAll()")}} is not live, which means that changes in the DOM are not reflected in the collection. This is different from other DOM querying methods that return live node lists.
 
 You may find examples and details by reading the documentation for the {{domxref("Element.querySelector()")}} and {{domxref("Element.querySelectorAll()")}} methods.
 

--- a/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article is an overview of some powerful, fundamental DOM level 1 methods and how to use them from JavaScript. You will learn how to create, access and control, and remove HTML elements dynamically. The DOM methods presented here are not specific to HTML; they also apply to XML. The demonstrations provided here will work fine in any modern browser.
 
-> **Note:** The DOM methods presented here are part of the Document Object Model (Core) level 1 specification. DOM level 1 includes both methods for generic document access and manipulation (DOM 1 Core) as well as methods specific to HTML documents (DOM 1 HTML).
+> [!NOTE]
+> The DOM methods presented here are part of the Document Object Model (Core) level 1 specification. DOM level 1 includes both methods for generic document access and manipulation (DOM 1 Core) as well as methods specific to HTML documents (DOM 1 HTML).
 
 ## Creating an HTML table dynamically
 
@@ -272,7 +273,8 @@ The basic steps to create the table in sample1.html are:
 - Create all the elements.
 - Finally, append each child according to the table structure (as in the above figure). The following source code is a commented version for the sample1.html.
 
-> **Note:** At the end of the `start` function, there is a new line of code. The table's `border` property was set using another DOM method, `setAttribute()`. `setAttribute()` has two arguments: the attribute name and the attribute value. You can set any attribute of any element using the `setAttribute` method.
+> [!NOTE]
+> At the end of the `start` function, there is a new line of code. The table's `border` property was set using another DOM method, `setAttribute()`. `setAttribute()` has two arguments: the attribute name and the attribute value. You can set any attribute of any element using the `setAttribute` method.
 
 ```html
 <html lang="en">
@@ -335,7 +337,8 @@ Once you have the returned list, use `[x]` method to retrieve the desired child 
 
 Then, to display the results in this example, it creates a new text node whose content is the data of `myCellText`, and appends it as a child of the `<body>` element.
 
-> **Note:** If your object is a text node, you can use the data attribute and retrieve the text content of the node.
+> [!NOTE]
+> If your object is a text node, you can use the data attribute and retrieve the text content of the node.
 
 ```js
 myBody = document.getElementsByTagName("body")[0];

--- a/files/en-us/web/api/document_picture-in-picture_api/using/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/using/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This guide provides a walkthrough of typical usage of the {{domxref("Document Picture-in-Picture API", "Document Picture-in-Picture API", "", "nocode")}}.
 
-> **Note:** You can see the featured demo in action at [Document Picture-in-Picture API Example](https://mdn.github.io/dom-examples/document-picture-in-picture/) (see the full [source code](https://github.com/mdn/dom-examples/tree/main/document-picture-in-picture) also).
+> [!NOTE]
+> You can see the featured demo in action at [Document Picture-in-Picture API Example](https://mdn.github.io/dom-examples/document-picture-in-picture/) (see the full [source code](https://github.com/mdn/dom-examples/tree/main/document-picture-in-picture) also).
 
 ## Sample HTML
 
@@ -208,7 +209,8 @@ documentPictureInPicture.addEventListener("enter", (event) => {
 });
 ```
 
-> **Note:** The {{domxref("DocumentPictureInPictureEvent")}} event object contains a `window` property to access the Picture-in-Picture window.
+> [!NOTE]
+> The {{domxref("DocumentPictureInPictureEvent")}} event object contains a `window` property to access the Picture-in-Picture window.
 
 ## Access elements and handle events
 

--- a/files/en-us/web/api/documentfragment/getelementbyid/index.md
+++ b/files/en-us/web/api/documentfragment/getelementbyid/index.md
@@ -12,7 +12,8 @@ The **`getElementById()`** method of the {{domxref("DocumentFragment")}} returns
 
 If you need to get access to an element which doesn't have an ID, you can use {{domxref("Document.querySelector", "querySelector()")}} to find the element using any {{Glossary("CSS selector", "selector")}}.
 
-> **Note:** IDs should be unique inside a document fragment. If two or more elements in a document fragment have the same ID, this method returns the first element found.
+> [!NOTE]
+> IDs should be unique inside a document fragment. If two or more elements in a document fragment have the same ID, this method returns the first element found.
 
 ## Syntax
 
@@ -20,7 +21,8 @@ If you need to get access to an element which doesn't have an ID, you can use {{
 getElementById(id)
 ```
 
-> **Note:** The capitalization of `"Id"` in the name of this method _must_ be correct for the code to function; `getElementByID()` is _not_ valid and will not work, however natural it may seem.
+> [!NOTE]
+> The capitalization of `"Id"` in the name of this method _must_ be correct for the code to function; `getElementByID()` is _not_ valid and will not work, however natural it may seem.
 
 ### Parameters
 

--- a/files/en-us/web/api/documentpictureinpicture/requestwindow/index.md
+++ b/files/en-us/web/api/documentpictureinpicture/requestwindow/index.md
@@ -31,7 +31,8 @@ requestWindow(options)
     - `width`
       - : A non-negative number representing the width to set for the Picture-in-Picture window's viewport, in pixels. If `options` is not specified, the default value 0 is used.
 
-> **Note:** If one of the options is specified, the other one must be too, otherwise an error is thrown. If both values are not specified, specified as 0, or set too large, the browser will clamp or ignore the values as appropriate to provide a reasonable user experience. The clamped size will vary depending on implementation, display size, and other factors.
+> [!NOTE]
+> If one of the options is specified, the other one must be too, otherwise an error is thrown. If both values are not specified, specified as 0, or set too large, the browser will clamp or ignore the values as appropriate to provide a reasonable user experience. The clamped size will vary depending on implementation, display size, and other factors.
 
 ### Return value
 

--- a/files/en-us/web/api/domexception/index.md
+++ b/files/en-us/web/api/domexception/index.md
@@ -37,7 +37,8 @@ Note that the following deprecated historical errors don't have an error name bu
 - Legacy code value: `6`, legacy constant name: `NO_DATA_ALLOWED_ERR`
 - Legacy code value: `16`, legacy constant name: `VALIDATION_ERR`
 
-> **Note:** Because historically the errors were identified by a numeric value that corresponded with a named variable defined to have that value, some of the entries below indicate the legacy code value and constant name that were used in the past.
+> [!NOTE]
+> Because historically the errors were identified by a numeric value that corresponded with a named variable defined to have that value, some of the entries below indicate the legacy code value and constant name that were used in the past.
 
 - `IndexSizeError`
   - : The index is not in the allowed range. For example, this can be thrown by the {{ domxref("Range") }} object. (Legacy code value: `1` and legacy constant name: `INDEX_SIZE_ERR`)

--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -23,7 +23,8 @@ Note that {{domxref("XMLHttpRequest")}} can parse XML and HTML directly
 from a URL-addressable resource, returning a `Document` in its
 {{domxref("XMLHttpRequest.response", "response")}} property.
 
-> **Note:** Be aware that [block-level elements](/en-US/docs/Glossary/Block-level_content)
+> [!NOTE]
+> Be aware that [block-level elements](/en-US/docs/Glossary/Block-level_content)
 > like `<p>` will be automatically closed if another
 > block-level element is nested inside and therefore parsed before the closing `</p>` tag.
 

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -10,7 +10,8 @@ browser-compat: api.DOMParser.parseFromString
 
 The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface parses a string containing either HTML or XML, returning an {{domxref("HTMLDocument")}} or an {{domxref("XMLDocument")}}.
 
-> **Note:** The [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) static method provides an ergonomic alternative for parsing HTML strings into a {{domxref("Document")}}.
+> [!NOTE]
+> The [`Document.parseHTMLUnsafe()`](/en-US/docs/Web/API/Document/parseHTMLUnsafe_static) static method provides an ergonomic alternative for parsing HTML strings into a {{domxref("Document")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/dompointreadonly/dompointreadonly/index.md
+++ b/files/en-us/web/api/dompointreadonly/dompointreadonly/index.md
@@ -37,7 +37,8 @@ new DOMPointReadOnly(x, y, z, w)
 - `w` {{optional_inline}}
   - : The value of the perspective, w, as a floating point number. The default is 1.
 
-> **Note:** Each of these values is what's called an _unrestricted_
+> [!NOTE]
+> Each of these values is what's called an _unrestricted_
 > number. In addition to any finite floating-point value, you may use special values
 > such as ±{{jsxref("Infinity")}} and {{jsxref("NaN")}}.
 

--- a/files/en-us/web/api/domtokenlist/item/index.md
+++ b/files/en-us/web/api/domtokenlist/item/index.md
@@ -11,7 +11,8 @@ browser-compat: api.DOMTokenList.item
 The **`item()`** method of the {{domxref("DOMTokenList")}} interface returns an item in the list,
 determined by its position in the list, its index.
 
-> **Note:** This method is equivalent as the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation).
+> [!NOTE]
+> This method is equivalent as the [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation).
 > So `aList.item(i)` is the same as `aList[i]`.
 
 ## Syntax

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.md
@@ -16,7 +16,8 @@ The `attack` property's default value is `0.003` and it can be set between `0` a
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.md
@@ -18,7 +18,8 @@ The `knee` property's default value is `30` and it can be set between `0` and `4
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.md
@@ -18,7 +18,8 @@ The `ratio` property's default value is `12` and it can be set between `1` and `
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/dynamicscompressornode/release/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.md
@@ -16,7 +16,8 @@ The `release` property's default value is `0.25` and it can be set between `0` a
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.md
@@ -18,7 +18,8 @@ The `threshold` property's default value is `-24` and it can be set between `-10
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the {{domxref("AudioParam")}} returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/element/afterscriptexecute_event/index.md
+++ b/files/en-us/web/api/element/afterscriptexecute_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.afterscriptexecute_event
 
 {{APIRef}}{{Non-standard_header}}
 
-> **Warning:** This event was a proposal in an early version of the specification. Do not rely on it.
+> [!WARNING]
+> This event was a proposal in an early version of the specification. Do not rely on it.
 
 The **`afterscriptexecute`** event is fired after a script has been executed.
 

--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -13,7 +13,8 @@ is a shortcut method which creates a new {{domxref("Animation")}}, applies it to
 element, then plays the animation. It returns the created {{domxref("Animation")}}
 object instance.
 
-> **Note:** Elements can have multiple animations applied to them. You can get a list of the
+> [!NOTE]
+> Elements can have multiple animations applied to them. You can get a list of the
 > animations that affect an element by calling {{domxref("Element.getAnimations()")}}.
 
 ## Syntax

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaChecked
 
 The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="checkbox"` as this element has built in semantics and does not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaDisabled
 
 The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 
-> **Note:** Where possible, use the {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element — because those elements have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible, use the {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element — because those elements have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -29,7 +29,8 @@ A string with one of the following values:
 - `"dialog"`
   - : The element has a popup that is a dialog.
 
-> **Warning:** Be aware that support for the different `aria-haspopup` values can vary depending on the element to which the attribute is specified. Ensure that when using `aria-haspopup`, it is done in accordance to the ARIA specification, and that it behaves as expected when testing with necessary browsers and assistive technologies.
+> [!WARNING]
+> Be aware that support for the different `aria-haspopup` values can vary depending on the element to which the attribute is specified. Ensure that when using `aria-haspopup`, it is done in accordance to the ARIA specification, and that it behaves as expected when testing with necessary browsers and assistive technologies.
 
 ## Examples
 

--- a/files/en-us/web/api/element/arialevel/index.md
+++ b/files/en-us/web/api/element/arialevel/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaLevel
 
 The **`ariaLevel`** property of the {{domxref("Element")}} interface reflects the value of the `aria-level` attribute, which defines the hierarchical level of an element within a structure.
 
-> **Note:** Where possible use an HTML {{htmlelement("Heading_Elements", "h1")}} or other correct heading level as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("Heading_Elements", "h1")}} or other correct heading level as these have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaMultiLine
 
 The **`ariaMultiLine`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaMultiSelectable
 
 The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 
-> **Note:** Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("select")}} element as this has built in semantics and does not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariaplaceholder/index.md
+++ b/files/en-us/web/api/element/ariaplaceholder/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaPlaceholder
 
 The **`ariaPlaceholder`** property of the {{domxref("Element")}} interface reflects the value of the `aria-placeholder` attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaPressed
 
 The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="button"` or the {{htmlelement("button")}} element as these have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaReadOnly
 
 The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/ariarequired/index.md
+++ b/files/en-us/web/api/element/ariarequired/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.ariaRequired
 
 The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the `aria-required` attribute, which indicates that user input is required on the element before a form may be submitted.
 
-> **Note:** Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
+> [!NOTE]
+> Where possible use an HTML {{htmlelement("input")}} element with `type="text"` or a {{htmlelement("textarea")}} as these have built in semantics and do not require ARIA attributes.
 
 ## Value
 

--- a/files/en-us/web/api/element/auxclick_event/index.md
+++ b/files/en-us/web/api/element/auxclick_event/index.md
@@ -28,7 +28,8 @@ A {{domxref("PointerEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("PointerEvent")}}
 
-> **Note:** In earlier versions of the specification the event type for this event was a {{domxref("MouseEvent")}}, and this is still the type passed in Firefox and Safari.
+> [!NOTE]
+> In earlier versions of the specification the event type for this event was a {{domxref("MouseEvent")}}, and this is still the type passed in Firefox and Safari.
 
 ## Event properties
 
@@ -137,7 +138,8 @@ h1 {
 
 {{EmbedLiveSample("Examples", 640, 300)}}
 
-> **Note:** If you are using a three-button mouse, you'll notice that the `onauxclick` handler is run when any of the non-left mouse buttons are clicked (usually including any "special" buttons on gaming mice).
+> [!NOTE]
+> If you are using a three-button mouse, you'll notice that the `onauxclick` handler is run when any of the non-left mouse buttons are clicked (usually including any "special" buttons on gaming mice).
 
 ## Specifications
 

--- a/files/en-us/web/api/element/beforeinput_event/index.md
+++ b/files/en-us/web/api/element/beforeinput_event/index.md
@@ -14,7 +14,8 @@ This allows web apps to override text edit behavior before the browser modifies 
 
 In the case of `contenteditable` and `designMode`, the event target is the **editing host**. If these properties apply to multiple elements, the editing host is the nearest ancestor element whose parent isn't editable.
 
-> **Note:** Not every user modification results in `beforeinput` firing. Also the event may fire but be non-cancelable. This may happen when the modification is done by autocomplete, by accepting a correction from a spell checker, by password manager autofill, by {{Glossary("Input method editor", "IME")}}, or in other ways. The details vary by browser and OS. To override the edit behavior in all situations, the code needs to handle the `input` event and possibly revert any modifications that were not handled by the `beforeinput` handler. See bugs [1673558](https://bugzil.la/1673558) and [1763669](https://bugzil.la/1763669).
+> [!NOTE]
+> Not every user modification results in `beforeinput` firing. Also the event may fire but be non-cancelable. This may happen when the modification is done by autocomplete, by accepting a correction from a spell checker, by password manager autofill, by {{Glossary("Input method editor", "IME")}}, or in other ways. The details vary by browser and OS. To override the edit behavior in all situations, the code needs to handle the `input` event and possibly revert any modifications that were not handled by the `beforeinput` handler. See bugs [1673558](https://bugzil.la/1673558) and [1763669](https://bugzil.la/1763669).
 
 ## Syntax
 

--- a/files/en-us/web/api/element/beforescriptexecute_event/index.md
+++ b/files/en-us/web/api/element/beforescriptexecute_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.beforescriptexecute_event
 
 {{APIRef}}{{Non-standard_header}}
 
-> **Warning:** This event was a proposal in an early version of the specification. Do not rely on it.
+> [!WARNING]
+> This event was a proposal in an early version of the specification. Do not rely on it.
 
 The **`beforescriptexecute`** event is fired when a script is about to be executed. Cancelling the event prevents the script from executing.
 

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -42,7 +42,8 @@ checkVisibility(options)
       - : `true` to check if the element is invisible due to the value of its {{cssxref("visibility")}} property.
         `false` by default.
 
-        > **Note:** Invisible elements include those that have [`visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden), and some element types that have [`visibility: collapse`](/en-US/docs/Web/CSS/visibility#collapse).
+        > [!NOTE]
+        > Invisible elements include those that have [`visibility: hidden`](/en-US/docs/Web/CSS/visibility#hidden), and some element types that have [`visibility: collapse`](/en-US/docs/Web/CSS/visibility#collapse).
 
     - `checkOpacity`
       - : A historic alias for [`opacityProperty`](#opacityproperty).

--- a/files/en-us/web/api/element/classname/index.md
+++ b/files/en-us/web/api/element/classname/index.md
@@ -41,7 +41,8 @@ instead of `""` if the `element` has an empty [`class` attribute](/en-US/docs/We
 elm.setAttribute("class", elm.getAttribute("class"));
 ```
 
-> **Note:** The `class` is an **HTML Attribute**, while the
+> [!NOTE]
+> The `class` is an **HTML Attribute**, while the
 > `className` is a **DOM Property**.
 
 ## Specifications

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -36,7 +36,8 @@ A {{domxref("PointerEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("PointerEvent")}}
 
-> **Note:** In earlier versions of the specification the event type for this event was a {{domxref("MouseEvent")}}, and this is still the type passed in Firefox and Safari.
+> [!NOTE]
+> In earlier versions of the specification the event type for this event was a {{domxref("MouseEvent")}}, and this is still the type passed in Firefox and Safari.
 
 ## Event properties
 

--- a/files/en-us/web/api/element/clientheight/index.md
+++ b/files/en-us/web/api/element/clientheight/index.md
@@ -20,7 +20,8 @@ When `clientHeight` is used on the root element (the
 `<html>` element), (or on `<body>` if the document is
 in quirks mode), the viewport's height (excluding any scrollbar) is returned. [This is a special case of `clientHeight`](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientheight).
 
-> **Note:** This property will round the value to an integer. If you need
+> [!NOTE]
+> This property will round the value to an integer. If you need
 > a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Value

--- a/files/en-us/web/api/element/clientleft/index.md
+++ b/files/en-us/web/api/element/clientleft/index.md
@@ -14,10 +14,12 @@ is an overflow causing a left vertical scrollbar to be rendered.
 `clientLeft` does not include the left margin or the left padding.
 `clientLeft` is read-only.
 
-> **Note:** This property will round the value to an integer. If you
+> [!NOTE]
+> This property will round the value to an integer. If you
 > need a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
-> **Note:** When an element has
+> [!NOTE]
+> When an element has
 > `display: inline`, `clientLeft` returns `0`
 > regardless of the element's border.
 

--- a/files/en-us/web/api/element/clienttop/index.md
+++ b/files/en-us/web/api/element/clienttop/index.md
@@ -20,7 +20,8 @@ starts immediately below the border, (client area includes padding.) Therefore, 
 Math.round(parseFloat()).) For example, if the computed "border-top-width" is zero,
 then **`clientTop`** is also zero.
 
-> **Note:** This property will round the value to an integer. If you
+> [!NOTE]
+> This property will round the value to an integer. If you
 > need a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Value

--- a/files/en-us/web/api/element/clientwidth/index.md
+++ b/files/en-us/web/api/element/clientwidth/index.md
@@ -17,7 +17,8 @@ When `clientWidth` is used on the root element (the
 `<html>` element), (or on `<body>` if the document is
 in quirks mode), the viewport's width (excluding any scrollbar) is returned. [This is a special case of `clientWidth`](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientwidth).
 
-> **Note:** This property will round the value to an integer. If you need
+> [!NOTE]
+> This property will round the value to an integer. If you need
 > a fractional value, use {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Value

--- a/files/en-us/web/api/element/contentvisibilityautostatechange_event/index.md
+++ b/files/en-us/web/api/element/contentvisibilityautostatechange_event/index.md
@@ -24,7 +24,8 @@ addEventListener("contentvisibilityautostatechange", (event) => {});
 oncontentvisibilityautostatechange = (event) => {};
 ```
 
-> **Note:** The event object is of type {{domxref("ContentVisibilityAutoStateChangeEvent")}}.
+> [!NOTE]
+> The event object is of type {{domxref("ContentVisibilityAutoStateChangeEvent")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/element/contextmenu_event/index.md
+++ b/files/en-us/web/api/element/contextmenu_event/index.md
@@ -14,7 +14,8 @@ In the latter case, the context menu is displayed at the bottom left of the focu
 
 Any right-click event that is not disabled (by calling the click event's {{domxref("Event.preventDefault", "preventDefault()")}} method) will result in a `contextmenu` event being fired at the targeted element.
 
-> **Note:** An exception to this in Firefox: if the user holds down the <kbd>Shift</kbd> key while right-clicking, then the context menu will be shown without a `contextmenu` event being fired.
+> [!NOTE]
+> An exception to this in Firefox: if the user holds down the <kbd>Shift</kbd> key while right-clicking, then the context menu will be shown without a `contextmenu` event being fired.
 
 ## Syntax
 
@@ -32,7 +33,8 @@ A {{domxref("PointerEvent")}}. Inherits from {{domxref("MouseEvent")}}.
 
 {{InheritanceDiagram("PointerEvent")}}
 
-> **Note:** In earlier versions of the specification the event type for this event was a {{domxref("MouseEvent")}}, and this is still the type passed in Firefox and Safari.
+> [!NOTE]
+> In earlier versions of the specification the event type for this event was a {{domxref("MouseEvent")}}, and this is still the type passed in Firefox and Safari.
 
 ## Event properties
 
@@ -69,7 +71,8 @@ _This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref
 
 In this example, the default action of the `contextmenu` event is canceled using `preventDefault()` when the `contextmenu` event is fired at the first paragraph. As a result, the first paragraph will do nothing when right-clicked, while the second paragraph will show the standard context menu offered by your browser.
 
-> **Note:** In Firefox, if you hold down the <kbd>Shift</kbd> key while right-clicking, then the context menu is shown without the `contextmenu` event being fired. Therefore, canceling the event does not stop the context menu from being shown.
+> [!NOTE]
+> In Firefox, if you hold down the <kbd>Shift</kbd> key while right-clicking, then the context menu is shown without the `contextmenu` event being fired. Therefore, canceling the event does not stop the context menu from being shown.
 
 #### HTML
 

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -45,11 +45,13 @@ The `detail` property describes the scroll more precisely, with positive values 
 
 If the event represents scrolling up by a page, the value of `detail` is -32768. If the event indicates scrolling down by a page, the value is +32768. Any other value represents the number of lines to scroll, with the direction indicated by the value's sign.
 
-> **Note:** Trusted events are never sent with a value of 0 for `detail`.
+> [!NOTE]
+> Trusted events are never sent with a value of 0 for `detail`.
 
 Trusted events are never fired with 0.
 
-> **Note:** If the platform's native mouse wheel events only provide scroll distance by pixels, or if the speed can be customized by the user, the value is computed using the line height of the nearest scrollable ancestor element of the event's target. If that element's font size is smaller than `mousewheel.min_line_scroll_amount`, that preference's value is used as the line height.
+> [!NOTE]
+> If the platform's native mouse wheel events only provide scroll distance by pixels, or if the speed can be customized by the user, the value is computed using the line height of the nearest scrollable ancestor element of the event's target. If that element's font size is smaller than `mousewheel.min_line_scroll_amount`, that preference's value is used as the line height.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -14,7 +14,8 @@ The `getAnimations()` method of the {{domxref("Element")}} interface
 in future. It can optionally return {{domxref("Animation")}} objects for descendant
 elements too.
 
-> **Note:** This array includes [CSS Animations](/en-US/docs/Web/CSS/CSS_animations), [CSS Transitions](/en-US/docs/Web/CSS/CSS_transitions), and [Web Animations](/en-US/docs/Web/API/Web_Animations_API).
+> [!NOTE]
+> This array includes [CSS Animations](/en-US/docs/Web/CSS/CSS_animations), [CSS Transitions](/en-US/docs/Web/CSS/CSS_transitions), and [Web Animations](/en-US/docs/Web/API/Web_Animations_API).
 
 ## Syntax
 

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -34,7 +34,8 @@ getAttributeNS(namespace, name)
 The string value of the specified attribute. If the attribute doesn't exist, the result
 is `null`.
 
-> **Note:** Earlier versions of the DOM specification had
+> [!NOTE]
+> Earlier versions of the DOM specification had
 > this method described as returning an empty string for non-existent attributes, but it
 > was not typically implemented this way since null makes more sense. The DOM4
 > specification now says this method should return null for non-existent attributes.

--- a/files/en-us/web/api/element/getelementsbyclassname/index.md
+++ b/files/en-us/web/api/element/getelementsbyclassname/index.md
@@ -46,7 +46,8 @@ immediately appears in the collection.
 The opposite is also true; as elements no longer match the set of names, they are
 immediately removed from the collection.
 
-> **Note:** In [quirks mode](/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode), the
+> [!NOTE]
+> In [quirks mode](/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode), the
 > class names are compared in a case-insensitive fashion. Otherwise, they're case
 > sensitive.
 

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -18,7 +18,8 @@ If the `id` value is not the empty string, it must be unique in a document.
 The `id` is often used with {{domxref("Document.getElementById()", "getElementById()")}} to retrieve a particular element.
 Another common case is to use an element's [ID as a selector](/en-US/docs/Web/CSS/ID_selectors) when styling the document with [CSS](/en-US/docs/Web/CSS).
 
-> **Note:** Identifiers are case-sensitive, but you should avoid creating
+> [!NOTE]
+> Identifiers are case-sensitive, but you should avoid creating
 > IDs that differ only in the capitalization.
 
 ## Value

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -57,7 +57,8 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 
   - : The namespace URI of the element, or `null` if it is no namespace.
 
-    > **Note:** In Firefox 3.5 and earlier, HTML elements are in no namespace. In later versions, HTML elements are in the [`http://www.w3.org/1999/xhtml`](https://www.w3.org/1999/xhtml/) namespace in both HTML and XML trees.
+    > [!NOTE]
+    > In Firefox 3.5 and earlier, HTML elements are in no namespace. In later versions, HTML elements are in the [`http://www.w3.org/1999/xhtml`](https://www.w3.org/1999/xhtml/) namespace in both HTML and XML trees.
 
 - {{DOMxRef("Element.nextElementSibling")}} {{ReadOnlyInline}}
   - : An `Element`, the element immediately following the given one in the tree, or `null` if there's no sibling node.

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -47,13 +47,15 @@ let contents = myElement.innerHTML;
 
 This lets you look at the HTML markup of the element's content nodes.
 
-> **Note:** The returned HTML or XML fragment is generated based on the current contents of the element, so the markup and formatting of the returned fragment is likely not to match the original page markup.
+> [!NOTE]
+> The returned HTML or XML fragment is generated based on the current contents of the element, so the markup and formatting of the returned fragment is likely not to match the original page markup.
 
 ### Replacing the contents of an element
 
 Setting the value of `innerHTML` lets you easily replace the existing contents of an element with new content.
 
-> **Warning:** This is a [security risk](#security_considerations) if the string to be inserted might contain potentially malicious content.
+> [!WARNING]
+> This is a [security risk](#security_considerations) if the string to be inserted might contain potentially malicious content.
 > When inserting user-supplied data you should always consider using a sanitizer library, in order to sanitize the content before it is inserted.
 
 For example, you can erase the entire contents of a document by clearing the contents of the document's {{domxref("Document.body", "body")}} attribute:
@@ -140,7 +142,8 @@ For that reason, it is recommended that instead of `innerHTML` you use:
 
 - {{domxref("Node.textContent")}} when inserting plain text, as this inserts it as raw text rather than parsing it as HTML.
 
-> **Warning:** If your project is one that will undergo any form of security review, using `innerHTML` most likely will result in your code being rejected.
+> [!WARNING]
+> If your project is one that will undergo any form of security review, using `innerHTML` most likely will result in your code being rejected.
 > For example, [if you use `innerHTML`](https://wiki.mozilla.org/Add-ons/Reviewers/Guide/Reviewing#Step_2:_Automatic_validation) in a [browser extension](/en-US/docs/Mozilla/Add-ons/WebExtensions) and submit
 > the extension to [addons.mozilla.org](https://addons.mozilla.org/), it may be rejected in the review process.
 > Please see [Safely inserting external content into a page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page) for alternative methods.

--- a/files/en-us/web/api/element/insertadjacentelement/index.md
+++ b/files/en-us/web/api/element/insertadjacentelement/index.md
@@ -61,7 +61,8 @@ The element that was inserted, or `null`, if the insertion failed.
 <!-- afterend -->
 ```
 
-> **Note:** The `beforebegin` and
+> [!NOTE]
+> The `beforebegin` and
 > `afterend` positions work only if the node is in a tree and has an element
 > parent.
 

--- a/files/en-us/web/api/element/insertadjacenttext/index.md
+++ b/files/en-us/web/api/element/insertadjacenttext/index.md
@@ -51,7 +51,8 @@ None ({{jsxref("undefined")}}).
 <!-- afterend -->
 ```
 
-> **Note:** The `beforebegin` and
+> [!NOTE]
+> The `beforebegin` and
 > `afterend` positions work only if the node is in a tree and has an element
 > parent.
 

--- a/files/en-us/web/api/element/keydown_event/index.md
+++ b/files/en-us/web/api/element/keydown_event/index.md
@@ -46,7 +46,8 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 
   - : Returns a string with the code value of the physical key represented by the event.
 
-    > **Warning:** This ignores the user's keyboard layout, so that if the user presses the key at the "Y" position in a QWERTY keyboard layout (near the middle of the row above the home row), this will always return "KeyY", even if the user has a QWERTZ keyboard (which would mean the user expects a "Z" and all the other properties would indicate a "Z") or a Dvorak keyboard layout (where the user would expect an "F"). If you want to display the correct keystrokes to the user, you can use {{domxref("Keyboard.getLayoutMap()")}}.
+    > [!WARNING]
+    > This ignores the user's keyboard layout, so that if the user presses the key at the "Y" position in a QWERTY keyboard layout (near the middle of the row above the home row), this will always return "KeyY", even if the user has a QWERTZ keyboard (which would mean the user expects a "Z" and all the other properties would indicate a "Z") or a Dvorak keyboard layout (where the user would expect an "F"). If you want to display the correct keystrokes to the user, you can use {{domxref("Keyboard.getLayoutMap()")}}.
 
 - {{domxref("KeyboardEvent.ctrlKey")}} {{ReadOnlyInline}}
 

--- a/files/en-us/web/api/element/keypress_event/index.md
+++ b/files/en-us/web/api/element/keypress_event/index.md
@@ -14,7 +14,8 @@ The **`keypress`** event is fired when a key that produces a character value is 
 
 Examples of keys that produce a character value are alphabetic, numeric, and punctuation keys. Examples of keys that don't produce a character value are modifier keys such as <kbd>Alt</kbd>, <kbd>Shift</kbd>, <kbd>Ctrl</kbd>, or <kbd>Meta</kbd>.
 
-> **Warning:** Since this event has been deprecated, you should use [`beforeinput`](/en-US/docs/Web/API/Element/beforeinput_event) or [`keydown`](/en-US/docs/Web/API/Element/keydown_event) instead.
+> [!WARNING]
+> Since this event has been deprecated, you should use [`beforeinput`](/en-US/docs/Web/API/Element/beforeinput_event) or [`keydown`](/en-US/docs/Web/API/Element/keydown_event) instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/keyup_event/index.md
+++ b/files/en-us/web/api/element/keyup_event/index.md
@@ -44,7 +44,8 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 
   - : Returns a string with the code value of the physical key represented by the event.
 
-    > **Warning:** This ignores the user's keyboard layout, so that if the user presses the key at the "Y" position in a QWERTY keyboard layout (near the middle of the row above the home row), this will always return "KeyY", even if the user has a QWERTZ keyboard (which would mean the user expects a "Z" and all the other properties would indicate a "Z") or a Dvorak keyboard layout (where the user would expect an "F"). If you want to display the correct keystrokes to the user, you can use {{domxref("Keyboard.getLayoutMap()")}}.
+    > [!WARNING]
+    > This ignores the user's keyboard layout, so that if the user presses the key at the "Y" position in a QWERTY keyboard layout (near the middle of the row above the home row), this will always return "KeyY", even if the user has a QWERTZ keyboard (which would mean the user expects a "Z" and all the other properties would indicate a "Z") or a Dvorak keyboard layout (where the user would expect an "F"). If you want to display the correct keystrokes to the user, you can use {{domxref("Keyboard.getLayoutMap()")}}.
 
 - {{domxref("KeyboardEvent.ctrlKey")}} {{ReadOnlyInline}}
 
@@ -103,7 +104,8 @@ eventTarget.addEventListener("keyup", (event) => {
 });
 ```
 
-> **Note:** Unlike `keydown`, `keyup` events do not have special {{domxref("KeyboardEvent/keyCode", "keyCode")}} values for IME events. However, like `keydown`, `compositionstart` may fire _after_ `keyup` when typing the first character that opens up the IME, and `compositionend` may fire _before_ `keyup` when typing the last character that closes the IME. In these cases, `isComposing` is false even when the event is part of composition.
+> [!NOTE]
+> Unlike `keydown`, `keyup` events do not have special {{domxref("KeyboardEvent/keyCode", "keyCode")}} values for IME events. However, like `keydown`, `compositionstart` may fire _after_ `keyup` when typing the first character that opens up the IME, and `compositionend` may fire _before_ `keyup` when typing the last character that closes the IME. In these cases, `isComposing` is false even when the event is part of composition.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -63,7 +63,8 @@ particular XML documents. For example, in the qualified name
 </ecomm:business>
 ```
 
-> **Note:** While the property returns the case of the internal DOM storage, which is lower case, note that {{domxref("element.tagName","tagName")}} property returns upper case for HTML elements in HTML DOMs.
+> [!NOTE]
+> While the property returns the case of the internal DOM storage, which is lower case, note that {{domxref("element.tagName","tagName")}} property returns upper case for HTML elements in HTML DOMs.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/mousedown_event/index.md
+++ b/files/en-us/web/api/element/mousedown_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.mousedown_event
 
 The **`mousedown`** event is fired at an {{domxref("Element")}} when a pointing device button is pressed while the pointer is inside the element.
 
-> **Note:** This differs from the {{domxref("Element/click_event", "click")}} event in that `click` is fired after a full click action occurs; that is, the mouse button is pressed and released while the pointer remains inside the same element. `mousedown` is fired the moment the button is initially pressed.
+> [!NOTE]
+> This differs from the {{domxref("Element/click_event", "click")}} event in that `click` is fired after a full click action occurs; that is, the mouse button is pressed and released while the pointer remains inside the same element. `mousedown` is fired the moment the button is initially pressed.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/mousewheel_event/index.md
+++ b/files/en-us/web/api/element/mousewheel_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Element.mousewheel_event
 
 The _obsolete_ and _non-standard_ **`mousewheel`** event is fired asynchronously at an {{domxref("Element")}} to provide updates while a mouse wheel or similar device is operated. The `mousewheel` event was never part of any standard, and while it was implemented by several browsers, it was never implemented by Firefox.
 
-> **Note:** Instead of this obsolete event, use the standard {{domxref("Element.wheel_event", "wheel")}} event.
+> [!NOTE]
+> Instead of this obsolete event, use the standard {{domxref("Element.wheel_event", "wheel")}} event.
 
 ## Syntax
 
@@ -62,7 +63,8 @@ _This interface inherits properties from its ancestors, {{DOMxRef("MouseEvent")}
 
 The value of the {{domxref("UIEvent/detail", "detail")}} property is always zero, except in Opera, which uses `detail` similarly to the Firefox-only {{domxref("Element.DOMMouseScroll_event", "DOMMouseScroll")}} event's `detail` value, which indicates the scroll distance in terms of lines, with negative values indicating the scrolling movement is either toward the bottom or toward the right, and positive values indicating scrolling to the top or left.
 
-> **Note:** On macOS, the scroll distance (and therefore the value of `detail`) is computed based on the accelerated scroll distance.
+> [!NOTE]
+> On macOS, the scroll distance (and therefore the value of `detail`) is computed based on the accelerated scroll distance.
 
 On Linux, `2` or `-2` is set per native wheel event.
 

--- a/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
+++ b/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Element.MozMousePixelScroll_event
 
 The Firefox-only, _non-standard_, and _obsolete_ **`MozMousePixelScroll`** event is fired at an {{domxref("Element")}} asynchronously when a mouse wheel or similar device is operated. It's represented by the {{ domxref("MouseScrollEvent") }} interface.
 
-> **Note:** Do not use this non-standard and obsolete event. Instead, you should always use the standard {{domxref("Element.wheel_event", "wheel")}} event.
+> [!NOTE]
+> Do not use this non-standard and obsolete event. Instead, you should always use the standard {{domxref("Element.wheel_event", "wheel")}} event.
 
 ## Syntax
 
@@ -37,7 +38,8 @@ The event's {{domxref("UIEvent/detail", "detail")}} property indicates the scrol
 
 If the platform's native mouse wheel events indicate the scroll distance in terms of lines or pages, the value of `detail` is computed using that value and the line height or page width/height of the nearest ancestor scrollable element that contains the target element.
 
-> **Note:** On macOS, the scroll distance (and therefore the value of `detail`) is computed based on the accelerated scroll distance.
+> [!NOTE]
+> On macOS, the scroll distance (and therefore the value of `detail`) is computed based on the accelerated scroll distance.
 
 The value of `detail` is never 0 if the events are legitimate.
 

--- a/files/en-us/web/api/element/pointercancel_event/index.md
+++ b/files/en-us/web/api/element/pointercancel_event/index.md
@@ -18,7 +18,8 @@ Some examples of situations that will trigger a `pointercancel` event:
 - The {{cssxref("touch-action")}} CSS property prevents the input from continuing.
 - When the user interacts with too many simultaneous pointers, the browser can fire this event for all existing pointers (even if the user is still touching the screen).
 
-> **Note:** After the `pointercancel` event is fired, the browser will also send {{domxref("Element/pointerout_event", "pointerout")}} followed by {{domxref("Element/pointerleave_event", "pointerleave")}}.
+> [!NOTE]
+> After the `pointercancel` event is fired, the browser will also send {{domxref("Element/pointerout_event", "pointerout")}} followed by {{domxref("Element/pointerleave_event", "pointerleave")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/pointerdown_event/index.md
+++ b/files/en-us/web/api/element/pointerdown_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Element.pointerdown_event
 
 The `pointerdown` event is fired when a pointer becomes active. For mouse, it is fired when the device transitions from no buttons pressed to at least one button pressed. For touch, it is fired when physical contact is made with the digitizer. For pen, it is fired when the stylus makes physical contact with the digitizer.
 
-> **Note:** For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), a `pointerdown` event triggers [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture), which causes the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set. The capture can be released manually by calling {{domxref('element.releasePointerCapture')}} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
+> [!NOTE]
+> For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), a `pointerdown` event triggers [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture), which causes the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set. The capture can be released manually by calling {{domxref('element.releasePointerCapture')}} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/queryselectorall/index.md
+++ b/files/en-us/web/api/element/queryselectorall/index.md
@@ -36,7 +36,8 @@ querySelectorAll(selectors)
 A non-live {{domxref("NodeList")}} containing one {{domxref("Element")}} object for
 each descendant node that matches at least one of the specified selectors.
 
-> **Note:** If the specified `selectors` include a [CSS pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), the returned list
+> [!NOTE]
+> If the specified `selectors` include a [CSS pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements), the returned list
 > is always empty.
 
 ### Exceptions

--- a/files/en-us/web/api/element/requestpointerlock/index.md
+++ b/files/en-us/web/api/element/requestpointerlock/index.md
@@ -12,7 +12,8 @@ The **`requestPointerLock()`** method of the {{domxref("Element")}} interface le
 
 To track the success or failure of the request, it is necessary to listen for the {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} and {{domxref("Document/pointerlockerror_event", "pointerlockerror")}} events at the {{domxref("Document")}} level.
 
-> **Note:** In the current specification, `requestPointerLock()` only communicates the success or failure of the request by firing {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} or {{domxref("Document/pointerlockerror_event", "pointerlockerror")}} events. [A proposed update to the specification](https://github.com/w3c/pointerlock/pull/49) updates `requestPointerLock()` to return a {{jsxref("Promise")}} which communicates success or failure. This page documents the version that returns a {{jsxref("Promise")}}. However, note that this version is not yet a standard and is not implemented by all browsers. See [Browser compatibility](#browser_compatibility) for more information.
+> [!NOTE]
+> In the current specification, `requestPointerLock()` only communicates the success or failure of the request by firing {{domxref("Document/pointerlockchange_event", "pointerlockchange")}} or {{domxref("Document/pointerlockerror_event", "pointerlockerror")}} events. [A proposed update to the specification](https://github.com/w3c/pointerlock/pull/49) updates `requestPointerLock()` to return a {{jsxref("Promise")}} which communicates success or failure. This page documents the version that returns a {{jsxref("Promise")}}. However, note that this version is not yet a standard and is not implemented by all browsers. See [Browser compatibility](#browser_compatibility) for more information.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/scrollheight/index.md
+++ b/files/en-us/web/api/element/scrollheight/index.md
@@ -23,7 +23,8 @@ such as {{cssxref("::before")}} or {{cssxref("::after")}}. If the element's cont
 fit without a need for vertical scrollbar, its `scrollHeight` is equal to
 {{domxref("Element.clientHeight", "clientHeight")}}
 
-> **Note:** This property will round the value to an integer. If you need a fractional value, use
+> [!NOTE]
+> This property will round the value to an integer. If you need a fractional value, use
 > {{domxref("Element.getBoundingClientRect()")}}.
 
 ## Value

--- a/files/en-us/web/api/element/scrollwidth/index.md
+++ b/files/en-us/web/api/element/scrollwidth/index.md
@@ -21,7 +21,8 @@ as {{cssxref("::before")}} or {{cssxref("::after")}}. If the element's content c
 without a need for horizontal scrollbar, its `scrollWidth` is equal to
 {{domxref("Element.clientWidth", "clientWidth")}}
 
-> **Note:** This property will round the value to an integer. If you need a fractional value,
+> [!NOTE]
+> This property will round the value to an integer. If you need a fractional value,
 > use {{ domxref("element.getBoundingClientRect()") }}.
 
 ## Value

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.md
@@ -15,7 +15,8 @@ It is normally handled by an event handler on the {{domxref("Window")}} or {{dom
 
 The handler can be assigned using the `onsecuritypolicyviolation` property or using {{domxref("EventTarget.addEventListener()")}}.
 
-> **Note:** You must add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
+> [!NOTE]
+> You must add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
 > While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.
 
 ## Syntax

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -14,7 +14,8 @@ browser-compat: api.Element.setCapture
 Call this method during the handling of a mousedown event to retarget all mouse events
 to this element until the mouse button is released or {{domxref("document.releaseCapture()")}} is called.
 
-> **Warning:** This interface never had much cross-browser
+> [!WARNING]
+> This interface never had much cross-browser
 > support and you probably looking for {{domxref("element.setPointerCapture")}} instead,
 > from the Pointer Events API.
 

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -59,7 +59,8 @@ document
 // Result (as a string): "abc  def"
 ```
 
-> **Note:** This example uses the default sanitizer.
+> [!NOTE]
+> This example uses the default sanitizer.
 > The {{domxref("Sanitizer/Sanitizer","Sanitizer")}} constructor is used to configure sanitizer options.
 
 ## Specifications

--- a/files/en-us/web/api/element/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/element/sethtmlunsafe/index.md
@@ -15,7 +15,8 @@ The suffix "Unsafe" in the method name indicates that the method does not saniti
 
 If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
 
-> **Note:** This method should be used instead of {{domxref("Element.innerHTML")}} when a string of HTML may contain declarative shadow roots.
+> [!NOTE]
+> This method should be used instead of {{domxref("Element.innerHTML")}} when a string of HTML may contain declarative shadow roots.
 
 ## Syntax
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaAtomic
 
 The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the `aria-relevant` attribute.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaAutoComplete
 
 The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaBusy
 
 The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaChecked
 
 The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaColCount
 
 The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaColIndex
 
 The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -11,7 +11,8 @@ browser-compat: api.ElementInternals.ariaColIndexText
 
 The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaColSpan
 
 The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaCurrent
 
 The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaDescription
 
 The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaDisabled
 
 The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaExpanded
 
 The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaHasPopup
 
 The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariahidden/index.md
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaHidden
 
 The **`ariaHidden`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaKeyShortcuts
 
 The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaLabel
 
 The **`ariaLabel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current Element.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaLevel
 
 The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/arialive/index.md
+++ b/files/en-us/web/api/elementinternals/arialive/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaLive
 
 The **`ariaLive`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaModal
 
 The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaMultiLine
 
 The **`ariaMultiLine`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaMultiSelectable
 
 The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.md
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaOrientation
 
 The **`ariaOrientation`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaPlaceholder
 
 The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaPosInSet
 
 The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaPressed
 
 The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaReadOnly
 
 The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -12,7 +12,8 @@ browser-compat: api.ElementInternals.ariaRelevant
 
 The **`ariaRelevant`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaRequired
 
 The **`ariaRequired`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaRoleDescription
 
 The **`ariaRoleDescription`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaRowCount
 
 The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaRowIndex
 
 The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -11,7 +11,8 @@ browser-compat: api.ElementInternals.ariaRowIndexText
 
 The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaRowSpan
 
 The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaSelected
 
 The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 4.
