### PR TITLE
Documentation for VideoFrameCopyToOptions' format and colorSpace

### DIFF
--- a/files/en-us/web/api/videoframe/allocationsize/index.md
+++ b/files/en-us/web/api/videoframe/allocationsize/index.md
@@ -33,6 +33,10 @@ allocationSize(options)
           - : An integer representing the offset in bytes where the given plane begins.
         - `stride`
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
+    - `format` {{Optional_Inline}}
+      - : A pixel format for the pixel data in the `destination`. Can be set to `"RGBA"`, `"RGBX"`, `"BGRA"`, `"BGRX"`. If unspecified, the {{domxref("VideoFrame.format","format")}} will be used.
+    - `colorSpace` {{Optional_Inline}}
+      - : Specifies the color space of the pixel data in the `destination`. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3). Only applicable for RGB pixel formats. If unspecified, `"srgb` will be used.
 
 ### Return value
 

--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -66,8 +66,8 @@ const videoRect = {
 const options = {
   rect: videoRect,
   format: "RGBX",
-  colorSpace: "display-p3"
-}
+  colorSpace: "display-p3",
+};
 const size = videoFrame.allocationSize(options);
 const buffer = new ArrayBuffer(size);
 const layout = await videoFrame.copyTo(buffer, options);

--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -36,6 +36,10 @@ copyTo(destination, options)
         - `stride`
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
             Planes may not overlap. If no `layout` is specified, the planes will be tightly packed.
+    - `format` {{Optional_Inline}}
+      - : A pixel format for the pixel data in the `destination`. Can be set to `"RGBA"`, `"RGBX"`, `"BGRA"`, `"BGRX"`. If unspecified, the {{domxref("VideoFrame.format","format")}} will be used.
+    - `colorSpace` {{Optional_Inline}}
+      - : Specifies the color space of the pixel data in the `destination`. Can be set to `"srgb"` for the [sRGB color space](https://en.wikipedia.org/wiki/SRGB) or `"display-p3"` for the [display-p3 color space](https://en.wikipedia.org/wiki/DCI-P3). Only applicable for RGB pixel formats. If unspecified, `"srgb` will be used.
 
 ### Return value
 
@@ -48,6 +52,25 @@ The following example copies the entire contents of `videoFrame`.
 ```js
 let buffer = new Uint8Array(videoFrame.allocationSize());
 let layout = await videoFrame.copyTo(buffer);
+```
+
+The following example converts a portion of the `videoFrame` to RGB format.
+
+```js
+const videoRect = {
+  x: 100,
+  y: 100,
+  width: 80,
+  height: 60,
+};
+const options = {
+  rect: videoRect,
+  format: "RGBX",
+  colorSpace: "display-p3"
+}
+const size = videoFrame.allocationSize(options);
+const buffer = new ArrayBuffer(size);
+const layout = await videoFrame.copyTo(buffer, options);
 ```
 
 ## Specifications


### PR DESCRIPTION
Spec link: https://www.w3.org/TR/webcodecs/#videoframe-copyto-options
Shipped in Chromium 127: https://chromestatus.com/feature/4668827056209920
