### PR TITLE
Convert noteblocks for web/api folder (part 12)

### DIFF
--- a/files/en-us/web/api/sharedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/close/index.md
@@ -34,7 +34,8 @@ close();
 
 `close()` and `self.close()` are effectively equivalent — both represent `close()` being called from inside the worker's inner scope.
 
-> **Note:** There is also a way to stop the worker from the main thread: the {{domxref("Worker.terminate")}} method.
+> [!NOTE]
+> There is also a way to stop the worker from the main thread: the {{domxref("Worker.terminate")}} method.
 
 ## Specifications
 

--- a/files/en-us/web/api/speculation_rules_api/index.md
+++ b/files/en-us/web/api/speculation_rules_api/index.md
@@ -19,7 +19,8 @@ The **Speculation Rules API** is designed to improve performance for future navi
 
 The Speculation Rules API provides an alternative to the widely-available [`<link rel="prefetch">`](/en-US/docs/Web/HTML/Attributes/rel/prefetch) feature and is designed to supersede the Chrome-only deprecated [`<link rel="prerender">`](/en-US/docs/Web/HTML/Attributes/rel/prerender) feature. It provides many improvements over these technologies, along with a more expressive, configurable syntax for specifying which documents should be prefetched or prerendered.
 
-> **Note:** The Speculation Rules API doesn't handle subresource prefetches; for that you'll need to use `<link rel="prefetch">`.
+> [!NOTE]
+> The Speculation Rules API doesn't handle subresource prefetches; for that you'll need to use `<link rel="prefetch">`.
 
 ## Concepts and usage
 
@@ -64,7 +65,8 @@ Speculation-Rules: "/rules/prefetch.json"
 
 The text resource containing the speculation rules JSON can have any valid name and extension, but it must be served with an `application/speculationrules+json` MIME type.
 
-> **Note:** Rules can be specified using both an inline script and the HTTP header simultaneously — all rules applied to a document are parsed and added to the document's speculation rules list.
+> [!NOTE]
+> Rules can be specified using both an inline script and the HTTP header simultaneously — all rules applied to a document are parsed and added to the document's speculation rules list.
 
 You specify a different array to contain the rules for each speculative loading type (for example `"prerender"` or `"prefetch"`). Each rule is contained in an object that specifies for example a list of resources to be fetched, plus options such as an explicit {{httpheader("Referrer-Policy")}} setting for each rule. Note that prerendered URLs are also prefetched.
 
@@ -80,7 +82,8 @@ This means that if you prefetch something the user doesn't navigate to, it is ge
 
 Same-site and cross-site prefetches will work, but cross-site prefetches are limited (see ["same-site" and "cross-site"](https://web.dev/articles/same-site-same-origin#same-site-cross-site) for an explanation of the difference between the two). For privacy reasons cross-site prefetches will currently only work if the user has no cookies set for the destination site — we don't want sites to be able to track user activity via prefetched pages (which they may never even actually visit) based on previously-set cookies.
 
-> **Note:** In the future an opt-in for cross-site prefetches will be provided via the {{httpheader("Supports-Loading-Mode")}} header, but this was not implemented at the time of writing (only cross-origin, same-site [prerendering](#using_prerendering) opt-in was available).
+> [!NOTE]
+> In the future an opt-in for cross-site prefetches will be provided via the {{httpheader("Supports-Loading-Mode")}} header, but this was not implemented at the time of writing (only cross-origin, same-site [prerendering](#using_prerendering) opt-in was available).
 
 For browsers that support it, speculation rules prefetch should be preferred over older prefetch mechanisms, namely [`<link rel="prefetch">`](/en-US/docs/Web/HTML/Attributes/rel/prefetch) and {{domxref("Window/fetch", "fetch()")}} with a `priority: "low"` option set on it. Because we know that speculation rules prefetch is for navigations, not general resource prefetching:
 
@@ -101,9 +104,11 @@ Future navigations to a prerendered page will be near-instant. The browser activ
 
 Prerendering uses memory and network bandwidth. If you prerender something the user doesn't navigate to, these are wasted (although the result may populate the HTTP cache if headers allow, allowing later use). The upfront cost of a prerender is much larger than the upfront cost of a prefetch, and other conditions could also make content unsafe to prerender (see [Unsafe speculative loading conditions](#unsafe_speculative_loading_conditions) for more details). As a result, you are encouraged to adopt prerendering more sparingly, carefully considering cases where there is a high likelihood of the page being navigated to, and you think the user experience benefit is worth the extra cost.
 
-> **Note:** To put the amount of potential resource wastage in perspective, a prerender uses about the same amount of resources as rendering an {{htmlelement("iframe")}}.
+> [!NOTE]
+> To put the amount of potential resource wastage in perspective, a prerender uses about the same amount of resources as rendering an {{htmlelement("iframe")}}.
 
-> **Note:** Many APIs will be automatically deferred when prerendering/until activation. See [Platform features deferred or restricted during prerender](#platform_features_deferred_or_restricted_during_prerender) for more details.
+> [!NOTE]
+> Many APIs will be automatically deferred when prerendering/until activation. See [Platform features deferred or restricted during prerender](#platform_features_deferred_or_restricted_during_prerender) for more details.
 
 Prerendering is restricted to same-origin documents by default. Cross-origin, same-site prerendering is possible — it requires the navigation target to opt-in using the {{httpheader("Supports-Loading-Mode")}} header with a value of `credentialed-prerender`. Cross-site prerendering is not possible at this time.
 
@@ -245,11 +250,13 @@ For example:
 
 Such issues can be mitigated on the server by watching for the {{httpheader("Sec-Purpose", "Sec-Purpose: prefetch")}} header as the requests come in, and then running specific code to defer problematic functionality. Later on, when the page is actually navigated to, you can initiate the deferred functionality via JavaScript if needed.
 
-> **Note:** You can find more details about the detection code in the [Detecting prefetched and prerendered pages](#detecting_prefetched_and_prerendered_pages) section.
+> [!NOTE]
+> You can find more details about the detection code in the [Detecting prefetched and prerendered pages](#detecting_prefetched_and_prerendered_pages) section.
 
 It is also potentially risky to prefetch a document whose server-rendered contents will change due to actions the user can take on the current page. This could include, for example, flash sale pages or movie theater seat maps. Test such cases carefully, and mitigate such issues by updating content once the page is loaded. See [Server-rendered varying state](#server-rendered_varying_state) for more details about these cases.
 
-> **Note:** Browsers will cache prefetched pages for a short time (Chrome for example caches them for 5 minutes) before discarding them, so in any case, your users might see content that is up to 5 minutes out of date.
+> [!NOTE]
+> Browsers will cache prefetched pages for a short time (Chrome for example caches them for 5 minutes) before discarding them, so in any case, your users might see content that is up to 5 minutes out of date.
 
 Prefetching is safe if all side effects of fetching the page result from JavaScript execution, since the JavaScript will not run until activation.
 
@@ -311,7 +318,8 @@ This design ensures that users get the expected experience when using the back b
 
 Because a prerendered page is opened in a hidden state, several APIs features that cause potentially intrusive behaviors are not activated in this state, and are instead **deferred** until the page is activated. Other web platform features that are problematic when prerendering are restricted altogether. This section provides details of what features are deferred or restricted.
 
-> **Note:** In the small number of cases where deferring and restricting are not possible, the prerender is canceled.
+> [!NOTE]
+> In the small number of cases where deferring and restricting are not possible, the prerender is canceled.
 
 ### Asynchronous API deferral
 

--- a/files/en-us/web/api/speechrecognition/index.md
+++ b/files/en-us/web/api/speechrecognition/index.md
@@ -9,7 +9,8 @@ browser-compat: api.SpeechRecognition
 
 The **`SpeechRecognition`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) is the controller interface for the recognition service; this also handles the {{domxref("SpeechRecognitionEvent")}} sent from the recognition service.
 
-> **Note:** On some browsers, like Chrome, using Speech Recognition on a web page involves a server-based recognition engine. Your audio is sent to a web service for recognition processing, so it won't work offline.
+> [!NOTE]
+> On some browsers, like Chrome, using Speech Recognition on a web page involves a server-based recognition engine. Your audio is sent to a web service for recognition processing, so it won't work offline.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/speechrecognitionalternative/confidence/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/confidence/index.md
@@ -12,7 +12,8 @@ The **`confidence`** read-only property of the
 {{domxref("SpeechRecognitionResult")}} interface returns a numeric estimate of how
 confident the speech recognition system is that the recognition is correct.
 
-> **Note:** Mozilla's implementation of `confidence` is still
+> [!NOTE]
+> Mozilla's implementation of `confidence` is still
 > being worked on — at the moment, it always seems to return 1.
 
 ## Value

--- a/files/en-us/web/api/speechrecognitionevent/emma/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/emma/index.md
@@ -16,7 +16,8 @@ The **`emma`** read-only property of the
 MultiModal Annotation markup language (EMMA) — XML — representation of the
 result.
 
-> **Note:** EMMA is defined in the specification [EMMA: Extensible MultiModal Annotation markup language](https://www.w3.org/TR/emma/). You can see multiple EMMA examples in the spec.
+> [!NOTE]
+> EMMA is defined in the specification [EMMA: Extensible MultiModal Annotation markup language](https://www.w3.org/TR/emma/). You can see multiple EMMA examples in the spec.
 
 ## Value
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/speechsynthesiserrorevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SpeechSynthesisErrorEvent.SpeechSynthesisErrorEvent
 
 The **`SpeechSynthesisErrorEvent()`** constructor creates a new {{domxref("SpeechSynthesisErrorEvent")}} object.
 
-> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
+> [!NOTE]
+> A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
 
 ## Syntax
 

--- a/files/en-us/web/api/speechsynthesisevent/elapsedtime/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/elapsedtime/index.md
@@ -14,7 +14,8 @@ The **`elapsedTime`** read-only property of the {{domxref("SpeechSynthesisEvent"
 
 A float containing the elapsed time, in seconds.
 
-> **Note:** Early versions of the specification required the elapsed time in milliseconds.
+> [!NOTE]
+> Early versions of the specification required the elapsed time in milliseconds.
 > Check the [compatibility table](#browser_compatibility) below for your browser.
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/speechsynthesisevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SpeechSynthesisEvent.SpeechSynthesisEvent
 
 The **`SpeechSynthesisEvent()`** constructor creates a new {{domxref("SpeechSynthesisEvent")}} object.
 
-> **Note:** A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
+> [!NOTE]
+> A web developer doesn't typically need to call this constructor, as the browser creates these objects itself when firing events.
 
 ## Syntax
 

--- a/files/en-us/web/api/speechsynthesisvoice/default/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/default/index.md
@@ -13,7 +13,8 @@ The **`default`** read-only property of the
 indicating whether the voice is the default voice for the current app
 (`true`), or not (`false`.)
 
-> **Note:** For some devices, it might be the default voice for the
+> [!NOTE]
+> For some devices, it might be the default voice for the
 > voice's language. The spec is not very clear on which it should be, so some
 > implementations may differ.
 

--- a/files/en-us/web/api/stereopannernode/pan/index.md
+++ b/files/en-us/web/api/stereopannernode/pan/index.md
@@ -14,7 +14,8 @@ The `pan` property of the {{ domxref("StereoPannerNode") }} interface is an [a-r
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} containing the panning to apply.
 
-> **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
+> [!NOTE]
+> Though the `AudioParam` returned is read-only, the value it represents is not.
 
 ## Examples
 

--- a/files/en-us/web/api/storage/clear/index.md
+++ b/files/en-us/web/api/storage/clear/index.md
@@ -40,7 +40,8 @@ function populateStorage() {
 }
 ```
 
-> **Note:** For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/getitem/index.md
+++ b/files/en-us/web/api/storage/getitem/index.md
@@ -50,7 +50,8 @@ function setStyles() {
 }
 ```
 
-> **Note:** To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/index.md
+++ b/files/en-us/web/api/storage/index.md
@@ -63,7 +63,8 @@ function setStyles() {
 }
 ```
 
-> **Note:** To see this running as a complete working example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> To see this running as a complete working example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/key/index.md
+++ b/files/en-us/web/api/storage/key/index.md
@@ -50,7 +50,8 @@ for (let i = 0; i < localStorage.length; i++) {
 }
 ```
 
-> **Note:** For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/length/index.md
+++ b/files/en-us/web/api/storage/length/index.md
@@ -31,7 +31,8 @@ function populateStorage() {
 }
 ```
 
-> **Note:** For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> For a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/removeitem/index.md
+++ b/files/en-us/web/api/storage/removeitem/index.md
@@ -58,7 +58,8 @@ function populateStorage() {
 }
 ```
 
-> **Note:** To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 ## Specifications
 

--- a/files/en-us/web/api/storage/setitem/index.md
+++ b/files/en-us/web/api/storage/setitem/index.md
@@ -47,7 +47,8 @@ function populateStorage() {
 }
 ```
 
-> **Note:** To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
+> [!NOTE]
+> To see this used within a real-world example, see our [Web Storage Demo](https://mdn.github.io/dom-examples/web-storage/).
 
 `Storage` only supports storing and retrieving strings. If you want to save other data types, you have to convert them to strings. For plain objects and arrays, you can use {{jsxref("JSON.stringify()")}}.
 

--- a/files/en-us/web/api/storage_access_api/index.md
+++ b/files/en-us/web/api/storage_access_api/index.md
@@ -62,7 +62,8 @@ Embedded content that has a legitimate need for third party cookie or unpartitio
 5. Once access is granted, a permission key is stored in the browser with the structure `<top-level site, embedded site>`. For example, if the embedding site is `embedder.com`, and the embed is `locator.example.com`, the key would be `<embedder.com, example.com>`. Same-site embeds (`docs.example.com`, `profile.example.com`, etc.) would then be able to call `requestStorageAccess()` and the promise would fulfill automatically, as mentioned earlier.
    - Older spec versions used the more specific permission key structure `<top-level site, embedded origin>`, which meant that same-site, cross-origin embeds didn't match the permission key and had to go through the whole process separately.
 
-> **Note:** In cases where a top-level site has its cookies [partitioned](#unpartitioned_versus_partitioned_cookies), the Storage Access API isn't required, as sharing the cookies by default has no privacy risk.
+> [!NOTE]
+> In cases where a top-level site has its cookies [partitioned](#unpartitioned_versus_partitioned_cookies), the Storage Access API isn't required, as sharing the cookies by default has no privacy risk.
 
 ## Security measures
 
@@ -87,7 +88,8 @@ Several different security measures could cause a {{domxref("Document.requestSto
 
 6. Usage of this feature may be blocked by a {{httpheader("Permissions-Policy/storage-access", "storage-access")}} [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) set on your server.
 
-> **Note:** The document may also be required to pass additional browser-specific checks. Examples: allowlists, blocklists, on-device classification, user settings, anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics, or prompting the user for explicit permission.
+> [!NOTE]
+> The document may also be required to pass additional browser-specific checks. Examples: allowlists, blocklists, on-device classification, user settings, anti-[clickjacking](/en-US/docs/Glossary/Clickjacking) heuristics, or prompting the user for explicit permission.
 
 ## Browser-specific variations
 
@@ -126,7 +128,8 @@ Documentation for Firefox's new storage access policy for blocking tracking cook
 - {{domxref("Document.requestStorageAccessFor()")}} {{experimental_inline}}
   - : A proposed extension to the Storage Access API that allows top-level sites to request third-party cookie access on behalf of embedded content originating from another site in the same [related website set](/en-US/docs/Web/API/Storage_Access_API/Related_website_sets). Returns a {{jsxref("Promise")}} that resolves if the access was granted, and rejects if access was denied.
 
-> **Note:** User interaction propagates to the promise returned by these methods, allowing the callers to take actions requiring user interaction without requiring a second click. For example, a caller could open a pop-up window from the resolved promise without triggering Firefox's pop-up blocker.
+> [!NOTE]
+> User interaction propagates to the promise returned by these methods, allowing the callers to take actions requiring user interaction without requiring a second click. For example, a caller could open a pop-up window from the resolved promise without triggering Firefox's pop-up blocker.
 
 ### Additions to other APIs
 

--- a/files/en-us/web/api/storage_access_api/related_website_sets/index.md
+++ b/files/en-us/web/api/storage_access_api/related_website_sets/index.md
@@ -10,7 +10,8 @@ spec-urls: https://wicg.github.io/first-party-sets/
 
 {{DefaultAPISidebar("Storage Access API")}}
 
-> **Warning:** This feature is currently opposed by two browser vendors. See the [Standards positions](#standards_positions) section below for details of opposition.
+> [!WARNING]
+> This feature is currently opposed by two browser vendors. See the [Standards positions](#standards_positions) section below for details of opposition.
 
 Related website sets are a mechanism for defining a set of related sites that share trusted content. As a result, browsers can grant default access for these sites to [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies) and [unpartitioned state](/en-US/docs/Web/Privacy/State_Partitioning#state_partitioning) when they have content embedded in other set members, without requiring users to grant access to the [Storage Access API](/en-US/docs/Web/API/Storage_Access_API) via a permission prompt.
 
@@ -72,7 +73,8 @@ A set is represented by a JSON structure. A hypothetical example is as follows:
 }
 ```
 
-> **Note:** The affiliation explanations must include a clear description of how the affiliation to the primary site is presented to users of those sites.
+> [!NOTE]
+> The affiliation explanations must include a clear description of how the affiliation to the primary site is presented to users of those sites.
 
 To use a set, its JSON must be added to the `related_website_sets.JSON` file available on the [Related Website Sets GitHub repository](https://github.com/GoogleChrome/related-website-sets/blob/main/related_website_sets.JSON), which Chrome then consumes to get the list of sets to apply RWS behavior to.
 

--- a/files/en-us/web/api/storage_access_api/using/index.md
+++ b/files/en-us/web/api/storage_access_api/using/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 The [Storage Access API](/en-US/docs/Web/API/Storage_Access_API) can be used by embedded cross-site documents to verify whether they have access to [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies) and [unpartitioned state](/en-US/docs/Web/Privacy/State_Partitioning#state_partitioning) and, if not, to request access. We'll briefly look at a common storage access scenario.
 
-> **Note:** When we talk about third-party cookies in the content of the Storage Access API, we implicitly mean [_unpartitioned_](/en-US/docs/Web/API/Storage_Access_API#unpartitioned_versus_partitioned_cookies) third-party cookies.
+> [!NOTE]
+> When we talk about third-party cookies in the content of the Storage Access API, we implicitly mean [_unpartitioned_](/en-US/docs/Web/API/Storage_Access_API#unpartitioned_versus_partitioned_cookies) third-party cookies.
 
 ## Usage notes
 
@@ -164,7 +165,8 @@ function rSAFor() {
 }
 ```
 
-> **Note:** Unlike with `requestStorageAccess()`, Chrome doesn't check for an interaction in a top-level document within the last 30 days when `requestStorageAccessFor()` is called because the user is already on the page. See [Browser-specific variations > Chrome](/en-US/docs/Web/API/Storage_Access_API#chrome) for more details of this behavior.
+> [!NOTE]
+> Unlike with `requestStorageAccess()`, Chrome doesn't check for an interaction in a top-level document within the last 30 days when `requestStorageAccessFor()` is called because the user is already on the page. See [Browser-specific variations > Chrome](/en-US/docs/Web/API/Storage_Access_API#chrome) for more details of this behavior.
 
 When querying permission status for storage access requests made on behalf of another origin, the permission name used is different from the rest of the Storage Access API: `"top-level-storage-access"` rather than `"storage-access"`. In the above code, we use the following call:
 

--- a/files/en-us/web/api/storageaccesshandle/broadcastchannel/index.md
+++ b/files/en-us/web/api/storageaccesshandle/broadcastchannel/index.md
@@ -8,7 +8,8 @@ browser-compat: api.StorageAccessHandle.BroadcastChannel
 
 {{APIRef("Storage Access API")}}
 
-> **Note:** See {{domxref("BroadcastChannel.BroadcastChannel", "BroadcastChannel()")}} to understand usage.
+> [!NOTE]
+> See {{domxref("BroadcastChannel.BroadcastChannel", "BroadcastChannel()")}} to understand usage.
 
 ## Syntax
 
@@ -46,7 +47,8 @@ document.requestStorageAccess({ BroadcastChannel: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/caches/index.md
+++ b/files/en-us/web/api/storageaccesshandle/caches/index.md
@@ -29,7 +29,8 @@ document.requestStorageAccess({ caches: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/createobjecturl/index.md
+++ b/files/en-us/web/api/storageaccesshandle/createobjecturl/index.md
@@ -8,7 +8,8 @@ browser-compat: api.StorageAccessHandle.createObjectURL
 
 {{APIRef("Storage Access API")}}
 
-> **Note:** See {{domxref("URL.createObjectURL_static", "createObjectURL()")}} to understand usage.
+> [!NOTE]
+> See {{domxref("URL.createObjectURL_static", "createObjectURL()")}} to understand usage.
 
 ## Syntax
 
@@ -46,7 +47,8 @@ document.requestStorageAccess({ createObjectURL: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/estimate/index.md
+++ b/files/en-us/web/api/storageaccesshandle/estimate/index.md
@@ -8,7 +8,8 @@ browser-compat: api.StorageAccessHandle.estimate
 
 {{APIRef("Storage Access API")}}
 
-> **Note:** See {{domxref("StorageManager.estimate()")}} to understand usage.
+> [!NOTE]
+> See {{domxref("StorageManager.estimate()")}} to understand usage.
 
 ## Syntax
 
@@ -45,7 +46,8 @@ document.requestStorageAccess({ estimate: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/getdirectory/index.md
+++ b/files/en-us/web/api/storageaccesshandle/getdirectory/index.md
@@ -8,7 +8,8 @@ browser-compat: api.StorageAccessHandle.getDirectory
 
 {{APIRef("Storage Access API")}}
 
-> **Note:** See {{domxref("StorageManager.getDirectory()")}} to understand usage.
+> [!NOTE]
+> See {{domxref("StorageManager.getDirectory()")}} to understand usage.
 
 ## Syntax
 
@@ -45,7 +46,8 @@ document.requestStorageAccess({ getDirectory: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/index.md
+++ b/files/en-us/web/api/storageaccesshandle/index.md
@@ -51,7 +51,8 @@ document.requestStorageAccess({ localStorage: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/indexeddb/index.md
+++ b/files/en-us/web/api/storageaccesshandle/indexeddb/index.md
@@ -28,7 +28,8 @@ document.requestStorageAccess({ indexedDB: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/localstorage/index.md
+++ b/files/en-us/web/api/storageaccesshandle/localstorage/index.md
@@ -28,7 +28,8 @@ document.requestStorageAccess({ localStorage: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/locks/index.md
+++ b/files/en-us/web/api/storageaccesshandle/locks/index.md
@@ -30,7 +30,8 @@ document.requestStorageAccess({ locks: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/revokeobjecturl/index.md
+++ b/files/en-us/web/api/storageaccesshandle/revokeobjecturl/index.md
@@ -8,7 +8,8 @@ browser-compat: api.StorageAccessHandle.revokeObjectURL
 
 {{APIRef("Storage Access API")}}
 
-> **Note:** See {{domxref("URL.revokeObjectURL_static", "revokeObjectURL()")}} to understand usage.
+> [!NOTE]
+> See {{domxref("URL.revokeObjectURL_static", "revokeObjectURL()")}} to understand usage.
 
 ## Syntax
 
@@ -46,7 +47,8 @@ document.requestStorageAccess({ revokeObjectURL: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/sessionstorage/index.md
+++ b/files/en-us/web/api/storageaccesshandle/sessionstorage/index.md
@@ -28,7 +28,8 @@ document.requestStorageAccess({ sessionStorage: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storageaccesshandle/sharedworker/index.md
+++ b/files/en-us/web/api/storageaccesshandle/sharedworker/index.md
@@ -8,7 +8,8 @@ browser-compat: api.StorageAccessHandle.SharedWorker
 
 {{APIRef("Storage Access API")}}
 
-> **Note:** See {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} to understand usage.
+> [!NOTE]
+> See {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} to understand usage.
 
 ## Syntax
 
@@ -54,7 +55,8 @@ document.requestStorageAccess({ SharedWorker: true }).then(
 );
 ```
 
-> **Note:** See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
+> [!NOTE]
+> See [Using the Storage Access API](/en-US/docs/Web/API/Storage_Access_API/Using) for a more complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/storagemanager/estimate/index.md
+++ b/files/en-us/web/api/storagemanager/estimate/index.md
@@ -33,7 +33,8 @@ A {{jsxref('Promise')}} that resolves to an object with the following properties
 - `usageDetails` {{Non-standard_Inline}}
   - : An object containing a breakdown of `usage` by storage system. All included properties will have a `usage` greater than 0 and any storage system with 0 `usage` will be excluded from the object.
 
-> **Note:** The returned values are not exact: between compression, deduplication, and obfuscation for security reasons, they will be imprecise.
+> [!NOTE]
+> The returned values are not exact: between compression, deduplication, and obfuscation for security reasons, they will be imprecise.
 
 You may find that the `quota` varies from origin to origin. This variance is based on factors such as:
 

--- a/files/en-us/web/api/storagemanager/getdirectory/index.md
+++ b/files/en-us/web/api/storagemanager/getdirectory/index.md
@@ -70,7 +70,8 @@ onmessage = async (e) => {
 };
 ```
 
-> **Note:** In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
+> [!NOTE]
+> In earlier versions of the spec, {{domxref("FileSystemSyncAccessHandle.close()", "close()")}}, {{domxref("FileSystemSyncAccessHandle.flush()", "flush()")}}, {{domxref("FileSystemSyncAccessHandle.getSize()", "getSize()")}}, and {{domxref("FileSystemSyncAccessHandle.truncate()", "truncate()")}} were wrongly specified as asynchronous methods, and older versions of some browsers implement them in this way. However, all current browsers that support these methods implement them as synchronous methods.
 
 ## Specifications
 

--- a/files/en-us/web/api/storagemanager/persist/index.md
+++ b/files/en-us/web/api/storagemanager/persist/index.md
@@ -10,7 +10,8 @@ browser-compat: api.StorageManager.persist
 
 The **`persist()`** method of the {{domxref("StorageManager")}} interface requests permission to use persistent storage, and returns a {{jsxref('Promise')}} that resolves to `true` if permission is granted and bucket mode is persistent, and `false` otherwise. The browser may or may not honor the request, depending on browser-specific rules. (For more details, see the guide to [Storage quotas and eviction criteria](/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria#does_browser-stored_data_persist).)
 
-> **Note:** This method is not available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API), though the {{domxref("StorageManager")}} interface is.
+> [!NOTE]
+> This method is not available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API), though the {{domxref("StorageManager")}} interface is.
 
 ## Syntax
 

--- a/files/en-us/web/api/streams_api/index.md
+++ b/files/en-us/web/api/streams_api/index.md
@@ -29,7 +29,8 @@ More complicated uses involve creating your own stream using the {{domxref("Read
 
 You can also write data to streams using {{domxref("WritableStream")}}.
 
-> **Note:** You can find a lot more details about the theory and practice of streams in our articles — [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts), [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams), [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams), and [Using writable streams](/en-US/docs/Web/API/Streams_API/Using_writable_streams).
+> [!NOTE]
+> You can find a lot more details about the theory and practice of streams in our articles — [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts), [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams), [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams), and [Using writable streams](/en-US/docs/Web/API/Streams_API/Using_writable_streams).
 
 ## Stream interfaces
 

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -11,7 +11,8 @@ They are intended for use cases where data might be supplied or requested in arb
 
 This article explains how readable byte streams compare to normal "default" streams, and how you create and consume them.
 
-> **Note:** Readable byte streams are almost identical to "normal" readable streams and almost all of the concepts are the same.
+> [!NOTE]
+> Readable byte streams are almost identical to "normal" readable streams and almost all of the concepts are the same.
 > This article assumes that you already understand those concepts and will only be covering them superficially (if at all).
 > If you're not familiar with the relevant concepts, please first read: [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams), [Streams concepts and usage overview](/en-US/docs/Web/API/Streams_API#concepts_and_usage), and [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts).
 
@@ -66,7 +67,8 @@ It uses a mocked "hypothetical socket" source that supplies data of arbitrary si
 The reader is deliberately delayed at various points to allow the underlying source to use both transfer and enqueuing to send data to the stream.
 Backpressure support is not demonstrated.
 
-> **Note:** An underlying byte source can also be used with a default reader.
+> [!NOTE]
+> An underlying byte source can also be used with a default reader.
 > If automatic buffer allocation is enabled the controller will supply fixed-size buffers for zero-copy transfers when there is an outstanding request from a reader and the stream's internal queues are empty.
 > If automatic buffer allocation is not enabled then all data from the byte stream will always be enqueued.
 > This is similar to the behavior shown in the "pull: underlying byte source examples.
@@ -417,7 +419,8 @@ The class generates random data to represent a file.
 The `read()` method reads a "semi-random" sized block of random data into a provided buffer from the specified position.
 The `close()` method does nothing: it is only provided to show where you might close the source when defining the constructor for the stream.
 
-> **Note:** A similar class is used for all the "pull source" examples.
+> [!NOTE]
+> A similar class is used for all the "pull source" examples.
 > It is shown here for information only (so that it is obvious that it is a mock).
 
 ```js

--- a/files/en-us/web/api/streams_api/using_readable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_streams/index.md
@@ -8,9 +8,11 @@ page-type: guide
 
 As a JavaScript developer, programmatically reading and manipulating streams of data received over the network, chunk by chunk, is very useful! But how do you use the Streams API's readable stream functionality? This article explains the basics.
 
-> **Note:** This article assumes that you understand the use cases of readable streams, and are aware of the high-level concepts. If not, we suggest that you first read the [Streams concepts and usage overview](/en-US/docs/Web/API/Streams_API#concepts_and_usage) and dedicated [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts) article, then come back.
+> [!NOTE]
+> This article assumes that you understand the use cases of readable streams, and are aware of the high-level concepts. If not, we suggest that you first read the [Streams concepts and usage overview](/en-US/docs/Web/API/Streams_API#concepts_and_usage) and dedicated [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts) article, then come back.
 
-> **Note:** If you are looking for information on writable streams try [Using writable streams](/en-US/docs/Web/API/Streams_API/Using_writable_streams) instead.
+> [!NOTE]
+> If you are looking for information on writable streams try [Using writable streams](/en-US/docs/Web/API/Streams_API/Using_writable_streams) instead.
 
 ## Finding some examples
 
@@ -162,7 +164,8 @@ fetch("http://example.com/somefile.txt")
   .catch((err) => console.error(err));
 ```
 
-> **Note:** The function looks as if `pump()` calls itself and leads to a potentially deep recursion.
+> [!NOTE]
+> The function looks as if `pump()` calls itself and leads to a potentially deep recursion.
 > However, because `pump` is asynchronous and each `pump()` call is at the end of the promise handler, it's actually analogous to a chain of promise handlers.
 
 Reading the stream is even easier when written using async/await rather than promises:
@@ -416,7 +419,8 @@ async function logChunks(url, { signal }) {
 The example log below shows the code running or reports that your browser does not support async iteration of `ReadableStream`.
 The right hand side shows the received chunks; you can press the cancel button to stop the fetch.
 
-> **Note:** This fetch operation is _mocked_ for the purpose of demonstration, and just returns a `ReadableStream` that generates random chunks of text.
+> [!NOTE]
+> This fetch operation is _mocked_ for the purpose of demonstration, and just returns a `ReadableStream` that generates random chunks of text.
 > The "Underlying source" on the left below is the data being generated in the mocked source, while the column on the right is log from the consumer.
 > (The code for the mocked source is not displayed as it is not relevant to the example.)
 
@@ -509,7 +513,8 @@ readableStream
 
 But a custom stream is still a `ReadableStream` instance, meaning you can attach a reader to it. As an example, have a look at our [Simple random stream demo](https://github.com/mdn/dom-examples/blob/main/streams/simple-random-stream/index.html) ([see it live also](https://mdn.github.io/dom-examples/streams/simple-random-stream/)), which creates a custom stream, enqueues some random strings into it, and then reads the data out of the stream again once the _Stop string generation_ button is pressed.
 
-> **Note:** In order to consume a stream using {{domxref("FetchEvent.respondWith()")}}, the enqueued stream contents must be of type {{jsxref("Uint8Array")}}; for example, encoded using {{domxref("TextEncoder")}}.
+> [!NOTE]
+> In order to consume a stream using {{domxref("FetchEvent.respondWith()")}}, the enqueued stream contents must be of type {{jsxref("Uint8Array")}}; for example, encoded using {{domxref("TextEncoder")}}.
 
 The custom stream constructor has a `start()` method that uses a {{domxref("setInterval()")}} call to generate a random string every second. {{domxref("ReadableStreamDefaultController.enqueue()")}} is then used to enqueue it into the stream. When the button is pressed, the interval is cancelled, and a function called `readStream()` is invoked to read the data back out of the stream again. We also close the stream, as we've stopped enqueuing chunks to it.
 

--- a/files/en-us/web/api/streams_api/using_writable_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_writable_streams/index.md
@@ -8,10 +8,12 @@ page-type: guide
 
 As a JavaScript developer, programmatically writing data to a stream is very useful! This article explains the [Streams API](/en-US/docs/Web/API/Streams_API)'s writable stream functionality.
 
-> **Note:** This article assumes that you understand the use cases of writable streams, and are aware of the high-level concepts.
+> [!NOTE]
+> This article assumes that you understand the use cases of writable streams, and are aware of the high-level concepts.
 > If not, we suggest that you first read the [Streams concepts and usage overview](/en-US/docs/Web/API/Streams_API#concepts_and_usage) and dedicated [Streams API concepts](/en-US/docs/Web/API/Streams_API/Concepts) article, then come back.
 
-> **Note:** If you are looking for information about readable streams, try [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams) and [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams) instead.
+> [!NOTE]
+> If you are looking for information about readable streams, try [Using readable streams](/en-US/docs/Web/API/Streams_API/Using_readable_streams) and [Using readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams) instead.
 
 ## Introducing an example
 

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -61,7 +61,8 @@ console.assert(clone.itself === clone); // and the circular reference is preserv
 
 [Transferable objects](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) (only) can be transferred rather than duplicated in the cloned object, using the `transfer` property of the `options` parameter. Transferring makes the original object unusable.
 
-> **Note:** A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
+> [!NOTE]
+> A scenario where this might be useful is when asynchronously validating some data in a buffer before saving it.
 > To avoid the buffer being modified before the data is saved, you can clone the buffer and validate that data.
 > If you also _transfer_ the data, any attempts to modify the original buffer will fail, preventing its accidental misuse.
 

--- a/files/en-us/web/api/stylesheetlist/index.md
+++ b/files/en-us/web/api/stylesheetlist/index.md
@@ -11,7 +11,8 @@ The `StyleSheetList` interface represents a list of {{domxref("CSSStyleSheet")}}
 
 It is an array-like object but can't be iterated over using {{jsxref("Array")}} methods. However it can be iterated over in a standard {{jsxref("Statements/for", "for")}} loop over its indices, or converted to an {{jsxref("Array")}}.
 
-> **Note:** Typically list interfaces like `StyleSheetList` wrap around {{jsxref("Array")}} types, so you can use `Array` methods on them.
+> [!NOTE]
+> Typically list interfaces like `StyleSheetList` wrap around {{jsxref("Array")}} types, so you can use `Array` methods on them.
 > This is not the case here for [historical reasons](https://stackoverflow.com/questions/74630989/why-use-domstringlist-rather-than-an-array/74641156#74641156).
 > However, you can convert `StyleSheetList` to an `Array` in order to use those methods (see the example below).
 

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -54,7 +54,8 @@ The `decrypt()` method supports the same algorithms as the [`encrypt()`](/en-US/
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
 
 ### RSA-OAEP
 

--- a/files/en-us/web/api/subtlecrypto/derivebits/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.md
@@ -81,7 +81,8 @@ See the [Supported algorithms section of the `deriveKey()` documentation](/en-US
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/derive-bits/index.html) on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/derive-bits/index.html) on GitHub.
 
 ### ECDH
 

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -122,7 +122,8 @@ PBKDF2 is specified in [RFC 2898](https://datatracker.ietf.org/doc/html/rfc2898)
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/derive-key/index.html) on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/derive-key/index.html) on GitHub.
 
 ### ECDH
 

--- a/files/en-us/web/api/subtlecrypto/digest/index.md
+++ b/files/en-us/web/api/subtlecrypto/digest/index.md
@@ -98,10 +98,12 @@ cryptography.
   </tbody>
 </table>
 
-> **Warning:** SHA-1 is now considered vulnerable and should not
+> [!WARNING]
+> SHA-1 is now considered vulnerable and should not
 > be used for cryptographic applications.
 
-> **Note:** If you are looking here for how to create a keyed-hash message authentication
+> [!NOTE]
+> If you are looking here for how to create a keyed-hash message authentication
 > code ([HMAC](/en-US/docs/Glossary/HMAC)), you need to use the [SubtleCrypto.sign()](/en-US/docs/Web/API/SubtleCrypto/sign#hmac) instead.
 
 ## Examples

--- a/files/en-us/web/api/subtlecrypto/encrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.md
@@ -91,7 +91,8 @@ Typically this is achieved by splitting the initial counter block value into two
 
 Essentially: the nonce should ensure that counter blocks are not reused from one message to the next, while the counter should ensure that counter blocks are not reused within a single message.
 
-> **Note:** See [Appendix B of the NIST SP800-38A standard](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf#%5B%7B%22num%22%3A70%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22Fit%22%7D%5D) for more information.
+> [!NOTE]
+> See [Appendix B of the NIST SP800-38A standard](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf#%5B%7B%22num%22%3A70%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22Fit%22%7D%5D) for more information.
 
 ### AES-CBC
 
@@ -105,7 +106,8 @@ One major difference between this mode and the others is that GCM is an "authent
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) out on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) out on GitHub.
 
 ### RSA-OAEP
 

--- a/files/en-us/web/api/subtlecrypto/exportkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/exportkey/index.md
@@ -64,7 +64,8 @@ The promise is rejected when one of the following exceptions is encountered:
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/export-key/index.html) out on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/export-key/index.html) out on GitHub.
 
 ### Raw export
 

--- a/files/en-us/web/api/subtlecrypto/generatekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.md
@@ -70,7 +70,8 @@ The promise is rejected when the following exception is encountered:
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
 
 ### RSA key pair generation
 

--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -199,7 +199,8 @@ A JSON Web Key looks something like this (this is an EC private key):
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/import-key/index.html) on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/import-key/index.html) on GitHub.
 
 ### Raw import
 

--- a/files/en-us/web/api/subtlecrypto/index.md
+++ b/files/en-us/web/api/subtlecrypto/index.md
@@ -11,7 +11,8 @@ The **`SubtleCrypto`** interface of the [Web Crypto API](/en-US/docs/Web/API/Web
 
 An instance of `SubtleCrypto` is available as the {{domxref("Crypto.subtle", "subtle")}} property of the {{domxref("Crypto")}} interface, which in turn is available in windows through the {{domxref("Window.crypto")}} property and in workers through the {{domxref("WorkerGlobalScope.crypto")}} property.
 
-> **Warning:** This API provides a number of low-level cryptographic primitives. It's very easy to misuse them, and the pitfalls involved can be very subtle.
+> [!WARNING]
+> This API provides a number of low-level cryptographic primitives. It's very easy to misuse them, and the pitfalls involved can be very subtle.
 >
 > Even assuming you use the basic cryptographic functions correctly, secure key management and overall security system design are extremely hard to get right, and are generally the domain of specialist security experts.
 >

--- a/files/en-us/web/api/subtlecrypto/sign/index.md
+++ b/files/en-us/web/api/subtlecrypto/sign/index.md
@@ -113,7 +113,8 @@ that you pass into {{domxref("SubtleCrypto.importKey()", "importKey()")}}.
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
 
 ### RSASSA-PKCS1-v1_5
 

--- a/files/en-us/web/api/subtlecrypto/unwrapkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/unwrapkey/index.md
@@ -99,7 +99,8 @@ The `unwrapKey()` method supports the same algorithms as the [`wrapKey()`](/en-U
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/unwrap-key/index.html) on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/unwrap-key/index.html) on GitHub.
 
 ### Unwrapping a "raw" key
 

--- a/files/en-us/web/api/subtlecrypto/verify/index.md
+++ b/files/en-us/web/api/subtlecrypto/verify/index.md
@@ -63,7 +63,8 @@ method.
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
 
 ### RSASSA-PKCS1-v1_5
 

--- a/files/en-us/web/api/subtlecrypto/wrapkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/wrapkey/index.md
@@ -90,7 +90,8 @@ AES-KW is specified in [RFC 3394](https://datatracker.ietf.org/doc/html/rfc3394)
 
 ## Examples
 
-> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/wrap-key/index.html) out on GitHub.
+> [!NOTE]
+> You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/wrap-key/index.html) out on GitHub.
 
 ### Raw wrap
 

--- a/files/en-us/web/api/svganimatedstring/animval/index.md
+++ b/files/en-us/web/api/svganimatedstring/animval/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGAnimatedString.animVal
 
 AnimVal attribute or animVal property contains the same value as the {{domxref("SVGAnimatedString.baseVal")}} property. If the given attribute or property is being animated, contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, then it contains the same value as baseVal
 
-> **Note:** The **animVal** property is a read only property.
+> [!NOTE]
+> The **animVal** property is a read only property.
 
 ## Syntax
 

--- a/files/en-us/web/api/svganimationelement/endevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/endevent_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGAnimationElement.endEvent_event
 
 The **`endEvent`** event of the {{domxref("SVGAnimationElement")}} interface is fired when at the active end of the animation is reached.
 
-> **Note:** This event is not raised at the simple end of each animation repeat. This event may be raised both in the course of normal (i.e. scheduled or interactive) timeline play, as well as in the case that the element was ended with a DOM method.
+> [!NOTE]
+> This event is not raised at the simple end of each animation repeat. This event may be raised both in the course of normal (i.e. scheduled or interactive) timeline play, as well as in the case that the element was ended with a DOM method.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/svganimationelement/repeatevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/repeatevent_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGAnimationElement.repeatEvent_event
 
 The **`repeatEvent`** event of the {{domxref("SVGAnimationElement")}} interface is fired when the element's local timeline repeats. It will be fired each time the element repeats, after the first iteration.
 
-> **Note:** Associated with the `repeatEvent` event is an integer that indicates which repeat iteration is beginning; this can be found in the `detail` property of the event object. The value is a 0-based integer, but the repeat event is not raised for the first iteration and so the observed values will be >= 1. This is supported in Firefox, but not in Chrome.
+> [!NOTE]
+> Associated with the `repeatEvent` event is an integer that indicates which repeat iteration is beginning; this can be found in the `detail` property of the event object. The value is a 0-based integer, but the repeat event is not raised for the first iteration and so the observed values will be >= 1. This is supported in Firefox, but not in Chrome.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGClipPathElement.clipPathUnits
 
 The read-only **`clipPathUnits`** property of the {{domxref("SVGClipPathElement")}} interface reflects the {{SVGAttr("clipPathUnits")}} attribute of a {{SVGElement("clipPath")}} element which defines the coordinate system to use for the content of the element.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgelement/style/index.md
+++ b/files/en-us/web/api/svgelement/style/index.md
@@ -18,7 +18,8 @@ Therefore, to add specific styles to an element without altering other style val
 
 A style declaration is reset by setting it to `null` or an empty string, e.g., `elt.style.color = null`.
 
-> **Note:** CSS property names are converted to JavaScript identifier with these rules:
+> [!NOTE]
+> CSS property names are converted to JavaScript identifier with these rules:
 >
 > - If the property is made of one word, it remains as it is: `height` stays as is (in lowercase).
 > - If the property is made of several words, separated by dashes, the dashes are removed and it is converted to {{Glossary("camel_case", "camel case")}}: `background-attachment` becomes `backgroundAttachment`.

--- a/files/en-us/web/api/svgglyphelement/index.md
+++ b/files/en-us/web/api/svgglyphelement/index.md
@@ -15,7 +15,8 @@ Object-oriented access to the attributes of the `<glyph>` element via the SVG DO
 
 {{InheritanceDiagram}}
 
-> **Warning:** This interface was removed in the SVG 2 specification.
+> [!WARNING]
+> This interface was removed in the SVG 2 specification.
 
 ## Instance properties
 

--- a/files/en-us/web/api/svgmaskelement/height/index.md
+++ b/files/en-us/web/api/svgmaskelement/height/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGMaskElement.height
 
 The read-only **`height`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("height")}} attribute of the {{SVGElement("marker")}}.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskcontentunits/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGMaskElement.maskContentUnits
 
 The read-only **`maskContentUnits`** property of the {{domxref("SVGMaskElement")}} interface reflects the {{SVGAttr("maskContentUnits")}} attribute. It indicates which coordinate system to use for the contents of the {{SVGElement("mask")}} element.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgmaskelement/maskunits/index.md
+++ b/files/en-us/web/api/svgmaskelement/maskunits/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGMaskElement.maskUnits
 
 The read-only **`maskUnits`** property of the {{domxref("SVGMaskElement")}} interface reflects the {{SVGAttr("maskUnits")}} attribute of a {{SVGElement("mask")}} element which defines the coordinate system to use for the mask of the element.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}} and {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgmaskelement/width/index.md
+++ b/files/en-us/web/api/svgmaskelement/width/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGMaskElement.width
 
 The read-only **`width`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("width")}} attribute of the {{SVGElement("marker")}}.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgmaskelement/x/index.md
+++ b/files/en-us/web/api/svgmaskelement/x/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGMaskElement.x
 
 The read-only **`x`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("x")}} attribute of the {{SVGElement("mask")}}. It represents the x-axis coordinate of the _top-left_ corner of the masking area.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgmaskelement/y/index.md
+++ b/files/en-us/web/api/svgmaskelement/y/index.md
@@ -10,7 +10,8 @@ browser-compat: api.SVGMaskElement.y
 
 The read-only **`y`** property of the {{domxref("SVGMaskElement")}} interface returns an {{domxref("SVGAnimatedLength")}} object containing the value of the {{SVGattr("y")}} attribute of the {{SVGElement("marker")}}. It represents the y-axis coordinate of the _top-left_ corner of the masking area.
 
-> **Note:** Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
+> [!NOTE]
+> Although this property is read-only, it is merely a container for two values you can modify, {{domxref("SVGAnimatedLength.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLength.animVal", "animVal")}}.
 
 ## Value
 

--- a/files/en-us/web/api/svgpathelement/index.md
+++ b/files/en-us/web/api/svgpathelement/index.md
@@ -11,7 +11,8 @@ The **`SVGPathElement`** interface corresponds to the {{SVGElement("path")}} ele
 
 {{InheritanceDiagram}}
 
-> **Note:** In SVG 2 the `getPathSegAtLength()` and `createSVGPathSeg*` methods were removed and the `pathLength` property and the `getTotalLength()` and `getPointAtLength()` methods were moved to {{domxref("SVGGeometryElement")}}.
+> [!NOTE]
+> In SVG 2 the `getPathSegAtLength()` and `createSVGPathSeg*` methods were removed and the `pathLength` property and the `getTotalLength()` and `getPointAtLength()` methods were moved to {{domxref("SVGGeometryElement")}}.
 
 ## Instance properties
 

--- a/files/en-us/web/api/svgrenderingintent/index.md
+++ b/files/en-us/web/api/svgrenderingintent/index.md
@@ -13,7 +13,8 @@ The **`SVGRenderingIntent`** interface defines the enumerated list of possible v
 
 {{InheritanceDiagram}}
 
-> **Warning:** This interface was removed in the SVG 2 specification.
+> [!WARNING]
+> This interface was removed in the SVG 2 specification.
 
 ## Constants
 

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -100,7 +100,8 @@ The HTML is similar to the previous case, but the SVG definition does not includ
 First we create the new SVG style node.
 This is done by first creating a style element in the SVG namespace using [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS), creating and appending a text node with the style definition, and then appending the node to the SVG defined above.
 
-> **Note:** You must use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and not [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) to create the style, or by default you'll create the equivalent HTML style element.
+> [!NOTE]
+> You must use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and not [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) to create the style, or by default you'll create the equivalent HTML style element.
 
 ```js
 const svg = document.querySelector("svg");

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -81,7 +81,8 @@ Press the button to toggle the value of the `media` property on the style (which
 
 {{EmbedLiveSample("Examples")}}
 
-> **Note:** The `media` property may be set to any string, but will be ignored if the string is not a valid media query.
+> [!NOTE]
+> The `media` property may be set to any string, but will be ignored if the string is not a valid media query.
 
 ## Specifications
 

--- a/files/en-us/web/api/svgsvgelement/index.md
+++ b/files/en-us/web/api/svgsvgelement/index.md
@@ -134,7 +134,8 @@ _This interface also inherits methods from its parent, {{domxref("SVGGraphicsEle
 
 The following {{domxref("Window")}} `onXYZ` event handler properties are also available as aliases targeting the `window` object. However, it is advised to listen to them on the `window` object directly rather than on `SVGSVGElement`.
 
-> **Note:** Using `addEventListener()` on `SVGSVGElement` will not work for the `onXYZ` event handlers listed below. Listen to the events on the {{domxref("window")}} object instead.
+> [!NOTE]
+> Using `addEventListener()` on `SVGSVGElement` will not work for the `onXYZ` event handlers listed below. Listen to the events on the {{domxref("window")}} object instead.
 
 - {{domxref("window.afterprint_event", "SVGSVGElement.onafterprint")}}
   - : Fired after the associated document has started printing or the print preview has been closed.

--- a/files/en-us/web/api/svgtextcontentelement/index.md
+++ b/files/en-us/web/api/svgtextcontentelement/index.md
@@ -61,13 +61,15 @@ _This interface also inherits methods from its parent, {{domxref("SVGGraphicsEle
 
   - : Returns a {{domxref("DOMPoint")}} representing the position of a typographic character after text layout has been performed.
 
-    > **Note:** In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
+    > [!NOTE]
+    > In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
 
 - {{domxref("SVGTextContentElement.getEndPositionOfChar()")}}
 
   - : Returns a {{domxref("DOMPoint")}} representing the trailing position of a typographic character after text layout has been performed.
 
-    > **Note:** In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
+    > [!NOTE]
+    > In SVG 1.1 this method returned an {{domxref("SVGPoint")}}.
 
 - {{domxref("SVGTextContentElement.getExtentOfChar()")}}
   - : Returns a {{domxref("DOMRect")}} representing the computed tight bounding box of the glyph cell that corresponds to a given typographic character.

--- a/files/en-us/web/api/taskcontroller/index.md
+++ b/files/en-us/web/api/taskcontroller/index.md
@@ -45,7 +45,8 @@ _This interface also inherits the properties of its parent, {{domxref("AbortCont
 
 ## Examples
 
-> **Note:** Additional "live" examples can be found in: [Prioritized Task Scheduling API Examples](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#examples).
+> [!NOTE]
+> Additional "live" examples can be found in: [Prioritized Task Scheduling API Examples](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#examples).
 
 First we create a task controller, setting the priority of its associated signal to `user-blocking`.
 

--- a/files/en-us/web/api/tasksignal/prioritychange_event/index.md
+++ b/files/en-us/web/api/tasksignal/prioritychange_event/index.md
@@ -78,7 +78,8 @@ if ("scheduler" in this) {
 }
 ```
 
-> **Note:** The code above uses a custom logging function `mylog()` to log to the text area below.
+> [!NOTE]
+> The code above uses a custom logging function `mylog()` to log to the text area below.
 > This is hidden as it isn't relevant to the example.
 
 The output below demonstrates shows that the [task's priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) changed from `user-blocking` to `background`.

--- a/files/en-us/web/api/text/wholetext/index.md
+++ b/files/en-us/web/api/text/wholetext/index.md
@@ -13,7 +13,8 @@ returns the full text of all {{domxref("Text")}} nodes logically adjacent to the
 The text is concatenated in document order.
 This allows specifying any text node and obtaining all adjacent text as a single string.
 
-> **Note:** This is similar to call {{domxref("Node.normalize()")}} followed by reading the text value,
+> [!NOTE]
+> This is similar to call {{domxref("Node.normalize()")}} followed by reading the text value,
 > but without modifying the tree.
 
 ## Value

--- a/files/en-us/web/api/textevent/inittextevent/index.md
+++ b/files/en-us/web/api/textevent/inittextevent/index.md
@@ -14,7 +14,8 @@ The **`initTextEventEvent()`** method of the {{domxref("TextEvent")}} interface 
 
 This method must be called to set the event before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}.
 
-> **Note:** In general, you won't create these events yourself; they are created by the browser.
+> [!NOTE]
+> In general, you won't create these events yourself; they are created by the browser.
 
 ## Syntax
 

--- a/files/en-us/web/api/texttrack/addcue/index.md
+++ b/files/en-us/web/api/texttrack/addcue/index.md
@@ -21,7 +21,8 @@ addCue(cue)
 - `cue`
   - : A {{domxref("TextTrackCue")}}.
 
-> **Note:** The {{domxref("TextTrackCue")}} interface is an abstract class used as the parent for other cue interfaces such as {{domxref("VTTCue")}}. Therefore, when adding a cue you will be using one of the cue types that inherit from `TextTrackCue`.
+> [!NOTE]
+> The {{domxref("TextTrackCue")}} interface is an abstract class used as the parent for other cue interfaces such as {{domxref("VTTCue")}}. Therefore, when adding a cue you will be using one of the cue types that inherit from `TextTrackCue`.
 
 ### Return value
 

--- a/files/en-us/web/api/texttrack/index.md
+++ b/files/en-us/web/api/texttrack/index.md
@@ -41,7 +41,8 @@ _This interface also inherits properties from {{domxref("EventTarget")}}._
 
 _This interface also inherits methods from {{domxref("EventTarget")}}._
 
-> **Note:** The {{domxref("TextTrackCue")}} interface is an abstract class used as the parent for other cue interfaces such as {{domxref("VTTCue")}}. Therefore, when adding or removing a cue you will be passing in one of the cue types that inherit from `TextTrackCue`.
+> [!NOTE]
+> The {{domxref("TextTrackCue")}} interface is an abstract class used as the parent for other cue interfaces such as {{domxref("VTTCue")}}. Therefore, when adding or removing a cue you will be passing in one of the cue types that inherit from `TextTrackCue`.
 
 - {{domxref("TextTrack.addCue()")}}
   - : Adds a cue (specified as a {{domxref("TextTrackCue")}} object) to the track's list of cues.

--- a/files/en-us/web/api/texttrack/removecue/index.md
+++ b/files/en-us/web/api/texttrack/removecue/index.md
@@ -30,7 +30,8 @@ Undefined.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if the given cue is not found in the list of cues.
 
-> **Note:** The {{domxref("TextTrackCue")}} interface is an abstract class used as the parent for other cue interfaces such as {{domxref("VTTCue")}}. Therefore, when removing a cue you will be passing in one of the cue types that inherit from `TextTrackCue`.
+> [!NOTE]
+> The {{domxref("TextTrackCue")}} interface is an abstract class used as the parent for other cue interfaces such as {{domxref("VTTCue")}}. Therefore, when removing a cue you will be passing in one of the cue types that inherit from `TextTrackCue`.
 
 ## Examples
 

--- a/files/en-us/web/api/topics_api/index.md
+++ b/files/en-us/web/api/topics_api/index.md
@@ -10,9 +10,11 @@ browser-compat: api.Document.browsingTopics
 
 {{DefaultAPISidebar("Topics API")}}{{SeeCompatTable}}{{non-standard_header}}
 
-> **Warning:** This feature is currently opposed by two browser vendors. See the [Standards positions](#standards_positions) section below for details of opposition.
+> [!WARNING]
+> This feature is currently opposed by two browser vendors. See the [Standards positions](#standards_positions) section below for details of opposition.
 
-> **Note:** An [Enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment) is required to use the Topics API in your applications. See the [Enrollment](#enrollment) section for details of what sub-features are gated by enrollment.
+> [!NOTE]
+> An [Enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment) is required to use the Topics API in your applications. See the [Enrollment](#enrollment) section for details of what sub-features are gated by enrollment.
 
 The **Topics API** provides a mechanism for developers to implement use cases such as **interest-based advertising (IBA)** based on topics collected by the browser as the user navigates different pages, rather than collected by the developer by tracking the user's journey around different sites with [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies).
 
@@ -24,7 +26,8 @@ The above process can be made more effective using interest-based advertising (I
 
 First of all, the browser infers a user's interests from the URLs of sites they visit that have ad tech `<iframe>`s embedded. These interests are mapped to specific **topics of interest**, and the browser calculates and records the users' top topic (i.e. the topic that their interests mapped to most often) at the end of each **epoch**. An epoch is a week by default. The top topic is updated each week so that interests are kept current and users don't start to see ads for topics that they are no longer interested in.
 
-> **Note:** This process only happens on sites where a Topics API feature is used (see [What API features enable the Topics API?](/en-US/docs/Web/API/Topics_API/Using#what_api_features_enable_the_topics_api)).
+> [!NOTE]
+> This process only happens on sites where a Topics API feature is used (see [What API features enable the Topics API?](/en-US/docs/Web/API/Topics_API/Using#what_api_features_enable_the_topics_api)).
 
 Once the browser has observed one or more topics for a user, the Topics API can retrieve them and send them to an ad tech platform. The platform can then use those topics to personalize the ads they serve to the user. The API helps to preserve privacy by _only returning topics to an API caller that have been observed by them_ on pages visited by the current user.
 

--- a/files/en-us/web/api/topics_api/using/index.md
+++ b/files/en-us/web/api/topics_api/using/index.md
@@ -8,9 +8,11 @@ status:
 
 {{DefaultAPISidebar("Topics API")}}
 
-> **Warning:** This feature is currently opposed by two browser vendors. See the [Standards positions](/en-US/docs/Web/API/Topics_API#standards_positions) section below for details of opposition.
+> [!WARNING]
+> This feature is currently opposed by two browser vendors. See the [Standards positions](/en-US/docs/Web/API/Topics_API#standards_positions) section below for details of opposition.
 
-> **Note:** An [Enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment) is required to use the Topics API in your applications. See the [Enrollment](/en-US/docs/Web/API/Topics_API#enrollment) section for details of what sub-features are gated by enrollment.
+> [!NOTE]
+> An [Enrollment process](/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment) is required to use the Topics API in your applications. See the [Enrollment](/en-US/docs/Web/API/Topics_API#enrollment) section for details of what sub-features are gated by enrollment.
 
 This page explains how the Topics API works and how it can be used to create an **interest-based advertising (IBA)** solution.
 
@@ -33,7 +35,8 @@ If the `<iframe>` content from `ad-tech1.example` implements a [feature that ena
 
 ### Selecting topics of interest to influence ad choice
 
-> **Note:** Different browser implementations may select topics in different ways. The below text is based on how Chrome currently selects topics, for demonstration purposes.
+> [!NOTE]
+> Different browser implementations may select topics in different ways. The below text is based on how Chrome currently selects topics, for demonstration purposes.
 
 On an ongoing basis, the browser will:
 
@@ -49,7 +52,8 @@ On an ongoing basis, the browser will:
 
 3. The top topics are returned to `ad-tech1.example`, only if `ad-tech1.example` appears in the list of caller domains for each topic, as stored in the topic's history entry.
 
-   > **Note:** Initially, no topics are returned, so the `<iframe>` will likely display a default non-targeted ad. However, once the end of the first epoch is reached, the API will start to return topics and `ad-tech1.example` can start to show more relevant ads based on the observed topics for the current user.
+   > [!NOTE]
+   > Initially, no topics are returned, so the `<iframe>` will likely display a default non-targeted ad. However, once the end of the first epoch is reached, the API will start to return topics and `ad-tech1.example` can start to show more relevant ads based on the observed topics for the current user.
 
 `ad-tech1.example` then selects a relevant ad to serve to the user, based on the returned topics.
 
@@ -80,13 +84,15 @@ When the request associated with one of the above features is sent:
 2. The ad tech server selects a relevant ad to display in the `<iframe>`, based on these topics, and sends the required data to display it in the response.
 3. An {{httpheader("Observe-Browsing-Topics")}} header should be set on the response to the request — this has the effect of causing the browser to record the current page visit as observed by the calling ad tech provider, so the associated topic(s) will be recorded in a topics history entry, and subsequently be used in [topic selection](#selecting_topics_of_interest_to_influence_ad_choice).
 
-   > **Note:** It is important to clarify that this doesn't record the top topics sent in the `Sec-Browsing-Topics` header as observed. It records the topics inferred from the calling site's URL (i.e. the site where the ad tech `<iframe>` is embedded) as observed.
+   > [!NOTE]
+   > It is important to clarify that this doesn't record the top topics sent in the `Sec-Browsing-Topics` header as observed. It records the topics inferred from the calling site's URL (i.e. the site where the ad tech `<iframe>` is embedded) as observed.
 
 ### The `browsingTopics()` method
 
 Alternatively, the embedded `<iframe>` can call {{domxref("Document.browsingTopics()")}} to return a user's current top topic(s), which can then be returned to the ad tech platform in a subsequent fetch request. This does not rely on the HTTP headers, but is somewhat less performant. You are advised to use one of the HTTP header methods listed above, falling back to `browsingTopics()` only in situations where the headers cannot be modified.
 
-> **Note:** Because the `browsingTopics()` method does not rely on the HTTP headers, the {{httpheader("Observe-Browsing-Topics")}} header is not used for setting the topics as observed and recording/updating topics history entries; the browser does this automatically when the method is called.
+> [!NOTE]
+> Because the `browsingTopics()` method does not rely on the HTTP headers, the {{httpheader("Observe-Browsing-Topics")}} header is not used for setting the topics as observed and recording/updating topics history entries; the browser does this automatically when the method is called.
 
 ## Private topic sets
 

--- a/files/en-us/web/api/touch/index.md
+++ b/files/en-us/web/api/touch/index.md
@@ -11,7 +11,8 @@ The **`Touch`** interface represents a single contact point on a touch-sensitive
 
 The {{ domxref("Touch.radiusX") }}, {{ domxref("Touch.radiusY") }}, and {{ domxref("Touch.rotationAngle") }} describe the area of contact between the user and the screen, the _touch area_. This can be helpful when dealing with imprecise pointing devices such as fingers. These values are set to describe an ellipse that as closely as possible matches the entire area of contact (such as the user's fingertip).
 
-> **Note:** Many of the properties' values are hardware-dependent; for example, if the device doesn't have a way to detect the amount of pressure placed on the surface, the `force` value will always be 0. This may also be the case for `radiusX` and `radiusY`; if the hardware reports only a single point, these values will be 1.
+> [!NOTE]
+> Many of the properties' values are hardware-dependent; for example, if the device doesn't have a way to detect the amount of pressure placed on the surface, the `force` value will always be 0. This may also be the case for `radiusX` and `radiusY`; if the hardware reports only a single point, these values will be 1.
 
 ## Constructor
 

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -37,7 +37,8 @@ Touch events are similar to mouse events except they support simultaneous touche
 
 This example tracks multiple touchpoints at a time, allowing the user to draw in a {{HTMLElement("canvas")}} with more than one finger at a time. It will only work on a browser that supports touch events.
 
-> **Note:** The text below uses the term "finger" when describing the contact with the surface, but it could, of course, also be a stylus or other contact method.
+> [!NOTE]
+> The text below uses the term "finger" when describing the contact with the surface, but it could, of course, also be a stylus or other contact method.
 
 ### Create a canvas
 
@@ -272,7 +273,8 @@ You can test this example on mobile devices by touching the box below.
 
 {{EmbedLiveSample('Example','100%', 900)}}
 
-> **Note:** More generally, the example will work on platforms that provide touch events.
+> [!NOTE]
+> More generally, the example will work on platforms that provide touch events.
 > You can test this on desktop platforms that can simulate such events:
 >
 > - On Firefox enable "touch simulation" in [Responsive Design Mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/index.html#toggling-responsive-design-mode) (you may need to reload the page).

--- a/files/en-us/web/api/touchevent/index.md
+++ b/files/en-us/web/api/touchevent/index.md
@@ -76,7 +76,8 @@ There are several types of event that can be fired to indicate that touch-relate
     This event is also sent
     if the values of the radius, rotation angle, or force attributes of a touch point change.
 
-    > **Note:** The rate at which `touchmove` events is sent is browser-specific, and may also vary depending on the capability of the user's hardware. You must not rely on a specific granularity of these events.
+    > [!NOTE]
+    > The rate at which `touchmove` events is sent is browser-specific, and may also vary depending on the capability of the user's hardware. You must not rely on a specific granularity of these events.
 
 - {{domxref("Element/touchcancel_event", "touchcancel")}}
 

--- a/files/en-us/web/api/touchevent/metakey/index.md
+++ b/files/en-us/web/api/touchevent/metakey/index.md
@@ -12,7 +12,8 @@ The read-only **`metaKey`** property of the {{domxref("TouchEvent")}} interface 
 
 This property is {{ReadOnlyInline}}.
 
-> **Note:** On Macintosh keyboards, this is the <kbd>⌘ Command</kbd> key. On Windows keyboards, this is the Windows key (<kbd>⊞</kbd>).
+> [!NOTE]
+> On Macintosh keyboards, this is the <kbd>⌘ Command</kbd> key. On Windows keyboards, this is the Windows key (<kbd>⊞</kbd>).
 
 ## Value
 

--- a/files/en-us/web/api/touchevent/touches/index.md
+++ b/files/en-us/web/api/touchevent/touches/index.md
@@ -16,7 +16,8 @@ target element was at {{domxref("Element/touchstart_event", "touchstart")}} time
 You can think of it as how many separate fingers are able to be identified as touching
 the screen.
 
-> **Note:** Touches inside the array are not necessarily ordered by order of occurrences (the
+> [!NOTE]
+> Touches inside the array are not necessarily ordered by order of occurrences (the
 > i-th element in the array being the i-th touch that happened). You cannot assume a specific order. To determine the order of occurrences of the touches, use the `touch` object IDs.
 
 ## Value

--- a/files/en-us/web/api/touchevent/touchevent/index.md
+++ b/files/en-us/web/api/touchevent/touchevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.TouchEvent.TouchEvent
 
 The **`TouchEvent()`** constructor creates a new {{domxref("TouchEvent")}} object.
 
-> **Note:** If you construct a synthetic event using this constructor, that event will not be _trusted_, for security reasons.
+> [!NOTE]
+> If you construct a synthetic event using this constructor, that event will not be _trusted_, for security reasons.
 > Only browser-generated `TouchEvent` objects are trusted and only trusted events trigger default actions.
 
 ## Syntax

--- a/files/en-us/web/api/transformstream/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/transformstream/index.md
@@ -58,7 +58,8 @@ new TransformStream(transformer, writableStrategy, readableStrategy)
       - : A method containing a parameter `chunk`. This indicates the size to
         use for each chunk, in bytes.
 
-> **Note:** You could define your own custom
+> [!NOTE]
+> You could define your own custom
 > `readableStrategy` or `writableStrategy`, or use an instance of
 > {{domxref("ByteLengthQueuingStrategy")}} or {{domxref("CountQueuingStrategy")}}
 > for the object values.

--- a/files/en-us/web/api/treewalker/index.md
+++ b/files/en-us/web/api/treewalker/index.md
@@ -46,7 +46,8 @@ _This interface doesn't inherit any property._
 
 _This interface doesn't inherit any method._
 
-> **Note:** in the context of a `TreeWalker`, a node is _visible_ if it exists in the logical view determined by the `whatToShow` and `filter` parameter arguments. (Whether or not the node is visible on the screen is irrelevant.)
+> [!NOTE]
+> in the context of a `TreeWalker`, a node is _visible_ if it exists in the logical view determined by the `whatToShow` and `filter` parameter arguments. (Whether or not the node is visible on the screen is irrelevant.)
 
 - {{domxref("TreeWalker.parentNode()")}}
   - : Moves the current {{domxref("Node")}} to the first _visible_ ancestor node in the document order, and returns the found node. It also moves the current node to this one. If no such node exists, or if it is before that the _root node_ defined at the object construction, returns `null` and the current node is not changed.

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -14,9 +14,11 @@ The **`createPolicy()`** method of the {{domxref("TrustedTypePolicyFactory")}} i
 
 In Chrome a policy with a name of "default" creates a special policy that will be used if a string (rather than a Trusted Type object) is passed to an injection sink. This can be used in a transitional phase while moving from an application that inserted strings into injection sinks.
 
-> **Note:** The above behavior is not yet settled in the specification and may change in future.
+> [!NOTE]
+> The above behavior is not yet settled in the specification and may change in future.
 
-> **Warning:** A lax default policy could defeat the purpose of using Trusted Types, and therefore should be defined with strict rules to ensure it cannot be used to run dangerous code.
+> [!WARNING]
+> A lax default policy could defeat the purpose of using Trusted Types, and therefore should be defined with strict rules to ensure it cannot be used to run dangerous code.
 
 ## Syntax
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.md
@@ -10,7 +10,8 @@ browser-compat: api.TrustedTypePolicyFactory.defaultPolicy
 
 The **`defaultPolicy`** read-only property of the {{domxref("TrustedTypePolicyFactory")}} interface returns the default {{domxref("TrustedTypePolicy")}} or null if this is empty.
 
-> **Note:** Information about the creation and use of default policies can be found in the [`createPolicy()`](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#the_default_policy) documentation.
+> [!NOTE]
+> Information about the creation and use of default policies can be found in the [`createPolicy()`](/en-US/docs/Web/API/TrustedTypePolicyFactory/createPolicy#the_default_policy) documentation.
 
 ## Value
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
@@ -10,7 +10,8 @@ browser-compat: api.TrustedTypePolicyFactory.isHTML
 
 The **`isHTML()`** method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedHTML")}} object.
 
-> **Note:** The purpose of the functions `isHTML()`, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.
+> [!NOTE]
+> The purpose of the functions `isHTML()`, {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.
 
 ## Syntax
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
@@ -10,7 +10,8 @@ browser-compat: api.TrustedTypePolicyFactory.isScript
 
 The **`isScript()`** method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScript")}} object.
 
-> **Note:** The purpose of the functions `isScript()`, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.
+> [!NOTE]
+> The purpose of the functions `isScript()`, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScriptURL","isScriptURL()")}} is to check if the object is a valid TrustedType object, created by a configured policy.
 
 ## Syntax
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
@@ -10,7 +10,8 @@ browser-compat: api.TrustedTypePolicyFactory.isScriptURL
 
 The **`isScriptURL()`** method of the {{domxref("TrustedTypePolicyFactory")}} interface returns true if it is passed a valid {{domxref("TrustedScriptURL")}} object.
 
-> **Note:** The purpose of the functions `isScriptURL()`, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.
+> [!NOTE]
+> The purpose of the functions `isScriptURL()`, {{domxref("TrustedTypePolicyFactory.isHTML","isHTML()")}}, and {{domxref("TrustedTypePolicyFactory.isScript","isScript()")}} is to check if the object is a valid TrustedType object, created by a configured policy.
 
 ## Syntax
 

--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -3058,7 +3058,8 @@ The values below are derived in part from a number of consumer electronics techn
 - [ANSI/CEA-2014-B](https://shop.cta.tech/products/web-based-protocol-and-framework-for-remote-user-interface-on-upnp-networks-and-the-internet): Web-based Protocol and Framework for Remote User Interface on UPnP™ Networks and the Internet
 - [Android KeyEvent key code values](https://developer.android.com/reference/android/view/KeyEvent.html)
 
-> **Note:** Remote controls typically include keys whose values are already defined elsewhere, such as under [Multimedia keys](#multimedia_keys) or [Audio control keys](#audio_control_keys). Those keys' values will match what's documented in those tables.
+> [!NOTE]
+> Remote controls typically include keys whose values are already defined elsewhere, such as under [Multimedia keys](#multimedia_keys) or [Audio control keys](#audio_control_keys). Those keys' values will match what's documented in those tables.
 
 <table class="no-markdown">
   <thead>
@@ -4529,7 +4530,8 @@ Some keyboards include special keys for controlling Web browsers. Those keys fol
 
 These keys are found on the keyboard's numeric keypad. However, not all are present on every keyboard. Although typical numeric keypads have numeric keys from <kbd>0</kbd> to <kbd>9</kbd> (encoded as `"0"` through `"9"`), some multimedia keyboards include additional number keys for higher numbers.
 
-> **Note:** The <kbd>10</kbd> key, if present, generates events with the `key` value of `"0"`.
+> [!NOTE]
+> The <kbd>10</kbd> key, if present, generates events with the `key` value of `"0"`.
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/uievent/inituievent/index.md
+++ b/files/en-us/web/api/uievent/inituievent/index.md
@@ -17,7 +17,8 @@ Events initialized in this way must have been created with the {{domxref("Docume
 before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}. Once
 dispatched, it doesn't do anything anymore.
 
-> **Warning:** Do not use this method anymore as it is deprecated.
+> [!WARNING]
+> Do not use this method anymore as it is deprecated.
 >
 > Instead use specific event constructors, like {{domxref("UIEvent.UIEvent", "UIEvent()")}}. The page on [Creating and triggering events](/en-US/docs/Web/Events/Creating_and_triggering_events) gives more information about the way to use these.
 

--- a/files/en-us/web/api/uievent/uievent/index.md
+++ b/files/en-us/web/api/uievent/uievent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.UIEvent.UIEvent
 
 The **`UIEvent()`** constructor creates a new {{domxref("UIEvent")}} object.
 
-> **Note:** If you construct a synthetic event using this constructor, that event will not be _trusted_, for security reasons.
+> [!NOTE]
+> If you construct a synthetic event using this constructor, that event will not be _trusted_, for security reasons.
 > Only browser-generated `UIEvent` objects are trusted and only trusted events trigger default actions.
 
 ## Syntax

--- a/files/en-us/web/api/uievent/which/index.md
+++ b/files/en-us/web/api/uievent/which/index.md
@@ -19,7 +19,8 @@ The **`UIEvent.which`** read-only property of the {{domxref("UIEvent")}} interfa
 For {{domxref("KeyboardEvent")}}, `event.which` contains the numeric code for a particular key pressed, depending on whether an alphanumeric or non-alphanumeric key was pressed.
 Please see deprecated {{domxref("KeyboardEvent.charCode")}} and {{domxref("KeyboardEvent.keyCode")}} for more details.
 
-> **Note:** Consider {{domxref("KeyboardEvent.key")}} or {{domxref("KeyboardEvent.code")}} for new code.
+> [!NOTE]
+> Consider {{domxref("KeyboardEvent.key")}} or {{domxref("KeyboardEvent.code")}} for new code.
 
 ### Value for MouseEvent {{Non-standard_Inline}}
 
@@ -33,7 +34,8 @@ For {{domxref("MouseEvent")}}, `event.which` is a number representing a given bu
 For a mouse configured for left-handed use, the button actions are reversed.
 In this case, the values are read from right to left.
 
-> **Note:** Consider {{domxref("MouseEvent.button")}} for new code.
+> [!NOTE]
+> Consider {{domxref("MouseEvent.button")}} for new code.
 
 ## Examples
 

--- a/files/en-us/web/api/url/canparse_static/index.md
+++ b/files/en-us/web/api/url/canparse_static/index.md
@@ -30,7 +30,8 @@ URL.canParse(url, base)
   - : A string representing the base URL to use in cases where `url` is a relative URL.
     If not specified, it defaults to `undefined`.
 
-> **Note:** The `url` and `base` arguments will each be stringified from whatever value you pass, just like with other Web APIs that accept a string.
+> [!NOTE]
+> The `url` and `base` arguments will each be stringified from whatever value you pass, just like with other Web APIs that accept a string.
 > In particular, you can use an existing {{domxref("URL")}} object for either argument, and it will be stringified to the object's {{domxref("URL.href", "href")}} property.
 
 ### Return value

--- a/files/en-us/web/api/url/createobjecturl_static/index.md
+++ b/files/en-us/web/api/url/createobjecturl_static/index.md
@@ -17,7 +17,8 @@ in the window on which it was created. The new object URL represents the specifi
 
 To release an object URL, call {{domxref("URL.revokeObjectURL_static", "revokeObjectURL()")}}.
 
-> **Note:** This feature is _not_ available in [Service Workers](/en-US/docs/Web/API/Service_Worker_API) due to its
+> [!NOTE]
+> This feature is _not_ available in [Service Workers](/en-US/docs/Web/API/Service_Worker_API) due to its
 > potential to create memory leaks.
 
 ## Syntax
@@ -60,7 +61,8 @@ In older versions of the Media Source specification, attaching a stream to a
 {{domxref("MediaStream")}}. This is no longer necessary, and browsers are removing
 support for doing this.
 
-> **Warning:** If you still have code that relies on
+> [!WARNING]
+> If you still have code that relies on
 > `createObjectURL()` to attach streams to media
 > elements, you need to update your code to set {{domxref("HTMLMediaElement.srcObject", "srcObject")}} to the `MediaStream` directly.
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 12.
