### PR TITLE
Replace 'elements' with 'entries'

### DIFF
--- a/files/en-us/web/api/history/length/index.md
+++ b/files/en-us/web/api/history/length/index.md
@@ -9,7 +9,7 @@ browser-compat: api.History.length
 {{APIRef("History API")}}
 
 The **`length`** read-only property of the {{DOMxRef("History")}} interface
-returns an integer representing the number of elements in the session
+returns an integer representing the number of entries in the session
 history, including the currently loaded page.
 
 For example, for a page loaded in a new tab this property returns `1`.


### PR DESCRIPTION
When I was reading this page I did a double take seeing the word 'elements' wondering if that referred to having HTML elements in the history API. But the history API has nothing to do with HTML elements. So seems like maybe a word like 'entries' may be a bit better than 'elements'.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Replace 'elements' with 'entries'

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I did a double take while reading this page and thought this might help other readers.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
