### PR TITLE
Ogg theora video codec is deprecated/removed

### DIFF
--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -49,7 +49,7 @@ The sections below describe the following optimization techniques:
 
 ### Compress all videos
 
-Most video compression work compares adjacent frames within a video, with the intent of removing detail that is identical in both frames. Compress the video and export to multiple video formats, including WebM, MPEG-4/H.264, and Ogg/Theora.
+Most video compression work compares adjacent frames within a video, with the intent of removing detail that is identical in both frames. Compress the video and export to multiple video formats, including WebM, and MPEG-4/H.264.
 
 Your video editing software probably has a feature to reduce file size. If not, there are online tools, such as [FFmpeg](https://www.ffmpeg.org/) (discussed in section below), that encode, decode, convert, and perform other optimization functions.
 
@@ -63,8 +63,6 @@ Order video source from smallest to largest. For example, given video compressio
   <source src="video.webm" type="video/webm" />
   <!-- MPEG-4/H.264: 12 MB -->
   <source src="video.mp4" type="video/mp4" />
-  <!-- Ogg/Theora: 13 MB -->
-  <source src="video.ogv" type="video/ogv" />
 </video>
 ```
 

--- a/files/en-us/learn/performance/video/index.md
+++ b/files/en-us/learn/performance/video/index.md
@@ -55,7 +55,7 @@ Your video editing software probably has a feature to reduce file size. If not, 
 
 ### Optimize `<source>` order
 
-Order video source from smallest to largest. For example, given video compressions in three different formats at 10MB, 12MB, and 13MB, declare the smallest first and the largest last:
+Order video source from smallest to largest. For example, given video compressions in the formats at 10MB and 12MB, declare the 10MB resource first:
 
 ```html
 <video width="400" height="300" controls="controls">

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -81,7 +81,9 @@ No notable changes.
 - The [`options_page` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page) is provided as an alias of the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key. This has been provided to offer extensions better compatibility with Chrome ([Firefox bug 1816960](https://bugzil.la/1816960)).
 - The {{WebExtAPIRef("tabs.captureVisibleTab")}} method is now also enabled by the `activeTab` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions), providing compatibility with Chrome and Safari ([Firefox bug 1784920](https://bugzil.la/1784920)).
 
-### Other
+## Other
+
+- The [Theora](/en-US/docs/Web/Media/Formats/Video_codecs#theora) codec was disabled by default, and will be removed in a future release ([Firefox bug 1860492](https://bugzil.la/1860492)).
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -59,7 +59,7 @@ No notable changes.
 
 #### Media, WebRTC, and Web Audio
 
-#### Removals
+##### Removals
 
 - The marquee events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handler attributes](/en-US/docs/Web/HTML/Element/marquee#event_handlers) defined on the [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) ([Firefox bug 1689705](https://bugzil.la/1689705)).
 - The [Theora](/en-US/docs/Web/Media/Formats/Video_codecs#theora) codec was disabled by default, and will be removed in a future release ([Firefox bug 1860492](https://bugzil.la/1860492)).

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -62,6 +62,7 @@ No notable changes.
 #### Removals
 
 - The marquee events [`bounce`](/en-US/docs/Web/API/HTMLMarqueeElement#bounce), [`finish`](/en-US/docs/Web/API/HTMLMarqueeElement#finish), and [`start`](/en-US/docs/Web/API/HTMLMarqueeElement#start) have been removed from [`HTMLMarqueeElement`](/en-US/docs/Web/API/HTMLMarqueeElement), along with the corresponding [event handler attributes](/en-US/docs/Web/HTML/Element/marquee#event_handlers) defined on the [`<marquee>` HTML element](/en-US/docs/Web/HTML/Element/marquee) ([Firefox bug 1689705](https://bugzil.la/1689705)).
+- The [Theora](/en-US/docs/Web/Media/Formats/Video_codecs#theora) codec was disabled by default, and will be removed in a future release ([Firefox bug 1860492](https://bugzil.la/1860492)).
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -80,10 +81,6 @@ No notable changes.
 - The `"webRequestAuthProvider"` permission is now supported. This provides compatibility with Chrome for requesting permission for {{WebExtAPIRef("webRequest.onAuthRequired")}} in Manifest V3 ([Firefox bug 1820569](https://bugzil.la/1820569)).
 - The [`options_page` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page) is provided as an alias of the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key. This has been provided to offer extensions better compatibility with Chrome ([Firefox bug 1816960](https://bugzil.la/1816960)).
 - The {{WebExtAPIRef("tabs.captureVisibleTab")}} method is now also enabled by the `activeTab` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions), providing compatibility with Chrome and Safari ([Firefox bug 1784920](https://bugzil.la/1784920)).
-
-## Other
-
-- The [Theora](/en-US/docs/Web/Media/Formats/Video_codecs#theora) codec was disabled by default, and will be removed in a future release ([Firefox bug 1860492](https://bugzil.la/1860492)).
 
 ## Experimental web features
 

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -142,7 +142,6 @@ li {
         <option>video/webm; codecs=vp9</option>
         <option>video/mp4; codecs=avc1</option>
         <option>video/mp4; codecs=avc1.420034</option>
-        <option>video/ogg; codecs=theora</option>
         <option>invalid</option>
       </select>
     </li>

--- a/files/en-us/web/media/formats/video_codecs/index.md
+++ b/files/en-us/web/media/formats/video_codecs/index.md
@@ -88,7 +88,7 @@ The following video codecs are those which are most commonly used on the web. Fo
       </td>
     </tr>
     <tr>
-      <th scope="row"><a href="#theora">Theora</a></th>
+      <th scope="row"><a href="#theora">Theora</a> {{deprecated_inline}}</th>
       <td>Theora</td>
       <td><a href="/en-US/docs/Web/Media/Formats/Containers#ogg">Ogg</a></td>
     </tr>
@@ -1505,6 +1505,10 @@ However, few web browsers support MPEG-2 without the support of a plugin, and wi
 
 ### Theora
 
+> [!WARNING]
+> This code is no longer longer recommended.
+> It has extremely small usage, and support is being removed from browsers.
+
 **[Theora](https://en.wikipedia.org/wiki/Theora)**, developed by [Xiph.org](https://xiph.org/), is an open and free video codec which may be used without royalties or licensing. Theora is comparable in quality and compression rates to MPEG-4 Part 2 Visual and AVC, making it a very good if not top-of-the-line choice for video encoding. But its status as being free from any licensing concerns and its relatively low CPU resource requirements make it a popular choice for many software and web projects. The low CPU impact is particularly useful since there are no hardware decoders available for Theora.
 
 Theora was originally based upon the VC3 codec by On2 Technologies. The codec and its specification were released under the LGPL license and entrusted to Xiph.org, which then developed it into the Theora standard.
@@ -1581,10 +1585,10 @@ The [Theora Cookbook](https://en.flossmanuals.net/ogg-theora/_full/) offers addi
             </tr>
             <tr>
               <th scope="row">Theora support</th>
-              <td>3</td>
-              <td>Yes</td>
-              <td>3.5</td>
-              <td>10.5</td>
+              <td>3 to 121</td>
+              <td>12 to 121</td>
+              <td>3.5 to 126</td>
+              <td>10.5 to 107</td>
               <td>No</td>
             </tr>
           </tbody>


### PR DESCRIPTION
Fixes #35271

See linked item - the theora codec is no longer maintained, and is considered a security risk. Effectively removed in chrome 121 and FF125 (behind prefs, but won't be renabled).

I have updated the video codec page to mark the codec as deprecated and add the support versions for Chrome, Firefox, Edge, Opera (assuming Edge/Opera have matching engine versions). I have added an FF126 release note.

The code is referenced in a number of places. I have removed it from the "easy ones". A more thorough cleanup should probably be done in the other cases where it is mentioned, but that doesn't have to be done now - requires more investigation.