### PR TITLE
Remove hatch, hatchpath, color-profile from SVGData

### DIFF
--- a/files/jsondata/SVGData.json
+++ b/files/jsondata/SVGData.json
@@ -12,7 +12,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -162,22 +161,6 @@
       ],
       "interfaces": ["SVGClipPathElement"]
     },
-    "color-profile": {
-      "categories": ["noCategory"],
-      "content": {
-        "description": "anyNumberOfElementsAnyOrder",
-        "elements": ["descriptiveElements"]
-      },
-      "attributes": [
-        "coreAttributes",
-        "xLinkAttributes",
-        "'local'",
-        "'name'",
-        "'rendering-intent'",
-        "'xlink:href'"
-      ],
-      "interfaces": ["SVGColorProfileElement"]
-    },
     "cursor": {
       "categories": ["noCategory"],
       "content": {
@@ -207,7 +190,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -853,7 +835,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -894,7 +875,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -949,55 +929,6 @@
         "'xlink:href'"
       ],
       "interfaces": ["SVGGlyphRefElement"]
-    },
-    "hatch": {
-      "categories": ["neverRenderedElement", "paintServerElement"],
-      "content": {
-        "description": "anyNumberOfElementsAnyOrder",
-        "elements": [
-          "animationElements",
-          "descriptiveElements",
-          "&lt;hatchpath&gt;",
-          "&lt;script&gt;",
-          "&lt;style&gt;"
-        ]
-      },
-      "attributes": [
-        "coreAttributes",
-        "globalEventAttributes",
-        "presentationAttributes",
-        "styleAttributes",
-        "'x'",
-        "'y'",
-        "'pitch'",
-        "'rotate'",
-        "'hatchUnits'",
-        "'hatchContentUnits'",
-        "'transform'",
-        "'href'"
-      ],
-      "interfaces": ["SVGHatchElement"]
-    },
-    "hatchpath": {
-      "categories": ["noCategory"],
-      "content": {
-        "description": "anyNumberOfElementsAnyOrder",
-        "elements": [
-          "animationElements",
-          "descriptiveElements",
-          "&lt;script&gt;",
-          "&lt;style&gt;"
-        ]
-      },
-      "attributes": [
-        "coreAttributes",
-        "globalEventAttributes",
-        "presentationAttributes",
-        "styleAttributes",
-        "'d'",
-        "'offset'"
-      ],
-      "interfaces": ["SVGHatchpathElement"]
     },
     "hkern": {
       "categories": ["fontElement"],
@@ -1096,7 +1027,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -1143,7 +1073,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -1196,7 +1125,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -1272,7 +1200,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -1472,7 +1399,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",
@@ -1552,7 +1478,6 @@
           "gradientElements",
           "&lt;a&gt;",
           "&lt;clipPath&gt;",
-          "&lt;color-profile&gt;",
           "&lt;cursor&gt;",
           "&lt;filter&gt;",
           "&lt;font&gt;",


### PR DESCRIPTION
Similar to https://github.com/mdn/content/pull/35042 and https://github.com/mdn/content/pull/5147, this PR removes the SVGData of these elements, fixing a lot of broken link flaws.