### PR TITLE
Fix CookieChangeEvent description

### DIFF
--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -10,6 +10,8 @@ browser-compat: api.CookieChangeEvent.changed
 
 The **`changed`** read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been changed.
 
+Note that this will exclude cookies which were created with an expiry date in the past, as these cookies are immediately deleted.
+
 ## Value
 
 An array of objects containing the changed cookie(s). Each object contains the following properties:

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -10,6 +10,8 @@ browser-compat: api.CookieChangeEvent.deleted
 
 The **`deleted`** read-only property of the {{domxref("CookieChangeEvent")}} interface returns an array of the cookies that have been deleted by the given `CookieChangeEvent` instance.
 
+Note that this will include cookies which were created with an expiry date in the past, as these cookies are immediately deleted.
+
 ## Value
 
 An array of objects containing the deleted cookie(s). Each object contains the following properties:

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -7,13 +7,7 @@ browser-compat: api.CookieChangeEvent
 
 {{securecontext_header}}{{APIRef("Cookie Store API")}}
 
-The **`CookieChangeEvent`** interface of the {{domxref("Cookie Store API", "", "", "nocode")}} is the event type of the {{domxref("CookieStore/change_event", "change")}} event fired at a {{domxref("CookieStore")}} when any cookie changes occur. A cookie change consists of a cookie and a type (either "changed" or "deleted").
-
-Cookie changes that will cause the `CookieChangeEvent` to be dispatched are:
-
-- A cookie is newly created and not immediately removed. In this case `type` is "changed".
-- A cookie is newly created and immediately removed. In this case `type` is "deleted".
-- A cookie is removed. In this case `type` is "deleted".
+The **`CookieChangeEvent`** interface of the {{domxref("Cookie Store API", "", "", "nocode")}} is the event type of the {{domxref("CookieStore/change_event", "change")}} event fired at a {{domxref("CookieStore")}} when any cookies are created or deleted.
 
 > [!NOTE]
 > A cookie that is replaced due to the insertion of another cookie with the same name, domain, and path, is ignored and does not trigger a change event.
@@ -30,9 +24,9 @@ Cookie changes that will cause the `CookieChangeEvent` to be dispatched are:
 _This interface also inherits properties from {{domxref("Event")}}._
 
 - {{domxref("CookieChangeEvent.changed")}} {{ReadOnlyInline}}
-  - : Returns an array containing one or more changed cookies.
+  - : An array listing all newly-created cookies. Note that this will exclude cookies which were created with an expiry date in the past, as these cookies are immediately deleted.
 - {{domxref("CookieChangeEvent.deleted")}} {{ReadOnlyInline}}
-  - : Returns an array containing one or more deleted cookies.
+  - : An array listing all cookies which were removed, either because they expired or because they were explicitly deleted. Note that this will include cookies which were created with an expiry date in the past.
 
 ## Instance methods
 


### PR DESCRIPTION
Fixes the description of `CookieChangeEvent`, per the suggestion in https://github.com/mdn/content/pull/33462#issuecomment-2115968446.

Closes https://github.com/mdn/content/pull/33462.