### PR TITLE
fix: incorrect description in WebExtensions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -32,7 +32,7 @@ let settingIcon = browser.action.setIcon(
 
 - `details`
 
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally a `tabId` property.
+  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and `windowId` property.
 
     - `imageData` {{optional_inline}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -32,7 +32,7 @@ let settingIcon = browser.action.setIcon(
 
 - `details`
 
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` properties.
+  - : `object`. An object containing the `imageData` or `path` property and, optionally, either or both of the `tabId` and `windowId` properties.
 
     - `imageData` {{optional_inline}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -32,7 +32,7 @@ let settingIcon = browser.action.setIcon(
 
 - `details`
 
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and `windowId` property.
+  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` propertyies.
 
     - `imageData` {{optional_inline}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -32,7 +32,7 @@ let settingIcon = browser.action.setIcon(
 
 - `details`
 
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` propertyies.
+  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` properties.
 
     - `imageData` {{optional_inline}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -29,7 +29,7 @@ let settingIcon = browser.browserAction.setIcon(
 
 - `details`
 
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally a `tabId` property.
+  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` properties.
 
     - `imageData` {{optional_inline}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -29,7 +29,7 @@ let settingIcon = browser.browserAction.setIcon(
 
 - `details`
 
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` properties.
+  - : `object`. An object containing the `imageData` or `path` property and, optionally, either or both of the `tabId` and `windowId` properties.
 
     - `imageData` {{optional_inline}}
 


### PR DESCRIPTION
```markdown
-  - : `object`. An object containing either `imageData` or `path` properties, and optionally a `tabId` property.
+  - : `object`. An object containing either `imageData` or `path` properties, and optionally `tabId` and/or `windowId` properties.
```