### PR TITLE
CSS: Remove bad practice

### DIFF
--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -98,7 +98,7 @@ See [how things are handled](/en-US/docs/Web/CSS/CSS_transitions/Using_CSS_trans
 
 ### Basic example
 
-In this example, when the user hovers over the element, there is a one-second delay before the four-second `font-size` transition occurs.
+In this example, when the user hovers over the element, there is a one-second delay before the four-second `background-color` transition occurs.
 
 #### HTML
 
@@ -112,12 +112,13 @@ We include two {{cssxref("time")}} values. In the `transition` shorthand, the fi
 
 ```css
 .target {
-  font-size: 14px;
-  transition: font-size 4s 1s;
+  font-size: 2rem;
+  background-color: palegoldenrod;
+  transition: background-color 4s 1s;
 }
 
 .target:hover {
-  font-size: 36px;
+  background-color: lime;
 }
 ```
 

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -118,7 +118,7 @@ We include two {{cssxref("time")}} values. In the `transition` shorthand, the fi
 }
 
 .target:hover {
-  background-color: lime;
+  background-color: darkorange;
 }
 ```
 

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -114,7 +114,7 @@ We include two {{cssxref("time")}} values. In the `transition` shorthand, the fi
 .target {
   font-size: 2rem;
   background-color: palegoldenrod;
-  transition: background-color 4s 1s;
+  transition: background-color 2s 500ms;
 }
 
 .target:hover {

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -98,7 +98,7 @@ See [how things are handled](/en-US/docs/Web/CSS/CSS_transitions/Using_CSS_trans
 
 ### Basic example
 
-In this example, when the user hovers over the element, there is a one-second delay before the four-second `background-color` transition occurs.
+In this example, when the user hovers over the element, there is a one-second delay before a four-second `background-color` transition occurs.
 
 #### HTML
 

--- a/files/en-us/web/css/transition/index.md
+++ b/files/en-us/web/css/transition/index.md
@@ -98,7 +98,7 @@ See [how things are handled](/en-US/docs/Web/CSS/CSS_transitions/Using_CSS_trans
 
 ### Basic example
 
-In this example, when the user hovers over the element, there is a one-second delay before a four-second `background-color` transition occurs.
+In this example, when the user hovers over the element, there is a half-second (`500ms`) delay before a two-second `background-color` transition occurs.
 
 #### HTML
 


### PR DESCRIPTION
changing a font-size on hover causes a reflow and repaint.

we shouldn't show transitions on properties that would require the whole page to be re-laid out.
switching from font-size to bgcolor.