### PR TITLE
Remove 'experimental' status from revert-layer

### DIFF
--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -5,7 +5,7 @@ page-type: css-keyword
 browser-compat: css.types.global_keywords.revert-layer
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`revert-layer`** [CSS-wide keyword](/en-US/docs/Web/CSS/CSS_Types#css-wide_keywords) rolls back the value of a property in a [cascade layer](/en-US/docs/Web/CSS/@layer) to the value of the property in a CSS rule matching the element in a previous cascade layer. The value of a property with this keyword is recalculated as if no rules were specified on the target element in the current cascade layer.
 

--- a/files/en-us/web/css/revert-layer/index.md
+++ b/files/en-us/web/css/revert-layer/index.md
@@ -2,8 +2,6 @@
 title: revert-layer
 slug: Web/CSS/revert-layer
 page-type: css-keyword
-status:
-  - experimental
 browser-compat: css.types.global_keywords.revert-layer
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

It doesn't appear to be experimental any more - it's available across browsers and has over 93% global usage according to caniuse.cpm

### Motivation

I was curious whether I could use this in my own personal projects, and it may be useful for new work projects too.

### Additional details

https://caniuse.com/?search=revert-layer

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
