### PR TITLE
Replace "ES6 In Depth: Symbols" with wayback machine link

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -213,4 +213,4 @@ obj[Object(sym)]; // still 1
 - [Polyfill of `Symbol` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Operators/typeof", "typeof")}}
 - [JavaScript data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)
-- [ES6 In Depth: Symbols](https://hacks.mozilla.org/2015/06/es6-in-depth-symbols/) on hacks.mozilla.org (2015)
+- [ES6 In Depth: Symbols](http://web.archive.org/web/20240110174646/https://hacks.mozilla.org/2015/06/es6-in-depth-symbols/) on hacks.mozilla.org (2015)

--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -213,4 +213,4 @@ obj[Object(sym)]; // still 1
 - [Polyfill of `Symbol` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Operators/typeof", "typeof")}}
 - [JavaScript data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)
-- [ES6 In Depth: Symbols](http://web.archive.org/web/20240110174646/https://hacks.mozilla.org/2015/06/es6-in-depth-symbols/) on hacks.mozilla.org (2015)
+- [ES6 In Depth: Symbols](https://web.archive.org/web/20240110174646/https://hacks.mozilla.org/2015/06/es6-in-depth-symbols/) on hacks.mozilla.org (2015)


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Replace "ES6 In Depth: Symbols" with wayback machine link

- This new link is styled correctly. The one I replaced is not. 
- This is likely a bug in the original link -- https://hacks.mozilla.org/2015/06/es6-in-depth-symbols/ -- but I don't know how to contact the webmaster about it.
- Even if the problem is fixed on the original link, this new link will prevent other bugs causing problems in the future.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
