### PR TITLE
Convert noteblocks for web/api folder (part 7)

### DIFF
--- a/files/en-us/web/api/htmlimageelement/x/index.md
+++ b/files/en-us/web/api/htmlimageelement/x/index.md
@@ -34,7 +34,8 @@ left edge of the content area.
 
 ![Diagram showing the relationships between the various boxes associated with an element](boxmodel-3.png)
 
-> **Note:** The `x` property is only valid if the computed
+> [!NOTE]
+> The `x` property is only valid if the computed
 > value of the image's {{cssxref("display")}} property is either
 > `table-column` or `table-column-group`; in other words, either
 > of those are set directly on the {{HTMLElement("img")}} or they're inherited from a

--- a/files/en-us/web/api/htmlimageelement/y/index.md
+++ b/files/en-us/web/api/htmlimageelement/y/index.md
@@ -34,7 +34,8 @@ edge of the content area.
 
 ![Diagram showing the relationships between the various boxes associated with an element](boxmodel-3.png)
 
-> **Note:** The `y` property is only valid if the computed
+> [!NOTE]
+> The `y` property is only valid if the computed
 > value of the image's {{cssxref("display")}} property is either
 > `table-column` or `table-column-group`; in other words,
 > either of those are set directly on the {{HTMLElement("img")}} or they're

--- a/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetaction/index.md
@@ -70,7 +70,8 @@ if (supportsPopover()) {
 }
 ```
 
-> **Note:** A popover element is hidden by default, but if the API is not supported your element will display "as usual".
+> [!NOTE]
+> A popover element is hidden by default, but if the API is not supported your element will display "as usual".
 
 You can try out the example below.
 Show and hide the popover by toggling the button.

--- a/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/popovertargetelement/index.md
@@ -83,7 +83,8 @@ if (supportsPopover()) {
 }
 ```
 
-> **Note:** A popover element is hidden by default, but if the API is not supported your element will display "as usual".
+> [!NOTE]
+> A popover element is hidden by default, but if the API is not supported your element will display "as usual".
 
 You can try out the example below.
 Show and hide the popover by toggling the button.

--- a/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectiondirection/index.md
@@ -21,9 +21,11 @@ A string. It can have one of the following values:
 - `none`
   - : The user is not extending the selection.
 
-> **Note:** On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
+> [!NOTE]
+> On Windows, the direction indicates the position of the caret relative to the selection: a "forward" selection has the caret at the end of the selection and a "backward" selection has the caret at the start of the selection. Windows has no "none" direction.
 
-> **Note:** On Mac, the direction indicates which end of the selection is affected when the user adjusts the size of the selection using the arrow keys with the Shift modifier: the "forward" direction means the end of the selection is modified, and the "backward" direction means the start of the selection is modified. The "none" direction is the default on Mac, it indicates that no particular direction has yet been selected. The user sets the direction implicitly when first adjusting the selection, based on which directional arrow key was used.
+> [!NOTE]
+> On Mac, the direction indicates which end of the selection is affected when the user adjusts the size of the selection using the arrow keys with the Shift modifier: the "forward" direction means the end of the selection is modified, and the "backward" direction means the start of the selection is modified. The "none" direction is the default on Mac, it indicates that no particular direction has yet been selected. The user sets the direction implicitly when first adjusting the selection, based on which directional arrow key was used.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.HTMLInputElement.selectionEnd
 
 The **`selectionEnd`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the end index of the selected text. When there is no selection, this returns the offset of the character immediately following the current text input cursor position.
 
-> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
+> [!NOTE]
+> According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionEnd` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionEnd` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionEnd` property on non-text input elements.
 
 If `selectionEnd` is less than `selectionStart`, then both are
 treated as the value of `selectionEnd`.

--- a/files/en-us/web/api/htmlinputelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.HTMLInputElement.selectionStart
 
 The **`selectionStart`** property of the {{domxref("HTMLInputElement")}} interface is a number that represents the beginning index of the selected text. When nothing is selected, then returns the position of the text input cursor (caret) inside of the `<input>` element.
 
-> **Note:** According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
+> [!NOTE]
+> According to the [WHATWG forms spec](https://html.spec.whatwg.org/multipage/forms.html#concept-input-apply) `selectionStart` property applies only to inputs of types text, search, URL, tel, and password. In modern browsers, throws an exception while setting `selectionStart` property on the rest of input types. Additionally, this property returns `null` while accessing `selectionStart` property on non-text input elements.
 
 If `selectionStart` is greater than `selectionEnd`, then both are
 treated as the value of `selectionEnd`.

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -60,7 +60,8 @@ if ("showPicker" in HTMLInputElement.prototype) {
 
 This example shows how this feature can be used for `color` and `file` input pickers.
 
-> **Note:** Pickers for `date`, `datetime-local`, `month`, `time`, `week` are launched in the same way.
+> [!NOTE]
+> Pickers for `date`, `datetime-local`, `month`, `time`, `week` are launched in the same way.
 > They cannot be shown here because live examples run in a cross-origin frame, and would cause a [`SecurityError`](#securityerror)
 
 #### HTML

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -14,7 +14,8 @@ and indicates that the {{HTMLElement("input")}} element should let the user sele
 When a directory is selected, the directory and its entire hierarchy of contents are included in the set of selected items.
 The selected file system entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} property.
 
-> **Note:** This property is called `webkitEntries` in the specification due to its
+> [!NOTE]
+> This property is called `webkitEntries` in the specification due to its
 > origins as a Google Chrome-specific API. It's likely to be renamed someday.
 
 ## Value
@@ -62,7 +63,8 @@ The entry for `PIC2343.jpg` will have a `webkitRelativePath` of
 `PhotoAlbums/Birthdays/Don's 40th birthday/PIC2343.jpg`. This makes it
 possible to know the hierarchy even though the {{domxref("FileList")}} is flat.
 
-> **Note:** The behavior of `webkitRelativePath` is different
+> [!NOTE]
+> The behavior of `webkitRelativePath` is different
 > in _Chromium < 72_. See [this bug](https://crbug.com/124187) for
 > further details.
 

--- a/files/en-us/web/api/htmlinputelement/webkitentries/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitentries/index.md
@@ -20,7 +20,8 @@ The array can only contain directories if the
 `true`. This means the `<input>` element was configured to
 let the user choose directories.
 
-> **Note:** This property is called `webkitEntries` in the specification due to its
+> [!NOTE]
+> This property is called `webkitEntries` in the specification due to its
 > origins as a Google Chrome-specific API. It's likely to be renamed someday.
 
 ## Value

--- a/files/en-us/web/api/htmllabelelement/control/index.md
+++ b/files/en-us/web/api/htmllabelelement/control/index.md
@@ -18,7 +18,8 @@ or `null` if the label isn't associated with a control.
 An {{domxref("HTMLElement")}} derived object representing the control with which the
 {{HTMLElement("label")}} is associated, or `null` if the label stands alone.
 
-> **Note:** If this property has a value and {{domxref("HTMLLabelElement.htmlFor")}} has a value,
+> [!NOTE]
+> If this property has a value and {{domxref("HTMLLabelElement.htmlFor")}} has a value,
 > the {{domxref("HTMLLabelElement.htmlFor")}} property must refer to the same control.
 
 ## Specifications

--- a/files/en-us/web/api/htmllabelelement/htmlfor/index.md
+++ b/files/en-us/web/api/htmllabelelement/htmlfor/index.md
@@ -18,7 +18,8 @@ script-accessible property is used to set and read the value of the content prop
 A string which contains the ID string of the element which is
 associated with the control.
 
-> **Note:** If this property has a value, the {{domxref("HTMLLabelElement.control")}} property
+> [!NOTE]
+> If this property has a value, the {{domxref("HTMLLabelElement.control")}} property
 > must refer to the same control.
 
 ## Specifications

--- a/files/en-us/web/api/htmllabelelement/index.md
+++ b/files/en-us/web/api/htmllabelelement/index.md
@@ -22,7 +22,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLLabelElement.htmlFor")}}
   - : A string containing the ID of the labeled control. This reflects the [`for`](/en-US/docs/Web/HTML/Element/label#for) attribute.
 
-> **Note:** To programmatically set the `for` attribute, use [`htmlFor`](/en-US/docs/Web/API/HTMLLabelElement/htmlFor).
+> [!NOTE]
+> To programmatically set the `for` attribute, use [`htmlFor`](/en-US/docs/Web/API/HTMLLabelElement/htmlFor).
 
 ## Instance methods
 

--- a/files/en-us/web/api/htmllinkelement/href/index.md
+++ b/files/en-us/web/api/htmllinkelement/href/index.md
@@ -12,7 +12,8 @@ The **`href`** property of the {{domxref("HTMLLinkElement")}} interface contains
 
 It reflects the `href` attribute of the {{HTMLElement("link")}} element. If the element does not have an `href` attribute, then this property's value is the empty string (`""`).
 
-> **Note:** Every `<link>` element must contain either one or both of the `href` or [`imagesrcset`](/en-US/docs/Web/HTML/Element/link#imagesrcset) attributes. This means, for each valid `<link>`, either this property or {{domxref("HTMLLinkElement.imageSrcset", "imageSrcset")}} will not be empty.
+> [!NOTE]
+> Every `<link>` element must contain either one or both of the `href` or [`imagesrcset`](/en-US/docs/Web/HTML/Element/link#imagesrcset) attributes. This means, for each valid `<link>`, either this property or {{domxref("HTMLLinkElement.imageSrcset", "imageSrcset")}} will not be empty.
 
 ## Value
 

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -54,7 +54,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
   - : A string representing the reverse relationship of the linked resource from the resource to the document.
 
-    > **Note:** Currently the W3C HTML 5.2 spec states that `rev` is no longer obsolete, whereas the WHATWG living standard still has it labeled obsolete. Until this discrepancy is resolved, you should still assume it is obsolete.
+    > [!NOTE]
+    > Currently the W3C HTML 5.2 spec states that `rev` is no longer obsolete, whereas the WHATWG living standard still has it labeled obsolete. Until this discrepancy is resolved, you should still assume it is obsolete.
 
 - {{domxref("HTMLLinkElement.target")}} {{deprecated_inline}}
   - : A string representing the name of the target frame to which the resource applies.

--- a/files/en-us/web/api/htmlmediaelement/autoplay/index.md
+++ b/files/en-us/web/api/htmlmediaelement/autoplay/index.md
@@ -17,7 +17,8 @@ A media element whose source is a {{domxref("MediaStream")}} and whose
 `autoplay` property is `true` will begin playback when it becomes
 active (that is, when {{domxref("MediaStream.active")}} becomes `true`).
 
-> **Note:** Sites which automatically play audio (or videos with an audio
+> [!NOTE]
+> Sites which automatically play audio (or videos with an audio
 > track) can be an unpleasant experience for users, so it should be avoided when
 > possible. If you must offer autoplay functionality, you should make it opt-in
 > (requiring a user to specifically enable it). However, autoplay can be useful when
@@ -32,7 +33,8 @@ A boolean value which is `true` if the media element will
 begin playback as soon as enough content has loaded to allow it to do so without
 interruption.
 
-> **Note:** Some browsers offer users the ability to override
+> [!NOTE]
+> Some browsers offer users the ability to override
 > `autoplay` in order to prevent disruptive audio or video from playing
 > without permission or in the background. Do not rely on `autoplay` actually
 > starting playback and instead use {{domxref("HTMLMediaElement.play_event", 'play')}}

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.md
@@ -14,7 +14,8 @@ This event occurs based upon {{domxref("HTMLMediaElement")}} ({{HTMLElement("aud
 
 This event is not cancelable and does not bubble.
 
-> **Note:** The `ended` event doesn't fire if the [`loop`](/en-US/docs/Web/API/HTMLMediaElement/loop) property is `true` and [`playbackRate`](/en-US/docs/Web/API/HTMLMediaElement/playbackRate) is non-negative.
+> [!NOTE]
+> The `ended` event doesn't fire if the [`loop`](/en-US/docs/Web/API/HTMLMediaElement/loop) property is `true` and [`playbackRate`](/en-US/docs/Web/API/HTMLMediaElement/playbackRate) is non-negative.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlmediaelement/fastseek/index.md
+++ b/files/en-us/web/api/htmlmediaelement/fastseek/index.md
@@ -11,7 +11,8 @@ browser-compat: api.HTMLMediaElement.fastSeek
 The **`HTMLMediaElement.fastSeek()`** method quickly seeks the
 media to the new time with precision tradeoff.
 
-> **Note:** If you need to seek with precision, you should set [`HTMLMediaElement.currentTime`](/en-US/docs/Web/API/HTMLMediaElement/currentTime)
+> [!NOTE]
+> If you need to seek with precision, you should set [`HTMLMediaElement.currentTime`](/en-US/docs/Web/API/HTMLMediaElement/currentTime)
 > instead.
 
 ## Syntax

--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -23,7 +23,8 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
 
   - : A boolean value that reflects the [`autoplay`](/en-US/docs/Web/HTML/Element/video#autoplay) HTML attribute, indicating whether playback should automatically begin as soon as enough media is available to do so without interruption.
 
-    > **Note:** Automatically playing audio when the user doesn't expect or desire it is a poor user experience and should be avoided in most cases, though there are exceptions. See the [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) for more information. Keep in mind that browsers may ignore autoplay requests, so you should ensure that your code isn't dependent on autoplay working.
+    > [!NOTE]
+    > Automatically playing audio when the user doesn't expect or desire it is a poor user experience and should be avoided in most cases, though there are exceptions. See the [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide) for more information. Keep in mind that browsers may ignore autoplay requests, so you should ensure that your code isn't dependent on autoplay working.
 
 - {{domxref("HTMLMediaElement.buffered")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("TimeRanges")}} object that indicates the ranges of the media source that the browser has buffered (if any) at the moment the `buffered` property is accessed.

--- a/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.HTMLMediaElement.loadeddata_event
 
 The **`loadeddata`** event is fired when the frame at the current playback position of the media has finished loading; often the first frame.
 
-> **Note:** This event will not fire in mobile/tablet devices if data-saver is on in browser settings.
+> [!NOTE]
+> This event will not fire in mobile/tablet devices if data-saver is on in browser settings.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -31,7 +31,8 @@ None.
 A {{jsxref("Promise")}} which is resolved when playback has been started, or is
 rejected if for any reason playback cannot be started.
 
-> **Note:** Browsers released before 2019 may not return a value from
+> [!NOTE]
+> Browsers released before 2019 may not return a value from
 > `play()`.
 
 ### Exceptions
@@ -66,7 +67,8 @@ interface that assumes playback has begun automatically, but should instead upda
 UI based on whether the returned promise is fulfilled or rejected. See the
 [example](#examples) below for more information.
 
-> **Note:** The `play()` method may cause the user to be asked
+> [!NOTE]
+> The `play()` method may cause the user to be asked
 > to grant permission to play the media, resulting in a possible delay before the
 > returned promise is resolved. Be sure your code doesn't expect an immediate response.
 

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -14,7 +14,8 @@ browser-compat: api.HTMLMediaElement.seekToNextFrame
 The **`HTMLMediaElement.seekToNextFrame()`** method
 asynchronously advances the current play position to the next frame in the media.
 
-> **Warning:** This non-standard method is part of an experimentation process around support for
+> [!WARNING]
+> This non-standard method is part of an experimentation process around support for
 > non-real-time access to media for tasks including filtering, editing, and so forth.
 > You should _not_ use this method in production code, because its implementation
 > may change—or be removed outright—without notice. You are, however, invited to

--- a/files/en-us/web/api/htmlmediaelement/src/index.md
+++ b/files/en-us/web/api/htmlmediaelement/src/index.md
@@ -12,7 +12,8 @@ The **`HTMLMediaElement.src`** property reflects the value of
 the HTML media element's `src` attribute, which indicates the URL of a media
 resource to use in the element.
 
-> **Note:** The best way to know the URL of the media resource currently
+> [!NOTE]
+> The best way to know the URL of the media resource currently
 > in active use in this element is to look at the value of the
 > {{domxref("HTMLMediaElement.currentSrc", "currentSrc")}} attribute, which also takes
 > into account selection of a best or preferred media resource from a list provided in

--- a/files/en-us/web/api/htmlmediaelement/srcobject/index.md
+++ b/files/en-us/web/api/htmlmediaelement/srcobject/index.md
@@ -15,7 +15,8 @@ the source of the media associated with the {{domxref("HTMLMediaElement")}}.
 The object can be a {{domxref("MediaStream")}}, a {{domxref("MediaSource")}}, a
 {{domxref("Blob")}}, or a {{domxref("File")}} (which inherits from `Blob`).
 
-> **Note:** As of March 2020, only Safari has full support for `srcObject`, i.e. using `MediaSource`, `MediaStream`, `Blob`, and `File` objects as values. Other browsers support `MediaStream` objects; until they catch up, consider falling back to creating a URL with {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}} and assigning it to {{domxref("HTMLMediaElement.src")}} (see below for an example). In addition, as of version 108 Chromium supports attaching a dedicated worker `MediaSource` object by assigning that object's {{domxref("MediaSourceHandle")}} instance (transferred from the worker) to `srcObject`.
+> [!NOTE]
+> As of March 2020, only Safari has full support for `srcObject`, i.e. using `MediaSource`, `MediaStream`, `Blob`, and `File` objects as values. Other browsers support `MediaStream` objects; until they catch up, consider falling back to creating a URL with {{domxref("URL.createObjectURL_static", "URL.createObjectURL()")}} and assigning it to {{domxref("HTMLMediaElement.src")}} (see below for an example). In addition, as of version 108 Chromium supports attaching a dedicated worker `MediaSource` object by assigning that object's {{domxref("MediaSourceHandle")}} instance (transferred from the worker) to `srcObject`.
 
 ## Value
 

--- a/files/en-us/web/api/htmlolistelement/start/index.md
+++ b/files/en-us/web/api/htmlolistelement/start/index.md
@@ -12,7 +12,8 @@ The **`start`** property of the {{domxref("HTMLOListElement")}} interface indica
 
 It reflects the [`start`](/en-US/docs/Web/HTML/Element/ol#start) attribute of the {{HTMLElement("ol")}} element.
 
-> **Note:** The `start` property value is independent of the {{domxref("HTMLOListElement.type")}} property; it is always numeric, even when type is letters or Roman numerals.
+> [!NOTE]
+> The `start` property value is independent of the {{domxref("HTMLOListElement.type")}} property; it is always numeric, even when type is letters or Roman numerals.
 
 ## Value
 

--- a/files/en-us/web/api/htmlolistelement/type/index.md
+++ b/files/en-us/web/api/htmlolistelement/type/index.md
@@ -12,7 +12,8 @@ The **`type`** property of the {{domxref("HTMLOListElement")}} interface indicat
 
 It reflects the [`type`](/en-US/docs/Web/HTML/Element/ol#type) attribute of the {{HTMLElement("ol")}} element.
 
-> **Note:** The `type` can be defined in CSS with the {{CSSxRef("list-style-type")}} property. The `list-style-type` property provides many more values.
+> [!NOTE]
+> The `type` can be defined in CSS with the {{CSSxRef("list-style-type")}} property. The `list-style-type` property provides many more values.
 
 ## Value
 

--- a/files/en-us/web/api/htmlscriptelement/attributionsrc/index.md
+++ b/files/en-us/web/api/htmlscriptelement/attributionsrc/index.md
@@ -14,7 +14,8 @@ The **`attributionSrc`** property of the {{domxref("HTMLScriptElement")}} interf
 
 On the server-side this is used to trigger sending an {{httpheader("Attribution-Reporting-Register-Source")}} or {{httpheader("Attribution-Reporting-Register-Trigger")}} header in the response, to register a JavaScript-based [attribution source](/en-US/docs/Web/API/Attribution_Reporting_API/Registering_sources#javascript-based_event_sources) or [attribution trigger](/en-US/docs/Web/API/Attribution_Reporting_API/Registering_triggers#javascript-based_attribution_triggers), respectively. Which response header should be sent back depends on the value of the `Attribution-Reporting-Eligible` header that triggered the registration.
 
-> **Note:** Alternatively, JavaScript-based attribution sources or triggers can be registered by sending a {{domxref("Window/fetch", "fetch()")}} request containing the `attributionReporting` option (either set directly on the `fetch()` call or on a {{domxref("Request")}} object passed into the `fetch()` call), or by sending an {{domxref("XMLHttpRequest")}} with {{domxref("XMLHttpRequest.setAttributionReporting", "setAttributionReporting()")}} invoked on the request object.
+> [!NOTE]
+> Alternatively, JavaScript-based attribution sources or triggers can be registered by sending a {{domxref("Window/fetch", "fetch()")}} request containing the `attributionReporting` option (either set directly on the `fetch()` call or on a {{domxref("Request")}} object passed into the `fetch()` call), or by sending an {{domxref("XMLHttpRequest")}} with {{domxref("XMLHttpRequest.setAttributionReporting", "setAttributionReporting()")}} invoked on the request object.
 
 See the [Attribution Reporting API](/en-US/docs/Web/API/Attribution_Reporting_API) for more details.
 
@@ -32,7 +33,8 @@ A string. There are two versions of this property that you can get and set:
 
   This is useful in cases where the requested resource is not on a server you control, or you just want to handle registering the attribution source on a different server. In this case, you can specify one or more URLs as the value of `attributionSrc`. When the resource request occurs the {{httpheader("Attribution-Reporting-Eligible")}} header will be sent to the URL(s) specified in `attributionSrc` in addition to the resource origin. These URLs can then respond with a {{httpheader("Attribution-Reporting-Register-Source")}} or {{httpheader("Attribution-Reporting-Register-Trigger")}} header as appropriate to complete registration.
 
-  > **Note:** Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data.
+  > [!NOTE]
+  > Specifying multiple URLs means that multiple attribution sources can be registered on the same feature. You might for example have different campaigns that you are trying to measure the success of, which involve generating different reports on different data.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -45,7 +45,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
   - : A string that joins and returns the contents of all {{domxref("Text")}} nodes inside the {{HTMLElement("script")}} element (ignoring other nodes like comments) in tree order. On setting, it acts the same way as the {{domxref("Node.textContent")}} property.
 
-    > **Note:** When inserted using the {{domxref("Document.write()")}} method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using {{domxref("Element.innerHTML")}} or {{domxref("Element.outerHTML")}}, they do not execute at all.
+    > [!NOTE]
+    > When inserted using the {{domxref("Document.write()")}} method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using {{domxref("Element.innerHTML")}} or {{domxref("Element.outerHTML")}}, they do not execute at all.
 
 - {{domxref("HTMLScriptElement.type")}}
   - : A string representing the type of the script. It reflects the `type` attribute of the {{HTMLElement("script")}} element.

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
@@ -46,7 +46,8 @@ A string; one of the following:
     will leak origins and paths from TLS-protected resources to insecure origins.
     Carefully consider the impact of this setting.
 
-> **Note:** An empty string value (`""`) is both the default
+> [!NOTE]
+> An empty string value (`""`) is both the default
 > value, and a fallback value if `referrerpolicy` is not supported. If
 > `referrerpolicy` is not explicitly specified on the
 > `<script>` element, it will adopt a higher-level referrer policy,

--- a/files/en-us/web/api/htmlslotelement/assign/index.md
+++ b/files/en-us/web/api/htmlslotelement/assign/index.md
@@ -10,7 +10,8 @@ browser-compat: api.HTMLSlotElement.assign
 
 The **`assign()`** method of the {{domxref("HTMLSlotElement")}} interface sets the slot's _manually assigned nodes_ to an ordered set of slottables. The manually assigned nodes set is initially empty until nodes are assigned using `assign()`.
 
-> **Note:** you cannot mix manually (imperative) and named (declarative, automatic) slot assignments. Therefore, for this method to work, the shadow tree needs to have been [created](/en-US/docs/Web/API/Element/attachShadow) with the `slotAssignment: "manual"` option.
+> [!NOTE]
+> you cannot mix manually (imperative) and named (declarative, automatic) slot assignments. Therefore, for this method to work, the shadow tree needs to have been [created](/en-US/docs/Web/API/Element/attachShadow) with the `slotAssignment: "manual"` option.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlslotelement/slotchange_event/index.md
+++ b/files/en-us/web/api/htmlslotelement/slotchange_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.HTMLSlotElement.slotchange_event
 
 The **`slotchange`** event is fired on an {{DOMxRef("HTMLSlotElement")}} instance ({{HTMLElement("slot")}} element) when the node(s) contained in that slot change.
 
-> **Note:** the `slotchange` event doesn't fire if the children of a slotted node change — only if you change (e.g. add or delete) the actual nodes themselves.
+> [!NOTE]
+> the `slotchange` event doesn't fire if the children of a slotted node change — only if you change (e.g. add or delete) the actual nodes themselves.
 
 In order to trigger a **slotchange** event, one has to set or remove the `slot` attribute.
 

--- a/files/en-us/web/api/htmlsourceelement/index.md
+++ b/files/en-us/web/api/htmlsourceelement/index.md
@@ -25,7 +25,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
   - : A string reflecting the [`src`](/en-US/docs/Web/HTML/Element/source#src) HTML attribute, containing the URL for the media resource. The {{domxref("HTMLSourceElement.src")}} property has a meaning only when the associated {{HTMLElement("source")}} element is nested in a media element that is a {{htmlelement("video")}} or an {{htmlelement("audio")}} element. It has no meaning and is ignored when it is nested in a {{HTMLElement("picture")}} element.
 
-    > **Note:** If the `src` property is updated (along with any siblings), the parent {{domxref("HTMLMediaElement")}}'s `load` method should be called when done, since `<source>` elements are not re-scanned automatically.
+    > [!NOTE]
+    > If the `src` property is updated (along with any siblings), the parent {{domxref("HTMLMediaElement")}}'s `load` method should be called when done, since `<source>` elements are not re-scanned automatically.
 
 - {{domxref("HTMLSourceElement.srcset")}}
   - : A string reflecting the [`srcset`](/en-US/docs/Web/HTML/Element/source#srcset) HTML attribute, containing a list of candidate images, separated by a comma (`',', U+002C COMMA`). A candidate image is a URL followed by a `'w'` with the width of the images, or an `'x'` followed by the pixel density.

--- a/files/en-us/web/api/htmltablecaptionelement/align/index.md
+++ b/files/en-us/web/api/htmltablecaptionelement/align/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableCaptionElement.align
 
 The **`align`** property of the {{domxref("HTMLTableCaptionElement")}} interface is a string indicating how to horizontally align text in the {{htmlelement("caption")}} table element.
 
-> **Note:** This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in the caption cell instead.
+> [!NOTE]
+> This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in the caption cell instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/abbr/index.md
+++ b/files/en-us/web/api/htmltablecellelement/abbr/index.md
@@ -13,7 +13,8 @@ indicates an abbreviation associated with the cell. If the cell does not represe
 
 It reflects the `abbr` attribute of the {{HTMLElement("th")}} element.
 
-> **Note:** this property doesn't have a visual effect in browsers. It adds information to help assistive technology like screenreaders that can use this abbreviation
+> [!NOTE]
+> this property doesn't have a visual effect in browsers. It adds information to help assistive technology like screenreaders that can use this abbreviation
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/align/index.md
+++ b/files/en-us/web/api/htmltablecellelement/align/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableCellElement.align
 
 The **`align`** property of the {{domxref("HTMLTableCellElement")}} interface is a string indicating how to horizontally align text in the {{htmlelement("th")}} or {{htmlelement("td")}} table cell.
 
-> **Note:** This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in a cell instead.
+> [!NOTE]
+> This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in a cell instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecellelement/ch/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableCellElement.ch
 
 The **`ch`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `char` attribute of the cell element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablecellelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecellelement/choff/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableCellElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableCellElement")}} interface does nothing. It reflects the `charoff` attribute of the cell element.
 
-> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablecellelement/colspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/colspan/index.md
@@ -14,7 +14,8 @@ The **`colSpan`** read-only property of the {{domxref("HTMLTableCellElement")}} 
 
 A positive number representing the number of columns.
 
-> **Note:** When setting a new value, the value is _clamped_ to the nearest strictly positive number.
+> [!NOTE]
+> When setting a new value, the value is _clamped_ to the nearest strictly positive number.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -34,7 +34,8 @@ _No specific method; inherits methods from its parent, {{domxref("HTMLElement")}
 
 ## Deprecated properties
 
-> **Warning:** These properties have been deprecated and should no longer be used. They are documented primarily to help understand older code bases.
+> [!WARNING]
+> These properties have been deprecated and should no longer be used. They are documented primarily to help understand older code bases.
 
 - {{domxref("HTMLTableCellElement.align")}} {{deprecated_inline}}
   - : A string containing the value of the [`align`](/en-US/docs/Web/HTML/Element/td#align) attribute, if present, or empty string if not set. It can be used to set the alignment of the element's contents to the surrounding context of `"left"`, `"right"`, and `"center"`. Use the CSS {{cssxref("text-align")}} property instead.

--- a/files/en-us/web/api/htmltablecellelement/nowrap/index.md
+++ b/files/en-us/web/api/htmltablecellelement/nowrap/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableCellElement.noWrap
 
 The **`noWrap`** property of the {{domxref("HTMLTableCellElement")}} interface returns a Boolean value indicating if the text of the cell may be wrapped on several lines or not.
 
-> **Note:** This property is deprecated and you should use the CSS {{cssxref("white-space")}} property with the value `nowrap` instead.
+> [!NOTE]
+> This property is deprecated and you should use the CSS {{cssxref("white-space")}} property with the value `nowrap` instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/rowspan/index.md
+++ b/files/en-us/web/api/htmltablecellelement/rowspan/index.md
@@ -14,7 +14,8 @@ The **`rowSpan`** read-only property of the {{domxref("HTMLTableCellElement")}} 
 
 A positive number representing the number of rows. If it is `0`, it means all remaining rows in the column.
 
-> **Note:** When setting a new value, a value different from 0 is _clamped_ to the nearest strictly positive number.
+> [!NOTE]
+> When setting a new value, a value different from 0 is _clamped_ to the nearest strictly positive number.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltablecellelement/scope/index.md
+++ b/files/en-us/web/api/htmltablecellelement/scope/index.md
@@ -13,7 +13,8 @@ indicates the scope of a {{HTMLElement("th")}} cell.
 
 Header cells can be configured, using the `scope` attribute, to apply to a specified row or column, or to the not-yet-scoped cells within the current row group (that is, the same ancestor {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, or {{HTMLElement("tfoot")}} element). If no value is specified for `scope`, the header is not associated directly with cells in this way. Permitted values for `scope` are:
 
-> **Note:** this property doesn't have a visual effect in browsers. It adds semantic information to help assistive technology like screenreaders to present the table in a more coherent way.
+> [!NOTE]
+> this property doesn't have a visual effect in browsers. It adds semantic information to help assistive technology like screenreaders to present the table in a more coherent way.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecellelement/valign/index.md
+++ b/files/en-us/web/api/htmltablecellelement/valign/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableCellElement.vAlign
 
 The **`vAlign`** property of the {{domxref("HTMLTableCellElement")}} interface is a string indicating how to vertically align text in a {{htmlelement("th")}} or {{htmlelement("td")}} table cell.
 
-> **Note:** This property is deprecated. Use the CSS {{cssxref("vertical-align")}} property to horizontally align text in a cell instead.
+> [!NOTE]
+> This property is deprecated. Use the CSS {{cssxref("vertical-align")}} property to horizontally align text in a cell instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablecolelement/align/index.md
+++ b/files/en-us/web/api/htmltablecolelement/align/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableColElement.align
 
 The **`align`** property of the {{domxref("HTMLTableColElement")}} interface is a string indicating how to horizontally align text in a table {{htmlelement("col")}} column element.
 
-> **Note:** This property is deprecated, and CSS should be used to align text horizontally in a column. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in a column instead.
+> [!NOTE]
+> This property is deprecated, and CSS should be used to align text horizontally in a column. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in a column instead.
 >
 > As {{htmlelement("td")}} are not children of {{htmlelement("col")}}, you can't set it directly on a {{HTMLElement("col")}} element, you need to select the cells of the column using a `td:nth-last-child(n)` or similar (`n` is the column number, counting from the end).
 

--- a/files/en-us/web/api/htmltablecolelement/ch/index.md
+++ b/files/en-us/web/api/htmltablecolelement/ch/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableColElement.ch
 
 The **`ch`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `char` attribute of the {{HTMLElement("col")}} element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablecolelement/choff/index.md
+++ b/files/en-us/web/api/htmltablecolelement/choff/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableColElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableColElement")}} interface does nothing. It reflects the `charoff` attribute of the {{HTMLElement("col")}} element.
 
-> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablecolelement/span/index.md
+++ b/files/en-us/web/api/htmltablecolelement/span/index.md
@@ -14,7 +14,8 @@ The **`span`** read-only property of the {{domxref("HTMLTableColElement")}} inte
 
 A positive number representing the number of columns.
 
-> **Note:** When setting a new value, the value is _clamped_ to the nearest strictly positive number (up to 1000).
+> [!NOTE]
+> When setting a new value, the value is _clamped_ to the nearest strictly positive number (up to 1000).
 
 ## Examples
 

--- a/files/en-us/web/api/htmltablecolelement/valign/index.md
+++ b/files/en-us/web/api/htmltablecolelement/valign/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableColElement.vAlign
 
 The **`vAlign`** property of the {{domxref("HTMLTableColElement")}} interface is a string indicating how to vertically align text in a table {{htmlelement("col")}} column element.
 
-> **Note:** This property is deprecated, and CSS should be used to align text vertically in a column. Use the CSS {{cssxref("vertical-align")}} property, which takes precedence, to vertically align text in each column cell instead.
+> [!NOTE]
+> This property is deprecated, and CSS should be used to align text vertically in a column. Use the CSS {{cssxref("vertical-align")}} property, which takes precedence, to vertically align text in each column cell instead.
 >
 > As {{htmlelement("td")}} are not children of {{htmlelement("col")}}, you can't set it directly on a {{HTMLElement("col")}}element , you need to select the cells of the column using a `td:nth-child(n)` or similar (`n` is the column number).
 

--- a/files/en-us/web/api/htmltableelement/bgcolor/index.md
+++ b/files/en-us/web/api/htmltableelement/bgcolor/index.md
@@ -13,7 +13,8 @@ browser-compat: api.HTMLTableElement.bgColor
 The **`bgcolor`** property of the {{domxref("HTMLTableElement")}} represents the
 background color of the table.
 
-> **Note:** Do not use this attribute anymore. Instead, use the CSS {{cssxref("background-color")}} property by modifying the element's [`style`](/en-US/docs/Web/API/HTMLElement/style) attribute or using a style rule.
+> [!NOTE]
+> Do not use this attribute anymore. Instead, use the CSS {{cssxref("background-color")}} property by modifying the element's [`style`](/en-US/docs/Web/API/HTMLElement/style) attribute or using a style rule.
 
 ## Value
 

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -13,7 +13,8 @@ The **`HTMLTableElement.createCaption()`** method returns the
 If no `<caption>` element exists on the table, this method creates
 it, and then returns it.
 
-> **Note:** If no caption exists, `createCaption()` inserts a
+> [!NOTE]
+> If no caption exists, `createCaption()` inserts a
 > new caption directly into the table. The caption does not need to be added
 > separately as would be the case if {{domxref("Document.createElement()")}} had
 > been used to create the new `<caption>` element.

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -12,7 +12,8 @@ The **`createTBody()`** method of
 {{domxref("HTMLTableElement")}} objects creates and returns a new
 {{HTMLElement("tbody")}} element associated with a given {{HtmlElement("table")}}.
 
-> **Note:** Unlike {{domxref("HTMLTableElement.createTHead()")}} and
+> [!NOTE]
+> Unlike {{domxref("HTMLTableElement.createTHead()")}} and
 > {{domxref("HTMLTableElement.createTFoot()")}}, `createTBody()`
 > systematically creates a new `<tbody>` element, even if the table
 > already contains one or more bodies. If so, the new one is inserted after the existing

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -13,7 +13,8 @@ The **`createTFoot()`** method of
 associated with a given {{HtmlElement("table")}}. If no footer exists in the table, this
 method creates it, and then returns it.
 
-> **Note:** If no footer exists, `createTFoot()` inserts a new
+> [!NOTE]
+> If no footer exists, `createTFoot()` inserts a new
 > footer directly into the table. The footer does not need to be added separately as
 > would be the case if {{domxref("Document.createElement()")}} had been used to create
 > the new `<tfoot>` element.

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -13,7 +13,8 @@ The **`createTHead()`** method of
 associated with a given {{HtmlElement("table")}}. If no header exists in the table, this
 method creates it, and then returns it.
 
-> **Note:** If no header exists, `createTHead()` inserts a new
+> [!NOTE]
+> If no header exists, `createTHead()` inserts a new
 > header directly into the table. The header does not need to be added separately as
 > would be the case if {{domxref("Document.createElement()")}} had been used to create
 > the new `<thead>` element.

--- a/files/en-us/web/api/htmltableelement/index.md
+++ b/files/en-us/web/api/htmltableelement/index.md
@@ -28,7 +28,8 @@ _Inherits properties from its parent, {{DOMxRef("HTMLElement")}}._
 
 ### Obsolete Properties
 
-> **Warning:** The following properties are obsolete. You should avoid using them.
+> [!WARNING]
+> The following properties are obsolete. You should avoid using them.
 
 - {{DOMxRef("HTMLTableElement.align")}} {{deprecated_inline}}
   - : A string containing an enumerated value reflecting the [`align`](/en-US/docs/Web/HTML/Element/table#align) attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.

--- a/files/en-us/web/api/htmltablerowelement/align/index.md
+++ b/files/en-us/web/api/htmltablerowelement/align/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableRowElement.align
 
 The **`align`** property of the {{domxref("HTMLTableRowElement")}} interface is a string indicating how to horizontally align text in the {{htmlelement("tr")}} table row. Individual cells can override it.
 
-> **Note:** This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in a row instead.
+> [!NOTE]
+> This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in a row instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablerowelement/ch/index.md
+++ b/files/en-us/web/api/htmltablerowelement/ch/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableRowElement.ch
 
 The **`ch`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `char` attribute of the {{HTMLElement("tr")}} element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablerowelement/choff/index.md
+++ b/files/en-us/web/api/htmltablerowelement/choff/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableRowElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableRowElement")}} interface does nothing. It reflects the `charoff` attribute of the {{HTMLElement("tr")}} element.
 
-> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablerowelement/index.md
+++ b/files/en-us/web/api/htmltablerowelement/index.md
@@ -33,7 +33,8 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}_.
 
 ## Deprecated properties
 
-> **Warning:** These properties have been deprecated and should no longer be used. They are documented primarily to help understand older code bases.
+> [!WARNING]
+> These properties have been deprecated and should no longer be used. They are documented primarily to help understand older code bases.
 
 - {{domxref("HTMLTableRowElement.align")}} {{deprecated_inline}}
   - : A string containing an enumerated value reflecting the [`align`](/en-US/docs/Web/HTML/Element/tr#align) attribute. It indicates the alignment of the element's contents to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.

--- a/files/en-us/web/api/htmltablerowelement/valign/index.md
+++ b/files/en-us/web/api/htmltablerowelement/valign/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableRowElement.vAlign
 
 The **`vAlign`** property of the {{domxref("HTMLTableRowElement")}} interface is a string indicating how to vertically align text in a {{htmlelement("tr")}} table row. Individual cells can override it.
 
-> **Note:** This property is deprecated. Use the CSS {{cssxref("vertical-align")}} property to horizontally align text in a row instead.
+> [!NOTE]
+> This property is deprecated. Use the CSS {{cssxref("vertical-align")}} property to horizontally align text in a row instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablesectionelement/align/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/align/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableSectionElement.align
 
 The **`align`** property of the {{domxref("HTMLTableSectionElement")}} interface is a string indicating how to horizontally align text in a {{htmlelement("thead")}}, {{htmlelement("tbody")}} or {{htmlelement("tfoot")}} table section. Individual rows and cells can override it.
 
-> **Note:** This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in section cells instead.
+> [!NOTE]
+> This property is deprecated, and CSS should be used to align text horizontally in a cell. Use the CSS {{cssxref("text-align")}} property, which takes precedence, to horizontally align text in section cells instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltablesectionelement/ch/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/ch/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableSectionElement.ch
 
 The **`ch`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `char` attribute of the section element.
 
-> **Note:** This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate to the ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablesectionelement/choff/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/choff/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableSectionElement.chOff
 
 The **`chOff`** property of the {{domxref("HTMLTableSectionElement")}} interface does nothing. It reflects the `charoff` attribute of the section element.
 
-> **Note:** This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
+> [!NOTE]
+> This property was designed to participate in an ability to align table cell content on a specific character (typically the decimal point), but was never implemented by browsers.
 >
 > To achieve such alignment, watch for the support of a string value with the {{cssxref("text-align")}} CSS property.
 

--- a/files/en-us/web/api/htmltablesectionelement/valign/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/valign/index.md
@@ -12,7 +12,8 @@ browser-compat: api.HTMLTableSectionElement.vAlign
 
 The **`vAlign`** property of the {{domxref("HTMLTableSectionElement")}} interface is a string indicating how to vertically align text in a {{htmlelement("thead")}}, {{htmlelement("tbody")}} or {{htmlelement("tfoot")}} table section. Individual rows and cells can override it.
 
-> **Note:** This property is deprecated. Use the CSS {{cssxref("vertical-align")}} property to horizontally align text in section cells instead.
+> [!NOTE]
+> This property is deprecated. Use the CSS {{cssxref("vertical-align")}} property to horizontally align text in section cells instead.
 
 ## Value
 

--- a/files/en-us/web/api/htmltemplateelement/index.md
+++ b/files/en-us/web/api/htmltemplateelement/index.md
@@ -9,7 +9,8 @@ browser-compat: api.HTMLTemplateElement
 
 The **`HTMLTemplateElement`** interface enables access to the contents of an HTML {{HTMLElement("template")}} element.
 
-> **Note:** An HTML parser can create either an `HTMLTemplateElement` or a {{domxref("ShadowRoot")}} when it parses a {{HTMLElement("template")}} element, depending on the `<template>` attributes.
+> [!NOTE]
+> An HTML parser can create either an `HTMLTemplateElement` or a {{domxref("ShadowRoot")}} when it parses a {{HTMLElement("template")}} element, depending on the `<template>` attributes.
 > If an `HTMLTemplateElement` is created the "shadow" attributes are reflected from the template.
 > However these are not useful, because an `HTMLTemplateElement` is not a shadow root and cannot subsequently be changed to a shadow root.
 

--- a/files/en-us/web/api/idbcursor/direction/index.md
+++ b/files/en-us/web/api/idbcursor/direction/index.md
@@ -36,7 +36,8 @@ In this simple fragment we create a transaction, retrieve an object store, then 
 cursor to iterate through all the records in the object store. Within each iteration we
 log the direction of the cursor.
 
-> **Note:** we can't change the direction of travel of the cursor using
+> [!NOTE]
+> we can't change the direction of travel of the cursor using
 > the `direction` property, as it is read-only. We specify the direction of
 > travel using the 2nd argument of {{domxref("IDBObjectStore.openCursor")}}.
 

--- a/files/en-us/web/api/idbcursor/index.md
+++ b/files/en-us/web/api/idbcursor/index.md
@@ -7,7 +7,8 @@ browser-compat: api.IDBCursor
 
 {{APIRef("IndexedDB")}} {{AvailableInWorkers}}
 
-> **Note:** Not to be confused with {{domxref("IDBCursorWithValue")}} which is just an **`IDBCursor`** interface with an additional **`value`** property.
+> [!NOTE]
+> Not to be confused with {{domxref("IDBCursorWithValue")}} which is just an **`IDBCursor`** interface with an additional **`value`** property.
 
 The **`IDBCursor`** interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) represents a [cursor](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#cursor) for traversing or iterating over multiple records in a database.
 
@@ -47,7 +48,8 @@ You can have an unlimited number of cursors at the same time. You always get the
 
 {{Deprecated_Header}}
 
-> **Warning:** These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Firefox bug 891944](https://bugzil.la/891944))
+> [!WARNING]
+> These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Firefox bug 891944](https://bugzil.la/891944))
 
 - `NEXT`: `"next"` : The cursor shows all records, including duplicates. It starts at the lower bound of the key range and moves upwards (monotonically increasing in the order of keys).
 - `NEXTUNIQUE` : `"nextunique"` : The cursor shows all records, excluding duplicates. If multiple records exist with the same key, only the first one iterated is retrieved. It starts at the lower bound of the key range and moves upwards.

--- a/files/en-us/web/api/idbdatabase/index.md
+++ b/files/en-us/web/api/idbdatabase/index.md
@@ -9,7 +9,8 @@ browser-compat: api.IDBDatabase
 
 The **`IDBDatabase`** interface of the IndexedDB API provides a [connection to a database](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection); you can use an `IDBDatabase` object to open a [transaction](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction) on your database then create, manipulate, and delete objects (data) in that database. The interface provides the only way to get and manage versions of the database.
 
-> **Note:** Everything you do in IndexedDB always happens in the context of a [transaction](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction), representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.
+> [!NOTE]
+> Everything you do in IndexedDB always happens in the context of a [transaction](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#transaction), representing interactions with data in the database. All objects in IndexedDB — including object stores, indexes, and cursors — are tied to a particular transaction. Thus, you cannot execute commands, access data, or open anything outside of a transaction.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/idbfactory/cmp/index.md
+++ b/files/en-us/web/api/idbfactory/cmp/index.md
@@ -12,7 +12,8 @@ The **`cmp()`** method of the {{domxref("IDBFactory")}}
 interface compares two values as keys to determine equality and ordering for IndexedDB
 operations, such as storing and iterating.
 
-> **Note:** Do not use this method for comparing arbitrary JavaScript
+> [!NOTE]
+> Do not use this method for comparing arbitrary JavaScript
 > values, because many JavaScript values are either not valid IndexedDB keys (booleans
 > and objects, for example) or are treated as equivalent IndexedDB keys (for example,
 > since IndexedDB ignores arrays with non-numeric properties and treats them as empty

--- a/files/en-us/web/api/idbindex/openkeycursor/index.md
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.md
@@ -18,7 +18,8 @@ specified direction.
 
 If the key range is not specified or is null, then the range includes all the keys.
 
-> **Note:** Cursors returned by `openKeyCursor()` do not
+> [!NOTE]
+> Cursors returned by `openKeyCursor()` do not
 > make the referenced value available as [`IDBIndex.openCursor`](/en-US/docs/Web/API/IDBIndex/openCursor) does.
 > This makes obtaining a list of keys much more efficient.
 

--- a/files/en-us/web/api/idbkeyrange/bound_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/bound_static/index.md
@@ -58,7 +58,8 @@ the values "A" and "F", as we haven't declared that they should be open bounds. 
 used `IDBKeyRange.bound("A", "F", true, true);`, then the range would not
 include `"A"` and `"F"`, only the values between them.
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at the idbkeyrange directory in the [indexeddb-examples](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo. (View the example [live](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/) too.
 
 ```js

--- a/files/en-us/web/api/idbkeyrange/index.md
+++ b/files/en-us/web/api/idbkeyrange/index.md
@@ -69,7 +69,8 @@ A key is in a key range if the following conditions are true:
 The following example illustrates how you'd use a key range. Here we declare a `keyRangeValue` as a range between values of `"A"` and `"F"`. We open a transaction (using {{domxref("IDBTransaction")}}) and an object store, and open a cursor with {{domxref("IDBObjectStore.openCursor")}}, declaring `keyRangeValue` as its optional key range value. This means that the cursor will only retrieve records with keys inside that range. This range includes the values `"A"` and `"F"`, as we haven't declared that they should be open bounds.
 If we used `IDBKeyRange.bound("A", "F", true, true);`, then the range would not include `"A"` and `"F"`, only the values between them.
 
-> **Note:** For a more complete example allowing you to experiment with key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
+> [!NOTE]
+> For a more complete example allowing you to experiment with key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 
 ```js
 function displayData() {

--- a/files/en-us/web/api/idbkeyrange/lower/index.md
+++ b/files/en-us/web/api/idbkeyrange/lower/index.md
@@ -29,7 +29,8 @@ its optional key range value.
 After declaring the key range, we log its `lower` property value to the
 console, which should appear as "F".
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo.
 > (View the example [live](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/) too.
 

--- a/files/en-us/web/api/idbkeyrange/lowerbound_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/lowerbound_static/index.md
@@ -48,7 +48,8 @@ the key value "F" and all that come after it. If we used
 `IDBKeyRange.lowerBound("F", true);`, then the range would not include "F";
 only the values after it.
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo
 > ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 

--- a/files/en-us/web/api/idbkeyrange/loweropen/index.md
+++ b/files/en-us/web/api/idbkeyrange/loweropen/index.md
@@ -35,7 +35,8 @@ After declaring the key range, we log its `lowerOpen` property value to the
 console, which should appear as "true": the lower bound is open, so won't be included in
 the range.
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/blob/main/indexeddb-examples/idbkeyrange) repo ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 
 ```js

--- a/files/en-us/web/api/idbkeyrange/only_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/only_static/index.md
@@ -40,7 +40,8 @@ store, and open a Cursor with {{domxref("IDBObjectStore.openCursor")}},
 declaring `keyRangeValue` as its optional key range value. This means that
 the cursor will only retrieve the record with the key value "A".
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange)
 > repo ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 

--- a/files/en-us/web/api/idbkeyrange/upper/index.md
+++ b/files/en-us/web/api/idbkeyrange/upper/index.md
@@ -28,7 +28,8 @@ its optional key range value.
 After declaring the key range, we log its `upper` property value to the
 console, which should appear as "W".
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo
 > ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 

--- a/files/en-us/web/api/idbkeyrange/upperbound_static/index.md
+++ b/files/en-us/web/api/idbkeyrange/upperbound_static/index.md
@@ -47,7 +47,8 @@ optional key range value.
 If we used `IDBKeyRange.upperBound("F", true);`, then the range excludes
 "F"; and instead only includes the values before it.
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/tree/main/indexeddb-examples/idbkeyrange) repo
 > ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 

--- a/files/en-us/web/api/idbkeyrange/upperopen/index.md
+++ b/files/en-us/web/api/idbkeyrange/upperopen/index.md
@@ -35,7 +35,8 @@ After declaring the key range, we log its `upperOpen` property value to the
 console, which should appear as "true": the upper bound is open, so won't be included in
 the range.
 
-> **Note:** For a more complete example allowing you to experiment with
+> [!NOTE]
+> For a more complete example allowing you to experiment with
 > key range, have a look at our [IDBKeyRange-example](https://github.com/mdn/dom-examples/blob/main/indexeddb-examples/idbkeyrange) repo ([view the example live too](https://mdn.github.io/dom-examples/indexeddb-examples/idbkeyrange/).)
 
 ```js

--- a/files/en-us/web/api/idbobjectstore/get/index.md
+++ b/files/en-us/web/api/idbobjectstore/get/index.md
@@ -17,7 +17,8 @@ If a value is successfully found, then a structured clone of it is created and s
 the [`result`](/en-US/docs/Web/API/IDBRequest/result) of the
 request object.
 
-> **Note:** This method produces the same result for: a) a record that doesn't exist in the database and b) a record that has an undefined value.
+> [!NOTE]
+> This method produces the same result for: a) a record that doesn't exist in the database and b) a record that has an undefined value.
 > To tell these situations apart, call the `openCursor()` method with the same key. That method provides a cursor if the record exists, and no cursor if it does not.
 
 ## Syntax

--- a/files/en-us/web/api/idbtransaction/error_event/index.md
+++ b/files/en-us/web/api/idbtransaction/error_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.IDBTransaction.error_event
 
 The `error` event is fired on `IDBTransaction` when a request returns an error and the event bubbles up to the transaction object.
 
-> **Note:** To handle all the ways a transaction can fail, consider listening for the {{domxref("IDBTransaction.abort_event", "abort")}} event instead.
+> [!NOTE]
+> To handle all the ways a transaction can fail, consider listening for the {{domxref("IDBTransaction.abort_event", "abort")}} event instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/idbtransaction/index.md
+++ b/files/en-us/web/api/idbtransaction/index.md
@@ -85,7 +85,8 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 
 {{Deprecated_Header}}
 
-> **Warning:** These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Firefox bug 888598](https://bugzil.la/888598))
+> [!WARNING]
+> These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Firefox bug 888598](https://bugzil.la/888598))
 
 Transactions can have one of three modes:
 

--- a/files/en-us/web/api/identitycredential/token/index.md
+++ b/files/en-us/web/api/identitycredential/token/index.md
@@ -18,7 +18,8 @@ The relying party (RP) sends the token to its server to validate the certificate
 
 If the user has never signed into the IdP or is logged out, the associated {{domxref("CredentialsContainer.get", "get()")}} call rejects with an error and the RP can direct the user to the IdP login page to sign in or create an account.
 
-> **Note:** The exact structure and content of the validation token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
+> [!NOTE]
+> The exact structure and content of the validation token is opaque to the FedCM API, and to the browser. The IdP decides on the syntax and usage of it, and the RP needs to follow the instructions provided by the IdP (see [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token), for example) to make sure they are using it correctly.
 
 ## Value
 

--- a/files/en-us/web/api/iirfilternode/index.md
+++ b/files/en-us/web/api/iirfilternode/index.md
@@ -44,7 +44,8 @@ Typically, it's best to use the {{domxref("BiquadFilterNode")}} interface to imp
 
 However, if you need to create an odd-ordered IIR filter, you'll need to use `IIRFilterNode`. You may also find this interface useful if you don't need automation, or for other reasons.
 
-> **Note:** Once the node has been created, you can't change its coefficients.
+> [!NOTE]
+> Once the node has been created, you can't change its coefficients.
 
 `IIRFilterNode`s have a tail-time reference; they continue to output non-silent audio with zero input. As an IIR filter, the non-zero input continues forever, but this can be limited after some finite time in practice, when the output has approached zero closely enough. The actual time that takes depends on the filter coefficients provided.
 

--- a/files/en-us/web/api/indexeddb_api/basic_terminology/index.md
+++ b/files/en-us/web/api/indexeddb_api/basic_terminology/index.md
@@ -39,7 +39,8 @@ If you have assumptions from working with other types of databases, you might ge
 
   The security boundary imposed on IndexedDB prevents applications from accessing data with a different origin. For example, while an app or a page in `http://www.example.com/app/` can retrieve data from `http://www.example.com/dir/`, because they have the same origin, it cannot retrieve data from `http://www.example.com:8080/dir/` (different port) or `https://www.example.com/dir/` (different protocol), because they have different origins.
 
-  > **Note:** Third party window content (e.g. {{htmlelement("iframe")}} content) can access the IndexedDB store for the origin it is embedded into, unless the browser is set to [never accept third party cookies](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection) (see [Firefox bug 1147821](https://bugzil.la/1147821).)
+  > [!NOTE]
+  > Third party window content (e.g. {{htmlelement("iframe")}} content) can access the IndexedDB store for the origin it is embedded into, unless the browser is set to [never accept third party cookies](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection) (see [Firefox bug 1147821](https://bugzil.la/1147821).)
 
 ### Limitations
 
@@ -82,7 +83,8 @@ In Firefox, IndexedDB used to be **durable**, meaning that in a readwrite transa
 
 As of Firefox 40, IndexedDB transactions have relaxed durability guarantees to increase performance (see [Firefox bug 1112702](https://bugzil.la/1112702)), which is the same behavior as other IndexedDB-supporting browsers. In this case the {{domxref("IDBTransaction.complete_event", "complete")}} event is fired after the OS has been told to write the data but potentially before that data has actually been flushed to disk. The event may thus be delivered quicker than before, however, there exists a small chance that the entire transaction will be lost if the OS crashes or there is a loss of system power before the data is flushed to disk. Since such catastrophic events are rare, most consumers should not need to concern themselves further.
 
-> **Note:** In Firefox, if you wish to ensure durability for some reason (e.g. you're storing critical data that cannot be recomputed later) you can force a transaction to flush to disk before delivering the `complete` event by creating a transaction using the experimental (non-standard) `readwriteflush` mode (see {{domxref("IDBDatabase.transaction")}}.) This is currently experimental, and can only be used if the `dom.indexedDB.experimental` pref is set to `true` in `about:config`.
+> [!NOTE]
+> In Firefox, if you wish to ensure durability for some reason (e.g. you're storing critical data that cannot be recomputed later) you can force a transaction to flush to disk before delivering the `complete` event by creating a transaction using the experimental (non-standard) `readwriteflush` mode (see {{domxref("IDBDatabase.transaction")}}.) This is currently experimental, and can only be used if the `dom.indexedDB.experimental` pref is set to `true` in `about:config`.
 
 #### index
 

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -79,7 +79,8 @@ In this segment, we check to see if the form fields have all been filled in. If 
 
 In this section we create an object called `newItem` that stores the data in the format required to insert it into the database. The next few lines open the database transaction and provide messages to notify the user if this was successful or failed. Then an `objectStore` is created into which the new item is added. The `notified` property of the data object indicates that the to-do list item's deadline has not yet come up and been notified - more on this later!
 
-> **Note:** The `db` variable stores a reference to the IndexedDB database instance; we can then use various properties of this variable to manipulate the data.
+> [!NOTE]
+> The `db` variable stores a reference to the IndexedDB database instance; we can then use various properties of this variable to manipulate the data.
 
 ```js
     request.onsuccess = (event) => {

--- a/files/en-us/web/api/indexeddb_api/index.md
+++ b/files/en-us/web/api/indexeddb_api/index.md
@@ -16,7 +16,8 @@ IndexedDB is a transactional database system, like an SQL-based Relational Datab
 - Read more about [IndexedDB key characteristics and basic terminology](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology).
 - Learn to use IndexedDB asynchronously from first principles with our [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) guide.
 
-> **Note:** Like most web storage solutions, IndexedDB follows a [same-origin policy](https://www.w3.org/Security/wiki/Same_Origin_Policy). So while you can access stored data within a domain, you cannot access data across different domains.
+> [!NOTE]
+> Like most web storage solutions, IndexedDB follows a [same-origin policy](https://www.w3.org/Security/wiki/Same_Origin_Policy). So while you can access stored data within a domain, you cannot access data across different domains.
 
 ### Synchronous and asynchronous
 

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
@@ -43,7 +43,8 @@ The open request doesn't open the database or start the transaction right away. 
 
 The second parameter to the open method is the version of the database. The version of the database determines the database schema — the object stores in the database and their structure. If the database doesn't already exist, it is created by the `open` operation, then an `onupgradeneeded` event is triggered and you create the database schema in the handler for this event. If the database does exist but you are specifying an upgraded version number, an `onupgradeneeded` event is triggered straight away, allowing you to provide an updated schema in its handler. More on this later in [Creating or updating the version of the database](#creating_or_updating_the_version_of_the_database) below, and the {{ domxref("IDBFactory.open") }} reference page.
 
-> **Warning:** The version number is an `unsigned long long` number, which means that it can be a very big integer. It also means that you can't use a float, otherwise it will be converted to the closest lower integer and the transaction may not start, nor the `upgradeneeded` event trigger. So for example, don't use 2.4 as a version number:
+> [!WARNING]
+> The version number is an `unsigned long long` number, which means that it can be a very big integer. It also means that you can't use a float, otherwise it will be converted to the closest lower integer and the transaction may not start, nor the `upgradeneeded` event trigger. So for example, don't use 2.4 as a version number:
 > `const request = indexedDB.open("MyTestDatabase", 2.4); // don't do this, as the version will be rounded to 2`
 
 #### Generating handlers
@@ -270,7 +271,8 @@ To change the "schema" or structure of the database—which involves creating or
 
 To read the records of an existing object store, the transaction can either be in `readonly` or `readwrite` mode. To make changes to an existing object store, the transaction must be in `readwrite` mode. You open such transactions with {{domxref("IDBDatabase.transaction")}}. The method accepts two parameters: the `storeNames` (the scope, defined as an array of object stores that you want to access) and the `mode` (`readonly` or `readwrite`) for the transaction. The method returns a transaction object containing the {{domxref("IDBIndex.objectStore")}} method, which you can use to access your object store. By default, where no mode is specified, transactions open in `readonly` mode.
 
-> **Note:** As of Firefox 40, IndexedDB transactions have relaxed durability guarantees to increase performance (see [Firefox bug 1112702](https://bugzil.la/1112702).) Previously in a `readwrite` transaction, a {{domxref("IDBTransaction.complete_event", "complete")}} event was fired only when all data was guaranteed to have been flushed to disk. In Firefox 40+ the `complete` event is fired after the OS has been told to write the data but potentially before that data has actually been flushed to disk. The `complete` event may thus be delivered quicker than before, however, there exists a small chance that the entire transaction will be lost if the OS crashes or there is a loss of system power before the data is flushed to disk. Since such catastrophic events are rare most consumers should not need to concern themselves further. If you must ensure durability for some reason (e.g. you're storing critical data that cannot be recomputed later) you can force a transaction to flush to disk before delivering the `complete` event by creating a transaction using the experimental (non-standard) `readwriteflush` mode (see {{domxref("IDBDatabase.transaction")}}).
+> [!NOTE]
+> As of Firefox 40, IndexedDB transactions have relaxed durability guarantees to increase performance (see [Firefox bug 1112702](https://bugzil.la/1112702).) Previously in a `readwrite` transaction, a {{domxref("IDBTransaction.complete_event", "complete")}} event was fired only when all data was guaranteed to have been flushed to disk. In Firefox 40+ the `complete` event is fired after the OS has been told to write the data but potentially before that data has actually been flushed to disk. The `complete` event may thus be delivered quicker than before, however, there exists a small chance that the entire transaction will be lost if the OS crashes or there is a loss of system power before the data is flushed to disk. Since such catastrophic events are rare most consumers should not need to concern themselves further. If you must ensure durability for some reason (e.g. you're storing critical data that cannot be recomputed later) you can force a transaction to flush to disk before delivering the `complete` event by creating a transaction using the experimental (non-standard) `readwriteflush` mode (see {{domxref("IDBDatabase.transaction")}}).
 
 You can speed up data access by using the right scope and mode in the transaction. Here are a couple of tips:
 
@@ -393,7 +395,8 @@ request.onsuccess = (event) => {
 
 So here we're creating an `objectStore` and requesting a customer record out of it, identified by its ssn value (`444-44-4444`). We then put the result of that request in a variable (`data`), update the `age` property of this object, then create a second request (`requestUpdate`) to put the customer record back into the `objectStore`, overwriting the previous value.
 
-> **Note:** In this case we've had to specify a `readwrite` transaction because we want to write to the database, not just read from it.
+> [!NOTE]
+> In this case we've had to specify a `readwrite` transaction because we want to write to the database, not just read from it.
 
 ### Using a cursor
 
@@ -431,7 +434,8 @@ objectStore.openCursor().onsuccess = (event) => {
 };
 ```
 
-> **Note:** Alternatively, you can use `getAll()` to handle this case (and `getAllKeys()`). The following code does precisely the same thing as above:
+> [!NOTE]
+> Alternatively, you can use `getAll()` to handle this case (and `getAllKeys()`). The following code does precisely the same thing as above:
 >
 > ```js
 > objectStore.getAll().onsuccess = (event) => {

--- a/files/en-us/web/api/ink_api/index.md
+++ b/files/en-us/web/api/ink_api/index.md
@@ -19,7 +19,8 @@ Pointers events are usually sent first to the browser process, which then forwar
 
 The Ink API significantly reduces this latency by allowing browsers to bypass the JavaScript event loop entirely. Where possible, browsers will pass such rendering instructions directly to OS-level compositors. If the underlying operating system does not have a specialized OS-level compositor to use for this purpose, browsers will use their own optimized rendering code. This is not as powerful as a compositor, but it still confers some improvements.
 
-> **Note:** Compositors are part of the rendering machinery that draws the UI to the screen in a browser or operating system. See [Inside look at modern web browser (part 3)](https://developer.chrome.com/blog/inside-browser-part3/) for some interesting insights into how a compositor functions inside a web browser.
+> [!NOTE]
+> Compositors are part of the rendering machinery that draws the UI to the screen in a browser or operating system. See [Inside look at modern web browser (part 3)](https://developer.chrome.com/blog/inside-browser-part3/) for some interesting insights into how a compositor functions inside a web browser.
 
 The entry point is the {{domxref("Navigator.ink")}} property, which returns an {{domxref("Ink")}} object for the current document. The {{domxref("Ink.requestPresenter","Ink.requestPresenter()")}} method returns a {{jsxref("Promise")}} that fulfills with an {{domxref("InkPresenter")}} object instance. This instructs the OS-level compositor to render ink strokes between pointer event dispatches in the next available frame in each case.
 

--- a/files/en-us/web/api/inkpresenter/index.md
+++ b/files/en-us/web/api/inkpresenter/index.md
@@ -79,7 +79,8 @@ canvas.width = window.innerWidth;
 canvas.height = window.innerHeight;
 ```
 
-> **Note:** See this example running live — [Delegated ink trail](https://mabian-ms.github.io/delegated-ink-trail.html).
+> [!NOTE]
+> See this example running live — [Delegated ink trail](https://mabian-ms.github.io/delegated-ink-trail.html).
 
 ## Specifications
 

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -58,7 +58,8 @@ A `MediaTrackCapabilities` object which specifies the value or range of values w
 - `resizeMode`
   - : A [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring) object containing the mode or an array of modes the UA can use to derive the resolution of the video track.
 
-> **Note:** If the user has not granted permission to access the input device an empty object will be returned.
+> [!NOTE]
+> If the user has not granted permission to access the input device an empty object will be returned.
 
 ## Examples
 

--- a/files/en-us/web/api/inputevent/inputtype/index.md
+++ b/files/en-us/web/api/inputevent/inputtype/index.md
@@ -63,7 +63,8 @@ Try editing the text inside the `<div>` and see what happens.
 
 {{EmbedLiveSample("Examples", '100%', 500)}}
 
-> **Note:** See also [Masayuki Nakano's InputEvent test suite](https://d-toybox.com/studio/lib/input_event_viewer.html) for a more detailed example.
+> [!NOTE]
+> See also [Masayuki Nakano's InputEvent test suite](https://d-toybox.com/studio/lib/input_event_viewer.html) for a more detailed example.
 
 ## Specifications
 

--- a/files/en-us/web/api/installevent/addroutes/index.md
+++ b/files/en-us/web/api/installevent/addroutes/index.md
@@ -117,7 +117,8 @@ addEventListener("install", (event) => {
 });
 ```
 
-> **Note:** If the cache does not exist, the browser defaults to using the network so that the requested resources can still be obtained provided the network is available.
+> [!NOTE]
+> If the cache does not exist, the browser defaults to using the network so that the requested resources can still be obtained provided the network is available.
 
 You can't combine `or` with another condition — this results in a `TypeError`. If for example you wanted to match files with extensions of `.png` or `.jpg` but only when the `requestMethod` is `get`, you'd need to specify two separate conditions:
 

--- a/files/en-us/web/api/installevent/index.md
+++ b/files/en-us/web/api/installevent/index.md
@@ -35,7 +35,8 @@ This code snippet is from the [service worker prefetch sample](https://github.co
 
 The code snippet also shows a best practice for versioning caches used by the service worker. Although this example has only one cache, you can use this approach for multiple caches. The code maps a shorthand identifier for a cache to a specific, versioned cache name.
 
-> **Note:** Logging statements are visible in Google Chrome via the "Inspect" interface for the relevant service worker accessed via chrome://serviceworker-internals.
+> [!NOTE]
+> Logging statements are visible in Google Chrome via the "Inspect" interface for the relevant service worker accessed via chrome://serviceworker-internals.
 
 ```js
 const CACHE_VERSION = 1;

--- a/files/en-us/web/api/intersectionobserver/observe/index.md
+++ b/files/en-us/web/api/intersectionobserver/observe/index.md
@@ -24,7 +24,8 @@ observer's callback is executed with an array of
 which occurred. Note that this design allows multiple elements' intersection changes to
 be processed by a single call to the callback.
 
-> **Note:** the observer [callback](/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#callback) will always fire the first render cycle after `observe()` is called, even if the observed element has not yet moved with respect to the viewport.
+> [!NOTE]
+> the observer [callback](/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#callback) will always fire the first render cycle after `observe()` is called, even if the observed element has not yet moved with respect to the viewport.
 > This means that, for example, an element that is outside the viewport when `observe()` is called on it will result in the callback being immediately called with at least one [entry](/en-US/docs/Web/API/IntersectionObserverEntry) with [`intersecting`](/en-US/docs/Web/API/IntersectionObserverEntry/isIntersecting) set to `false`.
 > An element inside the viewport will result in the callback being immediately called with at least one entry with `intersecting` set to `true`.
 

--- a/files/en-us/web/api/intersectionobserver/takerecords/index.md
+++ b/files/en-us/web/api/intersectionobserver/takerecords/index.md
@@ -15,7 +15,8 @@ has experienced an intersection change since the last time the intersections wer
 checked, either explicitly through a call to this method or implicitly by an automatic
 call to the observer's callback.
 
-> **Note:** If you use the callback to monitor these changes, you don't
+> [!NOTE]
+> If you use the callback to monitor these changes, you don't
 > need to call this method. Calling this method clears the pending intersection list, so
 > the callback will not be run.
 

--- a/files/en-us/web/api/intersectionobserver/thresholds/index.md
+++ b/files/en-us/web/api/intersectionobserver/thresholds/index.md
@@ -30,7 +30,8 @@ If no `threshold` option was included when
 `IntersectionObserver()` was used to instantiate the observer, the value of
 `thresholds` is `[0]`.
 
-> **Note:** Although the `options` object you can specify when creating an
+> [!NOTE]
+> Although the `options` object you can specify when creating an
 > {{domxref("IntersectionObserver")}} has a field named
 > `threshold`, this property is called
 > `thresholds`. Confusing? Yes. If you accidentally use

--- a/files/en-us/web/api/interventionreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/interventionreportbody/columnnumber/index.md
@@ -12,7 +12,8 @@ browser-compat: api.InterventionReportBody.columnNumber
 
 The **`columnNumber`** read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.
 
-> **Note:** This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} and {{domxref("InterventionReportBody.lineNumber")}} as it enables the location of the column in that file and line where the feature is used.
+> [!NOTE]
+> This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} and {{domxref("InterventionReportBody.lineNumber")}} as it enables the location of the column in that file and line where the feature is used.
 
 ## Value
 

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.md
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.md
@@ -12,7 +12,8 @@ browser-compat: api.InterventionReportBody.lineNumber
 
 The **`lineNumber`** read-only property of the {{domxref("InterventionReportBody")}} interface returns the line in the source file in which the intervention occurred.
 
-> **Note:** This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} as it enables the location of the line in that file where the feature is used.
+> [!NOTE]
+> This property is most useful alongside {{domxref("InterventionReportBody.sourceFile")}} as it enables the location of the line in that file where the feature is used.
 
 ## Value
 

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.md
@@ -12,7 +12,8 @@ browser-compat: api.InterventionReportBody.sourceFile
 
 The **`sourceFile`** read-only property of the {{domxref("InterventionReportBody")}} interface returns the path to the source file where the intervention occurred.
 
-> **Note:** This property can be used with {{domxref("InterventionReportBody.lineNumber")}} and {{domxref("InterventionReportBody.columnNumber")}} to locate the column and line in the file where the feature is used.
+> [!NOTE]
+> This property can be used with {{domxref("InterventionReportBody.lineNumber")}} and {{domxref("InterventionReportBody.columnNumber")}} to locate the column and line in the file where the feature is used.
 
 ## Value
 

--- a/files/en-us/web/api/keyboardevent/charcode/index.md
+++ b/files/en-us/web/api/keyboardevent/charcode/index.md
@@ -14,7 +14,8 @@ The **`charCode`** read-only property of the
 {{domxref("KeyboardEvent")}} interface returns the Unicode value of a character key
 pressed during a {{domxref("Element/keypress_event", "keypress")}} event.
 
-> **Warning:** Do not use this property, as it is deprecated. Instead, get the
+> [!WARNING]
+> Do not use this property, as it is deprecated. Instead, get the
 > Unicode value of the character using the {{domxref("KeyboardEvent.key", "key")}}
 > property.
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 7.
