### PR TITLE
Add consistently formatted "see also" links to all CSS value pages

### DIFF
--- a/files/en-us/web/css/actual_value/index.md
+++ b/files/en-us/web/css/actual_value/index.md
@@ -38,6 +38,8 @@ The {{glossary("user agent")}} performs four steps to calculate a property's act
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
+    - **Actual values**
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
   - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/actual_value/index.md
+++ b/files/en-us/web/css/actual_value/index.md
@@ -39,7 +39,6 @@ The {{glossary("user agent")}} performs four steps to calculate a property's act
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - [Used values](/en-US/docs/Web/CSS/used_value)
     - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
-    - **Actual values**
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
   - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/computed_value/index.md
+++ b/files/en-us/web/css/computed_value/index.md
@@ -38,7 +38,6 @@ However, for some properties (those where percentages are relative to something 
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
-    - **Computed values**
     - [Used values](/en-US/docs/Web/CSS/used_value)
     - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)

--- a/files/en-us/web/css/computed_value/index.md
+++ b/files/en-us/web/css/computed_value/index.md
@@ -38,7 +38,9 @@ However, for some properties (those where percentages are relative to something 
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
+    - **Computed values**
     - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)

--- a/files/en-us/web/css/initial_value/index.md
+++ b/files/en-us/web/css/initial_value/index.md
@@ -35,7 +35,6 @@ You can explicitly specify the initial value by using the {{cssxref("initial")}}
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values
-    - **Initial values**
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - [Used values](/en-US/docs/Web/CSS/used_value)
     - [Resolved values](/en-US/docs/Web/CSS/resolved_value)

--- a/files/en-us/web/css/initial_value/index.md
+++ b/files/en-us/web/css/initial_value/index.md
@@ -35,8 +35,10 @@ You can explicitly specify the initial value by using the {{cssxref("initial")}}
   - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
   - [Margin collapsing](/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing)
   - Values
+    - **Initial values**
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)

--- a/files/en-us/web/css/resolved_value/index.md
+++ b/files/en-us/web/css/resolved_value/index.md
@@ -25,7 +25,6 @@ For most properties, the resolved value is the [computed value](/en-US/docs/Web/
   - [Initial values](/en-US/docs/Web/CSS/initial_value)
   - [Computed values](/en-US/docs/Web/CSS/computed_value)
   - [Used values](/en-US/docs/Web/CSS/used_value)
-  - **Resolved values**
   - [Actual values](/en-US/docs/Web/CSS/actual_value)
 - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
 - [At-rules](/en-US/docs/Web/CSS/At-rule)

--- a/files/en-us/web/css/resolved_value/index.md
+++ b/files/en-us/web/css/resolved_value/index.md
@@ -19,9 +19,14 @@ For most properties, the resolved value is the [computed value](/en-US/docs/Web/
 
 ## See also
 
-- [Initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values
 - {{domxref("window.getComputedStyle")}}
 - {{domxref("CSSStyleDeclaration.getPropertyValue")}}
+- Values
+  - [Initial values](/en-US/docs/Web/CSS/initial_value)
+  - [Computed values](/en-US/docs/Web/CSS/computed_value)
+  - [Used values](/en-US/docs/Web/CSS/used_value)
+  - **Resolved values**
+  - [Actual values](/en-US/docs/Web/CSS/actual_value)
 - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
 - [At-rules](/en-US/docs/Web/CSS/At-rule)
 - [Specificity](/en-US/docs/Web/CSS/Specificity)

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -115,6 +115,7 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
     - **Used values**
+    - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
   - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -114,7 +114,6 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
   - Values
     - [Initial values](/en-US/docs/Web/CSS/initial_value)
     - [Computed values](/en-US/docs/Web/CSS/computed_value)
-    - **Used values**
     - [Resolved values](/en-US/docs/Web/CSS/resolved_value)
     - [Actual values](/en-US/docs/Web/CSS/actual_value)
   - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add consistently formatted "see also" links to all CSS value pages

### Motivation

I could only find five pages defining types of CSS values (e.g., "initial values," "computed values," "used values," etc.), and their "See also" sections were different on every page. I tried to make it consistent so that each page has links to its "siblings." 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
