### PR TITLE
:nth-of-type selector execution process

### DIFF
--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -85,9 +85,10 @@ p.fancy:nth-of-type(2n + 1) {
     <div class="children">2</div>
     <div class="children">3</div>
     <div class="children">4</div>
-    <div class="children">5</div>
+    <span class="children">5</span>
+    <div class="children">6</div>
   </div>
-  <p class="children">6</p>
+  <p class="children">7</p>
 </body>
 ```
 
@@ -101,9 +102,31 @@ p.fancy:nth-of-type(2n + 1) {
 </style>
 ```
 
-1. Use `.children` to find elements with content `2, 3, 4, 5, 6`.
-2. Get all sibling elements with the same tag (i.e., all `div` under father and `p` under body).
-3. Select and apply CSS styles based on `(2)`
+1. Use `.children` to find elements with content `2, 3, 4, 6, 7`.
+2. Get all sibling elements with the same tag (here, all `div`s under `father`, `span`s under `father`, and `p`s under `body`)
+3. Select and apply CSS styles based on `(2)` (The following is a simple comparison for easier understanding)
+   ```
+   // Please note that this is not a standard JSON format!
+   // All elements are HTML objects, and for ease of understanding, text is directly used here.
+   
+   {
+       "father": {
+           "span": [
+               <span class="children">5</span>   // class includes 'children' but index: 1 not selected.
+           ],
+           "div": [
+               <div class="aaa">1</div>    // index: 1 and class does not include 'children'. not selected.
+               <div class="children">2</div>   // index: 2 and class includes 'children'. Selected and rendered.
+               <div class="children">3</div>   // class includes 'children' but index: 3 not selected.
+               <div class="children">4</div>   // class includes 'children' but index: 4 not selected.
+               <div class="children">6</div>   // class includes 'children' but index: 5 not selected.
+           ]
+       },
+       "body": [
+           <p class="children">7</p>   // class includes 'children' but index: 1 not selected.
+       ]
+   }
+   ```
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -122,7 +122,7 @@ p.fancy:nth-of-type(2n + 1) {
        ]
      },
      "body": [
-       "<p class='children'>6</p>"   // class includes 'children' but index: 1 not selected.
+       "<p class='children'>6</p>" // class includes 'children' but index: 1 not selected.
      ]
    }
    ```

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -3,7 +3,6 @@ title: ":nth-of-type()"
 slug: Web/CSS/:nth-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-of-type
-
 ---
 
 {{CSSRef}}

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -114,11 +114,11 @@ p.fancy:nth-of-type(2n + 1) {
            "<span class='children'>5</span>"  // class includes 'children' but index: 1 not selected.
        ],
        "div": [
-           "<div class='aaa'>1</div>",    // index: 1 and class does not include 'children'. not selected.
-           "<div class='children'>2</div>",   // index: 2 and class includes 'children'. Selected and rendered.
-           "<div class='children'>3</div>",   // class includes 'children' but index: 3 not selected.
-           "<div class='children'>4</div>",   // class includes 'children' but index: 4 not selected.
-           "<div class='children'>6</div>"    // class includes 'children' but index: 5 not selected.
+         "<div class='aaa'>1</div>", // index: 1 and class does not include 'children'. not selected.
+         "<div class='children'>2</div>", // index: 2 and class includes 'children'. Selected and rendered.
+         "<div class='children'>3</div>", // class includes 'children' but index: 3 not selected.
+         "<div class='children'>4</div>", // class includes 'children' but index: 4 not selected.
+         "<div class='children'>6</div>" // class includes 'children' but index: 5 not selected.
        ]
      },
      "body": [

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -105,6 +105,7 @@ p.fancy:nth-of-type(2n + 1) {
 1. Use `.children` to find elements with content `2, 3, 4, 6, 7`.
 2. Get all sibling elements with the same tag (here, all `div`s under `father`, `span`s under `father`, and `p`s under `body`)
 3. Select and apply CSS styles based on `(2)` (The following is a simple comparison for easier understanding)
+
    ```json
    // Please note that this is not a standard JSON format!
    // All elements are HTML objects, and for ease of understanding, text is directly used here.

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -3,11 +3,14 @@ title: ":nth-of-type()"
 slug: Web/CSS/:nth-of-type
 page-type: css-pseudo-class
 browser-compat: css.selectors.nth-of-type
+
 ---
 
 {{CSSRef}}
 
 The **`:nth-of-type()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position among siblings of the same type (tag name).
+
+Tips:When you use non-tag selectors like div, p, etc., the browser first matches the selected elements, then parses the elements' tags, and finally matches them based on the position of the tags within the parent elements.
 
 {{EmbedInteractiveExample("pages/tabbed/pseudo-class-nth-of-type.html", "tabbed-shorter")}}
 
@@ -71,6 +74,37 @@ p.fancy:nth-of-type(2n + 1) {
 
 > [!NOTE]
 > There is no way to select the nth-of-class using this selector. The selector looks at the type only when creating the list of matches. You can however apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the example above.
+
+### Selector Execution Process
+
+#### HTML
+
+```html
+<body>
+<div class="father">
+  <div class="aaa">1</div>
+  <div class="children">2</div>
+  <div class="children">3</div>
+  <div class="children">4</div>
+  <div class="children">5</div>
+</div>
+<p class="children">6</p>
+</body>
+```
+
+#### CSS
+
+```css
+<style>
+.children:nth-of-type(2) {
+  background: blue;
+}
+</style>
+```
+
+1. Use `.children` to find elements with content `2, 3, 4, 5, 6`.
+2. Get all sibling elements with the same tag (i.e., all `div` under father and `p` under body).
+3. Select and apply CSS styles based on `(2)`
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -105,24 +105,25 @@ p.fancy:nth-of-type(2n + 1) {
 1. Use `.children` to find elements with content `2, 3, 4, 6, 7`.
 2. Get all sibling elements with the same tag (here, all `div`s under `father`, `span`s under `father`, and `p`s under `body`)
 3. Select and apply CSS styles based on `(2)` (The following is a simple comparison for easier understanding)
-   ```
+   
+   ```json
    // Please note that this is not a standard JSON format!
    // All elements are HTML objects, and for ease of understanding, text is directly used here.
    {
        "father": {
            "span": [
-               <span class="children">5</span>   // class includes 'children' but index: 1 not selected.
+               "<span class='children'>5</span>"  // class includes 'children' but index: 1 not selected.
            ],
            "div": [
-               <div class="aaa">1</div>    // index: 1 and class does not include 'children'. not selected.
-               <div class="children">2</div>   // index: 2 and class includes 'children'. Selected and rendered.
-               <div class="children">3</div>   // class includes 'children' but index: 3 not selected.
-               <div class="children">4</div>   // class includes 'children' but index: 4 not selected.
-               <div class="children">6</div>   // class includes 'children' but index: 5 not selected.
+               "<div class='aaa'>1</div>",    // index: 1 and class does not include 'children'. not selected.
+               "<div class='children'>2</div>",   // index: 2 and class includes 'children'. Selected and rendered.
+               "<div class='children'>3</div>",   // class includes 'children' but index: 3 not selected.
+               "<div class='children'>4</div>",   // class includes 'children' but index: 4 not selected.
+               "<div class='children'>6</div>"    // class includes 'children' but index: 5 not selected.
            ]
        },
        "body": [
-           <p class="children">7</p>   // class includes 'children' but index: 1 not selected.
+           "<p class='children'>6</p>"   // class includes 'children' but index: 1 not selected.
        ]
    }
    ```

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -105,26 +105,25 @@ p.fancy:nth-of-type(2n + 1) {
 1. Use `.children` to find elements with content `2, 3, 4, 6, 7`.
 2. Get all sibling elements with the same tag (here, all `div`s under `father`, `span`s under `father`, and `p`s under `body`)
 3. Select and apply CSS styles based on `(2)` (The following is a simple comparison for easier understanding)
-   
    ```json
    // Please note that this is not a standard JSON format!
    // All elements are HTML objects, and for ease of understanding, text is directly used here.
    {
-       "father": {
-           "span": [
-               "<span class='children'>5</span>"  // class includes 'children' but index: 1 not selected.
-           ],
-           "div": [
-               "<div class='aaa'>1</div>",    // index: 1 and class does not include 'children'. not selected.
-               "<div class='children'>2</div>",   // index: 2 and class includes 'children'. Selected and rendered.
-               "<div class='children'>3</div>",   // class includes 'children' but index: 3 not selected.
-               "<div class='children'>4</div>",   // class includes 'children' but index: 4 not selected.
-               "<div class='children'>6</div>"    // class includes 'children' but index: 5 not selected.
-           ]
-       },
-       "body": [
-           "<p class='children'>6</p>"   // class includes 'children' but index: 1 not selected.
+     "father": {
+       "span": [
+           "<span class='children'>5</span>"  // class includes 'children' but index: 1 not selected.
+       ],
+       "div": [
+           "<div class='aaa'>1</div>",    // index: 1 and class does not include 'children'. not selected.
+           "<div class='children'>2</div>",   // index: 2 and class includes 'children'. Selected and rendered.
+           "<div class='children'>3</div>",   // class includes 'children' but index: 3 not selected.
+           "<div class='children'>4</div>",   // class includes 'children' but index: 4 not selected.
+           "<div class='children'>6</div>"    // class includes 'children' but index: 5 not selected.
        ]
+     },
+     "body": [
+       "<p class='children'>6</p>"   // class includes 'children' but index: 1 not selected.
+     ]
    }
    ```
 

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -111,7 +111,7 @@ p.fancy:nth-of-type(2n + 1) {
    {
      "father": {
        "span": [
-           "<span class='children'>5</span>"  // class includes 'children' but index: 1 not selected.
+         "<span class='children'>5</span>" // class includes 'children' but index: 1 not selected.
        ],
        "div": [
          "<div class='aaa'>1</div>", // index: 1 and class does not include 'children'. not selected.

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -108,7 +108,6 @@ p.fancy:nth-of-type(2n + 1) {
    ```
    // Please note that this is not a standard JSON format!
    // All elements are HTML objects, and for ease of understanding, text is directly used here.
-   
    {
        "father": {
            "span": [

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -80,14 +80,14 @@ p.fancy:nth-of-type(2n + 1) {
 
 ```html
 <body>
-<div class="father">
-  <div class="aaa">1</div>
-  <div class="children">2</div>
-  <div class="children">3</div>
-  <div class="children">4</div>
-  <div class="children">5</div>
-</div>
-<p class="children">6</p>
+  <div class="father">
+    <div class="aaa">1</div>
+    <div class="children">2</div>
+    <div class="children">3</div>
+    <div class="children">4</div>
+    <div class="children">5</div>
+  </div>
+  <p class="children">6</p>
 </body>
 ```
 


### PR DESCRIPTION
Add more comprehensive examples

### Description

Provide a more detailed explanation of :nth-of-type

### Motivation

The current official documentation's explanation of :nth-of-type—matching elements based on their position among siblings of the same type (tag name)—may be difficult for beginners to understand. Added notes supplement the explanation above and include code examples for better comprehension.

### Additional details

None

### Related issues and pull requests

None
