### PR TITLE
Fix timetable instructions to match the proposed result

### DIFF
--- a/files/en-us/learn/html/tables/basics/index.md
+++ b/files/en-us/learn/html/tables/basics/index.md
@@ -543,10 +543,10 @@ Recreate the table by following the steps below.
 2. Add a `<colgroup>` element at the top of the table, just underneath the `<table>` tag, in which you can add your `<col>` elements (see the remaining steps below).
 3. The first two columns need to be left unstyled.
 4. Add a background color to the third column. The value for your `style` attribute is `background-color:#97DB9A;`
-5. Set a separate width on the fourth column. The value for your `style` attribute is `width: 100px;`
+5. Set a separate width on the fourth column. The value for your `style` attribute is `width: 42px;`
 6. Add a background color to the fifth column. The value for your `style` attribute is `background-color: #97DB9A;`
 7. Add a different background color plus a border to the sixth column, to signify that this is a special day and she's teaching a new class. The values for your `style` attribute are `background-color:#DCC48E; border:4px solid #C1437A;`
-8. The last two days are free days, so just set them to no background color but a set width; the value for the `style` attribute is `width: 100px;`
+8. The last two days are free days, so just set them to no background color but a set width; the value for the `style` attribute is `width: 42px;`
 
 See how you get on with the example. If you get stuck, or want to check your work, you can find our version on GitHub as [timetable-fixed.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/timetable-fixed.html) ([see it live also](https://mdn.github.io/learning-area/html/tables/basic/timetable-fixed.html)).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The current instructions say to set the width of certain columns to `width: 100px` but the example picture and solution use a value of `42px` for the width property. This fixes the instructions to correctly ask the reader to set the style to `width: 42px`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The instructions don't match the proposed results of the exercise. Hopefully it will keep beginners from wondering why their results don't look correct.

### Additional details

Here's the code of the fixed version: https://github.com/mdn/learning-area/blob/4416d0aea93f05d1c83ef07ccc2befdcefe2ece5/html/tables/basic/timetable-fixed.html#L40
 
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
