### PR TITLE
Minor: Pedantic sentence re animatable properties

### DIFF
--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
@@ -113,7 +113,7 @@ We have only specified the end state of the animation, and the beginning state i
 
 ## Attributes
 
-Keyframes may specify property-value pairs for any of the [animatable CSS properties](/en-US/docs/Web/CSS/CSS_animated_properties). The property names are specified using {{Glossary("camel_case", "camel case")}} so for example {{cssxref("background-color")}} becomes `backgroundColor` and {{cssxref("background-position-x")}} becomes `backgroundPositionX`. Shorthand values such as {{cssxref("margin")}} are also permitted.
+Keyframes specify property-value pairs of the [CSS properties to be animated](/en-US/docs/Web/CSS/CSS_animated_properties). The property names are specified using {{Glossary("camel_case", "camel case")}} so for example {{cssxref("background-color")}} becomes `backgroundColor` and {{cssxref("background-position-x")}} becomes `backgroundPositionX`. Shorthand values such as {{cssxref("margin")}} are also permitted.
 
 Two exceptional CSS properties are:
 


### PR DESCRIPTION
the page used to list CSS animatable properties, but now all properties are animatable and the linked page is an explainer, so updating sentence / link to remove it "if animatable" connotation.
