### PR TITLE
Synchronize with BCD v5.5.44

### DIFF
--- a/files/en-us/web/api/chapterinformation/artwork/index.md
+++ b/files/en-us/web/api/chapterinformation/artwork/index.md
@@ -3,10 +3,12 @@ title: "ChapterInformation: artwork property"
 short-title: artwork
 slug: Web/API/ChapterInformation/artwork
 page-type: web-api-instance-property
+status:
+  - experimental
 browser-compat: api.ChapterInformation.artwork
 ---
 
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The **`artwork`** read-only property of the
 {{domxref("ChapterInformation")}} interface returns an {{jsxref("Array")}} of objects representing images associated with the chapter.

--- a/files/en-us/web/api/chapterinformation/index.md
+++ b/files/en-us/web/api/chapterinformation/index.md
@@ -2,10 +2,12 @@
 title: ChapterInformation
 slug: Web/API/ChapterInformation
 page-type: web-api-interface
+status:
+  - experimental
 browser-compat: api.ChapterInformation
 ---
 
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The **`ChapterInformation`** interface of the {{domxref("Media Session API", "", "", "nocode")}} represents the metadata for an individual chapter of a media resource (i.e. a video or audio file).
 
@@ -15,11 +17,11 @@ You can access the chapter information for an existing {{domxref("MediaMetadata"
 
 ## Instance properties
 
-- {{domxref("ChapterInformation.artwork")}} {{ReadOnlyInline}}
+- {{domxref("ChapterInformation.artwork")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns an {{jsxref("Array")}} of objects representing images associated with the chapter.
-- {{domxref("ChapterInformation.startTime")}} {{ReadOnlyInline}}
+- {{domxref("ChapterInformation.startTime")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns a number, in seconds, representing the start time of the chapter.
-- {{domxref("ChapterInformation.title")}} {{ReadOnlyInline}}
+- {{domxref("ChapterInformation.title")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns a string representing the title of the chapter.
 
 ## Examples

--- a/files/en-us/web/api/chapterinformation/starttime/index.md
+++ b/files/en-us/web/api/chapterinformation/starttime/index.md
@@ -3,10 +3,12 @@ title: "ChapterInformation: startTime property"
 short-title: startTime
 slug: Web/API/ChapterInformation/startTime
 page-type: web-api-instance-property
+status:
+  - experimental
 browser-compat: api.ChapterInformation.startTime
 ---
 
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The **`startTime`** read-only property of the
 {{domxref("ChapterInformation")}} interface returns a number representing the start time of the chapter in seconds.

--- a/files/en-us/web/api/chapterinformation/title/index.md
+++ b/files/en-us/web/api/chapterinformation/title/index.md
@@ -3,10 +3,12 @@ title: "ChapterInformation: title property"
 short-title: title
 slug: Web/API/ChapterInformation/title
 page-type: web-api-instance-property
+status:
+  - experimental
 browser-compat: api.ChapterInformation.title
 ---
 
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The **`title`** read-only property of the
 {{domxref("ChapterInformation")}} interface returns a string representing the title of the chapter.

--- a/files/en-us/web/api/mediametadata/chapterinfo/index.md
+++ b/files/en-us/web/api/mediametadata/chapterinfo/index.md
@@ -3,10 +3,12 @@ title: "MediaMetadata: chapterInfo property"
 short-title: chapterInfo
 slug: Web/API/MediaMetadata/chapterInfo
 page-type: web-api-instance-property
+status:
+  - experimental
 browser-compat: api.MediaMetadata.chapterInfo
 ---
 
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The **`chapterInfo`** read-only property of the {{domxref("MediaMetadata")}} interface returns an array of chapter information metadata associated with playing media, represented by {{domxref("ChapterInformation")}} object instances.
 

--- a/files/en-us/web/api/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/index.md
@@ -22,7 +22,7 @@ The **`MediaMetadata`** interface of the {{domxref("Media Session API", "", "", 
   - : Returns or sets the name of the artist, group, creator, etc. of the media to be played.
 - {{domxref("MediaMetadata.artwork")}}
   - : Returns or sets an array of images associated with playing media.
-- {{domxref("MediaMetadata.chapterInfo")}} {{ReadOnlyInline}}
+- {{domxref("MediaMetadata.chapterInfo")}} {{ReadOnlyInline}} {{experimental_inline}}
   - : Returns an array of chapter information metadata associated with playing media, represented by {{domxref("ChapterInformation")}} object instances.
 - {{domxref("MediaMetadata.title")}}
   - : Returns or sets the title of the media to be played.

--- a/files/en-us/web/css/@starting-style/index.md
+++ b/files/en-us/web/css/@starting-style/index.md
@@ -2,12 +2,10 @@
 title: "@starting-style"
 slug: Web/CSS/@starting-style
 page-type: css-at-rule
-status:
-  - experimental
 browser-compat: css.at-rules.starting-style
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`@starting-style`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) is used to define starting values for properties set on an element that you want to transition from when the element receives its first style update, i.e. when an element is first displayed on a previously loaded page.
 

--- a/files/en-us/web/css/@view-transition/index.md
+++ b/files/en-us/web/css/@view-transition/index.md
@@ -2,10 +2,12 @@
 title: "@view-transition"
 slug: Web/CSS/@view-transition
 page-type: css-at-rule
+status:
+  - experimental
 browser-compat: css.at-rules.view-transition
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`@view-transition`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) is used to opt in the current and destination documents to undergo a [view transition](/en-US/docs/Web/API/View_Transitions_API), in the case of a cross-document navigation.
 

--- a/files/en-us/web/css/_colon_-moz-broken/index.md
+++ b/files/en-us/web/css/_colon_-moz-broken/index.md
@@ -3,11 +3,12 @@ title: ":-moz-broken"
 slug: Web/CSS/:-moz-broken
 page-type: css-pseudo-class
 status:
+  - deprecated
   - non-standard
 browser-compat: css.selectors.-moz-broken
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{deprecated_header}}
 
 The **`:-moz-broken`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that matches elements representing broken image links.
 

--- a/files/en-us/web/css/_colon_-moz-first-node/index.md
+++ b/files/en-us/web/css/_colon_-moz-first-node/index.md
@@ -3,11 +3,12 @@ title: ":-moz-first-node"
 slug: Web/CSS/:-moz-first-node
 page-type: css-pseudo-class
 status:
+  - experimental
   - non-standard
 browser-compat: css.selectors.-moz-first-node
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}{{CSSRef}}{{SeeCompatTable}}
 
 The **`:-moz-first-node`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that represents any element that is the first child node of some other element. It differs from {{Cssxref(":first-child")}} because it does not match a first-child element with (non-whitespace) text before it.
 

--- a/files/en-us/web/css/_colon_-moz-last-node/index.md
+++ b/files/en-us/web/css/_colon_-moz-last-node/index.md
@@ -3,11 +3,12 @@ title: ":-moz-last-node"
 slug: Web/CSS/:-moz-last-node
 page-type: css-pseudo-class
 status:
+  - experimental
   - non-standard
 browser-compat: css.selectors.-moz-last-node
 ---
 
-{{Non-standard_header}}{{CSSRef}}
+{{Non-standard_header}}{{CSSRef}}{{SeeCompatTable}}
 
 The **`:-moz-last-node`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that represents any element that is the last child node of some other element. It differs from {{cssxref(":last-child")}} because it does not match a last-child element with (non-whitespace) text after it.
 

--- a/files/en-us/web/css/_colon_state/index.md
+++ b/files/en-us/web/css/_colon_state/index.md
@@ -2,12 +2,10 @@
 title: ":state()"
 slug: Web/CSS/:state
 page-type: css-pseudo-class
-status:
-  - experimental
 browser-compat: css.selectors.state
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`:state()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches [custom elements](/en-US/docs/Web/API/Web_components/Using_custom_elements) that have the specified custom state.
 

--- a/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
@@ -4,10 +4,11 @@ slug: Web/CSS/::-moz-focus-inner
 page-type: css-pseudo-element
 status:
   - experimental
+  - non-standard
 browser-compat: css.selectors.-moz-focus-inner
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}{{SeeCompatTable}}{{non-standard_header}}
 
 The **`::-moz-focus-inner`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that represents an inner focus ring of the {{HTMLElement("button")}} element as well as the {{HTMLElement("input/button","button")}}, {{HTMLElement("input/submit","submit")}}, {{HTMLElement("input/reset","reset")}}, and {{HTMLElement("input/color","color")}} types of the {{HTMLElement("input")}} element.
 

--- a/files/en-us/web/css/_doublecolon_-moz-list-bullet/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-list-bullet/index.md
@@ -3,11 +3,12 @@ title: "::-moz-list-bullet"
 slug: Web/CSS/::-moz-list-bullet
 page-type: css-pseudo-element
 status:
+  - experimental
   - non-standard
 browser-compat: css.selectors.-moz-list-bullet
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{SeeCompatTable}}
 
 The **`::-moz-list-bullet`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that represents the marker (typically a bullet) of a list item ({{htmlelement("li")}}) in an unordered list ({{htmlelement("ul")}}).
 

--- a/files/en-us/web/css/_doublecolon_-moz-list-number/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-list-number/index.md
@@ -3,11 +3,12 @@ title: "::-moz-list-number"
 slug: Web/CSS/::-moz-list-number
 page-type: css-pseudo-element
 status:
+  - experimental
   - non-standard
 browser-compat: css.selectors.-moz-list-number
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{SeeCompatTable}}
 
 The **`::-moz-list-number`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that represents the marker (typically a number) of a list item ({{HTMLElement("li")}}) in an ordered list ({{HTMLElement("ol")}}).
 

--- a/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -3,11 +3,12 @@ title: "::-moz-progress-bar"
 slug: Web/CSS/::-moz-progress-bar
 page-type: css-pseudo-element
 status:
+  - experimental
   - non-standard
 browser-compat: css.selectors.-moz-progress-bar
 ---
 
-{{CSSRef}}{{Non-standard_header}}
+{{CSSRef}}{{Non-standard_header}}{{SeeCompatTable}}
 
 The **`::-moz-progress-bar`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) is a [Mozilla extension](/en-US/docs/Web/CSS/Mozilla_Extensions) that represents the progress bar inside a {{HTMLElement("progress")}} element. (The bar represents the amount of progress that has been made.)
 

--- a/files/en-us/web/css/_doublecolon_view-transition-group/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-group/index.md
@@ -2,12 +2,10 @@
 title: "::view-transition-group"
 slug: Web/CSS/::view-transition-group
 page-type: css-pseudo-element
-status:
-  - experimental
 browser-compat: css.selectors.view-transition-group
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`::view-transition-group`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) represents a single view transition snapshot group.
 

--- a/files/en-us/web/css/_doublecolon_view-transition-image-pair/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-image-pair/index.md
@@ -2,12 +2,10 @@
 title: "::view-transition-image-pair"
 slug: Web/CSS/::view-transition-image-pair
 page-type: css-pseudo-element
-status:
-  - experimental
 browser-compat: css.selectors.view-transition-image-pair
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`::view-transition-image-pair`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) represents a container for a [view transition's](/en-US/docs/Web/API/View_Transitions_API) "old" and "new" view states — before and after the transition.
 

--- a/files/en-us/web/css/_doublecolon_view-transition-new/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-new/index.md
@@ -2,12 +2,10 @@
 title: "::view-transition-new"
 slug: Web/CSS/::view-transition-new
 page-type: css-pseudo-element
-status:
-  - experimental
 browser-compat: css.selectors.view-transition-new
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`::view-transition-new`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) represents the "new" view state of a view transition — a snapshot live representation of the state after the transition.
 

--- a/files/en-us/web/css/_doublecolon_view-transition-old/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-old/index.md
@@ -2,12 +2,10 @@
 title: "::view-transition-old"
 slug: Web/CSS/::view-transition-old
 page-type: css-pseudo-element
-status:
-  - experimental
 browser-compat: css.selectors.view-transition-old
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`::view-transition-old`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) represents the "old" view state of a view transition — a static snapshot of the old view, before the transition.
 

--- a/files/en-us/web/css/_doublecolon_view-transition/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition/index.md
@@ -2,12 +2,10 @@
 title: "::view-transition"
 slug: Web/CSS/::view-transition
 page-type: css-pseudo-element
-status:
-  - experimental
 browser-compat: css.selectors.view-transition
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`::view-transition`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) represents the root of the [view transitions](/en-US/docs/Web/API/View_Transitions_API) overlay, which contains all view transition snapshot groups and sits over the top of all other page content.
 

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -86,7 +86,7 @@ align-items: unset;
 
   - : If the items are smaller than the alignment container, auto-sized items will be equally enlarged to fill the container, respecting the items' width and height limits.
 
-- `anchor-center` {{experimental_inline}}
+- `anchor-center`
 
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the items to the center of the associated anchor element in the block direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).
 

--- a/files/en-us/web/css/align-self/index.md
+++ b/files/en-us/web/css/align-self/index.md
@@ -78,7 +78,7 @@ align-self: unset;
     The fallback alignment for `first baseline` is `start`, the one for `last baseline` is `end`.
 - `stretch`
   - : If the combined size of the items along the cross axis is less than the size of the alignment container and the item is `auto`-sized, its size is increased equally (not proportionally), while still respecting the constraints imposed by {{cssxref("max-height")}}/{{cssxref("max-width")}} (or equivalent functionality), so that the combined size of all `auto`-sized items exactly fills the alignment container along the cross axis.
-- `anchor-center` {{experimental_inline}}
+- `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the item to the center of the associated anchor element in the block direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).
 - `safe`
   - : If the size of the item overflows the alignment container, the item is instead aligned as if the alignment mode were `start`.

--- a/files/en-us/web/css/anchor-size/index.md
+++ b/files/en-us/web/css/anchor-size/index.md
@@ -2,10 +2,12 @@
 title: anchor-size()
 slug: Web/CSS/anchor-size
 page-type: css-function
+status:
+  - experimental
 browser-compat: css.types.anchor-size
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`anchor-size()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) enables [sizing anchor-positioned elements](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#sizing_elements_based_on_anchor_size) relative to the dimensions of anchor elements. It returns the `<length>` of a specified side of the target anchor element. `anchor()` is only valid when used within the value of anchor-positioned elements' [sizing properties](#properties_that_accept_anchor-size_function_values).
 

--- a/files/en-us/web/css/anchor/index.md
+++ b/files/en-us/web/css/anchor/index.md
@@ -2,10 +2,12 @@
 title: anchor()
 slug: Web/CSS/anchor
 page-type: css-function
+status:
+  - experimental
 browser-compat: css.types.anchor
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`anchor()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) can be used within an **anchor-positioned** element's [inset property](#properties_that_accept_anchor_function_values) values, returning a length value relative to the position of the edges of its associated anchor element.
 

--- a/files/en-us/web/css/basic-shape/index.md
+++ b/files/en-us/web/css/basic-shape/index.md
@@ -109,7 +109,7 @@ path( <`fill-rule`>?, ]? <string> )
 
 The required `<string>` is an [SVG path](/en-US/docs/Web/SVG/Attribute/d) as a quoted string. The `path()` function is not a valid {{cssxref("shape-outside")}} property value.
 
-### Syntax for shapes {{Experimental_Inline}}
+### Syntax for shapes
 
 The {{cssxref("basic-shape/shape","shape()")}} function defines a shape using an initial starting point and a series of shape commands.
 

--- a/files/en-us/web/css/basic-shape/shape/index.md
+++ b/files/en-us/web/css/basic-shape/shape/index.md
@@ -2,10 +2,12 @@
 title: shape()
 slug: Web/CSS/basic-shape/shape
 page-type: css-function
+status:
+  - experimental
 browser-compat: css.types.basic-shape.shape
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`shape()`** [CSS function](/en-US/docs/Web/CSS/CSS_Functions) is used to define a shape for the {{cssxref("clip-path")}} and {{cssxref("offset-path")}} properties. It combines an initial starting point with a series of shape commands that define the path of the shape. The `shape()` function is a member of the {{cssxref("&lt;basic-shape&gt;")}} data type.
 

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -73,7 +73,7 @@ The `clip-path` property is specified as one or a combination of the values list
       - : Defines a shape using an optional SVG filling rule and an SVG path definition.
     - {{cssxref("basic-shape/rect","rect()")}}
       - : Defines a rectangle using the specified distances from the edges of the reference box.
-    - {{cssxref("basic-shape/shape","shape()")}} {{Experimental_Inline}}
+    - {{cssxref("basic-shape/shape","shape()")}}
       - : Defines a shape using an optional SVG filling rule and shape commands for lines, curves, and arcs.
     - {{cssxref("basic-shape/xywh","xywh()")}}
       - : Defines a rectangle using the specified distances from the top and left edges of the reference box and the specified width and height of the rectangle.

--- a/files/en-us/web/css/content-visibility/index.md
+++ b/files/en-us/web/css/content-visibility/index.md
@@ -2,12 +2,10 @@
 title: content-visibility
 slug: Web/CSS/content-visibility
 page-type: css-property
-status:
-  - experimental
 browser-compat: css.properties.content-visibility
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`content-visibility`** [CSS](/en-US/docs/Web/CSS) property controls whether or not an element renders its contents at all, along with forcing a strong set of containments, allowing user agents to potentially omit large swathes of layout and rendering work until it becomes needed. It enables the user agent to skip an element's rendering work (including layout and painting) until it is needed — which makes the initial page load much faster.
 

--- a/files/en-us/web/css/css_animations/using_css_animations/index.md
+++ b/files/en-us/web/css/css_animations/using_css_animations/index.md
@@ -38,7 +38,7 @@ The sub-properties of the {{cssxref("animation")}} property are:
   - : Specifies the name of the {{cssxref("@keyframes")}} at-rule describing an animation's keyframes.
 - {{cssxref("animation-play-state")}}
   - : Specifies whether to pause or play an animation sequence.
-- {{cssxref("animation-timeline")}} {{experimental_inline}}
+- {{cssxref("animation-timeline")}}
   - : Specifies the timeline that is used to control the progress of a CSS animation.
 - {{cssxref("animation-timing-function")}}
   - : Specifies how an animation transitions through keyframes by establishing acceleration curves.

--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -200,11 +200,11 @@ The {{CSSxRef("color_value","&lt;color&gt;")}} CSS [data type](/en-US/docs/Web/C
   - : Specifies a particular, specified colorspace rather than the implicit sRGB colorspace.
 - {{CSSxRef("color_value/color-mix", "color-mix()")}}
   - : Mixes two color values in a given colorspace by a given amount.
-- {{CSSxRef("color_value/color-contrast", "color-contrast()")}} {{Experimental_Inline}}
+- {{CSSxRef("color_value/color-contrast", "color-contrast()")}}
   - : Selects the highest color contrast from a list of colors, compare to a base color value.
-- {{CSSxRef("color_value/device-cmyk", "device-cmyk()")}} {{Experimental_Inline}}
+- {{CSSxRef("color_value/device-cmyk", "device-cmyk()")}}
   - : Defines CMYK colors in a device-dependent way.
-- {{CSSXref("color_value/light-dark", "light-dark()")}} {{Experimental_Inline}}
+- {{CSSXref("color_value/light-dark", "light-dark()")}}
   - : Returns one of two provided colors based on the current color scheme.
 
 ## Image functions
@@ -228,13 +228,13 @@ The {{CSSxRef("&lt;image&gt;")}} CSS [data type](/en-US/docs/Web/CSS/CSS_Types) 
 
 ### Image functions
 
-- {{CSSxRef("image/image","image()")}} {{Experimental_Inline}}
+- {{CSSxRef("image/image","image()")}}
   - : Defines an {{CSSxRef("&lt;image&gt;")}} in a similar fashion to the {{CSSxRef("url", "url()")}} function, but with added functionality including specifying the image's directionality and fallback images for when the preferred image is not supported.
 - {{CSSxRef("image/image-set","image-set()")}}
   - : Picks the most appropriate CSS image from a given set, primarily for high pixel density screens.
 - {{CSSxRef("cross-fade", "cross-fade()")}}
   - : Blends two or more images at a defined transparency.
-- {{CSSxRef("element", "element()")}} {{Experimental_Inline}}
+- {{CSSxRef("element", "element()")}}
   - : Defines an {{CSSxRef("&lt;image&gt;")}} value generated from an arbitrary HTML element.
 - {{CSSxRef("image/paint", "paint()")}}
   - : Defines an {{CSSxRef("&lt;image&gt;")}} value generated with a PaintWorklet.
@@ -260,9 +260,9 @@ The {{CSSxRef("&lt;basic-shape&gt;")}} CSS [data type](/en-US/docs/Web/CSS/CSS_T
   - : Defines an ellipse shape.
 - {{CSSxRef("basic-shape/inset","inset()")}}
   - : Defines an inset rectangle shape.
-- {{CSSxRef("basic-shape/rect","rect()")}} {{Experimental_Inline}}
+- {{CSSxRef("basic-shape/rect","rect()")}}
   - : Defines a rectangle shape using the distances from the top and left edges of the reference box.
-- {{CSSxRef("basic-shape/xywh","xywh()")}} {{Experimental_Inline}}
+- {{CSSxRef("basic-shape/xywh","xywh()")}}
   - : Defines a rectangle shape using the specified distances from the top and left edges of the reference box and the rectangle width and height.
 - {{CSSxRef("basic-shape/polygon","polygon()")}}
   - : Defines a polygon shape.

--- a/files/en-us/web/css/css_media_queries/using_media_queries/index.md
+++ b/files/en-us/web/css/css_media_queries/using_media_queries/index.md
@@ -52,7 +52,7 @@ Media queries are case-insensitive.
   - {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}}
   - {{cssxref("@media/prefers-contrast", "prefers-contrast")}}
   - {{cssxref("@media/prefers-reduced-motion", "prefers-reduced-motion")}}
-  - {{cssxref("@media/prefers-reduced-transparency", "prefers-reduced-transparency")}} {{experimental_inline}}
+  - {{cssxref("@media/prefers-reduced-transparency", "prefers-reduced-transparency")}}
   - {{cssxref("@media/resolution", "resolution")}}
   - {{cssxref("@media/scripting", "scripting")}}
   - {{cssxref("@media/update", "update")}}

--- a/files/en-us/web/css/field-sizing/index.md
+++ b/files/en-us/web/css/field-sizing/index.md
@@ -2,6 +2,8 @@
 title: field-sizing
 slug: Web/CSS/field-sizing
 page-type: css-property
+status:
+  - experimental
 browser-compat: css.properties.field-sizing
 ---
 

--- a/files/en-us/web/css/initial-letter/index.md
+++ b/files/en-us/web/css/initial-letter/index.md
@@ -2,12 +2,10 @@
 title: initial-letter
 slug: Web/CSS/initial-letter
 page-type: css-property
-status:
-  - experimental
 browser-compat: css.properties.initial-letter
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The `initial-letter` CSS property sets styling for dropped, raised, and sunken initial letters.
 

--- a/files/en-us/web/css/inset-area/index.md
+++ b/files/en-us/web/css/inset-area/index.md
@@ -2,6 +2,8 @@
 title: inset-area
 slug: Web/CSS/inset-area
 page-type: css-property
+status:
+  - experimental
 browser-compat: css.properties.inset-area
 ---
 

--- a/files/en-us/web/css/inset-area_value/index.md
+++ b/files/en-us/web/css/inset-area_value/index.md
@@ -2,10 +2,12 @@
 title: <inset-area>
 slug: Web/CSS/inset-area_value
 page-type: css-type
+status:
+  - experimental
 browser-compat: css.properties.inset-area
 ---
 
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The **`<inset-area>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) defines the cell or spanned cells of an **inset-area grid**, an 3x3 grid whose center cell is an anchor element.
 

--- a/files/en-us/web/css/justify-items/index.md
+++ b/files/en-us/web/css/justify-items/index.md
@@ -99,7 +99,7 @@ This property can take one of four different forms:
     The fallback alignment for `first baseline` is `start`, the one for `last baseline` is `end`.
 - `stretch`
   - : If the combined size of the items is less than the size of the alignment container, any `auto`-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by {{CSSxRef("max-height")}}/{{CSSxRef("max-width")}} (or equivalent functionality), so that the combined size exactly fills the alignment container.
-- `anchor-center` {{experimental_inline}}
+- `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the items to the center of the associated anchor element in the inline direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).
 - `safe`
   - : If the size of the item overflows the alignment container, the item is instead aligned as if the alignment mode were `start`.

--- a/files/en-us/web/css/justify-self/index.md
+++ b/files/en-us/web/css/justify-self/index.md
@@ -102,7 +102,7 @@ This property can take one of three different forms:
     The fallback alignment for `first baseline` is `start`, the one for `last baseline` is `end`.
 - `stretch`
   - : If the combined size of the items is less than the size of the alignment container, any `auto`-sized items have their size increased equally (not proportionally), while still respecting the constraints imposed by {{CSSxRef("max-height")}}/{{CSSxRef("max-width")}} (or equivalent functionality), so that the combined size exactly fills the alignment container.
-- `anchor-center` {{experimental_inline}}
+- `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the item to the center of the associated anchor element in the inline direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).
 - `safe`
   - : If the size of the item overflows the alignment container, the item is instead aligned as if the alignment mode were `start`.

--- a/files/en-us/web/css/place-self/index.md
+++ b/files/en-us/web/css/place-self/index.md
@@ -76,7 +76,7 @@ place-self: unset;
     The fallback alignment for `first baseline` is `start`, the one for `last baseline` is `end`.
 - `stretch`
   - : If the combined size of the items along the cross axis is less than the size of the alignment container and the item is `auto`-sized, its size is increased equally (not proportionally), while still respecting the constraints imposed by {{cssxref("max-height")}}/{{cssxref("max-width")}} (or equivalent functionality), so that the combined size of all `auto`-sized items exactly fills the alignment container along the cross axis.
-- `anchor-center` {{experimental_inline}}
+- `anchor-center`
   - : In the case of [anchor-positioned](/en-US/docs/Web/CSS/CSS_anchor_positioning) elements, aligns the item to the center of the associated anchor element in the block and inline direction. See [Centering on the anchor using `anchor-center`](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using#centering_on_the_anchor_using_anchor-center).
 
 ## Formal definition

--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -210,13 +210,13 @@ B
 C
 
 - {{CSSxRef(":checked")}}
-- {{CSSxRef(":current")}} {{Experimental_Inline}}
+- {{CSSxRef(":current")}}
 
 D
 
 - {{CSSxRef(":default")}}
 - {{CSSxRef(":defined")}}
-- {{CSSxRef(":dir", ":dir()")}} {{Experimental_Inline}}
+- {{CSSxRef(":dir", ":dir()")}}
 - {{CSSxRef(":disabled")}}
 
 E
@@ -257,7 +257,7 @@ L
 - {{CSSxRef(":last-of-type")}}
 - {{CSSxRef(":left")}}
 - {{CSSxRef(":link")}}
-- {{CSSxRef(":local-link")}} {{Experimental_Inline}}
+- {{CSSxRef(":local-link")}}
 
 M
 
@@ -280,7 +280,7 @@ O
 
 P
 
-- {{CSSxRef(":past")}} {{Experimental_Inline}}
+- {{CSSxRef(":past")}}
 - {{CSSxRef(":paused")}}
 - {{CSSxRef(":picture-in-picture")}}
 - {{CSSxRef(":placeholder-shown")}}
@@ -297,7 +297,7 @@ R
 S
 
 - {{CSSxRef(":scope")}}
-- {{CSSxRef(":state", ":state()")}} {{Experimental_Inline}}
+- {{CSSxRef(":state", ":state()")}}
 
 T
 
@@ -306,7 +306,7 @@ T
 
 U
 
-- {{CSSxRef(":user-invalid")}} {{Experimental_Inline}}
+- {{CSSxRef(":user-invalid")}}
 
 V
 

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -92,11 +92,11 @@ T
 
 V
 
-- {{cssxref("::view-transition")}} {{Experimental_Inline}}
-- {{cssxref("::view-transition-image-pair()")}} {{Experimental_Inline}}
-- {{cssxref("::view-transition-group()")}} {{Experimental_Inline}}
-- {{cssxref("::view-transition-new()")}} {{Experimental_Inline}}
-- {{cssxref("::view-transition-old()")}} {{Experimental_Inline}}
+- {{cssxref("::view-transition")}}
+- {{cssxref("::view-transition-image-pair()")}}
+- {{cssxref("::view-transition-group()")}}
+- {{cssxref("::view-transition-new()")}}
+- {{cssxref("::view-transition-old()")}}
 
 > [!NOTE]
 > Browsers support the single colon syntax only for the original four pseudo-elements: `::before`, `::after`, `::first-line`, and `::first-letter`.

--- a/files/en-us/web/css/ruby-align/index.md
+++ b/files/en-us/web/css/ruby-align/index.md
@@ -2,12 +2,10 @@
 title: ruby-align
 slug: Web/CSS/ruby-align
 page-type: css-property
-status:
-  - experimental
 browser-compat: css.properties.ruby-align
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`ruby-align`** [CSS](/en-US/docs/Web/CSS) property defines the distribution of the different ruby elements over the base.
 

--- a/files/en-us/web/css/view-transition-name/index.md
+++ b/files/en-us/web/css/view-transition-name/index.md
@@ -2,12 +2,10 @@
 title: view-transition-name
 slug: Web/CSS/view-transition-name
 page-type: css-property
-status:
-  - experimental
 browser-compat: css.properties.view-transition-name
 ---
 
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`view-transition-name`** [CSS](/en-US/docs/Web/CSS) property provides the selected element with a distinct identifying name (a {{cssxref("custom-ident")}}) and causes it to participate in a separate [view transition](/en-US/docs/Web/API/View_Transitions_API) from the root view transition — or no view transition if the `none` value is specified.
 


### PR DESCRIPTION
- addresses https://github.com/mdn/content/pull/35300#issuecomment-2268136225

The script has been updated, and the PR syncs stalled CSS status headers and the front-matter status property. The PR also removes all the remaining inline status macros from CSS pages, such as landing pages, which do not have a BCD query and [can not be automatically updated](https://github.com/mdn/content/pull/35332/files#diff-944db485ff47e20964b205032de191958f7bfe2bd38fa421b9f5ee7e1fb59ee0L213). 