### PR TITLE
"message" in window.confirm(message) is optional

### DIFF
--- a/files/en-us/web/api/window/confirm/index.md
+++ b/files/en-us/web/api/window/confirm/index.md
@@ -15,12 +15,13 @@ Under some conditions — for example, when the user switches tabs — the brows
 ## Syntax
 
 ```js-nolint
+confirm()
 confirm(message)
 ```
 
 ### Parameters
 
-- `message`
+- `message` {{optional_inline}}
   - : A string you want to display in the confirmation dialog.
 
 ### Return value


### PR DESCRIPTION
Small change inspired by almost identical method: https://developer.mozilla.org/en-US/docs/Web/API/Window/alert

Demonstration of calling `confirm()` with no arguments:
![image](https://github.com/user-attachments/assets/6862692e-748d-42a3-9cbc-0f99410182af)
