### PR TITLE
Securitypolicyviolationevent sidebar

### DIFF
--- a/files/en-us/web/api/document/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/document/securitypolicyviolation_event/index.md
@@ -10,12 +10,13 @@ browser-compat: api.Document.securitypolicyviolation_event
 
 The **`securitypolicyviolation`** event is fired when a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) is violated.
 
-The event is fired on the global scope when violates the policy and will bubble to the {{domxref("Window")}} object. The event may also bubble from {{domxref("Node", "nodes", "", "nocode")}} contained in the document tree.
+The event is fired on the document when there is a violation of the document CSP policy (and may also bubble from elements in the document).
 
-The handler can be assigned using the `onsecuritypolicyviolation` event handler property or using {{domxref("EventTarget.addEventListener()")}}.
+This event [bubbles](/en-US/docs/Learn/JavaScript/Building_blocks/Event_bubbling) to the {{domxref("Window")}} object, and is [composed](/en-US/docs/Web/API/Event/composed).
 
 > [!NOTE]
-> It is recommended to add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}). While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.
+> You should add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
+> While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.md
@@ -39,6 +39,10 @@ A {{domxref("SecurityPolicyViolationEvent")}}. Inherits from {{domxref("Event")}
 
 The code below shows how you might add an event handler function using the `onsecuritypolicyviolation` global event handler property or `addEventListener()` on the top level `Window` (you could use exactly the same approach on `Document`).
 
+> [!NOTE]
+> The example doesn't assign the handler directly to an element because, as noted above, for elements defined in HTML, the event would fired before this code could run.
+> You might however add the event listener directly to an element that is dynamically constructed!
+
 ```js
 window.onsecuritypolicyviolation = (e) => {
   // Handle SecurityPolicyViolationEvent e here

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.md
@@ -10,13 +10,13 @@ browser-compat: api.Element.securitypolicyviolation_event
 
 The **`securitypolicyviolation`** event is fired when a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) is violated.
 
-The event is fired on the element that violates the policy and bubbles.
+The event is fired on the element when there is a violation of the CSP policy.
+
+This event [bubbles](/en-US/docs/Learn/JavaScript/Building_blocks/Event_bubbling) and is [composed](/en-US/docs/Web/API/Event/composed).
 It is normally handled by an event handler on the {{domxref("Window")}} or {{domxref("Document")}} object.
 
-The handler can be assigned using the `onsecuritypolicyviolation` property or using {{domxref("EventTarget.addEventListener()")}}.
-
 > [!NOTE]
-> You must add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
+> You should add the handler for this event to a top level object (i.e. {{domxref("Window")}} or {{domxref("Document")}}).
 > While the property exists in HTML elements, you can't assign a handler to the property until the elements have been loaded, by which time this event will already have fired.
 
 ## Syntax

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -53,8 +53,6 @@ The Reporting API spec also defines a Generate Test Report [WebDriver](/en-US/do
 
 ## Interfaces
 
-- {{domxref("CSPViolationReportBody")}}
-  - : Contains details of a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) violation.
 - {{domxref("DeprecationReportBody")}}
   - : Contains details of deprecated web platform features that a website is using.
 - {{domxref("InterventionReportBody")}}
@@ -63,6 +61,15 @@ The Reporting API spec also defines a Generate Test Report [WebDriver](/en-US/do
   - : An object representing a single report.
 - {{domxref("ReportingObserver")}}
   - : An object that can be used to collect and access reports as they are generated.
+
+### Related interfaces
+
+These interfaces are defined as part of the HTTP [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) specifications:
+
+- {{domxref("CSPViolationReportBody")}}
+  - : Contains details of a CSP violation.
+- {{domxref("SecurityPolicyViolationEvent")}}
+  - : Represents the event object of a `securitypolicyviolation` event fired on an element, document, or worker when its CSP is violated.
 
 ## Examples
 

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
@@ -30,6 +30,6 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 {{Compat}}
 
-## See Also
+## See also
 
 - [`CSPViolationReportBody.blockedURL`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.blockedurl)

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.blockedURI
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`blockedURI`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the URI of the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
@@ -6,11 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.blockedURI
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`blockedURI`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing the URI of the resource that was blocked because it violates a policy.
+The **`blockedURI`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the URI of the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
 ## Value
 
@@ -32,6 +30,6 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 {{Compat}}
 
-## See also
+## See Also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.blockedURL`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.blockedurl)

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.columnNumber
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`columnNumber`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is the column number in the document or worker script at which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -6,11 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.columnNumber
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`columnNumber`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is the column number in the
-document or worker at which the violation occurred.
+The **`columnNumber`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is the column number in the document or worker script at which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 
 ## Value
 
@@ -34,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.columnNumber`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.columnnumber)

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
@@ -6,16 +6,18 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.disposition
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`disposition`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface indicates how the violated policy
-is configured to be treated by the user agent.
+The **`disposition`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface indicates how the violated [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) is configured to be treated by the user agent.
 
 ## Value
 
-A value defined in the [SecurityPolicyViolationEventDisposition enum](https://w3c.github.io/webappsec-csp/#enumdef-securitypolicyviolationeventdisposition)
-representing the URI of the blocked resource. Possible values are `"enforce"` or `"report"`
+Possible values are:
+
+- `"enforce"`
+  - : The policy is enforced and the resource request is blocked.
+- `"report"`
+  - : The violation is reported but the resource request is not blocked.
 
 ## Examples
 
@@ -35,4 +37,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.disposition`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.disposition)

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.disposition
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`disposition`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface indicates how the violated [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) is configured to be treated by the user agent.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.documentURI
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`documentURI`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the URI of the document or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
@@ -6,16 +6,13 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.documentURI
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`documentURI`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing the URI of the document or worker in which the violation was found.
+The **`documentURI`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the URI of the document or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 
 ## Value
 
-A string representing the URI of the document or worker in which the
-violation was found.
+A string representing the URI of the document or worker in which the violation occurred.
 
 ## Examples
 
@@ -35,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.documentURL`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.documenturl)

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
@@ -6,16 +6,15 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.effectiveDirective
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`effectiveDirective`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing the directive whose enforcement uncovered the violation.
+The **`effectiveDirective`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
+
+This supersedes {{domxref("SecurityPolicyViolationEvent.violatedDirective")}}, its historial alias.
 
 ## Value
 
-A string representing the directive whose enforcement uncovered the
-violation.
+A string representing the particular [`Content-Security-Policy` directive](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#directives) that was violated.
 
 ## Examples
 
@@ -35,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.effectiveDirective`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.effectivedirective)

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.effectiveDirective
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`effectiveDirective`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/index.md
@@ -5,9 +5,9 @@ page-type: web-api-interface
 browser-compat: api.SecurityPolicyViolationEvent
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event")}}, and represents the event object of an event sent on a document or worker when its content security policy is violated.
+The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event")}}, and represents the event object of a `securitypolicyviolation` event sent on an {{domxref("Element/securitypolicyviolation_event", "Element")}}, {{domxref("Document/securitypolicyviolation_event", "Document")}}, or {{domxref("WorkerGlobalScope/securitypolicyviolation_event", "worker","","nocode")}} when its [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) is violated.
 
 {{InheritanceDiagram}}
 
@@ -23,25 +23,27 @@ The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event"
 - {{domxref("SecurityPolicyViolationEvent.columnNumber")}} {{ReadOnlyInline}}
   - : The column number in the document or worker at which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.disposition")}} {{ReadOnlyInline}}
-  - : Indicates how the violated policy is configured to be treated by the user agent. This will be `"enforce"` or `"report"`.
+  - : A string indicating whether the user agent is configured to enforce or just report the policy violation.
 - {{domxref("SecurityPolicyViolationEvent.documentURI")}} {{ReadOnlyInline}}
-  - : A string representing the URI of the document or worker in which the violation was found.
+  - : A string representing the URI of the document or worker in which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.effectiveDirective")}} {{ReadOnlyInline}}
-  - : A string representing the directive whose enforcement uncovered the violation.
+  - : A string representing the directive that was violated.
 - {{domxref("SecurityPolicyViolationEvent.lineNumber")}} {{ReadOnlyInline}}
   - : The line number in the document or worker at which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.originalPolicy")}} {{ReadOnlyInline}}
-  - : A string containing the policy whose enforcement uncovered the violation.
+  - : A string containing the policy whose enforcement caused the violation.
 - {{domxref("SecurityPolicyViolationEvent.referrer")}} {{ReadOnlyInline}}
   - : A string representing the URL for the referrer of the resources whose policy was violated, or `null`.
 - {{domxref("SecurityPolicyViolationEvent.sample")}} {{ReadOnlyInline}}
   - : A string representing a sample of the resource that caused the violation, usually the first 40 characters. This will only be populated if the resource is an inline script, event handler, or style — external resources causing a violation will not generate a sample.
 - {{domxref("SecurityPolicyViolationEvent.sourceFile")}} {{ReadOnlyInline}}
-  - : If the violation occurred as a result of a script, this will be the URL of the script; otherwise, it will be `null`. Both `columnNumber` and `lineNumber` should have non-null values if this property is not `null`.
+  - : If the violation occurred as a result of a script, this will be the URL of the script; otherwise, it will be `null`.
+    Both `columnNumber` and `lineNumber` should have non-null values if this property is not `null`.
 - {{domxref("SecurityPolicyViolationEvent.statusCode")}} {{ReadOnlyInline}}
   - : A number representing the HTTP status code of the document or worker in which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.violatedDirective")}} {{ReadOnlyInline}}
-  - : A string representing the directive whose enforcement uncovered the violation.
+  - : A string representing the directive that was violated.
+    This is a historical alias of [`effectiveDirective`](#effectivedirective).
 
 ## Examples
 
@@ -63,4 +65,8 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- HTTP [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- {{domxref("CSPViolationReportBody")}}
+- The {{domxref("Element/securitypolicyviolation_event", "securitypolicyviolation")}} event of the {{domxref("Element")}} interface
+- The {{domxref("Document/securitypolicyviolation_event", "securitypolicyviolation")}} event of the {{domxref("Document")}} interface
+- The {{domxref("WorkerGlobalScope/securitypolicyviolation_event", "securitypolicyviolation")}} event of the {{domxref("WorkerGlobalScope")}} interface

--- a/files/en-us/web/api/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.SecurityPolicyViolationEvent
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event")}}, and represents the event object of a `securitypolicyviolation` event sent on an {{domxref("Element/securitypolicyviolation_event", "Element")}}, {{domxref("Document/securitypolicyviolation_event", "Document")}}, or {{domxref("WorkerGlobalScope/securitypolicyviolation_event", "worker","","nocode")}} when its [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) is violated.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.lineNumber
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`lineNumber`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is the line number in the document or worker script at which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
@@ -6,11 +6,9 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.lineNumber
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`lineNumber`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is the line number in the document
-or worker at which the violation occurred.
+The **`lineNumber`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is the line number in the document or worker script at which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 
 ## Value
 
@@ -34,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.lineNumber`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.linenumber)

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.originalPolicy
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`originalPolicy`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string containing the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) whose enforcement uncovered the violation.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
@@ -6,16 +6,15 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.originalPolicy
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`originalPolicy`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-containing the policy whose enforcement uncovered the violation.
+The **`originalPolicy`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string containing the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) whose enforcement uncovered the violation.
 
 ## Value
 
-A string representing the policy whose enforcement uncovered the
-violation.
+A string representing the policy whose enforcement uncovered the violation.
+
+This is the string in the {{HTTPHeader("Content-Security-Policy")}} HTTP header that contains the list of [directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#directives) and their values that make the CSP policy.
 
 ## Examples
 
@@ -35,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.originalPolicy`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.originalpolicy)

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.referrer
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`referrer`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the referrer for the resources whose [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) was violated.
 This will be a URL or `null`.

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
@@ -6,17 +6,14 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.referrer
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`referrer`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing the referrer of the resources whose policy was violated. This will be a URL
-or `null`.
+The **`referrer`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the referrer for the resources whose [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) was violated.
+This will be a URL or `null`.
 
 ## Value
 
-A string representing the URL of the referrer of the violating
-resources.
+A string representing the URL for the referrer of the resources whose policy was violated, or `null`.
 
 ## Examples
 
@@ -36,4 +33,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.referrer`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.referrer)

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
@@ -6,17 +6,14 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.sample
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`sample`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing a sample of the resource that caused the violation.
+The **`sample`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing a sample of the resource that caused the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
 
 ## Value
 
-A string containing a sample of the resource that caused the
-violation, usually the first 40 characters. This will only be populated if the resource
-is an inline script, event handler, or style — external resources causing a violation
+A string containing a sample of the resource that caused the violation, usually the first 40 characters.
+This will only be populated if the resource is an inline script, event handler, or style — external resources causing a violation
 will not generate a sample.
 
 ## Examples
@@ -37,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.sample`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.sample)

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.sample
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`sample`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing a sample of the resource that caused the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.SecurityPolicyViolationEvent.SecurityPolicyViolationEvent
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`SecurityPolicyViolationEvent()`** constructor creates a new {{domxref("SecurityPolicyViolationEvent")}} object.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.SecurityPolicyViolationEvent.SecurityPolicyViolationEvent
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
 The **`SecurityPolicyViolationEvent()`** constructor creates a new {{domxref("SecurityPolicyViolationEvent")}} object.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
@@ -6,16 +6,15 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.sourceFile
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`sourceFile`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing the URI of the document or worker in which the violation was found.
+The **`sourceFile`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the URL of the script in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 
 ## Value
 
-A string representing the URI of the document or worker in which the
-violation was found.
+A string representing the URL of the script in which the violation occurred, or `null` if the violation is not in a script.
+
+Note that both `columnNumber` and `lineNumber` should have non-null values if this property is not `null`.
 
 ## Examples
 
@@ -35,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.sourceFile`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.sourcefile)

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.sourceFile
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`sourceFile`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the URL of the script in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
@@ -6,16 +6,13 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.statusCode
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`statusCode`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a number representing the HTTP
-status code of the document or worker in which the violation occurred.
+The **`statusCode`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a number representing the HTTP status code of the window or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occured.
 
 ## Value
 
-A number representing the status code of the document or worker in which the violation
-occurred.
+A number representing the status code of the window or worker in which the violation occurred.
 
 ## Examples
 
@@ -35,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)
+- [`CSPViolationReportBody.statusCode`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.statuscode)

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.statusCode
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`statusCode`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a number representing the HTTP status code of the window or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occured.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.violatedDirective
 ---
 
-{{APIRef}}
+{{APIRef("Reporting API")}}
 
 The **`violatedDirective`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
 

--- a/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
@@ -6,16 +6,15 @@ page-type: web-api-instance-property
 browser-compat: api.SecurityPolicyViolationEvent.violatedDirective
 ---
 
-{{HTTPSidebar}}
+{{APIRef}}
 
-The **`violatedDirective`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a string
-representing the directive whose enforcement uncovered the violation.
+The **`violatedDirective`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is a string representing the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
+
+This is a historical alias of {{domxref("SecurityPolicyViolationEvent.effectiveDirective")}}, and has the same value.
 
 ## Value
 
-A string representing the directive whose enforcement uncovered the
-violation.
+A string representing the [`Content-Security-Policy` directive](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#directives) that was violated.
 
 ## Examples
 
@@ -32,7 +31,3 @@ document.addEventListener("securitypolicyviolation", (e) => {
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP)

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -153,7 +153,7 @@ Reporting directives control the reporting process of CSP violations. See also t
     > the **`report-uri`** directive will be ignored.
 
 - {{CSP("report-to")}}
-  - : Fires a `SecurityPolicyViolationEvent`.
+  - : Fires a {{domxref("SecurityPolicyViolationEvent")}}.
 
 ### Other directives
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -153,7 +153,8 @@ Reporting directives control the reporting process of CSP violations. See also t
     > the **`report-uri`** directive will be ignored.
 
 - {{CSP("report-to")}}
-  - : Fires a {{domxref("SecurityPolicyViolationEvent")}}.
+  - : Provides the browser with a token identifying the reporting endpoint or group of endpoints for sending CSP violation information.
+    The endpoints that the token represents may be provided through other HTTP headers, such as {{HTTPHeader("Reporting-Endpoints")}}.
 
 ### Other directives
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -250,6 +250,13 @@
       "properties": ["Navigator.credentials"],
       "events": []
     },
+    "Content Security Policy": {
+      "overview": [],
+      "interfaces": ["SecurityPolicyViolationEvent"],
+      "methods": [],
+      "properties": [],
+      "events": []
+    },
     "CSS Counter Styles": {
       "overview": ["CSS Counter Styles"],
       "interfaces": ["CSSCounterStyleRule"],
@@ -1303,7 +1310,8 @@
         "Report",
         "ReportBody",
         "ReportError",
-        "ReportingObserver"
+        "ReportingObserver",
+        "SecurityPolicyViolationEvent"
       ],
       "methods": [],
       "properties": [],

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -250,13 +250,6 @@
       "properties": ["Navigator.credentials"],
       "events": []
     },
-    "Content Security Policy": {
-      "overview": [],
-      "interfaces": ["SecurityPolicyViolationEvent"],
-      "methods": [],
-      "properties": [],
-      "events": []
-    },
     "CSS Counter Styles": {
       "overview": ["CSS Counter Styles"],
       "interfaces": ["CSSCounterStyleRule"],


### PR DESCRIPTION
[`SecurityPolicyViolationEvent`](https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent) docs have HTTP sidebar, even though its a Web API `Event`. However it is defined in the HTTP CSP spec rather than an API.

I wanted to have it in its own API group, but given there is no way to show related APIs properly, decided against.
In the end I have made it as part of the [Reporting_API](https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API).

The reporting API _already includes_ the only other API entity in the CSP spec - [CSPViolationReportBody](https://developer.mozilla.org/en-US/docs/Web/API/CSPViolationReportBody). Even though that fits better here than the event does, it is not a completely unexpected fit - the content _is_ related, and is already documented as being associated with CSP.
It isn't perfect, but IMO reasonable compromise.

FYI @chrisdavidmills @wbamberg 

Fixes #35320

Part of work around #35279