### PR TITLE
Convert noteblocks for web/api folder (part 5)

### DIFF
--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaSetSize
 
 The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaSort
 
 The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaValueMax
 
 The **`ariaValueMax`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute, which defines the maximum allowed value for a range widget.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaValueMin
 
 The **`ariaValueMin`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) attribute, which defines the minimum allowed value for a range widget.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaValueNow
 
 The **`ariaValueNow`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ElementInternals.ariaValueText
 
 The **`ariaValueText`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of aria-valuenow for a range widget.
 
-> **Note:** Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> Setting aria attributes on `ElementInternals` allows default semantics to be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 ## Value
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -35,7 +35,8 @@ This interface has no constructor. An `ElementInternals` object is returned when
 
 The `ElementInternals` interface also includes the following properties.
 
-> **Note:** These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
+> [!NOTE]
+> These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 - {{domxref("ElementInternals.ariaAtomic")}}
   - : A string reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.

--- a/files/en-us/web/api/elementinternals/setformvalue/index.md
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.md
@@ -25,7 +25,8 @@ setFormValue(value, state)
   - : A {{domxref("File")}}, a string, or a {{domxref("FormData")}} representing the input made by the user.
     This allows the application to re-display the information that the user submitted, in the form that they submitted it, if required.
 
-> **Note:** In general, `state` is used to pass information specified by a user, the `value` is suitable for submission to a server, post sanitization.
+> [!NOTE]
+> In general, `state` is used to pass information specified by a user, the `value` is suitable for submission to a server, post sanitization.
 > For example, if a custom element asked a user to submit a date, the user might enter "3/15/2019".
 > This would be the `state`.
 > The server expects a date format of `2019-03-15`, the date in this format would be passed as the `value`.

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -45,7 +45,8 @@ setValidity(flags, message, anchor)
     - `customError`
       - : A boolean value indicating whether the element's custom validity message has been set to a non-empty string by calling the element's {{domxref('HTMLObjectElement.setCustomValidity', 'setCustomValidity()')}} method.
 
-    > **Note:** To set all flags to `false`, indicating that this element passes all constraints validation, pass in an empty object `{}`. In this case, you do not need to also pass a `message`.
+    > [!NOTE]
+    > To set all flags to `false`, indicating that this element passes all constraints validation, pass in an empty object `{}`. In this case, you do not need to also pass a `message`.
 
 - `message` {{Optional_Inline}}
   - : A string containing a message, which will be set if any `flags` are `true`. This parameter is only optional if all `flags` are `false`.

--- a/files/en-us/web/api/event/bubbles/index.md
+++ b/files/en-us/web/api/event/bubbles/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Event.bubbles
 
 The **`bubbles`** read-only property of the {{domxref("Event")}} interface indicates whether the event bubbles up through the DOM tree or not.
 
-> **Note:** See [Event bubbling](/en-US/docs/Learn/JavaScript/Building_blocks/Event_bubbling) for more information on bubbling.
+> [!NOTE]
+> See [Event bubbling](/en-US/docs/Learn/JavaScript/Building_blocks/Event_bubbling) for more information on bubbling.
 
 ## Value
 

--- a/files/en-us/web/api/event/index.md
+++ b/files/en-us/web/api/event/index.md
@@ -15,7 +15,8 @@ There are many types of events, some of which use other interfaces based on the 
 
 Many DOM elements can be set up to accept (or "listen" for) these events, and execute code in response to process (or "handle") them. Event-handlers are usually connected (or "attached") to various [HTML elements](/en-US/docs/Web/HTML/Element) (such as `<button>`, `<div>`, `<span>`, etc.) using [`EventTarget.addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener), and this generally replaces using the old HTML [event handler attributes](/en-US/docs/Web/HTML/Global_attributes). Further, when properly added, such handlers can also be disconnected if needed using [`removeEventListener()`](/en-US/docs/Web/API/EventTarget/removeEventListener).
 
-> **Note:** One element can have several such handlers, even for the exact same event—particularly if separate, independent code modules attach them, each for its own independent purposes. (For example, a webpage with an advertising-module and statistics-module both monitoring video-watching.)
+> [!NOTE]
+> One element can have several such handlers, even for the exact same event—particularly if separate, independent code modules attach them, each for its own independent purposes. (For example, a webpage with an advertising-module and statistics-module both monitoring video-watching.)
 
 When there are many nested elements, each with its own handler(s), event processing can become very complicated—especially where a parent element receives the very same event as its child elements because "spatially" they overlap so the event technically occurs in both, and the processing order of such events depends on the [Event bubbling](/en-US/docs/Learn/JavaScript/Building_blocks/Event_bubbling) settings of each handler triggered.
 

--- a/files/en-us/web/api/event/returnvalue/index.md
+++ b/files/en-us/web/api/event/returnvalue/index.md
@@ -18,7 +18,8 @@ It is set to `true` by
 default, allowing the default action to occur. Setting this property to
 `false` prevents the default action.
 
-> **Note:** While `returnValue` has been adopted into the DOM
+> [!NOTE]
+> While `returnValue` has been adopted into the DOM
 > standard, it is present primarily to support existing code. Use
 > {{DOMxRef("Event.preventDefault", "preventDefault()")}}, and
 > {{domxref("Event.defaultPrevented", "defaultPrevented")}} instead of this historical

--- a/files/en-us/web/api/eventsource/close/index.md
+++ b/files/en-us/web/api/eventsource/close/index.md
@@ -12,7 +12,8 @@ The **`close()`** method of the {{domxref("EventSource")}}
 interface closes the connection, if one is made, and sets the
 {{domxref("EventSource.readyState")}} attribute to `2` (closed).
 
-> **Note:** If the connection is already closed, the method does nothing.
+> [!NOTE]
+> If the connection is already closed, the method does nothing.
 
 ## Syntax
 
@@ -40,7 +41,8 @@ button.onclick = () => {
 };
 ```
 
-> **Note:** You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 ## Specifications
 

--- a/files/en-us/web/api/eventsource/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/eventsource/index.md
@@ -46,7 +46,8 @@ evtSource.onmessage = (e) => {
 };
 ```
 
-> **Note:** You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 ## Specifications
 

--- a/files/en-us/web/api/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/index.md
@@ -17,7 +17,8 @@ Once the connection is opened, incoming messages from the server are delivered t
 
 Unlike [WebSockets](/en-US/docs/Web/API/WebSockets_API), server-sent events are unidirectional; that is, data messages are delivered in one direction, from the server to the client (such as a user's web browser). That makes them an excellent choice when there's no need to send data from the client to the server in message form. For example, `EventSource` is a useful approach for handling things like social media status updates, news feeds, or delivering data into a [client-side storage](/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage) mechanism like [IndexedDB](/en-US/docs/Web/API/IndexedDB_API) or [web storage](/en-US/docs/Web/API/Web_Storage_API).
 
-> **Warning:** When **not used over HTTP/2**, SSE suffers from a limitation to the maximum number of open connections, which can be specially painful when opening various tabs as the limit is _per browser_ and set to a very low number (6). The issue has been marked as "Won't fix" in [Chrome](https://crbug.com/275955) and [Firefox](https://bugzil.la/906896). This limit is per browser + domain, so that means that you can open 6 SSE connections across all of the tabs to `www.example1.com` and another 6 SSE connections to `www.example2.com`. (from [Stackoverflow](https://stackoverflow.com/questions/5195452/websockets-vs-server-sent-events-eventsource/5326159)). When using HTTP/2, the maximum number of simultaneous _HTTP streams_ is negotiated between the server and the client (defaults to 100).
+> [!WARNING]
+> When **not used over HTTP/2**, SSE suffers from a limitation to the maximum number of open connections, which can be specially painful when opening various tabs as the limit is _per browser_ and set to a very low number (6). The issue has been marked as "Won't fix" in [Chrome](https://crbug.com/275955) and [Firefox](https://bugzil.la/906896). This limit is per browser + domain, so that means that you can open 6 SSE connections across all of the tabs to `www.example1.com` and another 6 SSE connections to `www.example2.com`. (from [Stackoverflow](https://stackoverflow.com/questions/5195452/websockets-vs-server-sent-events-eventsource/5326159)). When using HTTP/2, the maximum number of simultaneous _HTTP streams_ is negotiated between the server and the client (defaults to 100).
 
 ## Constructor
 
@@ -71,7 +72,8 @@ evtSource.onmessage = (e) => {
 
 Each received event causes our `EventSource` object's `onmessage` event handler to be run. It, in turn, creates a new {{HTMLElement("li")}} element and writes the message's data into it, then appends the new element to the list element already in the document.
 
-> **Note:** You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 To listen to named events, you'll require a listener for each type of event sent.
 

--- a/files/en-us/web/api/eventsource/readystate/index.md
+++ b/files/en-us/web/api/eventsource/readystate/index.md
@@ -30,7 +30,8 @@ const evtSource = new EventSource("sse.php");
 console.log(evtSource.readyState);
 ```
 
-> **Note:** You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 ## Specifications
 

--- a/files/en-us/web/api/eventsource/url/index.md
+++ b/files/en-us/web/api/eventsource/url/index.md
@@ -23,7 +23,8 @@ const evtSource = new EventSource("sse.php");
 console.log(evtSource.url);
 ```
 
-> **Note:** You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 ## Specifications
 

--- a/files/en-us/web/api/eventsource/withcredentials/index.md
+++ b/files/en-us/web/api/eventsource/withcredentials/index.md
@@ -25,7 +25,8 @@ const evtSource = new EventSource("sse.php");
 console.log(evtSource.withCredentials);
 ```
 
-> **Note:** You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 ## Specifications
 

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -14,7 +14,8 @@ sets up a function that will be called whenever the specified event is delivered
 Common targets are {{domxref("Element")}}, or its children, {{domxref("Document")}}, and {{domxref("Window")}},
 but the target may be any object that supports events (such as {{domxref("IDBRequest")}}).
 
-> **Note:** The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
+> [!NOTE]
+> The `addEventListener()` method is the _recommended_ way to register an event listener. The benefits are as follows:
 >
 > - It allows adding more than one handler for an event. This is particularly
 >   useful for libraries, JavaScript modules, or any other kind of
@@ -25,7 +26,8 @@ but the target may be any object that supports events (such as {{domxref("IDBReq
 The method `addEventListener()` works by adding a function, or an object that implements a `handleEvent()` function, to the list of event listeners for the specified event type
 on the {{domxref("EventTarget")}} on which it's called. If the function or object is already in the list of event listeners for this target, the function or object is not added a second time.
 
-> **Note:** If a particular anonymous function is in the list of event listeners registered for a certain target, and then later in the code, an identical anonymous function is given in an `addEventListener` call, the second function will _also_ be added to the list of event listeners for that target.
+> [!NOTE]
+> If a particular anonymous function is in the list of event listeners registered for a certain target, and then later in the code, an identical anonymous function is given in an `addEventListener` call, the second function will _also_ be added to the list of event listeners for that target.
 >
 > Indeed, anonymous functions are not identical even if defined using
 > the _same_ unchanging source-code called repeatedly, **even if in a loop**.
@@ -91,7 +93,8 @@ addEventListener(type, listener, useCapture)
     the event. See [DOM Level 3 Events](https://www.w3.org/TR/DOM-Level-3-Events/#event-flow) and [JavaScript Event order](https://www.quirksmode.org/js/events_order.html#link4) for a detailed explanation.
     If not specified, `useCapture` defaults to `false`.
 
-    > **Note:** For event listeners attached to the event target, the event is in the target phase, rather than the capturing and bubbling phases.
+    > [!NOTE]
+    > For event listeners attached to the event target, the event is in the target phase, rather than the capturing and bubbling phases.
     > Event listeners in the _capturing_ phase are called before event listeners in any non-capturing phases.
 
 - `wantsUntrusted` {{optional_inline}} {{non-standard_inline}}

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -16,7 +16,8 @@ dispatched manually with `dispatchEvent()`.
 Calling `dispatchEvent()` is the last step to _firing an event_. The event
 should have already been created and initialized using an {{domxref("Event/Event", "Event()")}} constructor.
 
-> **Note:** When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
+> [!NOTE]
+> When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
 
 Unlike "native" events, which are fired by the browser and invoke event handlers
 asynchronously via the [event loop](/en-US/docs/Web/JavaScript/Event_loop),
@@ -43,7 +44,8 @@ dispatchEvent(event)
 - `InvalidStateError` {{domxref("DomException")}}
   - : Thrown if the event's type was not specified during event initialization.
 
-> **Warning:** Exceptions thrown by event handlers are reported as uncaught exceptions. The event
+> [!WARNING]
+> Exceptions thrown by event handlers are reported as uncaught exceptions. The event
 > handlers run on a nested callstack; they block the caller until they complete, but
 > exceptions do not propagate to the caller.
 

--- a/files/en-us/web/api/eventtarget/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.md
@@ -10,7 +10,8 @@ browser-compat: api.EventTarget.EventTarget
 
 The **`EventTarget()`** constructor creates a new {{domxref("EventTarget")}} object instance.
 
-> **Note:** It is fairly rare to explicitly call this constructor. Most of the time, this constructor is used inside the constructor of an object extending the {{domxref("EventTarget")}} interface, using the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) keyword.
+> [!NOTE]
+> It is fairly rare to explicitly call this constructor. Most of the time, this constructor is used inside the constructor of an object extending the {{domxref("EventTarget")}} interface, using the [`super`](/en-US/docs/Web/JavaScript/Reference/Operators/super) keyword.
 
 ## Syntax
 

--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.md
@@ -20,7 +20,8 @@ effect.
 
 If an [event listener](/en-US/docs/Web/API/EventTarget/addEventListener#the_event_listener_callback) is removed from an {{domxref("EventTarget")}} while another listener of the target is processing an event, it will not be triggered by the event. However, it can be reattached.
 
-> **Warning:** If a listener is registered twice, one with the _capture_ flag set and one without, you must remove each one separately. Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.
+> [!WARNING]
+> If a listener is registered twice, one with the _capture_ flag set and one without, you must remove each one separately. Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.
 
 Event listeners can also be removed by passing an {{domxref("AbortSignal")}} to an {{domxref("EventTarget/addEventListener()", "addEventListener()")}} and then later calling {{domxref("AbortController/abort()", "abort()")}} on the controller owning the signal.
 

--- a/files/en-us/web/api/ext_blend_minmax/index.md
+++ b/files/en-us/web/api/ext_blend_minmax/index.md
@@ -12,7 +12,8 @@ The **`EXT_blend_minmax`** extension is part of the [WebGL API](/en-US/docs/Web/
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are `gl.MIN` and `gl.MAX`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are `gl.MIN` and `gl.MAX`.
 
 ## Constants
 

--- a/files/en-us/web/api/ext_color_buffer_float/index.md
+++ b/files/en-us/web/api/ext_color_buffer_float/index.md
@@ -12,7 +12,8 @@ The **`EXT_color_buffer_float`** extension is part of [WebGL](/en-US/docs/Web/AP
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts only.
+> [!NOTE]
+> This extension is available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts only.
 >
 > For {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, see the {{domxref("EXT_color_buffer_half_float")}} and {{domxref("WEBGL_color_buffer_float")}} extensions.
 

--- a/files/en-us/web/api/ext_color_buffer_half_float/index.md
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.md
@@ -12,7 +12,8 @@ The **`EXT_color_buffer_half_float`** extension is part of the [WebGL API](/en-U
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. On WebGL 2, it's an alternative to using the {{domxref("EXT_color_buffer_float")}} extension on platforms that support 16-bit floating point render targets but not 32-bit floating point render targets.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. On WebGL 2, it's an alternative to using the {{domxref("EXT_color_buffer_float")}} extension on platforms that support 16-bit floating point render targets but not 32-bit floating point render targets.
 >
 > The {{domxref("OES_texture_half_float")}} extension implicitly enables this extension.
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.md
@@ -12,7 +12,8 @@ The **EXT_disjoint_timer_query** extension is part of the [WebGL API](/en-US/doc
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension should be available in {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts only. {{domxref("EXT_disjoint_timer_query_webgl2")}} is available in {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts .
+> [!NOTE]
+> This extension should be available in {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts only. {{domxref("EXT_disjoint_timer_query_webgl2")}} is available in {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts .
 >
 > In WebGL 2, the {{domxref("WebGLRenderingContext.getQueryObject")}} was renamed to {{domxref("WebGL2RenderingContext.getQueryParameter")}}.
 > In WebGL 2, other queries (such as occlusion queries and primitive queries) are possible using {{domxref("WebGLQuery")}} objects.

--- a/files/en-us/web/api/ext_float_blend/index.md
+++ b/files/en-us/web/api/ext_float_blend/index.md
@@ -12,7 +12,8 @@ The [WebGL API](/en-US/docs/Web/API/WebGL_API)'s `EXT_float_blend` extension all
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. However, to use it, you need to enable the use of 32-bit floating-point draw buffers by enabling the extension {{domxref("WEBGL_color_buffer_float")}} (for WebGL1) or {{domxref("EXT_color_buffer_float")}} (for WebGL2). Doing so automatically enables `EXT_float_blend` as well, if and only if `EXT_float_blend` is also supported. Support for `EXT_color_buffer_float` does not imply support for `EXT_float_blend`.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts. However, to use it, you need to enable the use of 32-bit floating-point draw buffers by enabling the extension {{domxref("WEBGL_color_buffer_float")}} (for WebGL1) or {{domxref("EXT_color_buffer_float")}} (for WebGL2). Doing so automatically enables `EXT_float_blend` as well, if and only if `EXT_float_blend` is also supported. Support for `EXT_color_buffer_float` does not imply support for `EXT_float_blend`.
 
 With this extension enabled, calling {{domxref("WebGLRenderingContext.drawArrays", "drawArrays()")}} or {{domxref("WebGLRenderingContext.drawElements", "drawElements()")}} with blending enabled and a draw buffer with 32-bit floating-point components will no longer result in an `INVALID_OPERATION` error.
 

--- a/files/en-us/web/api/ext_frag_depth/index.md
+++ b/files/en-us/web/api/ext_frag_depth/index.md
@@ -12,7 +12,8 @@ The **`EXT_frag_depth`** extension is part of the [WebGL API](/en-US/docs/Web/AP
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL `#version 300 es`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL `#version 300 es`.
 
 ## Examples
 

--- a/files/en-us/web/api/ext_shader_texture_lod/index.md
+++ b/files/en-us/web/api/ext_shader_texture_lod/index.md
@@ -12,7 +12,8 @@ The **`EXT_shader_texture_lod`** extension is part of the [WebGL API](/en-US/doc
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL `#version 300 es`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. It requires GLSL `#version 300 es`.
 
 ## GLSL built-in functions
 

--- a/files/en-us/web/api/ext_srgb/index.md
+++ b/files/en-us/web/api/ext_srgb/index.md
@@ -12,7 +12,8 @@ The **`EXT_sRGB`** extension is part of the [WebGL API](/en-US/docs/Web/API/WebG
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are: `gl.SRGB`, `gl.SRGB8`, `gl.SRGB8_ALPHA8` and `gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constants in WebGL2 are: `gl.SRGB`, `gl.SRGB8`, `gl.SRGB8_ALPHA8` and `gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING`.
 
 ## Constants
 

--- a/files/en-us/web/api/ext_texture_compression_bptc/index.md
+++ b/files/en-us/web/api/ext_texture_compression_bptc/index.md
@@ -12,7 +12,8 @@ The `EXT_texture_compression_bptc` extension is part of the [WebGL API](/en-US/d
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** Support depends on the system's graphics driver. There is no support on Windows.
+> [!NOTE]
+> Support depends on the system's graphics driver. There is no support on Windows.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 

--- a/files/en-us/web/api/ext_texture_compression_rgtc/index.md
+++ b/files/en-us/web/api/ext_texture_compression_rgtc/index.md
@@ -12,7 +12,8 @@ The `EXT_texture_compression_rgtc` extension is part of the [WebGL API](/en-US/d
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** Support depends on the system's graphics driver. There is no support on Windows.
+> [!NOTE]
+> Support depends on the system's graphics driver. There is no support on Windows.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.md
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.md
@@ -14,7 +14,8 @@ AF improves the quality of mipmapped texture access when viewing a textured prim
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Constants
 

--- a/files/en-us/web/api/ext_texture_norm16/index.md
+++ b/files/en-us/web/api/ext_texture_norm16/index.md
@@ -17,7 +17,8 @@ When this extension is enabled:
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.
 
 ## Constants
 

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -12,7 +12,8 @@ The **`ExtendableCookieChangeEvent()`** constructor creates a new {{domxref("Ext
 which is the event type passed to {{domxref("ServiceWorkerGlobalScope/cookiechange_event", "cookiechange")}} event fired at the {{domxref("ServiceWorkerGlobalScope")}} when any cookie changes occur which match the service worker's cookie change subscription list.
 This constructor is called by the browser when a change event occurs.
 
-> **Note:** This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.
+> [!NOTE]
+> This event constructor is generally not needed for production websites. It's primary use is for tests that require an instance of this event.
 
 ## Syntax
 

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -15,7 +15,8 @@ Cookie changes that cause the `ExtendableCookieChangeEvent` to be dispatched are
 - A cookie is newly created and immediately removed. In this case `type` is "deleted"
 - A cookie is removed. In this case `type` is "deleted".
 
-> **Note:** A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
+> [!NOTE]
+> A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/index.md
@@ -15,7 +15,8 @@ This interface inherits from the {{domxref("Event")}} interface.
 
 {{InheritanceDiagram}}
 
-> **Note:** This interface is only available when the global scope is a {{domxref("ServiceWorkerGlobalScope")}}. It is not available when it is a {{domxref("Window")}}, or the scope of another kind of worker.
+> [!NOTE]
+> This interface is only available when the global scope is a {{domxref("ServiceWorkerGlobalScope")}}. It is not available when it is a {{domxref("Window")}}, or the scope of another kind of worker.
 
 ## Constructor
 
@@ -39,7 +40,8 @@ This code snippet is from the [service worker prefetch sample](https://github.co
 
 The code snippet also shows a best practice for versioning caches used by the service worker. Though there's only one cache in this example, the same approach can be used for multiple caches. It maps a shorthand identifier for a cache to a specific, versioned cache name.
 
-> **Note:** In Chrome, logging statements are visible via the "Inspect" interface for the relevant service worker accessed via chrome://serviceworker-internals.
+> [!NOTE]
+> In Chrome, logging statements are visible via the "Inspect" interface for the relevant service worker accessed via chrome://serviceworker-internals.
 
 ```js
 const CACHE_VERSION = 1;
@@ -80,7 +82,8 @@ self.addEventListener("install", (event) => {
 });
 ```
 
-> **Note:** When fetching resources, it's very important to use `{mode: 'no-cors'}` if there is any chance that the resources are served off of a server that doesn't support {{glossary("CORS")}}. In this example, [www.chromium.org](https://www.chromium.org/) doesn't support CORS.
+> [!NOTE]
+> When fetching resources, it's very important to use `{mode: 'no-cors'}` if there is any chance that the resources are served off of a server that doesn't support {{glossary("CORS")}}. In this example, [www.chromium.org](https://www.chromium.org/) doesn't support CORS.
 
 ## Specifications
 

--- a/files/en-us/web/api/fedcm_api/idp_integration/index.md
+++ b/files/en-us/web/api/fedcm_api/idp_integration/index.md
@@ -85,9 +85,11 @@ The following table summarizes the different requests made by the FedCM API:
 | `client_metadata_endpoint` | `GET`  | No                          | Yes                               |
 | `id_assertion_endpoint`    | `POST` | Yes                         | Yes                               |
 
-> **Note:** For a description of the FedCM flow in which these endpoints are accessed, see [FedCM sign-in flow](/en-US/docs/Web/API/FedCM_API/RP_sign-in#fedcm_sign-in_flow).
+> [!NOTE]
+> For a description of the FedCM flow in which these endpoints are accessed, see [FedCM sign-in flow](/en-US/docs/Web/API/FedCM_API/RP_sign-in#fedcm_sign-in_flow).
 
-> **Note:** None of the requests made by the FedCM API to the endpoints detailed here allow for following redirects, for privacy purposes.
+> [!NOTE]
+> None of the requests made by the FedCM API to the endpoints detailed here allow for following redirects, for privacy purposes.
 
 ### The accounts list endpoint
 
@@ -209,7 +211,8 @@ The request payload contains the following params:
 - `is_auto_selected`
   - : A string of `"true"` or `"false"` indicating whether the authentication validation request has been issued as a result of [auto-reauthentication](/en-US/docs/Web/API/FedCM_API/RP_sign-in#auto-reauthentication), i.e. without user mediation. This can occur when the {{domxref("CredentialsContainer.get", "get()")}} call is issued with a [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option value of `"optional"` or `"silent"`. It is useful for the IdP to know whether auto reauthentication occurred for performance evaluation and in case higher security is desired. For example, the IdP could return an error code telling the RP that it requires explicit user mediation (`mediation="required"`).
 
-> **Note:** If the {{domxref("CredentialsContainer.get", "get()")}} call succeeds, the `is_auto_selected` value is also communicated to the RP via the {{domxref("IdentityCredential.isAutoSelected")}} property.
+> [!NOTE]
+> If the {{domxref("CredentialsContainer.get", "get()")}} call succeeds, the `is_auto_selected` value is also communicated to the RP via the {{domxref("IdentityCredential.isAutoSelected")}} property.
 
 #### ID assertion error responses
 

--- a/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
+++ b/files/en-us/web/api/fedcm_api/rp_sign-in/index.md
@@ -18,7 +18,8 @@ The RP sends the token to its server to validate the certificate, and on success
 
 If the user has never signed into the IdP or is logged out, the `get()` method rejects with an error and the RP can direct the user to the IdP login page to sign in or create an account.
 
-> **Note:** The exact structure and content of the validation token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
+> [!NOTE]
+> The exact structure and content of the validation token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
 
 A typical request might look like this:
 
@@ -42,7 +43,8 @@ async function signIn() {
 
 The `identity.providers` property takes an array containing a single object specifying the path to an IdP config file (`configURL`) and the RP's client identifier (`clientId`) issued by the IdP.
 
-> **Note:** Currently FedCM only allows the API to be invoked with a single IdP, i.e. the `identity.providers` array has to have a length of 1. To offer users a choice of identity provider, the RP will need to call `get()` separately for each. This may change in the future.
+> [!NOTE]
+> Currently FedCM only allows the API to be invoked with a single IdP, i.e. the `identity.providers` array has to have a length of 1. To offer users a choice of identity provider, the RP will need to call `get()` separately for each. This may change in the future.
 
 The example above also includes a couple of optional features:
 
@@ -75,7 +77,8 @@ The flow is as follows:
 
 4. If the browser has the [IdP's login status](/en-US/docs/Web/API/FedCM_API/IDP_integration#update_login_status_using_the_login_status_api) set to `"logged-in"`, it makes a credentialed request (i.e. with a cookie that identifies the user that is signed in) to the [`accounts_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_accounts_list_endpoint) inside the IdP config file for the user's account details. This is a `GET` request with cookies, but without a `client_id` parameter or the {{httpheader("Origin")}} header. This effectively prevents the IdP from learning which RP the user is trying to sign in to. As a result, the list of accounts returned is RP-agnostic.
 
-   > **Note:** If the IdP login status is `"logged-out"`, the `get()` call rejects with a `NetworkError` {{domxref("DOMException")}} and does not make a request to the IdP's `accounts_endpoint`. In this case it is up to the developer to handle the flow, for example by prompting the user to go and sign in to a suitable IdP. Note that there may be some delay in the rejection to avoid leaking the IdP login status to the RP.
+   > [!NOTE]
+   > If the IdP login status is `"logged-out"`, the `get()` call rejects with a `NetworkError` {{domxref("DOMException")}} and does not make a request to the IdP's `accounts_endpoint`. In this case it is up to the developer to handle the flow, for example by prompting the user to go and sign in to a suitable IdP. Note that there may be some delay in the rejection to avoid leaking the IdP login status to the RP.
 
 5. The IdP responds with the account information requested from the `accounts_endpoint`. This is an array of all accounts associated with the user's IdP cookies for any RPs associated with the IdP.
 
@@ -85,7 +88,8 @@ The flow is as follows:
 
 8. The browser uses the information obtained by the previous two requests to create the UI asking the user to choose an account to sign in to the RP with (in the case where there is more than one available). The UI also asks the user for permission to sign in to the RP using their chosen federated IdP account.
 
-   > **Note:** At this stage, if the user has previously authenticated with a federated RP account in the current browser instance (i.e. created a new account with the RP or signed into the RP's website using an existing account), they may be able to **auto-reauthenticate**, depending on what the [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option is set to in the `get()` call. If so the user will be signed in automatically without entering their credentials, as soon as `get()` is invoked. See the [Auto-reauthentication](#auto-reauthentication) section for more details.
+   > [!NOTE]
+   > At this stage, if the user has previously authenticated with a federated RP account in the current browser instance (i.e. created a new account with the RP or signed into the RP's website using an existing account), they may be able to **auto-reauthenticate**, depending on what the [`mediation`](/en-US/docs/Web/API/CredentialsContainer/get#mediation) option is set to in the `get()` call. If so the user will be signed in automatically without entering their credentials, as soon as `get()` is invoked. See the [Auto-reauthentication](#auto-reauthentication) section for more details.
 
 9. If the user grants permission to do so, the browser makes a credentialed request to the [`id_assertion_endpoint`](/en-US/docs/Web/API/FedCM_API/IDP_integration#the_id_assertion_endpoint) to request a validation token from the IdP for the selected account.
 
@@ -95,7 +99,8 @@ The flow is as follows:
 
 10. The IdP checks that the account ID sent by the RP matches the ID for the account that is already signed in, and that the `Origin` matches the origin of the RP, which will have been registered in advance with the IdP. If everything looks good, it responds with the requested validation token.
 
-    > **Note:** The origin of the RP will be registered with the IdP in a completely separate process when the RP first integrates with the IdP. This process will be specific to each IdP.
+    > [!NOTE]
+    > The origin of the RP will be registered with the IdP in a completely separate process when the RP first integrates with the IdP. This process will be specific to each IdP.
 
 11. When the flow is complete, the `get()` promise resolves with an {{domxref("IdentityCredential")}} object, which provides further RP functionality. Most notably, this object contains a token that the RP can verify comes from the IdP (using a certificate) and that contains trusted information about the signed in user. Once the RP validates the token, they can use the contained information to sign the user in and start a new session, sign them up to their service, etc. The format and structure of the token depends on the IdP and has nothing to do with the FedCM API (the RP needs to follow the IdP's instructions).
 
@@ -143,7 +148,8 @@ If auto-reauthentication fails, the behavior depends on the `mediation` value th
 - `optional`: the user _will_ be shown the dialog box and asked for confirmation again. As a result, this option tends to make sense to use on a page where a user journey is not in mid-flow, such an RP sign-in page.
 - `silent`: The `get()` promise will reject and the developer will need to handle guiding the user back to the sign-in page to start the process again. This option makes sense on pages where a user journey is in flow and you need to keep them signed in until completion, for example the pages of a checkout flow on an e-commerce website.
 
-> **Note:** The {{domxref("IdentityCredential.isAutoSelected")}} property provides an indication of whether the federated sign-in was carried out using auto-reauthentication. This is helpful to evaluate the API performance and improve UX accordingly. Also, when it's unavailable, the user may be prompted to sign in with explicit user mediation, which is a `get()` call with `mediation: required`.
+> [!NOTE]
+> The {{domxref("IdentityCredential.isAutoSelected")}} property provides an indication of whether the federated sign-in was carried out using auto-reauthentication. This is helpful to evaluate the API performance and improve UX accordingly. Also, when it's unavailable, the user may be prompted to sign in with explicit user mediation, which is a `get()` call with `mediation: required`.
 
 ## See also
 

--- a/files/en-us/web/api/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/index.md
@@ -11,7 +11,8 @@ browser-compat: api.FederatedCredential
 
 The **`FederatedCredential`** interface of the [Credential Management API](/en-US/docs/Web/API/Credential_Management_API) provides information about credentials from a federated identity provider. A federated identity provider is an entity that a website trusts to correctly authenticate a user, and that provides an API for that purpose. [OpenID Connect](https://openid.net/developers/specs/) is an example of a federated identity provider framework.
 
-> **Note:** The [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) provides a more complete solution for handling identity federation in the browser, and uses the {{domxref("IdentityCredential")}} type.
+> [!NOTE]
+> The [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) provides a more complete solution for handling identity federation in the browser, and uses the {{domxref("IdentityCredential")}} type.
 
 In browsers that support it, an instance of this interface may be passed in the `credential` member of the `init` object for global {{domxref("Window/fetch", "fetch()")}}.
 

--- a/files/en-us/web/api/federatedcredentialinit/index.md
+++ b/files/en-us/web/api/federatedcredentialinit/index.md
@@ -9,7 +9,8 @@ spec-urls: https://w3c.github.io/webappsec-credential-management/#dom-federatedc
 
 The **`FederatedCredentialInit`** dictionary represents the object passed to {{domxref("CredentialsContainer.create()")}} as the value of the `federated` option: that is, when creating a {{domxref("FederatedCredential")}} object representing a credential associated with a federated identify provider.
 
-> **Note:** The [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) supersedes the {{domxref("FederatedCredential")}} interface in favor of the {{domxref("IdentityCredential")}} interface.
+> [!NOTE]
+> The [Federated Credential Management API (FedCM)](/en-US/docs/Web/API/FedCM_API) supersedes the {{domxref("FederatedCredential")}} interface in favor of the {{domxref("IdentityCredential")}} interface.
 >
 > The `FederatedCredentialInit` dictionary is not used when working with the `IdentityCredential`interface.
 

--- a/files/en-us/web/api/fence/index.md
+++ b/files/en-us/web/api/fence/index.md
@@ -13,7 +13,8 @@ The **`Fence`** interface of the {{domxref("Fenced Frame API", "Fenced Frame API
 
 `Fence` objects are accessed through the {{domxref("Window.fence")}} property, but they are only available to documents embedded inside {{htmlelement("fencedframe")}}s (loaded via {{domxref("FencedFrameConfig")}}s) or {{htmlelement("iframe")}}s (loaded via opaque URNs).
 
-> **Note:** See [How do `<fencedframe>`s work?](/en-US/docs/Web/API/Fenced_frame_API#how_do_fencedframes_work) for some description around `FencedFrameConfig`s and opaque URNs.
+> [!NOTE]
+> See [How do `<fencedframe>`s work?](/en-US/docs/Web/API/Fenced_frame_API#how_do_fencedframes_work) for some description around `FencedFrameConfig`s and opaque URNs.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/fenced_frame_api/communication_with_embedded_frames/index.md
+++ b/files/en-us/web/api/fenced_frame_api/communication_with_embedded_frames/index.md
@@ -20,7 +20,8 @@ From the `<iframe>`, you can listen to a [`message`](/en-US/docs/Web/API/Window/
 
 Fenced frames are intended to be used for cases such as displaying targeted ads selected via the [Protected Audience API](https://developer.chrome.com/en/docs/privacy-sandbox/fledge/) and {{domxref("WindowSharedStorage.selectURL()")}}. Communicating between `<fencedframe>`s and other pages outside the `<fencedframe>` on the page is intentionally limited, but one method of communication between the embedder and shared storage worklets does exist — {{domxref("FencedFrameConfig.setSharedStorageContext()")}}.
 
-> **Note:** Within the same `<fencedframe>` tree, communication between frames is allowed. For example, a root `<fencedframe>` can send a message to a child `<iframe>` in its own tree, and a child `<iframe>` can send a message to the parent `<fencedframe>`.
+> [!NOTE]
+> Within the same `<fencedframe>` tree, communication between frames is allowed. For example, a root `<fencedframe>` can send a message to a child `<iframe>` in its own tree, and a child `<iframe>` can send a message to the parent `<fencedframe>`.
 
 Let's look at a more complex example that uses a Select URL output gate operation to render an ad in a `<fencedframe>`.
 

--- a/files/en-us/web/api/fenced_frame_api/index.md
+++ b/files/en-us/web/api/fenced_frame_api/index.md
@@ -59,7 +59,8 @@ frame.config = frameConfig;
 
 Either way, the browser stores a URL containing the target location of the content to embed — mapped to the opaque URN, or the `FencedFrameConfig`'s internal `url` property. The URL value cannot be read by JavaScript running in the embedding context.
 
-> **Note:** Support is provided for opaque URNs in `<iframe>`s to ease migration of existing implementations over to [privacy sandbox](https://developer.chrome.com/docs/privacy-sandbox/) APIs. This support is intended to be temporary and will be removed in the future as adoption grows.
+> [!NOTE]
+> Support is provided for opaque URNs in `<iframe>`s to ease migration of existing implementations over to [privacy sandbox](https://developer.chrome.com/docs/privacy-sandbox/) APIs. This support is intended to be temporary and will be removed in the future as adoption grows.
 
 > **Note:** `FencedFrameConfig` has a {{domxref("FencedFrameConfig.setSharedStorageContext", "setSharedStorageContext()")}} method that is used to pass in data from the embedding document to the `<fencedframe>`'s shared storage. It could for example be accessed in a {{domxref("Worklet")}} via the `<fencedframe>` and used to generate a report. See the [Shared Storage API](https://developer.chrome.com/docs/privacy-sandbox/shared-storage/) for more details.
 
@@ -123,7 +124,8 @@ Other effects of fenced frames on HTTP headers are as follows:
 
 Certain API features that create {{domxref("FencedFrameConfig")}}s such as {{domxref("Navigator.runAdAuction()")}} ([Protected Audience API](https://developer.chrome.com/docs/privacy-sandbox/fledge/)) and {{domxref("WindowSharedStorage.selectURL()")}} ([Shared Storage API](/en-US/docs/Web/API/Shared_Storage_API)), as well as other features such as {{domxref("Fence.reportEvent()")}}, require you to enroll your site in a [privacy sandbox enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment). If you don't do this, the API calls will fail with a console warning.
 
-> **Note:** In Chrome, you can still test your fenced frame code locally without enrollment. To allow local testing, enable the following Chrome developer flag:
+> [!NOTE]
+> In Chrome, you can still test your fenced frame code locally without enrollment. To allow local testing, enable the following Chrome developer flag:
 >
 > `chrome://flags/#privacy-sandbox-enrollment-overrides`
 

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -384,7 +384,8 @@ Here is a live demo of the code above:
 
 This example shows how to let the user upload files (such as the images selected using the previous example) to a server.
 
-> **Note:** It's usually preferable to make HTTP requests using the [Fetch API](/en-US/docs/Web/API/Fetch_API) instead of {{domxref("XMLHttpRequest")}}. However, in this case we want to show the user the upload progress, and this feature is still not supported by the Fetch API, so the example uses `XMLHttpRequest`.
+> [!NOTE]
+> It's usually preferable to make HTTP requests using the [Fetch API](/en-US/docs/Web/API/Fetch_API) instead of {{domxref("XMLHttpRequest")}}. However, in this case we want to show the user the upload progress, and this feature is still not supported by the Fetch API, so the example uses `XMLHttpRequest`.
 >
 > Work to track standardization of progress notifications using the Fetch API is at <https://github.com/whatwg/fetch/issues/607>.
 

--- a/files/en-us/web/api/file_system_api/index.md
+++ b/files/en-us/web/api/file_system_api/index.md
@@ -32,9 +32,11 @@ You can also gain access to file handles via:
 
 Each handle provides its own functionality and there are a few differences depending on which one you are using (see the [interfaces](#interfaces) section for specific details). You then can access file data, or information (including children) of the directory selected. This API opens up potential functionality the web has been lacking. Still, security has been of utmost concern when designing the API, and access to file/directory data is disallowed unless the user specifically permits it (note that this is not the case with the [Origin private file system](#origin_private_file_system), because it is not visible to the user).
 
-> **Note:** The different exceptions that can be thrown when using the features of this API are listed on relevant pages as defined in the spec. However, the situation is made more complex by the interaction of the API and the underlying operating system. A proposal has been made to [list the error mappings in the spec](https://github.com/whatwg/fs/issues/57), which includes useful related information.
+> [!NOTE]
+> The different exceptions that can be thrown when using the features of this API are listed on relevant pages as defined in the spec. However, the situation is made more complex by the interaction of the API and the underlying operating system. A proposal has been made to [list the error mappings in the spec](https://github.com/whatwg/fs/issues/57), which includes useful related information.
 
-> **Note:** Objects based on {{domxref("FileSystemHandle")}} can also be serialized into an {{domxref("IndexedDB API", "IndexedDB", "", "nocode")}} database instance, or transferred via {{domxref("window.postMessage", "postMessage()")}}.
+> [!NOTE]
+> Objects based on {{domxref("FileSystemHandle")}} can also be serialized into an {{domxref("IndexedDB API", "IndexedDB", "", "nocode")}} database instance, or transferred via {{domxref("window.postMessage", "postMessage()")}}.
 
 ### Origin private file system
 
@@ -231,7 +233,8 @@ onmessage = async (e) => {
 };
 ```
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were unergonomically specified as asynchronous methods. This has now been [amended](https://github.com/whatwg/fs/issues/7), but some browsers still support the asynchronous versions.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were unergonomically specified as asynchronous methods. This has now been [amended](https://github.com/whatwg/fs/issues/7), but some browsers still support the asynchronous versions.
 
 ## Specifications
 

--- a/files/en-us/web/api/file_system_api/origin_private_file_system/index.md
+++ b/files/en-us/web/api/file_system_api/origin_private_file_system/index.md
@@ -40,7 +40,8 @@ To access the OPFS in the first place, you call the {{domxref("StorageManager.ge
 
 When accessing the OPFS from the main thread, you will use asynchronous, {{jsxref("Promise")}}-based APIs. You can access file ({{domxref("FileSystemFileHandle")}}) and directory ({{domxref("FileSystemDirectoryHandle")}}) handles by calling {{domxref("FileSystemDirectoryHandle.getFileHandle()")}} and {{domxref("FileSystemDirectoryHandle.getDirectoryHandle()")}} respectively on the {{domxref("FileSystemDirectoryHandle")}} object representing the OPFS root (and child directories, as they are created).
 
-> **Note:** Passing `{ create: true }` into the above methods causes the file or folder to be created if it doesn't exist.
+> [!NOTE]
+> Passing `{ create: true }` into the above methods causes the file or folder to be created if it doesn't exist.
 
 ```js
 // Create a hierarchy of files and folders
@@ -121,7 +122,8 @@ Web Workers don't block the main thread, which means you can use the synchronous
 
 You can synchronously access a file by calling {{domxref("FileSystemFileHandle.createSyncAccessHandle()")}} on a regular {{domxref("FileSystemFileHandle")}}:
 
-> **Note:** Despite having "Sync" in its name, the `createSyncAccessHandle()` method itself is asynchronous.
+> [!NOTE]
+> Despite having "Sync" in its name, the `createSyncAccessHandle()` method itself is asynchronous.
 
 ```js
 const opfsRoot = await navigator.storage.getDirectory();

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -12,7 +12,8 @@ browser-compat: api.FileEntrySync
 
 The `FileEntrySync` interface represents a file in a file system. It lets you write content to a file.
 
-> **Warning:** This interface is deprecated and is no more on the standard track.
+> [!WARNING]
+> This interface is deprecated and is no more on the standard track.
 > _Do not use it anymore._ Use the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Basic concepts

--- a/files/en-us/web/api/filereader/readasarraybuffer/index.md
+++ b/files/en-us/web/api/filereader/readasarraybuffer/index.md
@@ -15,7 +15,8 @@ operation is finished, the {{domxref("FileReader.readyState","readyState")}} pro
 triggered. At that time, the {{domxref("FileReader.result","result")}} property
 contains an {{jsxref("ArrayBuffer")}} representing the file's data.
 
-> **Note:** The {{domxref("Blob.arrayBuffer()")}} method is a newer promise-based API to read a
+> [!NOTE]
+> The {{domxref("Blob.arrayBuffer()")}} method is a newer promise-based API to read a
 > file as an array buffer.
 
 ## Syntax

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -10,7 +10,8 @@ browser-compat: api.FileReader.readAsBinaryString
 
 {{APIRef("File API")}}{{AvailableInWorkers}}{{Deprecated_Header}}
 
-> **Note:** This method is deprecated in favor of {{DOMxRef("FileReader.readAsArrayBuffer","readAsArrayBuffer()")}}.
+> [!NOTE]
+> This method is deprecated in favor of {{DOMxRef("FileReader.readAsArrayBuffer","readAsArrayBuffer()")}}.
 
 The **`readAsBinaryString()`** method of the {{domxref("FileReader")}} interface is used to start reading the contents of the
 specified {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is

--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -15,7 +15,8 @@ The **`readAsDataURL()`** method of the {{domxref("FileReader")}} interface is u
 {{domxref("FileReader.result","result")}} attribute contains the data as a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) representing the
 file's data as a base64 encoded string.
 
-> **Note:** The blob's {{domxref("FileReader.result","result")}} cannot be
+> [!NOTE]
+> The blob's {{domxref("FileReader.result","result")}} cannot be
 > directly decoded as Base64 without first removing the Data-URL declaration preceding
 > the Base64-encoded data. To retrieve only the Base64 encoded string, first
 > remove `data:*/*;base64,` from the result.

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -12,9 +12,11 @@ The **`readAsText()`** method of the {{domxref("FileReader")}} interface is used
 When the read operation is complete, the {{domxref("FileReader.readyState","readyState")}} property is changed to `DONE`,
 the {{domxref("FileReader/loadend_event", "loadend")}} event is triggered, and the {{domxref("FileReader.result","result")}} property contains the contents of the file as a text string.
 
-> **Note:** The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as text.
+> [!NOTE]
+> The {{domxref("Blob.text()")}} method is a newer promise-based API to read a file as text.
 
-> **Note:** This method loads the entire file's content into memory and is not suitable for large files. Prefer {{domxref("FileReader.readAsArrayBuffer", "readAsArrayBuffer()")}} for large files.
+> [!NOTE]
+> This method loads the entire file's content into memory and is not suitable for large files. Prefer {{domxref("FileReader.readAsArrayBuffer", "readAsArrayBuffer()")}} for large files.
 
 ## Syntax
 

--- a/files/en-us/web/api/filereadersync/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/filereadersync/index.md
@@ -31,7 +31,8 @@ function readFile(blob) {
 }
 ```
 
-> **Note:** This snippet must be used inside a {{domxref("Worker")}}, as synchronous interfaces can't be used on the main thread.
+> [!NOTE]
+> This snippet must be used inside a {{domxref("Worker")}}, as synchronous interfaces can't be used on the main thread.
 
 ## Specifications
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.md
@@ -10,7 +10,8 @@ browser-compat: api.FileReaderSync.readAsBinaryString
 
 {{APIRef("File API")}}{{deprecated_header}} {{AvailableInWorkers("worker_except_service")}}
 
-> **Note:** This method is deprecated in favor of {{DOMxRef("FileReaderSync.readAsArrayBuffer","readAsArrayBuffer()")}}.
+> [!NOTE]
+> This method is deprecated in favor of {{DOMxRef("FileReaderSync.readAsArrayBuffer","readAsArrayBuffer()")}}.
 
 The **`readAsBinaryString()`** method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into a string. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 

--- a/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.md
@@ -65,7 +65,8 @@ a single parameter: a {{domxref("FileError")}} object describing the error. The
     - Too many file system calls are being made.
     - Other security concerns as raised by the user agent or the operating system.
 
-> **Note:** If you try to delete a directory which contains one or more files that can't be
+> [!NOTE]
+> If you try to delete a directory which contains one or more files that can't be
 > removed, or if an error occurs while deletion of a number of files is underway, some
 > files may not be deleted. You should provide an `errorCallback` to watch
 > for and handle this, perhaps by trying again.

--- a/files/en-us/web/api/filesystementry/isdirectory/index.md
+++ b/files/en-us/web/api/filesystementry/isdirectory/index.md
@@ -16,7 +16,8 @@ and `false` if it's not.
 You can also use {{domxref("FileSystemEntry.isFile", "isFile")}} to determine if the
 entry is a file.
 
-> **Warning:** You should not assume that any entry which isn't a directory is a file or vice versa.
+> [!WARNING]
+> You should not assume that any entry which isn't a directory is a file or vice versa.
 > There are other types of file descriptors on many operating systems. Be sure to use
 > both `isDirectory` and `isFile` as needed to ensure that the
 > entry is something you know how to work with.

--- a/files/en-us/web/api/filesystementry/isfile/index.md
+++ b/files/en-us/web/api/filesystementry/isfile/index.md
@@ -16,7 +16,8 @@ represents a file (meaning it's a {{domxref("FileSystemFileEntry")}}) and
 You can also use {{domxref("FileSystemEntry.isDirectory", "isDirectory")}} to determine
 if the entry is a directory.
 
-> **Warning:** You should not assume that any entry which isn't a file is a directory or vice versa.
+> [!WARNING]
+> You should not assume that any entry which isn't a file is a directory or vice versa.
 > There are other types of file descriptors on many operating systems. Be sure to use
 > both `isDirectory` and `isFile` as needed to ensure that the
 > entry is something you know how to work with.

--- a/files/en-us/web/api/filesystemfilehandle/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/index.md
@@ -118,7 +118,8 @@ onmessage = async (e) => {
 };
 ```
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Specifications
 

--- a/files/en-us/web/api/filesystemsync/index.md
+++ b/files/en-us/web/api/filesystemsync/index.md
@@ -12,7 +12,8 @@ browser-compat: api.FileSystemSync
 
 In the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction), a `FileSystemSync` object represents a file system. It has two properties.
 
-> **Warning:** This interface is deprecated and is no more on the standard track.
+> [!WARNING]
+> This interface is deprecated and is no more on the standard track.
 > _Do not use it anymore._ Use the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Basic concepts

--- a/files/en-us/web/api/filesystemsyncaccesshandle/close/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/close/index.md
@@ -11,7 +11,8 @@ browser-compat: api.FileSystemSyncAccessHandle.close
 The **`close()`** method of the
 {{domxref("FileSystemSyncAccessHandle")}} interface closes an open synchronous file handle, disabling any further operations on it and releasing the exclusive lock previously put on the file associated with the file handle.
 
-> **Note:** In earlier versions of the spec, `close()`, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, `close()`, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/flush/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/flush/index.md
@@ -13,7 +13,8 @@ The **`flush()`** method of the
 
 Bear in mind that you only need to call this method if you need the changes committed to disk at a specific time, otherwise you can leave the underlying operating system to handle this when it sees fit, which should be OK in most cases.
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, `flush()`, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, `flush()`, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/getsize/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/getsize/index.md
@@ -11,7 +11,8 @@ browser-compat: api.FileSystemSyncAccessHandle.getSize
 The **`getSize()`** method of the
 {{domxref("FileSystemSyncAccessHandle")}} interface returns the size of the file associated with the handle in bytes.
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, `getSize()`, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, `getSize()`, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/index.md
@@ -15,7 +15,8 @@ As a result, its methods are not subject to the same security checks as methods 
 
 The interface is accessed through the {{domxref('FileSystemFileHandle.createSyncAccessHandle()')}} method.
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Instance properties
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/read/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/read/index.md
@@ -79,7 +79,8 @@ onmessage = async (e) => {
 };
 ```
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Specifications
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/truncate/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/truncate/index.md
@@ -11,7 +11,8 @@ browser-compat: api.FileSystemSyncAccessHandle.truncate
 The **`truncate()`** method of the
 {{domxref("FileSystemSyncAccessHandle")}} interface resizes the file associated with the handle to a specified number of bytes.
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and `truncate()` were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and `truncate()` were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Syntax
 

--- a/files/en-us/web/api/filesystemsyncaccesshandle/write/index.md
+++ b/files/en-us/web/api/filesystemsyncaccesshandle/write/index.md
@@ -28,7 +28,8 @@ write(buffer, options)
     - `at`
       - : A number representing the offset in bytes from the start of the file that the buffer should be written at.
 
-> **Note:** You cannot directly manipulate the contents of an `ArrayBuffer`. Instead, you create a typed array object like an {{jsxref("Int8Array")}} or a {{jsxref("DataView")}} object, which represents the buffer in a specific format, and use that to read and write the contents of the buffer.
+> [!NOTE]
+> You cannot directly manipulate the contents of an `ArrayBuffer`. Instead, you create a typed array object like an {{jsxref("Int8Array")}} or a {{jsxref("DataView")}} object, which represents the buffer in a specific format, and use that to read and write the contents of the buffer.
 
 ### Return value
 
@@ -83,7 +84,8 @@ onmessage = async (e) => {
 };
 ```
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Specifications
 

--- a/files/en-us/web/api/formdata/append/index.md
+++ b/files/en-us/web/api/formdata/append/index.md
@@ -28,7 +28,8 @@ append(name, value, filename)
 - `filename` {{optional_inline}}
   - : The filename reported to the server (a string), when a {{domxref("Blob")}} or {{domxref("File")}} is passed as the second parameter. The default filename for {{domxref("Blob")}} objects is "blob". The default filename for {{domxref("File")}} objects is the file's filename.
 
-> **Note:** If you specify a {{domxref("Blob")}} as the data to append to the `FormData` object, the filename that will be reported to the server in the "Content-Disposition" header used to vary from browser to browser.
+> [!NOTE]
+> If you specify a {{domxref("Blob")}} as the data to append to the `FormData` object, the filename that will be reported to the server in the "Content-Disposition" header used to vary from browser to browser.
 
 ### Return value
 

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -54,7 +54,8 @@ formData.append("username", "Chris");
 
 You can specify the optional `form` and `submitter` arguments when creating the `FormData` object, to prepopulate it with values from the specified form.
 
-> **Note:** Only successful form controls are included in a FormData object, i.e. those with a name and not in a disabled state.
+> [!NOTE]
+> Only successful form controls are included in a FormData object, i.e. those with a name and not in a disabled state.
 
 #### HTML
 

--- a/files/en-us/web/api/formdata/set/index.md
+++ b/files/en-us/web/api/formdata/set/index.md
@@ -28,7 +28,8 @@ set(name, value, filename)
 - `filename` {{optional_inline}}
   - : The filename reported to the server (a string), when a {{domxref("Blob")}} or {{domxref("File")}} is passed as the second parameter. The default filename for {{domxref("Blob")}} objects is "blob". The default filename for {{domxref("File")}} objects is the file's filename.
 
-> **Note:** If you specify a {{domxref("Blob")}} as the data to append to the `FormData` object, the filename that will be reported to the server in the "Content-Disposition" header used to vary from browser to browser.
+> [!NOTE]
+> If you specify a {{domxref("Blob")}} as the data to append to the `FormData` object, the filename that will be reported to the server in the "Content-Disposition" header used to vary from browser to browser.
 
 ### Return value
 

--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -43,7 +43,8 @@ When fullscreen mode is successfully engaged, the document which contains the el
 
 It's not guaranteed that you'll be able to switch into fullscreen mode. For example, {{HTMLElement("iframe")}} elements have the [`allowfullscreen`](/en-US/docs/Web/HTML/Element/iframe#allowfullscreen) attribute in order to opt-in to allowing their content to be displayed in fullscreen mode. In addition, certain kinds of content, such as windowed plug-ins, cannot be presented in fullscreen mode. Attempting to put an element which can't be displayed in fullscreen mode (or the parent or descendant of such an element) won't work. Instead, the element which requested fullscreen will receive a `mozfullscreenerror` event. When a fullscreen request fails, Firefox will log an error message to the Web Console explaining why the request failed. In Chrome and newer versions of Opera however, no such warning is generated.
 
-> **Note:** Fullscreen requests need to be called from within an event handler or otherwise they will be denied.
+> [!NOTE]
+> Fullscreen requests need to be called from within an event handler or otherwise they will be denied.
 
 ## Getting out of full screen mode
 

--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -47,7 +47,8 @@ The Fullscreen API adds methods to the {{DOMxRef("Document")}} and {{DOMxRef("El
 
   - : A Boolean value which is `true` if the document has an element currently being displayed in fullscreen mode; otherwise, this returns `false`.
 
-    > **Note:** Use the {{DOMxRef("Document.fullscreenElement", "fullscreenElement")}} property on the {{DOMxRef("Document")}} or {{DOMxRef("ShadowRoot")}} instead; if it's not `null`, then it's an {{DOMxRef("Element")}} currently being displayed in fullscreen mode.
+    > [!NOTE]
+    > Use the {{DOMxRef("Document.fullscreenElement", "fullscreenElement")}} property on the {{DOMxRef("Document")}} or {{DOMxRef("ShadowRoot")}} instead; if it's not `null`, then it's an {{DOMxRef("Element")}} currently being displayed in fullscreen mode.
 
 ## Events
 
@@ -64,7 +65,8 @@ The availability of fullscreen mode can be controlled using a [Permissions Polic
 
 Users can choose to exit fullscreen mode by pressing the <kbd>ESC</kbd> (or <kbd>F11</kbd>) key, rather than waiting for the site or app to programmatically do so. Make sure you provide, somewhere in your user interface, appropriate user interface elements that inform the user that this option is available to them.
 
-> **Note:** Navigating to another page, changing tabs, or switching to another application using any application switcher (or <kbd>Alt</kbd>-<kbd>Tab</kbd>) will likewise exit fullscreen mode.
+> [!NOTE]
+> Navigating to another page, changing tabs, or switching to another application using any application switcher (or <kbd>Alt</kbd>-<kbd>Tab</kbd>) will likewise exit fullscreen mode.
 
 ## Examples
 

--- a/files/en-us/web/api/gainnode/gain/index.md
+++ b/files/en-us/web/api/gainnode/gain/index.md
@@ -14,7 +14,8 @@ The `gain` property of the {{ domxref("GainNode") }} interface is an [a-rate](/e
 
 An {{domxref("AudioParam")}}.
 
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -15,7 +15,8 @@ The **`displayId`** read-only property of the {{domxref("Gamepad")}} interface _
 
 A Gamepad is considered to be associated with a {{domxref("VRDisplay")}} if it reports a pose that is in the same space as the display's pose, see {{domxref("VRDisplay.getPose()")}}.
 
-> **Note:** This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute). It has been superseded by the [WebXR Gamepads Module](https://immersive-web.github.io/webxr-gamepads-module/).
+> [!NOTE]
+> This property was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/#gamepad-getvrdisplays-attribute). It has been superseded by the [WebXR Gamepads Module](https://immersive-web.github.io/webxr-gamepads-module/).
 >
 > There is no direct replacement for this property. The {{domxref("Gamepad")}} object associated with an {{domxref("XRInputSource")}} can be obtained using the {{domxref("XRInputSource.gamepad")}} property.
 

--- a/files/en-us/web/api/gamepad/timestamp/index.md
+++ b/files/en-us/web/api/gamepad/timestamp/index.md
@@ -19,7 +19,8 @@ relative to the `navigationStart` attribute of the
 increasing, meaning that they can be compared to determine the ordering of updates, as
 newer values will always be greater than or equal to older values.
 
-> **Note:** This property is not currently supported anywhere.
+> [!NOTE]
+> This property is not currently supported anywhere.
 
 ## Value
 

--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -15,7 +15,8 @@ The [Gamepad API](/en-US/docs/Web/API/Gamepad_API) introduces new events on the 
 
 When a new gamepad is connected to the computer, the focused page first receives a {{ domxref("Window/gamepadconnected_event", "gamepadconnected") }} event. If a gamepad is already connected when the page loaded, the {{ domxref("Window/gamepadconnected_event", "gamepadconnected") }} event is dispatched to the focused page when the user presses a button or moves an axis.
 
-> **Note:** In Firefox, gamepads are only exposed to a page when the user interacts with one with the page visible. This helps prevent gamepads from being used for [fingerprinting](/en-US/docs/Glossary/Fingerprinting) the user. Once one gamepad has been interacted with, other gamepads that are connected will automatically be visible.
+> [!NOTE]
+> In Firefox, gamepads are only exposed to a page when the user interacts with one with the page visible. This helps prevent gamepads from being used for [fingerprinting](/en-US/docs/Glossary/Fingerprinting) the user. Once one gamepad has been interacted with, other gamepads that are connected will automatically be visible.
 
 You can use {{domxref("Window/gamepadconnected_event", "gamepadconnected")}} like this:
 
@@ -117,7 +118,8 @@ The {{ domxref("Gamepad") }} object's properties are as follows:
 - `axes`: An array representing the controls with axes present on the device (e.g. analog thumb sticks). Each entry in the array is a floating point value in the range -1.0 - 1.0, representing the axis position from the lowest value (-1.0) to the highest value (1.0).
 - `timestamp`: This returns a {{ domxref("DOMHighResTimeStamp") }} representing the last time the data for this gamepad was updated, allowing developers to determine if the `axes` and `button` data have been updated from the hardware. The value must be relative to the `navigationStart` attribute of the {{ domxref("PerformanceTiming") }} interface. Values are monotonically increasing, meaning that they can be compared to determine the ordering of updates, as newer values will always be greater than or equal to older values. Note that this property is not currently supported in Firefox.
 
-> **Note:** The Gamepad object is available on the {{ domxref("Window/gamepadconnected_event", "gamepadconnected") }} event rather than the {{ domxref("Window") }} object itself, for security reasons. Once we have a reference to it, we can query its properties for information about the current state of the gamepad. Behind the scenes, this object will be updated every time the gamepad's state changes.
+> [!NOTE]
+> The Gamepad object is available on the {{ domxref("Window/gamepadconnected_event", "gamepadconnected") }} event rather than the {{ domxref("Window") }} object itself, for security reasons. Once we have a reference to it, we can query its properties for information about the current state of the gamepad. Behind the scenes, this object will be updated every time the gamepad's state changes.
 
 ### Using button information
 

--- a/files/en-us/web/api/gamepadhapticactuator/effects/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/effects/index.md
@@ -21,7 +21,8 @@ An array representing the supported haptic effects. Possible included values are
 - `"trigger-rumble"`
   - : Localized rumbling effects on the surface of a controller's trigger buttons created by vibrational motors located in each button. These buttons most commonly take the form of spring-loaded triggers.
 
-> **Note:** If an effect is not listed that is known to be supported by the hardware, it may be that the browser does not support playing effects of that type.
+> [!NOTE]
+> If an effect is not listed that is known to be supported by the hardware, it may be that the browser does not support playing effects of that type.
 
 ## Examples
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -47,7 +47,8 @@ playEffect(type, params)
       - : The rumble intensity of the bottom-right front trigger, normalized to the range between `0.0` and `1.0`.
         Defaults to `0.0`.
 
-> **Note:** A new call to `playEffect()` overrides a previous ongoing call.
+> [!NOTE]
+> A new call to `playEffect()` overrides a previous ongoing call.
 
 ### Return value
 

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
@@ -23,7 +23,8 @@ pulse(value, duration)
 - `duration`
   - : A double representing the duration of the pulse, in milliseconds.
 
-> **Note:** Repeated calls to `pulse()` override the previous calls if they are still ongoing.
+> [!NOTE]
+> Repeated calls to `pulse()` override the previous calls if they are still ongoing.
 
 ### Return value
 

--- a/files/en-us/web/api/gamepadpose/orientation/index.md
+++ b/files/en-us/web/api/gamepadpose/orientation/index.md
@@ -29,7 +29,8 @@ A {{jsxref("Float32Array")}}, or `null` if the VR sensor is not able to provide 
 
 TBD
 
-> **Note:** An orientation of `{ x: 0, y: 0, z: 0, w: 1 }` is considered to be "forward".
+> [!NOTE]
+> An orientation of `{ x: 0, y: 0, z: 0, w: 1 }` is considered to be "forward".
 
 ## Specifications
 

--- a/files/en-us/web/api/gamepadpose/position/index.md
+++ b/files/en-us/web/api/gamepadpose/position/index.md
@@ -24,7 +24,8 @@ Positions are measured in meters from an origin point — this point is the posi
 
 A {{jsxref("Float32Array")}}, or `null` if the gamepad is not able to provide position data.
 
-> **Note:** User agents may provide emulated position values through certain techniques; when doing so they should still report {{domxref("GamepadPose.hasPosition")}} as false.
+> [!NOTE]
+> User agents may provide emulated position values through certain techniques; when doing so they should still report {{domxref("GamepadPose.hasPosition")}} as false.
 
 ## Examples
 

--- a/files/en-us/web/api/geolocation/index.md
+++ b/files/en-us/web/api/geolocation/index.md
@@ -11,7 +11,8 @@ The **`Geolocation`** interface represents an object able to obtain the position
 
 An object with this interface is obtained using the {{domxref("navigator.geolocation")}} property implemented by the {{domxref("Navigator")}} object.
 
-> **Note:** For security reasons, when a web page tries to access location information, the user is notified and asked to grant permission. Be aware that each browser has its own policies and methods for requesting this permission.
+> [!NOTE]
+> For security reasons, when a web page tries to access location information, the user is notified and asked to grant permission. Be aware that each browser has its own policies and methods for requesting this permission.
 
 ## Instance properties
 

--- a/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.md
@@ -26,7 +26,8 @@ if ("geolocation" in navigator) {
 
 To obtain the user's current location, you can call the {{domxref("Geolocation.getCurrentPosition","getCurrentPosition()")}} method. This initiates an asynchronous request to detect the user's position, and queries the positioning hardware to get up-to-date information. When the position is determined, the defined callback function is executed. You can optionally provide a second callback function to be executed if an error occurs. A third, optional, parameter is an options object where you can set the maximum age of the position returned, the time to wait for a request, and if you want high accuracy for the position.
 
-> **Note:** By default, {{domxref("Geolocation.getCurrentPosition","getCurrentPosition()")}} tries to answer as fast as possible with a low accuracy result. It is useful if you need a quick answer regardless of the accuracy. Devices with a GPS, for example, can take a minute or more to get a GPS fix, so less accurate data (IP location or Wi-Fi) may be returned to `getCurrentPosition()`.
+> [!NOTE]
+> By default, {{domxref("Geolocation.getCurrentPosition","getCurrentPosition()")}} tries to answer as fast as possible with a low accuracy result. It is useful if you need a quick answer regardless of the accuracy. Devices with a GPS, for example, can take a minute or more to get a GPS fix, so less accurate data (IP location or Wi-Fi) may be returned to `getCurrentPosition()`.
 
 ```js
 navigator.geolocation.getCurrentPosition((position) => {
@@ -40,7 +41,8 @@ The above example will cause the `doSomething()` function to execute when the lo
 
 If the position data changes (either by device movement or if more accurate geo information arrives), you can set up a callback function that is called with that updated position information. This is done using the {{domxref("Geolocation.watchPosition","watchPosition()")}} function, which has the same input parameters as {{domxref("Geolocation.getCurrentPosition","getCurrentPosition()")}}. The callback function is called multiple times, allowing the browser to either update your location as you move, or provide a more accurate location as different techniques are used to geolocate you. The error callback function, which is optional just as it is for `getCurrentPosition()`, can be called repeatedly.
 
-> **Note:** You can use {{domxref("Geolocation.watchPosition","watchPosition()")}} without an initial {{domxref("Geolocation.getCurrentPosition","getCurrentPosition()")}} call.
+> [!NOTE]
+> You can use {{domxref("Geolocation.watchPosition","watchPosition()")}} without an initial {{domxref("Geolocation.getCurrentPosition","getCurrentPosition()")}} call.
 
 ```js
 const watchID = navigator.geolocation.watchPosition((position) => {

--- a/files/en-us/web/api/geolocationcoordinates/longitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/longitude/index.md
@@ -17,7 +17,8 @@ The value in `longitude` is the geographical longitude of the location on
 Earth described by the `Coordinates` object, in decimal degrees. The value is
 defined by the World Geodetic System 1984 specification (WGS 84).
 
-> **Note:** The zero meridian (also known as the prime meridian or the
+> [!NOTE]
+> The zero meridian (also known as the prime meridian or the
 > reference meridian) is not precisely the same as the Greenwich meridian that most
 > people think of. It is, instead, the [IERS Reference Meridian](https://en.wikipedia.org/wiki/IERS_Reference_Meridian), which is located 5.3 [arcseconds](https://en.wikipedia.org/wiki/Arcseconds) (102
 > meters / 335 feet) east of the [Greenwich meridian](https://en.wikipedia.org/wiki/Greenwich_meridian). This

--- a/files/en-us/web/api/gpu/requestadapter/index.md
+++ b/files/en-us/web/api/gpu/requestadapter/index.md
@@ -38,7 +38,8 @@ requestAdapter(options)
 
         This hint's primary purpose is to influence which GPU is used in a multi-GPU system. For instance, some laptops have a low-power integrated GPU and a high-performance discrete GPU. Different factors may affect which adapter is returned including battery status, attached displays, or removable GPUs.
 
-        > **Note:** On Chrome running on dual-GPU macOS devices, if `requestAdapter()` is called without a `powerPreference` option, the high-performance discrete GPU is returned when the user's device is on AC power. Otherwise, the low-power integrated GPU is returned.
+        > [!NOTE]
+        > On Chrome running on dual-GPU macOS devices, if `requestAdapter()` is called without a `powerPreference` option, the high-performance discrete GPU is returned when the user's device is on AC power. Otherwise, the low-power integrated GPU is returned.
 
 ### Fallback adapters
 
@@ -46,7 +47,8 @@ The adapter provided by the user agent may be a **fallback adapter**, if it dete
 
 If you wish to prevent your apps from running on fallback adapters, you should check the {{domxref("GPUAdapter.isFallbackAdapter")}} attribute prior to requesting a {{domxref("GPUDevice")}}.
 
-> **Note:** The specification includes a `forceFallbackAdapter` option for `requestAdapter()`. This is a boolean that, if set to `true`, forces the user agent to return a fallback adapter if one is available. This is not yet supported by any browser.
+> [!NOTE]
+> The specification includes a `forceFallbackAdapter` option for `requestAdapter()`. This is a boolean that, if set to `true`, forces the user agent to return a fallback adapter if one is available. This is not yet supported by any browser.
 
 ### Return value
 

--- a/files/en-us/web/api/gpu/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/gpu/wgsllanguagefeatures/index.md
@@ -13,7 +13,8 @@ browser-compat: api.GPU.wgslLanguageFeatures
 The **`wgslLanguageFeatures`** read-only property of the
 {{domxref("GPU")}} interface returns a {{domxref("WGSLLanguageFeatures")}} object that reports the [WGSL language extensions](https://gpuweb.github.io/gpuweb/wgsl/#language-extension) supported by the WebGPU implementation.
 
-> **Note:** Not all WGSL language extensions are available to WebGPU in all browsers that support the API. We recommend you thoroughly test any extensions you choose to use.
+> [!NOTE]
+> Not all WGSL language extensions are available to WebGPU in all browsers that support the API. We recommend you thoroughly test any extensions you choose to use.
 
 ## Value
 

--- a/files/en-us/web/api/gpuadapter/requestadapterinfo/index.md
+++ b/files/en-us/web/api/gpuadapter/requestadapterinfo/index.md
@@ -15,7 +15,8 @@ The **`requestAdapterInfo()`** method of the
 
 The intention behind this method is to allow developers to request specific details about the user's GPU so that they can preemptively apply workarounds for GPU-specific bugs, or provide different codepaths to better suit different GPU architectures. Providing such information does present a security risk — it could be used for fingerprinting — therefore the information shared is to be kept at a minimum, and different browser vendors are likely to share different information types and granularities.
 
-> **Note:** The specification includes an `unmaskHints` parameter for `requestAdapterInfo()`, which is intended to mitigate the security risk mentioned above. Once it is supported, developers will be able to specify the values they really need to know, and users will be given a permission prompt asking them if they are OK to share this information when the method is invoked. Browser vendors are likely to share more useful information if it is guarded by a permissions prompt, as it makes the method a less viable target for fingerprinting.
+> [!NOTE]
+> The specification includes an `unmaskHints` parameter for `requestAdapterInfo()`, which is intended to mitigate the security risk mentioned above. Once it is supported, developers will be able to specify the values they really need to know, and users will be given a permission prompt asking them if they are OK to share this information when the method is invoked. Browser vendors are likely to share more useful information if it is guarded by a permissions prompt, as it makes the method a less viable target for fingerprinting.
 
 ## Syntax
 

--- a/files/en-us/web/api/gpuadapter/requestdevice/index.md
+++ b/files/en-us/web/api/gpuadapter/requestdevice/index.md
@@ -33,7 +33,8 @@ requestDevice(descriptor)
     - `requiredLimits` {{optional_inline}}
       - : An object containing properties representing the limits that you want supported by the returned {{domxref("GPUDevice")}}. The `requestDevice()` call will fail if the `GPUAdapter` cannot provide these limits. Each key must be the name of a member of {{domxref("GPUSupportedLimits")}}. This defaults to an empty object if no value is provided.
 
-> **Note:** Not all features and limits will be available to WebGPU in all browsers that support it, even if they are supported by the underlying hardware. See the {{domxref("GPUAdapter.features", "features")}} and {{domxref("GPUAdapter.limits", "limits")}} pages for more information.
+> [!NOTE]
+> Not all features and limits will be available to WebGPU in all browsers that support it, even if they are supported by the underlying hardware. See the {{domxref("GPUAdapter.features", "features")}} and {{domxref("GPUAdapter.limits", "limits")}} pages for more information.
 
 ### Return value
 

--- a/files/en-us/web/api/gpubindgroup/index.md
+++ b/files/en-us/web/api/gpubindgroup/index.md
@@ -22,7 +22,8 @@ A `GPUBindGroup` object instance is created using the {{domxref("GPUDevice.creat
 
 ## Examples
 
-> **Note:** The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
+> [!NOTE]
+> The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
 
 ### Basic example
 

--- a/files/en-us/web/api/gpubindgrouplayout/index.md
+++ b/files/en-us/web/api/gpubindgrouplayout/index.md
@@ -22,7 +22,8 @@ A `GPUBindGroupLayout` object instance is created using the {{domxref("GPUDevice
 
 ## Examples
 
-> **Note:** The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
+> [!NOTE]
+> The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
 
 ### Basic example
 

--- a/files/en-us/web/api/gpucommandbuffer/index.md
+++ b/files/en-us/web/api/gpucommandbuffer/index.md
@@ -13,7 +13,8 @@ The **`GPUCommandBuffer`** interface of the {{domxref("WebGPU API", "WebGPU API"
 
 A `GPUCommandBuffer` is created via the {{domxref("GPUCommandEncoder.finish()")}} method; the GPU commands recorded within are submitted for execution by passing the `GPUCommandBuffer` into the parameter of a {{domxref("GPUQueue.submit()")}} call.
 
-> **Note:** Once a `GPUCommandBuffer` object has been submitted, it cannot be used again.
+> [!NOTE]
+> Once a `GPUCommandBuffer` object has been submitted, it cannot be used again.
 
 {{InheritanceDiagram}}
 
@@ -31,7 +32,8 @@ const commandBuffer = commandEncoder.finish();
 device.queue.submit([commandBuffer]);
 ```
 
-> **Note:** Study the [WebGPU samples](https://webgpu.github.io/webgpu-samples/) to find complete examples.
+> [!NOTE]
+> Study the [WebGPU samples](https://webgpu.github.io/webgpu-samples/) to find complete examples.
 
 ## Specifications
 

--- a/files/en-us/web/api/gpucommandencoder/begincomputepass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/begincomputepass/index.md
@@ -38,7 +38,8 @@ beginComputePass(descriptor)
         - `queryIndex`: A number specifying the index position in the `querySet` that the timestamp will be written to.
         - `querySet`: The {{domxref("GPUQuerySet")}} that the timestamp will be written to.
 
-        > **Note:** To use timestamp queries, the `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} must be enabled in the {{domxref("GPUDevice")}}.
+        > [!NOTE]
+        > To use timestamp queries, the `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} must be enabled in the {{domxref("GPUDevice")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
+++ b/files/en-us/web/api/gpucommandencoder/beginrenderpass/index.md
@@ -45,7 +45,8 @@ beginRenderPass(descriptor)
         - `queryIndex`: A number specifying the index position in the `querySet` that the timestamp will be written to.
         - `querySet`: The {{domxref("GPUQuerySet")}} that the timestamp will be written to.
 
-        > **Note:** To use timestamp queries, the `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} must be enabled in the {{domxref("GPUDevice")}}.
+        > [!NOTE]
+        > To use timestamp queries, the `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} must be enabled in the {{domxref("GPUDevice")}}.
 
 ### Color attachment object structure
 
@@ -81,7 +82,8 @@ Color attachment objects can have the following properties:
     - `"clear"`: Loads the `clearValue` for this attachment into the render pass.
     - `"load"`: Loads the existing value for this attachment into the render pass.
 
-    > **Note:** It is recommended to always use `"clear"` in cases where the initial value doesn't matter, as it will give better performance on some devices such as mobiles.
+    > [!NOTE]
+    > It is recommended to always use `"clear"` in cases where the initial value doesn't matter, as it will give better performance on some devices such as mobiles.
 
 - `storeOp`
   - : An enumerated value indicating the store operation to perform on `view` after executing the render pass. Possible values are:
@@ -93,7 +95,8 @@ Color attachment objects can have the following properties:
 
   - : A {{domxref("GPUTextureView")}} object representing the texture subresource that will be output to for this color attachment.
 
-    > **Note:** Each color or depth/stencil attachment must be a unique texture subresource, and texture subresources used as attachments cannot be used inside the render pass.
+    > [!NOTE]
+    > Each color or depth/stencil attachment must be a unique texture subresource, and texture subresources used as attachments cannot be used inside the render pass.
 
 ### Depth/stencil attachment object structure
 
@@ -112,7 +115,8 @@ The `depthStencilAttachment` object can have the following properties:
     - `"clear"`: Loads the `clearValue` for this attachment into the render pass.
     - `"load"`: Loads the existing value for this attachment into the render pass.
 
-    > **Note:** It is recommended to always use `"clear"` in cases where the initial value doesn't matter, as it will give better performance on some devices such as mobiles.
+    > [!NOTE]
+    > It is recommended to always use `"clear"` in cases where the initial value doesn't matter, as it will give better performance on some devices such as mobiles.
 
 - `depthReadOnly` {{optional_inline}}
   - : A boolean. Setting the value to `true` causes the depth component of `view` to be read-only. If `depthReadOnly` is omitted, it defaults to `false`.
@@ -133,7 +137,8 @@ The `depthStencilAttachment` object can have the following properties:
     - `"clear"`: Loads the `clearValue` for this attachment into the render pass.
     - `"load"`: Loads the existing value for this attachment into the render pass.
 
-    > **Note:** It is recommended to always use `"clear"` in cases where the initial value doesn't matter, as it will give better performance on some devices such as mobiles.
+    > [!NOTE]
+    > It is recommended to always use `"clear"` in cases where the initial value doesn't matter, as it will give better performance on some devices such as mobiles.
 
 - `stencilReadOnly` {{optional_inline}}
   - : A boolean. Setting the value to `true` causes the stencil component of `view` to be read-only. If `stencilReadOnly` is omitted, it defaults to `false`.

--- a/files/en-us/web/api/gpucommandencoder/index.md
+++ b/files/en-us/web/api/gpucommandencoder/index.md
@@ -97,7 +97,8 @@ The commands encoded by the `GPUCommandEncoder` are recoded into a {{domxref("GP
 device.queue.submit([commandEncoder.finish()]);
 ```
 
-> **Note:** Study the [WebGPU samples](https://webgpu.github.io/webgpu-samples/) to find more command encoding examples.
+> [!NOTE]
+> Study the [WebGPU samples](https://webgpu.github.io/webgpu-samples/) to find more command encoding examples.
 
 ## Specifications
 

--- a/files/en-us/web/api/gpucommandencoder/writetimestamp/index.md
+++ b/files/en-us/web/api/gpucommandencoder/writetimestamp/index.md
@@ -13,7 +13,8 @@ browser-compat: api.GPUCommandEncoder.writeTimestamp
 The **`writeTimestamp()`** method of the
 {{domxref("GPUCommandEncoder")}} interface encodes a command that writes a timestamp into a {{domxref("GPUQuerySet")}} once the previous commands recorded into the same queued {{domxref("GPUCommandBuffer")}} have been executed by the GPU.
 
-> **Note:** To use timestamp queries, the `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} must be enabled in the {{domxref("GPUDevice")}}.
+> [!NOTE]
+> To use timestamp queries, the `timestamp-query` {{domxref("GPUSupportedFeatures", "feature", "", "nocode")}} must be enabled in the {{domxref("GPUDevice")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroups/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroups/index.md
@@ -30,7 +30,8 @@ dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)
 - `workgroupCountZ` {{optional_inline}}
   - : The Z dimension of the grid of workgroups to dispatch. If omitted, `workgroupCountZ` defaults to 1.
 
-> **Note:** The X, Y, and Z dimension values passed to `dispatchWorkgroups()` and {{domxref("GPUComputePassEncoder.dispatchWorkgroupsIndirect()")}} are the number of workgroups to dispatch for each dimension, not the number of shader invocations to perform across each dimension. This matches the behavior of modern native GPU APIs, but differs from the behavior of OpenCL. This means that if a {{domxref("GPUShaderModule")}} defines an entry point with `@workgroup_size(4, 4)`, and work is dispatched to it with the call `passEncoder.dispatchWorkgroups(8, 8);`, the entry point will be invoked 1024 times total — Dispatching a 4 x 4 workgroup 8 times along both the X and Y axes. `4 * 4 * 8 * 8 = 1024`.
+> [!NOTE]
+> The X, Y, and Z dimension values passed to `dispatchWorkgroups()` and {{domxref("GPUComputePassEncoder.dispatchWorkgroupsIndirect()")}} are the number of workgroups to dispatch for each dimension, not the number of shader invocations to perform across each dimension. This matches the behavior of modern native GPU APIs, but differs from the behavior of OpenCL. This means that if a {{domxref("GPUShaderModule")}} defines an entry point with `@workgroup_size(4, 4)`, and work is dispatched to it with the call `passEncoder.dispatchWorkgroups(8, 8);`, the entry point will be invoked 1024 times total — Dispatching a 4 x 4 workgroup 8 times along both the X and Y axes. `4 * 4 * 8 * 8 = 1024`.
 
 ### Return value
 

--- a/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroupsindirect/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroupsindirect/index.md
@@ -38,7 +38,8 @@ dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)
 - `indirectOffset`
   - : The offset, in bytes, into `indirectBuffer` where the dimension data begins.
 
-> **Note:** The X, Y, and Z dimension values passed to {{domxref("GPUComputePassEncoder.dispatchWorkgroups()")}} and `dispatchWorkgroupsIndirect()` are the number of workgroups to dispatch for each dimension, not the number of shader invocations to perform across each dimension. This matches the behavior of modern native GPU APIs, but differs from the behavior of OpenCL. This means that if a {{domxref("GPUShaderModule")}} defines an entry point with `@workgroup_size(4, 4)`, and work is dispatched to it with the call `dispatchWorkgroupsIndirect(indirectBuffer);` with `indirectBuffer` specifying X and Y dimensions of 8 and 8, the entry point will be invoked 1024 times total — Dispatching a 4 x 4 workgroup 8 times along both the X and Y axes. `4 * 4 * 8 * 8 = 1024`.
+> [!NOTE]
+> The X, Y, and Z dimension values passed to {{domxref("GPUComputePassEncoder.dispatchWorkgroups()")}} and `dispatchWorkgroupsIndirect()` are the number of workgroups to dispatch for each dimension, not the number of shader invocations to perform across each dimension. This matches the behavior of modern native GPU APIs, but differs from the behavior of OpenCL. This means that if a {{domxref("GPUShaderModule")}} defines an entry point with `@workgroup_size(4, 4)`, and work is dispatched to it with the call `dispatchWorkgroupsIndirect(indirectBuffer);` with `indirectBuffer` specifying X and Y dimensions of 8 and 8, the entry point will be invoked 1024 times total — Dispatching a 4 x 4 workgroup 8 times along both the X and Y axes. `4 * 4 * 8 * 8 = 1024`.
 
 ### Return value
 

--- a/files/en-us/web/api/gpucomputepipeline/getbindgrouplayout/index.md
+++ b/files/en-us/web/api/gpucomputepipeline/getbindgrouplayout/index.md
@@ -39,7 +39,8 @@ The following criteria must be met when calling **`getBindGroupLayout()`**, othe
 
 ## Examples
 
-> **Note:** You can see complete working examples with `getBindGroupLayout()` in action in the [WebGPU samples](https://webgpu.github.io/webgpu-samples/).
+> [!NOTE]
+> You can see complete working examples with `getBindGroupLayout()` in action in the [WebGPU samples](https://webgpu.github.io/webgpu-samples/).
 
 ```js
 // ...

--- a/files/en-us/web/api/gpucomputepipeline/index.md
+++ b/files/en-us/web/api/gpucomputepipeline/index.md
@@ -27,7 +27,8 @@ A `GPUComputePipeline` object instance can be created using the {{domxref("GPUDe
 
 ## Examples
 
-> **Note:** The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
+> [!NOTE]
+> The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
 
 ### Basic example
 

--- a/files/en-us/web/api/gpudevice/createbindgroup/index.md
+++ b/files/en-us/web/api/gpudevice/createbindgroup/index.md
@@ -85,7 +85,8 @@ The following criteria must be met when calling **`createBindGroup()`**, otherwi
 
 ## Examples
 
-> **Note:** The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
+> [!NOTE]
+> The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
 
 ### Basic example
 

--- a/files/en-us/web/api/gpudevice/createbindgrouplayout/index.md
+++ b/files/en-us/web/api/gpudevice/createbindgrouplayout/index.md
@@ -153,7 +153,8 @@ The following criteria must be met when calling **`createBindGroupLayout()`**, o
 
 ## Examples
 
-> **Note:** The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
+> [!NOTE]
+> The [WebGPU samples](https://webgpu.github.io/webgpu-samples/) feature many more examples.
 
 ### Basic example
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 5.
