### PR TITLE
Fix cssxref that results in consecutive code spans or nested code spans

### DIFF
--- a/files/en-us/glossary/pseudo-class/index.md
+++ b/files/en-us/glossary/pseudo-class/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In CSS, a **pseudo-class** selector targets elements depending on their state rather than on information from the document tree. For example, the selector `a`{{ cssxref(":visited") }} applies styles only to links that the user has already followed.
+In CSS, a **pseudo-class** selector targets elements depending on their state rather than on information from the document tree. For example, the selector {{cssxref(":visited", "a:visited")}} applies styles only to links that the user has already followed.
 
 ## See also
 

--- a/files/en-us/glossary/pseudo-element/index.md
+++ b/files/en-us/glossary/pseudo-element/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-In CSS, a **pseudo-element** selector applies styles to parts of your document content in scenarios where there isn't a specific HTML element to select. For example, rather than putting the first letter of each paragraph in its own element, you can style them all with `p`{{ Cssxref("::first-letter") }}.
+In CSS, a **pseudo-element** selector applies styles to parts of your document content in scenarios where there isn't a specific HTML element to select. For example, rather than putting the first letter of each paragraph in its own element, you can style them all with {{Cssxref("::first-letter", "p::first-letter")}}.
 
 ## See also
 

--- a/files/en-us/learn/accessibility/css_and_javascript/index.md
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.md
@@ -207,7 +207,7 @@ There are many instances where a visual design will require that not all content
 
 Screen reader users don't care about any of this — they are happy with the content as long as the source order makes sense, and they can get to it all. Absolute positioning (as used in this example) is generally seen as one of the best mechanisms of hiding content for visual effect because it doesn't stop screen readers from getting to it.
 
-On the other hand, you shouldn't use {{cssxref("visibility")}}`:hidden` or {{cssxref("display")}}`:none`, because they do hide content from screen readers. Unless of course, there is a good reason why you want this content to be hidden from screen readers.
+On the other hand, you shouldn't use {{cssxref("visibility", "visibility: hidden")}} or {{cssxref("display", "display: none")}}, because they do hide content from screen readers. Unless of course, there is a good reason why you want this content to be hidden from screen readers.
 
 > **Note:** [Invisible Content Just for Screen Reader Users](https://webaim.org/techniques/css/invisiblecontent/) has a lot more useful detail surrounding this topic.
 

--- a/files/en-us/learn/css/building_blocks/styling_tables/index.md
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.md
@@ -293,8 +293,8 @@ There is nothing remarkable here, except for the {{cssxref("caption-side")}} pro
 Before moving on, we thought we'd provide you with a quick list of the most useful points illustrated above:
 
 - Make your table markup as simple as possible, and keep things flexible, e.g. by using percentages, so the design is more responsive.
-- Use {{cssxref("table-layout")}}`: fixed` to create a more predictable table layout that allows you to easily set column widths by setting {{cssxref("width")}} on their headings ({{htmlelement("th")}}).
-- Use {{cssxref("border-collapse")}}`: collapse` to make table elements borders collapse into each other, producing a neater and easier to control look.
+- Use {{cssxref("table-layout", "table-layout: fixed")}} to create a more predictable table layout that allows you to easily set column widths by setting {{cssxref("width")}} on their headings ({{htmlelement("th")}}).
+- Use {{cssxref("border-collapse", "border-collapse: collapse")}} to make table elements borders collapse into each other, producing a neater and easier to control look.
 - Use {{htmlelement("thead")}}, {{htmlelement("tbody")}}, and {{htmlelement("tfoot")}} to break up your table into logical chunks and provide extra places to apply CSS to, so it is easier to layer styles on top of one another if required.
 - Use zebra striping to make alternative rows easier to read.
 - Use {{cssxref("text-align")}} to line up your {{htmlelement("th")}} and {{htmlelement("td")}} text, to make things neater and easier to follow.

--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -299,7 +299,7 @@ First of all, we need some additional HTML to represent the webpage's main conte
 
 ### Changes to the existing CSS
 
-Next we need to make some small changes to the existing CSS, to get the info-box placed and positioned. Change your `.info-box` rule to get rid of `margin: 0 auto;` (we no longer want the info-box centered), add {{cssxref("position")}}`: fixed;`, and stick it to the {{cssxref("top")}} of the browser viewport.
+Next we need to make some small changes to the existing CSS, to get the info-box placed and positioned. Change your `.info-box` rule to get rid of `margin: 0 auto;` (we no longer want the info-box centered), add {{cssxref("position", "position: fixed;")}}, and stick it to the {{cssxref("top")}} of the browser viewport.
 
 It should now look like this:
 
@@ -417,7 +417,7 @@ A lot going on here — let's discuss it bit by bit:
 - First, we set some simple {{cssxref("background-color")}} and {{cssxref("color")}} on the info box.
 - Next, we set a fixed {{cssxref("width")}} on the panel, and make its {{cssxref("height")}} the entire height of the browser viewport.
 - We also include some horizontal {{cssxref("padding")}} to space it out a bit.
-- Next we set {{cssxref("position")}}`: fixed;` on the panel so it will always appear in the same place, even if the page has content to scroll. We glue it to the {{cssxref("top")}} of the viewport, and set it so that by default it is offscreen to the {{cssxref("right")}}.
+- Next we set {{cssxref("position", "position: fixed;")}} on the panel so it will always appear in the same place, even if the page has content to scroll. We glue it to the {{cssxref("top")}} of the viewport, and set it so that by default it is offscreen to the {{cssxref("right")}}.
 - Finally, we set a {{cssxref("transition")}} on the element. Transition is an interesting feature that allows you to make changes between states happen smoothly, rather than just going "on" or "off" abruptly. In this case, we intend to make the panel slide smoothly onscreen when the checkbox is checked. (Or to put it another way, when the question mark icon is clicked.)
 
 ### Setting the checked state

--- a/files/en-us/learn/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn/forms/advanced_form_styling/index.md
@@ -157,7 +157,7 @@ Different browsers handle the checkbox and span differently, often ugly ways:
 
 #### Using appearance: none on radios/checkboxes
 
-As we showed before, you can remove the default appearance of a checkbox or radio button altogether with {{cssxref('appearance')}}`:none;`. Let's take this example HTML:
+As we showed before, you can remove the default appearance of a checkbox or radio button altogether with {{cssxref("appearance", "appearance: none;")}}. Let's take this example HTML:
 
 ```html
 <form>

--- a/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.md
@@ -202,7 +202,7 @@ Last but not least, let's look at the CSS for the timer:
 }
 ```
 
-- We set the outer `.timer` element to have `flex: 5`, so it takes up most of the width of the controls bar. We also give it {{cssxref("position")}}`: relative`, so that we can position elements inside it conveniently according to its boundaries, and not the boundaries of the {{htmlelement("body")}} element.
+- We set the outer `.timer` element to have `flex: 5`, so it takes up most of the width of the controls bar. We also give it {{cssxref("position", "position: relative")}}, so that we can position elements inside it conveniently according to its boundaries, and not the boundaries of the {{htmlelement("body")}} element.
 - The inner `<div>` is absolutely positioned to sit directly on top of the outer `<div>`. It is also given an initial width of 0, so you can't see it at all. As the video plays, the width will be increased via JavaScript as the video elapses.
 - The `<span>` is also absolutely positioned to sit near the left-hand side of the timer bar.
 - We also give our inner `<div>` and `<span>` the right amount of {{cssxref("z-index")}} so that the timer will be displayed on top, and the inner `<div>` below that. This way, we make sure we can see all the information — one box is not obscuring another.

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/accessibility/index.md
@@ -237,7 +237,7 @@ There are many instances where a visual design will require that not all content
 
 Screen reader users don't care about any of this — they are happy with the content as long as the source order makes sense, and they can get to it all. Absolute positioning (as used in this example) is generally seen as one of the best mechanisms of hiding content for visual effect, because it doesn't stop screen readers from getting to it.
 
-On the other hand, you shouldn't use {{cssxref("visibility")}}`:hidden` or {{cssxref("display")}}`:none`, because they do hide content from screen readers. Unless of course, there is a good reason why you want this content to be hidden from screen readers.
+On the other hand, you shouldn't use {{cssxref("visibility", "visibility: hidden")}} or {{cssxref("display", "display: none")}}, because they do hide content from screen readers. Unless of course, there is a good reason why you want this content to be hidden from screen readers.
 
 > **Note:** [Invisible Content Just for Screen Reader Users](https://webaim.org/techniques/css/invisiblecontent/) has a lot more useful detail surrounding this topic.
 

--- a/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -27,7 +27,7 @@ The first panel on the left contains two components: a {{HTMLElement("video")}} 
 
 This is straightforward, and we'll see how it ties together when we get into the JavaScript code.
 
-Next, we have a {{HTMLElement("canvas")}} element into which the captured frames are stored, potentially manipulated in some way, and then converted into an output image file. This canvas is kept hidden by styling the canvas with {{cssxref("display")}}`:none`, to avoid cluttering up the screen — the user does not need to see this intermediate stage.
+Next, we have a {{HTMLElement("canvas")}} element into which the captured frames are stored, potentially manipulated in some way, and then converted into an output image file. This canvas is kept hidden by styling the canvas with {{cssxref("display", "display: none")}}, to avoid cluttering up the screen — the user does not need to see this intermediate stage.
 
 We also have an {{HTMLElement("img")}} element into which we will draw the image — this is the final display shown to the user.
 

--- a/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
+++ b/files/en-us/web/api/paintworkletglobalscope/registerpaint/index.md
@@ -81,7 +81,7 @@ the `CSS.paintWorklet.addModule()` method:
 ```
 
 You can then use the `{{cssxref('image/paint', 'paint()')}}` CSS function in your
-CSS anywhere an `{{cssxref('&lt;image&gt;')}}` value is valid.
+CSS anywhere an {{cssxref('&lt;image&gt;')}} value is valid.
 
 ```css
 li {

--- a/files/en-us/web/css/-webkit-mask-box-image/index.md
+++ b/files/en-us/web/css/-webkit-mask-box-image/index.md
@@ -59,7 +59,7 @@ The values includes the `<image>` to be used as the mask border, and optionally 
   - : Used to specify that a border box is to have no mask image.
 - {{cssxref("length")}}
   - : The size of the mask image's offset. See {{cssxref("&lt;length&gt;")}} for possible units.
-- `{{cssxref("percentage")}}`
+- {{cssxref("percentage")}}
   - : The mask image's offset has a percentage value relative to the border box's corresponding dimension (width or height).
 - {{cssxref("number")}}
   - : The size of the mask image's offset in pixels.
@@ -74,7 +74,7 @@ The values includes the `<image>` to be used as the mask border, and optionally 
 
 The outset values, or edge offsets, define the distances from the top, right, bottom, and left edges of the image, in that order. The values can be set as {{cssxref("length")}}, {{cssxref("number")}}, or {{cssxref("percentage")}}, with numbers interpreted as pixel lengths.
 
-Border repeat styles, when included, are interpreted in the order of `<repeat-x> <repeat-y>`. If only one value is declared, the value is the same for both axes. While similar to `{{cssxref("background-repeat")}}`, the `cover` and `contain` values are not supported.
+Border repeat styles, when included, are interpreted in the order of `<repeat-x> <repeat-y>`. If only one value is declared, the value is the same for both axes. While similar to {{cssxref("background-repeat")}}, the `cover` and `contain` values are not supported.
 
 ## Formal definition
 

--- a/files/en-us/web/css/animation-delay/index.md
+++ b/files/en-us/web/css/animation-delay/index.md
@@ -34,7 +34,7 @@ animation-delay: unset;
 
 ### Values
 
-- `{{cssxref("&lt;time&gt;")}}`
+- {{cssxref("&lt;time&gt;")}}
 
   - : The time offset, from the moment at which the animation is applied to the element, at which the animation should begin. This may be specified in either seconds (`s`) or milliseconds (`ms`). The unit is required.
 

--- a/files/en-us/web/css/animation-duration/index.md
+++ b/files/en-us/web/css/animation-duration/index.md
@@ -39,7 +39,7 @@ animation-duration: unset;
 
   - : For time-based animations, `auto` is equivalent to a value of `0s` (see below). For [CSS scroll-driven animations](/en-US/docs/Web/CSS/CSS_scroll-driven_animations), `auto` fills the entire timeline with the animation.
 
-- `{{cssxref("&lt;time&gt;")}}`
+- {{cssxref("&lt;time&gt;")}}
 
   - : The time that an animation takes to complete one cycle. This may be specified in either seconds (`s`) or milliseconds (`ms`). The value must be positive or zero and the unit is required.
 

--- a/files/en-us/web/css/animation-iteration-count/index.md
+++ b/files/en-us/web/css/animation-iteration-count/index.md
@@ -40,7 +40,7 @@ The **`animation-iteration-count`** property is specified as one or more comma-s
 
 - `infinite`
   - : The animation will repeat forever.
-- `{{cssxref("&lt;number&gt;")}}`
+- {{cssxref("&lt;number&gt;")}}
   - : The number of times the animation will repeat; this is `1` by default. You may specify non-integer values to play part of an animation cycle: for example, `0.5` will play half of the animation cycle. Negative values are invalid.
 
 > [!NOTE]

--- a/files/en-us/web/css/box-decoration-break/index.md
+++ b/files/en-us/web/css/box-decoration-break/index.md
@@ -43,7 +43,7 @@ The `box-decoration-break` property is specified as one of the keyword values li
 - `slice`
   - : The element is initially rendered as if its box were not fragmented, after which the rendering for this hypothetical box is sliced into pieces for each line/column/page. Note that the hypothetical box can be different for each fragment since it uses its own height if the break occurs in the inline direction, and its own width if the break occurs in the block direction. See the CSS specification for details.
 - `clone`
-  - : Each box fragment is rendered independently with the specified border, padding, and margin wrapping each fragment. The {{ Cssxref("border-radius") }}, {{ Cssxref("border-image") }}, and {{ Cssxref("box-shadow") }} are applied to each fragment independently. The background is also drawn independently for each fragment, which means that a background image with {{ Cssxref("background-repeat") }}`: no-repeat` may nevertheless repeat multiple times.
+  - : Each box fragment is rendered independently with the specified border, padding, and margin wrapping each fragment. The {{ Cssxref("border-radius") }}, {{ Cssxref("border-image") }}, and {{ Cssxref("box-shadow") }} are applied to each fragment independently. The background is also drawn independently for each fragment, which means that a background image with {{ Cssxref("background-repeat", "background-repeat: no-repeat") }} may nevertheless repeat multiple times.
 
 ## Formal definition
 

--- a/files/en-us/web/css/content/index.md
+++ b/files/en-us/web/css/content/index.md
@@ -376,7 +376,7 @@ When generating content on regular elements (rather than just on pseudo-elements
 
 ### Element replacement with `<gradient>`
 
-This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The element's contents are replaced with a {{cssxref("gradient/linear-gradient" ,"linear-gradient()")}}. With {{cssxref("@supports")}}, we provide alt text support and a {{cssxref("gradient/repeating-linear-gradient" ,"repeating-linear-gradient()")}} for browsers that support alt text with element content replacement.
+This example demonstrates how an element's contents can be replaced by any type of `<image>`, in this case, a CSS gradient. The element's contents are replaced with a {{cssxref("gradient/linear-gradient", "linear-gradient()")}}. With {{cssxref("@supports")}}, we provide alt text support and a {{cssxref("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}} for browsers that support alt text with element content replacement.
 
 #### HTML
 
@@ -414,7 +414,7 @@ Check the [browser compatibility chart](#browser_compatibility). All browsers su
 
 ### Element replacement with `image-set()`
 
-This example replaces an element's content with a {{cssxref("image/image-set" ,"image-set()")}}. If the users display has normal resolution the `1x.png` will be displayed screens with a higher resolution will display the `2x.png` image.
+This example replaces an element's content with a {{cssxref("image/image-set", "image-set()")}}. If the users display has normal resolution the `1x.png` will be displayed screens with a higher resolution will display the `2x.png` image.
 
 #### HTML
 

--- a/files/en-us/web/css/css_display/block_formatting_context/index.md
+++ b/files/en-us/web/css/css_display/block_formatting_context/index.md
@@ -14,18 +14,18 @@ A block formatting context is created by at least one of the following:
 - The root element of the document (`<html>`).
 - Floats (elements where {{ cssxref("float") }} isn't `none`).
 - Absolutely positioned elements (elements where {{ cssxref("position") }} is `absolute` or `fixed`).
-- Inline-blocks (elements with {{ cssxref("display") }}`: inline-block`).
-- Table cells (elements with {{ cssxref("display") }}`: table-cell`, which is the default for HTML table cells).
-- Table captions (elements with {{ cssxref("display") }}`: table-caption`, which is the default for HTML table captions).
-- Anonymous table cells implicitly created by the elements with {{ cssxref("display") }}`: table`, `table-row`, `table-row-group`, `table-header-group`, `table-footer-group` (which is the default for HTML tables, table rows, table bodies, table headers, and table footers, respectively), or `inline-table`.
+- Inline-blocks (elements with {{cssxref("display", "display: inline-block")}}).
+- Table cells (elements with {{cssxref("display", "display: table-cell")}}, which is the default for HTML table cells).
+- Table captions (elements with {{cssxref("display", "display: table-caption")}}, which is the default for HTML table captions).
+- Anonymous table cells implicitly created by the elements with {{cssxref("display", "display: table")}}, `table-row`, `table-row-group`, `table-header-group`, `table-footer-group` (which is the default for HTML tables, table rows, table bodies, table headers, and table footers, respectively), or `inline-table`.
 - Block elements where {{ cssxref("overflow") }} has a value other than `visible` and `clip`.
-- Elements with {{ cssxref("display") }}`: flow-root`.
+- Elements with {{cssxref("display", "display: flow-root")}}.
 - {{htmlelement("button")}} elements and button {{htmlelement("input")}} types defaulting to `display: flow-root`.
-- Elements with {{ cssxref("contain") }}`: layout`, `content`, or `paint`.
-- Flex items (direct children of the element with {{ cssxref("display") }}`: flex` or `inline-flex`) if they are neither [flex](/en-US/docs/Glossary/Flex_Container) nor [grid](/en-US/docs/Glossary/Grid_Container) nor [table](/en-US/docs/Web/CSS/CSS_table) containers themselves.
-- Grid items (direct children of the element with {{ cssxref("display") }}`: grid` or `inline-grid`) if they are neither [flex](/en-US/docs/Glossary/Flex_Container) nor [grid](/en-US/docs/Glossary/Grid_Container) nor [table](/en-US/docs/Web/CSS/CSS_table) containers themselves.
+- Elements with {{cssxref("contain", "contain: layout")}}, `content`, or `paint`.
+- Flex items (direct children of the element with {{cssxref("display", "display: flex")}} or `inline-flex`) if they are neither [flex](/en-US/docs/Glossary/Flex_Container) nor [grid](/en-US/docs/Glossary/Grid_Container) nor [table](/en-US/docs/Web/CSS/CSS_table) containers themselves.
+- Grid items (direct children of the element with {{cssxref("display", "display: grid")}} or `inline-grid`) if they are neither [flex](/en-US/docs/Glossary/Flex_Container) nor [grid](/en-US/docs/Glossary/Grid_Container) nor [table](/en-US/docs/Web/CSS/CSS_table) containers themselves.
 - Multicol containers (elements where {{ cssxref("column-count") }} or {{ cssxref("column-width") }} isn't `auto`, including elements with `column-count: 1`).
-- {{ cssxref("column-span") }}`: all`, even when the `column-span: all` element isn't contained by a multicol container.
+- {{cssxref("column-span", "column-span: all")}}, even when the `column-span: all` element isn't contained by a multicol container.
 
 Formatting contexts affect layout because an element that establishes a new block formatting context will:
 

--- a/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -60,7 +60,7 @@ Whether you use flexbox or grid to lay out a list of card components, these layo
 
 ![Two card components showing that the internals of the component do not stretch with the wrapper.](flex-cards.png)
 
-Flexbox solves this. We make the card a flex container, with {{cssxref("flex-direction")}}`: column`. We then set the content area to `flex: 1`, which is the shorthand for `flex: 1 1 0` — the item can grow and shrink from a flex basis of `0`. As this is the only item that can grow, it takes up all available space in the flex container and pushes the footer to the bottom. If you remove the `flex` property from the live example you will see the footer moves up to sit directly under the content.
+Flexbox solves this. We make the card a flex container, with {{cssxref("flex-direction", "flex-direction: column")}}. We then set the content area to `flex: 1`, which is the shorthand for `flex: 1 1 0` — the item can grow and shrink from a flex basis of `0`. As this is the only item that can grow, it takes up all available space in the flex container and pushes the footer to the bottom. If you remove the `flex` property from the live example you will see the footer moves up to sit directly under the content.
 
 {{EmbedGHLiveSample("css-examples/flexbox/use-cases/cards.html", '100%', 800)}}
 

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_grids/index.md
@@ -500,7 +500,7 @@ This is all looking fairly complete now, however we sometimes have these cards w
 
 ![The layout has gaps as there is not space to lay out a two track item.](11-grid-auto-flow-sparse.png)
 
-We can cause a grid to backfill those gaps by setting {{cssxref("grid-auto-flow")}}`: dense` on the grid container. Take care when doing this however as it does take items away from their logical source order. You should only do this if your items do not have a set order – and be aware of the [issues](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility#visual_not_logical_re-ordering) of the tab order following the source and not your reordered display.
+We can cause a grid to backfill those gaps by setting {{cssxref("grid-auto-flow", "grid-auto-flow: dense")}} on the grid container. Take care when doing this however as it does take items away from their logical source order. You should only do this if your items do not have a set order – and be aware of the [issues](/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility#visual_not_logical_re-ordering) of the tab order following the source and not your reordered display.
 
 ```html hidden
 <ul class="listing">

--- a/files/en-us/web/css/css_lists/consistent_list_indentation/index.md
+++ b/files/en-us/web/css/css_lists/consistent_list_indentation/index.md
@@ -14,7 +14,7 @@ To understand why this is the case, and more importantly how to avoid the proble
 
 ### The stand-alone list item
 
-First, we consider the pure list item, not nested in a list of items. When using the HTML {{htmlelement("li")}} element, the browser sets the {{cssxref("display")}} value to `list-item`. Whether list items not nested in a list are provided a marker (otherwise known as a "bullet") depends on the browser. We can remove that bullet with {{cssxref("list-style-type")}}`: none`.
+First, we consider the pure list item, not nested in a list of items. When using the HTML {{htmlelement("li")}} element, the browser sets the {{cssxref("display")}} value to `list-item`. Whether list items not nested in a list are provided a marker (otherwise known as a "bullet") depends on the browser. We can remove that bullet with {{cssxref("list-style-type", "list-style-type: none")}}.
 
 ```css
 li {

--- a/files/en-us/web/css/css_transitions/using_css_transitions/index.md
+++ b/files/en-us/web/css/css_transitions/using_css_transitions/index.md
@@ -359,7 +359,7 @@ el.addEventListener("transitionstart", signalStart, true);
 ```
 
 > [!NOTE]
-> The `transitionend` event doesn't fire if the transition is aborted before the transition is completed because either the element is made {{cssxref("display")}}`: none` or the animating property's value is changed.
+> The `transitionend` event doesn't fire if the transition is aborted before the transition is completed because either the element is made {{cssxref("display", "display: none")}} or the animating property's value is changed.
 
 ## Specifications
 

--- a/files/en-us/web/css/image-resolution/index.md
+++ b/files/en-us/web/css/image-resolution/index.md
@@ -31,7 +31,7 @@ image-resolution: unset;
 
 ### Values
 
-- `{{cssxref("&lt;resolution&gt;")}}`
+- {{cssxref("&lt;resolution&gt;")}}
   - : Specifies the intrinsic resolution explicitly.
 - `from-image`
   - : Uses the intrinsic resolution as specified by the image format. If the image does not specify its own resolution, the explicitly specified resolution is used (if given), else it defaults to `1dppx` (1 image pixel per CSS px unit).

--- a/files/en-us/web/css/mask-size/index.md
+++ b/files/en-us/web/css/mask-size/index.md
@@ -65,7 +65,7 @@ Each value can be a `<length>`, a `<percentage>`, or `auto`.
 ### Values
 
 - `<length>`
-  - : A `{{cssxref("&lt;length&gt;")}}` value scales the mask image to the specified length in the corresponding dimension. Negative lengths are not allowed.
+  - : A {{cssxref("&lt;length&gt;")}} value scales the mask image to the specified length in the corresponding dimension. Negative lengths are not allowed.
 - `<percentage>`
   - : A {{cssxref("&lt;percentage&gt;")}} value scales the mask image in the corresponding dimension to the specified percentage of the mask positioning area, which is determined by the value of {{cssxref("mask-origin")}}. The mask positioning area is, by default, the area containing the content of the box and its padding; the area may also be changed to just the content or to the area containing borders, padding and content. Negative percentages are not allowed.
 - `auto`

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -18,7 +18,7 @@ Firefox supports a number of _Mozilla extensions to [CSS](/en-US/docs/Web/CSS)_,
 - {{CSSxRef("box-align", "-moz-box-align")}} {{deprecated_inline}}
 - {{CSSxRef("box-direction", "-moz-box-direction")}} {{deprecated_inline}}
 - {{CSSxRef("box-flex", "-moz-box-flex")}} {{deprecated_inline}}
-- {{CSSxRef("box-ordinal-group" ,"-moz-box-ordinal-group")}} {{deprecated_inline}}
+- {{CSSxRef("box-ordinal-group", "-moz-box-ordinal-group")}} {{deprecated_inline}}
 - {{CSSxRef("box-orient", "-moz-box-orient")}} {{deprecated_inline}}
 - {{CSSxRef("box-pack", "-moz-box-pack")}} {{deprecated_inline}}
 - {{CSSxRef("-moz-float-edge")}} {{deprecated_inline}}

--- a/files/en-us/web/css/offset-distance/index.md
+++ b/files/en-us/web/css/offset-distance/index.md
@@ -31,7 +31,7 @@ offset-distance: revert-layer;
 offset-distance: unset;
 ```
 
-- `{{cssxref('&lt;length-percentage&gt;')}}`
+- {{cssxref('&lt;length-percentage&gt;')}}
 
   - : A length that specifies how far the element is along the path (defined with {{cssxref('offset-path')}}).
 

--- a/files/en-us/web/css/offset-rotate/index.md
+++ b/files/en-us/web/css/offset-rotate/index.md
@@ -38,7 +38,7 @@ offset-rotate: unset;
 
 - `auto`
   - : The element is rotated by the angle of the direction of the {{cssxref("offset-path")}}, relative to the positive x-axis. This is the default value.
-- `{{cssxref("&lt;angle&gt;")}}`
+- {{cssxref("&lt;angle&gt;")}}
   - : The element has a constant clockwise rotation transformation applied to it by the specified rotation angle.
 - `auto <angle>`
   - : If `auto` is followed by an {{cssxref("&lt;angle&gt;")}}, the computed value of the angle is added to the computed value of `auto`.

--- a/files/en-us/web/css/scroll-padding-top/index.md
+++ b/files/en-us/web/css/scroll-padding-top/index.md
@@ -32,7 +32,7 @@ scroll-padding-top: unset;
 
 ### Values
 
-- `{{cssxref("&lt;length-percentage&gt;")}}`
+- {{cssxref("&lt;length-percentage&gt;")}}
   - : An inwards offset from the top edge of the scrollport, as a valid length or a percentage.
 - `auto`
   - : The offset is determined by the user agent. This will generally be 0px, but a user agent is able to detect and do something else if a non-zero value is more appropriate.

--- a/files/en-us/web/css/sign/index.md
+++ b/files/en-us/web/css/sign/index.md
@@ -10,7 +10,7 @@ browser-compat: css.types.sign
 The **`sign()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) contains one calculation, and returns `-1` if the numeric value of the argument is negative, `+1` if the numeric value of the argument is positive, `0⁺` if the numeric value of the argument is 0⁺, and `0⁻` if the numeric value of the argument is 0⁻.
 
 > [!NOTE]
-> While `{{CSSxRef("abs")}}` returns the absolute value of the argument, `sign()` returns the sign of the argument.
+> While {{CSSxRef("abs")}} returns the absolute value of the argument, `sign()` returns the sign of the argument.
 
 ## Syntax
 

--- a/files/en-us/web/css/text-decoration-style/index.md
+++ b/files/en-us/web/css/text-decoration-style/index.md
@@ -46,7 +46,7 @@ text-decoration-style: unset;
 - wavy
   - : Draws a wavy line.
 - \-moz-none
-  - : Draws no line. Use {{ cssxref("text-decoration-line") }}`: none` instead.
+  - : Draws no line. Use {{cssxref("text-decoration-line", "text-decoration-line: none")}} instead.
 
 ## Formal definition
 

--- a/files/en-us/web/css/text-justify/index.md
+++ b/files/en-us/web/css/text-justify/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.text-justify
 
 {{CSSRef}}
 
-The **`text-justify`** [CSS](/en-US/docs/Web/CSS) property sets what type of justification should be applied to text when {{cssxref("text-align")}}`: justify;` is set on an element.
+The **`text-justify`** [CSS](/en-US/docs/Web/CSS) property sets what type of justification should be applied to text when {{cssxref("text-align", "text-align: justify;")}} is set on an element.
 
 ## Syntax
 

--- a/files/en-us/web/html/attributes/disabled/index.md
+++ b/files/en-us/web/html/attributes/disabled/index.md
@@ -49,7 +49,7 @@ Because a disabled field cannot have its value changed, [`required`](/en-US/docs
 
 Browsers display disabled form controls greyed as disabled form controls are immutable, won't receive focus or any browsing events, like mouse clicks or focus-related ones, and aren't submitted with the form.
 
-If present on a supporting elements, the `{{cssxref(':disabled')}}` pseudo class will match. If the attribute is not included, the `{{cssxref(':enabled')}}` pseudo class will match. If the element doesn't support the disabled attribute, the attribute will have no effect, including not leading to being matched by the `:disabled` and `:enabled` pseudo classes.
+If present on a supporting elements, the {{cssxref(':disabled')}} pseudo class will match. If the attribute is not included, the {{cssxref(':enabled')}} pseudo class will match. If the element doesn't support the disabled attribute, the attribute will have no effect, including not leading to being matched by the `:disabled` and `:enabled` pseudo classes.
 
 ### Constraint validation
 

--- a/files/en-us/web/html/element/abbr/index.md
+++ b/files/en-us/web/html/element/abbr/index.md
@@ -38,7 +38,7 @@ In languages with [grammatical number](https://en.wikipedia.org/wiki/Grammatical
 
 ## Default styling
 
-The purpose of this element is purely for the convenience of the author and all browsers display it inline ({{cssxref('display')}}`: inline`) by default, though its default styling varies from one browser to another:
+The purpose of this element is purely for the convenience of the author and all browsers display it inline ({{cssxref("display", "display: inline")}}) by default, though its default styling varies from one browser to another:
 
 Some browsers add a dotted underline to the content of the element. Others add a dotted underline while converting the contents to small caps. Others may not style it differently than a {{HTMLElement("span")}} element. To control this styling, use {{cssxref('text-decoration')}} and {{cssxref('font-variant')}}.
 

--- a/files/en-us/web/html/element/acronym/index.md
+++ b/files/en-us/web/html/element/acronym/index.md
@@ -40,7 +40,7 @@ This element implements the {{domxref('HTMLElement')}} interface.
 Though the purpose of this tag is purely for the convenience of the author, its default styling varies from one browser to another:
 
 - Opera, Firefox, Chrome, and some others add a dotted underline to the content of the element.
-- A few browsers not only add a dotted underline, but also put it in small caps; to avoid this styling, adding something like {{cssxref('font-variant')}}`: none` in the CSS takes care of this case.
+- A few browsers not only add a dotted underline, but also put it in small caps; to avoid this styling, adding something like {{cssxref("font-variant", "font-variant: none")}} in the CSS takes care of this case.
 
 It is therefore recommended that web authors either explicitly style this element, or accept some cross-browser variation.
 

--- a/files/en-us/web/html/element/bdi/index.md
+++ b/files/en-us/web/html/element/bdi/index.md
@@ -34,7 +34,7 @@ If `EMBEDDED-TEXT` is LTR, this works fine. But if `EMBEDDED-TEXT` is RTL, then 
 
 If you know the directionality of `EMBEDDED-TEXT` in advance, you can fix this problem by wrapping `EMBEDDED-TEXT` in a {{HTMLElement("span")}} with the [`dir`](/en-US/docs/Web/HTML/Global_attributes#dir) attribute set to the known directionality. But if you don't know the directionality - for example, because `EMBEDDED-TEXT` is being read from a database or entered by the user - you should use `<bdi>` to prevent the directionality of `EMBEDDED-TEXT` from affecting its surroundings.
 
-Though the same visual effect can be achieved using the CSS rule {{cssxref("unicode-bidi")}}`: isolate` on a {{HTMLElement("span")}} or another text-formatting element, HTML authors should not use this approach because it is not semantic and browsers are allowed to ignore CSS styling.
+Though the same visual effect can be achieved using the CSS rule {{cssxref("unicode-bidi", "unicode-bidi: isolate")}} on a {{HTMLElement("span")}} or another text-formatting element, HTML authors should not use this approach because it is not semantic and browsers are allowed to ignore CSS styling.
 
 Embedding the characters in `<span dir="auto">` has the same effect as using `<bdi>`, but its semantics are less clear.
 

--- a/files/en-us/web/html/element/center/index.md
+++ b/files/en-us/web/html/element/center/index.md
@@ -57,7 +57,7 @@ This element implements the {{domxref("HTMLElement")}} interface.
 {{EmbedLiveSample("Example 3 (CSS alternative)")}}
 
 > [!NOTE]
-> Applying {{Cssxref("text-align")}}`:center` to a {{HTMLElement("div")}} or {{HTMLElement("p")}} element centers the _contents_ of those elements while leaving their overall dimensions unchanged.
+> Applying {{cssxref("text-align", "text-align: center")}} to a {{HTMLElement("div")}} or {{HTMLElement("p")}} element centers the _contents_ of those elements while leaving their overall dimensions unchanged.
 
 <!-- ## Technical summary -->
 

--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -272,7 +272,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 `<img>` is a [replaced element](/en-US/docs/Web/CSS/Replaced_element); it has a {{cssxref("display")}} value of `inline` by default, but its default dimensions are defined by the embedded image's intrinsic values, like it were `inline-block`. You can set properties like {{cssxref("border")}}/{{cssxref("border-radius")}}, {{cssxref("padding")}}/{{cssxref("margin")}}, {{cssxref("width")}}, {{cssxref("height")}}, etc. on an image.
 
-`<img>` has no baseline, so when images are used in an inline formatting context with {{cssxref("vertical-align")}}`: baseline`, the bottom of the image will be placed on the text baseline.
+`<img>` has no baseline, so when images are used in an inline formatting context with {{cssxref("vertical-align", "vertical-align: baseline")}}, the bottom of the image will be placed on the text baseline.
 
 You can use the {{cssxref("object-position")}} property to position the image within the element's box, and the {{cssxref("object-fit")}} property to adjust the sizing of the image within the box (for example, whether the image should fit the box or fill it even if clipping is required).
 

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -102,7 +102,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ### Baseline inconsistency
 
-The HTML specification doesn't define where the baseline of a `<textarea>` is, so different browsers set it to different positions. For Gecko, the `<textarea>` baseline is set on the baseline of the first line of the textarea, on another browser it may be set on the bottom of the `<textarea>` box. Don't use {{cssxref("vertical-align")}}`: baseline` on it; the behavior is unpredictable.
+The HTML specification doesn't define where the baseline of a `<textarea>` is, so different browsers set it to different positions. For Gecko, the `<textarea>` baseline is set on the baseline of the first line of the textarea, on another browser it may be set on the bottom of the `<textarea>` box. Don't use {{cssxref("vertical-align", "vertical-align: baseline")}} on it; the behavior is unpredictable.
 
 ### Controlling whether a textarea is resizable
 


### PR DESCRIPTION
This PR fixes code of the style ``{{cssxref("foo")}}`: bar` ``, resulting in prettier rendered output.