### PR TITLE
Web API entity pages should not use DefaultAPISidebar

### DIFF
--- a/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/ended_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.AudioScheduledSourceNode.ended_event
 ---
 
-{{DefaultAPISidebar("Web Audio API")}}
+{{APIRef("Web Audio API")}}
 
 The `ended` event of the {{domxref("AudioScheduledSourceNode")}} interface is fired when the source node has stopped playing.
 

--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaAtomic
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
 

--- a/files/en-us/web/api/element/ariaautocomplete/index.md
+++ b/files/en-us/web/api/element/ariaautocomplete/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaAutoComplete
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 

--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaBusy
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaChecked
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaColCount
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 

--- a/files/en-us/web/api/element/ariacolindex/index.md
+++ b/files/en-us/web/api/element/ariacolindex/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaColIndex
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/element/ariacolspan/index.md
+++ b/files/en-us/web/api/element/ariacolspan/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaColSpan
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/element/ariacurrent/index.md
+++ b/files/en-us/web/api/element/ariacurrent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaCurrent
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 

--- a/files/en-us/web/api/element/ariadescription/index.md
+++ b/files/en-us/web/api/element/ariadescription/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaDescription
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaDisabled
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 

--- a/files/en-us/web/api/element/ariaexpanded/index.md
+++ b/files/en-us/web/api/element/ariaexpanded/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaExpanded
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaHasPopup
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 

--- a/files/en-us/web/api/element/ariahidden/index.md
+++ b/files/en-us/web/api/element/ariahidden/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaHidden
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaHidden`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)) attribute, which indicates whether the element is exposed to an accessibility API.
 

--- a/files/en-us/web/api/element/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaKeyShortcuts
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaKeyShortcuts`** property of the {{domxref("Element")}} interface reflects the value of the `aria-keyshortcuts` attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 

--- a/files/en-us/web/api/element/arialabel/index.md
+++ b/files/en-us/web/api/element/arialabel/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaLabel
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaLabel`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current element.
 

--- a/files/en-us/web/api/element/arialevel/index.md
+++ b/files/en-us/web/api/element/arialevel/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaLevel
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaLevel`** property of the {{domxref("Element")}} interface reflects the value of the `aria-level` attribute, which defines the hierarchical level of an element within a structure.
 

--- a/files/en-us/web/api/element/arialive/index.md
+++ b/files/en-us/web/api/element/arialive/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaLive
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaLive`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the [live region](/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 

--- a/files/en-us/web/api/element/ariamodal/index.md
+++ b/files/en-us/web/api/element/ariamodal/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaModal
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaModal`** property of the {{domxref("Element")}} interface reflects the value of the `aria-modal` attribute, which indicates whether an element is modal when displayed. Applying the `aria-modal` property to an element with `role="dialog"` replaces the technique of using aria-hidden on the background for informing assistive technologies that content outside a dialog is inert.
 

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaMultiLine
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaMultiLine`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaMultiSelectable
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 

--- a/files/en-us/web/api/element/ariaorientation/index.md
+++ b/files/en-us/web/api/element/ariaorientation/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaOrientation
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaOrientation`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 

--- a/files/en-us/web/api/element/ariaplaceholder/index.md
+++ b/files/en-us/web/api/element/ariaplaceholder/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaPlaceholder
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaPlaceholder`** property of the {{domxref("Element")}} interface reflects the value of the `aria-placeholder` attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaPosInSet
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaPressed
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaReadOnly
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 

--- a/files/en-us/web/api/element/ariarequired/index.md
+++ b/files/en-us/web/api/element/ariarequired/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaRequired
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects the value of the `aria-required` attribute, which indicates that user input is required on the element before a form may be submitted.
 

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaRoleDescription
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaRowCount
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 

--- a/files/en-us/web/api/element/ariarowindex/index.md
+++ b/files/en-us/web/api/element/ariarowindex/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaRowIndex
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/element/ariarowspan/index.md
+++ b/files/en-us/web/api/element/ariarowspan/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaRowSpan
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 

--- a/files/en-us/web/api/element/ariaselected/index.md
+++ b/files/en-us/web/api/element/ariaselected/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaSelected
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 

--- a/files/en-us/web/api/element/ariasetsize/index.md
+++ b/files/en-us/web/api/element/ariasetsize/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaSetSize
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 

--- a/files/en-us/web/api/element/ariasort/index.md
+++ b/files/en-us/web/api/element/ariasort/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaSort
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 

--- a/files/en-us/web/api/element/ariavaluemax/index.md
+++ b/files/en-us/web/api/element/ariavaluemax/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaValueMax
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaValueMax`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute, which defines the maximum allowed value for a range widget.
 

--- a/files/en-us/web/api/element/ariavaluemin/index.md
+++ b/files/en-us/web/api/element/ariavaluemin/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaValueMin
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaValueMin`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) attribute, which defines the minimum allowed value for a range widget.
 

--- a/files/en-us/web/api/element/ariavaluenow/index.md
+++ b/files/en-us/web/api/element/ariavaluenow/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaValueNow
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaValueNow`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuenow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 

--- a/files/en-us/web/api/element/ariavaluetext/index.md
+++ b/files/en-us/web/api/element/ariavaluetext/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Element.ariaValueText
 ---
 
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ariaValueText`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human-readable text alternative of aria-valuenow for a range widget.
 

--- a/files/en-us/web/api/idbtransaction/durability/index.md
+++ b/files/en-us/web/api/idbtransaction/durability/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.IDBTransaction.durability
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("IndexedDB")}}
+{{securecontext_header}}{{APIRef("IndexedDB")}}
 
 The **`durability`** read-only property of the {{domxref("IDBTransaction")}} interface returns the durability hint the transaction was created with.
 This is a hint to the user agent of whether to prioritize performance or durability when committing the transaction.

--- a/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.md
+++ b/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.IDBVersionChangeEvent.IDBVersionChangeEvent
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("IndexedDB")}}
+{{securecontext_header}}{{APIRef("IndexedDB")}}
 
 The **`IDBVersionChangeEvent()`** constructor
 creates a new {{domxref("IDBVersionChangeEvent")}} object, which is used to represent

--- a/files/en-us/web/api/midiport/close/index.md
+++ b/files/en-us/web/api/midiport/close/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.MIDIPort.close
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`close()`** method of the {{domxref("MIDIPort")}} interface makes the access to the MIDI device connected to this `MIDIPort` unavailable.
 

--- a/files/en-us/web/api/midiport/connection/index.md
+++ b/files/en-us/web/api/midiport/connection/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.connection
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`connection`** read-only property of the {{domxref("MIDIPort")}} interface returns the connection state of the port.
 

--- a/files/en-us/web/api/midiport/id/index.md
+++ b/files/en-us/web/api/midiport/id/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.id
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`id`** read-only property of the {{domxref("MIDIPort")}} interface returns the unique ID of the port.
 

--- a/files/en-us/web/api/midiport/index.md
+++ b/files/en-us/web/api/midiport/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.MIDIPort
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`MIDIPort`** interface of the {{domxref('Web MIDI API','','',' ')}} represents a MIDI input or output port.
 

--- a/files/en-us/web/api/midiport/manufacturer/index.md
+++ b/files/en-us/web/api/midiport/manufacturer/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.manufacturer
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`manufacturer`** read-only property of the {{domxref("MIDIPort")}} interface returns the manufacturer of the port.
 

--- a/files/en-us/web/api/midiport/name/index.md
+++ b/files/en-us/web/api/midiport/name/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.name
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`name`** read-only property of the {{domxref("MIDIPort")}} interface returns the system name of the port.
 

--- a/files/en-us/web/api/midiport/open/index.md
+++ b/files/en-us/web/api/midiport/open/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.MIDIPort.open
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`open()`** method of the {{domxref("MIDIPort")}} interface makes the MIDI device connected to this `MIDIPort` explicitly available.
 

--- a/files/en-us/web/api/midiport/state/index.md
+++ b/files/en-us/web/api/midiport/state/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.state
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`state`** read-only property of the {{domxref("MIDIPort")}} interface returns the state of the port.
 

--- a/files/en-us/web/api/midiport/statechange_event/index.md
+++ b/files/en-us/web/api/midiport/statechange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.MIDIPort.statechange_event
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`statechange`** event of the {{domxref("MIDIPort")}} interface is fired when a port changes from open to closed, or closed to open.
 

--- a/files/en-us/web/api/midiport/type/index.md
+++ b/files/en-us/web/api/midiport/type/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.type
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`type`** read-only property of the {{domxref("MIDIPort")}} interface returns the type of the port, indicating whether this is an input or output MIDI port.
 

--- a/files/en-us/web/api/midiport/version/index.md
+++ b/files/en-us/web/api/midiport/version/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.MIDIPort.version
 ---
 
-{{securecontext_header}}{{DefaultAPISidebar("Web MIDI API")}}
+{{securecontext_header}}{{APIRef("Web MIDI API")}}
 
 The **`version`** read-only property of the {{domxref("MIDIPort")}} interface returns the version of the port.
 

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Navigator.requestMediaKeySystemAccess
 ---
 
-{{DefaultAPISidebar("Encrypted Media Extensions")}}{{SecureContext_Header}}
+{{APIRef("Encrypted Media Extensions")}}{{SecureContext_Header}}
 
 The **`requestMediaKeySystemAccess()`** method of the {{domxref("Navigator")}} interface returns a {{jsxref('Promise')}} which delivers a {{domxref('MediaKeySystemAccess')}} object that can be used to access a particular media key system, which can in turn be used to create keys for decrypting a media stream.
 

--- a/files/en-us/web/api/navigator/requestmidiaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmidiaccess/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Navigator.requestMIDIAccess
 ---
 
-{{DefaultAPISidebar("Web MIDI API")}}{{SecureContext_Header}}
+{{APIRef("Web MIDI API")}}{{SecureContext_Header}}
 
 The **`requestMIDIAccess()`** method of the {{domxref('Navigator')}} interface returns a {{jsxref('Promise')}} representing a request for access to MIDI devices on a user's system.
 This method is part of the [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API), which provides a means for accessing, enumerating, and manipulating MIDI devices.

--- a/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.OfflineAudioContext.complete_event
 ---
 
-{{DefaultAPISidebar("Web Audio API")}}
+{{APIRef("Web Audio API")}}
 
 The `complete` event of the {{domxref("OfflineAudioContext")}} interface is fired when the rendering of an offline audio context is complete.
 

--- a/files/en-us/web/api/presentationconnection/url/index.md
+++ b/files/en-us/web/api/presentationconnection/url/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.PresentationConnection.url
 ---
 
-{{SeeCompatTable}}{{DefaultAPISidebar("Presentation API")}}{{SecureContext_Header}}
+{{SeeCompatTable}}{{APIRef("Presentation API")}}{{SecureContext_Header}}
 
 The **`url`** readonly property of the
 {{domxref("PresentationConnection")}} interface returns the URL used to create or

--- a/files/en-us/web/api/presentationrequest/start/index.md
+++ b/files/en-us/web/api/presentationrequest/start/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.PresentationRequest.start
 ---
 
-{{DefaultAPISidebar("Presentation API")}}{{SeeCompatTable}}{{SecureContext_Header}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`start()`** property of the {{domxref("PresentationRequest")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("PresentationConnection")}} after the user agent prompts the user to select a display and grant permission to use that display.
 

--- a/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.PushSubscriptionOptions.applicationServerKey
 ---
 
-{{DefaultAPISidebar("Push API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+{{APIRef("Push API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`applicationServerKey`** read-only property of the {{domxref("PushSubscriptionOptions")}} interface contains the public key used by the push server.
 

--- a/files/en-us/web/api/pushsubscriptionoptions/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.PushSubscriptionOptions
 ---
 
-{{DefaultAPISidebar("Push API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+{{APIRef("Push API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`PushSubscriptionOptions`** interface of the {{domxref('Push API','','',' ')}} represents the options associated with a push subscription.
 

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.PushSubscriptionOptions.userVisibleOnly
 ---
 
-{{DefaultAPISidebar("Push API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
+{{APIRef("Push API")}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`userVisibleOnly`** read-only property of the {{domxref("PushSubscriptionOptions")}} interface indicates if the returned push subscription will only be used for messages whose effect is made visible to the user.
 

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.md
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ResizeObserverSize.blockSize
 ---
 
-{{DefaultAPISidebar("Resize Observer API")}}
+{{APIRef("Resize Observer API")}}
 
 The **`blockSize`** read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the block dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the vertical dimension, or height; if the writing-mode is vertical, this is the horizontal dimension, or width.
 

--- a/files/en-us/web/api/resizeobserversize/index.md
+++ b/files/en-us/web/api/resizeobserversize/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.ResizeObserverSize
 ---
 
-{{DefaultAPISidebar("Resize Observer API")}}
+{{APIRef("Resize Observer API")}}
 
 The **`ResizeObserverSize`** interface of the [Resize Observer API](/en-US/docs/Web/API/Resize_Observer_API) is used by the {{domxref("ResizeObserverEntry")}} interface to access the box sizing properties of the element being observed.
 

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.md
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.ResizeObserverSize.inlineSize
 ---
 
-{{DefaultAPISidebar("Resize Observer API")}}
+{{APIRef("Resize Observer API")}}
 
 The **`inlineSize`** read-only property of the {{domxref("ResizeObserverSize")}} interface returns the length of the observed element's border box in the inline dimension. For boxes with a horizontal {{cssxref("writing-mode")}}, this is the horizontal dimension, or width; if the writing-mode is vertical, this is the vertical dimension, or height.
 

--- a/files/en-us/web/api/rtccertificatestats/index.md
+++ b/files/en-us/web/api/rtccertificatestats/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCStatsReport.type_certificate
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The **`RTCCertificateStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) is used to report information about a certificate used by an {{domxref("RTCDtlsTransport")}} and its underlying {{domxref("RTCIceTransport")}}.
 

--- a/files/en-us/web/api/rtccodecstats/index.md
+++ b/files/en-us/web/api/rtccodecstats/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCStatsReport.type_codec
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The **`RTCCodecStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides statistics about a codec used by {{Glossary("RTP")}} streams that are being sent or received by the associated {{domxref("RTCPeerConnection")}} object.
 

--- a/files/en-us/web/api/rtcdatachannelstats/index.md
+++ b/files/en-us/web/api/rtcdatachannelstats/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCStatsReport.type_data-channel
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The **`RTCDataChannelStats`** dictionary of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) provides statistics related to one {{domxref("RTCDataChannel")}} object on the connection.
 

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCError
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The **`RTCError`** interface describes an error which has occurred while handling [WebRTC](/en-US/docs/Web/API/WebRTC_API) operations. It's based upon the standard {{domxref("DOMException")}} interface that describes general DOM errors.
 

--- a/files/en-us/web/api/rtcerrorevent/error/index.md
+++ b/files/en-us/web/api/rtcerrorevent/error/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCErrorEvent.error
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The read-only {{domxref("RTCErrorEvent")}} property **`error`**
 contains an {{domxref("RTCError")}} object describing the details of the error which the

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCErrorEvent
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The WebRTC API's **`RTCErrorEvent`** interface represents an error sent to a WebRTC object. It's based on the standard {{domxref("Event")}} interface, but adds RTC-specific information describing the error, as shown below.
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCPeerConnectionIceErrorEvent.address
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The {{domxref("RTCPeerConnectionIceErrorEvent")}} property
 **`address`** is a string which indicates the local IP address

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
@@ -6,7 +6,7 @@ page-type: web-api-static-method
 browser-compat: api.RTCRtpReceiver.getCapabilities_static
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The _static method_ **`RTCRtpReceiver.getCapabilities()`** returns an object describing the codec and header extension capabilities supported by {{domxref("RTCRtpReceiver")}} objects on the current device.
 

--- a/files/en-us/web/api/rtcrtpreceiver/transport/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/transport/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCRtpReceiver.transport
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The read-only **`transport`** property of an
 {{domxref("RTCRtpReceiver")}} object provides the {{domxref("RTCDtlsTransport")}} object

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
@@ -6,7 +6,7 @@ page-type: web-api-static-method
 browser-compat: api.RTCRtpSender.getCapabilities_static
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The _static method_ **`RTCRtpSender.getCapabilities()`** returns an object describing the codec and header extension capabilities supported by the {{domxref("RTCRtpSender")}}.
 

--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.RTCRtpSender.getParameters
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The **`getParameters()`** method of the {{domxref("RTCRtpSender")}} interface returns an object describing the current configuration for how the sender's {{domxref("RTCRtpSender.track", "track")}} will be encoded and transmitted to a remote {{domxref("RTCRtpReceiver")}}.
 

--- a/files/en-us/web/api/rtcrtpsender/transport/index.md
+++ b/files/en-us/web/api/rtcrtpsender/transport/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCRtpSender.transport
 ---
 
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The read-only **`transport`** property of an
 {{domxref("RTCRtpSender")}} object provides the {{domxref("RTCDtlsTransport")}} object


### PR DESCRIPTION
Follow up to https://github.com/mdn/content/pull/35327; use the interface-specific sidebar instead of the generic API sidebar