### PR TITLE
`setTimeout` IDs can in fact be reused

### DIFF
--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -57,7 +57,7 @@ cancel the timeout.
 
 It is guaranteed that a `timeoutID` value will never be reused by a subsequent call to
 `setTimeout()` or `setInterval()` on the same object (a window or
-a worker). However, different objects use separate pools of IDs.
+a worker) while the timer is still active. However, different objects use separate pools of IDs.
 
 ## Description
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There was some misleading language here. Web browsers can and will reuse setTimeout IDs eventually, as there is only a finite number of them.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Additional details
The specification for pertaining to setTimeout IDs is here: 
https://html.spec.whatwg.org/#timer-initialisation-steps

It doesn't specify how the IDs are chosen, only that they must be positive and can't be currently in use. (Although there is some discussion of standardising them to simply start at 1, increase by one every time, and eventually wrap back around to 1. This would make it rare to see reused IDs, but still not impossible.)
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

