### PR TITLE
FF129 Relnote: HTTPS DNS records resolve using OS DNS resolver

### DIFF
--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -36,7 +36,7 @@ This article provides information about the changes in Firefox 129 that affect d
 
 ### HTTP
 
-- HTTPS DNS records can now be resolved using the operating system's DNS resolver on Windows 11, Linux, and Android 10+. This ensures that [DNS over HTTPS (DoH)](https://support.mozilla.org/en-US/kb/dns-over-https-doh-faqs) will be used if the user has chosen to enable it on the device, even if it has not been enabled in the browser. This feature has the other benefits that it allows the use of HTTP/3 without needing to use the {{httpheader("Alt-Svc")}} header, enables automatic upgrade of HTTP requests to HTTPS when the "HTTP DNS" record is present, and allows the [Encrypted Client Hello (ECH)](https://support.mozilla.org/en-US/kb/faq-encrypted-client-hello) privacy feature to be used if DoH is enabled on the device. ([Firefox bug 1906239](https://bugzil.la/1906239)).
+- HTTPS DNS records can now be resolved using the operating system's DNS resolver on Windows 11, Linux, and Android 10+. This ensures that [DNS over HTTPS (DoH)](https://support.mozilla.org/en-US/kb/dns-over-https-doh-faqs) will be used if a user has enabled it on the device, even if it is not enabled in the browser. This feature allows the use of HTTP/3 without needing to use the {{httpheader("Alt-Svc")}} header and enables automatic upgrade of HTTP requests to HTTPS when the HTTPS DNS record is present. Most importantly, it now allows the use of [Encrypted Client Hello (ECH)](https://support.mozilla.org/en-US/kb/faq-encrypted-client-hello) privacy feature even when DoH is only enabled on the device, not in the browser. ([Firefox bug 1906239](https://bugzil.la/1906239)).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -36,6 +36,8 @@ This article provides information about the changes in Firefox 129 that affect d
 
 ### HTTP
 
+- HTTPS DNS records can now be resolved using the operating system's DNS resolver on Windows 11, Linux, and Android 10+, instead of requiring [DNS over HTTPS](https://support.mozilla.org/en-US/kb/dns-over-https-doh-faqs) to be enabled. This capability allows the use of HTTP/3 without needing to use the {{httpheader("Alt-Svc")}} header, upgrades requests to HTTPS when the DNS record is present, and enables the use of the [Encrypted Client Hello (ECH)](https://support.mozilla.org/en-US/kb/faq-encrypted-client-hello) privacy feature in more circumstances. ([Firefox bug 1906239](https://bugzil.la/1906239).)
+
 #### Removals
 
 ### Security

--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -36,7 +36,7 @@ This article provides information about the changes in Firefox 129 that affect d
 
 ### HTTP
 
-- HTTPS DNS records can now be resolved using the operating system's DNS resolver on Windows 11, Linux, and Android 10+, instead of requiring [DNS over HTTPS](https://support.mozilla.org/en-US/kb/dns-over-https-doh-faqs) to be enabled. This capability allows the use of HTTP/3 without needing to use the {{httpheader("Alt-Svc")}} header, upgrades requests to HTTPS when the DNS record is present, and enables the use of the [Encrypted Client Hello (ECH)](https://support.mozilla.org/en-US/kb/faq-encrypted-client-hello) privacy feature in more circumstances. ([Firefox bug 1906239](https://bugzil.la/1906239).)
+- HTTPS DNS records can now be resolved using the operating system's DNS resolver on Windows 11, Linux, and Android 10+. This ensures that [DNS over HTTPS (DoH)](https://support.mozilla.org/en-US/kb/dns-over-https-doh-faqs) will be used if the user has chosen to enable it on the device, even if it has not been enabled in the browser. This feature has the other benefits that it allows the use of HTTP/3 without needing to use the {{httpheader("Alt-Svc")}} header, enables automatic upgrade of HTTP requests to HTTPS when the "HTTP DNS" record is present, and allows the [Encrypted Client Hello (ECH)](https://support.mozilla.org/en-US/kb/faq-encrypted-client-hello) privacy feature to be used if DoH is enabled on the device. ([Firefox bug 1906239](https://bugzil.la/1906239)).
 
 #### Removals
 


### PR DESCRIPTION
FF129 supports resolving HTTPS dns records using OS resolver in https://bugzilla.mozilla.org/show_bug.cgi?id=1906239. This adds a release note explaining why it is significant.

Related docs in #34707