### PR TITLE
fix: convert fence tags from text->plain

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -64,7 +64,7 @@ It is important to clarify the current standardization status of such features t
 
 - Adding this banner to the landing page for that feature (not for every subpage for the feature):
 
-  ```plain
+  ```md
   > [!WARNING]
   > This feature is currently opposed by <number> browser vendor(s). See the [Standards positions](#standards_positions) section below for details of opposition.
   ```

--- a/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -64,7 +64,7 @@ It is important to clarify the current standardization status of such features t
 
 - Adding this banner to the landing page for that feature (not for every subpage for the feature):
 
-  ```text
+  ```plain
   > [!WARNING]
   > This feature is currently opposed by <number> browser vendor(s). See the [Standards positions](#standards_positions) section below for details of opposition.
   ```

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.md
@@ -63,7 +63,7 @@ If the manifest contains:
 
 You see this in the console log:
 
-```text
+```plain
 "0.1"
 ```
 

--- a/files/en-us/web/css/anchor-size/index.md
+++ b/files/en-us/web/css/anchor-size/index.md
@@ -32,7 +32,7 @@ block-size: anchor-size(--myAnchor block, 200px);
 
 The `anchor-size()` function's syntax is as follows:
 
-```text
+```plain
 anchor-size(<anchor-element> <anchor-size>, <length-percentage>)
 ```
 

--- a/files/en-us/web/css/anchor/index.md
+++ b/files/en-us/web/css/anchor/index.md
@@ -32,7 +32,7 @@ left: calc(anchor(--myAnchor right, 0%) + 10px);
 
 The `anchor()` function's syntax is as follows:
 
-```text
+```plain
 anchor(<anchor-element> <anchor-side>, <length-percentage>)
 ```
 

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -33,7 +33,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 color(colorspace c1 c2 c3[ / A])
 ```
 
@@ -55,7 +55,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 color(from <color> colorspace c1 c2 c3[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/hsl/index.md
+++ b/files/en-us/web/css/color_value/hsl/index.md
@@ -41,7 +41,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 hsl(H S L[ / A])
 ```
 
@@ -66,7 +66,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 hsl(from <color> H S L[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/hwb/index.md
+++ b/files/en-us/web/css/color_value/hwb/index.md
@@ -43,7 +43,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 ### Absolute value syntax
 
-```text
+```plain
 hwb(H W B[ / A])
 ```
 
@@ -71,7 +71,7 @@ The parameters are as follows:
 
 ### Relative value syntax
 
-```text
+```plain
 hwb(from <color> H W B[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/lab/index.md
+++ b/files/en-us/web/css/color_value/lab/index.md
@@ -34,7 +34,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 lab(L a b[ / A])
 ```
 
@@ -53,7 +53,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 lab(from <color> L a b[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/lch/index.md
+++ b/files/en-us/web/css/color_value/lch/index.md
@@ -36,7 +36,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 lch(L C H[ / A])
 ```
 
@@ -66,7 +66,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 lch(from <color> L C H[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -40,7 +40,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 oklab(L a b[ / A])
 ```
 
@@ -59,7 +59,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 oklab(from <color> L a b[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -36,7 +36,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 oklch(L C H[ / A])
 ```
 
@@ -66,7 +66,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 oklch(from <color> L C H[ / A])
 ```
 

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -37,7 +37,7 @@ Below are descriptions of the allowed values for both absolute and [relative col
 
 #### Absolute value syntax
 
-```text
+```plain
 rgb(R G B[ / A])
 ```
 
@@ -52,7 +52,7 @@ The parameters are as follows:
 
 #### Relative value syntax
 
-```text
+```plain
 rgb(from <color> R G B[ / A])
 ```
 

--- a/files/en-us/web/css/css_anchor_positioning/try_options_hiding/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/try_options_hiding/index.md
@@ -251,7 +251,7 @@ Scroll the page and check out the effect of these position-try fallback options 
 
 To use custom position fallback options that aren't available via the above mechanisms, you can create your own with the {{cssxref("@position-try")}} at-rule. The syntax is:
 
-```text
+```plain
 @position-try --try-fallback-name {
   descriptor-list
 }

--- a/files/en-us/web/css/css_anchor_positioning/using/index.md
+++ b/files/en-us/web/css/css_anchor_positioning/using/index.md
@@ -156,7 +156,7 @@ CSS anchor positioning changes this paradigm, enabling anchor-positioned element
 
 The function components look like this:
 
-```text
+```plain
 anchor(<anchor-element> <anchor-side>, <fallback>)
 ```
 
@@ -568,7 +568,7 @@ Sizing properties that can accept an `anchor-size()` value include:
 
 `anchor-size()` functions resolve to {{cssxref("length")}} values. Their syntax looks like this:
 
-```text
+```plain
 anchor-size(<anchor-element> <anchor-size>, <length-percentage>)
 ```
 

--- a/files/en-us/web/css/font-palette/palette-mix/index.md
+++ b/files/en-us/web/css/font-palette/palette-mix/index.md
@@ -35,7 +35,7 @@ font-palette: palette-mix(in hsl shorter hue, --blues, --yellows)
 
 Functional notation:
 
-```text
+```plain
 palette-mix(method, palette1 [p1], palette2 [p2])
 ```
 

--- a/files/en-us/web/css/inset-area_value/index.md
+++ b/files/en-us/web/css/inset-area_value/index.md
@@ -13,7 +13,7 @@ The `<inset-area>` keyword values can be set as the value of the {{cssxref("inse
 
 ## Syntax
 
-```text
+```plain
 <inset-area> = [
   [ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ]
 ||

--- a/files/en-us/web/html/element/script/type/speculationrules/index.md
+++ b/files/en-us/web/html/element/script/type/speculationrules/index.md
@@ -322,13 +322,13 @@ Multiple conditions can be combined inside `"and"` or `"or"` conditions — thes
 
 It is useful to think of the `"where"` object as being equivalent to an `if` statement. So
 
-```text
+```plain
 { and: [A, B, { or: [C, { not: D }] }] }
 ```
 
 is equivalent to
 
-```text
+```plain
 if (A && B && (C || !D)) {
   apply speculation rule
 }

--- a/files/en-us/web/http/headers/no-vary-search/index.md
+++ b/files/en-us/web/http/headers/no-vary-search/index.md
@@ -59,14 +59,14 @@ No-Vary-Search: key-order
 
 When this header is added to the associated responses, the following URLs would be treated as equivalent when searching the cache:
 
-```text
+```plain
 https://search.example.com?a=1&b=2&c=3
 https://search.example.com?b=2&a=1&c=3
 ```
 
 The presence of different URL parameters, however, will cause these URLs to be cached separately. For example:
 
-```text
+```plain
 https://search.example.com?a=1&b=2&c=3
 https://search.example.com?b=2&a=1&c=3&d=4
 ```

--- a/files/en-us/web/security/practical_implementation_guides/robots_txt/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/robots_txt/index.md
@@ -24,14 +24,14 @@ Also be aware that some robots, such as malware robots and email address harvest
 
 Stop all search engines from crawling a site:
 
-```text
+```plain
 User-agent: *
 Disallow: /
 ```
 
 Hide certain directories (this is not recommended):
 
-```text example-bad
+```plain example-bad
 User-agent: *
 Disallow: /secret/admin-interface
 ```

--- a/files/en-us/web/security/practical_implementation_guides/robots_txt/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/robots_txt/index.md
@@ -24,14 +24,14 @@ Also be aware that some robots, such as malware robots and email address harvest
 
 Stop all search engines from crawling a site:
 
-```plain
+```http
 User-agent: *
 Disallow: /
 ```
 
 Hide certain directories (this is not recommended):
 
-```plain example-bad
+```http example-bad
 User-agent: *
 Disallow: /secret/admin-interface
 ```

--- a/files/en-us/web/security/practical_implementation_guides/tls/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/tls/index.md
@@ -75,7 +75,7 @@ To fix the "different hosts" problem:
 
 Redirect all incoming HTTP requests to the same site and URI on HTTPS, using NGINX:
 
-```text
+```plain
 server {
   listen 80;
 
@@ -85,7 +85,7 @@ server {
 
 Redirect `site.example.org` from HTTP to HTTPS, using Apache:
 
-```text
+```plain
 <VirtualHost *:80>
   ServerName site.example.org
   Redirect permanent / https://site.example.org/

--- a/files/en-us/web/security/practical_implementation_guides/tls/index.md
+++ b/files/en-us/web/security/practical_implementation_guides/tls/index.md
@@ -75,7 +75,7 @@ To fix the "different hosts" problem:
 
 Redirect all incoming HTTP requests to the same site and URI on HTTPS, using NGINX:
 
-```plain
+```nginx
 server {
   listen 80;
 
@@ -85,7 +85,7 @@ server {
 
 Redirect `site.example.org` from HTTP to HTTPS, using Apache:
 
-```plain
+```apacheconf
 <VirtualHost *:80>
   ServerName site.example.org
   Redirect permanent / https://site.example.org/


### PR DESCRIPTION
According to [the guidelines](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#example_code_blocks), text code fences need to have a `plain` tag rather than a `text` tag.

/cc @Josh-Cena 