### PR TITLE
fix: typo in WebExtensions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
@@ -41,7 +41,7 @@ browser.action.setBadgeBackgroundColor(
     - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}
-      - : `integer`. Sets the badge background color only for the given tab.
+      - : `integer`. Sets the badge background color only for the given window.
 
 <!---->
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
@@ -37,7 +37,7 @@ browser.action.setBadgeTextColor(
     - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge text color only for the given tab. The color is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}
-      - : `integer`. Sets the badge text color only for the given tab.
+      - : `integer`. Sets the badge text color only for the given window.
 
 <!---->
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -38,7 +38,7 @@ browser.browserAction.setBadgeBackgroundColor(
     - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}
-      - : `integer`. Sets the badge background color only for the given tab.
+      - : `integer`. Sets the badge background color only for the given window.
 
 <!---->
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -34,7 +34,7 @@ browser.browserAction.setBadgeTextColor(
     - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge text color only for the given tab. The color is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}
-      - : `integer`. Sets the badge text color only for the given tab.
+      - : `integer`. Sets the badge text color only for the given window.
 
 <!---->
 


### PR DESCRIPTION
`windowId` should specify the **WINDOW** instead of **TAB**. (also tested that it's the window being modified instead of the tab.)