### PR TITLE
Convert noteblocks for web/api folder (part 11)

### DIFF
--- a/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.md
@@ -28,7 +28,8 @@ communicate with the TURN server. The possible values are:
 - `udp`
   - : UDP (User Datagram Protocol) is being used to communicate with the TURN server.
 
-> **Note:** This property is only present on
+> [!NOTE]
+> This property is only present on
 > {{domxref("RTCIceCandidateStats")}} objects that represent local candidates.
 
 ## Specifications

--- a/files/en-us/web/api/rtcicecandidatestats/url/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/url/index.md
@@ -20,7 +20,8 @@ candidate described by the `RTCIceCandidateStats` was obtained. This is the
 same URL that would be received in the {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} event's
 {{domxref("RTCPeerConnectionIceEvent.url", "url")}} property.
 
-> **Note:** This property does not exist for remote candidates.
+> [!NOTE]
+> This property does not exist for remote candidates.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.md
+++ b/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.md
@@ -35,7 +35,8 @@ From that time forward, the best matching pair of candidates will always be avai
 
 As ICE negotiation continues, any time a pair of candidates is discovered that is better than the currently-selected pair, the new pair is selected, replacing the previous pairing, and the `selectedcandidatepairchange` event is fired again.
 
-> **Note:** It's possible for one of the configurations in the selected candidate pair to remain unchanged when a new pairing is chosen.
+> [!NOTE]
+> It's possible for one of the configurations in the selected candidate pair to remain unchanged when a new pairing is chosen.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.md
@@ -33,7 +33,8 @@ By using the FEC parity information to attempt to reconstruct damaged packets, i
 possible to avoid the need to retransmit damaged packets, which in turn helps to
 reduce lag, or the need to skip damaged frames entirely.
 
-> **Note:** This counter may also be incremented when FEC packets arrive
+> [!NOTE]
+> This counter may also be incremented when FEC packets arrive
 > in-band along with media content; this can happen with Opus, for example.
 
 ## Usage notes

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
@@ -14,7 +14,8 @@ The **`lastPacketReceivedTimestamp`** property of the {{domxref("RTCInboundRtpSt
 
 A {{domxref("DOMHighResTimeStamp")}} which specifies the time at which the most recently received packet arrived on this RTP stream.
 
-> **Note:** This value differs from the {{domxref("RTCInboundRtpStreamStats.timestamp", "timestamp")}},
+> [!NOTE]
+> This value differs from the {{domxref("RTCInboundRtpStreamStats.timestamp", "timestamp")}},
 > which represents the time at which the statistics object was created.
 
 ## Specifications

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.md
@@ -14,7 +14,8 @@ comprised of key/value pairs in which each key is a string representation of a
 Differentiated Services Code Point and the value is the number of packets received for
 that DCSP.
 
-> **Note:** Not all operating systems make data available on a per-DSCP
+> [!NOTE]
+> Not all operating systems make data available on a per-DSCP
 > basis, so this property shouldn't be relied upon on those systems.
 
 ## Value
@@ -22,7 +23,8 @@ that DCSP.
 A record comprised of string/value pairs. Each key is the string representation of a
 single Differentiated Services Code Point (DSCP)'s ID number.
 
-> **Note:** Due to network bleaching and remapping, the numbers seen on
+> [!NOTE]
+> Due to network bleaching and remapping, the numbers seen on
 > this record are not necessarily going to match the values as they were when the data
 > was sent.
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.md
@@ -25,7 +25,8 @@ An unsigned 64-bit integer value which indicates the sum of the quantization par
 larger to indicate higher compression factors, the larger this sum is, the more heavily
 compressed the stream generally has been.
 
-> **Note:** This value is only available for video media.
+> [!NOTE]
+> This value is only available for video media.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.md
@@ -30,7 +30,8 @@ be an indication of an unreliable network.
 
 This is a very technical part of how video codecs work. For details, see {{RFC(4585, "6.3.2")}}.
 
-> **Note:** This value is only present for video media.
+> [!NOTE]
+> This value is only present for video media.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.md
@@ -18,7 +18,8 @@ source.
 An integer value indicating the total number of video frames that this sender has
 encoded so far for this stream.
 
-> **Note:** This property is only valid for video streams.
+> [!NOTE]
+> This property is only valid for video streams.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.md
@@ -13,7 +13,8 @@ of the {{domxref("RTCOutboundRtpStreamStats")}} dictionary is a record comprised
 key/value pairs in which each key is a string representation of a Differentiated
 Services Code Point and the value is the number of packets sent for that DCSP.
 
-> **Note:** Not all operating systems make data available on a per-DSCP
+> [!NOTE]
+> Not all operating systems make data available on a per-DSCP
 > basis, so this property shouldn't be relied upon on those systems.
 
 ## Value
@@ -21,7 +22,8 @@ Services Code Point and the value is the number of packets sent for that DCSP.
 A record comprised of string/value pairs. Each key is the string representation of a
 single Differentiated Services Code Point (DSCP)'s ID number.
 
-> **Note:** Due to network bleaching and remapping, the numbers seen on
+> [!NOTE]
+> Due to network bleaching and remapping, the numbers seen on
 > this record are not necessarily going to match the values as they were when the data
 > was sent.
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.md
@@ -24,7 +24,8 @@ the remote peer's {{domxref("RTCRtpReceiver")}}. These are sent by the receiver'
 decoder to notify the sender's encoder that an undefined amount of coded video data,
 which may span frame boundaries, has been lost.
 
-> **Note:** This property is only used for video streams.
+> [!NOTE]
+> This property is only used for video streams.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
@@ -17,7 +17,8 @@ In general, the higher this number is, the more heavily compressed the video dat
 An unsigned 64-bit integer value which indicates the sum of the quantization parameter (QP) value for every frame sent so far on the track described by the {{domxref("RTCOutboundRtpStreamStats")}} object.
 Since the value of QP is typically larger to indicate higher compression factors, the larger this sum is, the more heavily compressed the stream generally has been.
 
-> **Note:** This value is only available for video media.
+> [!NOTE]
+> This value is only available for video media.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.md
@@ -28,7 +28,8 @@ an indication of an unreliable network.
 
 This is a very technical part of how video codecs work. For details, see {{RFC(4585, "6.3.2")}}.
 
-> **Note:** This value is only present for video media.
+> [!NOTE]
+> This value is only present for video media.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -72,7 +72,8 @@ addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 
         Additional information can be found in {{domxref("RTCIceCandidate.candidate")}}.
 
-        > **Note:** For backward compatibility with older versions of the WebRTC specification, the constructor also accepts this string directly as an argument.
+        > [!NOTE]
+        > For backward compatibility with older versions of the WebRTC specification, the constructor also accepts this string directly as an argument.
 
     - `sdpMid` {{optional_inline}}
 

--- a/files/en-us/web/api/rtcpeerconnection/addstream_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addstream_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.RTCPeerConnection.addstream_event
 
 The obsolete **`addstream`** event is sent to an {{domxref("RTCPeerConnection")}} when new media, in the form of a {{domxref("MediaStream")}} object, has been added to it.
 
-> **Warning:** This event has been removed from the WebRTC specification. You should instead watch for the {{domxref("RTCPeerConnection.track_event", "track")}} event, which is sent for each media track added to the `RTCPeerConnection`.
+> [!WARNING]
+> This event has been removed from the WebRTC specification. You should instead watch for the {{domxref("RTCPeerConnection.track_event", "track")}} event, which is sent for each media track added to the `RTCPeerConnection`.
 
 You can, similarly, watch for streams to be removed from the connection by monitoring the {{domxref("RTCPeerConnection.removestream_event", "removestream")}} event.
 

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
@@ -10,7 +10,8 @@ browser-compat: api.RTCPeerConnection.addTrack
 
 The **`addTrack()`** method of the {{domxref("RTCPeerConnection")}} interface adds a new media track to the set of tracks which will be transmitted to the other peer.
 
-> **Note:** Adding a track to a connection triggers renegotiation by firing a {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event.
+> [!NOTE]
+> Adding a track to a connection triggers renegotiation by firing a {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event.
 > See [Starting negotiation](/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling#starting_negotiation) for details.
 
 ## Syntax
@@ -37,7 +38,8 @@ Any tracks that are added to the same stream on the local end of the connection 
 
 The {{domxref("RTCRtpSender")}} object which will be used to transmit the media data.
 
-> **Note:** Every `RTCRtpSender` is paired with an {{domxref("RTCRtpReceiver")}} to make up an {{domxref("RTCRtpTransceiver")}}.
+> [!NOTE]
+> Every `RTCRtpSender` is paired with an {{domxref("RTCRtpReceiver")}} to make up an {{domxref("RTCRtpTransceiver")}}.
 > The associated receiver is muted (indicating that it is not able to deliver packets) until and unless one or more streams are added to the receiver by the remote peer.
 
 ### Exceptions

--- a/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -21,7 +21,8 @@ That way, the offer contains all of the candidates.
 A boolean value that is `true` if the remote peer can accept trickled ICE candidates and `false` if it cannot.
 If no remote peer has been established, this value is `null`.
 
-> **Note:** This property's value is determined once the local peer has called {{domxref("RTCPeerConnection.setRemoteDescription()")}};
+> [!NOTE]
+> This property's value is determined once the local peer has called {{domxref("RTCPeerConnection.setRemoteDescription()")}};
 > the provided description is used by the ICE agent to determine whether or not the remote peer supports trickled ICE candidates.
 
 ## Examples

--- a/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
@@ -59,7 +59,8 @@ A {{jsxref("Promise")}} whose fulfillment handler is called with an object confo
 Here is a segment of code taken from the code that goes with the article [Signaling and video calling](/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling).
 This code comes from the handler for the message sent to carry an offer to another peer across the signaling channel.
 
-> **Note:** Keep in mind that this is part of the signaling process, the transport layer for which is an implementation detail that's entirely up to you.
+> [!NOTE]
+> Keep in mind that this is part of the signaling process, the transport layer for which is an implementation detail that's entirely up to you.
 > In this case, a [WebSocket](/en-US/docs/Web/API/WebSockets_API) connection is used to send a {{Glossary("JSON")}} message with a `type` field with the value "video-answer" to the other peer, carrying the answer to the device which sent the offer to connect.
 > The contents of the object being passed to the `sendToServer()` function, along with everything else in the promise fulfillment handler, depend entirely on your design
 

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
@@ -56,7 +56,8 @@ createDataChannel(label, options)
         permitted values are 0 to 65534.
         If you don't include this option, the user agent will select an ID for you.
 
-> **Note:** These options represent the script-settable subset of the properties on the {{domxref("RTCDataChannel")}} interface.
+> [!NOTE]
+> These options represent the script-settable subset of the properties on the {{domxref("RTCDataChannel")}} interface.
 
 ### Return value
 

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
@@ -77,7 +77,8 @@ Your rejection handler should examine the received exception to determine which 
 
 Here we see a handler for the {{DOMxRef("RTCPeerConnection/negotiationneeded_event", "negotiationneeded")}} event which creates the offer and sends it to the remote system over a signaling channel.
 
-> **Note:** Keep in mind that this is part of the signaling process, the transport layer for which is an implementation detail that's entirely up to you.
+> [!NOTE]
+> Keep in mind that this is part of the signaling process, the transport layer for which is an implementation detail that's entirely up to you.
 > In this case, a [WebSocket](/en-US/docs/Web/API/WebSockets_API) connection is used to send a {{Glossary("JSON")}} message with a `type` field with the value "video-offer" to the other peer.
 > The contents of the object being passed to the `sendToServer()` function, along with everything else in the promise fulfillment handler, depend entirely on your design.
 

--- a/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.md
@@ -14,7 +14,8 @@ Also included is a list of any ICE candidates that may already have been generat
 To change the `currentLocalDescription`, call {{domxref("RTCPeerConnection.setLocalDescription()")}}, which triggers a series of events which leads to this value being set.
 For details on what exactly happens and why the change isn't necessarily instantaneous, see [Pending and current descriptions](/en-US/docs/Web/API/WebRTC_API/Connectivity#pending_and_current_descriptions) in the WebRTC Connectivity page.
 
-> **Note:** Unlike {{domxref("RTCPeerConnection.localDescription")}}, this value represents the actual current state of the local end of the connection;
+> [!NOTE]
+> Unlike {{domxref("RTCPeerConnection.localDescription")}}, this value represents the actual current state of the local end of the connection;
 > `localDescription` may specify a description which the connection is currently in the process of switching over to.
 
 ## Value
@@ -46,7 +47,8 @@ if (sd) {
 
 {{Compat}}
 
-> **Note:** The addition of `currentLocalDescription` and {{domxref("RTCPeerConnection.pendingLocalDescription", "pendingLocalDescription")}} to the WebRTC spec is relatively recent.
+> [!NOTE]
+> The addition of `currentLocalDescription` and {{domxref("RTCPeerConnection.pendingLocalDescription", "pendingLocalDescription")}} to the WebRTC spec is relatively recent.
 > In browsers which don't support them, just use {{domxref("RTCPeerConnection.localDescription", "localDescription")}}.
 
 ## See also

--- a/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.md
@@ -15,7 +15,8 @@ Also included is a list of any ICE candidates that may already have been generat
 To change the `currentRemoteDescription`, call {{domxref("RTCPeerConnection.setRemoteDescription()")}}, which triggers a series of events which leads to this value being set.
 For details on what exactly happens and why the change isn't necessarily instantaneous, see [Pending and current descriptions](/en-US/docs/Web/API/WebRTC_API/Connectivity#pending_and_current_descriptions) in the WebRTC Connectivity page.
 
-> **Note:** Unlike {{domxref("RTCPeerConnection.remoteDescription")}}, this value represents the actual current state of the local end of the connection;
+> [!NOTE]
+> Unlike {{domxref("RTCPeerConnection.remoteDescription")}}, this value represents the actual current state of the local end of the connection;
 > `remoteDescription` may specify a description which the connection is currently in the process of switching over to.
 
 ## Value

--- a/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.RTCPeerConnection.datachannel_event
 
 A **`datachannel`** event is sent to an {{domxref("RTCPeerConnection")}} instance when an {{domxref("RTCDataChannel")}} has been added to the connection, as a result of the remote peer calling {{domxref("RTCPeerConnection.createDataChannel()")}}.
 
-> **Note:** This event is _not_ dispatched when the local end of the connection creates the channel.
+> [!NOTE]
+> This event is _not_ dispatched when the local end of the connection creates the channel.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
@@ -13,7 +13,8 @@ This signifies that the value of the connection's {{domxref("RTCPeerConnection.i
 
 When ICE first starts to gather connection candidates, the value changes from `new` to `gathering` to indicate that the process of collecting candidate configurations for the connection has begun. When the value changes to `complete`, all of the transports that make up the `RTCPeerConnection` have finished gathering ICE candidates.
 
-> **Note:** While you can determine that ICE candidate gathering is complete by watching for `icegatheringstatechange` events and checking for the value of {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} to become `complete`, you can also have your handler for the {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} event look to see if its {{domxref("RTCPeerConnectionIceEvent.candidate", "candidate")}} property is `null`. This also indicates that collection of candidates is finished.
+> [!NOTE]
+> While you can determine that ICE candidate gathering is complete by watching for `icegatheringstatechange` events and checking for the value of {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} to become `complete`, you can also have your handler for the {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} event look to see if its {{domxref("RTCPeerConnectionIceEvent.candidate", "candidate")}} property is `null`. This also indicates that collection of candidates is finished.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity/index.md
@@ -18,7 +18,8 @@ A JavaScript {{jsxref("Promise")}} which resolves to an {{domxref("RTCIdentityAs
 If an error occurs while attempting to validate an incoming identity assertion (that is, the information describing a peer's identity), the promise is rejected.
 If there isn't already a target peer identity, `peerIdentity` is set to a newly created promise and the process begins again, until the process succeeds or no further attempts to authenticate occur.
 
-> **Note:** The promise returned by {{domxref("RTCPeerConnection.setRemoteDescription", "setRemoteDescription()")}} cannot resolve until any target peer identity that's been set is validated.
+> [!NOTE]
+> The promise returned by {{domxref("RTCPeerConnection.setRemoteDescription", "setRemoteDescription()")}} cannot resolve until any target peer identity that's been set is validated.
 > If the identity hasn't been validated yet, the promise returned by `setRemoteDescription()` will be rejected.
 > If there's no target peer identity, `setRemoteDescription()` doesn't need to wait for validation to occur before it resolves.
 

--- a/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.md
@@ -42,7 +42,8 @@ if (sd) {
 
 {{Compat}}
 
-> **Note:** The addition of `pendingLocalDescription` and {{domxref("RTCPeerConnection.currentLocalDescription", "currentLocalDescription")}} to the WebRTC spec is relatively recent.
+> [!NOTE]
+> The addition of `pendingLocalDescription` and {{domxref("RTCPeerConnection.currentLocalDescription", "currentLocalDescription")}} to the WebRTC spec is relatively recent.
 > In browsers which don't support them, only {{domxref("RTCPeerConnection.localDescription", "localDescription")}} is available.
 
 ## See also

--- a/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.md
@@ -43,7 +43,8 @@ if (sd) {
 
 {{Compat}}
 
-> **Note:** The addition of `pendingRemoteDescription` and {{domxref("RTCPeerConnection.currentRemoteDescription", "currentRemoteDescription")}} to the WebRTC spec is relatively recent.
+> [!NOTE]
+> The addition of `pendingRemoteDescription` and {{domxref("RTCPeerConnection.currentRemoteDescription", "currentRemoteDescription")}} to the WebRTC spec is relatively recent.
 > In browsers which don't support them, only {{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} is available.
 
 ## See also

--- a/files/en-us/web/api/rtcpeerconnection/removestream_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removestream_event/index.md
@@ -16,7 +16,8 @@ You can use the `RTCPeerConnection` interface's `onremovestream` property to set
 
 This is the counterpart to the {{domxref("RTCPeerConnection.addstream_event", "addstream")}} event, which is also obsolete.
 
-> **Warning:** This event has been removed from the WebRTC specification in favor of the existing {{DOMxRef("MediaStream/removetrack_event", "removetrack")}} event on the remote {{domxref("MediaStream")}} and the corresponding event handler property of the remote {{domxref("MediaStream")}}. The {{domxref("RTCPeerConnection")}} API is now track-based, so having zero tracks in the remote stream is equivalent to the remote stream being removed, which caused a `removestream` event.
+> [!WARNING]
+> This event has been removed from the WebRTC specification in favor of the existing {{DOMxRef("MediaStream/removetrack_event", "removetrack")}} event on the remote {{domxref("MediaStream")}} and the corresponding event handler property of the remote {{domxref("MediaStream")}}. The {{domxref("RTCPeerConnection")}} API is now track-based, so having zero tracks in the remote stream is equivalent to the remote stream being removed, which caused a `removestream` event.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.md
@@ -42,13 +42,15 @@ new RTCPeerConnection(configuration)
 
       - : An {{jsxref("Array")}} of objects of type {{domxref("RTCCertificate")}} which are used by the connection for authentication. If this property isn't specified, a set of certificates is generated automatically for each {{domxref("RTCPeerConnection")}} instance. Although only one certificate is used by a given connection, providing certificates for multiple algorithms may improve the odds of successfully connecting in some circumstances. See [Using certificates](#using_certificates) for further information.
 
-        > **Note:** This configuration option cannot be changed after it is first specified; once the certificates have been set, this property is ignored in future calls to {{domxref("RTCPeerConnection.setConfiguration()")}}.
+        > [!NOTE]
+        > This configuration option cannot be changed after it is first specified; once the certificates have been set, this property is ignored in future calls to {{domxref("RTCPeerConnection.setConfiguration()")}}.
 
     - `iceCandidatePoolSize` {{optional_inline}}
 
       - : An unsigned 16-bit integer value which specifies the size of the prefetched ICE candidate pool. The default value is 0 (meaning no candidate prefetching will occur). You may find in some cases that connections can be established more quickly by allowing the ICE agent to start fetching ICE candidates before you start trying to connect, so that they're already available for inspection when {{domxref("RTCPeerConnection.setLocalDescription()")}} is called.
 
-        > **Note:** Changing the size of the ICE candidate pool may trigger the beginning of ICE gathering.
+        > [!NOTE]
+        > Changing the size of the ICE candidate pool may trigger the beginning of ICE gathering.
 
     - `iceServers` {{optional_inline}}
 

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -19,7 +19,8 @@ The most common use case for this method (and even then, probably not a very com
   Perhaps the user has moved into a new region, so using new regional ICE servers is necessary, for example.
   In this situation, one might call `setConfiguration()` to switch to new regional ICE servers, then initiate an [ICE restart](/en-US/docs/Web/API/WebRTC_API/Session_lifetime#ice_restart).
 
-> **Note:** You cannot change the identity information for a connection once it's already been set.
+> [!NOTE]
+> You cannot change the identity information for a connection once it's already been set.
 
 ## Syntax
 

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
@@ -36,7 +36,8 @@ setLocalDescription(sessionDescription, successCallback, errorCallback) // depre
 A {{jsxref("Promise")}} which is fulfilled once the value of {{domxref("RTCPeerConnection.localDescription")}} is successfully changed or rejected if the change cannot be applied (for example, if the specified description is incompatible with one or both of the peers on the connection).
 The promise's fulfillment handler receives no input parameters.
 
-> **Note:** The process of changing descriptions actually involves intermediary steps handled by the WebRTC layer to ensure that an active connection can be changed without losing the connection if the change does not succeed.
+> [!NOTE]
+> The process of changing descriptions actually involves intermediary steps handled by the WebRTC layer to ensure that an active connection can be changed without losing the connection if the change does not succeed.
 > See [Pending and current descriptions](/en-US/docs/Web/API/WebRTC_API/Connectivity#pending_and_current_descriptions) in the WebRTC Connectivity page for more details on this process.
 
 #### Implicit description

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
@@ -60,7 +60,8 @@ Since it's unnecessary, the {{domxref("RTCSessionDescription.RTCSessionDescripti
 A {{jsxref("Promise")}} which is fulfilled once the value of the connection's {{domxref("RTCPeerConnection.remoteDescription", "remoteDescription")}} is successfully changed or rejected if the change cannot be applied (for example, if the specified description is incompatible with one or both of the peers on the connection).
 The promise fulfillment handler receives no input parameters.
 
-> **Note:** The process of changing descriptions actually involves intermediary steps handled by the WebRTC layer to ensure that an active connection can be changed without losing the connection if the change does not succeed.
+> [!NOTE]
+> The process of changing descriptions actually involves intermediary steps handled by the WebRTC layer to ensure that an active connection can be changed without losing the connection if the change does not succeed.
 > See [Pending and current descriptions](/en-US/docs/Web/API/WebRTC_API/Connectivity#pending_and_current_descriptions) in the WebRTC Connectivity page for more details on this process.
 
 ### Exceptions
@@ -93,7 +94,8 @@ This begins a new negotiation session, with the newly-established offer as the s
 Upon starting the new negotiation with the newly-established offer, the local peer is now the callee, even if it was previously the caller.
 This happens instead of throwing an exception, thereby reducing the number of potential errors which might occur, and simplifies the processing you need to do when you receive an offer, by eliminating the need to handle the offer/answer process differently depending on whether the local peer is the caller or callee.
 
-> **Note:** Earlier implementations of WebRTC would throw an exception if an offer was set outside a `stable` or `have-remote-offer` state.
+> [!NOTE]
+> Earlier implementations of WebRTC would throw an exception if an offer was set outside a `stable` or `have-remote-offer` state.
 
 ## Deprecated syntax
 

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/ssrc/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/ssrc/index.md
@@ -18,7 +18,8 @@ The manner in which these values are generated is not mandated by the specificat
 You should not make any assumptions based on the value of `ssrc` other than that any two objects with the same `ssrc` value refer to the same source.
 See {{RFC("3550", "", "8")}} for additional information about `ssrc`.
 
-> **Note:** The specification includes an example that generates values for `ssrc` using MD5.
+> [!NOTE]
+> The specification includes an example that generates values for `ssrc` using MD5.
 > While not part of the standard, exactly, it is a good mechanism that may be used by some browsers; others may use other methods, such as random number generators.
 > _Do not_ rely upon these values meaning anything other than "these objects are associated with the same source."
 

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
@@ -35,7 +35,8 @@ The returned object has the following properties:
 
   - : An array of objects, each describing the basic capabilities of a single [media codec](/en-US/docs/Web/Media/Formats/WebRTC_codecs) supported by the {{domxref("RTCRtpReceiver")}}.
 
-    > **Note:** The array contains special entries that represent the underlying components of the transport — these may be ignored if you're only interested in the actual codecs used for the media itself.
+    > [!NOTE]
+    > The array contains special entries that represent the underlying components of the transport — these may be ignored if you're only interested in the actual codecs used for the media itself.
     > These are described below in the section [The codecs array](#the_codecs_array).
 
     Each codec object has the following properties:
@@ -129,7 +130,8 @@ log.textContent = `RTCRtpReceiver.getCapabilities() supported: ${Object.hasOwn(
 
 The function below returns a Boolean indicating whether or not the device supports receiving H.264 video on a WebRTC connection.
 
-> **Note:** Since `RTCRtpReceiver.getCapabilities()` actually only indicates > _probable_ support, attempting to receive H.264 video might still fail even after getting a positive response from this function.
+> [!NOTE]
+> Since `RTCRtpReceiver.getCapabilities()` actually only indicates > _probable_ support, attempting to receive H.264 video might still fail even after getting a positive response from this function.
 
 ```js
 function canReceiveH264() {

--- a/files/en-us/web/api/rtcrtpscripttransformer/generatekeyframe/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/generatekeyframe/index.md
@@ -56,7 +56,8 @@ The RID values being used can be queried by calling {{domxref("RTCRtpSender.getP
 
 The promise returned by the method will resolve just before enqueuing the corresponding key frame in a `RTCRtpScriptTransformer` readable.
 
-> **Note:** Sending multiple streams (RID) at a time is called "simulcast".
+> [!NOTE]
+> Sending multiple streams (RID) at a time is called "simulcast".
 > This feature provides a [middlebox](https://en.wikipedia.org/wiki/Middlebox) with the same stream in multiple levels of video quality, allowing it to manage bandwidth by selectively transmitting appropriate levels to participants and switch resolution rapidly on the fly (i.e. switching to forward low-quality video for everyone except the active speaker).
 > The recipient only ever gets one stream, which is why the comparable receiver method {{domxref("RTCRtpScriptTransformer.sendKeyFrameRequest()")}} does not require that an RID is specified.
 

--- a/files/en-us/web/api/rtcrtpscripttransformer/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/index.md
@@ -9,7 +9,8 @@ browser-compat: api.RTCRtpScriptTransformer
 
 The **`RTCRtpScriptTransformer`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides a worker-side [Stream API](/en-US/docs/Web/API/Streams_API) interface that a [WebRTC Encoded Transform](/en-US/docs/Web/API/WebRTC_API/Using_Encoded_Transforms) can use to modify encoded media frames in the incoming and outgoing WebRTC pipelines.
 
-> **Note:** This feature is available in [_Dedicated_ Web Workers](/en-US/docs/Web/API/Web_Workers_API#worker_types).
+> [!NOTE]
+> This feature is available in [_Dedicated_ Web Workers](/en-US/docs/Web/API/Web_Workers_API#worker_types).
 
 ## Instance properties
 

--- a/files/en-us/web/api/rtcrtpscripttransformer/sendkeyframerequest/index.md
+++ b/files/en-us/web/api/rtcrtpscripttransformer/sendkeyframerequest/index.md
@@ -13,7 +13,8 @@ The **`sendKeyFrameRequest()`** method of the {{domxref("RTCRtpScriptTransformer
 The method may only be called when receiving _video_ (not audio) frames and if, for whatever reason, a recipient will not be able to decode the video without a new key frame.
 Note that the user agent can decide that the request for a key frame is not necessary, in which case the returned promise will fulfill even though the request was not actually sent.
 
-> **Note:** It might be called, for example, if a new user joins a WebRTC conference, in order to reduce the time before they receive a key frame and can hence start displaying video.
+> [!NOTE]
+> It might be called, for example, if a new user joins a WebRTC conference, in order to reduce the time before they receive a key frame and can hence start displaying video.
 > For more information see [Triggering a key frame](/en-US/docs/Web/API/WebRTC_API/Using_Encoded_Transforms#triggering_a_key_frame) in Using WebRTC Encoded Transforms.
 
 ## Syntax

--- a/files/en-us/web/api/rtcrtpsender/dtmf/index.md
+++ b/files/en-us/web/api/rtcrtpsender/dtmf/index.md
@@ -20,7 +20,8 @@ An {{domxref("RTCDTMFSender")}} which can be used to send DTMF over the RTP sess
 `null` if the track being carried by the RTP session or the
 {{domxref("RTCPeerConnection")}} as a whole doesn't support DTMF.
 
-> **Note:** Only audio tracks can support DTMF, and typically only one audio track per
+> [!NOTE]
+> Only audio tracks can support DTMF, and typically only one audio track per
 > `RTCPeerConnection` will have an associated {{domxref("RTCDTMFSender")}}
 
 ## Example

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
@@ -35,7 +35,8 @@ The returned object has the following properties:
 
   - : An array of objects, each describing the basic capabilities of a single [media codec](/en-US/docs/Web/Media/Formats/WebRTC_codecs) supported by the {{domxref("RTCRtpSender")}}.
 
-    > **Note:** The array contains special entries that represent the underlying components of the transport — these may be ignored if you're only interested in the actual codecs used for the media itself.
+    > [!NOTE]
+    > The array contains special entries that represent the underlying components of the transport — these may be ignored if you're only interested in the actual codecs used for the media itself.
     > These are described below in the section [The codecs array](#the_codecs_array).
 
     Each codec object has the following properties:
@@ -130,7 +131,8 @@ log.textContent = `RTCRtpSender.getCapabilities() supported: ${Object.hasOwn(
 
 The function below returns a `true` or `false` indicating whether or not the device supports sending H.264 video on an {{domxref("RTCRtpSender")}}.
 
-> **Note:** Since `RTCRtpSender.getCapabilities()` actually only indicates _probable_ support.
+> [!NOTE]
+> Since `RTCRtpSender.getCapabilities()` actually only indicates _probable_ support.
 > So below H.264 support might still fail even after getting a positive response from this function.
 
 ```js

--- a/files/en-us/web/api/rtcrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/index.md
@@ -13,7 +13,8 @@ While the dictionary has a base set of properties that are present in each of th
 
 `RTCRtpStreamStats` is the base class for all RTP-related statistics reports.
 
-> **Note:** This interface was called `RTCRTPStreamStats` until a specification update in the spring of 2017.
+> [!NOTE]
+> This interface was called `RTCRTPStreamStats` until a specification update in the spring of 2017.
 > Check the [Browser compatibility](#browser_compatibility) table to know if and when the name change was implemented in specific browsers.
 
 ## Instance properties

--- a/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.md
@@ -21,7 +21,8 @@ or more of the {{Glossary("RTP")}} packets it sent were lost in transport.
 An integer value indicating how many times the receiver sent a NACK packet to the
 sender after detecting that one or more packets were lost during transport.
 
-> **Note:** This value is only available on the receiver.
+> [!NOTE]
+> This value is only available on the receiver.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/plicount/index.md
@@ -32,7 +32,8 @@ techniques to mitigate network performance issues. This is often achieved by met
 such as increasing the compression, lowering resolution, or finding other ways to reduce
 the bit rate of the stream.
 
-> **Note:** This value is only available on the receiver, and only for
+> [!NOTE]
+> This value is only available on the receiver, and only for
 > video media.
 
 ## Specifications

--- a/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
@@ -25,7 +25,8 @@ An unsigned 64-bit integer value which indicates the sum of the quantization par
 indicate higher compression factors, the larger this sum is, the more heavily compressed
 the stream generally has been.
 
-> **Note:** This value is only available for video media.
+> [!NOTE]
+> This value is only available for video media.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.md
@@ -26,7 +26,8 @@ value of `ssrc` other than that any two objects with the same
 `ssrc` value refer to the same source. See {{RFC("3550", "", "8")}} for
 additional information about `ssrc`.
 
-> **Note:** The specification includes an example that generates values
+> [!NOTE]
+> The specification includes an example that generates values
 > for `ssrc` using MD5. While not part of the standard, exactly, it is a good
 > mechanism that may be used by some browsers; others may use other methods, such as
 > random number generators. _Do not_ rely upon these values meaning anything

--- a/files/en-us/web/api/rtcrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/trackid/index.md
@@ -20,7 +20,8 @@ A string which uniquely identifies the
 {{domxref("RTCMediaStreamTrackStats")}} object that provides statistics for the track
 for which statistics are being collected by this {{domxref("RTCStatsReport")}}.
 
-> **Note:** This value is _not_ the same as the value of
+> [!NOTE]
+> This value is _not_ the same as the value of
 > {{domxref("MediaStreamTrack.id")}}.
 
 ## Specifications

--- a/files/en-us/web/api/rtcrtptransceiver/setcodecpreferences/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/setcodecpreferences/index.md
@@ -40,7 +40,8 @@ setCodecPreferences(codecs)
   - : An array of objects, each providing the parameters for one of the transceiver's supported [media codecs](/en-US/docs/Web/Media/Formats/WebRTC_codecs), ordered by preference.
     If `codecs` is empty, the codec configurations are all returned to the user agent's defaults.
 
-    > **Note:** Any codecs not included in `codecs` will not be considered during the process of negotiating a connection.
+    > [!NOTE]
+    > Any codecs not included in `codecs` will not be considered during the process of negotiating a connection.
     > This lets you prevent the use of codecs you don't wish to use.
 
     Each codec object in the array has the following properties:

--- a/files/en-us/web/api/rtcrtptransceiver/stop/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/stop/index.md
@@ -39,7 +39,8 @@ Renegotiation is triggered by sending a {{domxref("RTCPeerConnection.negotiation
 The method does nothing if the transceiver is already stopped.
 You can check whether it has stopped by comparing {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}} to `"stopped"`.
 
-> **Note:** Earlier versions of the specification used the deprecated {{domxref("RTCRtpTransceiver.stopped", "stopped")}} {{deprecated_inline}} property to indicate if the transceiver has stopped.
+> [!NOTE]
+> Earlier versions of the specification used the deprecated {{domxref("RTCRtpTransceiver.stopped", "stopped")}} {{deprecated_inline}} property to indicate if the transceiver has stopped.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcrtptransceiver/stopped/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/stopped/index.md
@@ -10,7 +10,8 @@ browser-compat: api.RTCRtpTransceiver.stopped
 
 {{APIRef("WebRTC")}}{{deprecated_header}}
 
-> **Note:** Instead of using this deprecated property, compare {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}} to `"stopped"`.
+> [!NOTE]
+> Instead of using this deprecated property, compare {{domxref("RTCRtpTransceiver.currentDirection", "currentDirection")}} to `"stopped"`.
 
 The read-only **`stopped`** property on the {{domxref("RTCRtpTransceiver")}} interface indicates whether or not the transceiver's associated sender and receiver have both been stopped.
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
@@ -14,7 +14,8 @@ The **`RTCSessionDescription()`** constructor creates a new
 {{domxref("RTCSessionDescription")}} with its properties initialized as described in the
 specified object.
 
-> **Note:** This constructor has been deprecated because
+> [!NOTE]
+> This constructor has been deprecated because
 > {{domxref("RTCPeerConnection.setLocalDescription()")}} and other methods which take
 > SDP as input now directly accept an object conforming to the
 > `RTCSessionDescriptionInit` dictionary, so you don't have to instantiate an
@@ -44,7 +45,8 @@ new RTCSessionDescription(options)
 This example uses the constructor to convert an SDP offer into an
 `RTCSessionDescription` object.
 
-> **Note:** This is no longer necessary, however;
+> [!NOTE]
+> This is no longer necessary, however;
 > {{domxref("RTCPeerConnection.setLocalDescription()")}} and other methods which take
 > SDP as input now directly accept an object conforming to the
 > `RTCSessionDescriptionInit` dictionary, so you don't have to instantiate an

--- a/files/en-us/web/api/rtctrackevent/index.md
+++ b/files/en-us/web/api/rtctrackevent/index.md
@@ -45,7 +45,8 @@ In addition, the {{domxref("MediaStreamTrack")}} specified by the receiver's {{d
 
 You can add a `track` event listener to be notified when the new track is available so that you can, for example, attach its media to a {{HTMLElement("video")}} element, using either {{domxref("EventTarget.addEventListener", "RTCPeerConnection.addEventListener()")}} or the `ontrack` event handler property.
 
-> **Note:** It may be helpful to keep in mind that you receive the `track` event when a new inbound track has been added to your connection, and you call {{domxref("RTCPeerConnection.addTrack", "addTrack()")}} to add a track to the far end of the connection, thereby triggering a `track` event on the remote peer.
+> [!NOTE]
+> It may be helpful to keep in mind that you receive the `track` event when a new inbound track has been added to your connection, and you call {{domxref("RTCPeerConnection.addTrack", "addTrack()")}} to add a track to the far end of the connection, thereby triggering a `track` event on the remote peer.
 
 ## Example
 

--- a/files/en-us/web/api/rtctrackevent/receiver/index.md
+++ b/files/en-us/web/api/rtctrackevent/receiver/index.md
@@ -20,7 +20,8 @@ sender and other properties which establish a single bidirectional {{Glossary("R
 stream for use by the {{domxref("RTCTrackEvent.track", "track")}} associated with the
 `RTCTrackEvent`.
 
-> **Note:** The {{domxref("RTCTrackEvent.transceiver", "transceiver")}}
+> [!NOTE]
+> The {{domxref("RTCTrackEvent.transceiver", "transceiver")}}
 > includes its own {{domxref("RTCRtpTransceiver.receiver", "receiver")}} property, which
 > will always be the same {{domxref("RTCRtpReceiver")}} as this one.
 

--- a/files/en-us/web/api/rtctrackevent/transceiver/index.md
+++ b/files/en-us/web/api/rtctrackevent/transceiver/index.md
@@ -23,7 +23,8 @@ sender and other properties which establish a single bidirectional {{Glossary("R
 stream for use by the {{domxref("RTCTrackEvent.track", "track")}} associated with the
 `RTCTrackEvent`.
 
-> **Note:** The {{domxref("RTCRtpReceiver")}} referred to by this
+> [!NOTE]
+> The {{domxref("RTCRtpReceiver")}} referred to by this
 > `RTCRtpReceiver`'s {{domxref("RTCRtpTransceiver.receiver", "receiver")}}
 > property will always be the same as the {{domxref("RTCTrackEvent")}}'s
 > {{domxref("RTCTrackEvent.receiver", "receiver")}} property.

--- a/files/en-us/web/api/rtcvideosourcestats/index.md
+++ b/files/en-us/web/api/rtcvideosourcestats/index.md
@@ -12,7 +12,8 @@ The **`RTCVideoSourceStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API
 
 These statistics can be obtained by iterating the {{domxref("RTCStatsReport")}} returned by {{domxref("RTCRtpSender.getStats()")}} or {{domxref("RTCPeerConnection.getStats()")}} until you find a report with the [`type`](#type) of `media-source` and a [`kind`](#kind) of `video`.
 
-> **Note:** For video information about remotely sourced tracks (that are being received), see {{domxref("RTCInboundRtpStreamStats")}}.
+> [!NOTE]
+> For video information about remotely sourced tracks (that are being received), see {{domxref("RTCInboundRtpStreamStats")}}.
 
 ## Instance properties
 

--- a/files/en-us/web/api/sanitizer/sanitize/index.md
+++ b/files/en-us/web/api/sanitizer/sanitize/index.md
@@ -18,7 +18,8 @@ For example when sanitizing a `Document` instance in a frame.
 The default `Sanitizer()` configuration strips out XSS-relevant input by default, including {{HTMLElement("script")}} tags, custom elements, and comments.
 The sanitizer configuration may be customized using {{domxref("Sanitizer.Sanitizer","Sanitizer()")}} constructor options.
 
-> **Note:** To sanitize strings, instead use {{domxref("Element.setHTML()")}}.
+> [!NOTE]
+> To sanitize strings, instead use {{domxref("Element.setHTML()")}}.
 > See {{domxref('HTML Sanitizer API')}} for more information.
 
 ## Syntax

--- a/files/en-us/web/api/scheduler/posttask/index.md
+++ b/files/en-us/web/api/scheduler/posttask/index.md
@@ -177,7 +177,8 @@ bckg 2
 [Task priorities](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) can also take their initial value from a {{domxref("TaskSignal")}} passed to `postTask()` in the optional second argument.
 If set in this way, the priority of the task [can then be changed]/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#mutable_and_immutable_task_priority) using the controller associated with the signal.
 
-> **Note:** Setting and changing task priorities using a signal only works when the `options.priority` argument to `postTask()` is not set, and when the `options.signal` is a {{domxref("TaskSignal")}} (and not an {{domxref("AbortSignal")}}).
+> [!NOTE]
+> Setting and changing task priorities using a signal only works when the `options.priority` argument to `postTask()` is not set, and when the `options.signal` is a {{domxref("TaskSignal")}} (and not an {{domxref("AbortSignal")}}).
 
 The code below first shows how to create a {{domxref("TaskController")}}, setting the initial priority of its signal to `user-blocking` in the [`TaskController()` constructor](/en-US/docs/Web/API/TaskController/TaskController).
 

--- a/files/en-us/web/api/screen/isextended/index.md
+++ b/files/en-us/web/api/screen/isextended/index.md
@@ -19,7 +19,8 @@ This property is typically accessed via `window.screen.isExtended`, and can be u
 
 A boolean value — `true` if the device has multiple screens, and `false` if not.
 
-> **Note:** If a {{httpheader("Permissions-Policy/window-management", "window-management")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Permissions_Policy) is set that blocks use the Window Management API, `isExtended` will always return `false`.
+> [!NOTE]
+> If a {{httpheader("Permissions-Policy/window-management", "window-management")}} [Permissions-Policy](/en-US/docs/Web/HTTP/Permissions_Policy) is set that blocks use the Window Management API, `isExtended` will always return `false`.
 
 ## Examples
 

--- a/files/en-us/web/api/screen/lockorientation/index.md
+++ b/files/en-us/web/api/screen/lockorientation/index.md
@@ -13,9 +13,11 @@ browser-compat: api.Screen.lockOrientation
 The **`lockOrientation()`** method of the {{DOMxRef("Screen")}}
 interface locks the screen into a specified orientation.
 
-> **Warning:** This feature is deprecated and should be avoided. Use the {{DOMxRef("ScreenOrientation.lock()")}} method instead.
+> [!WARNING]
+> This feature is deprecated and should be avoided. Use the {{DOMxRef("ScreenOrientation.lock()")}} method instead.
 
-> **Note:** This method only works for installed Web apps or for Web pages
+> [!NOTE]
+> This method only works for installed Web apps or for Web pages
 > in [fullscreen mode](/en-US/docs/Web/API/Fullscreen_API).
 
 ## Syntax
@@ -72,7 +74,8 @@ lockOrientation(orientation)
         if the panel resolution is 1280\*800, `default` will make it landscape, if
         the resolution is 800\*1280, `default` will make it to portrait.
 
-> **Note:** It's possible to set several locks at the same time. So, if
+> [!NOTE]
+> It's possible to set several locks at the same time. So, if
 > the lock is set for only one orientation, the screen orientation will never change
 > until the screen orientation is unlocked. Otherwise, the screen orientation will
 > change from an orientation to another as long as the orientations are amongst the

--- a/files/en-us/web/api/screen/unlockorientation/index.md
+++ b/files/en-us/web/api/screen/unlockorientation/index.md
@@ -14,9 +14,11 @@ The **`Screen.unlockOrientation()`** method removes all the
 previous screen locks set by the page/app. The {{DOMxRef("ScreenOrientation.unlock()")}}
 method should be used instead.
 
-> **Warning:** This feature is deprecated and should be avoided. Use the {{DOMxRef("ScreenOrientation.unlock()")}} method instead.
+> [!WARNING]
+> This feature is deprecated and should be avoided. Use the {{DOMxRef("ScreenOrientation.unlock()")}} method instead.
 
-> **Note:** This method only works for installed Web apps or for Web pages
+> [!NOTE]
+> This method only works for installed Web apps or for Web pages
 > in [fullscreen mode](/en-US/docs/Web/API/Fullscreen_API).
 
 ## Syntax

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -9,7 +9,8 @@ browser-compat: api.MediaDevices.getDisplayMedia
 
 In this article, we will examine how to use the Screen Capture API and its {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} method to capture part or all of a screen for streaming, recording, or sharing during a [WebRTC](/en-US/docs/Web/API/WebRTC_API) conference session.
 
-> **Note:** It may be useful to note that recent versions of the [WebRTC adapter.js shim](https://github.com/webrtcHacks/adapter) include implementations of `getDisplayMedia()` to enable screen sharing on browsers that support it but do not implement the current standard API. This works with at least Chrome, Edge, and Firefox.
+> [!NOTE]
+> It may be useful to note that recent versions of the [WebRTC adapter.js shim](https://github.com/webrtcHacks/adapter) include implementations of `getDisplayMedia()` to enable screen sharing on browsers that support it but do not implement the current standard API. This works with at least Chrome, Edge, and Firefox.
 
 ## Capturing screen contents
 
@@ -90,11 +91,13 @@ The `video` and `audio` objects passed into the options object can also hold add
 
 None of the constraints are applied in any way until after the content to capture has been selected. The constraints alter what you see in the resulting stream. For example, if you specify a {{domxref("MediaTrackConstraints.width", "width")}} constraint for the video, it's applied by scaling the video after the user selects the area to share. It doesn't establish a restriction on the size of the source itself.
 
-> **Note:** Constraints _never_ cause changes to the list of sources available for capture by the Screen Sharing API. This ensures that web applications can't force the user to share specific content by restricting the source list until only one item is left.
+> [!NOTE]
+> Constraints _never_ cause changes to the list of sources available for capture by the Screen Sharing API. This ensures that web applications can't force the user to share specific content by restricting the source list until only one item is left.
 
 While display capture is in effect, the machine which is sharing screen contents will display some form of indicator so the user is aware that sharing is taking place.
 
-> **Note:** For privacy and security reasons, screen sharing sources are not enumerable using {{domxref("MediaDevices.enumerateDevices", "enumerateDevices()")}}. Related to this, the {{domxref("MediaDevices/devicechange_event", "devicechange")}} event is never sent when there are changes to the sources available for `getDisplayMedia()`.
+> [!NOTE]
+> For privacy and security reasons, screen sharing sources are not enumerable using {{domxref("MediaDevices.enumerateDevices", "enumerateDevices()")}}. Related to this, the {{domxref("MediaDevices/devicechange_event", "devicechange")}} event is never sent when there are changes to the sources available for `getDisplayMedia()`.
 
 ### Capturing shared audio
 

--- a/files/en-us/web/api/screendetailed/availleft/index.md
+++ b/files/en-us/web/api/screendetailed/availleft/index.md
@@ -15,7 +15,8 @@ The **`availLeft`** read-only property of the
 
 This is equal to the {{domxref("ScreenDetailed.left")}} property, plus the width of any OS UI element drawn on the left of the screen. Windows cannot be placed in those areas, so `availLeft` is useful for giving you the left boundary of the actual area available to open or place windows.
 
-> **Note:** A non-standard implementation of the `availLeft` property is available on the `Screen` interface in all browsers. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
+> [!NOTE]
+> A non-standard implementation of the `availLeft` property is available on the `Screen` interface in all browsers. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
 
 ## Value
 

--- a/files/en-us/web/api/screendetailed/availtop/index.md
+++ b/files/en-us/web/api/screendetailed/availtop/index.md
@@ -15,7 +15,8 @@ The **`availTop`** read-only property of the
 
 This is equal to the {{domxref("ScreenDetailed.top")}} property, plus the height of any OS UI element drawn at the top of the screen. Windows cannot be placed in those areas, so `availTop` is useful for giving you the top boundary of the actual area available to open or place windows.
 
-> **Note:** A non-standard implementation of the `availTop` property is available on the `Screen` interface in all browsers. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
+> [!NOTE]
+> A non-standard implementation of the `availTop` property is available on the `Screen` interface in all browsers. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
 
 ## Value
 

--- a/files/en-us/web/api/screendetailed/index.md
+++ b/files/en-us/web/api/screendetailed/index.md
@@ -69,7 +69,8 @@ window.open(
 );
 ```
 
-> **Note:** See [Multi-window learning environment](https://mdn.github.io/dom-examples/window-management-api/) for a full example (see the [source code](https://github.com/mdn/dom-examples/tree/main/window-management-api) also).
+> [!NOTE]
+> See [Multi-window learning environment](https://mdn.github.io/dom-examples/window-management-api/) for a full example (see the [source code](https://github.com/mdn/dom-examples/tree/main/window-management-api) also).
 
 ## Specifications
 

--- a/files/en-us/web/api/screendetailed/left/index.md
+++ b/files/en-us/web/api/screendetailed/left/index.md
@@ -15,7 +15,8 @@ The **`left`** read-only property of the
 
 This is equal to the true left-hand edge, ignoring any OS UI element drawn at the left of the screen. Windows cannot be placed in those areas; to get the left-hand coordinate of the screen area that windows can be placed in, use {{domxref("ScreenDetailed.availLeft")}}.
 
-> **Note:** In Firefox, a non-standard implementation of the `left` property is available on the `Screen` interface. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
+> [!NOTE]
+> In Firefox, a non-standard implementation of the `left` property is available on the `Screen` interface. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
 
 ## Value
 

--- a/files/en-us/web/api/screendetailed/top/index.md
+++ b/files/en-us/web/api/screendetailed/top/index.md
@@ -15,7 +15,8 @@ The **`top`** read-only property of the
 
 This is equal to the true top edge, ignoring any OS UI element drawn at the top of the screen. Windows cannot be placed in those areas; to get the top coordinate of the screen area that windows can be placed in, use {{domxref("ScreenDetailed.availTop")}}.
 
-> **Note:** In Firefox, a non-standard implementation of the `top` property is available on the `Screen` interface. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
+> [!NOTE]
+> In Firefox, a non-standard implementation of the `top` property is available on the `Screen` interface. See the [Non-standard example](#non-standard_example) below for usage details, and see the [`Screen`](/en-US/docs/Web/API/Screen#browser_compatibility) reference page for browser support information relating to the non-standard implementation.
 
 ## Value
 

--- a/files/en-us/web/api/screendetails/index.md
+++ b/files/en-us/web/api/screendetails/index.md
@@ -40,7 +40,8 @@ _Inherits properties from its parent, {{DOMxRef("EventTarget")}}._
 
 ## Examples
 
-> **Note:** See [Multi-window learning environment](https://mdn.github.io/dom-examples/window-management-api/) for a full example (see the [source code](https://github.com/mdn/dom-examples/tree/main/window-management-api) also).
+> [!NOTE]
+> See [Multi-window learning environment](https://mdn.github.io/dom-examples/window-management-api/) for a full example (see the [source code](https://github.com/mdn/dom-examples/tree/main/window-management-api) also).
 
 ### Basic screen information access
 

--- a/files/en-us/web/api/scriptprocessornode/audioprocess_event/index.md
+++ b/files/en-us/web/api/scriptprocessornode/audioprocess_event/index.md
@@ -12,7 +12,8 @@ browser-compat: api.ScriptProcessorNode.audioprocess_event
 
 The `audioprocess` event of the {{domxref("ScriptProcessorNode")}} interface is fired when an input buffer of a script processor is ready to be processed.
 
-> **Note:** This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
+> [!NOTE]
+> This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.md
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.md
@@ -12,7 +12,8 @@ browser-compat: api.ScriptProcessorNode.bufferSize
 
 The `bufferSize` property of the {{domxref("ScriptProcessorNode")}} interface returns an integer representing both the input and output buffer size, in sample-frames. Its value can be a power of 2 value in the range `256` – `16384`.
 
-> **Note:** This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
+> [!NOTE]
+> This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
 
 ## Value
 

--- a/files/en-us/web/api/scriptprocessornode/index.md
+++ b/files/en-us/web/api/scriptprocessornode/index.md
@@ -13,7 +13,8 @@ The `ScriptProcessorNode` interface allows the generation, processing, or analyz
 
 {{InheritanceDiagram}}
 
-> **Note:** This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
+> [!NOTE]
+> This feature was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
 
 The `ScriptProcessorNode` interface is an {{domxref("AudioNode")}} audio-processing module that is linked to two buffers, one containing the input audio data, one containing the processed output audio data. An event, implementing the {{domxref("AudioProcessingEvent")}} interface, is sent to the object each time the input buffer contains new data, and the event handler terminates when it has filled the output buffer with data.
 

--- a/files/en-us/web/api/securepaymentconfirmationrequest/index.md
+++ b/files/en-us/web/api/securepaymentconfirmationrequest/index.md
@@ -29,7 +29,8 @@ An instance of this dictionary must be passed into the {{domxref("PaymentRequest
       - : A boolean value indicating whether the icon must be successfully fetched and shown for the request to succeed. Defaults to `true`.
 - `locale` {{optional_inline}}
   - : An optional list of well-formed {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}} language tags, in descending order of priority, that identify the local preferences of the website. That is, this represents a language priority list {{RFC(4647, "Matching of Language Tags")}}, which the user agent can use to perform [language negotiation](/en-US/docs/Web/HTTP/Content_negotiation) and locale-affected formatting with the caller.
-    > **Note:** The locale is distinct from language or direction metadata associated with specific input members, in that it represents the caller's requested localized experience rather than assertion about a specific string value. See [SPC internationalization Considerations](https://w3c.github.io/secure-payment-confirmation/#sctn-i18n-considerations) for more discussion.
+    > [!NOTE]
+    > The locale is distinct from language or direction metadata associated with specific input members, in that it represents the caller's requested localized experience rather than assertion about a specific string value. See [SPC internationalization Considerations](https://w3c.github.io/secure-payment-confirmation/#sctn-i18n-considerations) for more discussion.
 - `payeeName` {{optional_inline}}
   - : A string that serves as the display name of the payee that this SPC call is for (e.g., the merchant). Optional, may be provided alongside or instead of `payeeOrigin`.
 - `payeeOrigin` {{optional_inline}}

--- a/files/en-us/web/api/selection/addrange/index.md
+++ b/files/en-us/web/api/selection/addrange/index.md
@@ -28,7 +28,8 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-> **Note:** Currently only Firefox supports multiple selection ranges, other browsers will not
+> [!NOTE]
+> Currently only Firefox supports multiple selection ranges, other browsers will not
 > add new ranges to the selection if it already contains one.
 
 ### HTML

--- a/files/en-us/web/api/selection/collapse/index.md
+++ b/files/en-us/web/api/selection/collapse/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Selection.collapse
 
 The **`Selection.collapse()`** method collapses the current selection to a single point. The document is not modified. If the content is focused and editable, the caret will blink there.
 
-> **Note:** This method is an alias for the {{domxref("Selection.setPosition()")}} method.
+> [!NOTE]
+> This method is an alias for the {{domxref("Selection.setPosition()")}} method.
 
 ## Syntax
 

--- a/files/en-us/web/api/selection/empty/index.md
+++ b/files/en-us/web/api/selection/empty/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Selection.empty
 
 The **`Selection.empty()`** method removes all ranges from the selection, leaving the {{domxref("Selection.anchorNode", "anchorNode")}} and {{domxref("Selection.focusNode","focusNode")}} properties equal to `null` and nothing selected. When this method is called, a {{domxref("Document/selectionchange_event", "selectionchange")}} event is fired at the document.
 
-> **Note:** This method is an alias for the {{domxref("Selection.removeAllRanges()")}} method.
+> [!NOTE]
+> This method is an alias for the {{domxref("Selection.removeAllRanges()")}} method.
 
 ## Syntax
 

--- a/files/en-us/web/api/selection/getcomposedranges/index.md
+++ b/files/en-us/web/api/selection/getcomposedranges/index.md
@@ -20,7 +20,8 @@ The returned ranges represent the range at the time that `getComposedRanges()` w
 If the DOM or a shadow DOM is mutated, the selected range is likely to be incorrect.
 Application code might use a {{domxref("MutationObserver")}} to monitor for DOM mutations and then call {{domxref("Selection.setBaseAndExtent()")}} to update the selection.
 
-> **Note:** This method should be used instead of {{domxref("Selection.getRangeAt()")}} when selecting ranges that can potentially cross shadow root boundaries.
+> [!NOTE]
+> This method should be used instead of {{domxref("Selection.getRangeAt()")}} when selecting ranges that can potentially cross shadow root boundaries.
 > {{domxref("Selection.getRangeAt()")}} is not aware of shadow roots.
 > The returned range is not specified, and varies between browsers.
 

--- a/files/en-us/web/api/selection/getrangeat/index.md
+++ b/files/en-us/web/api/selection/getrangeat/index.md
@@ -13,7 +13,8 @@ The **`getRangeAt()`** method of the {{domxref("Selection")}} interface returns 
 If the endpoints of the selected range are within a {{glossary("shadow tree")}} then JavaScript does not have visibility of the shadow nodes, and the method should re-scope the range to include the host element that contains the end point.
 In practice most browsers do not yet implement this behavior, and the returned range is unpredictable.
 
-> **Note:** When selecting within nodes that might contain a shadow root, you can use {{domxref("Selection.getComposedRanges()")}} (if supported) to get a selection range inside a shadow tree, or to reliably re-scope the selection to the host node.
+> [!NOTE]
+> When selecting within nodes that might contain a shadow root, you can use {{domxref("Selection.getComposedRanges()")}} (if supported) to get a selection range inside a shadow tree, or to reliably re-scope the selection to the host node.
 
 ## Syntax
 

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -108,7 +108,8 @@ The behavior is as follows:
 2. A Selection API method is called, causing a new selection to be made with the selection range inside the editing host.
 3. Focus then moves to the editing host.
 
-> **Note:** The Selection API methods may only move focus to an editing host, not to other focusable elements (e.g., {{HTMLElement("a")}}).
+> [!NOTE]
+> The Selection API methods may only move focus to an editing host, not to other focusable elements (e.g., {{HTMLElement("a")}}).
 
 The above behavior applies to selections made using the following methods:
 
@@ -144,7 +145,8 @@ Other key terms used in this section.
 
   - : The _focus_ of a selection is the end point of the selection. When making a selection with a mouse, the focus is where in the document the mouse button is released. As the user changes the selection using the mouse or the keyboard, the focus is the end of the selection that moves.
 
-    > **Note:** This is not the same as the focused _element_ of the document, as returned by {{DOMxRef("document.activeElement")}}.
+    > [!NOTE]
+    > This is not the same as the focused _element_ of the document, as returned by {{DOMxRef("document.activeElement")}}.
 
 - `range`
 

--- a/files/en-us/web/api/selection/modify/index.md
+++ b/files/en-us/web/api/selection/modify/index.md
@@ -34,12 +34,14 @@ modify(alter, direction, granularity)
     `"sentenceboundary"`, `"paragraphboundary"`, or
     `"documentboundary"`.
 
-> **Note:** Firefox does **not** implement
+> [!NOTE]
+> Firefox does **not** implement
 > `"sentence"`, `"paragraph"`, `"sentenceboundary"`,
 > `"paragraphboundary"`, or `"documentboundary"`. WebKit and Blink
 > do.
 
-> **Note:** Starting in Firefox 5, the `"word"`
+> [!NOTE]
+> Starting in Firefox 5, the `"word"`
 > granularity no longer includes the following space, regardless of the default platform
 > behavior. This makes the behavior more consistent, as well as making it work the same
 > way WebKit used to work, but unfortunately they have recently changed their behavior.

--- a/files/en-us/web/api/selection/removeallranges/index.md
+++ b/files/en-us/web/api/selection/removeallranges/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Selection.removeAllRanges
 
 The **`Selection.removeAllRanges()`** method removes all ranges from the selection, leaving the {{domxref("Selection.anchorNode", "anchorNode")}} and {{domxref("Selection.focusNode","focusNode")}} properties equal to `null` and nothing selected. When this method is called, a {{domxref("Document/selectionchange_event", "selectionchange")}} event is fired at the document.
 
-> **Note:** This method is an alias for the {{domxref("Selection.empty()")}} method.
+> [!NOTE]
+> This method is an alias for the {{domxref("Selection.empty()")}} method.
 
 ## Syntax
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -41,7 +41,8 @@ setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
 
     If `focusNode` is a {{domxref("Text")}} node, the offset refers to the number of characters from the start of the {{domxref("Node.textContent")}} that should be included in the selection.
 
-> **Note:** If the focus position appears before the anchor position in the document, the direction of the selection is reversed — the caret is placed at the beginning of the text rather the end, which matters for any keyboard command that might follow.
+> [!NOTE]
+> If the focus position appears before the anchor position in the document, the direction of the selection is reversed — the caret is placed at the beginning of the text rather the end, which matters for any keyboard command that might follow.
 > For example, <kbd>Shift</kbd> + <kbd>➡︎</kbd> would cause the selection to narrow from the beginning rather than grow at the end.
 
 ### Return value
@@ -90,7 +91,8 @@ We also have a button that when pressed invokes a function that runs the `setBas
 <p><strong>Output</strong>: <span class="output"></span></p>
 ```
 
-> **Note:** There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example)).
+> [!NOTE]
+> There is intentionally no [whitespace](/en-US/docs/Web/API/Document_Object_Model/Whitespace) between the `<p class="one">` and `<p class="two">` start tags and the `<span>` start tags which follow them — to avoid the presence of text nodes that would affect the number of child nodes expected. (Even though those text nodes would be whitespace-only, they would still be additional child nodes; find out more from the [`Node.firstChild` example](/en-US/docs/Web/API/Node/firstChild#example)).
 
 The JavaScript looks like so:
 
@@ -123,7 +125,8 @@ Play with the live example below, setting different offset values to see how thi
 
 {{ EmbedLiveSample('Examples', '100%', 370) }}
 
-> **Note:** You can find this [example on GitHub](https://github.com/chrisdavidmills/selection-api-examples/blob/master/setBaseAndExtent.html) ([see it live also](https://chrisdavidmills.github.io/selection-api-examples/setBaseAndExtent.html).)
+> [!NOTE]
+> You can find this [example on GitHub](https://github.com/chrisdavidmills/selection-api-examples/blob/master/setBaseAndExtent.html) ([see it live also](https://chrisdavidmills.github.io/selection-api-examples/setBaseAndExtent.html).)
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/setposition/index.md
+++ b/files/en-us/web/api/selection/setposition/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Selection.setPosition
 
 The **`Selection.setPosition()`** method collapses the current selection to a single point. The document is not modified. If the content is focused and editable, the caret will blink there.
 
-> **Note:** This method is an alias for the {{domxref("Selection.collapse()")}} method.
+> [!NOTE]
+> This method is an alias for the {{domxref("Selection.collapse()")}} method.
 
 ## Syntax
 

--- a/files/en-us/web/api/selection_api/index.md
+++ b/files/en-us/web/api/selection_api/index.md
@@ -7,7 +7,8 @@ spec-urls: https://w3c.github.io/selection-api/#selection-interface
 
 {{DefaultAPISidebar("Selection API")}}
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
 The **Selection API** enables developers to access and manipulate the portion of a document selected by the user.
 

--- a/files/en-us/web/api/server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/index.md
@@ -9,7 +9,8 @@ spec-urls: https://html.spec.whatwg.org/multipage/server-sent-events.html#server
 
 Traditionally, a web page has to send a request to the server to receive new data; that is, the page requests data from the server. With server-sent events, it's possible for a server to send new data to a web page at any time, by pushing messages to the web page. These incoming messages can be treated as _[Events](/en-US/docs/Web/API/Event) + data_ inside the web page.
 
-> **Note:** Firefox does not currently support the use of server-sent events in service workers (it does support them in dedicated and shared workers). See [Firefox bug 1681218](https://bugzil.la/1681218).
+> [!NOTE]
+> Firefox does not currently support the use of server-sent events in service workers (it does support them in dedicated and shared workers). See [Firefox bug 1681218](https://bugzil.la/1681218).
 
 ## Concepts and usage
 

--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -61,7 +61,8 @@ evtSource.addEventListener("ping", (event) => {
 
 This code will be called whenever the server sends a message with the `event` field set to `ping`; it then parses the JSON in the `data` field and outputs that information.
 
-> **Warning:** When **not used over HTTP/2**, SSE suffers from a limitation to the maximum number of open connections, which can be especially painful when opening multiple tabs, as the limit is _per browser_ and is set to a very low number (6). The issue has been marked as "Won't fix" in [Chrome](https://crbug.com/275955) and [Firefox](https://bugzil.la/906896). This limit is per browser + domain, which means that you can open 6 SSE connections across all of the tabs to `www.example1.com` and another 6 SSE connections to `www.example2.com` (per [Stackoverflow](https://stackoverflow.com/questions/5195452/websockets-vs-server-sent-events-eventsource/5326159)). When using HTTP/2, the maximum number of simultaneous _HTTP streams_ is negotiated between the server and the client (defaults to 100).
+> [!WARNING]
+> When **not used over HTTP/2**, SSE suffers from a limitation to the maximum number of open connections, which can be especially painful when opening multiple tabs, as the limit is _per browser_ and is set to a very low number (6). The issue has been marked as "Won't fix" in [Chrome](https://crbug.com/275955) and [Firefox](https://bugzil.la/906896). This limit is per browser + domain, which means that you can open 6 SSE connections across all of the tabs to `www.example1.com` and another 6 SSE connections to `www.example2.com` (per [Stackoverflow](https://stackoverflow.com/questions/5195452/websockets-vs-server-sent-events-eventsource/5326159)). When using HTTP/2, the maximum number of simultaneous _HTTP streams_ is negotiated between the server and the client (defaults to 100).
 
 ## Sending events from the server
 
@@ -110,7 +111,8 @@ The code above generates an event every second, with the event type "ping". Each
 The loop will keep running independent of the connection status, so a check is included
 to break the loop if the connection has been closed (e.g. client closes the page).
 
-> **Note:** You can find a full example that uses the code shown in this article on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
+> [!NOTE]
+> You can find a full example that uses the code shown in this article on GitHub — see [Simple SSE demo using PHP](https://github.com/mdn/dom-examples/tree/main/server-sent-events).
 
 ## Error handling
 
@@ -134,7 +136,8 @@ evtSource.close();
 
 The event stream is a simple stream of text data which must be encoded using [UTF-8](/en-US/docs/Glossary/UTF-8). Messages in the event stream are separated by a pair of newline characters. A colon as the first character of a line is in essence a comment, and is ignored.
 
-> **Note:** The comment line can be used to prevent connections from timing out; a server can send a comment periodically to keep the connection alive.
+> [!NOTE]
+> The comment line can be used to prevent connections from timing out; a server can send a comment periodically to keep the connection alive.
 
 Each message consists of one or more lines of text listing the fields for that message. Each field is represented by the field name, followed by a colon, followed by the text data for that field's value.
 
@@ -153,7 +156,8 @@ Each message received has some combination of the following fields, one per line
 
 All other field names are ignored.
 
-> **Note:** If a line doesn't contain a colon, the entire line is treated as the field name with an empty value string.
+> [!NOTE]
+> If a line doesn't contain a colon, the entire line is treated as the field name with an empty value string.
 
 ### Examples
 

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -19,11 +19,14 @@ Service workers can't import JavaScript modules dynamically, and [`import()`](/e
 
 Service workers only run over HTTPS, for security reasons. Most significantly, HTTP connections are susceptible to malicious code injection by {{Glossary("MitM", "man in the middle")}} attacks, and such attacks could be worse if allowed access to these powerful APIs. In Firefox, service worker APIs are also hidden and cannot be used when the user is in [private browsing mode](https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history).
 
-> **Note:** On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the **Enable Service Workers over HTTP (when toolbox is open)** option in the Firefox Devtools options/gear menu.
+> [!NOTE]
+> On Firefox, for testing you can run service workers over HTTP (insecurely); simply check the **Enable Service Workers over HTTP (when toolbox is open)** option in the Firefox Devtools options/gear menu.
 
-> **Note:** Unlike previous attempts in this area such as [AppCache](https://alistapart.com/article/application-cache-is-a-douchebag/), service workers don't make assumptions about what you are trying to do, but then break when those assumptions are not exactly right. Instead, service workers give you much more granular control.
+> [!NOTE]
+> Unlike previous attempts in this area such as [AppCache](https://alistapart.com/article/application-cache-is-a-douchebag/), service workers don't make assumptions about what you are trying to do, but then break when those assumptions are not exactly right. Instead, service workers give you much more granular control.
 
-> **Note:** Service workers make heavy use of [promises](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), as generally they will wait for responses to come through, after which they will respond with a success or failure action. The promises architecture is ideal for this.
+> [!NOTE]
+> Service workers make heavy use of [promises](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), as generally they will wait for responses to come through, after which they will respond with a success or failure action. The promises architecture is ideal for this.
 
 ### Registration
 
@@ -56,7 +59,8 @@ There is also an {{domxref("ServiceWorkerGlobalScope/activate_event", "activate"
 
 Your service worker can respond to requests using the {{DOMxRef("FetchEvent")}} event. You can modify the response to these requests in any way you want, using the {{DOMxRef("FetchEvent.respondWith()")}} method.
 
-> **Note:** Because `install`/`activate` events could take a while to complete, the service worker spec provides a {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} method. Once it is called on `install` or `activate` events with a promise, functional events such as `fetch` and `push` will wait until the promise is successfully resolved.
+> [!NOTE]
+> Because `install`/`activate` events could take a while to complete, the service worker spec provides a {{domxref("ExtendableEvent.waitUntil", "waitUntil()")}} method. Once it is called on `install` or `activate` events with a promise, functional events such as `fetch` and `push` will wait until the promise is successfully resolved.
 
 For a complete tutorial to show how to build up your first basic example, read [Using Service Workers](/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers).
 

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -88,7 +88,8 @@ This registers a service worker, which runs in a worker context, and therefore h
 
 A single service worker can control many pages. Each time a page within your scope is loaded, the service worker is installed against that page and operates on it. Bear in mind therefore that you need to be careful with global variables in the service worker script: each page doesn't get its own unique worker.
 
-> **Note:** One great thing about service workers is that if you use feature detection like we've shown above, browsers that don't support service workers can just use your app online in the normal expected fashion.
+> [!NOTE]
+> One great thing about service workers is that if you use feature detection like we've shown above, browsers that don't support service workers can just use your app online in the normal expected fashion.
 
 #### Why is my service worker failing to register?
 
@@ -384,7 +385,8 @@ Note that in this example we download and cache the same data for the resource w
 
 If your service worker has previously been installed, but then a new version of the worker is available on refresh or page load, the new version is installed in the background, but not yet activated. It is only activated when there are no longer any pages loaded that are still using the old service worker. As soon as there are no more such pages still loaded, the new service worker activates.
 
-> **Note:** It is possible to bypass this by using [`Clients.claim()`](/en-US/docs/Web/API/Clients/claim).
+> [!NOTE]
+> It is possible to bypass this by using [`Clients.claim()`](/en-US/docs/Web/API/Clients/claim).
 
 You'll want to update your `install` event listener in the new service worker to something like this (notice the new version number):
 

--- a/files/en-us/web/api/serviceworkercontainer/startmessages/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/startmessages/index.md
@@ -25,7 +25,8 @@ example if you've invoked a message handler using
 {{domxref("EventTarget.addEventListener()")}} before the page has finished loading, but
 want to start processing the messages right away.
 
-> **Note:** The messages start being sent automatically when setting the
+> [!NOTE]
+> The messages start being sent automatically when setting the
 > handler directly using {{domxref("ServiceWorkerContainer.message_event", "onmessage")}}. In this you
 > don't need `startMessages()`.
 

--- a/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/pushsubscriptionchange_event/index.md
@@ -34,7 +34,8 @@ Although examples demonstrating how to share subscription related information wi
 
 Consider using another method to synchronize subscription information between your service worker and the app server, or make sure your code using `fetch()` is robust enough to handle cases where attempts to exchange data fail.
 
-> **Note:** In earlier drafts of the specification, this event was defined to be sent when a {{domxref("PushSubscription")}} has expired.
+> [!NOTE]
+> In earlier drafts of the specification, this event was defined to be sent when a {{domxref("PushSubscription")}} has expired.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworkerregistration/active/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/active/index.md
@@ -17,7 +17,8 @@ An active worker controls a {{domxref("Client")}} if the client's URL
 falls within the scope of the registration (the `scope` option set when
 {{domxref("ServiceWorkerContainer.register")}} is first called.)
 
-> **Note:** Once an active worker is `activating`, neither a
+> [!NOTE]
+> Once an active worker is `activating`, neither a
 > runtime script error nor a force termination of the active worker prevents the active
 > worker from getting `activated`.
 

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -45,7 +45,8 @@ The returned `intervalID` is a numeric, non-zero value which identifies the time
 It may be helpful to be aware that `setInterval()` and {{domxref("setTimeout()")}} share the same pool of IDs, and that `clearInterval()` and {{domxref("clearTimeout", "clearTimeout()")}} can technically be used interchangeably.
 For clarity, however, you should try to always match them to avoid confusion when maintaining your code.
 
-> **Note:** The `delay` argument is converted to a signed 32-bit integer.
+> [!NOTE]
+> The `delay` argument is converted to a signed 32-bit integer.
 > This effectively limits `delay` to 2147483647 ms, roughly 24.8 days, since it's specified as a signed integer in the IDL.
 
 ## Examples

--- a/files/en-us/web/api/shadowroot/adoptedstylesheets/index.md
+++ b/files/en-us/web/api/shadowroot/adoptedstylesheets/index.md
@@ -10,7 +10,8 @@ browser-compat: api.ShadowRoot.adoptedStyleSheets
 
 The **`adoptedStyleSheets`** property of the {{domxref("ShadowRoot")}} interface sets an array of constructed stylesheets to be used by the shadow DOM subtree.
 
-> **Note:** A constructed stylesheet is a stylesheet created programmatically using the [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) (as compared to one created by a user-agent when importing a stylesheet from a script, imported using {{HTMLElement('style')}} and {{CSSXref('@import')}}, or linked to via {{HTMLElement('link')}}).
+> [!NOTE]
+> A constructed stylesheet is a stylesheet created programmatically using the [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) (as compared to one created by a user-agent when importing a stylesheet from a script, imported using {{HTMLElement('style')}} and {{CSSXref('@import')}}, or linked to via {{HTMLElement('link')}}).
 
 The same constructed stylesheet can be adopted by multiple {{domxref("ShadowRoot")}} instances, and by the parent document (using the {{domxref("Document.adoptedStyleSheets")}} property).
 Changing an adopted stylesheet will affect all the adopting objects.

--- a/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
+++ b/files/en-us/web/api/shadowroot/sethtmlunsafe/index.md
@@ -15,7 +15,8 @@ The suffix "Unsafe" in the method name indicates that the method does not saniti
 
 If the string of HTML defines more than one [declarative shadow root](/en-US/docs/Web/HTML/Element/template#declarative_shadow_dom) in a particular shadow host then only the first {{domxref("ShadowRoot")}} is created — subsequent declarations are parsed as `<template>` elements within that shadow root.
 
-> **Note:** This method should be used instead of {{domxref("ShadowRoot.innerHTML")}} when a string of HTML may contain declarative shadow roots.
+> [!NOTE]
+> This method should be used instead of {{domxref("ShadowRoot.innerHTML")}} when a string of HTML may contain declarative shadow roots.
 
 ## Syntax
 

--- a/files/en-us/web/api/shared_storage_api/index.md
+++ b/files/en-us/web/api/shared_storage_api/index.md
@@ -27,7 +27,8 @@ To extract useful results from a shared storage worklet, you need to use an **ou
 
 The currently available output gates for the Shared Storage API are discussed in the sections below. In each section, we list typical use cases for each gate and provide links to guides with more information and code examples.
 
-> **Note:** More output gates will likely be added in the future to support additional use cases.
+> [!NOTE]
+> More output gates will likely be added in the future to support additional use cases.
 
 ### URL Selection
 
@@ -76,7 +77,8 @@ async function injectContent() {
 }
 ```
 
-> **Note:** The `ignoreIfPresent: true` option causes the `set()` function to abort if the shared storage already contains a data item with the specified key.
+> [!NOTE]
+> The `ignoreIfPresent: true` option causes the `set()` function to abort if the shared storage already contains a data item with the specified key.
 
 ### Reading and processing data from shared storage
 
@@ -99,7 +101,8 @@ The URL Selection operation is a JavaScript class that must follow the rules bel
 - The actual functionality must be contained in an asynchronous `run()` method, which takes an array of objects containing URLs as its first parameter and a data object as its second parameter (when called, the data argument is optional).
 - The `run()` method must return a number, which will equate to the number of the URL chosen.
 
-> **Note:** Each output gate has a corresponding interface that defines the required structure of its class and `run()` method. For URL Selection, see {{domxref("SharedStorageSelectURLOperation")}}.
+> [!NOTE]
+> Each output gate has a corresponding interface that defines the required structure of its class and `run()` method. For URL Selection, see {{domxref("SharedStorageSelectURLOperation")}}.
 
 Once the operation is defined, it needs to be registered using {{domxref("SharedStorageWorkletGlobalScope.register()")}}.
 
@@ -120,7 +123,8 @@ register("ab-testing", SelectURLOperation);
 
 Notice how the value set in our main app context is retrieved using {{domxref("WorkletSharedStorage.get()")}}. To reiterate, to preserve privacy and mitigate data leakage, you can read values from shared storage only within a worklet.
 
-> **Note:** It is possible to define and register multiple operations in the same shared storage worklet module script with different names; see {{domxref("SharedStorageOperation")}} for an example.
+> [!NOTE]
+> It is possible to define and register multiple operations in the same shared storage worklet module script with different names; see {{domxref("SharedStorageOperation")}} for an example.
 
 #### Add the module to the shared storage worklet
 

--- a/files/en-us/web/api/sharedstorage/append/index.md
+++ b/files/en-us/web/api/sharedstorage/append/index.md
@@ -25,7 +25,8 @@ append(key, value)
 - `value`
   - : A string that you want to append to the existing value of the key-value pair.
 
-> **Note:** If the specified `key` isn't found in the shared storage, the `append()` operation is equivalent to {{domxref("SharedStorage.set", "set()")}}, that is, a new key-value pair with the specified `key` is added to the shared storage.
+> [!NOTE]
+> If the specified `key` isn't found in the shared storage, the `append()` operation is equivalent to {{domxref("SharedStorage.set", "set()")}}, that is, a new key-value pair with the specified `key` is added to the shared storage.
 
 ### Return value
 
@@ -39,7 +40,8 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
   - The calling site does not have the Shared Storage API included in a successful [privacy sandbox enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment).
 - In the case of {{domxref("WorkletSharedStorage")}}, the `Promise` rejects with a {{jsxref("TypeError")}} if the worklet module has not been added with {{domxref("Worklet.addModule", "SharedStorageWorklet.addModule()")}}.
 
-> **Note:** In the case of {{domxref("WindowSharedStorage")}}, if the `append()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
+> [!NOTE]
+> In the case of {{domxref("WindowSharedStorage")}}, if the `append()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/sharedstorage/clear/index.md
+++ b/files/en-us/web/api/sharedstorage/clear/index.md
@@ -33,7 +33,8 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
   - The calling site does not have the Shared Storage API included in a successful [privacy sandbox enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment).
 - In the case of {{domxref("WorkletSharedStorage")}}, the `Promise` rejects with a {{jsxref("TypeError")}} if the worklet module has not been added with {{domxref("Worklet.addModule", "SharedStorageWorklet.addModule()")}}.
 
-> **Note:** In the case of {{domxref("WindowSharedStorage")}}, if the `clear()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
+> [!NOTE]
+> In the case of {{domxref("WindowSharedStorage")}}, if the `clear()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/sharedstorage/delete/index.md
+++ b/files/en-us/web/api/sharedstorage/delete/index.md
@@ -36,9 +36,11 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
 - In the case of {{domxref("WorkletSharedStorage")}}, the `Promise` rejects with a {{jsxref("TypeError")}} if:
   - The worklet module has not been added with {{domxref("Worklet.addModule", "SharedStorageWorklet.addModule()")}}.
 
-> **Note:** If the key-value pair doesn't exist in the shared storage, no error is thrown — the operation still fulfills with `undefined`.
+> [!NOTE]
+> If the key-value pair doesn't exist in the shared storage, no error is thrown — the operation still fulfills with `undefined`.
 
-> **Note:** In the case of {{domxref("WindowSharedStorage")}}, if the `delete()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
+> [!NOTE]
+> In the case of {{domxref("WindowSharedStorage")}}, if the `delete()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/sharedstorage/set/index.md
+++ b/files/en-us/web/api/sharedstorage/set/index.md
@@ -42,7 +42,8 @@ A {{jsxref("Promise")}} that fulfills with `undefined`.
   - The calling site does not have the Shared Storage API included in a successful [privacy sandbox enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment).
 - In the case of {{domxref("WorkletSharedStorage")}}, the `Promise` rejects with a {{jsxref("TypeError")}} if the worklet module has not been added with {{domxref("Worklet.addModule", "SharedStorageWorklet.addModule()")}}.
 
-> **Note:** In the case of {{domxref("WindowSharedStorage")}}, if the `set()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
+> [!NOTE]
+> In the case of {{domxref("WindowSharedStorage")}}, if the `set()` operation doesn't successfully write to the database for a reason other than shared storage not being available, no error is thrown — the operation still fulfills with `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/sharedstoragerunoperation/index.md
+++ b/files/en-us/web/api/sharedstoragerunoperation/index.md
@@ -59,7 +59,8 @@ class ReachMeasurementOperation {
 register("reach-measurement", ReachMeasurementOperation);
 ```
 
-> **Note:** It is possible to define and register multiple operations in the same shared storage worklet module script with different names. See {{domxref("SharedStorageOperation")}} for an example.
+> [!NOTE]
+> It is possible to define and register multiple operations in the same shared storage worklet module script with different names. See {{domxref("SharedStorageOperation")}} for an example.
 
 In the main browsing context, the `reach-measurement` operation is invoked using the {{domxref("WindowSharedStorage.run()")}} method:
 

--- a/files/en-us/web/api/sharedstorageselecturloperation/index.md
+++ b/files/en-us/web/api/sharedstorageselecturloperation/index.md
@@ -38,7 +38,8 @@ class SelectURLOperation {
 register("ab-testing", SelectURLOperation);
 ```
 
-> **Note:** It is possible to define and register multiple operations in the same shared storage worklet module script with different names; see {{domxref("SharedStorageOperation")}} for an example.
+> [!NOTE]
+> It is possible to define and register multiple operations in the same shared storage worklet module script with different names; see {{domxref("SharedStorageOperation")}} for an example.
 
 In the main browsing context, the `ab-testing` operation is invoked using the {{domxref("WindowSharedStorage.selectURL()")}} method:
 

--- a/files/en-us/web/api/sharedstorageworkletglobalscope/register/index.md
+++ b/files/en-us/web/api/sharedstorageworkletglobalscope/register/index.md
@@ -58,7 +58,8 @@ register("ab-testing", SelectURLOperation);
 
 See the [Shared Storage API](/en-US/docs/Web/API/Shared_Storage_API) landing page for a walkthrough of this example and for links to other examples.
 
-> **Note:** It is possible to define and register multiple operations in the same shared storage worklet module script with different names; see {{domxref("SharedStorageOperation")}} for an example.
+> [!NOTE]
+> It is possible to define and register multiple operations in the same shared storage worklet module script with different names; see {{domxref("SharedStorageOperation")}} for an example.
 
 ## Specifications
 

--- a/files/en-us/web/api/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/index.md
@@ -9,7 +9,8 @@ browser-compat: api.SharedWorker
 
 The **`SharedWorker`** interface represents a specific kind of worker that can be _accessed_ from several browsing contexts, such as several windows, iframes or even workers. They implement an interface different than dedicated workers and have a different global scope, {{domxref("SharedWorkerGlobalScope")}}.
 
-> **Note:** If SharedWorker can be accessed from several browsing contexts, all those browsing contexts must share the exact same origin (same protocol, host and port).
+> [!NOTE]
+> If SharedWorker can be accessed from several browsing contexts, all those browsing contexts must share the exact same origin (same protocol, host and port).
 
 {{InheritanceDiagram}}
 
@@ -44,7 +45,8 @@ The following code snippet shows creation of a `SharedWorker` object using the {
 const myWorker = new SharedWorker("worker.js");
 ```
 
-> **Note:** Once a shared worker is created, any script running in the same origin can obtain a reference to that worker and communicate with it. The shared worker will be alive as long as its global scope's owner set (a set of `Document` and `WorkerGlobalScope` objects) is not empty (for example, if there is any live page holding a reference to it, maybe through `new SharedWorker()`). To read more about shared worker lifetime, see [The worker's lifetime](https://html.spec.whatwg.org/multipage/workers.html#the-worker's-lifetime) section of the HTML specification.
+> [!NOTE]
+> Once a shared worker is created, any script running in the same origin can obtain a reference to that worker and communicate with it. The shared worker will be alive as long as its global scope's owner set (a set of `Document` and `WorkerGlobalScope` objects) is not empty (for example, if there is any live page holding a reference to it, maybe through `new SharedWorker()`). To read more about shared worker lifetime, see [The worker's lifetime](https://html.spec.whatwg.org/multipage/workers.html#the-worker's-lifetime) section of the HTML specification.
 
 Both scripts then access the worker through a {{domxref("MessagePort")}} object created using the {{domxref("SharedWorker.port")}} property. If the onmessage event is attached using addEventListener, the port is manually started using its `start()` method:
 
@@ -54,7 +56,8 @@ myWorker.port.start();
 
 When the port is started, both scripts post messages to the worker and handle messages sent from it using `port.postMessage()` and `port.onmessage`, respectively:
 
-> **Note:** You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome, the URL `chrome://inspect/#workers`, and in FireFox, the URL `about:debugging#workers`.
+> [!NOTE]
+> You can use browser devtools to debug your SharedWorker, by entering a URL in your browser address bar to access the devtools workers inspector; for example, in Chrome, the URL `chrome://inspect/#workers`, and in FireFox, the URL `about:debugging#workers`.
 
 ```js
 first.onchange = () => {

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -12,7 +12,8 @@ The **`SharedWorker()`** constructor creates a
 {{domxref("SharedWorker")}} object that executes the script at the specified URL. This
 script must obey the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
-> **Note:** there is disagreement among browser manufacturers about
+> [!NOTE]
+> there is disagreement among browser manufacturers about
 > whether a data URL is of the same origin or not. Although Firefox 10.0
 > and later accept data URLs, that's not the case in all other
 > browsers.


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 11.
