### PR TITLE
"Noteblocks" now has an official name

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -179,7 +179,7 @@ This issue was resolved in:
 Sometimes writers want to call special attention to a piece of content. To do this, they can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/), which is a blockquote with a special first line. There are three types of these: notes, warnings, and callouts.
 
 > [!NOTE]
-> MDN Web Docs supported GFM Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.
+> MDN Web Docs supported Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.
 >
 > Before the syntax had an official name, MDN referred to GFM Alerts as "noteblocks".
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -176,7 +176,7 @@ This issue was resolved in:
 
 ## Notes, warnings, and callouts
 
-Sometimes writers want to call special attention to a piece of content. To do this, they can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/), which is a blockquote with a special first line. There are three types of these: notes, warnings, and callouts.
+Writers can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/) to call special attention to content. There are three types of alerts: notes, warnings, and callouts.
 
 > [!NOTE]
 > MDN Web Docs supported Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -184,8 +184,8 @@ Writers can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14
 > Before the syntax had an official name, MDN referred to Alerts as "noteblocks".
 
 - To add a note, create a blockquote whose first line is `[!NOTE]`.
-- To add a warning, create a GFM blockquote whose first line is `[!WARNING]`.
-- To add a callout, create a GFM blockquote whose first line is `[!CALLOUT]`.
+- To add a warning, create a blockquote whose first line is `[!WARNING]`.
+- To add a callout, create a blockquote whose first line is `[!CALLOUT]`.
 
 Notes and warnings will add a localized **Note:** or **Warning:** to the beginning of the output, while callouts will not. This makes callouts a good choice when an author wants to provide a custom title.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -179,9 +179,9 @@ This issue was resolved in:
 Writers can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/) to call special attention to content. There are three types of alerts: notes, warnings, and callouts.
 
 > [!NOTE]
-> MDN Web Docs supported Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.
->
-> Before the syntax had an official name, MDN referred to Alerts as "noteblocks".
+> MDN Web Docs supported alerts with its own syntax prior to support for GFM alerts, and referred to them as "noteblocks".
+> MDN does not support the following GFM alerts: `[!TIP]`, `[!CAUTION]`, `[!IMPORTANT]`.
+> GFM does not support `[!CALLOUT]`.
 
 - To add a note, create a blockquote whose first line is `[!NOTE]`.
 - To add a warning, create a blockquote whose first line is `[!WARNING]`.

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -176,10 +176,12 @@ This issue was resolved in:
 
 ## Notes, warnings, and callouts
 
-Sometimes writers want to call special attention to a piece of content. To do this, they will use the [GFM noteblock syntax](https://github.com/orgs/community/discussions/16925), which is a GFM blockquote with a special first line. There are three types of these: notes, warnings, and callouts.
+Sometimes writers want to call special attention to a piece of content. To do this, they will use the [proposed GFM Alerts syntax](https://github.com/orgs/community/discussions/16925), which is a GFM blockquote with a special first line. There are three types of these: notes, warnings, and callouts.
 
 > [!NOTE]
-> MDN Web Docs supported noteblocks with its own syntax before GFM added the noteblock syntax. As such, MDN supports only two of the five noteblock types GFM supports, and it supports an additional type that GFM does not.
+> MDN Web Docs supported GFM Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.
+>
+> Before the syntax had an official name, MDN referred to GFM Alerts as "noteblocks".
 
 - To add a note, create a GFM blockquote whose first line is `[!NOTE]`.
 - To add a warning, create a GFM blockquote whose first line is `[!WARNING]`.

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -183,7 +183,7 @@ Sometimes writers want to call special attention to a piece of content. To do th
 >
 > Before the syntax had an official name, MDN referred to Alerts as "noteblocks".
 
-- To add a note, create a GFM blockquote whose first line is `[!NOTE]`.
+- To add a note, create a blockquote whose first line is `[!NOTE]`.
 - To add a warning, create a GFM blockquote whose first line is `[!WARNING]`.
 - To add a callout, create a GFM blockquote whose first line is `[!CALLOUT]`.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -176,7 +176,7 @@ This issue was resolved in:
 
 ## Notes, warnings, and callouts
 
-Sometimes writers want to call special attention to a piece of content. To do this, they will use the [proposed GFM Alerts syntax](https://github.com/orgs/community/discussions/16925), which is a GFM blockquote with a special first line. There are three types of these: notes, warnings, and callouts.
+Sometimes writers want to call special attention to a piece of content. To do this, they can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/), which is a blockquote with a special first line. There are three types of these: notes, warnings, and callouts.
 
 > [!NOTE]
 > MDN Web Docs supported GFM Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -190,7 +190,12 @@ Sometimes writers want to call special attention to a piece of content. To do th
 Notes and warnings will add a localized **Note:** or **Warning:** to the beginning of the output, while callouts will not. This makes callouts a good choice when an author wants to provide a custom title.
 
 > [!WARNING]
-> In the older MDN syntax, the type was localized and added to the first paragraph in bold text, i.e. `**Note:** Foo bar` instead of `[!NOTE] ⏎ Foo bar`. This syntax is still supported for migration purposes. Avoid using it in new documentation.
+> In the older MDN syntax, the type was localized and added to the first paragraph in bold text, i.e. `**Note:** Foo bar` instead of `[!NOTE] ⏎ Foo bar`.
+>
+> The older syntax is still supported for migration purposes. Avoid using it in new documentation.
+
+> [!WARNING]
+> Currently, due to a [Prettier bug](https://github.com/prettier/prettier/issues/15479), GFM Alerts syntax cannot be used if the first character of a note or warning is a formatting symbol, such as a backquote, asterisk, square bracket or curly bracket.
 
 Multiple lines are produced by an empty block quote line in the same way as normal paragraphs. Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -176,7 +176,7 @@ This issue was resolved in:
 
 ## Notes, warnings, and callouts
 
-Writers can use the [GFM Alerts syntax](https://github.blog/changelog/2023-12-14-new-markdown-extension-alerts-provide-distinctive-styling-for-significant-content/) to call special attention to content. There are three types of alerts: notes, warnings, and callouts.
+Writers can use the [GFM alerts syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) to call special attention to content. There are three types of alerts: notes, warnings, and callouts.
 
 > [!NOTE]
 > MDN Web Docs supported alerts with its own syntax prior to support for GFM alerts, and referred to them as "noteblocks".
@@ -195,7 +195,7 @@ Notes and warnings will add a localized **Note:** or **Warning:** to the beginni
 > The older syntax is still supported for migration purposes. Avoid using it in new documentation.
 
 > [!WARNING]
-> Currently, due to a [Prettier bug](https://github.com/prettier/prettier/issues/15479), GFM Alerts syntax cannot be used if the first character of a note or warning is a formatting symbol, such as a backquote, asterisk, square bracket or curly bracket. In this case, use the old syntax `> **Note:**` instead. Writers are not required to rephrase the content to work around the formatter.
+> Currently, due to a [Prettier bug](https://github.com/prettier/prettier/issues/15479), the GFM alert syntax cannot be used if the first character of a note or warning is a formatting symbol, such as a backquote, asterisk, square bracket or curly bracket. In this case, use the old syntax `> **Note:**` instead. Writers are not required to rephrase the content to work around the formatter.
 
 Multiple lines are produced by an empty block quote line in the same way as normal paragraphs. Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -195,7 +195,7 @@ Notes and warnings will add a localized **Note:** or **Warning:** to the beginni
 > The older syntax is still supported for migration purposes. Avoid using it in new documentation.
 
 > [!WARNING]
-> Currently, due to a [Prettier bug](https://github.com/prettier/prettier/issues/15479), GFM Alerts syntax cannot be used if the first character of a note or warning is a formatting symbol, such as a backquote, asterisk, square bracket or curly bracket.
+> Currently, due to a [Prettier bug](https://github.com/prettier/prettier/issues/15479), GFM Alerts syntax cannot be used if the first character of a note or warning is a formatting symbol, such as a backquote, asterisk, square bracket or curly bracket. In this case, use the old syntax `> **Note:**` instead. Writers are not required to rephrase the content to work around the formatter.
 
 Multiple lines are produced by an empty block quote line in the same way as normal paragraphs. Further, multiple lines without a space are also treated like normal Markdown lines, and concatenated.
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -181,7 +181,7 @@ Sometimes writers want to call special attention to a piece of content. To do th
 > [!NOTE]
 > MDN Web Docs supported Alerts with its own syntax before the GFM proposal was formed. As such, MDN supports only two of the five alert types GFM supports, and it supports an additional type that GFM does not.
 >
-> Before the syntax had an official name, MDN referred to GFM Alerts as "noteblocks".
+> Before the syntax had an official name, MDN referred to Alerts as "noteblocks".
 
 - To add a note, create a GFM blockquote whose first line is `[!NOTE]`.
 - To add a warning, create a GFM blockquote whose first line is `[!WARNING]`.


### PR DESCRIPTION
This PR updates the Markdown writing page to update all references to "noteblocks" with the new official name that GitHub has coined for them, "Alerts".
