### PR TITLE
Convert noteblocks for web/api folder (part 14)

### DIFF
--- a/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
+++ b/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
@@ -115,7 +115,8 @@ One place it may be worthwhile, is if you want to test a file from a third party
 
 A phrase you may have heard before is _"Salting the hash"_. It's not immediately relevant to our topics at hand, but it is good to know about.
 
-> **Note:** this section is talking about password security and the hash functions provided by SubtleCrypto are not suitable for this use case. For these purposes you need expensive slow hash functions like `scrypt` and `bcrypt`. SHA is designed to be pretty fast and efficient, which makes it unsuitable for password hashing. This section is purely for your interest — do not use the Web Crypto API to hash passwords on the client.
+> [!NOTE]
+> this section is talking about password security and the hash functions provided by SubtleCrypto are not suitable for this use case. For these purposes you need expensive slow hash functions like `scrypt` and `bcrypt`. SHA is designed to be pretty fast and efficient, which makes it unsuitable for password hashing. This section is purely for your interest — do not use the Web Crypto API to hash passwords on the client.
 
 A popular use case for hashing is passwords, you never ever want to store a users password in plain text, its simply a terrible idea. Instead you store a hash of the users password, so the original password cannot be recovered should a hacker obtain your username and password database. The eagle eyed among may notice you can still work out the original passwords by comparing the hashes from lists of known passwords against the obtained password hash list. Concatenating a string to the passwords changes the hash so it no longer matches. This is known as **salting**. Another tricky problem is if you use the same salt for each password, then passwords with matching hashes will also be the same original password. Thus if you know one then you know all matching passwords.
 

--- a/files/en-us/web/api/web_nfc_api/index.md
+++ b/files/en-us/web/api/web_nfc_api/index.md
@@ -11,7 +11,8 @@ browser-compat: api.NDEFReader
 
 The Web NFC API allows exchanging data over NFC via light-weight NFC Data Exchange Format (NDEF) messages.
 
-> **Note:** Devices and tags have to be formatted and recorded specifically to support NDEF record format to be used with Web NFC. Low-level operations are currently not supported by the API, however there is a public discussion about API that would add such functionality.
+> [!NOTE]
+> Devices and tags have to be formatted and recorded specifically to support NDEF record format to be used with Web NFC. Low-level operations are currently not supported by the API, however there is a public discussion about API that would add such functionality.
 
 ## Interfaces
 

--- a/files/en-us/web/api/web_share_api/index.md
+++ b/files/en-us/web/api/web_share_api/index.md
@@ -12,9 +12,11 @@ spec-urls: https://w3c.github.io/web-share/
 
 The **Web Share API** provides a mechanism for sharing text, links, files, and other content to an arbitrary _share target_ selected by the user.
 
-> **Note:** This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
+> [!NOTE]
+> This API is _not available_ in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (not exposed via {{domxref("WorkerNavigator")}}).
 
-> **Note:** This API should not be confused with the [Web Share Target API](/en-US/docs/Web/Manifest/share_target), which allows a website to specify itself as a share target.
+> [!NOTE]
+> This API should not be confused with the [Web Share Target API](/en-US/docs/Web/Manifest/share_target), which allows a website to specify itself as a share target.
 
 ## Concepts and usage
 

--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -13,7 +13,8 @@ Speech recognition involves receiving speech through a device's microphone, whic
 
 The Web Speech API has a main controller interface for this — {{domxref("SpeechRecognition")}} — plus a number of closely-related interfaces for representing grammar, results, etc. Generally, the default speech recognition system available on the device will be used for the speech recognition — most modern OSes have a speech recognition system for issuing voice commands. Think about Dictation on macOS, Siri on iOS, Cortana on Windows 10, Android Speech, etc.
 
-> **Note:** On some browsers, such as Chrome, using Speech Recognition on a web page involves a server-based recognition engine. Your audio is sent to a web service for recognition processing, so it won't work offline.
+> [!NOTE]
+> On some browsers, such as Chrome, using Speech Recognition on a web page involves a server-based recognition engine. Your audio is sent to a web service for recognition processing, so it won't work offline.
 
 ### Demo
 

--- a/files/en-us/web/api/web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/index.md
@@ -29,7 +29,8 @@ Developers should be cautious when performing operations on `sessionStorage` or 
 
 Asynchronous alternatives, such as [IndexedDB](/en-US/docs/Web/API/IndexedDB_API), may be more suitable for scenarios where performance is a concern or when dealing with larger datasets. These alternatives allow for non-blocking operations, enabling smoother user experiences and better performance in web applications.
 
-> **Note:** Access to Web Storage from third-party IFrames is denied if the user has [disabled third-party cookies](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection).
+> [!NOTE]
+> Access to Web Storage from third-party IFrames is denied if the user has [disabled third-party cookies](https://support.mozilla.org/en-US/kb/third-party-cookies-firefox-tracking-protection).
 
 ## Determining storage access by a third party
 

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -23,7 +23,8 @@ localStorage["colorSetting"] = "#a4509b";
 localStorage.setItem("colorSetting", "#a4509b");
 ```
 
-> **Note:** It's recommended to use the Web Storage API (`setItem`, `getItem`, `removeItem`, `key`, `length`) to prevent the [pitfalls](https://2ality.com/2012/01/objects-as-maps.html) associated with using plain objects as key-value stores.
+> [!NOTE]
+> It's recommended to use the Web Storage API (`setItem`, `getItem`, `removeItem`, `key`, `length`) to prevent the [pitfalls](https://2ality.com/2012/01/objects-as-maps.html) associated with using plain objects as key-value stores.
 
 The two mechanisms within Web Storage are as follows:
 
@@ -40,7 +41,8 @@ To be able to use localStorage, we should first verify that it is supported and 
 
 ### Testing for availability
 
-> **Note:** This API is available in current versions of all major browsers. Testing for availability is necessary only if you must support very old browsers, or in the limited circumstances described below.
+> [!NOTE]
+> This API is available in current versions of all major browsers. Testing for availability is necessary only if you must support very old browsers, or in the limited circumstances described below.
 
 Browsers that support localStorage have a property on the window object named `localStorage`. However, just asserting that the property exists may throw exceptions. If the `localStorage` object does exist, there is still no guarantee that the localStorage API is actually available, as various browsers offer settings that disable localStorage. So a browser may _support_ localStorage, but not make it _available_ to the scripts on the page.
 
@@ -95,7 +97,8 @@ We have also provided an [event output page](https://mdn.github.io/dom-examples/
 
 ![Event output page](event-output.png)
 
-> **Note:** As well as viewing the example pages live using the above links, you can also [check out the source code](https://github.com/mdn/dom-examples/tree/main/web-storage).
+> [!NOTE]
+> As well as viewing the example pages live using the above links, you can also [check out the source code](https://github.com/mdn/dom-examples/tree/main/web-storage).
 
 ### Testing whether your storage has been populated
 
@@ -111,7 +114,8 @@ if (!localStorage.getItem("bgcolor")) {
 
 The {{domxref("Storage.getItem()")}} method is used to get a data item from storage; in this case, we are testing to see whether the `bgcolor` item exists; if not, we run `populateStorage()` to add the existing customization values to the storage. If there are already values there, we run `setStyles()` to update the page styling with the stored values.
 
-> **Note:** You could also use {{domxref("Storage.length")}} to test whether the storage object is empty or not.
+> [!NOTE]
+> You could also use {{domxref("Storage.length")}} to test whether the storage object is empty or not.
 
 ### Getting values from storage
 

--- a/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -40,7 +40,8 @@ The following functions are **only** available to workers:
 
 ## Web APIs available in workers
 
-> **Note:** If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
+> [!NOTE]
+> If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
 
 The following Web APIs are available to workers:
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -29,7 +29,8 @@ There are a number of different types of workers:
 - {{domxref("SharedWorker", "Shared workers", "", "nocode")}} are workers that can be utilized by multiple scripts running in different windows, IFrames, etc., as long as they are in the same domain as the worker. They are a little more complex than dedicated workers — scripts must communicate via an active port.
 - {{domxref("Service Worker API", "Service Workers", "", "nocode")}} essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 
-> **Note:** As per the [Web workers Spec](https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2), worker error events should not bubble (see [Firefox bug 1188141](https://bugzil.la/1188141)). This has been implemented in Firefox 42.
+> [!NOTE]
+> As per the [Web workers Spec](https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2), worker error events should not bubble (see [Firefox bug 1188141](https://bugzil.la/1188141)). This has been implemented in Firefox 42.
 
 ### Worker global contexts and functions
 
@@ -63,7 +64,8 @@ The following functions are **only** available to workers:
 
 ### Supported Web APIs
 
-> **Note:** If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
+> [!NOTE]
+> If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
 
 The following Web APIs are available to workers:
 

--- a/files/en-us/web/api/web_workers_api/transferable_objects/index.md
+++ b/files/en-us/web/api/web_workers_api/transferable_objects/index.md
@@ -91,7 +91,8 @@ The items that various specifications indicate can be _transferred_ are:
 Browser support should be indicated in the respective object's compatibility information by the `transferable` subfeature (see [`RTCDataChannel`](/en-US/docs/Web/API/RTCDataChannel#browser_compatibility) for an example).
 At time of writing, not all transferable objects have been updated with this information.
 
-> **Note:** Transferable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Transferable]`.
+> [!NOTE]
+> Transferable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Transferable]`.
 
 ## See also
 

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -17,7 +17,8 @@ A worker is an object created using a constructor (e.g. {{domxref("Worker.Worker
 
 The worker context is represented by a {{domxref("DedicatedWorkerGlobalScope")}} object in the case of dedicated workers (standard workers that are utilized by a single script; shared workers use {{domxref("SharedWorkerGlobalScope")}}). A dedicated worker is only accessible from the script that first spawned it, whereas shared workers can be accessed from multiple scripts.
 
-> **Note:** See [The Web Workers API landing page](/en-US/docs/Web/API/Web_Workers_API) for reference documentation on workers and additional guides.
+> [!NOTE]
+> See [The Web Workers API landing page](/en-US/docs/Web/API/Web_Workers_API) for reference documentation on workers and additional guides.
 
 You can run whatever code you like inside the worker thread, with some exceptions. For example, you can't directly manipulate the DOM from inside a worker, or use some default methods and properties of the {{domxref("window")}} object. But you can use a large number of items available under `window`, including [WebSockets](/en-US/docs/Web/API/WebSockets_API), and data storage mechanisms like [IndexedDB](/en-US/docs/Web/API/IndexedDB_API). See [Functions and classes available to workers](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) for more details.
 
@@ -93,9 +94,11 @@ myWorker.onmessage = (e) => {
 
 Here we grab the message event data and set it as the `textContent` of the result paragraph, so the user can see the result of the calculation.
 
-> **Note:** Notice that `onmessage` and `postMessage()` need to be hung off the `Worker` object when used in the main script thread, but not when used in the worker. This is because, inside the worker, the worker is effectively the global scope.
+> [!NOTE]
+> Notice that `onmessage` and `postMessage()` need to be hung off the `Worker` object when used in the main script thread, but not when used in the worker. This is because, inside the worker, the worker is effectively the global scope.
 
-> **Note:** When a message is passed between the main thread and worker, it is copied or "transferred" (moved), not shared. Read [Transferring data to and from workers: further details](#transferring_data_to_and_from_workers_further_details) for a much more thorough explanation.
+> [!NOTE]
+> When a message is passed between the main thread and worker, it is copied or "transferred" (moved), not shared. Read [Transferring data to and from workers: further details](#transferring_data_to_and_from_workers_further_details) for a much more thorough explanation.
 
 ### Terminating a worker
 
@@ -141,7 +144,8 @@ importScripts(
 
 The browser loads each listed script and executes it. Any global objects from each script may then be used by the worker. If the script can't be loaded, `NETWORK_ERROR` is thrown, and subsequent code will not be executed. Previously executed code (including code deferred using {{domxref("setTimeout()")}}) will still be functional though. Function declarations **after** the `importScripts()` method are also kept, since these are always evaluated before the rest of the code.
 
-> **Note:** Scripts may be downloaded in any order, but will be executed in the order in which you pass the filenames into `importScripts()`. This is done synchronously; `importScripts()` does not return until all the scripts have been loaded and executed.
+> [!NOTE]
+> Scripts may be downloaded in any order, but will be executed in the order in which you pass the filenames into `importScripts()`. This is done synchronously; `importScripts()` does not return until all the scripts have been loaded and executed.
 
 ## Shared workers
 
@@ -149,9 +153,11 @@ A shared worker is accessible by multiple scripts — even if they are being acc
 
 Here we'll concentrate on the differences between dedicated and shared workers. Note that in this example we have two HTML pages, each with JavaScript applied that uses the same single worker file.
 
-> **Note:** If SharedWorker can be accessed from several browsing contexts, all those browsing contexts must share the exact same origin (same protocol, host, and port).
+> [!NOTE]
+> If SharedWorker can be accessed from several browsing contexts, all those browsing contexts must share the exact same origin (same protocol, host, and port).
 
-> **Note:** In Firefox, shared workers cannot be shared between documents loaded in private and non-private windows ([Firefox bug 1177621](https://bugzil.la/1177621)).
+> [!NOTE]
+> In Firefox, shared workers cannot be shared between documents loaded in private and non-private windows ([Firefox bug 1177621](https://bugzil.la/1177621)).
 
 ### Spawning a shared worker
 
@@ -165,7 +171,8 @@ One big difference is that with a shared worker you have to communicate via a `p
 
 The port connection needs to be started either implicitly by use of the `onmessage` event handler or explicitly with the `start()` method before any messages can be posted. Calling `start()` is only needed if the `message` event is wired up via the `addEventListener()` method.
 
-> **Note:** When using the `start()` method to open the port connection, it needs to be called from both the parent thread and the worker thread if two-way communication is needed.
+> [!NOTE]
+> When using the `start()` method to open the port connection, it needs to be called from both the parent thread and the worker thread if two-way communication is needed.
 
 ### Sending messages to and from a shared worker
 
@@ -815,9 +822,11 @@ You can use most standard JavaScript features inside a web worker, including:
 
 The main thing you _can't_ do in a Worker is directly affect the parent page. This includes manipulating the DOM and using that page's objects. You have to do it indirectly, by sending a message back to the main script via {{domxref("DedicatedWorkerGlobalScope.postMessage")}}, then doing the changes in event handler.
 
-> **Note:** You can test whether a method is available to workers using the site: <https://worker-playground.glitch.me/>. For example, if you enter [EventSource](/en-US/docs/Web/API/EventSource) into the site on Firefox 84 you'll see that this is not supported in service workers, but is in dedicated and shared workers.
+> [!NOTE]
+> You can test whether a method is available to workers using the site: <https://worker-playground.glitch.me/>. For example, if you enter [EventSource](/en-US/docs/Web/API/EventSource) into the site on Firefox 84 you'll see that this is not supported in service workers, but is in dedicated and shared workers.
 
-> **Note:** For a complete list of functions available to workers, see [Functions and interfaces available to workers](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers).
+> [!NOTE]
+> For a complete list of functions available to workers, see [Functions and interfaces available to workers](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers).
 
 ## Specifications
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
@@ -13,7 +13,8 @@ of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) renders primitives from
 array data like the {{domxref("WebGLRenderingContext.drawArrays()", "gl.drawArrays()")}}
 method. In addition, it can execute multiple instances of the range of elements.
 
-> **Note:** When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}},
+> [!NOTE]
+> When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}},
 > the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
 > too.
 

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
@@ -13,7 +13,8 @@ of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) renders primitives from
 array data like the {{domxref("WebGLRenderingContext.drawElements()", "gl.drawElements()")}} method. In addition, it can execute multiple instances of a set
 of elements.
 
-> **Note:** When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
+> [!NOTE]
+> When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
 > too.
 
 ## Syntax

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -16,7 +16,8 @@ const canvas = document.getElementById("myCanvas");
 const gl = canvas.getContext("webgl2");
 ```
 
-> **Note:** WebGL 2 is an extension to WebGL 1. The `WebGL2RenderingContext` interface implements all members of the {{domxref("WebGLRenderingContext")}} interface. Some methods of the WebGL 1 context can accept additional values when used in a WebGL 2 context. You will find this info noted on the WebGL 1 reference pages.
+> [!NOTE]
+> WebGL 2 is an extension to WebGL 1. The `WebGL2RenderingContext` interface implements all members of the {{domxref("WebGLRenderingContext")}} interface. Some methods of the WebGL 1 context can accept additional values when used in a WebGL 2 context. You will find this info noted on the WebGL 1 reference pages.
 
 The [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial) has more information, examples, and resources on how to get started with WebGL.
 

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
@@ -12,7 +12,8 @@ The **`WebGL2RenderingContext.uniformMatrix[234]x[234]fv()`**
 methods of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) specify matrix
 values for uniform variables.
 
-> **Note:** There are no `2x2`, `3x3`, and `4x4` versions of
+> [!NOTE]
+> There are no `2x2`, `3x3`, and `4x4` versions of
 > this method. They are abbreviated in `2`, `3`, and
 > `4`, respectively. See the syntax below.
 

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
@@ -13,7 +13,8 @@ of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) modifies the rate at
 which generic vertex attributes advance when rendering multiple instances of primitives
 with {{domxref("WebGL2RenderingContext.drawArraysInstanced()", "gl.drawArraysInstanced()")}} and {{domxref("WebGL2RenderingContext.drawElementsInstanced()", "gl.drawElementsInstanced()")}}.
 
-> **Note:** When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
+> [!NOTE]
+> When using {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}}, the {{domxref("ANGLE_instanced_arrays")}} extension can provide this method,
 > too.
 
 ## Syntax

--- a/files/en-us/web/api/webgl_api/basic_2d_animation_example/index.md
+++ b/files/en-us/web/api/webgl_api/basic_2d_animation_example/index.md
@@ -204,7 +204,8 @@ First, {{domxref("WebGLRenderingContext.createProgram", "gl.createProgram()")}} 
 
 Then, for each shader in the specified list of shaders, we call a `compileShader()` function to compile it, passing into it the ID and type of the shader function to build. Each of those objects includes, as mentioned before, the ID of the `<script>` element the shader code is found in and the type of shader it is. The compiled shader is attached to the shader program by passing it into {{domxref("WebGLRenderingContext.attachShader", "gl.attachShader()")}}.
 
-> **Note:** We could go a step farther here, actually, and look at the value of the `<script>` element's `type` attribute to determine the shader type.
+> [!NOTE]
+> We could go a step farther here, actually, and look at the value of the `<script>` element's `type` attribute to determine the shader type.
 
 Once all of the shaders are compiled, the program is linked using {{domxref("WebGLRenderingContext.linkProgram", "gl.linkProgram()")}}.
 

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This WebGL example demonstrates a very basic GLSL shader program that draws a solid color square.
 
-> **Note:** This example will most likely work in all modern desktop browsers. But it may not work in some mobile or older browsers. If the canvas remains blank, you can check the output of the next example, which draws exactly the same thing. But remember to read through the explanations and code on this page, before moving on to the next.
+> [!NOTE]
+> This example will most likely work in all modern desktop browsers. But it may not work in some mobile or older browsers. If the canvas remains blank, you can check the output of the next example, which draws exactly the same thing. But remember to read through the explanations and code on this page, before moving on to the next.
 
 ## Hello World program in GLSL
 

--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
@@ -145,7 +145,8 @@ let identityMatrix = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 let someMatrixResult = multiplyMatrices(identityMatrix, someMatrix);
 ```
 
-> **Warning:** These matrix functions are written for clarity of explanation, not for speed or memory management. These functions create a lot of new arrays, which can be particularly expensive for real-time operations due to garbage collection. In real production code it would be best to use optimized functions. [glMatrix](https://glmatrix.net) is an example of a library that has a focus on speed and performance. The focus in the glMatrix library is to have target arrays that are allocated before the update loop.
+> [!WARNING]
+> These matrix functions are written for clarity of explanation, not for speed or memory management. These functions create a lot of new arrays, which can be particularly expensive for real-time operations due to garbage collection. In real production code it would be best to use optimized functions. [glMatrix](https://glmatrix.net) is an example of a library that has a focus on speed and performance. The focus in the glMatrix library is to have target arrays that are allocated before the update loop.
 
 ## Translation matrix
 

--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -14,7 +14,8 @@ The complete source code for this project is [available on GitHub](https://githu
 
 This project uses the [glMatrix](https://glmatrix.net/) library to perform its matrix operations, so you will need to include that in your project. We're loading a copy from a CDN.
 
-> **Note:** Update your "index.html" so it looks like this:
+> [!NOTE]
+> Update your "index.html" so it looks like this:
 
 ```html
 <!doctype html>
@@ -59,7 +60,8 @@ The vertex shader can, as needed, also do things like determine the coordinates 
 
 Our vertex shader below receives vertex position values from an attribute we define called `aVertexPosition`. That position is then multiplied by two 4x4 matrices we provide called `uProjectionMatrix` and `uModelViewMatrix`; `gl_Position` is set to the result. For more info on projection and other matrixes [you might find this article useful](https://webglfundamentals.org/webgl/lessons/webgl-3d-perspective.html).
 
-> **Note:** Add this code to your `main()` function:
+> [!NOTE]
+> Add this code to your `main()` function:
 
 ```js
 // Vertex shader program
@@ -83,7 +85,8 @@ The **fragment shader** is called once for every pixel on each shape to be drawn
 
 In this case, we're returning white every time, since we're just drawing a white square, with no lighting in use.
 
-> **Note:** Add this code to your `main()` function:
+> [!NOTE]
+> Add this code to your `main()` function:
 
 ```js
 const fsSource = `
@@ -97,7 +100,8 @@ const fsSource = `
 
 Now that we've defined the two shaders we need to pass them to WebGL, compile them, and link them together. The code below creates the two shaders by calling `loadShader()`, passing the type and source for the shader. It then creates a program, attaches the shaders and links them together. If compiling or linking fails the code displays an alert.
 
-> **Note:** Add these two functions to your "webgl-demo.js" script:
+> [!NOTE]
+> Add these two functions to your "webgl-demo.js" script:
 
 ```js
 //
@@ -165,7 +169,8 @@ The `loadShader()` function takes as input the WebGL context, the shader type, a
 4. To check to be sure the shader successfully compiled, the shader parameter `gl.COMPILE_STATUS` is checked. To get its value, we call {{domxref("WebGLRenderingContext.getShaderParameter", "gl.getShaderParameter()")}}, specifying the shader and the name of the parameter we want to check (`gl.COMPILE_STATUS`). If that's `false`, we know the shader failed to compile, so show an alert with log information obtained from the compiler using {{domxref("WebGLRenderingContext.getShaderInfoLog", "gl.getShaderInfoLog()")}}, then delete the shader and return `null` to indicate a failure to load the shader.
 5. If the shader was loaded and successfully compiled, the compiled shader is returned to the caller.
 
-> **Note:** Add this code to your `main()` function:
+> [!NOTE]
+> Add this code to your `main()` function:
 
 ```js
 // Initialize a shader program; this is where all the lighting
@@ -175,7 +180,8 @@ const shaderProgram = initShaderProgram(gl, vsSource, fsSource);
 
 After we've created a shader program we need to look up the locations that WebGL assigned to our inputs. In this case we have one attribute and two uniforms. Attributes receive values from buffers. Each iteration of the vertex shader receives the next value from the buffer assigned to that attribute. [Uniforms](/en-US/docs/Web/API/WebGL_API/Data#uniforms) are similar to JavaScript global variables. They stay the same value for all iterations of a shader. Since the attribute and uniform locations are specific to a single shader program we'll store them together to make them easy to pass around
 
-> **Note:** Add this code to your `main()` function:
+> [!NOTE]
+> Add this code to your `main()` function:
 
 ```js
 // Collect all the info needed to use the shader program.
@@ -199,7 +205,8 @@ Before we can render our square plane, we need to create the buffer that contain
 
 We'll do that using a function we call `initBuffers()`, which we will implement in a separate [JavaScript module](/en-US/docs/Web/JavaScript/Guide/Modules). As we explore more advanced WebGL concepts, this module will be augmented to create more — and more complex — 3D objects.
 
-> **Note:** Create a new file called "init-buffers.js", and give it the following contents:
+> [!NOTE]
+> Create a new file called "init-buffers.js", and give it the following contents:
 
 ```js
 function initBuffers(gl) {
@@ -240,7 +247,8 @@ Once that's done, we create a JavaScript array containing the position for each 
 
 Once the shaders are established, the locations are looked up, and the square plane's vertex positions put in a buffer, we can actually render the scene. We'll do this in a `drawScene()` function that, again, we'll implement in a separate JavaScript module.
 
-> **Note:** Create a new file called "draw-scene.js", and give it the following contents:
+> [!NOTE]
+> Create a new file called "draw-scene.js", and give it the following contents:
 
 ```js
 function drawScene(gl, programInfo, buffers) {
@@ -338,14 +346,16 @@ Then we establish the position of the square plane by loading the identity posit
 
 Finally, let's call `initBuffers()` and `drawScene()`.
 
-> **Note:** Add this code to the start of your "webgl-demo.js" file:
+> [!NOTE]
+> Add this code to the start of your "webgl-demo.js" file:
 
 ```js
 import { initBuffers } from "./init-buffers.js";
 import { drawScene } from "./draw-scene.js";
 ```
 
-> **Note:** Add this code to the end of your `main()` function:
+> [!NOTE]
+> Add this code to the end of your `main()` function:
 
 ```js
 // Here's where we call the routine that builds all the

--- a/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -10,7 +10,8 @@ page-type: guide
 
 In this example, we'll actually rotate our camera. By doing so, it will look as if we are rotating the square. First we'll need some variables in which to track the current rotation of the camera.
 
-> **Note:** Add this code at the start of your "webgl-demo.js" script:
+> [!NOTE]
+> Add this code at the start of your "webgl-demo.js" script:
 
 ```js
 let squareRotation = 0.0;
@@ -19,13 +20,15 @@ let deltaTime = 0;
 
 Now we need to update the `drawScene()` function to apply the current rotation to the camera when drawing it. After translating the camera to the initial drawing position for the square, we apply the rotation.
 
-> **Note:** In your "draw-scene.js" module, update the declaration of your `drawScene()` function so it can be passed the rotation to use:
+> [!NOTE]
+> In your "draw-scene.js" module, update the declaration of your `drawScene()` function so it can be passed the rotation to use:
 
 ```js-nolint
 function drawScene(gl, programInfo, buffers, squareRotation) {
 ```
 
-> **Note:** In your `drawScene()` function, right after the line `mat4.translate()` call, add this code:
+> [!NOTE]
+> In your `drawScene()` function, right after the line `mat4.translate()` call, add this code:
 
 ```js
 mat4.rotate(
@@ -40,7 +43,8 @@ This rotates the modelViewMatrix by the current value of `squareRotation`, aroun
 
 To actually animate, we need to add code that changes the value of `squareRotation` over time.
 
-> **Note:** Add this code at the end of your `main()` function, replacing the existing `drawScene()` call:
+> [!NOTE]
+> Add this code at the end of your `main()` function, replacing the existing `drawScene()` call:
 
 ```js
 let then = 0;

--- a/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -12,14 +12,16 @@ In this demonstration, we build upon the previous example by replacing our stati
 
 The first step is to create the {{ HTMLElement("video") }} element that we'll use to retrieve the video frames.
 
-> **Note:** Add this declaration to that start of your "webgl-demo.js" script:
+> [!NOTE]
+> Add this declaration to that start of your "webgl-demo.js" script:
 
 ```js
 // will set to true when video can be copied to texture
 let copyVideo = false;
 ```
 
-> **Note:** Add this function your "webgl-demo.js" script:
+> [!NOTE]
+> Add this function your "webgl-demo.js" script:
 
 ```js
 function setupVideo(url) {
@@ -76,7 +78,8 @@ The video must be loaded from a secure source in order to be used to provide tex
 
 The next change is to initialize the texture, which becomes much simpler, since we no longer need to load an image file. Instead, we create an empty texture object, put a single pixel in it, and set its filtering for later use.
 
-> **Note:** Replace the `loadTexture()` function in "webgl-demo.js" with the following code:
+> [!NOTE]
+> Replace the `loadTexture()` function in "webgl-demo.js" with the following code:
 
 ```js
 function initTexture(gl) {
@@ -117,7 +120,8 @@ function initTexture(gl) {
 }
 ```
 
-> **Note:** Add the following function to "webgl-demo.js":
+> [!NOTE]
+> Add the following function to "webgl-demo.js":
 
 ```js
 function updateTexture(gl, texture, video) {
@@ -141,16 +145,19 @@ You've seen this code before. It's nearly identical to the image onload function
 
 Next, we need to call these new functions from our `main()` function.
 
-> **Note:** In your `main()` function, replace the call to `loadTexture()` with this code:
+> [!NOTE]
+> In your `main()` function, replace the call to `loadTexture()` with this code:
 
 ```js
 const texture = initTexture(gl);
 const video = setupVideo("Firefox.mp4");
 ```
 
-> **Note:** You'll also need to download the [Firefox.mp4](https://github.com/mdn/dom-examples/blob/main/webgl-examples/tutorial/sample8/Firefox.mp4) file to the same local directory as your JavaScript files.
+> [!NOTE]
+> You'll also need to download the [Firefox.mp4](https://github.com/mdn/dom-examples/blob/main/webgl-examples/tutorial/sample8/Firefox.mp4) file to the same local directory as your JavaScript files.
 
-> **Note:** In your `main()` function, replace the `render()` function with this:
+> [!NOTE]
+> In your `main()` function, replace the `render()` function with this:
 
 ```js
 // Draw the scene repeatedly

--- a/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -14,7 +14,8 @@ Consider: each face requires four vertices to define it, but each vertex is shar
 
 First, let's build the cube's vertex position buffer by updating the code in `initBuffers()`. This is pretty much the same as it was for the square plane, but somewhat longer since there are 24 vertices (4 per side).
 
-> **Note:** In the `initPositionBuffer()` function of your "init-buffers.js" module, replace the `positions` declaration with this code:
+> [!NOTE]
+> In the `initPositionBuffer()` function of your "init-buffers.js" module, replace the `positions` declaration with this code:
 
 ```js
 const positions = [
@@ -40,7 +41,8 @@ const positions = [
 
 Since we've added a z-component to our vertices, we need to update the `numComponents` of our `vertexPosition` attribute to 3.
 
-> **Note:** In the `setPositionAttribute()` function of your "draw-scene.js" module, change the `numComponents` constant from `2` to `3`:
+> [!NOTE]
+> In the `setPositionAttribute()` function of your "draw-scene.js" module, change the `numComponents` constant from `2` to `3`:
 
 ```js
 const numComponents = 3;
@@ -50,7 +52,8 @@ const numComponents = 3;
 
 We also need to build an array of colors for each of the 24 vertices. This code starts by defining a color for each face, then uses a loop to assemble an array of all the colors for each of the vertices.
 
-> **Note:** In the `initColorBuffer()` function of your "init-buffers.js" module, replace the `colors` declaration with this code:
+> [!NOTE]
+> In the `initColorBuffer()` function of your "init-buffers.js" module, replace the `colors` declaration with this code:
 
 ```js
 const faceColors = [
@@ -77,7 +80,8 @@ for (var j = 0; j < faceColors.length; ++j) {
 
 Once the vertex arrays are generated, we need to build the element array.
 
-> **Note:** In your "init-buffer.js" module, add the following function:
+> [!NOTE]
+> In your "init-buffer.js" module, add the following function:
 
 ```js
 function initIndexBuffer(gl) {
@@ -143,7 +147,8 @@ The `indices` array defines each face like a pair of triangles, specifying each 
 
 Next, you need to call this new function from `initBuffers()`, and return the buffer it creates.
 
-> **Note:** At the end of the `initBuffers()` function of your "init-buffers.js" module, add the following code, replacing the existing `return` statement:
+> [!NOTE]
+> At the end of the `initBuffers()` function of your "init-buffers.js" module, add the following code, replacing the existing `return` statement:
 
 ```js
 const indexBuffer = initIndexBuffer(gl);
@@ -159,14 +164,16 @@ return {
 
 Next we need to add code to our `drawScene()` function to draw using the cube's index buffer, adding new {{domxref("WebGLRenderingContext.bindBuffer()", "gl.bindBuffer()")}} and {{domxref("WebGLRenderingContext.drawElements()", "gl.drawElements()")}} calls.
 
-> **Note:** In your `drawScene()` function, add the following code just before the `gl.useProgram` line:
+> [!NOTE]
+> In your `drawScene()` function, add the following code just before the `gl.useProgram` line:
 
 ```js
 // Tell WebGL which indices to use to index the vertices
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers.indices);
 ```
 
-> **Note:** In the `drawScene()` function of your "draw-scene.js" module, replace the block just after the two `gl.uniformMatrix4fv` calls, that contains the `gl.drawArrays()` line, with the following block:
+> [!NOTE]
+> In the `drawScene()` function of your "draw-scene.js" module, replace the block just after the two `gl.uniformMatrix4fv` calls, that contains the `gl.drawArrays()` line, with the following block:
 
 ```js
 {
@@ -181,19 +188,22 @@ Since each face of our cube is comprised of two triangles, there are 6 vertices 
 
 Finally, let's replace our variable `squareRotation` by `cubeRotation` and add a second rotation around the x axis.
 
-> **Note:** At the start of your "webgl-demo.js" file, replace the `squareRotation` declaration with this line:
+> [!NOTE]
+> At the start of your "webgl-demo.js" file, replace the `squareRotation` declaration with this line:
 
 ```js
 let cubeRotation = 0.0;
 ```
 
-> **Note:** In your `drawScene()` function declaration, replace the `squareRotation` with `cubeRotation`:
+> [!NOTE]
+> In your `drawScene()` function declaration, replace the `squareRotation` with `cubeRotation`:
 
 ```js-nolint
 function drawScene(gl, programInfo, buffers, cubeRotation) {
 ```
 
-> **Note:** In your `drawScene()` function, replace the `mat4.rotate` call with the following code:
+> [!NOTE]
+> In your `drawScene()` function, replace the `mat4.rotate` call with the following code:
 
 ```js
 mat4.rotate(
@@ -216,7 +226,8 @@ mat4.rotate(
 ); // axis to rotate around (X)
 ```
 
-> **Note:** In your `main()` function, replace the code that calls `drawScene()` and updates `squareRotation` to pass in and update `cubeRotation` instead:
+> [!NOTE]
+> In your `main()` function, replace the code that calls `drawScene()` and updates `squareRotation` to pass in and update `cubeRotation` instead:
 
 ```js
 drawScene(gl, programInfo, buffers, cubeRotation);

--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -33,7 +33,8 @@ Then we update the vertex shader to adjust the color of each vertex, taking into
 
 The first thing we need to do is generate the array of normals for all the vertices that comprise our cube. Since a cube is a very simple object, this is easy to do; obviously for more complex objects, calculating the normals will be more involved.
 
-> **Note:** Add this function to your "init-buffer.js" module:
+> [!NOTE]
+> Add this function to your "init-buffer.js" module:
 
 ```js
 function initNormalBuffer(gl) {
@@ -74,7 +75,8 @@ This should look pretty familiar by now; we create a new buffer, bind it to be t
 
 As before, we have updated `initBuffers()` to call our new function, and to return the buffer it created.
 
-> **Note:** At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
+> [!NOTE]
+> At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
 
 ```js
 const normalBuffer = initNormalBuffer(gl);
@@ -89,7 +91,8 @@ return {
 
 Then we add the code to the "draw-scene.js" module to bind the normals array to a shader attribute so the shader code can get access to it.
 
-> **Note:** Add this function to your "draw-scene.js" module:
+> [!NOTE]
+> Add this function to your "draw-scene.js" module:
 
 ```js
 // Tell WebGL how to pull out the normals from
@@ -113,7 +116,8 @@ function setNormalAttribute(gl, buffers, programInfo) {
 }
 ```
 
-> **Note:** Add this line to the `drawScene()` function of your "draw-scene.js" module, just before the `gl.useProgram()` line:
+> [!NOTE]
+> Add this line to the `drawScene()` function of your "draw-scene.js" module, just before the `gl.useProgram()` line:
 
 ```js
 setNormalAttribute(gl, buffers, programInfo);
@@ -121,7 +125,8 @@ setNormalAttribute(gl, buffers, programInfo);
 
 Finally, we need to update the code that builds the uniform matrices to generate and deliver to the shader a **normal matrix**, which is used to transform the normals when dealing with the current orientation of the cube in relation to the light source.
 
-> **Note:** Add the following code to the `drawScene()` function of your "draw-scene.js" module, just after the three `mat4.rotate()` calls:
+> [!NOTE]
+> Add the following code to the `drawScene()` function of your "draw-scene.js" module, just after the three `mat4.rotate()` calls:
 
 ```js
 const normalMatrix = mat4.create();
@@ -129,7 +134,8 @@ mat4.invert(normalMatrix, modelViewMatrix);
 mat4.transpose(normalMatrix, normalMatrix);
 ```
 
-> **Note:** Add the following code to the `drawScene()` function of your "draw-scene.js" module, just after the two previous `gl.uniformMatrix4fv()` calls:
+> [!NOTE]
+> Add the following code to the `drawScene()` function of your "draw-scene.js" module, just after the two previous `gl.uniformMatrix4fv()` calls:
 
 ```js
 gl.uniformMatrix4fv(
@@ -147,7 +153,8 @@ Now that all the data the shaders need is available to them, we need to update t
 
 The first thing to do is update the vertex shader so it generates a shading value for each vertex based on the ambient lighting as well as the directional lighting.
 
-> **Note:** Update the `vsSource` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `vsSource` declaration in your `main()` function like this:
 
 ```js
 const vsSource = `
@@ -190,7 +197,8 @@ Once the amount of directional lighting is computed, we can generate the lightin
 
 The fragment shader now needs to be updated to take into account the lighting value computed by the vertex shader.
 
-> **Note:** Update the `fsSource` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `fsSource` declaration in your `main()` function like this:
 
 ```js
 const fsSource = `
@@ -211,7 +219,8 @@ Here we fetch the color of the texel, just like we did in the previous example, 
 
 The only thing left is to look up the location of the `aVertexNormal` attribute and the `uNormalMatrix` uniform.
 
-> **Note:** Update the `programInfo` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `programInfo` declaration in your `main()` function like this:
 
 ```js
 const programInfo = {

--- a/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -14,7 +14,8 @@ In WebGL objects are built using sets of vertices, each of which has a position 
 
 Let's say we want to render a gradient in which each corner of the square is a different color: red, blue, green, and white. The first thing to do is to establish these colors for the four vertices. To do this, we first need to create an array of vertex colors, then store it into a WebGL buffer.
 
-> **Note:** Add the following function to your `init-buffers.js` module:
+> [!NOTE]
+> Add the following function to your `init-buffers.js` module:
 
 ```js
 function initColorBuffer(gl) {
@@ -49,7 +50,8 @@ This code starts by creating a JavaScript array containing four 4-value vectors,
 
 Of course, we also need to call this new function from `initBuffers()`, and return the new buffer it creates.
 
-> **Note:** At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
+> [!NOTE]
+> At the end of your `initBuffers()` function, add the following code, replacing the existing `return` statement:
 
 ```js
 const colorBuffer = initColorBuffer(gl);
@@ -62,7 +64,8 @@ return {
 
 To use these colors, the vertex shader needs to be updated to pull the appropriate color from the color buffer.
 
-> **Note:** Update the `vsSource` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `vsSource` declaration in your `main()` function like this:
 
 ```js
 // Vertex shader program
@@ -89,7 +92,8 @@ The key difference here is that for each vertex, we pass its color using a `vary
 
 In order to pick up the interpolated color for each pixel, we need to change the fragment shader to fetch the value from the `vColor` varying.
 
-> **Note:** Update the `fsSource` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `fsSource` declaration in your `main()` function like this:
 
 ```js
 // Fragment shader program
@@ -109,7 +113,8 @@ Each fragment receives the interpolated color based on its position relative to 
 
 Next, you need to add code to look up the attribute location for the colors and set up that attribute for the shader program.
 
-> **Note:** Update the `programInfo` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `programInfo` declaration in your `main()` function like this:
 
 ```js
 // Collect all the info needed to use the shader program.
@@ -131,7 +136,8 @@ const programInfo = {
 
 Next, `drawScene()` needs to use these colors when drawing the square.
 
-> **Note:** Add the following function to your `draw-scene.js` module:
+> [!NOTE]
+> Add the following function to your `draw-scene.js` module:
 
 ```js
 // Tell WebGL how to pull out the colors from the color buffer
@@ -155,7 +161,8 @@ function setColorAttribute(gl, buffers, programInfo) {
 }
 ```
 
-> **Note:** Call the `setColorAttribute()` function from `drawScene()`, right before the `gl.useProgram()` call:
+> [!NOTE]
+> Call the `setColorAttribute()` function from `drawScene()`, right before the `gl.useProgram()` call:
 
 ```js
 setColorAttribute(gl, buffers, programInfo);

--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -12,9 +12,11 @@ Now that our sample program has a rotating 3D cube, let's map a texture onto it 
 
 The first thing to do is add code to load the textures. In our case, we'll be using a single texture, mapped onto all six sides of our rotating cube, but the same technique can be used for any number of textures.
 
-> **Note:** It's important to note that the loading of textures follows [cross-domain rules](/en-US/docs/Web/HTTP/CORS); that is, you can only load textures from sites for which your content has CORS approval. See [Cross-domain textures below](#cross-domain_textures) for details.
+> [!NOTE]
+> It's important to note that the loading of textures follows [cross-domain rules](/en-US/docs/Web/HTTP/CORS); that is, you can only load textures from sites for which your content has CORS approval. See [Cross-domain textures below](#cross-domain_textures) for details.
 
-> **Note:** Add these two functions to your "webgl-demo.js" script:
+> [!NOTE]
+> Add these two functions to your "webgl-demo.js" script:
 
 ```js
 //
@@ -113,7 +115,8 @@ But also note: Browsers copy pixels from the loaded image in top-to-bottom order
 
 So in order to prevent the resulting image texture from having the wrong orientation when rendered, we also need call [`pixelStorei()`](/en-US/docs/Web/API/WebGLRenderingContext/pixelStorei) with the `gl.UNPACK_FLIP_Y_WEBGL` parameter set to `true` — to cause the pixels to be flipped into the bottom-to-top order that WebGL expects.
 
-> **Note:** Add the following code to your `main()` function, right after the call to `initBuffers()`:
+> [!NOTE]
+> Add the following code to your `main()` function, right after the call to `initBuffers()`:
 
 ```js
 // Load texture
@@ -122,13 +125,15 @@ const texture = loadTexture(gl, "cubetexture.png");
 gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
 ```
 
-> **Note:** Finally, download the [cubetexture.png](https://raw.githubusercontent.com/mdn/dom-examples/main/webgl-examples/tutorial/sample6/cubetexture.png) file to the same local directory as your JavaScript files.
+> [!NOTE]
+> Finally, download the [cubetexture.png](https://raw.githubusercontent.com/mdn/dom-examples/main/webgl-examples/tutorial/sample6/cubetexture.png) file to the same local directory as your JavaScript files.
 
 ## Mapping the texture onto the faces
 
 At this point, the texture is loaded and ready to use. But before we can use it, we need to establish the mapping of the texture coordinates to the vertices of the faces of our cube. This replaces all the previously existing code for configuring colors for each of the cube's faces in `initBuffers()`.
 
-> **Note:** Add this function to your "init-buffer.js" module:
+> [!NOTE]
+> Add this function to your "init-buffer.js" module:
 
 ```js
 function initTextureBuffer(gl) {
@@ -170,13 +175,15 @@ Then we return the new buffer.
 
 Next, we need to update `initBuffers()` to create and return the texture coordinates buffer instead of the color buffer.
 
-> **Note:** In the `initBuffers()` function of your "init-buffers.js" module, replace the call to `initColorBuffer()` with the following line:
+> [!NOTE]
+> In the `initBuffers()` function of your "init-buffers.js" module, replace the call to `initColorBuffer()` with the following line:
 
 ```js
 const textureCoordBuffer = initTextureBuffer(gl);
 ```
 
-> **Note:** In the `initBuffers()` function of your "init-buffers.js" module, replace the `return` statement with the following:
+> [!NOTE]
+> In the `initBuffers()` function of your "init-buffers.js" module, replace the `return` statement with the following:
 
 ```js
 return {
@@ -194,7 +201,8 @@ The shader program also needs to be updated to use the textures instead of solid
 
 We need to replace the vertex shader so that instead of fetching color data, it instead fetches the texture coordinate data.
 
-> **Note:** Update the `vsSource` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `vsSource` declaration in your `main()` function like this:
 
 ```js
 const vsSource = `
@@ -219,7 +227,8 @@ The key change here is that instead of fetching the vertex color, we're fetching
 
 The fragment shader likewise needs to be updated.
 
-> **Note:** Update the `fsSource` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `fsSource` declaration in your `main()` function like this:
 
 ```js
 const fsSource = `
@@ -240,7 +249,8 @@ Instead of assigning a color value to the fragment's color, the fragment's color
 
 Because we changed an attribute and added a uniform we need to look up their locations.
 
-> **Note:** Update the `programInfo` declaration in your `main()` function like this:
+> [!NOTE]
+> Update the `programInfo` declaration in your `main()` function like this:
 
 ```js
 const programInfo = {
@@ -261,7 +271,8 @@ const programInfo = {
 
 The changes to the `drawScene()` function are simple.
 
-> **Note:** In the `drawScene()` function of your "draw-scene.js" module, add the following function:
+> [!NOTE]
+> In the `drawScene()` function of your "draw-scene.js" module, add the following function:
 
 ```js
 // tell webgl how to pull out the texture coordinates from buffer
@@ -284,7 +295,8 @@ function setTextureAttribute(gl, buffers, programInfo) {
 }
 ```
 
-> **Note:** In the `drawScene()` function of your "draw-scene.js" module, replace the call to `setColorAttribute()` with the following line:
+> [!NOTE]
+> In the `drawScene()` function of your "draw-scene.js" module, replace the call to `setColorAttribute()` with the following line:
 
 ```js
 setTextureAttribute(gl, buffers, programInfo);
@@ -292,7 +304,8 @@ setTextureAttribute(gl, buffers, programInfo);
 
 Then add code to specify the texture to map onto the faces.
 
-> **Note:** In your `drawScene()` function, just after the two calls to `gl.uniformMatrix4fv()`, add the following code:
+> [!NOTE]
+> In your `drawScene()` function, just after the two calls to `gl.uniformMatrix4fv()`, add the following code:
 
 ```js
 // Tell WebGL we want to affect texture unit 0
@@ -309,13 +322,15 @@ WebGL provides a minimum of 8 texture units; the first of these is `gl.TEXTURE0`
 
 Lastly, add `texture` as a parameter to the `drawScene()` function, both where it is defined and where it is called.
 
-> **Note:** Update the declaration of your `drawScene()` function to add the new parameter:
+> [!NOTE]
+> Update the declaration of your `drawScene()` function to add the new parameter:
 
 ```js-nolint
 function drawScene(gl, programInfo, buffers, texture, cubeRotation) {
 ```
 
-> **Note:** Update the place in your `main()` function where you call `drawScene()`:
+> [!NOTE]
+> Update the place in your `main()` function where you call `drawScene()`:
 
 ```js
 drawScene(gl, programInfo, buffers, texture, cubeRotation);

--- a/files/en-us/web/api/webgl_api/using_extensions/index.md
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 WebGL, like its sister APIs (OpenGL and OpenGL ES), supports extensions. A complete list of extensions is available in the [khronos webgl extension registry](https://www.khronos.org/registry/webgl/extensions/).
 
-> **Note:** In WebGL, unlike in other GL APIs, extensions are only available if explicitly requested.
+> [!NOTE]
+> In WebGL, unlike in other GL APIs, extensions are only available if explicitly requested.
 
 ## Canonical extension names, vendor prefixes and preferences
 

--- a/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article explores how to take data within a [WebGL](/en-US/docs/Web/API/WebGL_API) project, and project it into the proper spaces to display it on the screen. It assumes a knowledge of basic matrix math using translation, scale, and rotation matrices. It explains the three core matrices that are typically used when composing a 3D scene: the model, view and projection matrices.
 
-> **Note:** This article is also available as an [MDN content kit](https://github.com/gregtatum/mdn-model-view-projection). It also uses a collection of [utility functions](https://github.com/gregtatum/mdn-webgl) available under the `MDN` global object.
+> [!NOTE]
+> This article is also available as an [MDN content kit](https://github.com/gregtatum/mdn-model-view-projection). It also uses a collection of [utility functions](https://github.com/gregtatum/mdn-webgl) available under the `MDN` global object.
 
 ## The model, view, and projection matrices
 
@@ -32,7 +33,8 @@ For this section we will put our data into the clip space coordinate system dire
 
 This example will create a custom `WebGLBox` object that will draw a 2D box on the screen.
 
-> **Note:** The code for each WebGLBox example is available in this [GitHub repo](https://github.com/gregtatum/mdn-model-view-projection/tree/master/lessons) and is organized by section. In addition there is a JSFiddle link at the bottom of each section.
+> [!NOTE]
+> The code for each WebGLBox example is available in this [GitHub repo](https://github.com/gregtatum/mdn-model-view-projection/tree/master/lessons) and is organized by section. In addition there is a JSFiddle link at the bottom of each section.
 
 #### WebGLBox constructor
 
@@ -410,7 +412,8 @@ In the shader, each position vertex is first transformed into a homogeneous coor
 gl_Position = model * vec4(position, 1.0);
 ```
 
-> **Note:** In JavaScript, matrix multiplication requires a custom function, while in the shader it is built into the language with the simple \* operator.
+> [!NOTE]
+> In JavaScript, matrix multiplication requires a custom function, while in the shader it is built into the language with the simple \* operator.
 
 ### The results
 

--- a/files/en-us/web/api/webgl_color_buffer_float/index.md
+++ b/files/en-us/web/api/webgl_color_buffer_float/index.md
@@ -12,7 +12,8 @@ The **`WEBGL_color_buffer_float`** extension is part of the [WebGL API](/en-US/d
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} contexts only. For {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}}, use the {{domxref("EXT_color_buffer_float")}} extension.
+> [!NOTE]
+> This extension is available to {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} contexts only. For {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}}, use the {{domxref("EXT_color_buffer_float")}} extension.
 >
 > The {{domxref("OES_texture_float")}} extension implicitly enables this extension.
 

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.md
@@ -14,7 +14,8 @@ For more information, see the article [Using ASTC Texture Compression for Game A
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** ASTC compression is typically available on Mali ARM GPUs, Intel GPUs, and NVIDIA Tegra chips.
+> [!NOTE]
+> ASTC compression is typically available on Mali ARM GPUs, Intel GPUs, and NVIDIA Tegra chips.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 

--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.md
@@ -14,7 +14,8 @@ Compressed textures reduce the amount of memory needed to store a texture on the
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Constants
 

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.md
@@ -14,7 +14,8 @@ Compressed textures reduce the amount of memory needed to store a texture on the
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Constants
 

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
@@ -14,12 +14,14 @@ Compressed textures reduce the amount of memory needed to store a texture on the
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** PVRTC is typically only available on mobile devices with PowerVR chipsets.
+> [!NOTE]
+> PVRTC is typically only available on mobile devices with PowerVR chipsets.
 > It is used in all generations of the iPhone, iPod Touch and iPad and supported on certain Android devices that use a PowerVR GPU.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
-> **Note:** On iOS devices, this extension is named `WEBKIT_WEBGL_compressed_texture_pvrtc`.
+> [!NOTE]
+> On iOS devices, this extension is named `WEBKIT_WEBGL_compressed_texture_pvrtc`.
 
 ## Constants
 

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc/index.md
@@ -14,7 +14,8 @@ Compressed textures reduce the amount of memory needed to store a texture on the
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Constants
 

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.md
@@ -14,7 +14,8 @@ Compressed textures reduce the amount of memory needed to store a texture on the
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Constants
 

--- a/files/en-us/web/api/webgl_debug_renderer_info/index.md
+++ b/files/en-us/web/api/webgl_debug_renderer_info/index.md
@@ -14,7 +14,8 @@ Depending on the privacy settings of the browser, this extension might only be a
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** Depending on the privacy settings of the browser, this extension might only be available to privileged contexts or not work at all. In Firefox, if `privacy.resistFingerprinting` is set to `true`, this extensions is disabled.
+> [!NOTE]
+> Depending on the privacy settings of the browser, this extension might only be available to privileged contexts or not work at all. In Firefox, if `privacy.resistFingerprinting` is set to `true`, this extensions is disabled.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 

--- a/files/en-us/web/api/webgl_debug_shaders/index.md
+++ b/files/en-us/web/api/webgl_debug_shaders/index.md
@@ -14,7 +14,8 @@ This extension is not directly available to websites as the way of how the shade
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** Depending on the privacy settings of the browser, this extension might only be available to privileged contexts.
+> [!NOTE]
+> Depending on the privacy settings of the browser, this extension might only be available to privileged contexts.
 >
 > This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 

--- a/files/en-us/web/api/webgl_depth_texture/index.md
+++ b/files/en-us/web/api/webgl_depth_texture/index.md
@@ -12,7 +12,8 @@ The **`WEBGL_depth_texture`** extension is part of the [WebGL API](/en-US/docs/W
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is `gl.UNSIGNED_INT_24_8`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. The constant in WebGL2 is `gl.UNSIGNED_INT_24_8`.
 
 ## Constants
 
@@ -33,7 +34,8 @@ This extension extends {{domxref("WebGLRenderingContext.framebufferTexture2D()")
 
 - The `attachment` parameter now accepts `gl.DEPTH_STENCIL_ATTACHMENT`.
 
-> **Note:** Incorrectly stated as the `target` parameter in the specification, see <https://www.khronos.org/bugzilla/show_bug.cgi?id=674>.
+> [!NOTE]
+> Incorrectly stated as the `target` parameter in the specification, see <https://www.khronos.org/bugzilla/show_bug.cgi?id=674>.
 
 ## Examples
 

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
@@ -14,7 +14,8 @@ the draw buffers to which all fragment colors are written.
 
 This method is part of the {{domxref("WEBGL_draw_buffers")}} extension.
 
-> **Note:** When using {{domxref("WebGL2RenderingContext", "WebGL2")}},
+> [!NOTE]
+> When using {{domxref("WebGL2RenderingContext", "WebGL2")}},
 > this method is available as {{domxref("WebGL2RenderingContext.drawBuffers()", "gl.drawBuffers()")}}
 > by default and the constants are named `gl.COLOR_ATTACHMENT1` etc. without the "WEBGL" suffix.
 

--- a/files/en-us/web/api/webgl_draw_buffers/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/index.md
@@ -12,7 +12,8 @@ The **`WEBGL_draw_buffers`** extension is part of the [WebGL API](/en-US/docs/We
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constants are available without the "WEBGL" suffix and the new GLSL built-ins require GLSL `#version 300 es`.
+> [!NOTE]
+> This extension is only available to {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts. In {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}}, the functionality of this extension is available on the WebGL2 context by default. In WebGL 2, the constants are available without the "WEBGL" suffix and the new GLSL built-ins require GLSL `#version 300 es`.
 
 ## Constants
 

--- a/files/en-us/web/api/webgl_lose_context/index.md
+++ b/files/en-us/web/api/webgl_lose_context/index.md
@@ -12,7 +12,8 @@ The **WEBGL_lose_context** extension is part of the [WebGL API](/en-US/docs/Web/
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
-> **Note:** This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
+> [!NOTE]
+> This extension is available to both, {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} and {{domxref("WebGL2RenderingContext", "WebGL2", "", 1)}} contexts.
 
 ## Instance methods
 

--- a/files/en-us/web/api/webgl_multi_draw/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/index.md
@@ -19,7 +19,8 @@ When this extension is enabled:
   (see method list below).
 - The `gl_DrawID` built-in is added to the shading language.
 
-> **Note:** This extension is available to both,
+> [!NOTE]
+> This extension is available to both,
 > {{domxref("WebGLRenderingContext", "WebGL 1", "", 1)}} and
 > {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.
 >

--- a/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/webglcontextevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.WebGLContextEvent.WebGLContextEvent
 
 The **`WebGLContextEvent()`** constructor creates a new {{domxref("WebGLContextEvent")}} object.
 
-> **Note:** You typically don't need to call this constructor; the browser creates these objects automatically when WebGL context events get fired. To manually trigger a `webglcontextlost` event, use {{domxref("WEBGL_lose_context.loseContext()")}}.
+> [!NOTE]
+> You typically don't need to call this constructor; the browser creates these objects automatically when WebGL context events get fired. To manually trigger a `webglcontextlost` event, use {{domxref("WEBGL_lose_context.loseContext()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
@@ -12,7 +12,8 @@ The {{domxref("WebGLRenderingContext")}} method
 **`enableVertexAttribArray()`**, part of the [WebGL API](/en-US/docs/Web/API/WebGL_API), turns on the generic vertex
 attribute array at the specified index into the list of attribute arrays.
 
-> **Note:** You can disable the attribute array by calling
+> [!NOTE]
+> You can disable the attribute array by calling
 > {{domxref("WebGLRenderingContext.disableVertexAttribArray", "disableVertexAttribArray()")}}.
 
 In WebGL, values that apply to a specific vertex are stored in [attributes](/en-US/docs/Web/API/WebGL_API/Data#attributes). These are only
@@ -77,7 +78,8 @@ gl.vertexAttribPointer(
 gl.drawArrays(gl.TRIANGLES, 0, vertexCount);
 ```
 
-> **Note:** This code snippet is taken from [the function `animateScene()`](/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) in "A basic 2D WebGL animation example." See
+> [!NOTE]
+> This code snippet is taken from [the function `animateScene()`](/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) in "A basic 2D WebGL animation example." See
 > that article for the full sample and to see the resulting animation in action.
 
 This code sets the buffer of vertexes that will be used to draw the triangles of the

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -79,7 +79,8 @@ The `WebGLUniformLocation` is an opaque value used to uniquely identify the
 location in the GPU's memory at which the uniform variable is located. With this value
 in hand, you can call other WebGL methods to access the value of the uniform variable.
 
-> **Note:** The `WebGLUniformLocation` type is compatible with the
+> [!NOTE]
+> The `WebGLUniformLocation` type is compatible with the
 > `GLint` type when specifying the index or location of a uniform
 > attribute.
 
@@ -112,7 +113,8 @@ gl.uniform2fv(uRotationVector, currentRotation);
 gl.uniform4fv(uGlobalColor, [0.1, 0.7, 0.2, 1.0]);
 ```
 
-> **Note:** This code snippet is taken from [the function `animateScene()`](/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) in "A basic 2D WebGL animation example."
+> [!NOTE]
+> This code snippet is taken from [the function `animateScene()`](/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#drawing_and_animating_the_scene) in "A basic 2D WebGL animation example."
 > See that article for the full sample and to see the resulting animation in action.
 
 After setting the current shading program to `shaderProgram`, this code

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
@@ -11,7 +11,8 @@ browser-compat: api.WebGLRenderingContext.lineWidth
 The **`WebGLRenderingContext.lineWidth()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) sets the line width of rasterized
 lines.
 
-> **Warning:** The webgl spec, based on the OpenGL ES 2.0/3.0 specs points out that the minimum and
+> [!WARNING]
+> The webgl spec, based on the OpenGL ES 2.0/3.0 specs points out that the minimum and
 > maximum width for a line is implementation defined. The maximum minimum width is
 > allowed to be 1.0. The minimum maximum width is also allowed to be 1.0. Because of
 > these implementation defined limits it is not recommended to use line widths other

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -15,7 +15,8 @@ when the program object is linked successfully. They retain the values assigned 
 by a call to this method until the next successful link operation occurs on the program
 object, when they are once again initialized to 0.
 
-> **Note:** Many of the functions described here have expanded WebGL 2 interfaces, which can be
+> [!NOTE]
+> Many of the functions described here have expanded WebGL 2 interfaces, which can be
 > found under
 > [`WebGL2RenderingContext.uniform[1234][uif][v]()`](/en-US/docs/Web/API/WebGL2RenderingContext/uniform).
 

--- a/files/en-us/web/api/webglvertexarrayobject/index.md
+++ b/files/en-us/web/api/webglvertexarrayobject/index.md
@@ -18,7 +18,8 @@ When working with `WebGLVertexArrayObject` objects, the following methods are us
 - {{domxref("WebGL2RenderingContext.isVertexArray()")}}
 - {{domxref("WebGL2RenderingContext.bindVertexArray()")}}
 
-> **Note:** The {{domxref("OES_vertex_array_object")}} extension allows you to use vertex array objects in a WebGL 1 context.
+> [!NOTE]
+> The {{domxref("OES_vertex_array_object")}} extension allows you to use vertex array objects in a WebGL 1 context.
 
 ## Examples
 

--- a/files/en-us/web/api/webgpu_api/index.md
+++ b/files/en-us/web/api/webgpu_api/index.md
@@ -39,7 +39,8 @@ There are several layers of abstraction between a device GPU and a web browser r
   - Discrete GPUs, which live on their own board, separate from the CPU.
   - Software "GPUs", implemented on the CPU.
 
-  > **Note:** The above diagram assumes a device with only one GPU.
+  > [!NOTE]
+  > The above diagram assumes a device with only one GPU.
 
 - A native GPU API, which is part of the OS (e.g. Metal on macOS), is a programming interface allowing native applications to use the capabilities of the GPU. API instructions are sent to the GPU (and responses received) via a driver. It is possible for a system to have multiple native OS APIs and drivers available to communicate with the GPU, although the above diagram assumes a device with only one native API/driver.
 - A browser's WebGPU implementation handles communicating with the GPU via a native GPU API driver. A WebGPU adapter effectively represents a physical GPU and driver available on the underlying system, in your code.
@@ -134,7 +135,8 @@ fn fragment_main(fragData: VertexOut) -> @location(0) vec4f
 `;
 ```
 
-> **Note:** In our demos we are storing our shader code inside a template literal, but you can store it anywhere from which it can easily be retrieved as text to be fed into your WebGPU program. For example, another common practice is to store shaders inside a {{htmlelement("script")}} element and retrieve the contents using {{domxref("Node.textContent")}}. The correct mime type to use for WGSL is `text/wgsl`.
+> [!NOTE]
+> In our demos we are storing our shader code inside a template literal, but you can store it anywhere from which it can easily be retrieved as text to be fed into your WebGPU program. For example, another common practice is to store shaders inside a {{htmlelement("script")}} element and retrieve the contents using {{domxref("Node.textContent")}}. The correct mime type to use for WGSL is `text/wgsl`.
 
 To make your shader code available to WebGPU, you have to put it inside a {{domxref("GPUShaderModule")}} via a {{domxref("GPUDevice.createShaderModule()")}} call, passing your shader code as a property inside a descriptor object. For example:
 
@@ -161,7 +163,8 @@ context.configure({
 });
 ```
 
-> **Note:** The best practice for determining the texture format is to use the {{domxref("GPU.getPreferredCanvasFormat()")}} method; this selects the most efficient format (either `bgra8unorm` or `rgba8unorm`) for the user's device.
+> [!NOTE]
+> The best practice for determining the texture format is to use the {{domxref("GPU.getPreferredCanvasFormat()")}} method; this selects the most efficient format (either `bgra8unorm` or `rgba8unorm`) for the user's device.
 
 ### Create a buffer and write our triangle data into it
 
@@ -396,7 +399,8 @@ const bindGroup = device.createBindGroup({
 });
 ```
 
-> **Note:** You could retrieve an implicit layout to use when creating a bind group by calling the {{domxref("GPUComputePipeline.getBindGroupLayout()")}} method. There is also a version available for render pipelines: see {{domxref("GPURenderPipeline.getBindGroupLayout()")}}.
+> [!NOTE]
+> You could retrieve an implicit layout to use when creating a bind group by calling the {{domxref("GPUComputePipeline.getBindGroupLayout()")}} method. There is also a version available for render pipelines: see {{domxref("GPURenderPipeline.getBindGroupLayout()")}}.
 
 ### Create a compute pipeline
 
@@ -481,7 +485,8 @@ We have attempted to provide useful information to help you understand why error
 
 You can find more information about WebGPU error handling in the explainer — see [Object validity and destroyed-ness](https://gpuweb.github.io/gpuweb/explainer/#invalid-and-destroyed) and [Errors](https://gpuweb.github.io/gpuweb/explainer/#errors). [WebGPU Error Handling best practices](https://toji.dev/webgpu-best-practices/error-handling) provides useful real-world examples and advice.
 
-> **Note:** The historic way of handling errors in WebGL is to provide a {{domxref("WebGLRenderingContext.getError", "getError()")}} method to return error information. This is problematic in that it returns errors synchronously, which is bad for performance — each call requires a round-trip to the GPU and requires all previously issued operations to be finished. Its state model is also flat, meaning that errors can leak between unrelated code. The creators of WebGPU were determined to improve on this.
+> [!NOTE]
+> The historic way of handling errors in WebGL is to provide a {{domxref("WebGLRenderingContext.getError", "getError()")}} method to return error information. This is problematic in that it returns errors synchronously, which is bad for performance — each call requires a round-trip to the GPU and requires all previously issued operations to be finished. Its state model is also flat, meaning that errors can leak between unrelated code. The creators of WebGPU were determined to improve on this.
 
 ## Interfaces
 

--- a/files/en-us/web/api/webkitpoint/index.md
+++ b/files/en-us/web/api/webkitpoint/index.md
@@ -12,7 +12,8 @@ browser-compat: api.WebKitPoint
 
 **`Point`** is an interface which represents a point in 2-dimensional space. It is non-standard, not broadly compatible, and should not be used.
 
-> **Note:** Although it is not directly related to this defunct interface, you are probably looking for {{domxref("DOMPoint")}}.
+> [!NOTE]
+> Although it is not directly related to this defunct interface, you are probably looking for {{domxref("DOMPoint")}}.
 
 ## Instance properties
 

--- a/files/en-us/web/api/webotp_api/index.md
+++ b/files/en-us/web/api/webotp_api/index.md
@@ -62,7 +62,8 @@ Your verification code is 123456.
   - Followed by a space.
   - Followed by the OTP, preceded by a pound sign (`#`).
 
-> **Note:** The provided domain value must not include a URL schema, port, or other URL features not shown above.
+> [!NOTE]
+> The provided domain value must not include a URL schema, port, or other URL features not shown above.
 
 If the `get()` method is invoked by a third-party site embedded in an {{htmlelement("iframe")}}, the SMS structure should be:
 
@@ -96,7 +97,8 @@ Or you could specify it directly on the `<iframe>` like this:
 <iframe src="https://embedded.com/..." allow="otp-credentials"> ... </iframe>
 ```
 
-> **Note:** Where a policy forbids use of WebOTP `get()`, {{jsxref("Promise", "promises")}} returned by it will reject with a `SecurityError` {{domxref("DOMException")}}.
+> [!NOTE]
+> Where a policy forbids use of WebOTP `get()`, {{jsxref("Promise", "promises")}} returned by it will reject with a `SecurityError` {{domxref("DOMException")}}.
 
 ## Interfaces
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.md
@@ -22,7 +22,8 @@ Now our users can make a call, but they can't answer one. Let's add the next pie
 
    ![A browser prompt that asks "Do you want to answer?" with two options: "Cancel" and "Ok"](confirm_prompt.png)
 
-   > **Warning:** Since we're using a `confirm` prompt to ask the user if they want to answer the call, it's important that the browser and tab that's being called is "active", which means the window shouldn't be minimized, and the tab should be on screen and have the mouse's focus somewhere inside it. Ideally, in a production version of this app you'd create your own modal window in HTML which wouldn't have these limitations.
+   > [!WARNING]
+   > Since we're using a `confirm` prompt to ask the user if they want to answer the call, it's important that the browser and tab that's being called is "active", which means the window shouldn't be minimized, and the tab should be on screen and have the mouse's focus somewhere inside it. Ideally, in a production version of this app you'd create your own modal window in HTML which wouldn't have these limitations.
 
 2. Let's flesh out this event listener. Update it as follows:
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.md
@@ -32,8 +32,10 @@ You've nearly finished! The last thing you want to do is ensure your callers hav
 
 3. Test out your app again, and try closing a call.
 
-> **Note:** The `on('close')` event that is called on the `conn` variable isn't available in Firefox yet; this just means that in Firefox each caller will have to hang up individually.
+> [!NOTE]
+> The `on('close')` event that is called on the `conn` variable isn't available in Firefox yet; this just means that in Firefox each caller will have to hang up individually.
 
-> **Warning:** The way we've currently coded things means that when a connection is closed, both browsers will be updated **only** if the person who started the call presses "Hang up" first. If the person who answered the call clicks "Hang up" first, the other caller will also have to click "Hang up" to see the correct HTML.
+> [!WARNING]
+> The way we've currently coded things means that when a connection is closed, both browsers will be updated **only** if the person who started the call presses "Hang up" first. If the person who answered the call clicks "Hang up" first, the other caller will also have to click "Hang up" to see the correct HTML.
 
 {{PreviousMenuNext("Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call", "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading")}}

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
@@ -34,7 +34,8 @@ The `getUserMedia()` endpoint takes a `constraints` object that specifies which 
    - `window.localAudio.srcObject = stream` sets the [`<audio>` element](/en-US/docs/Web/HTML/Element/audio) with the ID of `localAudio`'s `src` attribute to be the `MediaStream` returned by the promise so that it will play our stream.
    - `window.localAudio.autoplay = true` sets the `autoplay` attribute of the `<audio>` element to true, so that the audio plays automatically.
 
-   > **Warning:** If you've done some sleuthing online, you may have come across [`navigator.getUserMedia`](/en-US/docs/Web/API/Navigator/getUserMedia) and assumed you can use that instead of `navigator.mediaDevices.getUserMedia`. You'd be wrong. The former is a deprecated method, which requires callbacks as well as constraints as arguments. The latter uses a promise so you don't need to use callbacks.
+   > [!WARNING]
+   > If you've done some sleuthing online, you may have come across [`navigator.getUserMedia`](/en-US/docs/Web/API/Navigator/getUserMedia) and assumed you can use that instead of `navigator.mediaDevices.getUserMedia`. You'd be wrong. The former is a deprecated method, which requires callbacks as well as constraints as arguments. The latter uses a promise so you don't need to use callbacks.
 
 2. Try calling your `getLocalStream` function by adding the following line at the bottom of your code:
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
@@ -23,7 +23,8 @@ This is an intermediate level tutorial; before attempting it you should already 
 
 Before you get started, you'll want to make sure you've [installed node](https://nodejs.org/en/download/) and [Yarn](https://classic.yarnpkg.com/en/docs/install) (the instructions in later articles assume Yarn, but you can feel free to use [npm](https://docs.npmjs.com/getting-started/) or another manager if you'd prefer).
 
-> **Note:** If you learn better by following step-by-step code, we've also provided this [tutorial in code](https://github.com/SamsungInternet/WebPhone/tree/master/tutorial), which you can use instead.
+> [!NOTE]
+> If you learn better by following step-by-step code, we've also provided this [tutorial in code](https://github.com/SamsungInternet/WebPhone/tree/master/tutorial), which you can use instead.
 
 ### Table of Contents
 

--- a/files/en-us/web/api/webrtc_api/connectivity/index.md
+++ b/files/en-us/web/api/webrtc_api/connectivity/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 This article describes how the various WebRTC-related protocols interact with one another in order to create a connection and transfer data and/or media among peers.
 
-> **Note:** This page needs heavy rewriting for structural integrity and content completeness. Lots of info here is good but the organization is a mess since this is sort of a dumping ground right now.
+> [!NOTE]
+> This page needs heavy rewriting for structural integrity and content completeness. Lots of info here is good but the organization is a mess since this is sort of a dumping ground right now.
 
 ## Signaling
 
@@ -54,7 +55,8 @@ When reading the description (returned by {{domxref("RTCPeerConnection.localDesc
 
 When changing the description by calling `setLocalDescription()` or `setRemoteDescription()`, the specified description is set as the pending description, and the WebRTC layer begins to evaluate whether or not it's acceptable. Once the proposed description has been agreed upon, the value of `currentLocalDescription` or `currentRemoteDescription` is changed to the pending description, and the pending description is set to null again, indicating that there isn't a pending description.
 
-> **Note:** The `pendingLocalDescription` contains not just the offer or answer under consideration, but any local ICE candidates which have already been gathered since the offer or answer was created. Similarly, `pendingRemoteDescription` includes any remote ICE candidates which have been provided by calls to {{domxref("RTCPeerConnection.addIceCandidate()")}}.
+> [!NOTE]
+> The `pendingLocalDescription` contains not just the offer or answer under consideration, but any local ICE candidates which have already been gathered since the offer or answer was created. Similarly, `pendingRemoteDescription` includes any remote ICE candidates which have been provided by calls to {{domxref("RTCPeerConnection.addIceCandidate()")}}.
 
 See the individual articles on these properties and methods for more specifics, and [Codecs used by WebRTC](/en-US/docs/Web/Media/Formats/WebRTC_codecs) for information about codecs supported by WebRTC and which are compatible with which browsers. The codecs guide also offers guidance to help you choose the best codecs for your needs.
 
@@ -62,7 +64,8 @@ See the individual articles on these properties and methods for more specifics, 
 
 As well as exchanging information about the media (discussed above in Offer/Answer and SDP), peers must exchange information about the network connection. This is known as an **ICE candidate** and details the available methods the peer is able to communicate (directly or through a TURN server). Typically, each peer will propose its best candidates first, making their way down the line toward their worse candidates. Ideally, candidates are UDP (since it's faster, and media streams are able to recover from interruptions relatively easily), but the ICE standard does allow TCP candidates as well.
 
-> **Note:** Generally, ICE candidates using TCP are only going to be used when UDP is not available or is restricted in ways that make it not suitable for media streaming. Not all browsers support ICE over TCP, however.
+> [!NOTE]
+> Generally, ICE candidates using TCP are only going to be used when UDP is not available or is restricted in ways that make it not suitable for media streaming. Not all browsers support ICE over TCP, however.
 
 ICE allows candidates to represent connections over either {{Glossary("TCP")}} or {{Glossary("UDP")}}, with UDP generally being preferred (and being more widely supported). Each protocol supports a few types of candidate, with the candidate types defining how the data makes its way from peer to peer.
 

--- a/files/en-us/web/api/webrtc_api/intro_to_rtp/index.md
+++ b/files/en-us/web/api/webrtc_api/intro_to_rtp/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 The **Real-time Transport Protocol** (**RTP**), defined in {{RFC(3550)}}, is an IETF standard protocol to enable real-time connectivity for exchanging data that needs real-time priority. This article provides an overview of what RTP is and how it functions in the context of WebRTC.
 
-> **Note:** WebRTC actually uses **SRTP** (Secure Real-time Transport Protocol) to ensure that the exchanged data is secure and authenticated as appropriate.
+> [!NOTE]
+> WebRTC actually uses **SRTP** (Secure Real-time Transport Protocol) to ensure that the exchanged data is secure and authenticated as appropriate.
 
 Keeping latency to a minimum is especially important for WebRTC, since face-to-face communication needs to be performed with as little {{Glossary("latency")}} as possible. The more time lag there is between one user saying something and another hearing it, the more likely there is to be episodes of cross-talking and other forms of confusion.
 
@@ -55,7 +56,8 @@ Each {{domxref("RTCPeerConnection")}} has methods which provide access to the li
 
 Because the streams for an `RTCPeerConnection` are implemented using RTP and the interfaces [above](#rtcpeerconnection_and_rtp), you can take advantage of the access this gives you to the internals of streams to make adjustments. Among the simplest things you can do is to implement a "hold" feature, wherein a participant in a call can click a button and turn off their microphone, begin sending music to the other peer instead, and stop accepting incoming audio.
 
-> **Note:** This example makes use of modern JavaScript features including [async functions](/en-US/docs/Web/JavaScript/Reference/Statements/async_function) and the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) expression. This enormously simplifies and makes far more readable the code dealing with the promises returned by WebRTC methods.
+> [!NOTE]
+> This example makes use of modern JavaScript features including [async functions](/en-US/docs/Web/JavaScript/Reference/Statements/async_function) and the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) expression. This enormously simplifies and makes far more readable the code dealing with the promises returned by WebRTC methods.
 
 In the examples below, we'll refer to the peer which is turning "hold" mode on and off as the local peer and the user being placed on hold as the remote peer.
 

--- a/files/en-us/web/api/webrtc_api/session_lifetime/index.md
+++ b/files/en-us/web/api/webrtc_api/session_lifetime/index.md
@@ -10,7 +10,8 @@ WebRTC lets you build peer-to-peer communication of arbitrary data, audio, or vi
 
 This article doesn't get into details of the actual APIs involved in establishing and handling a WebRTC connection; it reviews the process in general with some information about why each step is required. See [Signaling and video calling](/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling) for an actual example with a step-by-step explanation of what the code does.
 
-> **Note:** This page is currently under construction, and some of the content will move to other pages as the WebRTC guide material is built out. Pardon our dust!
+> [!NOTE]
+> This page is currently under construction, and some of the content will move to other pages as the WebRTC guide material is built out. Pardon our dust!
 
 ## Establishing the connection
 
@@ -62,7 +63,8 @@ There's a sequence of things that have to happen in order to make it possible to
 
 Sometimes, during the lifetime of a WebRTC session, network conditions change. One of the users might transition from a cellular to a Wi-Fi network, or the network might become congested, for example. When this happens, the ICE agent may choose to perform **ICE restart**. This is a process by which the network connection is renegotiated, exactly the same way the initial ICE negotiation is performed, with one exception: media continues to flow across the original network connection until the new one is up and running. Then media shifts to the new network connection and the old one is closed.
 
-> **Note:** Different browsers support ICE restart under different sets of conditions. Not all browsers will perform ICE restart due to network congestion, for example.
+> [!NOTE]
+> Different browsers support ICE restart under different sets of conditions. Not all browsers will perform ICE restart due to network congestion, for example.
 
 If you need to change the configuration of the connection in some way (such as changing to a different set of ICE servers), you can do so before restarting ICE by calling {{domxref("RTCPeerConnection.setConfiguration()")}} with an updated configuration object before restarting ICE.
 

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -12,7 +12,8 @@ page-type: guide
 
 In this article, we will further enhance the [WebSocket chat](https://webrtc-from-chat.glitch.me/) first created as part of our WebSocket documentation (this article link is forthcoming; it isn't actually online yet) to support opening a two-way video call between users. You can [try out this example on Glitch](https://webrtc-from-chat.glitch.me/), and you can [remix the example](https://glitch.com/edit/#!/remix/webrtc-from-chat) to experiment with it as well. You can also [look at the full project](https://github.com/mdn/samples-server/tree/master/s/webrtc-from-chat) on GitHub.
 
-> **Note:** If you try out the example on Glitch, please note that any changes made to the code will immediately reset any connections. In addition, there is a short timeout period; the Glitch instance is for quick experiments and testing only.
+> [!NOTE]
+> If you try out the example on Glitch, please note that any changes made to the code will immediately reset any connections. In addition, there is a short timeout period; the Glitch instance is for quick experiments and testing only.
 
 ## The signaling server
 
@@ -104,13 +105,15 @@ Each ICE candidate is sent to the other peer by sending a JSON message of type `
 
 Each ICE message suggests a communication protocol (TCP or UDP), IP address, port number, connection type (for example, whether the specified IP is the peer itself or a relay server), along with other information needed to link the two computers together. This includes NAT or other networking complexity.
 
-> **Note:** The important thing to note is this: the only thing your code is responsible for during ICE negotiation is accepting outgoing candidates from the ICE layer and sending them across the signaling connection to the other peer when your {{domxref("RTCPeerConnection.icecandidate_event", "onicecandidate")}} handler is executed, and receiving ICE candidate messages from the signaling server (when the `"new-ice-candidate"` message is received) and delivering them to your ICE layer by calling {{domxref("RTCPeerConnection.addIceCandidate()")}}. That's it.
+> [!NOTE]
+> The important thing to note is this: the only thing your code is responsible for during ICE negotiation is accepting outgoing candidates from the ICE layer and sending them across the signaling connection to the other peer when your {{domxref("RTCPeerConnection.icecandidate_event", "onicecandidate")}} handler is executed, and receiving ICE candidate messages from the signaling server (when the `"new-ice-candidate"` message is received) and delivering them to your ICE layer by calling {{domxref("RTCPeerConnection.addIceCandidate()")}}. That's it.
 >
 > The contents of the SDP are irrelevant to you in essentially all cases. Avoid the temptation to try to make it more complicated than that until you really know what you're doing. That way lies madness.
 
 All your signaling server now needs to do is send the messages it's asked to. Your workflow may also demand login/authentication functionality, but such details will vary.
 
-> **Note:** The {{domxref("RTCPeerConnection.icecandidate_event", "onicecandidate")}} Event and {{domxref("RTCPeerConnection.createAnswer", "createAnswer()")}} Promise are both async calls which are handled separately. Be sure that your signaling does not change order! For example {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}} with the server's ice candidates must be called after setting the answer with {{domxref("RTCPeerConnection.setRemoteDescription", "setRemoteDescription()")}}.
+> [!NOTE]
+> The {{domxref("RTCPeerConnection.icecandidate_event", "onicecandidate")}} Event and {{domxref("RTCPeerConnection.createAnswer", "createAnswer()")}} Promise are both async calls which are handled separately. Be sure that your signaling does not change order! For example {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}} with the server's ice candidates must be called after setting the answer with {{domxref("RTCPeerConnection.setRemoteDescription", "setRemoteDescription()")}}.
 
 ### Signaling transaction flow
 
@@ -207,7 +210,8 @@ function handleUserlistMsg(msg) {
 
 After getting a reference to the {{HTMLElement("ul")}} which contains the list of user names into the variable `listElem`, we empty the list by removing each of its child elements.
 
-> **Note:** Obviously, it would be more efficient to update the list by adding and removing individual users instead of rebuilding the whole list every time it changes, but this is good enough for the purposes of this example.
+> [!NOTE]
+> Obviously, it would be more efficient to update the list by adding and removing individual users instead of rebuilding the whole list every time it changes, but this is good enough for the purposes of this example.
 
 Then we iterate over the array of user names using {{jsxref("Array.forEach", "forEach()")}}. For each name, we create a new {{HTMLElement("li")}} element, then create a new text node containing the user name using {{domxref("Document.createTextNode", "createTextNode()")}}. That text node is added as a child of the `<li>` element. Next, we set a handler for the {{domxref("Element/click_event", "click")}} event on the list item, that clicking on a user name calls our `invite()` method, which we'll look at in the next section.
 
@@ -258,7 +262,8 @@ Then we copy the name of the user we're calling into the variable `targetUsernam
 
 Once the `RTCPeerConnection` has been created, we request access to the user's camera and microphone by calling {{domxref("MediaDevices.getUserMedia()")}}, which is exposed to us through the {{domxref("MediaDevices.getUserMedia")}} property. When this succeeds, fulfilling the returned promise, our `then` handler is executed. It receives, as input, a {{domxref("MediaStream")}} object representing the stream with audio from the user's microphone and video from their webcam.
 
-> **Note:** We could restrict the set of permitted media inputs to a specific device or set of devices by calling {{domxref("MediaDevices.enumerateDevices", "navigator.mediaDevices.enumerateDevices()")}} to get a list of devices, filtering the resulting list based on our desired criteria, then using the selected devices' {{domxref("MediaTrackConstraints.deviceId", "deviceId")}} values in the `deviceId` field of the `mediaConstraints` object passed into `getUserMedia()`. In practice, this is rarely if ever necessary, since most of that work is done for you by `getUserMedia()`.
+> [!NOTE]
+> We could restrict the set of permitted media inputs to a specific device or set of devices by calling {{domxref("MediaDevices.enumerateDevices", "navigator.mediaDevices.enumerateDevices()")}} to get a list of devices, filtering the resulting list based on our desired criteria, then using the selected devices' {{domxref("MediaTrackConstraints.deviceId", "deviceId")}} values in the `deviceId` field of the `mediaConstraints` object passed into `getUserMedia()`. In practice, this is rarely if ever necessary, since most of that work is done for you by `getUserMedia()`.
 
 We attach the incoming stream to the local preview {{HTMLElement("video")}} element by setting the element's {{domxref("HTMLMediaElement.srcObject", "srcObject")}} property. Since the element is configured to automatically play incoming video, the stream begins playing in our local preview box.
 
@@ -329,7 +334,8 @@ function createPeerConnection() {
 
 When using the {{domxref("RTCPeerConnection.RTCPeerConnection", "RTCPeerConnection()")}} constructor, we will specify an object providing configuration parameters for the connection. We use only one of these in this example: `iceServers`. This is an array of objects describing STUN and/or TURN servers for the {{Glossary("ICE")}} layer to use when attempting to establish a route between the caller and the callee. These servers are used to determine the best route and protocols to use when communicating between the peers, even if they're behind a firewall or using {{Glossary("NAT")}}.
 
-> **Note:** You should always use STUN/TURN servers which you own, or which you have specific authorization to use. This example is using a known public STUN server but abusing these is bad form.
+> [!NOTE]
+> You should always use STUN/TURN servers which you own, or which you have specific authorization to use. This example is using a known public STUN server but abusing these is bad form.
 
 Each object in `iceServers` contains at least a `urls` field providing URLs at which the specified server can be reached. It may also provide `username` and `credential` values to allow authentication to take place, if needed.
 
@@ -377,7 +383,8 @@ To start the negotiation process, we need to create and send an SDP offer to the
 
 When `createOffer()` succeeds (fulfilling the promise), we pass the created offer information into {{domxref("RTCPeerConnection.setLocalDescription", "myPeerConnection.setLocalDescription()")}}, which configures the connection and media configuration state for the caller's end of the connection.
 
-> **Note:** Technically speaking, the string returned by `createOffer()` is an {{RFC(3264)}} offer.
+> [!NOTE]
+> Technically speaking, the string returned by `createOffer()` is an {{RFC(3264)}} offer.
 
 We know the description is valid, and has been set, when the promise returned by `setLocalDescription()` is fulfilled. This is when we send our offer to the other peer by creating a new `"video-offer"` message containing the local description (now the same as the offer), then sending it through our signaling server to the callee. The offer has the following members:
 
@@ -446,7 +453,8 @@ Once the answer has been created using {{domxref("RTCPeerConnection.createAnswer
 
 Any errors are caught and passed to `handleGetUserMediaError()`, described in [Handling getUserMedia() errors](#handling_getusermedia_errors).
 
-> **Note:** As is the case with the caller, once the `setLocalDescription()` fulfillment handler has run, the browser begins firing {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} events that the callee must handle, one for each candidate that needs to be transmitted to the remote peer.
+> [!NOTE]
+> As is the case with the caller, once the `setLocalDescription()` fulfillment handler has run, the browser begins firing {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} events that the callee must handle, one for each candidate that needs to be transmitted to the remote peer.
 
 Finally, the caller handles the answer message it received by creating a new {{domxref("RTCSessionDescription")}} object representing the callee's session description and passing it into
 {{domxref("RTCPeerConnection.setRemoteDescription", "myPeerConnection.setRemoteDescription()")}}.
@@ -487,7 +495,8 @@ This builds an object containing the candidate, then sends it to the other peer 
 
 The format of this message (as is the case with everything you do when handling signaling) is entirely up to you, depending on your needs; you can provide other information as required.
 
-> **Note:** It's important to keep in mind that the {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} event is **not** sent when ICE candidates arrive from the other end of the call. Instead, they're sent by your own end of the call so that you can take on the job of transmitting the data over whatever channel you choose. This can be confusing when you're new to WebRTC.
+> [!NOTE]
+> It's important to keep in mind that the {{domxref("RTCPeerConnection.icecandidate_event", "icecandidate")}} event is **not** sent when ICE candidates arrive from the other end of the call. Instead, they're sent by your own end of the call so that you can take on the job of transmitting the data over whatever channel you choose. This can be confusing when you're new to WebRTC.
 
 ##### Receiving ICE candidates
 
@@ -639,7 +648,8 @@ function handleICEConnectionStateChangeEvent(event) {
 
 Here, we apply our `closeVideoCall()` function when the ICE connection state changes to `"closed"` or `"failed"`. This handles shutting down our end of the connection so that we're ready start or accept a call once again.
 
-> **Note:** We don't watch the `disconnected` signaling state here as it can indicate temporary issues and may go back to a `connected` state after some time. Watching it would close the video call on any temporary network issue.
+> [!NOTE]
+> We don't watch the `disconnected` signaling state here as it can indicate temporary issues and may go back to a `connected` state after some time. Watching it would close the video call on any temporary network issue.
 
 ##### ICE signaling state
 
@@ -655,7 +665,8 @@ function handleSignalingStateChangeEvent(event) {
 }
 ```
 
-> **Note:** The `closed` signaling state has been deprecated in favor of the `closed` {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}}. We are watching for it here to add a bit of backward compatibility.
+> [!NOTE]
+> The `closed` signaling state has been deprecated in favor of the `closed` {{domxref("RTCPeerConnection.iceConnectionState", "iceConnectionState")}}. We are watching for it here to add a bit of backward compatibility.
 
 ##### ICE gathering state
 

--- a/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -99,7 +99,8 @@ This is quite straightforward. We declare variables and grab references to all t
 
 When the user clicks the "Connect" button, the `connectPeers()` method is called. We're going to break this up and look at it a bit at a time, for clarity.
 
-> **Note:** Even though both ends of our connection will be on the same page, we're going to refer to the one that starts the connection as the "local" one, and to the other as the "remote" end.
+> [!NOTE]
+> Even though both ends of our connection will be on the same page, we're going to refer to the one that starts the connection as the "local" one, and to the other as the "remote" end.
 
 #### Set up the local peer
 
@@ -128,7 +129,8 @@ The remote end is set up similarly, except that we don't need to explicitly crea
 
 The next step is to set up each connection with ICE candidate listeners; these will be called when there's a new ICE candidate to tell the other side about.
 
-> **Note:** In a real-world scenario in which the two peers aren't running in the same context, the process is a bit more involved; each side provides, one at a time, a suggested way to connect (for example, UDP, UDP with a relay, TCP, etc.) by calling {{domxref("RTCPeerConnection.addIceCandidate()")}}, and they go back and forth until agreement is reached. But here, we just accept the first offer on each side, since there's no actual networking involved.
+> [!NOTE]
+> In a real-world scenario in which the two peers aren't running in the same context, the process is a bit more involved; each side provides, one at a time, a suggested way to connect (for example, UDP, UDP with a relay, TCP, etc.) by calling {{domxref("RTCPeerConnection.addIceCandidate()")}}, and they go back and forth until agreement is reached. But here, we just accept the first offer on each side, since there's no actual networking involved.
 
 ```js
 localConnection.onicecandidate = (e) =>
@@ -171,7 +173,8 @@ Let's go through this line by line and decipher what it means.
 6. Finally, the local connection's remote description is set to refer to the remote peer by calling localConnection's {{domxref("RTCPeerConnection.setRemoteDescription()")}}.
 7. The `catch()` calls a routine that handles any errors that occur.
 
-> **Note:** Once again, this process is not a real-world implementation; in normal usage, there's two chunks of code running on two machines, interacting and negotiating the connection. A side channel, commonly called a "signalling server," is usually used to exchange the description (which is in **application/sdp** form) between the two peers.
+> [!NOTE]
+> Once again, this process is not a real-world implementation; in normal usage, there's two chunks of code running on two machines, interacting and negotiating the connection. A side channel, commonly called a "signalling server," is usually used to exchange the description (which is in **application/sdp** form) between the two peers.
 
 #### Handling successful peer connection
 

--- a/files/en-us/web/api/webrtc_api/using_data_channels/index.md
+++ b/files/en-us/web/api/webrtc_api/using_data_channels/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 In this guide, we'll examine how to add a data channel to a peer connection, which can then be used to securely exchange arbitrary data; that is, any kind of data we wish, in any format we choose.
 
-> **Note:** Since all WebRTC components are required to use encryption, any data transmitted on an `RTCDataChannel` is automatically secured using Datagram Transport Layer Security (**DTLS**). See [Security](#security) below for more information.
+> [!NOTE]
+> Since all WebRTC components are required to use encryption, any data transmitted on an `RTCDataChannel` is automatically secured using Datagram Transport Layer Security (**DTLS**). See [Security](#security) below for more information.
 
 ## Creating a data channel
 
@@ -81,7 +82,8 @@ In order to resolve this issue, a new system of **stream schedulers** (usually r
 
 Firefox support for ndata is in the process of being implemented; see [Firefox bug 1381145](https://bugzil.la/1381145) to track it becoming available for general use. The Chrome team is tracking their implementation of ndata support in [Chrome Bug 5696](https://bugs.chromium.org/p/webrtc/issues/detail?id=5696).
 
-> **Note:** Much of the information in this section is based in part on the blog post [Demystifying WebRTC's Data Channel Message Size Limitations](https://lgrahl.de/articles/demystifying-webrtc-dc-size-limit.html), written by Lennart Grahl. He goes into a bit more detail there, but as browsers have been updated since then some of it may be out-of-date. In addition, as time goes by, it will become more so, especially once EOR and ndata support are fully integrated in the major browsers.
+> [!NOTE]
+> Much of the information in this section is based in part on the blog post [Demystifying WebRTC's Data Channel Message Size Limitations](https://lgrahl.de/articles/demystifying-webrtc-dc-size-limit.html), written by Lennart Grahl. He goes into a bit more detail there, but as browsers have been updated since then some of it may be out-of-date. In addition, as time goes by, it will become more so, especially once EOR and ndata support are fully integrated in the major browsers.
 
 ## Security
 

--- a/files/en-us/web/api/webrtc_api/using_dtmf/index.md
+++ b/files/en-us/web/api/webrtc_api/using_dtmf/index.md
@@ -16,7 +16,8 @@ WebRTC doesn't send DTMF codes as audio data. Instead, they're sent out-of-band,
 - Entry of credit card or other payment information
 - Passcode entry
 
-> **Note:** While the DTMF is not sent to the remote peer as audio, browsers may choose to play the corresponding tone to the local user as part of their user experience, since users are typically used to hearing their phone play the tones audibly.
+> [!NOTE]
+> While the DTMF is not sent to the remote peer as audio, browsers may choose to play the corresponding tone to the local user as part of their user experience, since users are typically used to hearing their phone play the tones audibly.
 
 ## Sending DTMF on an RTCPeerConnection
 
@@ -32,7 +33,8 @@ If you'd like to know more about how this works, read {{RFC(3550, "RTP: A Transp
 
 This simple example constructs two {{domxref("RTCPeerConnection")}}s, establishes a connection between them, then waits for the user to click a "Dial" button. When the button is clicked, a DTMF string is sent over the connection using {{domxref("RTCDTMFSender.insertDTMF()")}}. Once the tones finish transmitting, the connection is closed.
 
-> **Note:** This example is obviously somewhat contrived, since normally the two `RTCPeerConnection` objects would exist on different devices, and signaling would be done over the network instead of it all being linked up inline as it is here.
+> [!NOTE]
+> This example is obviously somewhat contrived, since normally the two `RTCPeerConnection` objects would exist on different devices, and signaling would be done over the network instead of it all being linked up inline as it is here.
 
 ### HTML
 

--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -12,7 +12,8 @@ The **`WebSocket.close()`** method closes the
 {{domxref("WebSocket")}} connection or connection attempt, if any. If the connection is
 already `CLOSED`, this method does nothing.
 
-> **Note:** The process of closing the connection begins with a [closing handshake](https://www.rfc-editor.org/rfc/rfc6455.html#section-1.4), and the `close()` method does not discard previously-sent messages before starting that closing handshake; even if the user agent is still busy sending those messages, the handshake will only start after the messages are sent.
+> [!NOTE]
+> The process of closing the connection begins with a [closing handshake](https://www.rfc-editor.org/rfc/rfc6455.html#section-1.4), and the `close()` method does not discard previously-sent messages before starting that closing handshake; even if the user agent is still busy sending those messages, the handshake will only start after the messages are sent.
 
 ## Syntax
 
@@ -35,7 +36,8 @@ close(code, reason)
 
   - : A string providing a custom [WebSocket connection close reason](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.1.6) (a concise human-readable prose explanation for the closure). The value must be no longer than 123 bytes (encoded in UTF-8).
 
-    > **Note:** Because [UTF-8 uses two to four bytes](/en-US/docs/Glossary/UTF-8) to encode any non-[ASCII](/en-US/docs/Glossary/ASCII) characters, a 123-character `reason` value containing non-ASCII characters would exceed the 123-byte limit.
+    > [!NOTE]
+    > Because [UTF-8 uses two to four bytes](/en-US/docs/Glossary/UTF-8) to encode any non-[ASCII](/en-US/docs/Glossary/ASCII) characters, a 123-character `reason` value containing non-ASCII characters would exceed the 123-byte limit.
 
     If you specify a `reason` value, you should also specify a [`code`](#code) value.
 

--- a/files/en-us/web/api/websockets_api/index.md
+++ b/files/en-us/web/api/websockets_api/index.md
@@ -9,7 +9,8 @@ browser-compat: api.WebSocket
 
 The **WebSocket API** is an advanced technology that makes it possible to open a two-way interactive communication session between the user's browser and a server. With this API, you can send messages to a server and receive event-driven responses without having to poll the server for a reply.
 
-> **Note:** While a WebSocket connection is functionally somewhat similar to standard Unix-style sockets, they are not related.
+> [!NOTE]
+> While a WebSocket connection is functionally somewhat similar to standard Unix-style sockets, they are not related.
 
 ## Interfaces
 

--- a/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
+++ b/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
@@ -132,7 +132,8 @@ If we send "abcdef", we get these bytes:
 
   If the second byte minus 128 is between 0 and 125, this is the length of the message. If it is 126, the following 2 bytes (16-bit unsigned integer), if 127, the following 8 bytes (64-bit unsigned integer, the most significant bit MUST be 0) are the length.
 
-  > **Note:** It can take 128 because the first bit is always 1.
+  > [!NOTE]
+  > It can take 128 because the first bit is always 1.
 
 - 167, 225, 225 and 210 are the bytes of the key to decode. It changes every time.
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -8,7 +8,8 @@ page-type: guide
 
 WebSocket client applications use the [WebSocket API](/en-US/docs/Web/API/WebSockets_API) to communicate with [WebSocket servers](/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers) using the WebSocket protocol.
 
-> **Note:** The example snippets in this article are taken from our WebSocket chat client/server sample.
+> [!NOTE]
+> The example snippets in this article are taken from our WebSocket chat client/server sample.
 > [See the code](https://github.com/mdn/samples-server/tree/master/s/websocket-chat).
 
 ## Creating a WebSocket object

--- a/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
@@ -14,7 +14,8 @@ This server conforms to [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455
 
 WebSockets communicate over a [TCP (Transmission Control Protocol)](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) connection. Luckily, C# has a [TcpListener](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcplistener?view=net-6.0) class which does as the name suggests. It is in the `System.Net.Sockets` namespace.
 
-> **Note:** It is a good idea to include the namespace with the `using` keyword in order to write less. It allows usage of a namespace's classes without typing the full namespace every time.
+> [!NOTE]
+> It is a good idea to include the namespace with the `using` keyword in order to write less. It allows usage of a namespace's classes without typing the full namespace every time.
 
 ### TcpListener
 
@@ -26,7 +27,8 @@ TcpListener(System.Net.IPAddress localaddr, int port)
 
 `localaddr` specifies the IP of the listener, and `port` specifies the port.
 
-> **Note:** To create an `IPAddress` object from a `string`, use the `Parse` static method of `IPAddress`.
+> [!NOTE]
+> To create an `IPAddress` object from a `string`, use the `Parse` static method of `IPAddress`.
 
 Methods:
 
@@ -192,7 +194,8 @@ The second byte, which currently has a value of 131, is another bitfield that br
 - MASK bit: Defines whether the "Payload data" is masked. If set to 1, a masking key is present in Masking-Key, and this is used to unmask the "Payload data". All messages from the client to the server have this bit set.
 - Payload Length: If this value is between 0 and 125, then it is the length of message. If it is 126, the following 2 bytes (16-bit unsigned integer) are the length. If it is 127, the following 8 bytes (64-bit unsigned integer) are the length.
 
-> **Note:** Because the first bit is always 1 for client-to-server messages, you can subtract 128 from this byte to get rid of the MASK bit.
+> [!NOTE]
+> Because the first bit is always 1 for client-to-server messages, you can subtract 128 from this byte to get rid of the MASK bit.
 
 Note that the MASK bit is set in our message. This means that the next four bytes (61, 84, 35, and 6) are the mask bytes used to decode the message. These bytes change with every message.
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -12,7 +12,8 @@ A WebSocket server can be written in any server-side programming language that i
 
 This article assumes you're already familiar with how {{Glossary("HTTP")}} works, and that you have a moderate level of programming experience. Depending on language support, knowledge of TCP sockets may be required. The scope of this guide is to present the minimum knowledge you need to write a WebSocket server.
 
-> **Note:** Read the latest official WebSockets specification, [RFC 6455](https://datatracker.ietf.org/doc/rfc6455/?include_text=1). Sections 1 and 4-7 are especially interesting to server implementors. Section 10 discusses security and you should definitely peruse it before exposing your server.
+> [!NOTE]
+> Read the latest official WebSockets specification, [RFC 6455](https://datatracker.ietf.org/doc/rfc6455/?include_text=1). Sections 1 and 4-7 are especially interesting to server implementors. Section 10 discusses security and you should definitely peruse it before exposing your server.
 
 A WebSocket server is explained on a very low level here. WebSocket servers are often separate and specialized servers (for load-balancing or other practical reasons), so you will often use a [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) (such as a regular HTTP server) to detect WebSocket handshakes, pre-process them, and send those clients to a real WebSocket server. This means that you don't have to bloat your server code with cookie and authentication handlers (for example).
 
@@ -20,11 +21,13 @@ A WebSocket server is explained on a very low level here. WebSocket servers are 
 
 First, the server must listen for incoming socket connections using a standard TCP socket. Depending on your platform, this may be handled for you automatically. For example, let's assume that your server is listening on `example.com`, port 8000, and your socket server responds to {{HTTPMethod("GET")}} requests at `example.com/chat`.
 
-> **Warning:** The server may listen on any port it chooses, but if it chooses any port other than 80 or 443, it may have problems with firewalls and/or proxies. Browsers generally require a secure connection for WebSockets, although they may offer an exception for local devices.
+> [!WARNING]
+> The server may listen on any port it chooses, but if it chooses any port other than 80 or 443, it may have problems with firewalls and/or proxies. Browsers generally require a secure connection for WebSockets, although they may offer an exception for local devices.
 
 The handshake is the "Web" in WebSockets. It's the bridge from HTTP to WebSockets. In the handshake, details of the connection are negotiated, and either party can back out before completion if the terms are unfavorable. The server must be careful to understand everything the client asks for, otherwise security issues can occur.
 
-> **Note:** The request-uri (`/chat` here) has no defined meaning in the spec. So, many people use it to let one server handle multiple WebSocket applications. For example, `example.com/chat` could invoke a multiuser chat app, while `/game` on the same server might invoke a multiplayer game.
+> [!NOTE]
+> The request-uri (`/chat` here) has no defined meaning in the spec. So, many people use it to let one server handle multiple WebSocket applications. For example, `example.com/chat` could invoke a multiuser chat app, while `/game` on the same server might invoke a multiplayer game.
 
 ### Client handshake request
 
@@ -41,7 +44,8 @@ Sec-WebSocket-Version: 13
 
 The client can solicit extensions and/or subprotocols here; see [Miscellaneous](#miscellaneous) for details. Also, common headers like {{HTTPHeader("User-Agent")}}, {{HTTPHeader("Referer")}}, {{HTTPHeader("Cookie")}}, or authentication headers might be there as well. Do whatever you want with those; they don't directly pertain to the WebSocket. It's also safe to ignore them. In many common setups, a reverse proxy has already dealt with them.
 
-> **Note:** All **browsers** send an [`Origin` header](/en-US/docs/Web/HTTP/CORS#origin). You can use this header for security (checking for same origin, automatically allowing or denying, etc.) and send a [403 Forbidden](/en-US/docs/Web/HTTP/Status/403) if you don't like what you see. This is effective against [Cross Site WebSocket Hijacking (CSWH)](https://cwe.mitre.org/data/definitions/1385.html). However, be warned that non-browser agents can send a faked `Origin`. Most applications reject requests without this header.
+> [!NOTE]
+> All **browsers** send an [`Origin` header](/en-US/docs/Web/HTTP/CORS#origin). You can use this header for security (checking for same origin, automatically allowing or denying, etc.) and send a [403 Forbidden](/en-US/docs/Web/HTTP/Status/403) if you don't like what you see. This is effective against [Cross Site WebSocket Hijacking (CSWH)](https://cwe.mitre.org/data/definitions/1385.html). However, be warned that non-browser agents can send a faked `Origin`. Most applications reject requests without this header.
 
 If any header is not understood or has an incorrect value, the server should send a {{HTTPStatus("400")}} ("Bad Request") response and immediately close the socket. As usual, it may also give the reason why the handshake failed in the HTTP response body, but the message may never be displayed (browsers do not display it). If the server doesn't understand that version of WebSockets, it should send a {{HTTPHeader("Sec-WebSocket-Version")}} header back that contains the version(s) it does understand. In the example above, it indicates version 13 of the WebSocket protocol.
 
@@ -62,11 +66,13 @@ Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
 
 Additionally, the server can decide on extension/subprotocol requests here; see [Miscellaneous](#miscellaneous) for details. The `Sec-WebSocket-Accept` header is important in that the server must derive it from the {{HTTPHeader("Sec-WebSocket-Key")}} that the client sent to it. To get it, concatenate the client's `Sec-WebSocket-Key` and the string "`258EAFA5-E914-47DA-95CA-C5AB0DC85B11`" together (it's a "[magic string](https://en.wikipedia.org/wiki/Magic_string)"), take the [SHA-1 hash](https://en.wikipedia.org/wiki/SHA-1) of the result, and return the [base64](https://en.wikipedia.org/wiki/Base64) encoding of that hash.
 
-> **Note:** This seemingly overcomplicated process exists so that it's obvious to the client whether the server supports WebSockets. This is important because security issues might arise if the server accepts a WebSockets connection but interprets the data as a HTTP request.
+> [!NOTE]
+> This seemingly overcomplicated process exists so that it's obvious to the client whether the server supports WebSockets. This is important because security issues might arise if the server accepts a WebSockets connection but interprets the data as a HTTP request.
 
 So if the Key was "`dGhlIHNhbXBsZSBub25jZQ==`", the `Sec-WebSocket-Accept` header's value is "`s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`". Once the server sends these headers, the handshake is complete and you can start swapping data!
 
-> **Note:** The server can send other headers like {{HTTPHeader("Set-Cookie")}}, or ask for authentication or redirects via other status codes, before sending the reply handshake.
+> [!NOTE]
+> The server can send other headers like {{HTTPHeader("Set-Cookie")}}, or ask for authentication or redirects via other status codes, before sending the reply handshake.
 
 ### Keeping track of clients
 
@@ -170,7 +176,8 @@ At any point after the handshake, either the client or the server can choose to 
 
 A ping or pong is just a regular frame, but it's a **control frame**. Pings have an opcode of `0x9`, and pongs have an opcode of `0xA`. When you get a ping, send back a pong with the exact same Payload Data as the ping (for pings and pongs, the max payload length is 125). You might also get a pong without ever sending a ping; ignore this if it happens.
 
-> **Note:** If you have gotten more than one ping before you get the chance to send a pong, you only send one pong.
+> [!NOTE]
+> If you have gotten more than one ping before you get the chance to send a pong, you only send one pong.
 
 ## Closing the connection
 
@@ -178,7 +185,8 @@ To close a connection either the client or server can send a control frame with 
 
 ## Miscellaneous
 
-> **Note:** WebSocket codes, extensions, subprotocols, etc. are registered at the [IANA WebSocket Protocol Registry](https://www.iana.org/assignments/websocket/websocket.xml).
+> [!NOTE]
+> WebSocket codes, extensions, subprotocols, etc. are registered at the [IANA WebSocket Protocol Registry](https://www.iana.org/assignments/websocket/websocket.xml).
 
 WebSocket extensions and subprotocols are negotiated via headers during [the handshake](#the_websocket_handshake). Sometimes extensions and subprotocols are very similar, but there is a clear distinction. Extensions control the WebSocket _frame_ and _modify_ the payload, while subprotocols structure the WebSocket _payload_ and _never modify_ anything. Extensions are optional and generalized (like compression); subprotocols are mandatory and localized (like ones for chat and for MMORPG games).
 
@@ -186,13 +194,15 @@ WebSocket extensions and subprotocols are negotiated via headers during [the han
 
 Think of an extension as compressing a file before emailing it to someone. Whatever you do, you're sending the _same_ data in different forms. The recipient will eventually be able to get the same data as your local copy, but it is sent differently. That's what an extension does. WebSockets defines a protocol and a simple way to send data, but an extension such as compression could allow sending the same data but in a shorter format.
 
-> **Note:** Extensions are explained in sections 5.8, 9, 11.3.2, and 11.4 of the spec.
+> [!NOTE]
+> Extensions are explained in sections 5.8, 9, 11.3.2, and 11.4 of the spec.
 
 ### Subprotocols
 
 Think of a subprotocol as a custom [XML schema](https://en.wikipedia.org/wiki/XML_schema) or [doctype declaration](https://en.wikipedia.org/wiki/Document_Type_Definition). You're still using XML and its syntax, but you're additionally restricted by a structure you agreed on. WebSocket subprotocols are just like that. They do not introduce anything fancy, they just establish structure. Like a doctype or schema, both parties must agree on the subprotocol; unlike a doctype or schema, the subprotocol is implemented on the server and cannot be externally referred to by the client.
 
-> **Note:** Subprotocols are explained in sections 1.9, 4.2, 11.3.4, and 11.5 of the spec.
+> [!NOTE]
+> Subprotocols are explained in sections 1.9, 4.2, 11.3.4, and 11.5 of the spec.
 
 A client has to ask for a specific subprotocol. To do so, it will send something like this _as part of the original handshake_:
 
@@ -216,12 +226,14 @@ Now the server must pick one of the protocols that the client suggested and it s
 Sec-WebSocket-Protocol: soap
 ```
 
-> **Warning:** The server can't send more than one `Sec-Websocket-Protocol` header.
+> [!WARNING]
+> The server can't send more than one `Sec-Websocket-Protocol` header.
 > If the server doesn't want to use any subprotocol, **_it shouldn't send any `Sec-WebSocket-Protocol` header_**. Sending a blank header is incorrect. The client may close the connection if it doesn't get the subprotocol it wants.
 
 If you want your server to obey certain subprotocols, then naturally you'll need extra code on the server. Let's imagine we're using a subprotocol `json`. In this subprotocol, all data is passed as [JSON](https://en.wikipedia.org/wiki/JSON). If the client solicits this protocol and the server wants to use it, the server needs to have a JSON parser. Practically speaking, this will be part of a library, but the server needs to pass the data around.
 
-> **Note:** To avoid name conflict, it's recommended to make your subprotocol name part of a domain string. If you are building a custom chat app that uses a proprietary format exclusive to Example Inc., then you might use this: `Sec-WebSocket-Protocol: chat.example.com`. Note that this isn't required, it's just an optional convention, and you can use any string you wish.
+> [!NOTE]
+> To avoid name conflict, it's recommended to make your subprotocol name part of a domain string. If you are building a custom chat app that uses a proprietary format exclusive to Example Inc., then you might use this: `Sec-WebSocket-Protocol: chat.example.com`. Note that this isn't required, it's just an optional convention, and you can use any string you wish.
 
 ## Related
 

--- a/files/en-us/web/api/webtransport/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/webtransport/index.md
@@ -49,7 +49,8 @@ new WebTransport(url, options)
 
         This feature allows developers to connect to WebTransport servers that would normally find obtaining a publicly trusted certificate challenging, such as hosts that are not publicly routable, or ephemeral hosts like virtual machines.
 
-        > **Note:** The web application might typically fetch the hashes from a trusted intermediary.
+        > [!NOTE]
+        > The web application might typically fetch the hashes from a trusted intermediary.
         > For example, you might use a cloud provider to provision VMs that run your WebTransport servers.
         > The provider has trusted access to the server and can request its certificate, generate hashes, and provide these to the application via an API (which is mediated via PKI), or a cloud console.
         > The web application can now connect directly to the VM-hosted server using the supplied hashes, even though the VM itself does not have a long-lived TLS certificate.

--- a/files/en-us/web/api/webvr_api/concepts/index.md
+++ b/files/en-us/web/api/webvr_api/concepts/index.md
@@ -6,7 +6,8 @@ page-type: guide
 
 {{APIRef("WebVR API")}}{{deprecated_header}}
 
-> **Note:** WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
+> [!NOTE]
+> WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
 
 This article discusses some of the concepts and theory behind virtual reality (VR). If you are a newcomer to the area, it is worthwhile getting an understanding of these topics before you start diving into code.
 
@@ -39,7 +40,8 @@ There are two main types of setup, mobile or computer-connected. Their minimum h
 - Mobile: A Head-mounted display (HMD) is created using a smartphone — which acts as the VR display — mounted in a VR mount such as Google Cardboard, which contains the required lenses to provide stereoscopic vision of what is projected on the mobile screen.![Mobile based VR setup](mobilebasedvrsetup.png)
 - Computer-connected: A VR setup is connected to your computer — this consists of a Head Mounted Display (HMD) containing a high resolution landscape-oriented screen onto which the visuals for both the left and right eye are displayed, which also includes a lens for each eye to promote separation of the left and right eye scene (stereoscopic vision.) The setup also includes a separate position sensor that works out the position/orientation/velocity/acceleration of your head and constantly passes that information the computer. ![Computer based VR Setup](computerbasedvrsetup.png)
 
-> **Note:** Computer-connected systems sometimes don't include a position sensor, but they usually do.
+> [!NOTE]
+> Computer-connected systems sometimes don't include a position sensor, but they usually do.
 
 Other hardware that complements the VR experience includes:
 
@@ -86,7 +88,8 @@ The FOV is defined by the following values:
 
 The default values for these properties will differ slightly by VR hardware, although they tend to be around 53° up and down, and 47° left and right, with zNear and zFar coming in at around 0.1m and 10000m respectively.
 
-> **Note:** The user can potentially see all the way around them, which is a brand new concept for apps and games. Try to give people a reason to look around and see what's behind them — make them reach out and find things that are not visible at the very beginning. Describe what's behind their backs.
+> [!NOTE]
+> The user can potentially see all the way around them, which is a brand new concept for apps and games. Try to give people a reason to look around and see what's behind them — make them reach out and find things that are not visible at the very beginning. Describe what's behind their backs.
 
 ## Concepts for VR apps
 

--- a/files/en-us/web/api/webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Navigator.getVRDisplays
 
 {{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
-> **Note:** WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
+> [!NOTE]
+> WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
 
 WebVR provides support for exposing virtual reality devices — for example, head-mounted displays like the Oculus Rift or HTC Vive — to web apps, enabling developers to translate position and movement information from the display into movement around a 3D scene. This has numerous, interesting applications, from virtual product tours and interactive training apps to immersive first-person games.
 
@@ -35,7 +36,8 @@ A typical (simple) WebVR app would work like so:
 
 In addition, WebVR 1.1 adds a number of events on the {{DOMxRef("Window")}} object to allow JavaScript to respond to changes to the status of the display.
 
-> **Note:** You can find a lot more out about how the API works in our [Using the WebVR API](/en-US/docs/Web/API/WebVR_API/Using_the_WebVR_API) and [WebVR Concepts](/en-US/docs/Web/API/WebVR_API/Concepts) articles.
+> [!NOTE]
+> You can find a lot more out about how the API works in our [Using the WebVR API](/en-US/docs/Web/API/WebVR_API/Using_the_WebVR_API) and [WebVR Concepts](/en-US/docs/Web/API/WebVR_API/Concepts) articles.
 
 ### API availability
 
@@ -55,7 +57,8 @@ if (!navigator.getVRDisplays) {
 
 Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the [Gamepad API](/en-US/docs/Web/API/Gamepad_API), and specifically the [Gamepad Extensions API](/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions) that adds API features for accessing [controller pose](/en-US/docs/Web/API/GamepadPose), [haptic actuators](/en-US/docs/Web/API/GamepadHapticActuator), and more.
 
-> **Note:** Our [Using VR controllers with WebVR](/en-US/docs/Web/API/WebVR_API/Using_VR_controllers_with_WebVR) article explains the basics of how to use VR controllers with WebVR apps.
+> [!NOTE]
+> Our [Using VR controllers with WebVR](/en-US/docs/Web/API/WebVR_API/Using_VR_controllers_with_WebVR) article explains the basics of how to use VR controllers with WebVR apps.
 
 ## WebVR interfaces
 

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
@@ -6,7 +6,8 @@ page-type: guide
 
 {{APIRef("WebVR API")}}{{deprecated_header}}
 
-> **Note:** WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
+> [!NOTE]
+> WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
 
 The WebVR API is a fantastic addition to the web developer's toolkit, allowing WebGL scenes to be presented in virtual reality displays such as the Oculus Rift and HTC Vive. But how do you get started with developing VR apps for the Web? This article will guide you through the basics.
 
@@ -32,9 +33,11 @@ To illustrate how the WebVR API works, we'll study our raw-webgl-example, which 
 
 ![A gray rotating 3D cube](capture1.png)
 
-> **Note:** You can find the [source code of our demo](https://github.com/mdn/webvr-tests/tree/main/webvr/raw-webgl-example) on GitHub, and [view it live](https://mdn.github.io/webvr-tests/webvr/raw-webgl-example/) also.
+> [!NOTE]
+> You can find the [source code of our demo](https://github.com/mdn/webvr-tests/tree/main/webvr/raw-webgl-example) on GitHub, and [view it live](https://mdn.github.io/webvr-tests/webvr/raw-webgl-example/) also.
 
-> **Note:** If WebVR isn't working in your browser, you might need to make sure it is running through your graphics card. For example for NVIDIA cards, if you've got the NVIDIA control panel set up successfully, there will be a context menu option available — right click on Firefox, then choose _Run with graphics processor > High-performance NVIDIA processor_.
+> [!NOTE]
+> If WebVR isn't working in your browser, you might need to make sure it is running through your graphics card. For example for NVIDIA cards, if you've got the NVIDIA control panel set up successfully, there will be a context menu option available — right click on Firefox, then choose _Run with graphics processor > High-performance NVIDIA processor_.
 
 Our demo features the holy grail of WebGL demos — a rotating 3D cube. We've implemented this using raw [WebGL API](/en-US/docs/Web/API/WebGL_API) code. We won't be teaching any basic JavaScript or WebGL, just the WebVR parts.
 
@@ -45,7 +48,8 @@ Our demo also features:
 
 When you look through the source code of [our demo's main JavaScript file](https://github.com/mdn/webvr-tests/blob/main/webvr/raw-webgl-example/webgl-demo.js), you can easily find the WebVR-specific parts by searching for the string "WebVR" in preceding comments.
 
-> **Note:** To find out more about basic JavaScript and WebGL, consult our [JavaScript learning material](/en-US/docs/Learn/JavaScript), and our [WebGL Tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
+> [!NOTE]
+> To find out more about basic JavaScript and WebGL, consult our [JavaScript learning material](/en-US/docs/Learn/JavaScript), and our [WebGL Tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
 ## How does it work?
 
@@ -151,7 +155,8 @@ Inside the promise `then()` block, we check whether the array length is more tha
         console.log('Display found');
 ```
 
-> **Note:** It is unlikely that you'll have multiple VR displays connected to your computer, and this is just a simple demo, so this will do for now.
+> [!NOTE]
+> It is unlikely that you'll have multiple VR displays connected to your computer, and this is just a simple demo, so this will do for now.
 
 ### Starting and stopping the VR presentation
 

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -10,7 +10,8 @@ status:
 
 Many WebVR hardware setups feature controllers that go along with the headset. These can be used in WebVR apps via the [Gamepad API](/en-US/docs/Web/API/Gamepad_API), and specifically the [Gamepad Extensions API](/en-US/docs/Web/API/Gamepad_API#experimental_gamepad_extensions) that adds API features for accessing [controller pose](/en-US/docs/Web/API/GamepadPose), [haptic actuators](/en-US/docs/Web/API/GamepadHapticActuator), and more. This article explains the basics.
 
-> **Note:** WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
+> [!NOTE]
+> WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
 
 ## The WebVR API
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -70,7 +70,8 @@ These [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-ele
 - {{CSSxRef("::cue")}}
   - : Matches cues within a selected element in media with VTT tracks.
 
-> **Note:** The specification defines another pseudo-element, `::cue-region`, but this is not supported by any browsers.
+> [!NOTE]
+> The specification defines another pseudo-element, `::cue-region`, but this is not supported by any browsers.
 
 ## Examples
 
@@ -165,7 +166,8 @@ The `default` attribute may be added to just one `<track>`: this is the one that
 You can style WebVTT cues by matching elements using the {{cssxref("::cue")}} pseudo-element.
 This allows you to modify the appearance of all cue text, or just specific elements. In this example, we'll add some styling to the [first example above](#using_the_webvtt_api_to_add_captions).
 
-> **Note:** It is also possible to define styles in the [WebVTT File Format](/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format).
+> [!NOTE]
+> It is also possible to define styles in the [WebVTT File Format](/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format).
 
 #### HTML
 

--- a/files/en-us/web/api/webvtt_api/web_video_text_tracks_format/index.md
+++ b/files/en-us/web/api/webvtt_api/web_video_text_tracks_format/index.md
@@ -16,7 +16,8 @@ These can be used, for example, to add closed captions and subtitle text overlay
 The WebVTT files associated with a media element are added using the {{HTMLElement("track")}} element — see [Displaying VTT content defined in a file](/en-US/docs/Web/API/WebVTT_API#displaying_vtt_content_defined_in_a_file).
 A media element can be associated with a number of files, each representing different kinds of timed data, such as closed captions, subtitles, or chapter headings, translated into different locales.
 
-> **Note:** WebVTT content can also be created and managed programmatically using the [WebVTT API](/en-US/docs/Web/API/WebVTT_API).
+> [!NOTE]
+> WebVTT content can also be created and managed programmatically using the [WebVTT API](/en-US/docs/Web/API/WebVTT_API).
 
 ## Overview
 
@@ -423,7 +424,8 @@ NOTE TODO I might add a line to indicate work that still has to be done.
 `STYLE` blocks are optional sections that can be used to embed CSS styling of cues within a WebVTT file.
 Note that these are used to style the appearance and size of the cues, but not their position and layout, which are controlled by the [Cue settings](#cue_settings).
 
-> **Note:** WebVTT cues can also be matched by CSS styles loaded by the associated [document embedding the video/audio element](/en-US/docs/Web/API/WebVTT_API#styling_webvtt_in_html_or_a_stylesheet).
+> [!NOTE]
+> WebVTT cues can also be matched by CSS styles loaded by the associated [document embedding the video/audio element](/en-US/docs/Web/API/WebVTT_API#styling_webvtt_in_html_or_a_stylesheet).
 
 `STYLE` blocks must appear before any cue blocks in the file.
 
@@ -461,7 +463,8 @@ STYLE
 NOTE style blocks cannot appear after the first cue.
 ```
 
-> **Note:** There are live examples demonstrating many of the following cases in [More cue styling examples](/en-US/docs/Web/API/WebVTT_API#more_cue_styling_examples) in _WebVTT API_.
+> [!NOTE]
+> There are live examples demonstrating many of the following cases in [More cue styling examples](/en-US/docs/Web/API/WebVTT_API#more_cue_styling_examples) in _WebVTT API_.
 
 ### Match all cue payload text
 
@@ -593,7 +596,8 @@ Other pseudo-classes such as `link`, `nth-last-child`, and `nth-child` should wo
 
 Match against a particular cue `id` by specifying the `id` inside {{cssxref("::cue()")}}.
 
-> **Note:** At time of writing this does not appear to be supported in any of the main browsers.
+> [!NOTE]
+> At time of writing this does not appear to be supported in any of the main browsers.
 
 For example, the following WebVTT file should style the cue with identifier `cue1` in green.
 

--- a/files/en-us/web/api/webxr_device_api/cameras/index.md
+++ b/files/en-us/web/api/webxr_device_api/cameras/index.md
@@ -142,7 +142,8 @@ In this array, the leftmost column contains the entries `a1`, `a2`, `a3`, and `a
 
 Keep in mind that most WebGL and WebXR programming is done using third-party libraries which expand upon the basic functionality of WebGL by adding routines that make it much easier to perform not only core matrix and other operations, but often also to simulate these standard cinematography techniques. You should strongly consider using one instead of directly using WebGL. This guide uses WebGL directly since it's useful to understand to some extent what goes on under the hood, and to aide in the development of libraries or to help you optimize code.
 
-> **Note:** Even though we use phrases like "move the camera," what we're really doing is moving the entire world around the camera. This affects the way certain values work, which will be noted as they come up below.
+> [!NOTE]
+> Even though we use phrases like "move the camera," what we're really doing is moving the entire world around the camera. This affects the way certain values work, which will be noted as they come up below.
 
 ### Zooming
 

--- a/files/en-us/web/api/webxr_device_api/geometry/index.md
+++ b/files/en-us/web/api/webxr_device_api/geometry/index.md
@@ -43,7 +43,8 @@ let radiansToDegrees = (rad) => rad / RADIANS_PER_DEGREE;
 
 #### Times and durations
 
-> **Note:** For security reasons, `DOMHighResTimeStamp` usually introduces a
+> [!NOTE]
+> For security reasons, `DOMHighResTimeStamp` usually introduces a
 > small amount of imprecision to the clock in order to prevent it from being used in [fingerprinting](/en-US/docs/Glossary/Fingerprinting) and timing-based
 > attacks.
 
@@ -69,7 +70,8 @@ In augmented reality (AR), this is because of the need to insert virtual objects
 
 Thus it's all about creating a sense of space. From the perspective of an XR developer, designing the stage is the part that matters most to your users. Like an architect or a set designer, you have the power to create moods and experiences through a physical environment. How you structure that space will both depend on and influence how users can interact and explore it.
 
-> **Note:** A space will typically have foreground, mid-distance, and background elements. The right balance can create a unique presence and guide your user. The foreground includes objects and interfaces that you can interact with directly. The mid-distance includes objects you can interact with to some extent, or can approach in order to examine and engage with more closely. The background, on the other hand, is usually largely or entirely non-interactive, at least until and unless the user is able to approach it, bringing it into the mid-distance or foreground range.
+> [!NOTE]
+> A space will typically have foreground, mid-distance, and background elements. The right balance can create a unique presence and guide your user. The foreground includes objects and interfaces that you can interact with directly. The mid-distance includes objects you can interact with to some extent, or can approach in order to examine and engage with more closely. The background, on the other hand, is usually largely or entirely non-interactive, at least until and unless the user is able to approach it, bringing it into the mid-distance or foreground range.
 
 In WebXR, the fundamental concept of a **space**—as in, a coordinate space in which a scene takes place—is represented by an instance of {{domxref("XRSpace")}}. The space is used to make determinations about the relative positions and motion of objects and other entities (such as light sources and cameras) within the user's environment.
 
@@ -170,7 +172,8 @@ The compatibility issues that arise may be as fundamental as being unable to sup
 
 XR sessions are created using the {{domxref("XRSystem.requestSession", "navigator.xr.requestSession()")}} method. One of its optional parameters is an object which you can use to specify required and/or optional features that the session must (or should ideally) support. Currently, the only supported options are strings identifying the standard reference spaces. Using these, you can ensure before your code even runs that you have access to a WebXR session that can support the reference space type you require or prefer.
 
-> **Note:** At this time, the reference space to use or to prefer is the only option available when creating an {{domxref("XRSession")}}. In the future, it's likely that more options will become available.
+> [!NOTE]
+> At this time, the reference space to use or to prefer is the only option available when creating an {{domxref("XRSession")}}. In the future, it's likely that more options will become available.
 
 ## Positioning and orienting objects
 

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -180,7 +180,8 @@ See [Input profiles](#input_profiles) for more specific details on working with 
 
 In order to avoid having problems introduced by multiple controllers trying to inadvertently manipulate the UI at the same time, your app may need to have a "primary" controller. Not only would this controller then take the responsibility of clicking through the user interface of your app, but it would also be considered the "main hand," while other controllers would then be off-hand or additional controllers.
 
-> **Note:** This doesn't mean your app _needs_ to decide upon a primary controller. But if it does, these strategies may help.
+> [!NOTE]
+> This doesn't mean your app _needs_ to decide upon a primary controller. But if it does, these strategies may help.
 
 There are a few ways you can decide upon a primary controller. We'll look at three.
 
@@ -278,7 +279,8 @@ These types of input actions are described in more detail below.
 
 Each input source should define a **primary action**. A primary action (which will sometimes be shortened to "select action") is a platform-specific action which responds to the user manipulating it by delivering, in order, the events {{domxref("XRSession.selectstart_event", "selectstart")}}, {{domxref("XRSession.select_event", "select")}}, and {{domxref("XRSession.selectend_event", "selectend")}}. Each of these events is of type {{domxref("XRInputSourceEvent")}}.
 
-> **Note:** If an input source doesn't have a primary action, the input source is considered to be an **auxiliary input source**.
+> [!NOTE]
+> If an input source doesn't have a primary action, the input source is considered to be an **auxiliary input source**.
 
 When the user points a device along a target ray in your 3D space and then triggers a select action, the following events are sent to the active {{domxref("XRSession")}}:
 
@@ -484,7 +486,8 @@ Since the origin of the grip space is located at the center of the hand's grip, 
 
 An {{domxref("XRInputSource")}} has a {{domxref("XRInputSource.gamepad", "gamepad")}} property whose value, if not `null`, is a {{domxref("Gamepad")}} object which provides access to gamepad-style buttons, axis controllers (such as joysticks or thumbpads), and so forth. This may include the same buttons that trigger the standard {{domxref("XRInputSource")}} actions, but may include any number of additional buttons and controls.
 
-> **Note:** While `Gamepad` is defined by the [Gamepad API](/en-US/docs/Web/API/Gamepad_API), it is not managed by the Gamepad API, so you must not attempt to use any Gamepad API methods with it. The object type is reused as a convenience.
+> [!NOTE]
+> While `Gamepad` is defined by the [Gamepad API](/en-US/docs/Web/API/Gamepad_API), it is not managed by the Gamepad API, so you must not attempt to use any Gamepad API methods with it. The object type is reused as a convenience.
 
 If the value of `gamepad` is `null`, the input source doesn't define any controls using the `Gamepad` record, either because it doesn't support it or because it doesn't have any added controls on it.
 

--- a/files/en-us/web/api/webxr_device_api/movement_and_motion/index.md
+++ b/files/en-us/web/api/webxr_device_api/movement_and_motion/index.md
@@ -61,7 +61,8 @@ const MOUSE_SPEED = 0.003;
 - `MOVE_DISTANCE`
   - : The distance to move in response to any of the keys used to move the viewer through the scene.
 
-> **Note:** This example always displays what it renders on the screen, even if using `immersive-vr` mode. This lets you compare any differences in rendering between the two modes, and lets you see output from immersive mode even if you don't have a headset.
+> [!NOTE]
+> This example always displays what it renders on the screen, even if using `immersive-vr` mode. This lets you compare any differences in rendering between the two modes, and lets you see output from immersive mode even if you don't have a headset.
 
 ## Setup and utility functions
 
@@ -479,7 +480,8 @@ The time elapsed since the last frame was rendered (in seconds) is computed by s
 
 The `drawFrame()` function ends by iterating over every view found in the {{domxref("XRViewerPose")}}, setting up the viewport for the view, and calling `renderScene()` to render the frame. By setting the viewport for each view, we handle the typical scenario in which the views for each eye are each rendered onto half of the WebGL frame. The XR hardware then handles ensuring that each eye only sees the portion of that image that is intended for that eye.
 
-> **Note:** In this example, we're visually presenting the frame both on the XR device _and_ on the screen. To ensure that the on-screen canvas is the right size to allow us to do this, we set its width to be equal to the individual {{domxref("XRView")}} width multiplied by the number of views; the canvas height is always the same as the viewport's height. The two lines of code that adjust the canvas size are not needed in regular WebXR rendering loops.
+> [!NOTE]
+> In this example, we're visually presenting the frame both on the XR device _and_ on the screen. To ensure that the on-screen canvas is the right size to allow us to do this, we set its width to be equal to the individual {{domxref("XRView")}} width multiplied by the number of views; the canvas height is always the same as the viewport's height. The two lines of code that adjust the canvas size are not needed in regular WebXR rendering loops.
 
 ### Applying the user inputs
 

--- a/files/en-us/web/api/webxr_device_api/permissions_and_security/index.md
+++ b/files/en-us/web/api/webxr_device_api/permissions_and_security/index.md
@@ -33,7 +33,8 @@ Specifically:
 - If the document making the request isn't trustworthy, the request is denied and `false` is returned through the promise's fulfillment routine. A trustworthy document is one which is both responsible and active, and which currently has focus.
 - If the user's intent to open an inline XR presentation is not well understood, the request is denied. Understanding of the [user's intent](#user_intent) may be either implicit or explicit.
 
-> **Note:** Additional requirements may be put into effect due to the specific features requested by the options object when calling `requestSession()`.
+> [!NOTE]
+> Additional requirements may be put into effect due to the specific features requested by the options object when calling `requestSession()`.
 
 ## User intent
 

--- a/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
+++ b/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
@@ -12,7 +12,8 @@ The location and movement of the user's headset represent their head's position 
 
 In this guide, we'll explore how WebXR uses **spaces** and, more specifically, **reference spaces**, to track the positions, orientations, and movements of objects and of the user's body in the virtual world.
 
-> **Note:** This article presumes that you are familiar with the concepts introduced in [Geometry and reference spaces in WebXR](/en-US/docs/Web/API/WebXR_Device_API/Geometry): that is, the basics of 3D coordinate systems, as well as WebXR spaces, reference spaces, and how reference spaces are used to create local coordinate systems for individual objects or movable components within a scene.
+> [!NOTE]
+> This article presumes that you are familiar with the concepts introduced in [Geometry and reference spaces in WebXR](/en-US/docs/Web/API/WebXR_Device_API/Geometry): that is, the basics of 3D coordinate systems, as well as WebXR spaces, reference spaces, and how reference spaces are used to create local coordinate systems for individual objects or movable components within a scene.
 
 ## Representing a position using a reference space
 

--- a/files/en-us/web/api/webxr_device_api/startup_and_shutdown/index.md
+++ b/files/en-us/web/api/webxr_device_api/startup_and_shutdown/index.md
@@ -251,7 +251,8 @@ Next, any data and setup needed for the WebGL renderer is performed before then 
 
 At this point, the `XRSession` itself has been fully configured, so we can begin rendering. First, we need a reference space within which coordinates for the world will be stated. We can get the initial reference space for the session by calling the `XRSession`'s {{domxref("XRSession.requestReferenceSpace", "requestReferenceSpace()")}} method. We specify when calling `requestReferenceSpace()` the name of the type of reference space we want; in this case, `unbounded`. You might just as easily specify `local` or `viewer`, depending on your needs.
 
-> **Note:** To understand how to select the right reference space for your needs, see [Selecting the reference space type](/en-US/docs/Web/API/WebXR_Device_API/Geometry#selecting_the_reference_space_type).
+> [!NOTE]
+> To understand how to select the right reference space for your needs, see [Selecting the reference space type](/en-US/docs/Web/API/WebXR_Device_API/Geometry#selecting_the_reference_space_type).
 
 The reference space returned by `requestReferenceSpace()` places the origin (0, 0, 0) in the center of the space. This is great—if your player's viewpoint starts in the exact center of the world. But most likely, that's not the case at all. If that's so, you call {{domxref("XRReferenceSpace.getOffsetReferenceSpace", "getOffsetReferenceSpace()")}} on the initial reference space to create a _new_ reference space [which offsets the coordinate system](/en-US/docs/Web/API/WebXR_Device_API/Geometry#establishing_the_reference_space) so that (0, 0, 0) is located at the position of the viewer, with the orientation likewise shifted to face in the desired direction. The input value into `getOffsetReferenceSpace()` is an {{domxref("XRRigidTransform")}} encapsulating the player's position and orientation as specified in the default world coordinates.
 
@@ -298,7 +299,8 @@ Occasionally, discontinuities or jumps in the [native origin](/en-US/docs/Web/AP
 
 When this happens, a {{domxref("XRReferenceSpace.reset_event", "reset")}} event is sent to the session's {{domxref("XRReferenceSpace")}}. The event's {{domxref("XRReferenceSpaceEvent.transform", "transform")}} property is an {{domxref("XRRigidTransform")}} detailing the transform needed to realign the native origin.
 
-> **Note:** The `reset` event is fired at the {{domxref("XRReferenceSpace")}}, not the {{domxref("XRSession")}}!
+> [!NOTE]
+> The `reset` event is fired at the {{domxref("XRReferenceSpace")}}, not the {{domxref("XRSession")}}!
 
 Another common cause for `reset` events is when a bounded reference space (`bounded-floor`) has its geometry as specified by the {{domxref("XRBoundedReferenceSpace")}}'s property {{domxref("XRBoundedReferenceSpace.boundsGeometry", "boundsGeometry")}} change.
 

--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -13,7 +13,8 @@ The **`WGSLLanguageFeatures`** interface of the {{domxref("WebGPU API", "WebGPU 
 
 The `WGSLLanguageFeatures` object is accessed via the {{domxref("GPU.wgslLanguageFeatures")}} property.
 
-> **Note:** Not all WGSL language extensions are available to WebGPU in all browsers that support the API. We recommend you thoroughly test any extensions you choose to use.
+> [!NOTE]
+> Not all WGSL language extensions are available to WebGPU in all browsers that support the API. We recommend you thoroughly test any extensions you choose to use.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/wheelevent/index.md
+++ b/files/en-us/web/api/wheelevent/index.md
@@ -9,7 +9,8 @@ browser-compat: api.WheelEvent
 
 The **`WheelEvent`** interface represents events that occur due to the user moving a mouse wheel or similar input device.
 
-> **Note:** This is the standard wheel event interface to use. Old versions of browsers implemented the non-standard and non-cross-browser-compatible `MouseWheelEvent` and {{DOMxRef("MouseScrollEvent")}} interfaces. Use this interface and avoid the non-standard ones.
+> [!NOTE]
+> This is the standard wheel event interface to use. Old versions of browsers implemented the non-standard and non-cross-browser-compatible `MouseWheelEvent` and {{DOMxRef("MouseScrollEvent")}} interfaces. Use this interface and avoid the non-standard ones.
 
 Don't confuse the `wheel` event with the {{domxref("Element/scroll_event", "scroll")}} event:
 

--- a/files/en-us/web/api/wheelevent/wheelevent/index.md
+++ b/files/en-us/web/api/wheelevent/wheelevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.WheelEvent.WheelEvent
 
 The **`WheelEvent()`** constructor returns a new {{domxref("WheelEvent")}} object.
 
-> **Note:** If you construct a synthetic event using this constructor, that event will not be _trusted_, for security reasons.
+> [!NOTE]
+> If you construct a synthetic event using this constructor, that event will not be _trusted_, for security reasons.
 > Only browser-generated `WheelEvent` objects are trusted and only trusted events trigger default actions.
 
 ## Syntax

--- a/files/en-us/web/api/window/back/index.md
+++ b/files/en-us/web/api/window/back/index.md
@@ -14,7 +14,8 @@ The obsolete and non-standard method `back()` on the {{domxref("window")}}
 interface returns the window to the previous item in the history. This was a
 Firefox-specific method and was removed in Firefox 31.
 
-> **Note:** Use the standard {{domxref("history.back")}} method instead.
+> [!NOTE]
+> Use the standard {{domxref("history.back")}} method instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/beforeunload_event/index.md
+++ b/files/en-us/web/api/window/beforeunload_event/index.md
@@ -48,7 +48,8 @@ The `beforeunload` event suffers from some problems:
   2. The user then switches to a different app.
   3. Later, the user closes the browser from the app manager.
 
-  > **Note:** It is recommended to use the {{domxref("Document.visibilitychange_event", "visibilitychange")}} event as a more reliable signal for automatic app state saving that gets around problems like the above. See [Don't lose user and app state, use Page Visibility](https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/) for more details.
+  > [!NOTE]
+  > It is recommended to use the {{domxref("Document.visibilitychange_event", "visibilitychange")}} event as a more reliable signal for automatic app state saving that gets around problems like the above. See [Don't lose user and app state, use Page Visibility](https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/) for more details.
 
 - In Firefox, `beforeunload` is not compatible with the [back/forward cache](https://web.dev/articles/bfcache) (bfcache): that is, Firefox will not place pages in the bfcache if they have `beforeunload` listeners, and this is bad for performance.
 

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -12,7 +12,8 @@ browser-compat: api.Window.blur
 
 The **`Window.blur()`** method does nothing.
 
-> **Note:** Historically, this method was the programmatic equivalent of the user shifting focus away
+> [!NOTE]
+> Historically, this method was the programmatic equivalent of the user shifting focus away
 > from the current window. This behavior was removed due to hostile sites abusing this functionality.
 > In Firefox, you can enable the old behavior with the `dom.disable_window_flip` preference.
 

--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -12,7 +12,8 @@ browser-compat: api.Window.captureEvents
 
 The **`Window.captureEvents()`** method does nothing.
 
-> **Note:** This is an method long removed from the specification. It is kept in browsers to prevent code breakage but does nothing.
+> [!NOTE]
+> This is an method long removed from the specification. It is kept in browsers to prevent code breakage but does nothing.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/console/index.md
+++ b/files/en-us/web/api/window/console/index.md
@@ -32,4 +32,5 @@ For more examples, see the [Examples](/en-US/docs/Web/API/console#examples) sect
 
 {{Specifications}}
 
-> **Note:** Currently there are many implementation differences among browsers, but work is being done to bring them together and make them more consistent with one another.
+> [!NOTE]
+> Currently there are many implementation differences among browsers, but work is being done to bring them together and make them more consistent with one another.

--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -20,7 +20,8 @@ addEventListener("error", (event) => {});
 onerror = (event, source, lineno, colno, error) => {};
 ```
 
-> **Note:** Due to historical reasons, `onerror` on `window` is the only event handler property that receives more than one argument.
+> [!NOTE]
+> Due to historical reasons, `onerror` on `window` is the only event handler property that receives more than one argument.
 
 ## Event type
 
@@ -79,7 +80,8 @@ window.onerror = (a, b, c, d, e) => {
 };
 ```
 
-> **Note:** These parameter names are observable with an [HTML event handler attribute](/en-US/docs/Web/HTML/Attributes#event_handler_attributes), where the first parameter is called `event` instead of `message`.
+> [!NOTE]
+> These parameter names are observable with an [HTML event handler attribute](/en-US/docs/Web/HTML/Attributes#event_handler_attributes), where the first parameter is called `event` instead of `message`.
 
 This special behavior only happens for the `onerror` event handler on `window`. The [`Element.onerror`](/en-US/docs/Web/API/HTMLElement/error_event) handler still receives a single {{domxref("ErrorEvent")}} object.
 

--- a/files/en-us/web/api/window/event/index.md
+++ b/files/en-us/web/api/window/event/index.md
@@ -14,7 +14,8 @@ The read-only {{domxref("Window")}} property **`event`** returns the {{domxref("
 
 You _should_ avoid using this property in new code, and should instead use the {{domxref("Event")}} passed into the event handler function. This property is not universally supported and even when supported introduces potential fragility to your code.
 
-> **Note:** This property can be fragile, in that there may be situations in which the returned `Event` is not the expected value. In addition, `Window.event` is not accurate for events dispatched within {{Glossary("shadow tree", "shadow trees")}}.
+> [!NOTE]
+> This property can be fragile, in that there may be situations in which the returned `Event` is not the expected value. In addition, `Window.event` is not accurate for events dispatched within {{Glossary("shadow tree", "shadow trees")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/fence/index.md
+++ b/files/en-us/web/api/window/fence/index.md
@@ -14,7 +14,8 @@ The `fence` read-only property of the {{domxref("Window")}} interface returns a 
 
 `Fence` objects are only available to documents embedded inside {{htmlelement("fencedframe")}}s (loaded via {{domxref("FencedFrameConfig")}}s) or {{htmlelement("iframe")}}s (loaded via opaque URNs).
 
-> **Note:** See [How do `<fencedframe>`s work?](/en-US/docs/Web/API/Fenced_frame_API#how_do_fencedframes_work) for some description around `FencedFrameConfig`s and opaque URNs.
+> [!NOTE]
+> See [How do `<fencedframe>`s work?](/en-US/docs/Web/API/Fenced_frame_API#how_do_fencedframes_work) for some description around `FencedFrameConfig`s and opaque URNs.
 
 ## Value
 

--- a/files/en-us/web/api/window/fetch/index.md
+++ b/files/en-us/web/api/window/fetch/index.md
@@ -18,7 +18,8 @@ Instead, a `then()` handler must check the {{domxref("Response.ok")}} and/or {{d
 
 The `fetch()` method is controlled by the `connect-src` directive of [Content Security Policy](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) rather than the directive of the resources it's retrieving.
 
-> **Note:** The `fetch()` method's parameters are identical to those of the {{domxref("Request.Request","Request()")}} constructor.
+> [!NOTE]
+> The `fetch()` method's parameters are identical to those of the {{domxref("Request.Request","Request()")}} constructor.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Window.find
 
 {{ApiRef}}{{Non-standard_Header}}
 
-> **Note:** Support for `Window.find()` might change in future
+> [!NOTE]
+> Support for `Window.find()` might change in future
 > versions of Gecko. See [Firefox bug 672395](https://bugzil.la/672395).
 
 The **`Window.find()`** method finds a string in a window sequentially.

--- a/files/en-us/web/api/window/forward/index.md
+++ b/files/en-us/web/api/window/forward/index.md
@@ -12,7 +12,8 @@ status:
 
 Moves the window one document forward in history. This was a Firefox-specific method and was removed in Firefox 31.
 
-> **Note:** Use the standard {{domxref("History.forward", "history.forward()")}} method instead.
+> [!NOTE]
+> Use the standard {{domxref("History.forward", "history.forward()")}} method instead.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -12,7 +12,8 @@ The **`Window.frameElement`** property
 returns the element (such as {{HTMLElement("iframe")}} or {{HTMLElement("object")}})
 in which the window is embedded.
 
-> **Note:** Despite this property's name, it works for documents embedded
+> [!NOTE]
+> Despite this property's name, it works for documents embedded
 > within any embedding point, including {{HTMLElement("object")}},
 > {{HTMLElement("iframe")}}, or {{HTMLElement("embed")}}.
 

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -44,7 +44,8 @@ object, which updates automatically when the element's styles are changed.
     `pseudoElt` is not a valid pseudo-element selector or is
     {{CSSxRef("::part", "::part()")}} or {{CSSxRef("::slotted", "::slotted()")}}.
 
-    > **Note:** Valid pseudo-element selector refers to syntactic
+    > [!NOTE]
+    > Valid pseudo-element selector refers to syntactic
     > validity, e.g. `::unsupported` is considered valid, even though the
     > pseudo-element itself is not supported. Additionally, the latest W3 standard [explicitly supports](https://www.w3.org/TR/cssom-1/#dom-window-getcomputedstyle) only `::before` and `::after`, while the CSS
     > WG draft [does not restrict this value](https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle). Browser compatibility may vary.

--- a/files/en-us/web/api/window/getscreendetails/index.md
+++ b/files/en-us/web/api/window/getscreendetails/index.md
@@ -54,7 +54,8 @@ for (const screen of screenDetails.screens) {
 }
 ```
 
-> **Note:** See [Multi-window learning environment](https://mdn.github.io/dom-examples/window-management-api/) for a full example (see the [source code](https://github.com/mdn/dom-examples/tree/main/window-management-api) also).
+> [!NOTE]
+> See [Multi-window learning environment](https://mdn.github.io/dom-examples/window-management-api/) for a full example (see the [source code](https://github.com/mdn/dom-examples/tree/main/window-management-api) also).
 
 ## Specifications
 

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -15,7 +15,8 @@ This event is not cancelable and does not bubble.
 
 > **Note:** _All events named `load` will not propagate to `Window`_, even with `bubbles` initialized to `true`. To catch `load` events on the `window`, that `load` event must be dispatched directly to the `window`.
 
-> **Note:** The `load` event that is dispatched when the main document has loaded _is_ dispatched on the `window`, but has two mutated properties: `target` is `document`, and `path` is `undefined`. These two properties are mutated due to legacy conformance.
+> [!NOTE]
+> The `load` event that is dispatched when the main document has loaded _is_ dispatched on the `window`, but has two mutated properties: `target` is `document`, and `path` is `undefined`. These two properties are mutated due to legacy conformance.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/localstorage/index.md
+++ b/files/en-us/web/api/window/localstorage/index.md
@@ -63,7 +63,8 @@ The syntax for removing all the `localStorage` items is as follows:
 localStorage.clear();
 ```
 
-> **Note:** Please refer to the [Using the Web Storage API](/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) article for a full example.
+> [!NOTE]
+> Please refer to the [Using the Web Storage API](/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) article for a full example.
 
 ## Specifications
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 14.
