### PR TITLE
fix(ci): add markdownlint custom rule for GFM blockquotes

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -219,6 +219,12 @@
         "replace": "$1plain",
         "searchScope": "text",
       },
+      {
+        "name": "gfm-blockquote",
+        "message": "Use the GFM syntax: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#notes_warnings_and_callouts",
+        "searchPattern": "/^ *> \\*\\*(Note|Warning):\\*\\*/gm",
+        "searchScope": "text",
+      },
     ],
   },
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -222,7 +222,7 @@
       {
         "name": "gfm-blockquote",
         "message": "Use the GFM syntax: https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#notes_warnings_and_callouts",
-        "searchPattern": "/^ *> \\*\\*(Note|Warning):\\*\\*/gm",
+        "searchPattern": "/^ *> \\*\\*(Note|Warning|Callout):\\*\\*(?! [[{`_*])/gm",
         "searchScope": "text",
       },
     ],


### PR DESCRIPTION
This will encourage authors to use [the new syntax](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#notes_warnings_and_callouts).

We'll remove the rule once Yari removes support for the old syntax.

~The rule reported 401 violations at this point.~  All the 401 cases have been ignored due to a Prettier bug.