### PR TITLE
Advertise Firefox 113+ AVIF animation support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/113/index.md
+++ b/files/en-us/mozilla/firefox/releases/113/index.md
@@ -72,6 +72,12 @@ No notable changes.
 - Support is now provided for the {{WebExtAPIRef("declarativeNetRequest")}} API ([Firefox bug 1782685](https://bugzil.la/1782685)).
 - The `gecko_android` subkey has been added to the [`browser_specific_settings`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. This subkey enables an extension to specify the range of Firefox for Android versions it is compatible with ([Firefox bug 1824237](https://bugzil.la/1824237)).
 
+## Other
+
+- Support for animated [AVIF](/en-US/docs/Web/Media/Formats/Image_types#avif_image) (AV1 Image Format files) images.
+  Previously, they would display as still images with no way for web pages to detect this and fall back to another format.
+  ([Firefox bug 1825580](https://bugzil.la/1825580)).
+
 ## Older versions
 
 {{Firefox_for_developers}}

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -45,8 +45,7 @@ The image file formats that are most commonly used on the web are listed below.
         <p>
           Good choice for both images and animated images due to high performance and royalty free image format.
           It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency, etc.
-          Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the
-          <code><a href="/en-US/docs/Web/HTML/Element/picture">&#x3C;picture></a></code> element).<br />
+          Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the <code><a href="/en-US/docs/Web/HTML/Element/picture">&#x3C;picture></a></code> element).<br />
           <strong>Support:</strong> Chrome, Edge, Firefox, Opera, Safari.
         </p>
       </td>
@@ -57,8 +56,8 @@ The image file formats that are most commonly used on the web are listed below.
       <td><code>image/gif</code></td>
       <td><code>.gif</code></td>
       <td>
-        Good choice for simple images and animations. Prefer PNG for
-        lossless <em>and</em> indexed still images, and consider WebP, AVIF or APNG for animation sequences.<br />
+        Good choice for simple images and animations.
+        Prefer PNG for lossless <em>and</em> indexed still images, and consider WebP, AVIF or APNG for animation sequences.<br />
         <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
       </td>
     </tr>
@@ -74,9 +73,8 @@ The image file formats that are most commonly used on the web are listed below.
       </td>
       <td>
         <p>
-          Good choice for lossy compression of still images (currently the most
-          popular). Prefer PNG when more precise reproduction of the image is
-          required, or WebP/AVIF if both better reproduction and higher compression are required.<br />
+          Good choice for lossy compression of still images (currently the most popular).
+          Prefer PNG when more precise reproduction of the image is required, or WebP/AVIF if both better reproduction and higher compression are required.<br />
           <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
         </p>
       </td>
@@ -88,8 +86,7 @@ The image file formats that are most commonly used on the web are listed below.
       <td><code>.png</code></td>
       <td>
         <p>
-          PNG is preferred over JPEG for more precise reproduction of source
-          images, or when transparency is needed. WebP/AVIF provide even better compression and reproduction, but browser support is more limited.<br />
+          PNG is preferred over JPEG for more precise reproduction of source images, or when transparency is needed. WebP/AVIF provide even better compression and reproduction, but browser support is more limited.<br />
           <strong>Support:</strong> Chrome, Edge, Firefox, IE, Opera, Safari.
         </p>
       </td>
@@ -240,8 +237,7 @@ They're also commonly used for the animated portions of web browsers' user inter
               <th scope="row">Indexed color</th>
               <td>1, 2, 4, and 8</td>
               <td>
-                Each pixel is a <em>D</em>-bit value indicating an index into a
-                color palette which is contained within a <code><a href="https://www.w3.org/TR/PNG/#11PLTE">PLTE</a></code> chunk in the APNG file;
+                Each pixel is a <em>D</em>-bit value indicating an index into a color palette which is contained within a <code><a href="https://www.w3.org/TR/PNG/#11PLTE">PLTE</a></code> chunk in the APNG file;
                 the colors in the palette all use an 8-bit depth.
               </td>
             </tr>
@@ -271,8 +267,7 @@ They're also commonly used for the animated portions of web browsers' user inter
       <th scope="row">Licensing</th>
       <td>
         Free and open under the
-        <a href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike license</a>
-        (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>) version 3.0 or later.
+        <a href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike license</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>) version 3.0 or later.
       </td>
     </tr>
   </tbody>
@@ -336,7 +331,9 @@ As support is not yet comprehensive (and has little historical depth) you should
             Firefox 93 supports still images, with colorspace support for both full and limited range colors, image transforms for mirroring and rotation.
             The preference <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_compliance_strictness">image.avif.compliance_strictness</a>
             can be used to adjust the compliance strictness with the specification.
-            Firefox 113 supports animated images.
+          </li>
+          <li>
+            Firefox 113 and later support animated images.
           </li>
         </ul>
       </td>
@@ -467,8 +464,7 @@ Theoretically, several compression algorithms are supported, and the image data 
               <th scope="row">True color with alpha</th>
               <td>8 and 16</td>
               <td>
-                Each pixel is represented by four values representing the red,
-                green, blue, and alpha color components; each is <em>D</em> bits.
+                Each pixel is represented by four values representing the red, green, blue, and alpha color components; each is <em>D</em> bits.
               </td>
             </tr>
           </tbody>
@@ -715,25 +711,21 @@ If you use ICO files, you should use the BMP format, as support for PNG inside I
               <th scope="row">Indexed color</th>
               <td>1, 2, 4, and 8</td>
               <td>
-                Each pixel is a <em>D</em>-bit value indicating an index into a color palette which is contained within a
-                <code><a href="https://www.w3.org/TR/PNG/#11PLTE">PLTE</a></code>
-                chunk in the APNG file; the colors in the palette all use an 8-bit depth.
+                Each pixel is a <em>D</em>-bit value indicating an index into a color palette which is contained within a <code><a href="https://www.w3.org/TR/PNG/#11PLTE">PLTE</a></code> chunk in the APNG file; the colors in the palette all use an 8-bit depth.
               </td>
             </tr>
             <tr>
               <th scope="row">Greyscale with alpha</th>
               <td>8 and 16</td>
               <td>
-                Each pixel is represented by two <em>D</em>-bit values: the
-                intensity of the greyscale pixel and an alpha sample, indicating how opaque the pixel is.
+                Each pixel is represented by two <em>D</em>-bit values: the intensity of the greyscale pixel and an alpha sample, indicating how opaque the pixel is.
               </td>
             </tr>
             <tr>
               <th scope="row">True color with alpha</th>
               <td>8 and 16</td>
               <td>
-                Each pixel is comprised of four <em>D</em>-pixel color
-                components: red, green, blue, and the alpha sample indicating how opaque the pixel is.
+                Each pixel is comprised of four <em>D</em>-pixel color components: red, green, blue, and the alpha sample indicating how opaque the pixel is.
               </td>
             </tr>
           </tbody>
@@ -937,12 +929,7 @@ PNG is widely supported, with all major browsers offering full support for its f
     <tr>
       <th scope="row">Licensing</th>
       <td>
-        ©2003 <a href="https://www.w3.org/">W3C</a> (<a href="https://www.csail.mit.edu/">MIT</a>, <a href="https://www.ercim.eu/">ERCIM</a>,
-        <a href="https://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C
-        <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
-        <a href="https://www.w3.org/policies/#trademarks">trademark</a>, <a href="https://www.w3.org/copyright/document-license/">document use</a>
-        and
-        <a href="https://www.w3.org/copyright/software-license/">software licensing</a> rules apply. No known royalty-bearing patents.
+        ©2003 <a href="https://www.w3.org/">W3C</a> (<a href="https://www.csail.mit.edu/">MIT</a>, <a href="https://www.ercim.eu/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="https://www.w3.org/policies/#disclaimers">liability</a>, <a href="https://www.w3.org/policies/#trademarks">trademark</a>, <a href="https://www.w3.org/copyright/document-license/">document use</a> and <a href="https://www.w3.org/copyright/software-license/">software licensing</a> rules apply. No known royalty-bearing patents.
       </td>
     </tr>
   </tbody>
@@ -1005,26 +992,14 @@ It's not generally useful for strictly bitmap or photographic images, although i
     <tr>
       <th scope="row">Compression</th>
       <td>
-        SVG source may be compressed during transit using
-        <a href="/en-US/docs/Web/HTTP/Compression">HTTP compression</a>
-        techniques, or on disk as an <code>.svgz</code> file.
+        SVG source may be compressed during transit using <a href="/en-US/docs/Web/HTTP/Compression">HTTP compression</a> techniques, or on disk as an <code>.svgz</code> file.
       </td>
     </tr>
     <tr>
       <th scope="row">Licensing</th>
       <td>
-        ©2018 <a href="https://www.w3.org/">W3C</a> (<a
-          href="https://www.csail.mit.edu/"
-          >MIT</a
-        >, <a href="https://www.ercim.eu/">ERCIM</a>,
-        <a href="https://www.keio.ac.jp/">Keio</a>,
-        <a href="https://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
-        <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
-        <a href="https://www.w3.org/policies/#trademarks">trademark</a>,
-        <a href="https://www.w3.org/copyright/document-license/">document use</a>
-        and
-        <a href="https://www.w3.org/copyright/software-license/">software licensing</a>
-        rules apply. No known royalty-bearing patents.
+        ©2018 <a href="https://www.w3.org/">W3C</a> (<a href="https://www.csail.mit.edu/">MIT</a>, <a href="https://www.ercim.eu/">ERCIM</a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.
+        W3C <a href="https://www.w3.org/policies/#disclaimers">liability</a>, <a href="https://www.w3.org/policies/#trademarks">trademark</a>, <a href="https://www.w3.org/copyright/document-license/">document use</a> and <a href="https://www.w3.org/copyright/software-license/">software licensing</a> rules apply. No known royalty-bearing patents.
       </td>
     </tr>
   </tbody>
@@ -1075,8 +1050,7 @@ As such, TIFF files are not useful within the context of web content, _but_ it's
     <tr>
       <th scope="row">Specification</th>
       <td>
-        <a href="https://www.adobe.com/devnet-apps/photoshop/fileformatashtml"
-          >https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577413_pgfId-1035272</a>
+        <a href="https://www.adobe.com/devnet-apps/photoshop/fileformatashtml">https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577413_pgfId-1035272</a>
       </td>
     </tr>
     <tr>
@@ -1125,30 +1099,22 @@ As such, TIFF files are not useful within the context of web content, _but_ it's
               <th scope="row">Indexed color</th>
               <td>4 and 8</td>
               <td>
-                Each pixel is an index into a <code>ColorMap</code> record,
-                which defines the colors used in the image. The color map lists
-                all of the red values, then all of the green values, then all of
-                the blue values (rather than <code>rgb, rgb, rgb…</code>).
+                Each pixel is an index into a <code>ColorMap</code> record, which defines the colors used in the image.
+                The color map lists all of the red values, then all of the green values, then all of the blue values (rather than <code>rgb, rgb, rgb…</code>).
               </td>
             </tr>
             <tr>
               <th scope="row">Greyscale with alpha</th>
               <td>4 and 8</td>
               <td>
-                Alpha information is added by specifying that there are more
-                than 3 samples per pixel in the <code>SamplesPerPixel</code> field, and indicating the type of
-                alpha (1 for an associated, pre-multiplied alpha component, and
-                2 for unassociated alpha (a separate matte); however, alpha channels are rarely used in TIFF files and may be unsupported by the user's software.
+                Alpha information is added by specifying that there are more than 3 samples per pixel in the <code>SamplesPerPixel</code> field, and indicating the type of alpha (1 for an associated, pre-multiplied alpha component, and 2 for unassociated alpha - a separate matte); however, alpha channels are rarely used in TIFF files and may be unsupported by the user's software.
               </td>
             </tr>
             <tr>
               <th scope="row">True color with alpha</th>
               <td>8</td>
               <td>
-                Alpha information is added by specifying that there are more
-                than 3 samples per pixel in the <code>SamplesPerPixel</code> field, and indicating the type of
-                alpha (1 for an associated, pre-multiplied alpha component, and
-                2 for unassociated alpha (a separate matte); however, alpha channels are rarely used in TIFF files and may be unsupported by the user's software.
+                Alpha information is added by specifying that there are more than 3 samples per pixel in the <code>SamplesPerPixel</code> field, and indicating the type of alpha (1 for an associated, pre-multiplied alpha component, and 2 for unassociated alpha - a separate matte); however, alpha channels are rarely used in TIFF files and may be unsupported by the user's software.
               </td>
             </tr>
           </tbody>
@@ -1197,16 +1163,15 @@ Provide a fallback in either [JPEG](#jpeg_joint_photographic_experts_group_image
       <th scope="row">Specification</th>
       <td>
         <p>
-          <a href="https://developers.google.com/speed/webp/docs/riff_container">RIFF Container Specification</a><br />{{RFC(6386, "VP8 Data Format and Decoding Guide")}}
-          (lossy encoding)<br /><a href="https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification">WebP Lossless Bitstream Specification</a>
+          <a href="https://developers.google.com/speed/webp/docs/riff_container">RIFF Container Specification</a><br />{{RFC(6386, "VP8 Data Format and Decoding Guide")}} (lossy encoding)<br /><a href="https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification">WebP Lossless Bitstream Specification</a>
         </p>
       </td>
     </tr>
     <tr>
       <th scope="row">Browser compatibility</th>
       <td>
-        All versions of Chrome, Edge, Firefox, Opera, and Safari
-        <p>WebP can also be used for <em>exporting</em> images from a Canvas. See <a href="/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility"><code>HTMLCanvasElement.toBlob()</code></a> for more detailed support version information.</p>
+        All versions of Chrome, Edge, Firefox, Opera, and Safari <p>WebP can also be used for <em>exporting</em> images from a Canvas.
+        See <a href="/en-US/docs/Web/API/HTMLCanvasElement/toBlob#browser_compatibility"><code>HTMLCanvasElement.toBlob()</code></a> for more detailed support version information.</p>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/media/formats/image_types/index.md
+++ b/files/en-us/web/media/formats/image_types/index.md
@@ -47,7 +47,7 @@ The image file formats that are most commonly used on the web are listed below.
           It offers much better compression than PNG or JPEG with support for higher color depths, animated frames, transparency, etc.
           Note that when using AVIF, you should include fallbacks to formats with better browser support (i.e. using the
           <code><a href="/en-US/docs/Web/HTML/Element/picture">&#x3C;picture></a></code> element).<br />
-          <strong>Support:</strong> Chrome, Edge, Firefox (still images only: animated images not implemented), Opera, Safari.
+          <strong>Support:</strong> Chrome, Edge, Firefox, Opera, Safari.
         </p>
       </td>
     </tr>
@@ -304,7 +304,7 @@ AVIF does not support progressive rendering, so files must be fully downloaded b
 This often has little impact on real-world user experience because AVIF files are much smaller than the equivalent JPEG or PNG files, and hence can be downloaded and displayed much faster.
 For larger file size the impact can become significant, and you should consider using a format that supports progressive rendering.
 
-AVIF is supported in Chrome, Edge, Opera, Safari and Firefox (Firefox supports still images but not animations).
+AVIF is supported in Chrome, Edge, Opera, Safari and Firefox.
 As support is not yet comprehensive (and has little historical depth) you should provide a fallback in [WebP](#webp_image), [JPEG](#jpeg_joint_photographic_experts_group_image) or [PNG](#png_portable_network_graphics) format using [the `<picture>` element](/en-US/docs/Web/HTML/Element/picture) (or some other approach).
 
 <table class="standard-table">
@@ -336,7 +336,7 @@ As support is not yet comprehensive (and has little historical depth) you should
             Firefox 93 supports still images, with colorspace support for both full and limited range colors, image transforms for mirroring and rotation.
             The preference <a href="/en-US/docs/Mozilla/Firefox/Experimental_features#avif_compliance_strictness">image.avif.compliance_strictness</a>
             can be used to adjust the compliance strictness with the specification.
-            Animated images are not supported.
+            Firefox 113 supports animated images.
           </li>
         </ul>
       </td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Firefox has supported animated AVIF image files by default since version 113. The "Image file type and format guide" page still says it is not supported.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The supported formats should be accurate so web devs can make better informed decisions on animated image formats. Animated AVIF files far exceed both WebP and GIF in terms of image quality and efficiency. 

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://www.mozilla.org/en-US/firefox/113.0/releasenotes/#note-789536

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
