### PR TITLE
131 tab updates

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -66,6 +66,7 @@ Events have three functions:
         - "hidden"
         - "isArticle"
         - "mutedInfo"
+        - "openerTabId"
         - "pinned"
         - "status"
         - "title"
@@ -101,6 +102,8 @@ Lists the changes to the state of the tab that is updated. To learn more about t
   - : `boolean`. True if the tab is an article and is therefore eligible for display in {{WebExtAPIRef("tabs.toggleReaderMode()", "Reader Mode")}}.
 - `mutedInfo` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.MutedInfo')}}. The tab's new muted state and the reason for the change.
+- `openerTabId` {{optional_inline}}
+  - : `integer`. The ID of the tab that opened this tab, if any. This property is only present if the opener tab exists and is in the same window.
 - `pinned` {{optional_inline}}
   - : `boolean`. The tab's new pinned state.
 - `status` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -51,7 +51,7 @@ let updating = browser.tabs.update(
     - `muted` {{optional_inline}}
       - : `boolean`. Whether the tab should be muted.
     - `openerTabId` {{optional_inline}}
-      - : `integer`. The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.
+      - : `integer`. The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab. Set to `-1` to clear the set `openerTabId`.
     - `pinned` {{optional_inline}}
       - : `boolean`. Whether the tab should be pinned.
     - `selected` {{deprecated_inline}} {{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/131/index.md
+++ b/files/en-us/mozilla/firefox/releases/131/index.md
@@ -58,6 +58,9 @@ This article provides information about the changes in Firefox 131 that affect d
 
 ## Changes for add-on developers
 
+- {{WebExtAPIRef("tabs.onUpdated")}} is now triggered when `openerTabId` is changed through `tabs.update()` ([Firefox bug 1409262](https://bugzil.la/1409262)).
+- {{WebExtAPIRef("tabs.update")}} now accepts `openerTabId` set to `-1` to clear `openerTabId` ([Firefox bug 1409262](https://bugzil.la/1409262)).
+
 ### Removals
 
 ### Other


### PR DESCRIPTION
### Description

Documentation for the changes made in [Bug 1409262](https://bugzilla.mozilla.org/show_bug.cgi?id=1409262) Updated openerTabId is not notified via tabs.onUpdated if it is changed by tabs.update()

### Related issues and pull requests

Related BCD changes in PR https://github.com/mdn/browser-compat-data/pull/24069
