### PR TITLE
Fixed no examples in XSLTProcessor `transformToDocument()` method

### DIFF
--- a/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
+++ b/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
@@ -33,28 +33,32 @@ A {{domxref("Document")}}. The actual interface depends on the [output method](h
 
 ## Examples
 
+### Using transformToDocument()
+
 This example demonstrates how to use `transformToDocument()` to transform an XML document using XSLT, resulting in a new XML document structure.
+
+#### HTML
 
 ```html
 <div id="result"></div>
 ```
 
+#### JavaScript
+
 ```js
-// Sample XML data
 const xmlString = `
 <books>
-    <book>
-        <title>Book 1</title>
-        <author>Author 1</author>
-    </book>
-    <book>
-        <title>Book 2</title>
-        <author>Author 2</author>
-    </book>
+  <book>
+    <title>Book 1</title>
+    <author>Author 1</author>
+  </book>
+  <book>
+    <title>Book 2</title>
+    <author>Author 2</author>
+  </book>
 </books>
 `;
 
-// Sample XSLT stylesheet
 const xsltString = `
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" indent="yes"/>
@@ -71,12 +75,10 @@ const xsltString = `
 </xsl:stylesheet>
 `;
 
-// Parse the XML and XSLT strings into DOM objects
 const parser = new DOMParser();
 const xmlDoc = parser.parseFromString(xmlString, "application/xml");
 const xsltDoc = parser.parseFromString(xsltString, "application/xml");
 
-// Create an XSLTProcessor instance
 const xsltProcessor = new XSLTProcessor();
 xsltProcessor.importStylesheet(xsltDoc);
 
@@ -90,6 +92,10 @@ const resultString = serializer.serializeToString(resultDoc);
 // Display the transformed XML in the page
 document.getElementById("result").textContent = resultString;
 ```
+
+#### Result
+
+{{EmbedLiveSample("using_transformToDocument", "", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
+++ b/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
@@ -33,6 +33,8 @@ A {{domxref("Document")}}. The actual interface depends on the [output method](h
 
 ## Examples
 
+This example demonstrates how to use `transformToDocument()` to transform an XML document using XSLT, resulting in a new XML document structure.
+
 ```html
 <div id="result"></div>
 ```

--- a/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
+++ b/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
@@ -34,7 +34,7 @@ A {{domxref("Document")}}. The actual interface depends on the [output method](h
 ## Examples
 
 ```html
-<pre id="result"></pre>
+<div id="result"></div>
 ```
 
 ```js

--- a/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
+++ b/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
@@ -33,6 +33,62 @@ A {{domxref("Document")}}. The actual interface depends on the [output method](h
 
 ## Examples
 
+```html
+<pre id="result"></pre>
+```
+
+```js
+// Sample XML data
+const xmlString = `
+<books>
+    <book>
+        <title>Book 1</title>
+        <author>Author 1</author>
+    </book>
+    <book>
+        <title>Book 2</title>
+        <author>Author 2</author>
+    </book>
+</books>
+`;
+
+// Sample XSLT stylesheet
+const xsltString = `
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <catalog>
+      <xsl:for-each select="books/book">
+        <item>
+          <name><xsl:value-of select="title"/></name>
+          <writer><xsl:value-of select="author"/></writer>
+        </item>
+      </xsl:for-each>
+    </catalog>
+  </xsl:template>
+</xsl:stylesheet>
+`;
+
+// Parse the XML and XSLT strings into DOM objects
+const parser = new DOMParser();
+const xmlDoc = parser.parseFromString(xmlString, "application/xml");
+const xsltDoc = parser.parseFromString(xsltString, "application/xml");
+
+// Create an XSLTProcessor instance
+const xsltProcessor = new XSLTProcessor();
+xsltProcessor.importStylesheet(xsltDoc);
+
+// Perform the transformation, returning the result as a new XML document
+const resultDoc = xsltProcessor.transformToDocument(xmlDoc);
+
+// Serialize the result document to a string
+const serializer = new XMLSerializer();
+const resultString = serializer.serializeToString(resultDoc);
+
+// Display the transformed XML in the page
+document.getElementById("result").textContent = resultString;
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
+++ b/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
@@ -40,7 +40,7 @@ This example demonstrates how to use `transformToDocument()` to transform an XML
 #### HTML
 
 ```html
-<div id="result"></div>
+<pre id="result"></pre>
 ```
 
 #### JavaScript


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/transformToDocument
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/xsltprocessor/transformtodocument/index.md
* Last commit: https://github.com/mdn/content/commit/b71d118ffc6d72b77efad9661110fcc9ede464eb