### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/toggleevent/toggleevent/index.md
+++ b/files/en-us/web/api/toggleevent/toggleevent/index.md
@@ -19,7 +19,7 @@ new ToggleEvent(type, init)
 ### Parameters
 
 - `type`
-  - : A string representing the type of event. In the case of `ToggleEvent` this is always `toggleevent`.
+  - : A string representing the type of event. In the case of `ToggleEvent` this is always `toggle`.
 - `init`
   - : An object containing the following properties:
     - `newState`


### PR DESCRIPTION
The `type` of `ToggleEvent` is always `toggle`, not `toggleevent`.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I changed the name of the event type mentioned in the first paragraph to just `toggle`.

### Motivation

Stumbled upon it while fiddling with this event.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
