### PR TITLE
Glossary: classes and functions are block scoped too

### DIFF
--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -14,7 +14,7 @@ JavaScript has the following kinds of scopes:
 - Module scope: The scope for code running in module mode.
 - Function scope: The scope created with a {{glossary("function")}}.
 
-In addition, identifiers declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let), [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const), [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class), or (in strict mode) [`function`](/en-US/docs/Web/JavaScript/Reference/Statements/function) can belong to an additional scope:
+In addition, identifiers declared with certain syntaxes, including [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let), [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const), [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class), or (in strict mode) [`function`](/en-US/docs/Web/JavaScript/Reference/Statements/function), can belong to an additional scope:
 
 - Block scope: The scope created with a pair of curly braces (a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block)).
 

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -14,11 +14,9 @@ JavaScript has the following kinds of scopes:
 - Module scope: The scope for code running in module mode.
 - Function scope: The scope created with a {{glossary("function")}}.
 
-In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) can belong to an additional scope:
+In addition, identifiers declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let), [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const), [`class`](/en-US/docs/Web/JavaScript/Reference/Statements/class), or (in strict mode) [`function`](/en-US/docs/Web/JavaScript/Reference/Statements/function) can belong to an additional scope:
 
 - Block scope: The scope created with a pair of curly braces (a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block)).
-
-## Function scope
 
 A {{glossary("function")}} creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
 
@@ -48,10 +46,6 @@ console.log("Outside function");
 console.log(x);
 ```
 
-## Block scope
-
-### Variable declarations
-
 Blocks only scope `let` and `const` declarations, but not `var` declarations.
 
 ```js example-good
@@ -70,34 +64,7 @@ console.log(x); // 1
 console.log(x); // ReferenceError: x is not defined
 ```
 
-### Function declarations
-
-In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), function declarations are block-scoped.
-
-```js
-"use strict";
-
-{
-  function alarm() {
-    console.log("Beep-beep!");
-  }
-}
-
-alarm(); // ReferenceError: alarm is not defined
-```
-
-This behavior doesn't apply to "[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)".
-
-```js
-{
-  function alarm() {
-    console.log("Beep-beep!");
-  }
-}
-
-alarm(); // "Beep-beep!"
-```
-
 ## See also
 
 - [Scope (computer science)](<https://en.wikipedia.org/wiki/Scope_(computer_science)>) on Wikipedia
+- [Block scoping rules](/en-US/docs/Web/JavaScript/Reference/Statements/block#block_scoping_rules_with_let_const_class_or_function_declaration_in_strict_mode)

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -18,6 +18,8 @@ In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Referenc
 
 - Block scope: The scope created with a pair of curly braces (a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block)).
 
+## Function scope
+
 A {{glossary("function")}} creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
 
 ```js example-bad
@@ -46,12 +48,17 @@ console.log("Outside function");
 console.log(x);
 ```
 
+## Block scope
+
+### Variable declarations
+
 Blocks only scope `let` and `const` declarations, but not `var` declarations.
 
 ```js example-good
 {
   var x = 1;
 }
+
 console.log(x); // 1
 ```
 
@@ -59,7 +66,36 @@ console.log(x); // 1
 {
   const x = 1;
 }
+
 console.log(x); // ReferenceError: x is not defined
+```
+
+### Function declarations
+
+In [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode), function declarations are block-scoped.
+
+```js
+"use strict";
+
+{
+  function alarm() {
+    console.log("Beep-beep!");
+  }
+}
+
+alarm(); // ReferenceError: alarm is not defined
+```
+
+This behavior doesn't apply to "[sloppy mode](/en-US/docs/Glossary/Sloppy_mode)".
+
+```js
+{
+  function alarm() {
+    console.log("Beep-beep!");
+  }
+}
+
+alarm(); // "Beep-beep!"
 ```
 
 ## See also

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -52,7 +52,6 @@ Blocks only scope `let` and `const` declarations, but not `var` declarations.
 {
   var x = 1;
 }
-
 console.log(x); // 1
 ```
 
@@ -60,7 +59,6 @@ console.log(x); // 1
 {
   const x = 1;
 }
-
 console.log(x); // ReferenceError: x is not defined
 ```
 


### PR DESCRIPTION
I've added example for function declarations, they can also be block-scoped (in strict mode)

You can check this in node.js or browser, I am learning a popular Udemy course (JS), and encountered this topic. I think it might be a usefull addition

I would be happy to receive feedback!

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
