### PR TITLE
scrollingElement: Add the missing "not" in the quirks mode

### DIFF
--- a/files/en-us/web/api/document/scrollingelement/index.md
+++ b/files/en-us/web/api/document/scrollingelement/index.md
@@ -14,7 +14,7 @@ scrolls the document. In standards mode, this is the root element of the
 document, {{domxref("document.documentElement")}}.
 
 When in quirks mode, the `scrollingElement` attribute returns the HTML
-`body` element if it exists and is not [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null. This may look surprising but is true according to both the specification and browsers.
+`body` element if it exists and is _not_ [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns `null`. This may look surprising but is true according to both the specification and browsers.
 
 ## Value
 

--- a/files/en-us/web/api/document/scrollingelement/index.md
+++ b/files/en-us/web/api/document/scrollingelement/index.md
@@ -14,7 +14,7 @@ scrolls the document. In standards mode, this is the root element of the
 document, {{domxref("document.documentElement")}}.
 
 When in quirks mode, the `scrollingElement` attribute returns the HTML
-`body` element if it exists and is [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.
+`body` element if it exists and is not [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.
 
 ## Value
 

--- a/files/en-us/web/api/document/scrollingelement/index.md
+++ b/files/en-us/web/api/document/scrollingelement/index.md
@@ -14,7 +14,7 @@ scrolls the document. In standards mode, this is the root element of the
 document, {{domxref("document.documentElement")}}.
 
 When in quirks mode, the `scrollingElement` attribute returns the HTML
-`body` element if it exists and is not [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.
+`body` element if it exists and is not [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null. This may look surprising but is true according to both the specification and browsers.
 
 ## Value
 


### PR DESCRIPTION
> ~~This PR has been set to `DRAFT` since the behavior written in the specification may be incorrect: “I personally think the standard is wrong. If the body is not potentially scrollable, why return it as the scrollingElement?” [src](https://t.me/typescript_zh/105151)~~

### Description

Currently:

> When in quirks mode, the scrollingElement attribute returns the HTML body element if it exists and is [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.

Changes to:

> When in quirks mode, the scrollingElement attribute returns the HTML body element if it exists and is **not** [potentially scrollable](https://drafts.csswg.org/cssom-view/#potentially-scrollable), otherwise it returns null.

Because according to https://drafts.csswg.org/cssom-view/#potentially-scrollable, it states:

> If the Document is in quirks mode, follow these substeps:
> 1. If the body element exists, and it is **not** potentially scrollable, return the body element and abort these steps.

### Motivation

The current documentation regarding the behavior in quirk mode might be misleading, according to a reader's feedback.

### Additional details

This change was introduced in the documentation at <https://web.archive.org/web/20201004025304/https://developer.mozilla.org/en-US/docs/Web/API/Document/scrollingElement> (6ec6bf2b95fb1d10631d99d16e71d40cd0e33020). However, the reason for this change is unclear.

### Related issues and pull requests

Discussion https://t.me/typescript_zh/105136
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
