### PR TITLE
fix(css): The `content-visibility: auto` marks a containing block

### DIFF
--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -38,6 +38,7 @@ The process for identifying the containing block depends entirely on the value o
    2. A {{cssxref("contain")}} value of `layout`, `paint`, `strict` or `content` (e.g. `contain: paint;`).
    3. A {{cssxref("container-type")}} value other than `normal`.
    4. A {{cssxref("will-change")}} value containing a property for which a non-initial value would form a containing block (e.g. `filter` or `transform`).
+   5. A {{cssxref("content-visibility")}} value of `auto`.
 
 > [!NOTE]
 > The containing block in which the root element ({{HTMLElement("html")}}) resides is a rectangle called the **initial containing block**. It has the dimensions of the viewport (for continuous media) or the page area (for paged media).


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/35312

The following demo confirms it: https://developer.mozilla.org/en-US/play?id=jKTCb9VX0cniPqGhUD6dsZslEmcabu0eEfhGzObaupC%2Fn%2FhE219d7EQEqzxPjtvpqbBwmDX%2BDN4LOcSx