### PR TITLE
Add :popover-open to list

### DIFF
--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -285,6 +285,7 @@ P
 - {{CSSxRef(":picture-in-picture")}}
 - {{CSSxRef(":placeholder-shown")}}
 - {{CSSxRef(":playing")}}
+- {{CSSxRef(":popover-open")}}
 
 R
 


### PR DESCRIPTION
Added `:popover-open` to index

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I added the missing `:popover-open` to the index. It is baseline in 2024.

### Motivation

Bumped into this while looking up `:popover-open` in the index, but couldn't find it there.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
