### PR TITLE
FF130 Relnote: WebGLRenderingContext/WebGL2RenderingContext .drawingB…

### DIFF
--- a/files/en-us/mozilla/firefox/releases/130/index.md
+++ b/files/en-us/mozilla/firefox/releases/130/index.md
@@ -46,6 +46,8 @@ This article provides information about the changes in Firefox 130 that affect d
 
 #### Removals
 
+- {{domxref('WebGLRenderingContext.drawingBufferColorSpace')}} and [`WebGL2RenderingContext.drawingBufferColorSpace`](/en-US/docs/Web/API/WebGL2RenderingContext) were prematurely released (without an an implementation) in [Firefox 127](/en-US/docs/Mozilla/Firefox/Releases/127), and have been removed ([Firefox bug 1909559](https://bugzil.la/1909559)).
+
 ### WebAssembly
 
 #### Removals


### PR DESCRIPTION
`WebGLRenderingContext.drawingBufferColorSpace` and `WebGL2RenderingContext.drawingBufferColorSpace` were removed behind a preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1909559

This adds a release note

Related docs work can be tracked in #35422