### PR TITLE
Improve clarity of setCustomValidity example

### DIFF
--- a/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -31,10 +31,12 @@ None.
 
 ## Examples
 
-In this example, we pass the ID of an input element, and set different error messages
-depending on whether the value is missing, too low, or too high. Additionally you
-_must_ call the [`reportValidity()`](/en-US/docs/Web/API/HTMLInputElement/reportValidity)
-method on the same element or else nothing will happen.
+In this example, we pass the ID of an input element and set different error
+messages depending on whether the value is missing, too low, or too high. Note
+that the message will not be displayed immediately. Attempting to submit the
+form will display the message, or you can call the
+[`reportValidity()`](/en-US/docs/Web/API/HTMLInputElement/reportValidity) method
+on the element.
 
 ```js
 function validate(inputID) {

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
@@ -33,10 +33,12 @@ None.
 
 ## Examples
 
-In this example, we pass the ID of an input element, and set different error messages
-depending on whether the value is missing, too low or too high. Additionally you
-_must_ call the [reportValidity](/en-US/docs/Web/API/HTMLFormElement/reportValidity)
-method on the same element or nothing will happen.
+In this example, we pass the ID of an input element and set different error
+messages depending on whether the value is missing, too low, or too high. Note
+that the message will not be displayed immediately. Attempting to submit the
+form will display the message, or you can call the
+[`reportValidity()`](/en-US/docs/Web/API/HTMLInputElement/reportValidity) method
+on the element.
 
 ```js
 function validate(inputID) {


### PR DESCRIPTION
### Description

This expands the description on the `setCustomValidity` examples to be a bit clearer.

### Motivation

Calling `reportValidity` isn't strictly _necessary_; it's just the easiest way to display the message.
