### PR TITLE
Convert noteblocks for web/api folder (part 15)

### DIFF
--- a/files/en-us/web/api/window/moveby/index.md
+++ b/files/en-us/web/api/window/moveby/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Window.moveBy
 The **`moveBy()`** method of the {{domxref("Window")}}
 interface moves the current window by a specified amount.
 
-> **Note:** This function moves the window relative to its current
+> [!NOTE]
+> This function moves the window relative to its current
 > location. In contrast, {{domxref("window.moveTo()")}} moves the window to an absolute
 > location.
 
@@ -55,7 +56,8 @@ As of Firefox 7, websites can no longer move a browser window [in the following 
 1. You can't move a window or tab that wasn't created by {{domxref("Window.open()")}}.
 2. You can't move a window or tab when it's in a window with more than one tab.
 
-> **Note:** This function might not move the window synchronously.
+> [!NOTE]
+> This function might not move the window synchronously.
 > In some environments (like Wayland, or mobile) it might not move the window
 > at all. Currently there's no way to listen to a move event, see
 > [CSS Working Group issue #7693](https://github.com/w3c/csswg-drafts/issues/7693).

--- a/files/en-us/web/api/window/moveto/index.md
+++ b/files/en-us/web/api/window/moveto/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Window.moveTo
 The **`moveTo()`** method of the {{domxref("Window")}}
 interface moves the current window to the specified coordinates.
 
-> **Note:** This function moves the window to an absolute location. In
+> [!NOTE]
+> This function moves the window to an absolute location. In
 > contrast, {{domxref("window.moveBy()")}} moves the window relative to its current
 > location.
 
@@ -53,7 +54,8 @@ As of Firefox 7, websites can no longer move a browser window [in the following 
 1. You can't move a window or tab that wasn't created by {{domxref("Window.open()")}}.
 2. You can't move a window or tab when it's in a window with more than one tab.
 
-> **Note:** This function might not move the window synchronously.
+> [!NOTE]
+> This function might not move the window synchronously.
 > In some environments (like Wayland, or mobile) it might not move the window
 > at all. Currently there's no way to listen to a move event, see
 > [CSS Working Group issue #7693](https://github.com/w3c/csswg-drafts/issues/7693).

--- a/files/en-us/web/api/window/mozinnerscreenx/index.md
+++ b/files/en-us/web/api/window/mozinnerscreenx/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.mozInnerScreenX
 Gets the X coordinate of the top-left corner of the window's viewport, in screen
 coordinates.
 
-> **Note:** This coordinate is reported in CSS pixels, not in hardware pixels. That means it can be affected by the zoom level; to compute the actual number of physical screen pixels, you should use the `nsIDOMWindowUtils.screenPixelsPerCSSPixel` property.
+> [!NOTE]
+> This coordinate is reported in CSS pixels, not in hardware pixels. That means it can be affected by the zoom level; to compute the actual number of physical screen pixels, you should use the `nsIDOMWindowUtils.screenPixelsPerCSSPixel` property.
 
 ## Value
 

--- a/files/en-us/web/api/window/mozinnerscreeny/index.md
+++ b/files/en-us/web/api/window/mozinnerscreeny/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.mozInnerScreenY
 The `mozInnerScreenY` property of the {{domxref("Window")}} interface returns the Y coordinate of the top-left corner of the window's viewport, in screen
 coordinates.
 
-> **Note:** This coordinate is reported in CSS pixels, not in hardware pixels.
+> [!NOTE]
+> This coordinate is reported in CSS pixels, not in hardware pixels.
 
 ## Value
 

--- a/files/en-us/web/api/window/online_event/index.md
+++ b/files/en-us/web/api/window/online_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Window.online_event
 
 The **`online`** event of the {{domxref("Window")}} interface is fired when the browser has gained access to the network and the value of {{domxref("Navigator.onLine")}} switches to `true`.
 
-> **Note:** This event shouldn't be used to determine the availability of a particular website. Network problems or firewalls might still prevent the website from being reached.
+> [!NOTE]
+> This event shouldn't be used to determine the availability of a particular website. Network problems or firewalls might still prevent the website from being reached.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -86,7 +86,8 @@ open(url, target, windowFeatures)
 
     A [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) value is treated the same as the empty string (`""`).
 
-> **Note:** Requested position (`top`, `left`), and requested dimension (`width`, `height`) values in `windowFeatures` **will be corrected** if any of such requested value does not allow the entire browser popup to be rendered within the work area for applications of the user's operating system. In other words, no part of the new popup can be initially positioned offscreen.
+> [!NOTE]
+> Requested position (`top`, `left`), and requested dimension (`width`, `height`) values in `windowFeatures` **will be corrected** if any of such requested value does not allow the entire browser popup to be rendered within the work area for applications of the user's operating system. In other words, no part of the new popup can be initially positioned offscreen.
 
 ### Return value
 
@@ -180,7 +181,8 @@ link.addEventListener(
 
 The above code solves a few usability problems related to links opening popups. The purpose of the `event.preventDefault()` in the code is to cancel the default action of the link: if the event listener for `click` is executed, then there is no need to execute the default action of the link. But if JavaScript support is disabled or non-existent on the user's browser, then the event listener for `click` is ignored, and the browser loads the referenced resource in the target frame or window that has the name `"WikipediaWindowName"`. If no frame nor window has the name `"WikipediaWindowName"`, then the browser will create a new window and name it `"WikipediaWindowName"`.
 
-> **Note:** For more details about the `target` attribute, see [`<a>`](/en-US/docs/Web/HTML/Element/a#target) or [`<form>`](/en-US/docs/Web/HTML/Element/form#target).
+> [!NOTE]
+> For more details about the `target` attribute, see [`<a>`](/en-US/docs/Web/HTML/Element/a#target) or [`<form>`](/en-US/docs/Web/HTML/Element/form#target).
 
 ### Reuse existing windows and avoid `target="_blank"`
 

--- a/files/en-us/web/api/window/pagereveal_event/index.md
+++ b/files/en-us/web/api/window/pagereveal_event/index.md
@@ -87,7 +87,8 @@ window.addEventListener("pagereveal", async (e) => {
 });
 ```
 
-> **Note:** See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
+> [!NOTE]
+> See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/pageshow_event/index.md
+++ b/files/en-us/web/api/window/pageshow_event/index.md
@@ -17,7 +17,8 @@ This includes:
 - Restoring a frozen page on mobile OSes
 - Returning to the page using the browser's forward or back buttons
 
-> **Note:** During the initial page load, the `pageshow` event fires _after_ the {{domxref("Window/load_event", "load")}} event.
+> [!NOTE]
+> During the initial page load, the `pageshow` event fires _after_ the {{domxref("Window/load_event", "load")}} event.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/pageswap_event/index.md
+++ b/files/en-us/web/api/window/pageswap_event/index.md
@@ -90,7 +90,8 @@ window.addEventListener("pageswap", async (e) => {
 });
 ```
 
-> **Note:** See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
+> [!NOTE]
+> See [List of Chrome DevRel team members](https://view-transitions.netlify.app/profiles/mpa/) for the live demo this code is taken from.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/popstate_event/index.md
+++ b/files/en-us/web/api/window/popstate_event/index.md
@@ -48,7 +48,8 @@ Note that just calling `history.pushState()` or `history.replaceState()` won't t
 
 Browsers tend to handle the `popstate` event differently on page load. Chrome (prior to v34) and Safari always emit a `popstate` event on page load, but Firefox doesn't.
 
-> **Note:** When writing functions that process `popstate` event it is important to take into account that properties like `window.location` will already reflect the state change (if it affected the current URL), but `document` might still not. If the goal is to catch the moment when the new document state is already fully in place, a zero-delay {{domxref("setTimeout()")}} method call should be used to effectively put its inner _callback_ function that does the processing at the end of the browser event loop: `window.onpopstate = () => setTimeout(doSomeThing, 0);`
+> [!NOTE]
+> When writing functions that process `popstate` event it is important to take into account that properties like `window.location` will already reflect the state change (if it affected the current URL), but `document` might still not. If the goal is to catch the moment when the new document state is already fully in place, a zero-delay {{domxref("setTimeout()")}} method call should be used to effectively put its inner _callback_ function that does the processing at the end of the browser event loop: `window.onpopstate = () => setTimeout(doSomeThing, 0);`
 
 ## When popstate is sent
 

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -19,10 +19,12 @@ refresh rate. The most common refresh rate is 60hz,
 background tabs or hidden {{ HTMLElement("iframe") }}s, in order to improve
 performance and battery life.
 
-> **Note:** Your callback function must call `requestAnimationFrame()` again if
+> [!NOTE]
+> Your callback function must call `requestAnimationFrame()` again if
 > you want to animate another frame. `requestAnimationFrame()` is one-shot.
 
-> **Warning:** Be sure always to use the first argument (or some other method for
+> [!WARNING]
+> Be sure always to use the first argument (or some other method for
 > getting the current time) to calculate how much the animation will progress in
 > a frame — **otherwise, the animation will run faster on high refresh-rate screens**.
 > For ways to do that, see the examples below.

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -16,7 +16,8 @@ The non-standard {{domxref("Window")}} method
 method which lets a website or app gain access to a sandboxed file system for its own
 use. The returned {{domxref("FileSystem")}} is then available for use with the other [file system APIs](/en-US/docs/Web/API/File_and_Directory_Entries_API).
 
-> **Note:** This method is prefixed with `webkit` in all browsers that implement it.
+> [!NOTE]
+> This method is prefixed with `webkit` in all browsers that implement it.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -20,7 +20,8 @@ You can call `requestIdleCallback()` within an idle callback function to
 schedule another callback to take place no sooner than the next pass through the event
 loop.
 
-> **Note:** A `timeout` option is strongly recommended for required work,
+> [!NOTE]
+> A `timeout` option is strongly recommended for required work,
 > as otherwise it's possible multiple seconds will elapse before the callback is fired.
 
 ## Syntax

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -64,7 +64,8 @@ window.onresize = reportWindowSize;
 
 {{EmbedLiveSample("Window_size_logger")}}
 
-> **Note:** The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
+> [!NOTE]
+> The example output here is in an {{HTMLElement("iframe")}}, so the reported width and height values are for the `<iframe>`, not the window that this page is in. In particular, it will be hard to adjust the window size so as to see a difference in the reported height.
 >
 > The effect is easier to see if you {{LiveSampleLink("Window_size_logger", "view the example in its own window")}}.
 

--- a/files/en-us/web/api/window/resizeby/index.md
+++ b/files/en-us/web/api/window/resizeby/index.md
@@ -76,7 +76,8 @@ any information on, that window/tab.
 
 {{Compat}}
 
-> **Note:** This function might not resize the window synchronously.
+> [!NOTE]
+> This function might not resize the window synchronously.
 > In some environments (like mobile) it might not resize the window at all. You
 > can listen to the {{domxref("Window/resize_event", "resize")}} event to see
 > if/when the window got resized.

--- a/files/en-us/web/api/window/resizeto/index.md
+++ b/files/en-us/web/api/window/resizeto/index.md
@@ -55,7 +55,8 @@ Note: It's not possible to resize a window or tab that wasn't created by
 **`window.open()`**. It's also not possible to resize when the
 window has multiple tabs.
 
-> **Note:** This function might not resize the window synchronously.
+> [!NOTE]
+> This function might not resize the window synchronously.
 > In some environments (like mobile) it might not resize the window at all. You
 > can listen to the {{domxref("Window/resize_event", "resize")}} event to see
 > if/when the window got resized.

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -12,7 +12,8 @@ The **`Window.screenX`** read-only property returns the
 horizontal distance, in CSS pixels, of the left border of the user's browser viewport to
 the left side of the screen.
 
-> **Note:** An alias of `screenX` was implemented across modern
+> [!NOTE]
+> An alias of `screenX` was implemented across modern
 > browsers in more recent times — {{domxref("Window.screenLeft")}}. This was originally
 > supported only in IE but was introduced everywhere due to popularity.
 

--- a/files/en-us/web/api/window/screeny/index.md
+++ b/files/en-us/web/api/window/screeny/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Window.screenY
 
 The **`Window.screenY`** read-only property returns the vertical distance, in CSS pixels, of the top border of the user's browser viewport to the top edge of the screen.
 
-> **Note:** An alias of `screenY` was implemented across modern browsers in more recent times — {{domxref("Window.screenTop")}}. This was originally supported only in IE but was introduced everywhere due to popularity.
+> [!NOTE]
+> An alias of `screenY` was implemented across modern browsers in more recent times — {{domxref("Window.screenTop")}}. This was originally supported only in IE but was introduced everywhere due to popularity.
 
 ## Value
 

--- a/files/en-us/web/api/window/scrollx/index.md
+++ b/files/en-us/web/api/window/scrollx/index.md
@@ -14,7 +14,8 @@ The read-only **`scrollX`** property of the {{domxref("Window")}} interface retu
 
 A double-precision floating-point value indicating the number of pixels by which the document is currently scrolled horizontally from the origin, where a positive value means the content is scrolled to the right (to reveal more content to the right). In more technical terms, `scrollX` returns the X coordinate of the left edge of the current {{Glossary("viewport")}}. If the document isn't scrolled at all left or right, then `scrollX` is 0. If there is no viewport, the returned value is 0. If the document is rendered on a subpixel-precise device, then the returned value is also subpixel-precise and may contain a decimal component.
 
-> **Note:** If you need an integer value, you can use {{jsxref("Math.round()")}} to round it off.
+> [!NOTE]
+> If you need an integer value, you can use {{jsxref("Math.round()")}} to round it off.
 
 It's possible for `scrollX` to be negative if the document can be scrolled to the left from the initial containing block. For example, if the document is right-to-left and content grows to the left.
 

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -14,7 +14,8 @@ The read-only **`scrollY`** property of the {{domxref("Window")}} interface retu
 
 A double-precision floating-point value indicating the number of pixels by which the document is currently scrolled vertically from the origin, where a positive value means the content is scrolled down (to reveal more content to the bottom). In more technical terms, `scrollY` returns the Y coordinate of the top edge of the current {{Glossary("viewport")}}. If the document isn't scrolled at all top or down, then `scrollY` is 0. If there is no viewport, the returned value is 0. If the document is rendered on a subpixel-precise device, then the returned value is also subpixel-precise and may contain a decimal component.
 
-> **Note:** If you need an integer value, you can use {{jsxref("Math.round()")}} to round it off.
+> [!NOTE]
+> If you need an integer value, you can use {{jsxref("Math.round()")}} to round it off.
 
 Safari responds to overscrolling by updating `scrollY` beyond the maximum scroll position (unless the default "bounce" effect is disabled, such as by setting {{cssxref("overscroll-behavior")}} to `none`), while Chrome and Firefox do not. For example, `scrollY` may be negative on Safari just by continuing to scroll up when the document is already at the top.
 

--- a/files/en-us/web/api/window/sessionstorage/index.md
+++ b/files/en-us/web/api/window/sessionstorage/index.md
@@ -97,7 +97,8 @@ field.addEventListener("change", () => {
 });
 ```
 
-> **Note:** Please refer to the [Using the Web Storage API](/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) article for a full example.
+> [!NOTE]
+> Please refer to the [Using the Web Storage API](/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API) article for a full example.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/showmodaldialog/index.md
+++ b/files/en-us/web/api/window/showmodaldialog/index.md
@@ -11,7 +11,8 @@ browser-compat: api.Window.showModalDialog
 
 {{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}
 
-> **Warning:** This feature has been removed. Please fix your websites and applications.
+> [!WARNING]
+> This feature has been removed. Please fix your websites and applications.
 >
 > This method was removed in Chrome 43 and Firefox 56.
 
@@ -93,7 +94,8 @@ showModalDialog(uri, arguments, options)
   </tbody>
 </table>
 
-> **Note:** Firefox does not implement the `dialogHide`, `edge`, `status`, or `unadorned` arguments.
+> [!NOTE]
+> Firefox does not implement the `dialogHide`, `edge`, `status`, or `unadorned` arguments.
 
 ### Return value
 

--- a/files/en-us/web/api/window/storage_event/index.md
+++ b/files/en-us/web/api/window/storage_event/index.md
@@ -12,7 +12,8 @@ The **`storage`** event of the {{domxref("Window")}} interface fires when a stor
 
 This event is not cancelable and does not bubble.
 
-> **Note:** This won't work on the same {{Glossary("browsing context")}} that is making the changes — it is really a way for other browsing contexts on the domain using the storage to sync any changes that are made. Browsing contexts on other domains can't access the same storage objects.
+> [!NOTE]
+> This won't work on the same {{Glossary("browsing context")}} that is making the changes — it is really a way for other browsing contexts on the domain using the storage to sync any changes that are made. Browsing contexts on other domains can't access the same storage objects.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/unload_event/index.md
+++ b/files/en-us/web/api/window/unload_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Window.unload_event
 
 {{APIRef}}{{deprecated_header}}
 
-> **Warning:** Developers should avoid using this event. See "Usage notes" below.
+> [!WARNING]
+> Developers should avoid using this event. See "Usage notes" below.
 
 The **`unload`** event is fired when the document or a child resource is being unloaded.
 

--- a/files/en-us/web/api/window/vrdisplayactivate_event/index.md
+++ b/files/en-us/web/api/window/vrdisplayactivate_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.vrdisplayactivate_event
 
 The **`vrdisplayactivate`** event of the [WebVR API](/en-US/docs/Web/API/WebVR_API) is fired when a VR display is able to be presented to, for example if an HMD has been moved to bring it out of standby, or woken up by being put on.
 
-> **Note:** This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
+> [!NOTE]
+> This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/window/vrdisplayconnect_event/index.md
+++ b/files/en-us/web/api/window/vrdisplayconnect_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.vrdisplayconnect_event
 
 The **`vrdisplayconnect`** event of the [WebVR API](/en-US/docs/Web/API/WebVR_API) is fired when a compatible VR display is connected to the computer.
 
-> **Note:** This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
+> [!NOTE]
+> This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/window/vrdisplaydeactivate_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaydeactivate_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.vrdisplaydeactivate_event
 
 The **`vrdisplaydeactivate`** event of the [WebVR API](/en-US/docs/Web/API/WebVR_API) is fired when a VR display can no longer be presented to, for example if an HMD has gone into standby or sleep mode due to a period of inactivity.
 
-> **Note:** This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
+> [!NOTE]
+> This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/window/vrdisplaydisconnect_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaydisconnect_event/index.md
@@ -44,7 +44,8 @@ _`VRDisplayEvent` also inherits properties from its parent object, {{domxref("Ev
 
 You can use the `vrdisplaydisconnect` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
-> **Note:** This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
+> [!NOTE]
+> This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
 ```js
 window.addEventListener("vrdisplaydisconnect", () => {

--- a/files/en-us/web/api/window/vrdisplaypresentchange_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaypresentchange_event/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.vrdisplaypresentchange_event
 
 The **`vrdisplaypresentchange`** event of the [WebVR API](/en-US/docs/Web/API/WebVR_API) is fired when the presenting state of a VR display changes — i.e. goes from presenting to not presenting, or vice versa.
 
-> **Note:** This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
+> [!NOTE]
+> This event was part of the old [WebVR API](https://immersive-web.github.io/webvr/spec/1.1/). It has been superseded by the [WebXR Device API](https://immersive-web.github.io/webxr/).
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
@@ -13,7 +13,8 @@ browser-compat: api.Window.webkitConvertPointFromNodeToPage
 
 Given a {{domxref("WebKitPoint")}} specified in a particular DOM {{domxref("Node")}}'s coordinate system, the {{domxref("Window")}} method **`webkitConvertPointFromNodeToPage()`** returns a `Point` which specifies the same position in the page's coordinate system. This method is non-standard and _should not be used_.
 
-> **Warning:** Please review the [Browser compatibility](#browser_compatibility) section before using this method, as it's not widely supported (nor is the {{domxref("WebKitPoint")}} object it uses).
+> [!WARNING]
+> Please review the [Browser compatibility](#browser_compatibility) section before using this method, as it's not widely supported (nor is the {{domxref("WebKitPoint")}} object it uses).
 
 ## Syntax
 

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
@@ -16,7 +16,8 @@ Given a {{domxref("WebKitPoint")}} specified in the page's coordinate system, th
 returns a `Point` object specifying the same location in the coordinate
 system of the specified DOM {{domxref("Node")}}.
 
-> **Warning:** Please review the [Browser compatibility](#browser_compatibility) section before using this method,
+> [!WARNING]
+> Please review the [Browser compatibility](#browser_compatibility) section before using this method,
 > as it's not widely supported (nor is the {{domxref("WebKitPoint")}} object it uses).
 
 ## Syntax

--- a/files/en-us/web/api/window_management_api/index.md
+++ b/files/en-us/web/api/window_management_api/index.md
@@ -32,7 +32,8 @@ The Window Management API provides more robust, flexible window management. It a
 
 For details on how to use it, see [Using the Window Management API](/en-US/docs/Web/API/Window_Management_API/Using).
 
-> **Note:** In modern browsers, a separate user gesture event is required for each `Window.open()` call, for security purposes. This prevents sites from spamming users with lots of windows. However, this poses an issue for multi-window applications. To work around this limitation, you can design your applications to open no more than one new window at once, reuse existing windows to display different pages, or advise users on how to update their browser settings to allow multiple windows.
+> [!NOTE]
+> In modern browsers, a separate user gesture event is required for each `Window.open()` call, for security purposes. This prevents sites from spamming users with lots of windows. However, this poses an issue for multi-window applications. To work around this limitation, you can design your applications to open no more than one new window at once, reuse existing windows to display different pages, or advise users on how to update their browser settings to allow multiple windows.
 
 ### Use cases
 

--- a/files/en-us/web/api/window_management_api/multi-screen_origin/index.md
+++ b/files/en-us/web/api/window_management_api/multi-screen_origin/index.md
@@ -10,7 +10,8 @@ The [Window Management API](/en-US/docs/Web/API/Window_Management_API) introduce
 
 The primary screen can usually be specified by the user via OS settings, and generally contains OS UI features such as the taskbar/icon dock.
 
-> **Note:** Positive coordinate values are to the right and downwards on the screen arrangement, while negative ones are to the left and upwards.
+> [!NOTE]
+> Positive coordinate values are to the right and downwards on the screen arrangement, while negative ones are to the left and upwards.
 
 ## Effects on existing web platform features
 
@@ -20,7 +21,8 @@ The multi-screen origin is relevant to the following APIs:
 - The values of {{domxref("Window.screenLeft")}}, {{domxref("Window.screenTop")}}, {{domxref("Window.screenX")}}, {{domxref("Window.screenY")}} for each window are reported relative to the multi-screen origin.
 - When using {{domxref("Window.moveTo()")}} and {{domxref("Window.open()")}}, windows are positioned relative to the multi-screen origin.
 
-> **Note:** Not all browsers officially support multi-screen origin, but some have their own non-standard implementations. You are advised to check the browser compatibility information of the above features for the behavior in each browser.
+> [!NOTE]
+> Not all browsers officially support multi-screen origin, but some have their own non-standard implementations. You are advised to check the browser compatibility information of the above features for the behavior in each browser.
 
 ## Visual examples
 

--- a/files/en-us/web/api/window_management_api/using/index.md
+++ b/files/en-us/web/api/window_management_api/using/index.md
@@ -40,7 +40,8 @@ When `getScreenDetails()` is invoked, the user will be asked for permission to m
 
 {{domxref("ScreenDetailed")}} objects inherit the properties of the {{domxref("Screen")}} interface, and contain useful information for placing windows on specific screens.
 
-> **Note:** You can gate functionality based on whether the user has more than one screen available using the {{domxref("Screen.isExtended", "Window.screen.isExtended")}} property. This returns `true` if the device has multiple screens, and `false` if not.
+> [!NOTE]
+> You can gate functionality based on whether the user has more than one screen available using the {{domxref("Screen.isExtended", "Window.screen.isExtended")}} property. This returns `true` if the device has multiple screens, and `false` if not.
 
 ### Opening windows
 
@@ -122,9 +123,11 @@ function checkWindowClose() {
 }
 ```
 
-> **Note:** In our experiments, the {{domxref("setInterval()")}} polling method shown above seemed to work best for detecting window closure in the case of multiple windows. Using events such as {{domxref("Window.beforeunload_event", "beforeunload")}}, {{domxref("Window.pagehide_event", "pagehide")}}, or {{domxref("Document.visibilitychange_event", "visibilitychange")}} proved unreliable because, when opening multiple windows at the same time, the rapid shift in focus/visibility seemed to fire the handler function prematurely.
+> [!NOTE]
+> In our experiments, the {{domxref("setInterval()")}} polling method shown above seemed to work best for detecting window closure in the case of multiple windows. Using events such as {{domxref("Window.beforeunload_event", "beforeunload")}}, {{domxref("Window.pagehide_event", "pagehide")}}, or {{domxref("Document.visibilitychange_event", "visibilitychange")}} proved unreliable because, when opening multiple windows at the same time, the rapid shift in focus/visibility seemed to fire the handler function prematurely.
 
-> **Note:** One concern with the above example is that it uses constant values to represent the size of the Chrome window UI portions in the calculations — `WINDOW_CHROME_X` and `WINDOW_CHROME_Y` — to get the window size calculations correct. To create precisely-sized windows on other future implementations of the API, you'd need to keep a small library of browser chrome sizes, and employ browser detection to discover which browser is rendering your app and choose the correct size for calculations. Or you can rely on less precise window sizes.
+> [!NOTE]
+> One concern with the above example is that it uses constant values to represent the size of the Chrome window UI portions in the calculations — `WINDOW_CHROME_X` and `WINDOW_CHROME_Y` — to get the window size calculations correct. To create precisely-sized windows on other future implementations of the API, you'd need to keep a small library of browser chrome sizes, and employ browser detection to discover which browser is rendering your app and choose the correct size for calculations. Or you can rely on less precise window sizes.
 
 ### Handling browser popup blockers
 

--- a/files/en-us/web/api/windowsharedstorage/run/index.md
+++ b/files/en-us/web/api/windowsharedstorage/run/index.md
@@ -13,7 +13,8 @@ browser-compat: api.WindowSharedStorage.run
 The **`run()`** method of the
 {{domxref("WindowSharedStorage")}} interface executes a [run operation](/en-US/docs/Web/API/SharedStorageRunOperation) that is registered in a module added to the current origin's {{domxref("SharedStorageWorklet")}}.
 
-> **Note:** The [Run output gate](/en-US/docs/Web/API/Shared_Storage_API#run) is intended as a generic way to process some shared storage data.
+> [!NOTE]
+> The [Run output gate](/en-US/docs/Web/API/Shared_Storage_API#run) is intended as a generic way to process some shared storage data.
 
 ## Syntax
 

--- a/files/en-us/web/api/windowsharedstorage/selecturl/index.md
+++ b/files/en-us/web/api/windowsharedstorage/selecturl/index.md
@@ -13,7 +13,8 @@ browser-compat: api.WindowSharedStorage.selectURL
 The **`selectURL()`** method of the
 {{domxref("WindowSharedStorage")}} interface executes a [URL Selection operation](/en-US/docs/Web/API/SharedStorageSelectURLOperation) that is registered in a module added to the current origin's {{domxref("SharedStorageWorklet")}}.
 
-> **Note:** The [URL Selection output gate](/en-US/docs/Web/API/Shared_Storage_API#url_selection) is used to select a URL from a provided list to display to the user, based on shared storage data.
+> [!NOTE]
+> The [URL Selection output gate](/en-US/docs/Web/API/Shared_Storage_API#url_selection) is used to select a URL from a provided list to display to the user, based on shared storage data.
 
 ## Syntax
 

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -34,7 +34,8 @@ const myWorker = new Worker("worker.js");
 myWorker.terminate();
 ```
 
-> **Note:** DedicatedWorkers and SharedWorkers can also be stopped from the {{domxref("Worker")}} instance using the {{domxref("DedicatedWorkerGlobalScope.close()")}} or {{domxref("SharedWorkerGlobalScope.close()")}} methods.
+> [!NOTE]
+> DedicatedWorkers and SharedWorkers can also be stopped from the {{domxref("Worker")}} instance using the {{domxref("DedicatedWorkerGlobalScope.close()")}} or {{domxref("SharedWorkerGlobalScope.close()")}} methods.
 
 ## Specifications
 

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Worker.Worker
 
 The **`Worker()`** constructor creates a {{domxref("Worker")}} object that executes the script at the specified URL. This script must obey the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
-> **Note:** that there is a disagreement among browser manufacturers about whether a data URL is of the same origin or not. Though Firefox 10 and later accept data URLs, that's not the case in all other browsers.
+> [!NOTE]
+> that there is a disagreement among browser manufacturers about whether a data URL is of the same origin or not. Though Firefox 10 and later accept data URLs, that's not the case in all other browsers.
 
 ## Syntax
 

--- a/files/en-us/web/api/workerglobalscope/fetch/index.md
+++ b/files/en-us/web/api/workerglobalscope/fetch/index.md
@@ -18,7 +18,8 @@ Instead, a `then()` handler must check the {{domxref("Response.ok")}} and/or {{d
 
 The `fetch()` method is controlled by the `connect-src` directive of [Content Security Policy](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) rather than the directive of the resources it's retrieving.
 
-> **Note:** The `fetch()` method's parameters are identical to those of the {{domxref("Request.Request","Request()")}} constructor.
+> [!NOTE]
+> The `fetch()` method's parameters are identical to those of the {{domxref("Request.Request","Request()")}} constructor.
 
 ## Syntax
 

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -103,7 +103,8 @@ importScripts("foo.js");
 console.log(navigator);
 ```
 
-> **Note:** Since the global scope of the worker script is effectively the global scope of the worker you are running ({{domxref("DedicatedWorkerGlobalScope")}} or whatever) and all worker global scopes inherit methods, properties, etc. from `WorkerGlobalScope`, you can run lines such as those above without specifying a parent object.
+> [!NOTE]
+> Since the global scope of the worker script is effectively the global scope of the worker you are running ({{domxref("DedicatedWorkerGlobalScope")}} or whatever) and all worker global scopes inherit methods, properties, etc. from `WorkerGlobalScope`, you can run lines such as those above without specifying a parent object.
 
 ## Specifications
 

--- a/files/en-us/web/api/workerglobalscope/location/index.md
+++ b/files/en-us/web/api/workerglobalscope/location/index.md
@@ -40,7 +40,8 @@ WorkerLocation {hash: "", search: "", pathname: "/worker.js", port: "8000", host
 
 You could use this location object to return more information about the document's location, as you might do with a normal {{domxref("Location")}} object.
 
-> **Note:** Firefox has a bug with using `console.log` inside shared/service workers (see [Firefox bug 1058644](https://bugzil.la/1058644)), which may return strange results, but this should be fixed soon.
+> [!NOTE]
+> Firefox has a bug with using `console.log` inside shared/service workers (see [Firefox bug 1058644](https://bugzil.la/1058644)), which may return strange results, but this should be fixed soon.
 
 ## Specifications
 

--- a/files/en-us/web/api/workernavigator/appcodename/index.md
+++ b/files/en-us/web/api/workernavigator/appcodename/index.md
@@ -14,7 +14,8 @@ The value of the **`WorkerNavigator.appCodeName`** property is
 always "`Mozilla`", in any browser. This property is kept only for
 compatibility purposes.
 
-> **Note:** Do not rely on this property to return a real
+> [!NOTE]
+> Do not rely on this property to return a real
 > product name. All browsers return "`Mozilla`" as the value of this property.
 
 ## Value

--- a/files/en-us/web/api/workernavigator/appname/index.md
+++ b/files/en-us/web/api/workernavigator/appname/index.md
@@ -14,7 +14,8 @@ The value of the **`WorkerNavigator.appName`** property is always
 "`Netscape`", in any browser. This property is kept only for compatibility
 purposes.
 
-> **Note:** Do not rely on this property to return a real browser name. All browsers return "`Netscape`" as the value of this property.
+> [!NOTE]
+> Do not rely on this property to return a real browser name. All browsers return "`Netscape`" as the value of this property.
 
 ## Value
 

--- a/files/en-us/web/api/workernavigator/appversion/index.md
+++ b/files/en-us/web/api/workernavigator/appversion/index.md
@@ -13,7 +13,8 @@ browser-compat: api.WorkerNavigator.appVersion
 Returns either "`4.0`" or a string representing version information about
 the browser.
 
-> **Note:** Do not rely on this property to return the correct browser version.
+> [!NOTE]
+> Do not rely on this property to return the correct browser version.
 
 ## Value
 

--- a/files/en-us/web/api/workernavigator/product/index.md
+++ b/files/en-us/web/api/workernavigator/product/index.md
@@ -14,7 +14,8 @@ The value of the **`WorkerNavigator.product`** property is always
 "`Gecko`", in any browser. This property is kept only for compatibility
 purposes.
 
-> **Note:** Do not rely on this property to return a real product name. All browsers return "`Gecko`" as the value of this property.
+> [!NOTE]
+> Do not rely on this property to return a real product name. All browsers return "`Gecko`" as the value of this property.
 
 ## Value
 

--- a/files/en-us/web/api/workernavigator/useragent/index.md
+++ b/files/en-us/web/api/workernavigator/useragent/index.md
@@ -11,7 +11,8 @@ browser-compat: api.WorkerNavigator.userAgent
 The **`WorkerNavigator.userAgent`** read-only property returns the
 user agent string for the current browser.
 
-> **Note:** The specification asks browsers to provide as little information via this field as
+> [!NOTE]
+> The specification asks browsers to provide as little information via this field as
 > possible. Never assume that the value of this property will stay the same in future
 > versions of the same browser. Try not to use it at all, or only for current and past
 > versions of a browser. New browsers may start using the same UA, or part of it, as an

--- a/files/en-us/web/api/worklet/index.md
+++ b/files/en-us/web/api/worklet/index.md
@@ -76,7 +76,8 @@ Worklets are restricted to specific use cases; they cannot be used for arbitrary
   </tbody>
 </table>
 
-> **Note:** Paint worklets, defined by the [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API), don't subclass `Worklet`. They are accessed through a regular `Worklet` object obtained using {{DOMxref("CSS.paintWorklet_static", "CSS.paintWorklet")}}.
+> [!NOTE]
+> Paint worklets, defined by the [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API), don't subclass `Worklet`. They are accessed through a regular `Worklet` object obtained using {{DOMxref("CSS.paintWorklet_static", "CSS.paintWorklet")}}.
 
 For 3D rendering with [WebGL](/en-US/docs/Web/API/WebGL_API), you don't use worklets. Instead, you write vertex shaders and fragment shaders using GLSL code, and those shaders will then run on the graphics card.
 

--- a/files/en-us/web/api/workletglobalscope/index.md
+++ b/files/en-us/web/api/workletglobalscope/index.md
@@ -9,7 +9,8 @@ browser-compat: api.WorkletGlobalScope
 
 The **`WorkletGlobalScope`** interface is an abstract class that specific worklet scope classes inherit from. Each `WorkletGlobalScope` defines a new global environment.
 
-> **Note:** You don't normally need to interact with this interface. It is a base interface intended to be subclassed. You will encounter the subclasses {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside CSS paint {{domxref("Worklet")}} objects.
+> [!NOTE]
+> You don't normally need to interact with this interface. It is a base interface intended to be subclassed. You will encounter the subclasses {{domxref("AudioWorkletGlobalScope")}} inside {{domxref("AudioWorklet")}} objects, or {{domxref("PaintWorkletGlobalScope")}} inside CSS paint {{domxref("Worklet")}} objects.
 
 ## Instance properties
 

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -53,7 +53,8 @@ new WritableStream(underlyingSink, queuingStrategy)
     - `size(chunk)`
       - : A method containing a parameter `chunk` — this indicates the size to use for each chunk, in bytes.
 
-    > **Note:** You could define your own custom `queuingStrategy`, or use an instance of {{domxref("ByteLengthQueuingStrategy")}} or {{domxref("CountQueuingStrategy")}} for this object value.
+    > [!NOTE]
+    > You could define your own custom `queuingStrategy`, or use an instance of {{domxref("ByteLengthQueuingStrategy")}} or {{domxref("CountQueuingStrategy")}} for this object value.
     > If no `queuingStrategy` is supplied, the default used is the same as a `CountQueuingStrategy` with a high water mark of 1\.
 
 ### Return value

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -11,7 +11,8 @@ browser-compat: api.WritableStreamDefaultWriter.WritableStreamDefaultWriter
 The **`WritableStreamDefaultWriter()`**
 constructor creates a new {{domxref("WritableStreamDefaultWriter")}} object instance.
 
-> **Note:** You generally wouldn't use this constructor manually; instead,
+> [!NOTE]
+> You generally wouldn't use this constructor manually; instead,
 > you'd use the {{domxref("WritableStream.getWriter()")}} method.
 
 ## Syntax

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -16,7 +16,8 @@ if no response has been received.
 If a network error happened, an empty string
 is returned.
 
-> **Note:** For multipart requests, this returns the headers from the
+> [!NOTE]
+> For multipart requests, this returns the headers from the
 > _current_ part of the request, not from the original channel.
 
 ## Syntax
@@ -55,7 +56,8 @@ x-xss-protection: 1; mode=block\r\n
 Each line is terminated by both carriage return and line feed characters
 (`\r\n`). These are essentially delimiters separating each of the headers.
 
-> **Note:** In modern browsers, the header names are returned in all lower
+> [!NOTE]
+> In modern browsers, the header names are returned in all lower
 > case, as per the latest spec.
 
 ## Examples

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
@@ -17,7 +17,8 @@ with the same name, then their values are returned as a single concatenated stri
 where each value is separated from the previous one by a pair of comma and space. The
 `getResponseHeader()` method returns the value as a UTF byte sequence.
 
-> **Note:** The search for the header name is case-insensitive.
+> [!NOTE]
+> The search for the header name is case-insensitive.
 
 If you need to get the raw string of all of the headers, use the
 {{DOMxRef("XMLHttpRequest.getAllResponseHeaders", "getAllResponseHeaders()")}} method,

--- a/files/en-us/web/api/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/index.md
@@ -42,7 +42,8 @@ _This interface also inherits properties of {{domxref("XMLHttpRequestEventTarget
 
   - : Returns a string containing the response string returned by the HTTP server. Unlike {{domxref("XMLHttpRequest.status")}}, this includes the entire text of the response message ("`OK`", for example).
 
-    > **Note:** According to the HTTP/2 specification {{RFC(7540, "Response Pseudo-Header Fields", "8.1.2.4")}}, HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.
+    > [!NOTE]
+    > According to the HTTP/2 specification {{RFC(7540, "Response Pseudo-Header Fields", "8.1.2.4")}}, HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.
 
 - {{domxref("XMLHttpRequest.timeout")}}
   - : The time in milliseconds a request can take before automatically being terminated.

--- a/files/en-us/web/api/xmlhttprequest/mozbackgroundrequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozbackgroundrequest/index.md
@@ -9,10 +9,12 @@ status:
 
 {{APIRef("XMLHttpRequest API")}} {{AvailableInWorkers("window_and_worker_except_service")}}
 
-> **Note:** This method is not available from Web content. It requires elevated privileges to access.
+> [!NOTE]
+> This method is not available from Web content. It requires elevated privileges to access.
 
 **`XMLHttpRequest.mozBackgroundRequest`** is a Boolean, indicating if the object represents a background service request. If `true`, no load group is associated with the request, with security dialogs prevented from being shown to the user.
 
 In cases in where a security dialog (such as authentication or a bad certificate notification) would normally be shown, this request fails instead.
 
-> **Note:** This property must be set before calling `open()`.
+> [!NOTE]
+> This property must be set before calling `open()`.

--- a/files/en-us/web/api/xmlhttprequest/open/index.md
+++ b/files/en-us/web/api/xmlhttprequest/open/index.md
@@ -11,7 +11,8 @@ browser-compat: api.XMLHttpRequest.open
 The {{domxref("XMLHttpRequest")}} method **`open()`**
 initializes a newly-created request, or re-initializes an existing one.
 
-> **Note:** Calling this method for an already active request
+> [!NOTE]
+> Calling this method for an already active request
 > (one for which `open()` has already been called) is the equivalent of calling
 > {{domxref("XMLHttpRequest.abort", "abort()")}}.
 
@@ -41,7 +42,8 @@ open(method, url, async, user, password)
     listeners. This _must_ be true if the `multipart` attribute is
     `true`, or an exception will be thrown.
 
-    > **Note:** Synchronous requests on the main thread can
+    > [!NOTE]
+    > Synchronous requests on the main thread can
     > be easily disruptive to the user experience and should be avoided; in fact, many
     > browsers have deprecated synchronous XHR support on the main thread entirely.
     > Synchronous requests are permitted in {{domxref("Worker")}}s.

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
@@ -39,7 +39,8 @@ None ({{jsxref("undefined")}}).
 This example specifies a MIME type of `"text/plain"`, overriding the
 server's stated type for the data being received.
 
-> **Note:** If the server doesn't provide a
+> [!NOTE]
+> If the server doesn't provide a
 > [`Content-Type`](/en-US/docs/Web/HTTP/Headers/Content-Type)
 > header, {{domxref("XMLHttpRequest")}} assumes that the MIME type is
 > `"text/xml"`. If the content isn't valid XML, an "XML Parsing Error: not

--- a/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -10,7 +10,8 @@ browser-compat: api.XMLHttpRequest.readystatechange_event
 
 The `readystatechange` event is fired whenever the {{domxref("XMLHttpRequest.readyState", "readyState")}} property of the {{domxref("XMLHttpRequest")}} changes.
 
-> **Warning:** This should not be used with synchronous requests and must
+> [!WARNING]
+> This should not be used with synchronous requests and must
 > not be used from native code.
 
 ## Syntax

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.md
@@ -34,7 +34,8 @@ It can take the following values:
 - `"text"`
   - : The `response` is a text in a string.
 
-> **Note:** When setting `responseType` to a particular value, the author should make
+> [!NOTE]
+> When setting `responseType` to a particular value, the author should make
 > sure that the server is actually sending a response compatible with that format. If
 > the server returns data that is not compatible with the `responseType` that
 > was set, the value of {{domxref("XMLHttpRequest.response", "response")}} will be

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -13,7 +13,8 @@ a {{domxref("Document")}} containing the HTML or XML retrieved by the request; o
 `null` if the request was unsuccessful, has not yet been sent, or if the data
 can't be parsed as XML or HTML.
 
-> **Note:** The name `responseXML` is an artifact of this
+> [!NOTE]
+> The name `responseXML` is an artifact of this
 > property's history; it works for both HTML and XML.
 
 Usually, the response is parsed as "`text/xml`". If the

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -20,7 +20,8 @@ For security reasons, there are several {{Glossary("Forbidden_header_name", "for
 
 In addition, the [`Authorization`](/en-US/docs/Web/HTTP/Headers/Authorization) HTTP header may be added to a request, but will be removed if the request is redirected cross-origin.
 
-> **Note:** For your custom fields, you may encounter a "**not allowed by Access-Control-Allow-Headers in preflight response**" exception when you send requests across domains.
+> [!NOTE]
+> For your custom fields, you may encounter a "**not allowed by Access-Control-Allow-Headers in preflight response**" exception when you send requests across domains.
 > In this situation, you need to set up the {{HTTPHeader("Access-Control-Allow-Headers")}} in your response header at server side.
 
 ## Syntax

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.md
@@ -12,7 +12,8 @@ The read-only **`XMLHttpRequest.statusText`** property returns a string containi
 
 If the server response doesn't explicitly specify a status text, `statusText` will assume the default value "OK".
 
-> **Note:** Responses over an HTTP/2 connection will always have an empty string as status message as HTTP/2 does not support them.
+> [!NOTE]
+> Responses over an HTTP/2 connection will always have an empty string as status message as HTTP/2 does not support them.
 
 ## Value
 

--- a/files/en-us/web/api/xmlhttprequest/timeout/index.md
+++ b/files/en-us/web/api/xmlhttprequest/timeout/index.md
@@ -10,7 +10,8 @@ browser-compat: api.XMLHttpRequest.timeout
 
 The **`XMLHttpRequest.timeout`** property is an `unsigned long` representing the number of milliseconds a request can take before automatically being terminated. The default value is 0, which means there is no timeout. Timeout shouldn't be used for synchronous XMLHttpRequests requests used in a {{Glossary('document environment')}} or it will throw an `InvalidAccessError` exception. When a timeout happens, a [timeout](/en-US/docs/Web/API/XMLHttpRequest/timeout_event) event is fired.
 
-> **Note:** You may not use a timeout for synchronous requests with an owning window.
+> [!NOTE]
+> You may not use a timeout for synchronous requests with an owning window.
 
 [Using a timeout with an asynchronous request](/en-US/docs/Web/API/XMLHttpRequest_API/Synchronous_and_Asynchronous_Requests#example_using_a_timeout).
 

--- a/files/en-us/web/api/xmlhttprequest/upload/index.md
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.md
@@ -12,9 +12,11 @@ The {{domxref("XMLHttpRequest")}} `upload` property returns an {{domxref("XMLHtt
 
 It is an opaque object, but because it's also an {{domxref("XMLHttpRequestEventTarget")}}, event listeners can be attached to track its process.
 
-> **Note:** Attaching event listeners to this object prevents the request from being a "simple request" and will cause a preflight request to be issued if cross-origin; see [CORS](/en-US/docs/Web/HTTP/CORS). Because of this, event listeners need to be registered before calling {{domxref("XMLHttpRequest.send", "send()")}} or upload events won't be dispatched.
+> [!NOTE]
+> Attaching event listeners to this object prevents the request from being a "simple request" and will cause a preflight request to be issued if cross-origin; see [CORS](/en-US/docs/Web/HTTP/CORS). Because of this, event listeners need to be registered before calling {{domxref("XMLHttpRequest.send", "send()")}} or upload events won't be dispatched.
 
-> **Note:** The spec also seems to indicate that event listeners should be attached after {{domxref("XMLHttpRequest.open", "open()")}}. However, browsers are buggy on this matter, and often need the listeners to be registered _before_ {{domxref("XMLHttpRequest.open", "open()")}} to work.
+> [!NOTE]
+> The spec also seems to indicate that event listeners should be attached after {{domxref("XMLHttpRequest.open", "open()")}}. However, browsers are buggy on this matter, and often need the listeners to be registered _before_ {{domxref("XMLHttpRequest.open", "open()")}} to work.
 
 The following events can be triggered on an upload object and used to monitor the upload:
 

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
@@ -12,7 +12,8 @@ The **`XMLHttpRequest.withCredentials`** property is a boolean value that indica
 
 In addition, this flag is also used to indicate when cookies are to be ignored in the response. The default is `false`. `XMLHttpRequest` responses from a different domain cannot set cookie values for their own domain unless `withCredentials` is set to `true` before making the request. The [third-party cookies](/en-US/docs/Web/Privacy/Third-party_cookies) obtained by setting `withCredentials` to `true` will still honor same-origin policy and hence can not be accessed by the requesting script through [document.cookie](/en-US/docs/Web/API/Document/cookie) or from response headers.
 
-> **Note:** This never affects same-origin requests.
+> [!NOTE]
+> This never affects same-origin requests.
 
 > **Note:** `XMLHttpRequest` responses from a different domain _cannot_ set cookie values for their own domain unless `withCredentials` is set to `true` before making the request, regardless of `Access-Control-` header values.
 

--- a/files/en-us/web/api/xmlhttprequest_api/synchronous_and_asynchronous_requests/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/synchronous_and_asynchronous_requests/index.md
@@ -127,7 +127,8 @@ Here, we're specifying a timeout of 2000 ms.
 
 ## Synchronous request
 
-> **Warning:** Synchronous XHR requests often cause hangs on the web, especially with poor network conditions or when the remote server is slow to respond. Synchronous XHR is now deprecated and should be avoided in favor of asynchronous requests.
+> [!WARNING]
+> Synchronous XHR requests often cause hangs on the web, especially with poor network conditions or when the remote server is slow to respond. Synchronous XHR is now deprecated and should be avoided in favor of asynchronous requests.
 
 All new XHR features such as `timeout` or `abort` are not allowed for synchronous XHR. Doing so will raise an `InvalidAccessError`.
 
@@ -196,7 +197,8 @@ self.onmessage = (event) => {
 };
 ```
 
-> **Note:** The effect is asynchronous, because of the use of the `Worker`.
+> [!NOTE]
+> The effect is asynchronous, because of the use of the `Worker`.
 
 This pattern can be useful, for example in order to interact with the server in the background, or to preload content. See [Using web workers](/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) for examples and details.
 

--- a/files/en-us/web/api/xmlhttprequest_api/using_formdata_objects/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/using_formdata_objects/index.md
@@ -37,7 +37,8 @@ send.addEventListener("click", async () => {
 });
 ```
 
-> **Note:** The fields `"avatar"` and `"webmasterfile"` both contain a file. The number assigned to the field `"accountnum"` is immediately converted into a string by the [`FormData.append()`](/en-US/docs/Web/API/FormData/append) method (the field's value can be a {{ domxref("Blob") }}, {{ domxref("File") }}, or a string. If the value is neither a `Blob` nor a `File`, the value is converted to a string).
+> [!NOTE]
+> The fields `"avatar"` and `"webmasterfile"` both contain a file. The number assigned to the field `"accountnum"` is immediately converted into a string by the [`FormData.append()`](/en-US/docs/Web/API/FormData/append) method (the field's value can be a {{ domxref("Blob") }}, {{ domxref("File") }}, or a string. If the value is neither a `Blob` nor a `File`, the value is converted to a string).
 
 This example builds a `FormData` instance containing values for fields named `"username"`, `"accountnum"`, `"avatar"` and `"webmasterfile"`, then uses {{domxref("Window/fetch", "fetch()")}} to send the form's data. The field `"webmasterfile"` is a {{domxref("Blob")}}. A `Blob` object represents a file-like object of immutable, raw data. Blobs represent data that isn't necessarily in a JavaScript-native format. The {{ domxref("File") }} interface is based on `Blob`, inheriting blob functionality and expanding it to support files on the user's system. In order to build a `Blob` you can invoke [the `Blob()` constructor](/en-US/docs/Web/API/Blob/Blob).
 
@@ -144,9 +145,11 @@ form.addEventListener("submit", async (event) => {
 });
 ```
 
-> **Note:** If you pass in a reference to the form, the [request HTTP method](/en-US/docs/Web/HTTP/Methods) specified in the form will be used over the method specified in the `open()` call.
+> [!NOTE]
+> If you pass in a reference to the form, the [request HTTP method](/en-US/docs/Web/HTTP/Methods) specified in the form will be used over the method specified in the `open()` call.
 
-> **Warning:** When using `FormData` to submit POST requests using {{ domxref("XMLHttpRequest") }} or the [Fetch API](/en-US/docs/Web/API/Fetch_API) with the `multipart/form-data` content type (e.g. when uploading files and blobs to the server), _do not_ explicitly set the [`Content-Type`](/en-US/docs/Web/HTTP/Headers/Content-Type) header on the request. Doing so will prevent the browser from being able to set the `Content-Type` header with the boundary expression it will use to delimit form fields in the request body.
+> [!WARNING]
+> When using `FormData` to submit POST requests using {{ domxref("XMLHttpRequest") }} or the [Fetch API](/en-US/docs/Web/API/Fetch_API) with the `multipart/form-data` content type (e.g. when uploading files and blobs to the server), _do not_ explicitly set the [`Content-Type`](/en-US/docs/Web/HTTP/Headers/Content-Type) header on the request. Doing so will prevent the browser from being able to set the `Content-Type` header with the boundary expression it will use to delimit form fields in the request body.
 
 You can also append a {{ domxref("File") }} or {{ domxref("Blob") }} directly to the {{ domxref("FormData") }} object, like this:
 

--- a/files/en-us/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest_api/using_xmlhttprequest/index.md
@@ -34,7 +34,8 @@ req.send();
 
 A request made via `XMLHttpRequest` can fetch the data in one of two ways, asynchronously or synchronously. The type of request is dictated by the optional `async` argument (the third argument) that is set on the {{domxref("XMLHttpRequest.open()")}} method. If this argument is `true` or not specified, the `XMLHttpRequest` is processed asynchronously, otherwise the process is handled synchronously. A detailed discussion and demonstrations of these two types of requests can be found on the [synchronous and asynchronous requests](/en-US/docs/Web/API/XMLHttpRequest_API/Synchronous_and_Asynchronous_Requests) page. You can't use synchronous requests outside web workers as it freezes the main interface.
 
-> **Note:** The constructor `XMLHttpRequest` isn't limited to only XML documents. It starts with **"XML"** because when it was created the main format that was originally used for asynchronous data exchange was XML.
+> [!NOTE]
+> The constructor `XMLHttpRequest` isn't limited to only XML documents. It starts with **"XML"** because when it was created the main format that was originally used for asynchronous data exchange was XML.
 
 ## Handling responses
 
@@ -137,7 +138,8 @@ function transferCanceled(evt) {
 
 We add event listeners for the various events that are sent while performing a data transfer using `XMLHttpRequest`.
 
-> **Note:** You need to add the event listeners before calling `open()` on the request. Otherwise the `progress` events will not fire.
+> [!NOTE]
+> You need to add the event listeners before calling `open()` on the request. Otherwise the `progress` events will not fire.
 
 The progress event handler, specified by the `updateProgress()` function in this example, receives the total number of bytes to transfer as well as the number of bytes transferred so far in the event's `total` and `loaded` fields. However, if the `lengthComputable` field is false, the total length is not known and will be zero.
 
@@ -154,7 +156,8 @@ req.upload.addEventListener("abort", transferCanceled);
 req.open();
 ```
 
-> **Note:** Progress events are not available for the
+> [!NOTE]
+> Progress events are not available for the
 > `file:` protocol.
 
 Progress events come in for every chunk of data received, including the last chunk in cases in which the last packet is received and the connection closed before the progress event is fired. In this case, the progress event is automatically fired when the load event occurs for that packet. This lets you now reliably monitor progress by only watching the "progress" event.

--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -37,7 +37,8 @@ This involves creating a new `XMLSerializer` object, then passing the {{domxref(
 
 This example uses the {{domxref("Element.insertAdjacentHTML()")}} method to insert a new DOM {{domxref("Node")}} into the body of the {{domxref("Document")}}, based on XML created by serializing an {{domxref("Element")}} object.
 
-> **Note:** In the real world, you should usually instead call {{domxref("Document.importNode", "importNode()")}} method to import the new node into the DOM, then call one of the following methods to add the node to the DOM tree:
+> [!NOTE]
+> In the real world, you should usually instead call {{domxref("Document.importNode", "importNode()")}} method to import the new node into the DOM, then call one of the following methods to add the node to the DOM tree:
 >
 > - The {{domxref("Element.append()")}}/{{domxref("Element.prepend()")}} and {{domxref("Document.append()")}}/{{domxref("Document.prepend()")}} methods.
 > - The {{domxref("Element.replaceWith")}} method (to replace an existing node with the new one)

--- a/files/en-us/web/api/xrinputsource/profiles/index.md
+++ b/files/en-us/web/api/xrinputsource/profiles/index.md
@@ -10,7 +10,8 @@ browser-compat: api.XRInputSource.profiles
 
 The read-only {{domxref("XRInputSource")}} property **`profiles`** returns an array of strings, each describing a configuration profile for the input source. The profile strings are listed in order of specificity, with the most specific profile listed first.
 
-> **Note:** The `profiles` list is always empty when the WebXR
+> [!NOTE]
+> The `profiles` list is always empty when the WebXR
 > session is in inline mode.
 
 ## Value

--- a/files/en-us/web/api/xrmediabinding/index.md
+++ b/files/en-us/web/api/xrmediabinding/index.md
@@ -11,7 +11,7 @@ browser-compat: api.XRMediaBinding
 
 The **`XRMediaBinding`** interface is used to create layers that display the content of an {{domxref("HTMLVideoElement")}}.
 
-> **Note:**
+> [!NOTE]
 > Only the video frames will be displayed in the layer. Video controls need to be implemented separately and must be drawn in another layer.
 
 ## Constructor

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.md
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.md
@@ -51,7 +51,8 @@ There are a number of reasons why a reset might occur. Most common among them ar
 - The user is in an `unbounded` reference space and has moved far enough from the starting position (the reference space's origin) that floating-point or other forms of error or drift are problematic. The coordinate system is thus reset with its new origin at or near the user's current position.
 - The WebXR infrastructure or hardware drivers detected that the device had temporarily lost tracking, causing the hardware and software to be out of sync on position and orientation.
 
-> **Note:** A `reset` event will _not_ occur if the reference space is able to regain tracking of its previous origin, since that means the origin has not been forced to be relocated. This event is only fired when the origin has to be relocated to recover from the tracking loss.
+> [!NOTE]
+> A `reset` event will _not_ occur if the reference space is able to regain tracking of its previous origin, since that means the origin has not been forced to be relocated. This event is only fired when the origin has to be relocated to recover from the tracking loss.
 
 ### Manual resets
 

--- a/files/en-us/web/api/xrrigidtransform/position/index.md
+++ b/files/en-us/web/api/xrrigidtransform/position/index.md
@@ -18,7 +18,8 @@ transform.
 A read-only {{domxref("DOMPointReadOnly")}} indicating the 3D position component of the
 transform matrix. The units are meters.
 
-> **Note:** The `w` component of the point is always 1.0.
+> [!NOTE]
+> The `w` component of the point is always 1.0.
 
 ## Examples
 

--- a/files/en-us/web/api/xrsession/inputsources/index.md
+++ b/files/en-us/web/api/xrsession/inputsources/index.md
@@ -17,7 +17,8 @@ XR device and are currently available. These controllers may include handheld
 controllers, XR-equipped gloves, optically tracked hands, and gaze-based input methods.
 Keyboards, gamepads, and mice are _not_ considered WebXR input sources.
 
-> **Note:** Traditional gamepad controllers are supported using the [Gamepad API](/en-US/docs/Web/API/Gamepad_API).
+> [!NOTE]
+> Traditional gamepad controllers are supported using the [Gamepad API](/en-US/docs/Web/API/Gamepad_API).
 
 ## Value
 

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.md
@@ -26,7 +26,8 @@ any animation updates needed.
 You can cancel a previously scheduled animation by calling
 {{DOMxRef("XRSession.cancelAnimationFrame", "cancelAnimationFrame()")}}.
 
-> **Note:** Despite the obvious similarities between these methods and the
+> [!NOTE]
+> Despite the obvious similarities between these methods and the
 > global {{domxref("Window.requestAnimationFrame", "requestAnimationFrame()")}} function
 > provided by the `Window` interface, you _must not_ treat these as
 > interchangeable. There is _no_ guarantee that the latter will work at all while
@@ -66,7 +67,8 @@ remove the pending animation frame request.
 The following example requests `XRSession` with "inline" mode so that it can
 be displayed in an HTML element (without the need for a separate AR or VR device).
 
-> **Note:** A real application should check that the device and the User
+> [!NOTE]
+> A real application should check that the device and the User
 > Agent support WebXR API at all and then that they both support the desired session
 > type via {{DOMxRef("XRSystem.isSessionSupported()")}}.
 

--- a/files/en-us/web/api/xrspace/index.md
+++ b/files/en-us/web/api/xrspace/index.md
@@ -11,7 +11,8 @@ The **`XRSpace`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_
 
 Numeric values such as pose positions are thus coordinates in the corresponding `XRSpace`, relative to that space's origin.
 
-> **Note:** The `XRSpace` interface is never used directly; instead, all spaces are created using one of the interfaces based on `XRSpace`. At this time, those are {{domxref("XRReferenceSpace")}}, {{domxref("XRBoundedReferenceSpace")}}, and {{domxref("XRJointSpace")}}.
+> [!NOTE]
+> The `XRSpace` interface is never used directly; instead, all spaces are created using one of the interfaces based on `XRSpace`. At this time, those are {{domxref("XRReferenceSpace")}}, {{domxref("XRBoundedReferenceSpace")}}, and {{domxref("XRJointSpace")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.md
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.md
@@ -12,7 +12,8 @@ browser-compat: api.XRSystem.devicechange_event
 
 A **`devicechange`** event is fired on an {{DOMxRef("XRSystem")}} object whenever the availability of immersive XR devices has changed; for example, a VR headset or AR goggles have been connected or disconnected. It's a generic {{DOMxRef("Event")}} with no added properties.
 
-> **Note:** Not to be confused with the {{domxref("MediaDevices")}} {{DOMxRef("MediaDevices.devicechange_event", "devicechange")}} event.
+> [!NOTE]
+> Not to be confused with the {{domxref("MediaDevices")}} {{DOMxRef("MediaDevices.devicechange_event", "devicechange")}} event.
 
 ## Syntax
 

--- a/files/en-us/web/api/xrview/projectionmatrix/index.md
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.md
@@ -16,7 +16,8 @@ to apply to the underlying view. This should be used to integrate perspective to
 everything in the scene, in order to ensure the result is consistent with what the eye
 expects to see.
 
-> **Note:** Failure to apply proper perspective, or inconsistencies
+> [!NOTE]
+> Failure to apply proper perspective, or inconsistencies
 > in perspective, may result in possibly serious user discomfort or distress.
 
 ## Value

--- a/files/en-us/web/api/xrview/transform/index.md
+++ b/files/en-us/web/api/xrview/transform/index.md
@@ -89,7 +89,8 @@ Finally, we call the object's `render()` routine, passing along the
 `modelViewMatrix` and `normalMatrix` so the renderer can place and
 light the object properly.
 
-> **Note:** This example is derived from a larger example…
+> [!NOTE]
+> This example is derived from a larger example…
 > **<<<--- finish and add link --->>>**
 
 ## Specifications

--- a/files/en-us/web/api/xrviewerpose/views/index.md
+++ b/files/en-us/web/api/xrviewerpose/views/index.md
@@ -13,7 +13,8 @@ returns an array which contains every {{domxref("XRView")}} which must be render
 order to fully represent the scene from the viewpoint defined by the viewer pose. For
 monoscopic devices, this array contains a single view.
 
-> **Warning:** There is no guarantee that the number of views will
+> [!WARNING]
+> There is no guarantee that the number of views will
 > remain constant over the lifetime of an {{domxref("XRSession")}}. For each frame, you
 > should always use the current length of this array rather than caching the value.
 

--- a/files/en-us/web/api/xrviewport/y/index.md
+++ b/files/en-us/web/api/xrviewport/y/index.md
@@ -21,7 +21,8 @@ and {{domxref("XRViewport.height", "height")}} properties.
 The offset from the bottom edge of the rendering surface to the bottom edge of the
 viewport, in pixels.
 
-> **Note:** Although other web APIs typically consider the `y`
+> [!NOTE]
+> Although other web APIs typically consider the `y`
 > axis to begin at the top and grow larger progressing downward, WebGL reverses this,
 > with `y` growing larger as it goes upward on the screen.
 

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -54,7 +54,8 @@ framebuffer:
   alpha, regardless of whether or not the WebGL context's [`premultipliedAlpha`](/en-US/docs/Web/API/HTMLCanvasElement/getContext#premultipliedalpha) context
   attribute is set.
 
-> **Note:** The `depth` and `stencil` properties are
+> [!NOTE]
+> The `depth` and `stencil` properties are
 > not required to be supported in order for a browser to be construed as having full
 > WebGL support.
 

--- a/files/en-us/web/api/xsltprocessor/basic_example/index.md
+++ b/files/en-us/web/api/xsltprocessor/basic_example/index.md
@@ -56,7 +56,8 @@ To try out the example:
 2. [Start a local server](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server#running_a_simple_local_http_server) in the directory containing the files.
    This allows you to browse the files in the directory as though they were hosted on the internet.
 
-   > **Warning:** Opening the XML file directly from the file system will not work, because loading the stylesheet from the file system is a [cross-origin request](/en-US/docs/Web/HTTP/CORS), and will be disallowed by default.
+   > [!WARNING]
+   > Opening the XML file directly from the file system will not work, because loading the stylesheet from the file system is a [cross-origin request](/en-US/docs/Web/HTTP/CORS), and will be disallowed by default.
    > Hosting the XML and stylesheet on the same local server ensures that they have the same origin.
 
 3. Open **example.xml** from the browser.

--- a/files/en-us/web/api/xsltprocessor/getparameter/index.md
+++ b/files/en-us/web/api/xsltprocessor/getparameter/index.md
@@ -27,7 +27,8 @@ getParameter(namespaceURI, localName)
 
 An object that is the value associated with the parameter. It can be of any type.
 
-> **Note:** Firefox supports any kind of parameter. Chrome, Edge and Safari only support string parameters.
+> [!NOTE]
+> Firefox supports any kind of parameter. Chrome, Edge and Safari only support string parameters.
 
 ## Examples
 

--- a/files/en-us/web/api/xsltprocessor/setparameter/index.md
+++ b/files/en-us/web/api/xsltprocessor/setparameter/index.md
@@ -24,7 +24,8 @@ setParameter(namespaceURI, localName, value)
   - : The name of the parameter in the associated namespace.
 - `value`
   - : The value of the parameter.
-    > **Note:** Firefox supports any kind of parameter. Chrome, Edge and Safari only support string parameters.
+    > [!NOTE]
+    > Firefox supports any kind of parameter. Chrome, Edge and Safari only support string parameters.
 
 ### Return value
 


### PR DESCRIPTION
This PR converts the noteblocks for the 'web/api' folder to GFM syntax, using a [conversion script](https://github.com/queengooborg/mdn-toolkit/blob/main/upgrade-noteblock.js). This is part 15.
