### PR TITLE
Remove links to non-existent APIs

### DIFF
--- a/files/en-us/web/api/audioparammap/index.md
+++ b/files/en-us/web/api/audioparammap/index.md
@@ -23,9 +23,9 @@ The following methods are available to all read-only [`Map`-like objects](/en-US
 The following methods are available to all read-only [`Map`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis) (the below links are to the {{jsxref("Map")}} global object reference page).
 
 - {{jsxref("Map/entries", "entries()")}}
-  - : Returns a new iterator object that yields entries in `[key, value]` pairs in the map in insertion order.
+  - : Returns a new [iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) that yields entries in `[key, value]` pairs in the map in insertion order.
 - {{jsxref("Map/forEach", "forEach()")}}
-  - : Calls a provided callback function once for each value and key present in the map, in insertion order.
+  - : Calls a provided {{glossary("callback function")}} once for each value and key present in the map, in insertion order.
 - {{jsxref("Map/get", "get()")}}
   - : Returns the {{domxref("AudioParam")}} value associated with the string key, or `undefined` if there is none.
 - {{jsxref("Map/has", "has()")}}

--- a/files/en-us/web/api/audioparammap/index.md
+++ b/files/en-us/web/api/audioparammap/index.md
@@ -13,21 +13,27 @@ An `AudioParamMap` instance is a read-only [`Map`-like object](/en-US/docs/Web/J
 
 ## Instance properties
 
-- {{domxref("AudioParamMap.size", "size")}}
-  - : ?
+The following methods are available to all read-only [`Map`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis) (the below links are to the {{jsxref("Map")}} global object reference page).
+
+- {{jsxref("Map/size", "size")}}
+  - : Returns the number of entries in the map.
 
 ## Instance methods
 
-- {{domxref("AudioParamMap.entries", "entries()")}}
-  - : ?
-- {{domxref("AudioParamMap.forEach", "forEach()")}}
-  - : ?
-- {{domxref("AudioParamMap.has", "has()")}}
-  - : ?
-- {{domxref("AudioParamMap.keys", "keys()")}}
-  - : ?
-- {{domxref("AudioParamMap.values", "values()")}}
-  - : ?
+The following methods are available to all read-only [`Map`-like objects](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis) (the below links are to the {{jsxref("Map")}} global object reference page).
+
+- {{jsxref("Map/entries", "entries()")}}
+  - : Returns a new iterator object that yields entries in `[key, value]` pairs in the map in insertion order.
+- {{jsxref("Map/forEach", "forEach()")}}
+  - : Calls a provided callback function once for each value and key present in the map, in insertion order.
+- {{jsxref("Map/get", "get()")}}
+  - : Returns the {{domxref("AudioParam")}} value associated with the string key, or `undefined` if there is none.
+- {{jsxref("Map/has", "has()")}}
+  - : Returns a boolean indicating whether a key is present in the map or not.
+- {{jsxref("Map/keys", "keys()")}}
+  - : Returns a new iterator object that yields the string keys in the map in insertion order.
+- {{jsxref("Map/values", "values()")}}
+  - : Returns a new iterator object that yields the {{domxref("AudioParam")}} values in the map in insertion order.
 
 ## Specifications
 

--- a/files/en-us/web/api/audioparammap/index.md
+++ b/files/en-us/web/api/audioparammap/index.md
@@ -29,7 +29,7 @@ The following methods are available to all read-only [`Map`-like objects](/en-US
 - {{jsxref("Map/get", "get()")}}
   - : Returns the {{domxref("AudioParam")}} value associated with the string key, or `undefined` if there is none.
 - {{jsxref("Map/has", "has()")}}
-  - : Returns a boolean indicating whether a key is present in the map or not.
+  - : Returns a [boolean](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) indicating whether a key is present in the map or not.
 - {{jsxref("Map/keys", "keys()")}}
   - : Returns a new iterator object that yields the string keys in the map in insertion order.
 - {{jsxref("Map/values", "values()")}}

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -53,11 +53,6 @@ _This interface also inherits methods from its parent, {{domxref("HTMLElement")}
 - {{domxref("HTMLFormElement.submit", "submit()")}}
   - : Submits the form to the server.
 
-### Deprecated methods
-
-- {{domxref("HTMLFormElement.requestAutocomplete()")}} {{deprecated_inline}}
-  - : Triggers a native browser interface to assist the user in completing the fields which have an [autofill field name](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-field-name) value that is not `off` or `on`. The form will receive an event once the user has finished with the interface, the event will either be `autocomplete` when the fields have been filled or `autocompleteerror` when there was a problem.
-
 ## Events
 
 Listen to these events using `addEventListener()`, or by assigning an event listener to the `oneventname` property of this interface.

--- a/files/en-us/web/api/report/body/index.md
+++ b/files/en-us/web/api/report/body/index.md
@@ -17,8 +17,8 @@ containing the detailed report information.
 A `ReportBody` object containing the detailed report information. Depending
 on what `type` the {{domxref("Report")}} is, the object returned will
 actually be a
-{{domxref("DeprecationReportBody")}}, {{domxref("InterventionReportBody")}},
-{{domxref("CSPViolationReportBody")}}, or {{domxref("FeaturePolicyViolationReportBody")}}.
+{{domxref("DeprecationReportBody")}}, {{domxref("InterventionReportBody")}}, or
+{{domxref("CSPViolationReportBody")}}.
 These all inherit from the base `ReportBody` class — study their reference
 pages for more information on what the particular report body types contain.
 

--- a/files/en-us/web/api/texttrack/index.md
+++ b/files/en-us/web/api/texttrack/index.md
@@ -11,7 +11,7 @@ The **`TextTrack`** interface of the [WebVTT API](/en-US/docs/Web/API/WebVTT_API
 
 An object of this type owns the list of {{domxref("VTTCue")}} objects that will be displayed over the video at various points.
 
-`TextTrack` objects can be added to a {{domxref("HTMLVideoElement")}} or {{domxref("HTMLAudioElement")}} element using the {{domxref("HTMLMediaElement.addTrack()")}} method, which has the same effect as adding text tracks declaratively using {{htmlelement("track")}} elements inside a {{htmlelement("video")}} or {{htmlelement("audio")}} element.
+`TextTrack` objects can be added to a {{domxref("HTMLVideoElement")}} or {{domxref("HTMLAudioElement")}} element using the {{domxref("HTMLMediaElement.addTextTrack()")}} method, which has the same effect as adding text tracks declaratively using {{htmlelement("track")}} elements inside a {{htmlelement("video")}} or {{htmlelement("audio")}} element.
 The `TextTrack` objects are stored in a {{domxref("TextTrackList")}}, which can be retrieved using the {{domxref("HTMLMediaElement.textTracks")}} property.
 
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -284,7 +284,7 @@ Here, if `gain.length` indicates that there's only a single value in the `gain` 
 
 ### Accessing parameters from the main thread script
 
-Your main thread script can access the parameters just like it can any other node. To do so, first you need to get a reference to the parameter by calling the {{domxref("AudioWorkletNode")}}'s {{domxref("AudioWorkletNode.parameters", "parameters")}} property's {{domxref("AudioParamMap", "get()", "get")}} method:
+Your main thread script can access the parameters just like it can any other node. To do so, first you need to get a reference to the parameter by calling the {{domxref("AudioWorkletNode")}}'s {{domxref("AudioWorkletNode.parameters", "parameters")}} property's [`get()`](/en-US/docs/Web/API/AudioParamMap#get) method:
 
 ```js
 let gainParam = myAudioWorkletNode.parameters.get("gain");

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -284,7 +284,7 @@ Here, if `gain.length` indicates that there's only a single value in the `gain` 
 
 ### Accessing parameters from the main thread script
 
-Your main thread script can access the parameters just like it can any other node. To do so, first you need to get a reference to the parameter by calling the {{domxref("AudioWorkletNode")}}'s {{domxref("AudioWorkletNode.parameters", "parameters")}} property's {{domxref("AudioParamMap.get", "get()")}} method:
+Your main thread script can access the parameters just like it can any other node. To do so, first you need to get a reference to the parameter by calling the {{domxref("AudioWorkletNode")}}'s {{domxref("AudioWorkletNode.parameters", "parameters")}} property's {{domxref("AudioParamMap", "get()", "get")}} method:
 
 ```js
 let gainParam = myAudioWorkletNode.parameters.get("gain");

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -35,7 +35,7 @@ Lastly, a cue may have a label, which can be used to select it for CSS styling.
 
 A text track and cues can be defined in a file using the [WebVTT File Format](/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format), and then associated with a particular {{HTMLElement("video")}} element using the {{HTMLElement("track")}} element.
 
-Alternatively you can add a {{domxref("TextTrack")}} to a media element in JavaScript using [`HTMLMediaElement.addTextTrack()`](/en-US/docs/Web/API/HTMLMediaElement#htmlmediaelement.addtexttrack), and then add individual {{domxref("VTTCue")}} objects to the track with {{domxref("TextTrack.addCue()")}}.
+Alternatively you can add a {{domxref("TextTrack")}} to a media element in JavaScript using [`HTMLMediaElement.addTextTrack()`](/en-US/docs/Web/API/HTMLMediaElement/addTextTrack), and then add individual {{domxref("VTTCue")}} objects to the track with {{domxref("TextTrack.addCue()")}}.
 
 The {{cssxref("::cue")}} [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) can be used both in HTML and in a WebVTT file to style the cues for a particular element, for a particular tag within a cue, for a VTT class, or for a cue with a particular label.
 The `::cue-region` pseudo-element is intended for styling cues in a particular region, but is not supported in any browser.

--- a/files/en-us/web/html/element/track/index.md
+++ b/files/en-us/web/html/element/track/index.md
@@ -82,7 +82,7 @@ textTrackElem.addEventListener("cuechange", (event) => {
 The JavaScript interface that represents the `<track>` element is {{domxref("HTMLTrackElement")}}.
 The text track associated with an element can be obtained from the {{domxref("HTMLTrackElement.track")}} property, and is of type {{domxref("TextTrack")}}.
 
-`TextTrack` objects also can be added to a {{domxref("HTMLVideoElement")}} or {{domxref("HTMLAudioElement")}} elements using the {{domxref("HTMLMediaElement.addTrack()")}} method.
+`TextTrack` objects also can be added to a {{domxref("HTMLVideoElement")}} or {{domxref("HTMLAudioElement")}} elements using the {{domxref("HTMLMediaElement.addTextTrack()")}} method.
 The `TextTrack` objects associated with a media element stored in a {{domxref("TextTrackList")}}, which can be retrieved using the {{domxref("HTMLMediaElement.textTracks")}} property.
 
 ## Examples

--- a/files/en-us/web/media/autoplay_guide/index.md
+++ b/files/en-us/web/media/autoplay_guide/index.md
@@ -322,7 +322,7 @@ Browsers may have preferences that control the way autoplay works, or how autopl
 ### Firefox
 
 - `media.allowed-to-play.enabled`
-  - : A Boolean preference which specifies whether the {{domxref("HTMLMediaElement.allowedToPlay")}} property is exposed to the web. This is currently `false` by default (except in nightly builds, where it's `true` by default). If this is `false`, the `allowedToPlay` property is missing from the `HTMLMediaElement` interface, and is thus not present on either {{HTMLElement("audio")}} or {{HTMLElement("video")}} elements.
+  - : A Boolean preference which specifies whether the non-standard `HTMLMediaElement.allowedToPlay` property is exposed to the web. This is currently `false` by default (except in nightly builds, where it's `true` by default). If this is `false`, the `allowedToPlay` property is missing from the `HTMLMediaElement` interface, and is thus not present on either {{HTMLElement("audio")}} or {{HTMLElement("video")}} elements.
 - `media.autoplay.allow-extension-background-pages`
   - : This Boolean preference, if `true`, allows browser extensions' background scripts to autoplay audio media. Setting this value to `false` disables this capability. The default value is `true`.
 - `media.autoplay.allow-muted`

--- a/files/en-us/web/svg/content_type/index.md
+++ b/files/en-us/web/svg/content_type/index.md
@@ -293,8 +293,6 @@ SVG makes use of a number of data types. This article lists these types along wi
 
     The `context-fill` and `context-stroke` values allow for inheriting values in [marker](/en-US/docs/Web/SVG/Element/marker) and [use](/en-US/docs/Web/SVG/Element/use) elements.
 
-    Within the SVG DOM, \<paint> values are represented using {{domxref("SVGPaint")}} objects.
-
 ## Percentage
 
 - \<percentage>

--- a/files/en-us/web/webdriver/commands/getelementproperty/index.md
+++ b/files/en-us/web/webdriver/commands/getelementproperty/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.commands.GetElementProperty
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/WebDriver/Commands")}}
 
-The _Get Element Property_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the property of the referenced [web element](/en-US/docs/Web/WebDriver/WebElement). Given `<input value=foo>` where the user changes the value to `bar`, the returned property is `bar` rather than the initial value `foo`. This is equivalent to calling {{domxref("Element.getProperty")}} on the element.
+The _Get Element Property_ [command](/en-US/docs/Web/WebDriver/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the property of the referenced [web element](/en-US/docs/Web/WebDriver/WebElement). Given `<input value=foo>` where the user changes the value to `bar`, the returned property is `bar` rather than the initial value `foo`. This is equivalent to accessing the property on the element.
 
 ## Syntax
 


### PR DESCRIPTION
This PR adopts the `GPUSupportedFeatures` page structure for the `AudioParamMap` page. See https://github.com/orgs/mdn/discussions/707