### PR TITLE
Enable heading-increment Markdown lint rule

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -4,8 +4,7 @@
 
 {
   "default": true,
-  // Disabled, as some callouts include headings.
-  "heading-increment": false,
+  "heading-increment": true,
   "ul-style": {
     "style": "dash",
   },

--- a/files/en-us/learn/index.md
+++ b/files/en-us/learn/index.md
@@ -26,7 +26,7 @@ If you are not sure about committing to learning web development in-depth and wa
 
 > [!CALLOUT]
 >
-> #### Looking to become a front-end web developer?
+> **Looking to become a front-end web developer?**
 >
 > If you want to become a front-end web developer and are not sure what to learn first, we'd suggest using the [MDN Curriculum](/en-US/curriculum/) to plan your learning. It provides a structured learning pathway covering the essential skills and practices for being a successful front-end developer, along with recommended learning resources.
 >

--- a/files/en-us/learn/performance/html/index.md
+++ b/files/en-us/learn/performance/html/index.md
@@ -177,7 +177,7 @@ It is advisable to put the content into a single page. If you want to pull in ne
 
 If you must use `<iframe>`s, then use them sparingly.
 
-#### Lazy loading iframes
+### Lazy loading iframes
 
 In the same way as `<img>` elements, you can also use the `loading` attribute to instruct the browser to lazy-load `<iframe>` content that is initially offscreen, thereby improving performance:
 

--- a/files/en-us/learn/server-side/django/deployment/index.md
+++ b/files/en-us/learn/server-side/django/deployment/index.md
@@ -168,7 +168,7 @@ A full checklist of settings you might want to change is provided in [Deployment
 python3 manage.py check --deploy
 ```
 
-#### Gunicorn
+### Gunicorn
 
 [Gunicorn](https://gunicorn.org/) is a pure-Python HTTP server that is commonly used for serving Django WSGI applications.
 
@@ -181,7 +181,7 @@ Then install _Gunicorn_ locally on the command line using _pip_:
 pip3 install gunicorn
 ```
 
-#### Database configuration
+### Database configuration
 
 SQLite, the default Django database that you've been using for development, is a reasonable choice for small to medium websites.
 Unfortunately it cannot be used on some popular hosting services, such as Heroku, because they don't provide persistent data storage in the application environment (a requirement of SQLite).
@@ -194,7 +194,7 @@ The database connection information will be supplied to Django using an environm
 Rather than hard-coding this information into Django, we'll use the [dj-database-url](https://pypi.org/project/dj-database-url/) package to parse the `DATABASE_URL` environment variable and automatically convert it to Django's desired configuration format.
 In addition to installing the _dj-database-url_ package we'll also need to install [psycopg2](https://www.psycopg.org/), as Django needs this to interact with Postgres databases.
 
-##### dj-database-url
+#### dj-database-url
 
 _dj-database-url_ is used to extract the Django database configuration from an environment variable.
 
@@ -204,7 +204,7 @@ Install it locally so that it becomes part of our [requirements](#requirements) 
 pip3 install dj-database-url
 ```
 
-##### settings.py
+#### settings.py
 
 Open **/locallibrary/settings.py** and copy the following configuration into the bottom of the file:
 
@@ -222,7 +222,7 @@ if 'DATABASE_URL' in os.environ:
 Django will now use the database configuration in `DATABASE_URL` if the environment variable is set; otherwise it uses the default SQLite database.
 The value `conn_max_age=500` makes the connection persistent, which is far more efficient than recreating the connection on every request cycle (this is optional and can be removed if needed).
 
-##### psycopg2
+#### psycopg2
 
 <!-- Django 4.2 now supports Psycopg (3) : https://docs.djangoproject.com/en/5.0/releases/4.2/#psycopg-3-support
   But didn't work on Railway!
@@ -240,7 +240,7 @@ Note that Django will use the SQLite database during development by default, unl
 You can switch to Postgres completely and use the same hosted database for development and production by setting the same environment variable in your development environment (Railway makes it easy to use the same environment for production and development).
 Alternatively you can also install and use a [self-hosted Postgres database](https://www.psycopg.org/docs/install.html) on your local computer.
 
-#### Serving static files in production
+### Serving static files in production
 
 During development we use Django and the Django development web server to serve both our dynamic HTML and our static files (CSS, JavaScript, etc.).
 This is inefficient for static files, because the requests have to pass through Django even though Django doesn't do anything with them.
@@ -267,7 +267,7 @@ python3 manage.py collectstatic
 For this tutorial, _collectstatic_ can be run before the application is uploaded, copying all the static files in the application to the location specified in `STATIC_ROOT`.
 `Whitenoise` then finds the files from the location defined by `STATIC_ROOT` (by default) and serves them at the base URL defined by `STATIC_URL`.
 
-##### settings.py
+#### settings.py
 
 Open **/locallibrary/settings.py** and copy the following configuration into the bottom of the file.
 The `BASE_DIR` should already have been defined in your file (the `STATIC_URL` may already have been defined within the file when it was created.
@@ -286,7 +286,7 @@ STATIC_URL = '/static/'
 
 We'll actually do the file serving using a library called [WhiteNoise](https://pypi.org/project/whitenoise/), which we install and configure in the next section.
 
-#### Whitenoise
+### Whitenoise
 
 There are many ways to serve static files in production (we saw the relevant Django settings in the previous sections).
 The [WhiteNoise](https://pypi.org/project/whitenoise/) project provides one of the easiest methods for serving static assets directly from Gunicorn in production.
@@ -295,7 +295,7 @@ Check out [WhiteNoise](https://pypi.org/project/whitenoise/) documentation for a
 
 The steps to set up _WhiteNoise_ to use with the project are [given here](https://whitenoise.readthedocs.io/en/stable/django.html) (and reproduced below):
 
-##### Install whitenoise
+#### Install whitenoise
 
 Install whitenoise locally using the following command:
 
@@ -303,7 +303,7 @@ Install whitenoise locally using the following command:
 pip3 install whitenoise
 ```
 
-##### settings.py
+#### settings.py
 
 To install _WhiteNoise_ into your Django application, open **/locallibrary/settings.py**, find the `MIDDLEWARE` setting and add the `WhiteNoiseMiddleware` near the top of the list, just below the `SecurityMiddleware`:
 
@@ -336,7 +336,7 @@ STORAGES = {
 
 You don't need to do anything else to configure _WhiteNoise_ because it uses your project settings for `STATIC_ROOT` and `STATIC_URL` by default.
 
-#### Requirements
+### Requirements
 
 The Python requirements of your web application should be stored in a file **requirements.txt** in the root of your repository.
 Many hosting services will automatically install dependencies in this file (in others you have to do this yourself).

--- a/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
@@ -22,7 +22,7 @@ setBindGroup(index, bindGroup, dynamicOffsets, dynamicOffsetsStart,
              dynamicOffsetsLength)
 ```
 
-#### Parameters
+### Parameters
 
 - `index`
   - : The index to set the bind group at. This matches the `n` index value of the corresponding [`@group(n)`](https://gpuweb.github.io/gpuweb/wgsl/#attribute-group) attribute in the shader code ({{domxref("GPUShaderModule")}}) used in the related pipeline.

--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -102,6 +102,8 @@ align-content: unset;
 
 ## Examples
 
+### Effects of different align-content values
+
 In this example, you can switch between three different {{cssxref("display")}} property values, including `flex`, `grid`, and `block`. You can also switch between the different values for `align-content`.
 
 #### HTML

--- a/files/en-us/web/html/element/abbr/index.md
+++ b/files/en-us/web/html/element/abbr/index.md
@@ -48,16 +48,12 @@ Spelling out the acronym or abbreviation in full the first time it is used on a 
 
 Only include a `title` if expanding the abbreviation or acronym in the text is not possible. Having a difference between the announced word or phrase and what is displayed on the screen, especially if it's technical jargon the reader may not be familiar with, can be jarring.
 
-#### HTML
-
 ```html
 <p>
   JavaScript Object Notation (<abbr>JSON</abbr>) is a lightweight
   data-interchange format.
 </p>
 ```
-
-#### Result
 
 {{EmbedLiveSample("Accessibility_concerns")}}
 

--- a/files/en-us/web/html/element/caption/index.md
+++ b/files/en-us/web/html/element/caption/index.md
@@ -33,6 +33,8 @@ The following attributes are deprecated and should not be used. They are documen
 
 See {{HTMLElement("table")}} for a complete table example introducing common standards and best practices.
 
+### Table with caption
+
 This example demonstrates a basic table that includes a caption describing the data presented.
 
 Such a "title" is helpful for users who are quickly scanning the page, and it is especially beneficial for visually impaired users, allowing them to determine the table's relevance quickly without the need to have a screen reader read the contents of many cells just to find out what the table is about.

--- a/files/en-us/web/html/element/tfoot/index.md
+++ b/files/en-us/web/html/element/tfoot/index.md
@@ -49,6 +49,8 @@ The following attributes are deprecated and should not be used. They are documen
 
 See {{HTMLElement("table")}} for a complete table example introducing common standards and best practices.
 
+### Table with footer
+
 This example demonstrates a table divided into a head section with column headers, a body section with the table's main data, and a foot section summarizing data of one column.
 
 #### HTML


### PR DESCRIPTION
I noticed quite a few places where the heading sequence is off, and turns out that we don't have the `heading-increment` rule. Now there's actually only one callout that uses headings, so this rule can be enabled.