### PR TITLE
Update Firefox 129 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -74,14 +74,14 @@ This article provides information about the changes in Firefox 129 that affect d
 
 #### WebDriver BiDi
 
+- By default CDP (Chrome DevTools Protocol) is now disabled. It can be re-enabled via the `remote.active-protocols` preference. You can learn more about this on the following [blog post](https://fxdx.dev/deprecating-cdp-support-in-firefox-embracing-the-future-with-webdriver-bidi/). ([Firefox bug 1882089](https://bugzil.la/1882089))
 - Added support for the `network.setCacheBehavior` command, which allows to configure the browser to bypass the network cache either globally or for a set of top level browsing contexts. ([Firefox bug 1901032](https://bugzil.la/1901032) and [Firefox bug 1906100](https://bugzil.la/1906100))
 - Added support for prompts of type `beforeUnload` which can now be handled in the same way as other user prompts. ([Firefox bug 1824220](https://bugzil.la/1824220))
 - We now support all arguments for the `network.provideResponse` command when used in the `beforeRequestSent` phase, such as the `body` parameter which allows to return mock responses. ([Firefox bug 1853882](https://bugzil.la/1853882))
 - The `browsingContext.userPromptOpened` now includes the `handler` field which contains the user prompt handler configured for the prompt which triggered the event. ([Firefox bug 1904822](https://bugzil.la/1904822))
-- By default CDP (Chrome DevTools Protocol) is now disabled. It can be re-enabled via the `remote.active-protocols` preference. ([Firefox bug 1882089](https://bugzil.la/1882089))
 - The `BrowsingContextInfo` type will now provide an `originalOpener` field which is the context id of the "opener" browsing context. This will be set for instance if the new context was created by using a link (even with `rel=noopener`), `window.open` etc. If the new browsing context has no relevant opener, the field will be set to null. ([Firefox bug 1898004](https://bugzil.la/1898004))
 - Network events (`beforeRequestSent`, `responseStarted` and `responseCompleted`) are now created for requests to data URLs. In Firefox 129, only navigation requests will be listed. ([Firefox bug 1805176](https://bugzil.la/1805176))
-- We added support for the `promptUnload` argument for `browsingContext.close`, which allows to bypass before unload prompts when closing a context via this command. ([Firefox bug 1862380](https://bugzil.la/1862380))
+- We added support for the `promptUnload` argument for `browsingContext.close`, which allows to bypass "beforeunload" prompts when closing a context via this command. ([Firefox bug 1862380](https://bugzil.la/1862380))
 - Fixed a bug in `network.continueRequest` where you could not set multiple values for the same header. ([Firefox bug 1904379](https://bugzil.la/1904379))
 - Fixed a bug for the `unhandledPromptBehavior` capability, which could not be used with BiDi only sessions. ([Firefox bug 1907935](https://bugzil.la/1907935))
 - Fixed a bug with `session.end` and `browser.close` which would unexpectedly fail when no Marionette client was connected. ([Firefox bug 1890091](https://bugzil.la/1890091))

--- a/files/en-us/mozilla/firefox/releases/129/index.md
+++ b/files/en-us/mozilla/firefox/releases/129/index.md
@@ -74,7 +74,22 @@ This article provides information about the changes in Firefox 129 that affect d
 
 #### WebDriver BiDi
 
-#### Marionette
+- Added support for the `network.setCacheBehavior` command, which allows to configure the browser to bypass the network cache either globally or for a set of top level browsing contexts. ([Firefox bug 1901032](https://bugzil.la/1901032) and [Firefox bug 1906100](https://bugzil.la/1906100))
+- Added support for prompts of type `beforeUnload` which can now be handled in the same way as other user prompts. ([Firefox bug 1824220](https://bugzil.la/1824220))
+- We now support all arguments for the `network.provideResponse` command when used in the `beforeRequestSent` phase, such as the `body` parameter which allows to return mock responses. ([Firefox bug 1853882](https://bugzil.la/1853882))
+- The `browsingContext.userPromptOpened` now includes the `handler` field which contains the user prompt handler configured for the prompt which triggered the event. ([Firefox bug 1904822](https://bugzil.la/1904822))
+- By default CDP (Chrome DevTools Protocol) is now disabled. It can be re-enabled via the `remote.active-protocols` preference. ([Firefox bug 1882089](https://bugzil.la/1882089))
+- The `BrowsingContextInfo` type will now provide an `originalOpener` field which is the context id of the "opener" browsing context. This will be set for instance if the new context was created by using a link (even with `rel=noopener`), `window.open` etc. If the new browsing context has no relevant opener, the field will be set to null. ([Firefox bug 1898004](https://bugzil.la/1898004))
+- Network events (`beforeRequestSent`, `responseStarted` and `responseCompleted`) are now created for requests to data URLs. In Firefox 129, only navigation requests will be listed. ([Firefox bug 1805176](https://bugzil.la/1805176))
+- We added support for the `promptUnload` argument for `browsingContext.close`, which allows to bypass before unload prompts when closing a context via this command. ([Firefox bug 1862380](https://bugzil.la/1862380))
+- Fixed a bug in `network.continueRequest` where you could not set multiple values for the same header. ([Firefox bug 1904379](https://bugzil.la/1904379))
+- Fixed a bug for the `unhandledPromptBehavior` capability, which could not be used with BiDi only sessions. ([Firefox bug 1907935](https://bugzil.la/1907935))
+- Fixed a bug with `session.end` and `browser.close` which would unexpectedly fail when no Marionette client was connected. ([Firefox bug 1890091](https://bugzil.la/1890091))
+- Fixed a bug with `browsingContext.navigate` which would fail to resolve if a same-document navigation started on "beforeunload". ([Firefox bug 1879163](https://bugzil.la/1879163))
+- Improved the `browser.close` command to discard all "beforeunload" prompts when closing the top-level browsing contexts. ([Firefox bug 1873196](https://bugzil.la/1873196))
+- Fixed a bug in the `browsingContext.userPromptOpened` event, which would unexpectedly miss the `defaultValue` field ([Firefox bug 1859814](https://bugzil.la/1859814))
+- Fixed an issue with the `network.responseCompleted` event during authentication flows, which was emitted too many times compared to the specifications. Only one `responseCompleted` (or `fetchError`) event is expected for the whole HTTP authentication flow. ([Firefox bug 1906106](https://bugzil.la/1906106))
+- Improved the `browser.removeUserContext` command to skip all "beforeunload" prompts. ([Firefox bug 1876062](https://bugzil.la/1876062))
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
This updates the WebDriver section of the Firefox 129 release notes for all the [note-worthy WebDriver changes in this release](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox128&query_format=advanced&o1=equals&f1=cf_status_firefox129&o2=notequals&status_whiteboard=%5Bwebdriver%3Arelnote%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed).