### PR TITLE
Correct `at()` description when compared to the bracket notation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/at/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/at/index.md
@@ -28,7 +28,7 @@ The element in the array matching the given index. Always returns {{jsxref("unde
 
 ## Description
 
-The `at()` method is equivalent to the bracket notation when `index` is non-negative. For example, `array[0]` and `array.at(0)` both return the first item. However, when counting elements from the end of the array, you cannot use `array[-1]` like you may in Python or R, because all values inside the square brackets are treated literally as string properties, so you will end up reading `array["-1"]`, which is just a normal string property instead of an array index.
+The `at()` method is equivalent to the bracket notation when `index` is a non-negative integer. For example, `array[0]` and `array.at(0)` both return the first item. However, when counting elements from the end of the array, you cannot use `array[-1]` like you may in Python or R, because all values inside the square brackets are treated literally as string properties, so you will end up reading `array["-1"]`, which is just a normal string property instead of an array index.
 
 The usual practice is to access {{jsxref("Array/length", "length")}} and calculate the index from that — for example, `array[array.length - 1]`. The `at()` method allows relative indexing, so this can be shortened to `array.at(-1)`.
 


### PR DESCRIPTION
When the index is positive and is not an integer, `at()` is not equivalent to the bracket notation. For example:

```js
a = [1, 2, 3]
a[0.1] // undefined
a.at(0.1)  // 1
```
