### PR TITLE
fix: replace leftover glP3 with gl in drawingBufferColorSpace example

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/drawingbuffercolorspace/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbuffercolorspace/index.md
@@ -30,7 +30,7 @@ const canvas = document.getElementById("canvas");
 const gl = canvas.getContext("webgl");
 gl.drawingBufferColorSpace = "display-p3";
 gl.clearColor(1, 0, 0, 1);
-gl.clear(glP3.COLOR_BUFFER_BIT);
+gl.clear(gl.COLOR_BUFFER_BIT);
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fix a misnamed variable, probably coming from the source example it was taken from.

### Motivation

The example would throw an error because glP3 doesn't exist

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

N/A

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
