### PR TITLE
Fix BCD keys for CSS display values

### DIFF
--- a/files/en-us/web/css/display-inside/index.md
+++ b/files/en-us/web/css/display-inside/index.md
@@ -3,12 +3,11 @@ title: <display-inside>
 slug: Web/CSS/display-inside
 page-type: css-type
 browser-compat:
-  - css.properties.display.multi-keyword_values
   - css.properties.display.flow-root
-  - css.properties.display.table_values
-  - css.properties.display.grid
+  - css.properties.display.table
   - css.properties.display.flex
-  - css.properties.display.ruby_values
+  - css.properties.display.grid
+  - css.properties.display.ruby
 spec-urls: https://drafts.csswg.org/css-display/#typedef-display-inside
 ---
 

--- a/files/en-us/web/css/display-internal/index.md
+++ b/files/en-us/web/css/display-internal/index.md
@@ -3,8 +3,18 @@ title: <display-internal>
 slug: Web/CSS/display-internal
 page-type: css-type
 browser-compat:
-  - css.properties.display.table_values
-  - css.properties.display.ruby_values
+  - css.properties.display.table-row-group
+  - css.properties.display.table-header-group
+  - css.properties.display.table-footer-group
+  - css.properties.display.table-row
+  - css.properties.display.table-cell
+  - css.properties.display.table-column-group
+  - css.properties.display.table-column
+  - css.properties.display.table-caption
+  - css.properties.display.ruby-base
+  - css.properties.display.ruby-text
+  - css.properties.display.ruby-base-container
+  - css.properties.display.ruby-text-container
 ---
 
 {{CSSRef}}


### PR DESCRIPTION
Fix `table_values` and `ruby_values` with the exact BCD keys