### PR TITLE
Convert noteblocks for web/api folder (part 9)

### DIFF
--- a/files/en-us/web/api/node/insertbefore/index.md
+++ b/files/en-us/web/api/node/insertbefore/index.md
@@ -18,7 +18,8 @@ before appending it to the specified new parent.)
 
 This means that a node cannot be in two locations of the document simultaneously.
 
-> **Note:** The {{domxref("Node.cloneNode()")}} can be used to make a copy
+> [!NOTE]
+> The {{domxref("Node.cloneNode()")}} can be used to make a copy
 > of the node before appending it under the new parent. Note that the copies made with
 > `cloneNode()` will not be automatically kept in sync.
 
@@ -107,7 +108,8 @@ Pre-insert validity
 </script>
 ```
 
-> **Note:** There is no `insertAfter()` method.
+> [!NOTE]
+> There is no `insertAfter()` method.
 > It can be emulated by combining the `insertBefore` method
 > with {{domxref("Node.nextSibling")}}.
 >

--- a/files/en-us/web/api/node/isdefaultnamespace/index.md
+++ b/files/en-us/web/api/node/isdefaultnamespace/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Node.isDefaultNamespace
 The **`isDefaultNamespace()`** method of the {{domxref("Node")}} interface accepts a namespace URI as an argument.
 It returns a boolean value that is `true` if the namespace is the default namespace on the given node and `false` if not.
 
-> **Note:** The default namespace of an HTML element is always `""`. For a SVG element, it is set by the `xmlns` attribute.
+> [!NOTE]
+> The default namespace of an HTML element is always `""`. For a SVG element, it is set by the `xmlns` attribute.
 
 ## Syntax
 

--- a/files/en-us/web/api/node/isequalnode/index.md
+++ b/files/en-us/web/api/node/isequalnode/index.md
@@ -24,7 +24,8 @@ isEqualNode(otherNode)
 
 - `otherNode`
   - : The {{domxref("Node")}} to compare equality with.
-    > **Note:** This parameter is not optional, but can be set to `null`.
+    > [!NOTE]
+    > This parameter is not optional, but can be set to `null`.
 
 ### Return value
 

--- a/files/en-us/web/api/node/issamenode/index.md
+++ b/files/en-us/web/api/node/issamenode/index.md
@@ -13,7 +13,8 @@ is a legacy alias the [for the `===` strict equality operator](/en-US/docs/Web/J
 That is, it tests whether two nodes are the same
 (in other words, whether they reference the same object).
 
-> **Note:** There is no need to use `isSameNode()`; instead use the `===` strict equality operator.
+> [!NOTE]
+> There is no need to use `isSameNode()`; instead use the `===` strict equality operator.
 
 ## Syntax
 
@@ -25,7 +26,8 @@ isSameNode(otherNode)
 
 - `otherNode`
   - : The {{domxref("Node")}} to test against.
-    > **Note:** This parameter is not optional, but can be set to `null`.
+    > [!NOTE]
+    > This parameter is not optional, but can be set to `null`.
 
 ### Return value
 

--- a/files/en-us/web/api/node/lastchild/index.md
+++ b/files/en-us/web/api/node/lastchild/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Node.lastChild
 The read-only **`lastChild`** property of the {{domxref("Node")}} interface
 returns the last child of the node, or `null` if there are no child nodes.
 
-> **Note:** This property returns any type of node that is the last child of this one.
+> [!NOTE]
+> This property returns any type of node that is the last child of this one.
 > It may be a {{domxref("Text")}} or a {{domxref("Comment")}} node.
 > If you want to get the last {{domxref("Element")}} that is a child of another element,
 > consider using {{domxref("Element.lastElementChild")}}.

--- a/files/en-us/web/api/node/lookupnamespaceuri/index.md
+++ b/files/en-us/web/api/node/lookupnamespaceuri/index.md
@@ -22,7 +22,8 @@ lookupNamespaceURI(prefix)
 
 - `prefix`
   - : The prefix to look for.
-    > **Note:** This parameter is not optional, but can be set to `null`.
+    > [!NOTE]
+    > This parameter is not optional, but can be set to `null`.
 
 ### Return value
 

--- a/files/en-us/web/api/node/lookupprefix/index.md
+++ b/files/en-us/web/api/node/lookupprefix/index.md
@@ -23,7 +23,8 @@ lookupPrefix(namespace)
 
 - `namespace`
   - : A string containing the namespace to look the prefix up.
-    > **Note:** This parameter is not optional but can be set to `null`.
+    > [!NOTE]
+    > This parameter is not optional but can be set to `null`.
 
 ### Return value
 

--- a/files/en-us/web/api/node/nextsibling/index.md
+++ b/files/en-us/web/api/node/nextsibling/index.md
@@ -13,7 +13,8 @@ returns the node immediately following the specified one in their
 parent's {{domxref("Node.childNodes","childNodes")}}, or returns `null`
 if the specified node is the last child in the parent element.
 
-> **Note:** Browsers insert {{domxref("Text")}} nodes into a document to represent whitespace in the source markup.
+> [!NOTE]
+> Browsers insert {{domxref("Text")}} nodes into a document to represent whitespace in the source markup.
 > Therefore a node obtained, for example, using [`Node.firstChild`](/en-US/docs/Web/API/Node/firstChild)
 > or [`Node.previousSibling`](/en-US/docs/Web/API/Node/previousSibling)
 > may refer to a whitespace text node rather than the actual element the author

--- a/files/en-us/web/api/node/nodevalue/index.md
+++ b/files/en-us/web/api/node/nodevalue/index.md
@@ -31,7 +31,8 @@ The following table shows the return values for different types of nodes.
 | {{domxref("ProcessingInstruction")}} | Entire content excluding the target |
 | {{domxref("Text")}}                  | Content of the text node            |
 
-> **Note:** When `nodeValue` is defined to be `null`, setting it has no effect.
+> [!NOTE]
+> When `nodeValue` is defined to be `null`, setting it has no effect.
 
 ## Example
 

--- a/files/en-us/web/api/node/previoussibling/index.md
+++ b/files/en-us/web/api/node/previoussibling/index.md
@@ -13,7 +13,8 @@ returns the node immediately preceding the specified one in its parent's
 {{domxref("Node.childNodes", "childNodes")}} list,
 or `null` if the specified node is the first in that list.
 
-> **Note:** Browsers insert text nodes into a document to represent whitespace in the source markup.
+> [!NOTE]
+> Browsers insert text nodes into a document to represent whitespace in the source markup.
 > Therefore a node obtained, for example, using [`Node.firstChild`](/en-US/docs/Web/API/Node/firstChild)
 > or `Node.previousSibling`
 > may refer to a whitespace text node rather than the actual element the author intended to get.

--- a/files/en-us/web/api/node/removechild/index.md
+++ b/files/en-us/web/api/node/removechild/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Node.removeChild
 The **`removeChild()`** method of the {{domxref("Node")}} interface
 removes a child node from the DOM and returns the removed node.
 
-> **Note:** As long as a reference is kept on the removed child,
+> [!NOTE]
+> As long as a reference is kept on the removed child,
 > it still exists in memory, but is no longer part of the DOM.
 > It can still be reused later in the code.
 >

--- a/files/en-us/web/api/node/replacechild/index.md
+++ b/files/en-us/web/api/node/replacechild/index.md
@@ -20,11 +20,13 @@ replaceChild(newChild, oldChild)
 
 - `newChild`
   - : The new node to replace `oldChild`.
-    > **Warning:** If the new node is already present somewhere else in the DOM, it is first removed from that position.
+    > [!WARNING]
+    > If the new node is already present somewhere else in the DOM, it is first removed from that position.
 - `oldChild`
   - : The child to be replaced.
 
-> **Note:** The parameter order, _new_ before _old_, is unusual.
+> [!NOTE]
+> The parameter order, _new_ before _old_, is unusual.
 > [`Element.replaceWith()`](/en-US/docs/Web/API/Element/replaceWith), applying only to nodes that are elements,
 > may be easier to read and use.
 

--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -21,7 +21,8 @@ A string, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). Its 
 - If the node is a {{domxref("document")}} or a {{glossary("doctype")}},
   `textContent` returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
-  > **Note:** To get _all_ of the text and [CDATA data](/en-US/docs/Web/API/CDATASection) for the whole
+  > [!NOTE]
+  > To get _all_ of the text and [CDATA data](/en-US/docs/Web/API/CDATASection) for the whole
   > document, use `document.documentElement.textContent`.
 
 - If the node is a [CDATA section](/en-US/docs/Web/API/CDATASection),
@@ -33,7 +34,8 @@ A string, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). Its 
   `textContent` of every child node, excluding comments and processing
   instructions. (This is an empty string if the node has no children.)
 
-> **Warning:** Setting `textContent` on a node removes _all_ of the node's children
+> [!WARNING]
+> Setting `textContent` on a node removes _all_ of the node's children
 > and replaces them with a single text node with the given string value.
 
 ### Differences from innerText

--- a/files/en-us/web/api/notification/actions/index.md
+++ b/files/en-us/web/api/notification/actions/index.md
@@ -14,7 +14,8 @@ The **`actions`** read-only property of the {{domxref("Notification")}} interfac
 
 The actions are set using the `actions` option of the second argument for the {{DOMxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method and {{DOMxref("Notification/Notification", "Notification()")}} constructor.
 
-> **Note:** Browsers typically limit the maximum number of actions they will display for a particular notification. Check the static {{DOMxref("Notification.maxActions_static", "Notification.maxActions")}} property to determine the limit.
+> [!NOTE]
+> Browsers typically limit the maximum number of actions they will display for a particular notification. Check the static {{DOMxref("Notification.maxActions_static", "Notification.maxActions")}} property to determine the limit.
 
 ## Value
 

--- a/files/en-us/web/api/notification/close/index.md
+++ b/files/en-us/web/api/notification/close/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Notification.close
 The **`close()`** method of the {{domxref("Notification")}} interface is used to
 close/remove a previously displayed notification.
 
-> **Note:** This API shouldn't be used just to have the notification
+> [!NOTE]
+> This API shouldn't be used just to have the notification
 > removed from the screen after a fixed delay since this method will also remove the
 > notification from any notification tray, preventing users from interacting with it
 > after it was initially shown. A valid use for this API would be to remove a

--- a/files/en-us/web/api/notification/dir/index.md
+++ b/files/en-us/web/api/notification/dir/index.md
@@ -21,7 +21,8 @@ A string specifying the text direction. Possible values are:
 - `rtl`
   - : right to left.
 
-> **Note:** Most browsers seem to ignore explicit ltr and rtl settings, and just go with the browser-wide setting.
+> [!NOTE]
+> Most browsers seem to ignore explicit ltr and rtl settings, and just go with the browser-wide setting.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/index.md
+++ b/files/en-us/web/api/notification/index.md
@@ -133,7 +133,8 @@ function notifyMe() {
 
 We no longer show a live sample on this page, as Chrome and Firefox no longer allow notification permissions to be requested from cross-origin {{htmlelement("iframe")}}s, with other browsers to follow. To see an example in action, check out our [To-do list example](https://github.com/mdn/dom-examples/tree/main/to-do-notifications) (also see [the app running live](https://mdn.github.io/dom-examples/to-do-notifications/)).
 
-> **Note:** In the above example we spawn notifications in response to a user gesture (clicking a button). This is not only best practice — you should not be spamming users with notifications they didn't agree to — but going forward browsers will explicitly disallow notifications not triggered in response to a user gesture. Firefox is already doing this from version 72, for example.
+> [!NOTE]
+> In the above example we spawn notifications in response to a user gesture (clicking a button). This is not only best practice — you should not be spamming users with notifications they didn't agree to — but going forward browsers will explicitly disallow notifications not triggered in response to a user gesture. Firefox is already doing this from version 72, for example.
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Notification.Notification
 The **`Notification()`** constructor creates a new
 {{domxref("Notification")}} object instance, which represents a user notification.
 
-> **Note:** Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`. Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
+> [!NOTE]
+> Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`. Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/notification/requireinteraction/index.md
+++ b/files/en-us/web/api/notification/requireinteraction/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Notification.requireInteraction
 
 The **`requireInteraction`** read-only property of the {{domxref("Notification")}} interface returns a boolean value indicating that a notification should remain active until the user clicks or dismisses it, rather than closing automatically.
 
-> **Note:** This can be set when the notification is first created by setting the `requireInteraction` option to `true` in the options object of the {{domxref("Notification.Notification", "Notification()")}} constructor.
+> [!NOTE]
+> This can be set when the notification is first created by setting the `requireInteraction` option to `true` in the options object of the {{domxref("Notification.Notification", "Notification()")}} constructor.
 
 ## Value
 

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -11,7 +11,8 @@ The **`NotificationEvent`** interface of the {{domxref("Notifications API", "", 
 
 This interface inherits from the {{domxref("ExtendableEvent")}} interface.
 
-> **Note:** Only persistent notification events, fired at the {{domxref("ServiceWorkerGlobalScope")}} object, implement the `NotificationEvent` interface. Non-persistent notification events, fired at the {{domxref("Notification")}} object, implement the `Event` interface.
+> [!NOTE]
+> Only persistent notification events, fired at the {{domxref("ServiceWorkerGlobalScope")}} object, implement the `NotificationEvent` interface. Non-persistent notification events, fired at the {{domxref("Notification")}} object, implement the `Event` interface.
 
 {{InheritanceDiagram}}
 
@@ -61,7 +62,8 @@ self.addEventListener("notificationclick", (event) => {
 
 {{Specifications}}
 
-> **Note:** This interface is specified in the [Notifications API](/en-US/docs/Web/API/Notifications_API), but accessed through {{domxref("ServiceWorkerGlobalScope")}}.
+> [!NOTE]
+> This interface is specified in the [Notifications API](/en-US/docs/Web/API/Notifications_API), but accessed through {{domxref("ServiceWorkerGlobalScope")}}.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -35,7 +35,8 @@ Next, a new notification is created using the {{domxref("Notification.Notificati
 
 In addition, the Notifications API spec specifies a number of additions to the [ServiceWorker API](/en-US/docs/Web/API/Service_Worker_API), to allow service workers to fire notifications.
 
-> **Note:** To find out more about using notifications in your own app, read [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
+> [!NOTE]
+> To find out more about using notifications in your own app, read [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
 
 ## Interfaces
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -59,7 +59,8 @@ Notification.requestPermission((result) => {
 
 The callback version optionally accepts a callback function that is called once the user has responded to the request to display permissions.
 
-> **Note:** There's no way to reliably feature-test whether `Notification.requestPermission` supports the promise-based version. If you need to support older browsers, just use the callback-based version—although this is deprecated, it still works in new browsers. Check the [browser compatibility table](/en-US/docs/Web/API/Notification/requestPermission_static#browser_compatibility) for more information.
+> [!NOTE]
+> There's no way to reliably feature-test whether `Notification.requestPermission` supports the promise-based version. If you need to support older browsers, just use the callback-based version—although this is deprecated, it still works in new browsers. Check the [browser compatibility table](/en-US/docs/Web/API/Notification/requestPermission_static#browser_compatibility) for more information.
 
 ### Example
 
@@ -115,9 +116,11 @@ document.addEventListener("visibilitychange", () => {
 });
 ```
 
-> **Note:** This API shouldn't be used just to have the notification removed from the screen after a fixed delay (on modern browsers) since this method will also remove the notification from any notification tray, preventing users from interacting with it after it was initially shown.
+> [!NOTE]
+> This API shouldn't be used just to have the notification removed from the screen after a fixed delay (on modern browsers) since this method will also remove the notification from any notification tray, preventing users from interacting with it after it was initially shown.
 
-> **Note:** When you receive a "close" event, there is no guarantee that it's the user who closed the notification. This is in line with the specification, which states: "When a notification is closed, either by the underlying notifications platform or by the user, the close steps for it must be run."
+> [!NOTE]
+> When you receive a "close" event, there is no guarantee that it's the user who closed the notification. This is in line with the specification, which states: "When a notification is closed, either by the underlying notifications platform or by the user, the close steps for it must be run."
 
 ## Notification events
 

--- a/files/en-us/web/api/oes_draw_buffers_indexed/index.md
+++ b/files/en-us/web/api/oes_draw_buffers_indexed/index.md
@@ -11,7 +11,8 @@ The **`OES_draw_buffers_indexed`** extension is part of the [WebGL API](/en-US/d
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Instance methods
 

--- a/files/en-us/web/api/oes_element_index_uint/index.md
+++ b/files/en-us/web/api/oes_element_index_uint/index.md
@@ -12,7 +12,8 @@ The **`OES_element_index_uint`** extension is part of the [WebGL API](/en-US/doc
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.
 
 ## Extended methods
 

--- a/files/en-us/web/api/oes_fbo_render_mipmap/index.md
+++ b/files/en-us/web/api/oes_fbo_render_mipmap/index.md
@@ -12,7 +12,8 @@ The `OES_fbo_render_mipmap` extension is part of the [WebGL API](/en-US/docs/Web
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}.
 > In WebGL2, the functionality of this extension is available in the WebGL 2 context by default.
 
 ## Examples

--- a/files/en-us/web/api/oes_standard_derivatives/index.md
+++ b/files/en-us/web/api/oes_standard_derivatives/index.md
@@ -12,7 +12,8 @@ The **`OES_standard_derivatives`** extension is part of the [WebGL API](/en-US/d
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constant is available as `gl.FRAGMENT_SHADER_DERIVATIVE_HINT` and it requires GLSL `#version 300 es`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constant is available as `gl.FRAGMENT_SHADER_DERIVATIVE_HINT` and it requires GLSL `#version 300 es`.
 
 ## Constants
 

--- a/files/en-us/web/api/oes_texture_float/index.md
+++ b/files/en-us/web/api/oes_texture_float/index.md
@@ -12,7 +12,8 @@ The **`OES_texture_float`** extension is part of the [WebGL API](/en-US/docs/Web
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default.
 
 ## Extended methods
 

--- a/files/en-us/web/api/oes_texture_float_linear/index.md
+++ b/files/en-us/web/api/oes_texture_float_linear/index.md
@@ -12,7 +12,8 @@ The **`OES_texture_float_linear`** extension is part of the [WebGL API](/en-US/d
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Linear filtering
 

--- a/files/en-us/web/api/oes_texture_half_float/index.md
+++ b/files/en-us/web/api/oes_texture_half_float/index.md
@@ -12,7 +12,8 @@ The **`OES_texture_half_float`** extension is part of the [WebGL API](/en-US/doc
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is `gl.HALF_FLOAT`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is `gl.HALF_FLOAT`.
 
 ## Constants
 

--- a/files/en-us/web/api/oes_texture_half_float_linear/index.md
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.md
@@ -12,7 +12,8 @@ The **`OES_texture_half_float_linear`** extension is part of the [WebGL API](/en
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the extension is not needed.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the extension is not needed.
 
 ## Linear filtering
 

--- a/files/en-us/web/api/oes_vertex_array_object/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/index.md
@@ -12,7 +12,8 @@ The **OES_vertex_array_object** extension is part of the [WebGL API](/en-US/docs
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "`OES`" suffix.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "`OES`" suffix.
 
 ## Constants
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.md
@@ -9,7 +9,8 @@ browser-compat: api.OfflineAudioCompletionEvent
 
 The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `OfflineAudioCompletionEvent` interface represents events that occur when the processing of an {{domxref("OfflineAudioContext")}} is terminated. The {{domxref("OfflineAudioContext/complete_event", "complete")}} event uses this interface.
 
-> **Note:** This interface is marked as deprecated; it is still supported for legacy reasons, but it will soon be superseded when the promise version of {{domxref("OfflineAudioContext.startRendering")}} is supported in browsers, which will no longer need it.
+> [!NOTE]
+> This interface is marked as deprecated; it is still supported for legacy reasons, but it will soon be superseded when the promise version of {{domxref("OfflineAudioContext.startRendering")}} is supported in browsers, which will no longer need it.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.md
@@ -11,7 +11,8 @@ browser-compat: api.OfflineAudioCompletionEvent.OfflineAudioCompletionEvent
 The **`OfflineAudioCompletionEvent()`** constructor of the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) creates a new
 {{domxref("OfflineAudioCompletionEvent")}} object.
 
-> **Note:** You wouldn't generally use the constructor manually.
+> [!NOTE]
+> You wouldn't generally use the constructor manually.
 > `OfflineAudioCompletionEvent` events are dispatched to
 > {{domxref("OfflineAudioContext")}} instances for legacy reasons.
 

--- a/files/en-us/web/api/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/index.md
@@ -37,7 +37,8 @@ _Also inherits methods from its parent interface, {{domxref("BaseAudioContext")}
 - {{domxref("OfflineAudioContext.resume()")}}
   - : Resumes the progression of time in an audio context that has previously been suspended.
 
-> **Note:** The `resume()` method is still available — it is now defined on the {{domxref("BaseAudioContext")}} interface (see {{domxref("AudioContext.resume")}}) and thus can be accessed by both the {{domxref("AudioContext")}} and `OfflineAudioContext` interfaces.
+> [!NOTE]
+> The `resume()` method is still available — it is now defined on the {{domxref("BaseAudioContext")}} interface (see {{domxref("AudioContext.resume")}}) and thus can be accessed by both the {{domxref("AudioContext")}} and `OfflineAudioContext` interfaces.
 
 ## Events
 
@@ -56,7 +57,8 @@ When the `startRendering()` promise resolves, rendering has completed and the ou
 
 At this point we create another audio context, create an {{domxref("AudioBufferSourceNode")}} inside it, and set its buffer to be equal to the promise `AudioBuffer`. This is then played as part of a simple standard audio graph.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/offline-audio-context-promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/offline-audio-context-promise/).
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/offline-audio-context-promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/offline-audio-context-promise/).
 
 ```js
 // Define both online and offline audio contexts

--- a/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
@@ -39,7 +39,8 @@ When the `startRendering()` promise resolves, rendering has completed and the ou
 
 At this point we create another audio context, create an {{domxref("AudioBufferSourceNode")}} inside it, and set its buffer to be equal to the promise `AudioBuffer`. This is then played as part of a simple standard audio graph.
 
-> **Note:** You can [run the full example live](https://mdn.github.io/webaudio-examples/offline-audio-context-promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/offline-audio-context-promise/).
+> [!NOTE]
+> You can [run the full example live](https://mdn.github.io/webaudio-examples/offline-audio-context-promise/), or [view the source](https://github.com/mdn/webaudio-examples/blob/main/offline-audio-context-promise/).
 
 ```js
 // Define both online and offline audio contexts

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -33,7 +33,8 @@ getContext(contextType, contextAttributes)
     - `bitmaprenderer`
       - : Creates a {{domxref("ImageBitmapRenderingContext")}} which only provides functionality to replace the content of the canvas with a given {{domxref("ImageBitmap")}}.
 
-    > **Note:** The identifiers **`"experimental-webgl"`** or **`"experimental-webgl2"`** are also used in implementations of WebGL.
+    > [!NOTE]
+    > The identifiers **`"experimental-webgl"`** or **`"experimental-webgl2"`** are also used in implementations of WebGL.
     > These implementations have not reached test suite conformance, or the graphic drivers situation on the platform is not yet stable.
     > The [Khronos Group](https://www.khronos.org/) certifies WebGL implementations under certain [conformance rules](https://www.khronos.org/registry/webgl/sdk/tests/CONFORMANCE_RULES.txt).
 

--- a/files/en-us/web/api/oscillatornode/detune/index.md
+++ b/files/en-us/web/api/oscillatornode/detune/index.md
@@ -10,7 +10,8 @@ browser-compat: api.OscillatorNode.detune
 
 The `detune` property of the {{ domxref("OscillatorNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing detuning of oscillation in [cents](https://en.wikipedia.org/wiki/Cent_%28music%29).
 
-> **Note:** though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Value
 

--- a/files/en-us/web/api/oscillatornode/frequency/index.md
+++ b/files/en-us/web/api/oscillatornode/frequency/index.md
@@ -10,7 +10,8 @@ browser-compat: api.OscillatorNode.frequency
 
 The **`frequency`** property of the {{ domxref("OscillatorNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing the frequency of oscillation in hertz.
 
-> **Note:** though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Value
 

--- a/files/en-us/web/api/otpcredential/code/index.md
+++ b/files/en-us/web/api/otpcredential/code/index.md
@@ -35,7 +35,8 @@ navigator.credentials
   });
 ```
 
-> **Note:** For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
+> [!NOTE]
+> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
 
 ## Specifications
 

--- a/files/en-us/web/api/otpcredential/index.md
+++ b/files/en-us/web/api/otpcredential/index.md
@@ -43,7 +43,8 @@ navigator.credentials
   });
 ```
 
-> **Note:** For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
+> [!NOTE]
+> For a full explanation of the code, see the {{domxref('WebOTP API','','',' ')}} landing page. You can also [see this code as part of a full working demo](https://web-otp.glitch.me/).
 
 ## Specifications
 

--- a/files/en-us/web/api/ovr_multiview2/index.md
+++ b/files/en-us/web/api/ovr_multiview2/index.md
@@ -19,7 +19,8 @@ For more information, see also:
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** Support depends on the system's graphics driver (Windows+ANGLE and Android are supported; Windows+GL, Mac, Linux are not supported).
+> [!NOTE]
+> Support depends on the system's graphics driver (Windows+ANGLE and Android are supported; Windows+GL, Mac, Linux are not supported).
 >
 > This extension is only available to {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts as it needs GLSL 3.00 and texture arrays.
 >

--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -27,7 +27,8 @@ Let's consider a few use cases for the Page Visibility API.
 
 Developers have historically used imperfect proxies to detect this. For example, watching for {{domxref("Window/blur_event", "blur")}} and {{domxref("Window/focus_event", "focus")}} events on the window helps you know when your page is not the active page, but it does not tell you that your page is actually hidden to the user. The Page Visibility API addresses this.
 
-> **Note:** While {{domxref("Window.blur_event", "onblur")}} and {{domxref("Window.focus_event", "onfocus")}} will tell you if the user switches windows, it doesn't necessarily mean it's hidden. Pages only become hidden when the user switches tabs or minimizes the browser window containing the tab.
+> [!NOTE]
+> While {{domxref("Window.blur_event", "onblur")}} and {{domxref("Window.focus_event", "onfocus")}} will tell you if the user switches windows, it doesn't necessarily mean it's hidden. Pages only become hidden when the user switches tabs or minimizes the browser window containing the tab.
 
 ### Policies in place to aid background page performance
 

--- a/files/en-us/web/api/pagerevealevent/index.md
+++ b/files/en-us/web/api/pagerevealevent/index.md
@@ -89,7 +89,8 @@ window.addEventListener("pagereveal", async (e) => {
 });
 ```
 
-> **Note:** See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
+> [!NOTE]
+> See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
 
 ## Specifications
 

--- a/files/en-us/web/api/pageswapevent/index.md
+++ b/files/en-us/web/api/pageswapevent/index.md
@@ -77,7 +77,8 @@ window.addEventListener("pageswap", async (e) => {
 });
 ```
 
-> **Note:** See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
+> [!NOTE]
+> See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
 
 ## Specifications
 

--- a/files/en-us/web/api/pagetransitionevent/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/pagetransitionevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PageTransitionEvent.PageTransitionEvent
 
 The **`PageTransitionEvent()`** constructor creates a new {{domxref("PageTransitionEvent")}} object, that is used by the {{domxref("Window/pageshow_event", "pageshow")}} or {{domxref("Window/pagehide_event", "pagehide")}} events, fired at the {{domxref("window")}} object when a page is loaded or unloaded.
 
-> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/pageshow_event", "pageshow")}} or {{domxref("Window/pagehide_event", "pagehide")}} events.
+> [!NOTE]
+> A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing {{domxref("Window/pageshow_event", "pageshow")}} or {{domxref("Window/pagehide_event", "pagehide")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/index.md
@@ -49,7 +49,8 @@ A `PannerNode` always has exactly one input and one output: the input can be _mo
 
 _Inherits properties from its parent, {{domxref("AudioNode")}}_.
 
-> **Note:** The orientation and position value are set and retrieved using different syntaxes, since they're stored as {{domxref("AudioParam")}} values. Retrieval is done by accessing, for example, `PannerNode.positionX`. While setting the same property is done with `PannerNode.positionX.value`. This is why these values are not marked read only, which is how they appear in the WebIDL.
+> [!NOTE]
+> The orientation and position value are set and retrieved using different syntaxes, since they're stored as {{domxref("AudioParam")}} values. Retrieval is done by accessing, for example, `PannerNode.positionX`. While setting the same property is done with `PannerNode.positionX.value`. This is why these values are not marked read only, which is how they appear in the WebIDL.
 
 - {{domxref("PannerNode.coneInnerAngle")}}
   - : A double value describing the angle, in degrees, of a cone inside of which there will be no volume reduction.

--- a/files/en-us/web/api/pannernode/setorientation/index.md
+++ b/files/en-us/web/api/pannernode/setorientation/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PannerNode.setOrientation
 
 {{APIRef("Web Audio API")}}{{Deprecated_Header}}
 
-> **Note:** The suggested replacement for this deprecated method is to instead set the [`orientationX`](/en-US/docs/Web/API/PannerNode/orientationX), [`orientationY`](/en-US/docs/Web/API/PannerNode/orientationY), and [`orientationZ`](/en-US/docs/Web/API/PannerNode/orientationZ) attributes directly.
+> [!NOTE]
+> The suggested replacement for this deprecated method is to instead set the [`orientationX`](/en-US/docs/Web/API/PannerNode/orientationX), [`orientationY`](/en-US/docs/Web/API/PannerNode/orientationY), and [`orientationZ`](/en-US/docs/Web/API/PannerNode/orientationZ) attributes directly.
 
 The `setOrientation()` method of the {{ domxref("PannerNode") }} Interface defines the direction the audio source is playing in.
 

--- a/files/en-us/web/api/pannernode/setposition/index.md
+++ b/files/en-us/web/api/pannernode/setposition/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PannerNode.setPosition
 
 {{APIRef("Web Audio API")}}{{Deprecated_Header}}
 
-> **Note:** The suggested replacement for this deprecated method is to instead set the [`positionX`](/en-US/docs/Web/API/PannerNode/positionX), [`positionY`](/en-US/docs/Web/API/PannerNode/positionY), and [`positionZ`](/en-US/docs/Web/API/PannerNode/positionZ) attributes directly.
+> [!NOTE]
+> The suggested replacement for this deprecated method is to instead set the [`positionX`](/en-US/docs/Web/API/PannerNode/positionX), [`positionY`](/en-US/docs/Web/API/PannerNode/positionY), and [`positionZ`](/en-US/docs/Web/API/PannerNode/positionZ) attributes directly.
 
 The `setPosition()` method of the {{ domxref("PannerNode") }} Interface defines the position of the audio source relative to the listener (represented by an {{domxref("AudioListener")}} object stored in the {{domxref("BaseAudioContext.listener")}} attribute.) The three parameters `x`, `y` and `z` are unitless and describe the source's position in 3D space using the right-hand Cartesian coordinate system.
 

--- a/files/en-us/web/api/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/index.md
@@ -11,7 +11,8 @@ browser-compat: api.PasswordCredential
 
 The **`PasswordCredential`** interface of the [Credential Management API](/en-US/docs/Web/API/Credential_Management_API) provides information about a username/password pair. In supporting browsers an instance of this class may be passed in the `credential` member of the `init` object for global {{domxref("Window/fetch", "fetch()")}}.
 
-> **Note:** This interface is restricted to top-level contexts and cannot be used from an {{HTMLElement("iframe")}}.
+> [!NOTE]
+> This interface is restricted to top-level contexts and cannot be used from an {{HTMLElement("iframe")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/payment_handler_api/index.md
+++ b/files/en-us/web/api/payment_handler_api/index.md
@@ -128,7 +128,8 @@ When the {{domxref("PaymentRequest.show()")}} method is invoked by the merchant 
 - If there are multiple payment app options, a list of options is presented to the user for them to choose from. Selecting a payment app will start the payment flow, which causes the browser to Just-In-Time (JIT) install the web app if necessary, registering the service worker specified in the [`serviceworker`](/en-US/docs/Web/Manifest/serviceworker) member so it can handle the payment.
 - If there is only one payment app option, the {{domxref("PaymentRequest.show()")}} method will start the payment flow with this payment app, JIT-installing it if necessary, as described above. This is an optimization to avoid presenting the user with a list that contains only one payment app choice.
 
-> **Note:** If [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) is set to `true` in the payment app manifest, the browser will launch the platform-specific payment app specified in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) to handle the payment (if it is available) instead of the web payment app.
+> [!NOTE]
+> If [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) is set to `true` in the payment app manifest, the browser will launch the platform-specific payment app specified in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) to handle the payment (if it is available) instead of the web payment app.
 
 See [Serve a web app manifest](https://web.dev/articles/setting-up-a-payment-method#step_3_serve_a_web_app_manifest) for more details.
 

--- a/files/en-us/web/api/payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/index.md
@@ -17,7 +17,8 @@ To request a payment, a web page creates a {{domxref("PaymentRequest")}} object 
 
 You can find a complete guide in [Using the Payment Request API](/en-US/docs/Web/API/Payment_Request_API/Using_the_Payment_Request_API).
 
-> **Note:** The API is available inside cross-origin {{htmlelement("iframe")}} elements only if they have had the [`allowpaymentrequest`](/en-US/docs/Web/HTML/Element/iframe#allowpaymentrequest) attribute set on them.
+> [!NOTE]
+> The API is available inside cross-origin {{htmlelement("iframe")}} elements only if they have had the [`allowpaymentrequest`](/en-US/docs/Web/HTML/Element/iframe#allowpaymentrequest) attribute set on them.
 
 ## Interfaces
 

--- a/files/en-us/web/api/payment_request_api/using_secure_payment_confirmation/index.md
+++ b/files/en-us/web/api/payment_request_api/using_secure_payment_confirmation/index.md
@@ -108,7 +108,8 @@ For example:
 
 An origin may invoke the Payment Request API with the `"secure-payment-confirmation"` payment method to prompt the user to verify a Secure Payment Confirmation credential created by any other origin. The browser will display a native user interface (the "transaction dialog") with transaction details (e.g., the payment currency and amount and the payee origin).
 
-> **Note:** Per the Payment Request API, if `PaymentRequest` is used within a cross-origin iframe (e.g., if `merchant.com` embeds an iframe from `psp.com`, and `psp.com` wishes to use `PaymentRequest`), that iframe must have the `payment` permission policy set.
+> [!NOTE]
+> Per the Payment Request API, if `PaymentRequest` is used within a cross-origin iframe (e.g., if `merchant.com` embeds an iframe from `psp.com`, and `psp.com` wishes to use `PaymentRequest`), that iframe must have the `payment` permission policy set.
 
 ```js
 const request = new PaymentRequest(

--- a/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
@@ -12,7 +12,8 @@ The [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) provides a br
 
 This section details the basics of using the Payment Request API to make a payment.
 
-> **Note:** The code snippets from this section are from our [Feature detect support demo](https://github.com/mdn/dom-examples/blob/main/payment-request/feature-detect-support.html).
+> [!NOTE]
+> The code snippets from this section are from our [Feature detect support demo](https://github.com/mdn/dom-examples/blob/main/payment-request/feature-detect-support.html).
 
 ### Creating a new payment request object
 
@@ -141,7 +142,8 @@ if (window.PaymentRequest) {
 }
 ```
 
-> **Note:** See our [Feature detect support demo](https://mdn.github.io/dom-examples/payment-request/feature-detect-support.html) for the full code.
+> [!NOTE]
+> See our [Feature detect support demo](https://mdn.github.io/dom-examples/payment-request/feature-detect-support.html) for the full code.
 
 ## Checking whether users can make payments
 
@@ -177,7 +179,8 @@ if (window.PaymentRequest) {
 }
 ```
 
-> **Note:** See our [Customizing the payment button demo](https://mdn.github.io/dom-examples/payment-request/customize-button-can-make-payment.html) for the full code.
+> [!NOTE]
+> See our [Customizing the payment button demo](https://mdn.github.io/dom-examples/payment-request/customize-button-can-make-payment.html) for the full code.
 
 ### Checking before all prices are known
 
@@ -240,7 +243,8 @@ function onServerCheckoutDetailsRetrieved(checkoutObject) {
 }
 ```
 
-> **Note:** See our [Checking user can make payments before prices are known demo](https://mdn.github.io/dom-examples/payment-request/check-user-can-make-payment.html) for the full code.
+> [!NOTE]
+> See our [Checking user can make payments before prices are known demo](https://mdn.github.io/dom-examples/payment-request/check-user-can-make-payment.html) for the full code.
 
 ## Recommending a payment app when user has no apps
 
@@ -276,7 +280,8 @@ checkoutButton.addEventListener("click", () => {
 });
 ```
 
-> **Note:** See our [Recommending a payment app when user has no apps demo](https://mdn.github.io/dom-examples/payment-request/recommend-payment-app.html) for the full code.
+> [!NOTE]
+> See our [Recommending a payment app when user has no apps demo](https://mdn.github.io/dom-examples/payment-request/recommend-payment-app.html) for the full code.
 
 ## Showing additional user interface after successful payments
 
@@ -299,7 +304,8 @@ request
   });
 ```
 
-> **Note:** See our [Show additional user interface after successful payment demo](https://mdn.github.io/dom-examples/payment-request/show-additional-ui-after-payment.html) for the full code.
+> [!NOTE]
+> See our [Show additional user interface after successful payment demo](https://mdn.github.io/dom-examples/payment-request/show-additional-ui-after-payment.html) for the full code.
 
 ## Pre-authorizing transactions
 
@@ -341,7 +347,8 @@ self.addEventListener("canmakepayment", (evt) => {
 
 This payment handler would need to live in a service worker at `https://example.com/preauth` scope.
 
-> **Note:** See our [Pre-authorizing transactions demo](https://mdn.github.io/dom-examples/payment-request/pre-authorize-transaction.html) for the full code.
+> [!NOTE]
+> See our [Pre-authorizing transactions demo](https://mdn.github.io/dom-examples/payment-request/pre-authorize-transaction.html) for the full code.
 
 ## See also
 

--- a/files/en-us/web/api/paymentaddress/index.md
+++ b/files/en-us/web/api/paymentaddress/index.md
@@ -37,7 +37,8 @@ It may be useful to refer to the Universal Postal Union website's [Addressing S4
 - {{domxref('PaymentAddress.sortingCode')}} {{ReadOnlyInline}} {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : A string providing a postal sorting code such as is used in France.
 
-> **Note:** Properties for which values were not specified contain empty strings.
+> [!NOTE]
+> Properties for which values were not specified contain empty strings.
 
 ## Instance methods
 

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.md
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.md
@@ -40,7 +40,8 @@ request using the {{domxref('PaymentRequest.PaymentRequest()','PaymentRequest')}
 constructor. If the payment can't be processed, the promise receives a value of
 `false`.
 
-> **Note:** If you call this too often, the browser may reject the
+> [!NOTE]
+> If you call this too often, the browser may reject the
 > returned promise with a `DOMException`.
 
 ## Examples

--- a/files/en-us/web/api/paymentrequest/show/index.md
+++ b/files/en-us/web/api/paymentrequest/show/index.md
@@ -20,7 +20,8 @@ called, any other call to `show()` will by rejected with an
 fulfilled with a {{domxref("PaymentResponse")}} indicating the results of the payment
 request, or by being rejected with an error.
 
-> **Note:** In reality, despite the fact that the specification says this
+> [!NOTE]
+> In reality, despite the fact that the specification says this
 > can't be done, some browsers, including Firefox, support multiple active payment
 > requests at a time.
 

--- a/files/en-us/web/api/paymentresponse/complete/index.md
+++ b/files/en-us/web/api/paymentresponse/complete/index.md
@@ -42,7 +42,8 @@ complete(result)
         the user agent should not present any notification, even if it normally would.
         _This is the default value._
 
-    > **Note:** In older versions of the specification, an empty string,
+    > [!NOTE]
+    > In older versions of the specification, an empty string,
     > `""`, was used instead of `unknown` to indicate a completion
     > without a known result state. See the [Browser compatibility](#browser_compatibility) section
     > below for details.

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -12,7 +12,8 @@ The **`getEntries()`** method returns an array of all {{domxref("PerformanceEntr
 
 If you are only interested in performance entries of certain types or that have certain names, see {{domxref("Performance.getEntriesByType", "getEntriesByType()")}} and {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}.
 
-> **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
+> [!NOTE]
+> This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
 
 The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -12,7 +12,8 @@ The **`getEntriesByName()`** method returns an array of {{domxref("PerformanceEn
 
 If you are interested in performance entries of certain types, see {{domxref("Performance.getEntriesByType", "getEntriesByType()")}}. For all performance entries, see {{domxref("Performance.getEntries", "getEntries()")}}.
 
-> **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
+> [!NOTE]
+> This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
 
 The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -12,7 +12,8 @@ The **`getEntriesByType()`** method returns an array of {{domxref("PerformanceEn
 
 If you are interested in performance entries of certain name, see {{domxref("Performance.getEntriesByName", "getEntriesByName()")}}. For all performance entries, see {{domxref("Performance.getEntries", "getEntries()")}}.
 
-> **Note:** This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
+> [!NOTE]
+> This method does not notify you about new performance entries; you will only get entries that are present in the performance timeline at the time you call this method.
 > To receive notifications about entries as they become available, use a {{domxref("PerformanceObserver")}}.
 
 The following entry types are not supported by this method at all and won't be returned even if entries for these types might exist:

--- a/files/en-us/web/api/performance/navigation/index.md
+++ b/files/en-us/web/api/performance/navigation/index.md
@@ -18,7 +18,8 @@ redirections needed to fetch the resource.
 
 This property is not available in workers.
 
-> **Warning:** This property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the
+> [!WARNING]
+> This property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the
 > {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 ## Value

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -12,7 +12,8 @@ The **`timeOrigin`** read-only property of the {{domxref("Performance")}} interf
 
 In Window contexts, this value represents the time when navigation has started. In {{domxref("Worker")}} and {{domxref("ServiceWorker")}} contexts, this value represents the time when the worker is run. You can use this property to synchronize the time origins between the contexts (see example below).
 
-> **Note:** The value of `performance.timeOrigin` may differ from the value returned by {{jsxref("Date.now()")}} executed at the time origin, because `Date.now()` may have been impacted by system and user clock adjustments, clock skew, etc. The `timeOrigin` property is a [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock) which current time never decreases and which isn't subject to these adjustments.
+> [!NOTE]
+> The value of `performance.timeOrigin` may differ from the value returned by {{jsxref("Date.now()")}} executed at the time origin, because `Date.now()` may have been impacted by system and user clock adjustments, clock skew, etc. The `timeOrigin` property is a [monotonic clock](https://w3c.github.io/hr-time/#dfn-monotonic-clock) which current time never decreases and which isn't subject to these adjustments.
 
 ## Value
 

--- a/files/en-us/web/api/performance/timing/index.md
+++ b/files/en-us/web/api/performance/timing/index.md
@@ -17,7 +17,8 @@ performance information.
 
 This property is not available in workers.
 
-> **Warning:** This property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 ## Value

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -26,7 +26,8 @@ A {{jsxref("JSON")}} object that is the serialization of the {{domxref("Performa
 
 The returned JSON doesn't contain the {{domxref("Performance.eventCounts", "eventCounts")}} property because it is of type {{domxref("EventCounts")}}, which doesn't provide a `toJSON()` operation.
 
-> **Note:** The JSON object contains the serialization of the deprecated {{domxref("performance.timing")}} and {{domxref("performance.navigation")}} properties. To get a JSON representation of the newer {{domxref("PerformanceNavigationTiming")}} interface, call {{domxref("PerformanceNavigationTiming.toJSON()")}} instead.
+> [!NOTE]
+> The JSON object contains the serialization of the deprecated {{domxref("performance.timing")}} and {{domxref("performance.navigation")}} properties. To get a JSON representation of the newer {{domxref("PerformanceNavigationTiming")}} interface, call {{domxref("PerformanceNavigationTiming.toJSON()")}} instead.
 
 ## Examples
 

--- a/files/en-us/web/api/performance_api/long_animation_frame_timing/index.md
+++ b/files/en-us/web/api/performance_api/long_animation_frame_timing/index.md
@@ -104,7 +104,8 @@ Beyond the standard data returned by a {{domxref("PerformanceEntry")}} entry, th
     - {{domxref("PerformanceScriptTiming.windowAttribution", "script.windowAttribution")}} an {{domxref("PerformanceScriptTiming.window", "script.window")}}
       - : An enumerated value describing the relationship of the container (i.e. either the top-level document or and {{htmlelement("iframe")}}) this script was executed in to the top-level document, and a reference to its {{domxref("Window")}} object.
 
-    > **Note:** Script attribution is provided only for scripts running in the main thread of a page, including same-origin `<iframe>`s. However, cross-origin `<iframe>`s, [web workers](/en-US/docs/Web/API/Web_Workers_API), [service workers](/en-US/docs/Web/API/Service_Worker_API), and [extension](/en-US/docs/Mozilla/Add-ons/WebExtensions) code will not have script attribution in long animation frames, even if they impact the duration of one.
+    > [!NOTE]
+    > Script attribution is provided only for scripts running in the main thread of a page, including same-origin `<iframe>`s. However, cross-origin `<iframe>`s, [web workers](/en-US/docs/Web/API/Web_Workers_API), [service workers](/en-US/docs/Web/API/Service_Worker_API), and [extension](/en-US/docs/Mozilla/Add-ons/WebExtensions) code will not have script attribution in long animation frames, even if they impact the duration of one.
 
 ## Calculating timestamps
 

--- a/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
+++ b/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
@@ -20,7 +20,8 @@ To enable monitoring bfcache blocking reasons, the [`PerformanceNavigationTiming
 - Reasons why bfcache usage was blocked.
 - Details such as frame `id` and `name`, to help identify `<iframe>`s in the HTML.
 
-> **Note:** Historically, the deprecated {{domxref("PerformanceNavigation.type")}} property was used to monitor the bfcache, with developers testing for a `type` of "`TYPE_BACK_FORWARD`" to get an indication of the bfcache hit rate. This however did not provide any reasons for bfcache blocking, or any other data. The `notRestoredReasons` property should be used to monitor bfcache blocking, going forward.
+> [!NOTE]
+> Historically, the deprecated {{domxref("PerformanceNavigation.type")}} property was used to monitor the bfcache, with developers testing for a `type` of "`TYPE_BACK_FORWARD`" to get an indication of the bfcache hit rate. This however did not provide any reasons for bfcache blocking, or any other data. The `notRestoredReasons` property should be used to monitor bfcache blocking, going forward.
 
 ## Logging bfcache blocking reasons
 
@@ -187,4 +188,5 @@ Additional blocking reasons may be used by some browsers, for example:
 - {{domxref("PerformanceNavigationTiming.notRestoredReasons")}}
 - {{domxref("NotRestoredReasons")}}
 
-> **Note:** This article is adapted from [Back/forward cache notRestoredReasons API](https://developer.chrome.com/docs/web-platform/bfcache-notrestoredreasons/) by Chris Mills and Barry Pollard, originally published on `developer.chrome.com` in 2023 under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
+> [!NOTE]
+> This article is adapted from [Back/forward cache notRestoredReasons API](https://developer.chrome.com/docs/web-platform/bfcache-notrestoredreasons/) by Chris Mills and Barry Pollard, originally published on `developer.chrome.com` in 2023 under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/files/en-us/web/api/performance_api/user_timing/index.md
+++ b/files/en-us/web/api/performance_api/user_timing/index.md
@@ -108,7 +108,8 @@ There are many different performance entries in the browser's performance timeli
 
 To retrieve performance marks and measures at a single point in time, the {{domxref("Performance")}} interface provides three methods, as shown below.
 
-> **Note:** The methods below do not notify you about new performance markers; you will only get markers that have been created when you call these methods.
+> [!NOTE]
+> The methods below do not notify you about new performance markers; you will only get markers that have been created when you call these methods.
 > See the section [Observing performance measures](#observing_performance_measures) above for receiving notifications about new metrics as they become available using a {{domxref("PerformanceObserver")}}. Usually, using performance observers is the preferred way to get performance markers and measures.
 
 The {{domxref("Performance.getEntries","performance.getEntries()")}} method gets all performance entries. You can filter them as needed.

--- a/files/en-us/web/api/performancelonganimationframetiming/blockingduration/index.md
+++ b/files/en-us/web/api/performancelonganimationframetiming/blockingduration/index.md
@@ -24,7 +24,8 @@ There are three options to consider here in how the script might end up being pr
 2. Alternatively, the browser could run the rest of the script first, and then render the frame.
 3. We could also decide **not** to yield and let the browser process the entire script as a single task.
 
-> **Note:** The browser generally tries to prioritize important tasks, such as user interactions and rendering new frames, over less important tasks it might have queued. The browser _tries_ to render a new frame every 16ms.
+> [!NOTE]
+> The browser generally tries to prioritize important tasks, such as user interactions and rendering new frames, over less important tasks it might have queued. The browser _tries_ to render a new frame every 16ms.
 
 We mentioned earlier that the total processing time for the script is 145ms. Assuming the time for rendering the UI update is 10ms, the timings for the LoAFs in each of the three options are as follows:
 

--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -11,7 +11,8 @@ browser-compat: api.PerformanceNavigation
 
 The legacy **`PerformanceNavigation`** interface represents information about how the navigation to the current document was done.
 
-> **Warning:** This interface is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
+> [!WARNING]
+> This interface is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
 > Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 An object of this type can be obtained by calling the {{domxref("Performance.navigation")}} read-only attribute.

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.md
@@ -15,7 +15,8 @@ The legacy
 read-only property returns an `unsigned short` representing the number of
 REDIRECTs done before reaching the page.
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
 > Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 ## Value

--- a/files/en-us/web/api/performancenavigation/tojson/index.md
+++ b/files/en-us/web/api/performancenavigation/tojson/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceNavigation.toJSON
 
 {{APIRef("Performance API")}} {{deprecated_header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The **`toJSON()`** method of the {{domxref("PerformanceNavigation")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceNavigation")}} object.

--- a/files/en-us/web/api/performancenavigation/type/index.md
+++ b/files/en-us/web/api/performancenavigation/type/index.md
@@ -15,7 +15,8 @@ The legacy
 read-only property returns an `unsigned short` containing a constant
 describing how the navigation to this page was done.
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
 > Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 ## Value
@@ -62,7 +63,8 @@ Possible values are:
   </tbody>
 </table>
 
-> **Note:** Historically, developers tested for a `type` of "`TYPE_BACK_FORWARD`" to get an indication of back/forward cache ({{glossary("bfcache")}}) hit rate. This however did not provide any reasons for bfcache blocking, or any other data. The {{domxref("PerformanceNavigationTiming.notRestoredReasons")}} property should be used to monitor the bfcache, going forward. See [Monitoring bfcache blocking reasons](/en-US/docs/Web/API/Performance_API/Monitoring_bfcache_blocking_reasons) for more information.
+> [!NOTE]
+> Historically, developers tested for a `type` of "`TYPE_BACK_FORWARD`" to get an indication of back/forward cache ({{glossary("bfcache")}}) hit rate. This however did not provide any reasons for bfcache blocking, or any other data. The {{domxref("PerformanceNavigationTiming.notRestoredReasons")}} property should be used to monitor the bfcache, going forward. See [Monitoring bfcache blocking reasons](/en-US/docs/Web/API/Performance_API/Monitoring_bfcache_blocking_reasons) for more information.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceNavigationTiming.domInteractive
 
 The **`domInteractive`** read-only property returns a {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the user agent sets the document's [`readyState`](/en-US/docs/Web/API/Document/readyState) to `"interactive"`.
 
-> **Note:** This property is **not** {{Glossary("Time to interactive")}} (TTI). This property refers to the time when DOM construction is finished and interaction to it from JavaScript is possible. See also the `interactive` state of {{domxref("Document.readyState")}} which corresponds to this property.
+> [!NOTE]
+> This property is **not** {{Glossary("Time to interactive")}} (TTI). This property refers to the time when DOM construction is finished and interaction to it from JavaScript is possible. See also the `interactive` state of {{domxref("Document.readyState")}} which corresponds to this property.
 
 Measuring DOM processing time may not be consequential unless your site has a very large HTML source to a construct a Document Object Model from.
 

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceResourceTiming.initiatorType
 
 The **`initiatorType`** read-only property is a string representing web platform feature that initiated the resource load.
 
-> **Note:** This property does not represent the type of content fetched. A `.css` file can be fetched using a {{HTMLElement("link")}} element leading to an `initiatorType` of `link`. When loading images using `background: url()` in a CSS file, the `initiatorType` will be `css` and not `img`.
+> [!NOTE]
+> This property does not represent the type of content fetched. A `.css` file can be fetched using a {{HTMLElement("link")}} element leading to an `initiatorType` of `link`. When loading images using `background: url()` in a CSS file, the `initiatorType` will be `css` and not `img`.
 
 ## Value
 

--- a/files/en-us/web/api/performancetiming/connectend/index.md
+++ b/files/en-us/web/api/performancetiming/connectend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.connectEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/connectstart/index.md
+++ b/files/en-us/web/api/performancetiming/connectstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.connectStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domainLookupEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domainLookupStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domComplete
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domContentLoadedEventStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domInteractive
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/domloading/index.md
+++ b/files/en-us/web/api/performancetiming/domloading/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.domLoading
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.fetchStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -9,7 +9,8 @@ browser-compat: api.PerformanceTiming
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+> [!WARNING]
+> This interface is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 The **`PerformanceTiming`** interface is a legacy interface kept for backwards compatibility and contains properties that offer performance timing information for various events which occur during the loading and use of the current page. You get a `PerformanceTiming` object describing your page using the {{domxref("Performance.timing", "window.performance.timing")}} property.
 

--- a/files/en-us/web/api/performancetiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.loadEventEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface's {{domxref("PerformanceNavigationTiming.loadEventEnd")}} read-only property instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.loadEventStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface's {{domxref("PerformanceNavigationTiming.loadEventStart")}} read-only property instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/navigationstart/index.md
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.navigationStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
 > Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/redirectend/index.md
+++ b/files/en-us/web/api/performancetiming/redirectend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.redirectEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.redirectStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/requeststart/index.md
+++ b/files/en-us/web/api/performancetiming/requeststart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.requestStart
 
 {{ APIRef("PerformanceTiming") }} {{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/responseend/index.md
+++ b/files/en-us/web/api/performancetiming/responseend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.responseEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/responsestart/index.md
+++ b/files/en-us/web/api/performancetiming/responsestart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.responseStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.secureConnectionStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
 The legacy
 **`PerformanceTiming.secureConnectionStart`**

--- a/files/en-us/web/api/performancetiming/tojson/index.md
+++ b/files/en-us/web/api/performancetiming/tojson/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.toJSON
 
 {{APIRef("Performance API")}}{{deprecated_header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy **`toJSON()`** method of the {{domxref("PerformanceTiming")}} interface is a {{Glossary("Serialization","serializer")}}; it returns a JSON representation of the {{domxref("PerformanceTiming")}} object.

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.unloadEventEnd
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.md
@@ -10,7 +10,8 @@ browser-compat: api.PerformanceTiming.unloadEventStart
 
 {{APIRef("Performance API")}}{{Deprecated_Header}}
 
-> **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
+> [!WARNING]
+> This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
 The legacy

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -29,9 +29,11 @@ query(permissionDescriptor)
     - `sysex` (MIDI only)
       - : Indicates whether you need and/or receive system exclusive messages. The default is `false`.
 
-> **Note:** As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is granted (e.g. by the user, in the relevant permissions dialog), `navigator.permissions.query()` will return `true` for both `notifications` and `push`.
+> [!NOTE]
+> As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is granted (e.g. by the user, in the relevant permissions dialog), `navigator.permissions.query()` will return `true` for both `notifications` and `push`.
 
-> **Note:** The `persistent-storage` permission allows an origin to use a persistent box (i.e., [persistent storage](https://storage.spec.whatwg.org/#persistence)) for its storage, as per the [Storage API](https://storage.spec.whatwg.org/).
+> [!NOTE]
+> The `persistent-storage` permission allows an origin to use a persistent box (i.e., [persistent storage](https://storage.spec.whatwg.org/#persistence)) for its storage, as per the [Storage API](https://storage.spec.whatwg.org/).
 
 ### Return value
 

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -43,12 +43,14 @@ revoke(descriptor)
       - : Indicates whether you need and/or receive system
         exclusive messages. The default is `false`.
 
-> **Note:** As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is
+> [!NOTE]
+> As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is
 > granted (e.g. by the user, in the relevant permissions dialog),
 > `navigator.permissions.query()` will return `true` for both
 > `notifications` and `push`.
 
-> **Note:** The `persistent-storage` permission allows an
+> [!NOTE]
+> The `persistent-storage` permission allows an
 > origin to use a persistent box (i.e., [persistent storage](https://storage.spec.whatwg.org/#persistence)) for its
 > storage, as per the [Storage API](https://storage.spec.whatwg.org/).
 

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -9,7 +9,8 @@ browser-compat: api.PictureInPictureWindow
 
 The **Picture-in-Picture API** allow websites to create a floating, always-on-top video window. This allows users to continue consuming media while they interact with other sites or applications on their device.
 
-> **Note:** The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) extends the Picture-in-Picture API to allow the always-on-top window to be populated with _any_ arbitrary HTML content, not just a video.
+> [!NOTE]
+> The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) extends the Picture-in-Picture API to allow the always-on-top window to be populated with _any_ arbitrary HTML content, not just a video.
 
 ## Interfaces
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 9.
