### PR TITLE
Add accordion example to transition

### DIFF
--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -123,6 +123,45 @@ We include two {{cssxref("time")}} values. In the `transition` shorthand, the fi
 
 {{EmbedLiveSample('Basic_example', 600, 100)}}
 
+
+### Accordion example
+
+In this example, when the accordion is toggled open, there is a 0.5 second transition on `grid-template-rows`, smoothly expanding the content area to its full height.
+
+#### HTML
+
+```html
+<button onClick="document.getElementById('theWrapper').classList.toggle('is-open');">Toggle</button>
+<div class="wrapper" id="theWrapper" style="border: solid 1px blue;">
+  <div class="inner">
+    <p>Expandable content</p>
+    <div style="padding: 30px 10px; border: solid 2px red;">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </div>
+</div>
+```
+
+#### CSS
+
+Simply transition `grid-template-rows` from 0fr to 1fr, allowing the grid item to smoothly expand to its natural height.
+
+```css
+.wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.5s ease-out;
+}
+
+.wrapper.is-open {
+  grid-template-rows: 1fr;
+}
+
+.inner {
+  overflow: hidden;
+}
+```
+
+{{EmbedLiveSample('Accordion_example', 600, 300)}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -131,13 +131,21 @@ In this example, when the accordion is toggled open, there is a 0.5 second trans
 #### HTML
 
 ```html
-<button onClick="document.getElementById('theWrapper').classList.toggle('is-open');">Toggle</button>
-<div class="wrapper" id="theWrapper" style="border: solid 1px blue;">
+<button id="btn">Toggle</button>
+<div class="wrapper" id="wrapper">
   <div class="inner">
     <p>Expandable content</p>
-    <div style="padding: 30px 10px; border: solid 2px red;">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
   </div>
 </div>
+
+<script>
+  document
+    .getElementById("btn")
+    .addEventListener("click", () =>
+      document.getElementById("wrapper").classList.toggle("is-open"),
+    );
+</script>
 ```
 
 #### CSS
@@ -149,6 +157,7 @@ Simply transition `grid-template-rows` from 0fr to 1fr, allowing the grid item t
   display: grid;
   grid-template-rows: 0fr;
   transition: grid-template-rows 0.5s ease-out;
+  border: solid 1px red;
 }
 
 .wrapper.is-open {
@@ -158,9 +167,13 @@ Simply transition `grid-template-rows` from 0fr to 1fr, allowing the grid item t
 .inner {
   overflow: hidden;
 }
+
+.inner > div {
+  margin-bottom: 30px;
+}
 ```
 
-{{EmbedLiveSample('Accordion_example', 600, 300)}}
+{{EmbedLiveSample('Accordion_example', 600, 200)}}
 
 ## Specifications
 


### PR DESCRIPTION
### Description

This pull requests adds an example on how to do an accordion transition on elements. This solves the very common issue of trying to transition `height: auto`

### Motivation

So often people want to transition `height: auto` and I stumbled upon a solution for it, and wanted it to be better known.

### Additional details

Original code was found here, but I wasn't sure if I should add a link to credit it in the page:
https://keithjgrant.com/posts/2023/04/transitioning-to-height-auto/

### Related issues and pull requests

None