### PR TITLE
Remove unnecessary CSS rule targeting non-existent <em> tags in form

### DIFF
--- a/files/en-us/learn/forms/how_to_structure_a_web_form/example/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/example/index.md
@@ -170,18 +170,11 @@ button {
 }
 
 label {
-  position: relative;
   display: inline-block;
 }
 
 p label {
   width: 100%;
-}
-
-label em {
-  position: absolute;
-  right: 5px;
-  top: 20px;
 }
 ```
 

--- a/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
+++ b/files/en-us/learn/forms/how_to_structure_a_web_form/index.md
@@ -378,18 +378,11 @@ Let's put these ideas into practice and build a slightly more involved form — 
    }
 
    label {
-     position: relative;
      display: inline-block;
    }
 
    p label {
      width: 100%;
-   }
-
-   label em {
-     position: absolute;
-     right: 5px;
-     top: 20px;
    }
    ```
 


### PR DESCRIPTION
There is no `<em>` tag in the form. So no need to style it.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->
Description
<!-- ✍️ Summarize your changes in one or two sentences -->
Removed the unnecessary CSS rule targeting the `<em>` tag within `<label>` elements, as no such elements exist in the current HTML structure.

Motivation
<!-- ❓ Why are you making these changes and how do they help readers? -->
This change cleans up the CSS by removing unused styles, making the codebase more maintainable and easier to read. It also prevents potential confusion for future contributors who may wonder why the rule exists when there are no `<em>` tags in the form.

Additional details
<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
N/A

Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
N/A

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->