### PR TITLE
Django Tute: session count matches what is displayed

### DIFF
--- a/files/en-us/learn/server-side/django/sessions/index.md
+++ b/files/en-us/learn/server-side/django/sessions/index.md
@@ -14,10 +14,7 @@ This is a relatively simple example, but it does show how you can use the sessio
     <tr>
       <th scope="row">Prerequisites:</th>
       <td>
-        Complete all previous tutorial topics, including <a
-          href="/en-US/docs/Learn/Server-side/Django/Generic_views"
-          >Django Tutorial Part 6: Generic list and detail views</a
-        >
+        Complete all previous tutorial topics, including <a href="/en-US/docs/Learn/Server-side/Django/Generic_views">Django Tutorial Part 6: Generic list and detail views</a>
       </td>
     </tr>
     <tr>
@@ -126,7 +123,8 @@ def index(request):
 
     # Number of visits to this view, as counted in the session variable.
     num_visits = request.session.get('num_visits', 0)
-    request.session['num_visits'] = num_visits + 1
+    num_visits += 1
+    request.session['num_visits'] = num_visits
 
     context = {
         'num_books': num_books,


### PR DESCRIPTION
The value of num_visits in the Django tute was being fetched from session variable, updated, saved, and then displaying the last stored value. This was intentional, displaying "the number of visits you have done _before_ this one". It is however not how most/many people would interpret the text ("what number visit is this to the page").

This changes the meaning to the second case, by making sure that what is stored in the variable and what is displayed matches.

This is the English fix to mdn/translated-content#23260

Associated demo code fix in https://github.com/mdn/django-locallibrary-tutorial/pull/148

This will need to be pushed to the translation.