### PR TITLE
Add example for XSLTProcessor `importStylesheet()` method

### DIFF
--- a/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
+++ b/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
@@ -27,22 +27,26 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
+### Using importStylesheet()
+
 This example shows how `importStylesheet()` loads an XSLT stylesheet into an XSLTProcessor for use in transforming XML data.
+
+#### HTML
 
 ```html
 <div id="result"></div>
 ```
 
+#### JavaScript
+
 ```js
-// Simple XML data
 const xmlString = `
 <items>
-    <item>Item 1</item>
-    <item>Item 2</item>
+  <item>Item 1</item>
+  <item>Item 2</item>
 </items>
 `;
 
-// Simple XSLT stylesheet
 const xsltString = `
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:template match="/">
@@ -55,12 +59,10 @@ const xsltString = `
 </xsl:stylesheet>
 `;
 
-// Parse the XML and XSLT strings into DOM objects
 const parser = new DOMParser();
 const xmlDoc = parser.parseFromString(xmlString, "application/xml");
 const xsltDoc = parser.parseFromString(xsltString, "application/xml");
 
-// Create an XSLTProcessor instance
 const xsltProcessor = new XSLTProcessor();
 
 // Import the XSLT stylesheet into the XSLTProcessor
@@ -72,6 +74,10 @@ const resultFragment = xsltProcessor.transformToFragment(xmlDoc, document);
 // Display the transformed result in the page
 document.getElementById("result").appendChild(resultFragment);
 ```
+
+#### Result
+
+{{EmbedLiveSample("using_importStylesheet", "", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
+++ b/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
@@ -27,6 +27,52 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
+This example shows how `importStylesheet()` loads an XSLT stylesheet into an XSLTProcessor for use in transforming XML data.
+
+```html
+<div id="result"></div>
+```
+
+```js
+// Simple XML data
+const xmlString = `
+<items>
+    <item>Item 1</item>
+    <item>Item 2</item>
+</items>
+`;
+
+// Simple XSLT stylesheet
+const xsltString = `
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <ul>
+      <xsl:for-each select="items/item">
+        <li><xsl:value-of select="."/></li>
+      </xsl:for-each>
+    </ul>
+  </xsl:template>
+</xsl:stylesheet>
+`;
+
+// Parse the XML and XSLT strings into DOM objects
+const parser = new DOMParser();
+const xmlDoc = parser.parseFromString(xmlString, "application/xml");
+const xsltDoc = parser.parseFromString(xsltString, "application/xml");
+
+// Create an XSLTProcessor instance
+const xsltProcessor = new XSLTProcessor();
+
+// Import the XSLT stylesheet into the XSLTProcessor
+xsltProcessor.importStylesheet(xsltDoc);
+
+// Perform the transformation from XML to HTML
+const resultFragment = xsltProcessor.transformToFragment(xmlDoc, document);
+
+// Display the transformed result in the page
+document.getElementById("result").appendChild(resultFragment);
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
+++ b/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
@@ -29,7 +29,7 @@ None ({{jsxref("undefined")}}).
 
 ### Using importStylesheet()
 
-This example shows how `importStylesheet()` loads an XSLT stylesheet into an XSLTProcessor for use in transforming XML data.
+This example shows how `importStylesheet()` loads an XSLT stylesheet into an `XSLTProcessor` for use in transforming XML data.
 
 #### HTML
 


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/importStylesheet
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/xsltprocessor/importstylesheet/index.md
* Last commit: https://github.com/mdn/content/commit/7972ac25580ffbfb160e6d40013bbab3013d7cbe