### PR TITLE
Adapt SVGLengthList to correct API structure, write subpages

### DIFF
--- a/files/en-us/web/api/svglengthlist/appenditem/index.md
+++ b/files/en-us/web/api/svglengthlist/appenditem/index.md
@@ -32,7 +32,7 @@ The {{domxref("SVGLength")}} that was added to the list.
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/svglengthlist/appenditem/index.md
+++ b/files/en-us/web/api/svglengthlist/appenditem/index.md
@@ -1,0 +1,43 @@
+---
+title: "SVGLengthList: appendItem() method"
+short-title: appendItem()
+slug: Web/API/SVGLengthList/appendItem
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.appendItem
+---
+
+{{APIRef("SVG")}}
+
+The **`appendItem()`** method of the {{domxref("SVGLengthList")}} interface inserts a new item at the end of the list. If the given item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy.
+
+## Syntax
+
+```js-nolint
+appendItem(newItem)
+```
+
+### Parameters
+
+- `newItem`
+  - : The {{domxref("SVGLength")}} to add to the list.
+
+### Return value
+
+The {{domxref("SVGLength")}} that was added to the list.
+
+### Exceptions
+
+- {{domxref("DOMException")}} `NoModificationAllowedError`
+  - : Thrown when the list is read-only.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/clear/index.md
+++ b/files/en-us/web/api/svglengthlist/clear/index.md
@@ -1,0 +1,42 @@
+---
+title: "SVGLengthList: clear() method"
+short-title: clear()
+slug: Web/API/SVGLengthList/clear
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.clear
+---
+
+{{APIRef("SVG")}}
+
+The **`clear()`** method of the {{domxref("SVGLengthList")}} interface clears all existing current items from the list, with the result being an empty list.
+
+## Syntax
+
+```js-nolint
+clear()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- {{domxref("DOMException")}} `NoModificationAllowedError`
+  - : Thrown when the list is read-only.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/clear/index.md
+++ b/files/en-us/web/api/svglengthlist/clear/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGLengthList.clear
 
 {{APIRef("SVG")}}
 
-The **`clear()`** method of the {{domxref("SVGLengthList")}} interface clears all existing current items from the list, with the result being an empty list.
+The **`clear()`** method of the {{domxref("SVGLengthList")}} interface clears all existing items from the list, with the result being an empty list.
 
 ## Syntax
 
@@ -31,7 +31,7 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/svglengthlist/getitem/index.md
+++ b/files/en-us/web/api/svglengthlist/getitem/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGLengthList.getItem
 
 {{APIRef("SVG")}}
 
-The **`getItem()`** method of the {{domxref("SVGLengthList")}} interface returns the specified item from the list. The returned item is the item itself and not a copy. Any changes made to the item are immediately reflected in the list. The first item is number 0.
+The **`getItem()`** method of the {{domxref("SVGLengthList")}} interface returns the specified item from the list. The returned item is the item itself and not a copy. Any changes made to the item are immediately reflected in the list. The first item is indexed 0.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ The {{domxref("SVGLength")}} at the specified index in the list.
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/svglengthlist/getitem/index.md
+++ b/files/en-us/web/api/svglengthlist/getitem/index.md
@@ -1,0 +1,43 @@
+---
+title: "SVGLengthList: getItem() method"
+short-title: getItem()
+slug: Web/API/SVGLengthList/getItem
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.getItem
+---
+
+{{APIRef("SVG")}}
+
+The **`getItem()`** method of the {{domxref("SVGLengthList")}} interface returns the specified item from the list. The returned item is the item itself and not a copy. Any changes made to the item are immediately reflected in the list. The first item is number 0.
+
+## Syntax
+
+```js-nolint
+getItem(index)
+```
+
+### Parameters
+
+- `index`
+  - : A non-negative integer that specifies the index of the item to retrieve.
+
+### Return value
+
+The {{domxref("SVGLength")}} at the specified index in the list.
+
+### Exceptions
+
+- {{domxref("DOMException")}} `IndexSizeError`
+  - : Thrown when the index is out of bounds for the list.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/index.md
+++ b/files/en-us/web/api/svglengthlist/index.md
@@ -7,11 +7,11 @@ browser-compat: api.SVGLengthList
 
 {{APIRef("SVG")}}
 
-The `SVGLengthList` defines a list of {{ domxref("SVGLength") }} objects. It is used for the {{domxref("SVGAnimatedLengthList.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLengthList.animVal", "animVal")}} properties of {{domxref("SVGAnimatedLengthList")}}.
+The `SVGLengthList` interface defines a list of {{ domxref("SVGLength") }} objects. It is used for the {{domxref("SVGAnimatedLengthList.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLengthList.animVal", "animVal")}} properties of {{domxref("SVGAnimatedLengthList")}}.
 
 An `SVGLengthList` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-An `SVGLengthList` is indexable and can be accessed like an array.
+An `SVGLengthList` object is indexable and can be accessed like an array.
 
 ## Instance properties
 
@@ -25,9 +25,9 @@ An `SVGLengthList` is indexable and can be accessed like an array.
 - {{domxref("SVGLengthList.appendItem", "appendItem()")}}
   - : Inserts a new item at the end of the list.
 - {{domxref("SVGLengthList.clear", "clear()")}}
-  - : Clears all existing current items from the list, with the result being an empty list.
+  - : Clears all existing items from the list, with the result being an empty list.
 - {{domxref("SVGLengthList.initialize", "initialize()")}}
-  - : Clears all existing current items from the list and re-initializes the list to hold the single item specified by the parameter.
+  - : Clears all existing items from the list and re-initializes the list to hold the single item specified by the parameter.
 - {{domxref("SVGLengthList.getItem", "getItem()")}}
   - : Returns the specified item from the list.
 - {{domxref("SVGLengthList.insertItemBefore", "insertItemBefore()")}}
@@ -41,7 +41,7 @@ An `SVGLengthList` is indexable and can be accessed like an array.
 
 ### Using SVGLengthList
 
-`SVGLengthList` can be retrived from {{domxref("SVGAnimatedLengthList")}}, which itself is retrievable from many animatable length attributes, such as {{domxref("SVGTextPositioningElement.x")}}.
+An `SVGLengthList` object can be retrived from an {{domxref("SVGAnimatedLengthList")}} object, which itself is retrievable from many animatable length attributes, such as {{domxref("SVGTextPositioningElement.x")}}.
 
 #### HTML
 

--- a/files/en-us/web/api/svglengthlist/index.md
+++ b/files/en-us/web/api/svglengthlist/index.md
@@ -7,297 +7,112 @@ browser-compat: api.SVGLengthList
 
 {{APIRef("SVG")}}
 
-## SVG length list interface
-
-The `SVGLengthList` defines a list of {{ domxref("SVGLength") }} objects.
+The `SVGLengthList` defines a list of {{ domxref("SVGLength") }} objects. It is used for the {{domxref("SVGAnimatedLengthList.baseVal", "baseVal")}} and {{domxref("SVGAnimatedLengthList.animVal", "animVal")}} properties of {{domxref("SVGAnimatedLengthList")}}.
 
 An `SVGLengthList` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
 An `SVGLengthList` is indexable and can be accessed like an array.
 
-### Interface overview
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <th scope="row">Also implement</th>
-      <td><em>None</em></td>
-    </tr>
-    <tr>
-      <th scope="row">Methods</th>
-      <td>
-        <ul>
-          <li><code>void clear()</code></li>
-          <li>
-            {{ domxref("SVGLength") }}
-            <code
-              >initialize(in {{ domxref("SVGLength") }}
-              <em>newItem</em>)</code
-            >
-          </li>
-          <li>
-            {{ domxref("SVGLength") }}
-            <code>getItem(in unsigned long <em>index</em>)</code>
-          </li>
-          <li>
-            {{ domxref("SVGLength") }}
-            <code
-              >insertItemBefore(in {{ domxref("SVGLength") }}
-              <em>newItem</em>, in unsigned long <em>index</em>)</code
-            >
-          </li>
-          <li>
-            {{ domxref("SVGLength") }} <code>replaceItem(</code
-            ><code
-              >in {{ domxref("SVGLength") }} <em>newItem</em>, in
-              unsigned long <em>index</em></code
-            ><code>)</code>
-          </li>
-          <li>
-            {{ domxref("SVGLength") }}
-            <code>removeItem(in unsigned long <em>index</em>)</code>
-          </li>
-          <li>
-            {{ domxref("SVGLength") }}
-            <code
-              >appendItem(in {{ domxref("SVGLength") }}
-              <em>newItem</em>)</code
-            >
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Properties</th>
-      <td>
-        <ul>
-          <li>readonly unsigned long <code>numberOfItems</code></li>
-          <li>
-            readonly unsigned long
-            <code>length</code> {{ non-standard_inline() }}
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Normative document</th>
-      <td>
-        <a href="https://www.w3.org/TR/SVG11/types.html#InterfaceSVGLengthList"
-          >SVG 1.1 (2nd Edition)</a
-        >
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## Instance properties
 
-| Name                                 | Type          | Description                      |
-| ------------------------------------ | ------------- | -------------------------------- |
-| `numberOfItems`                      | unsigned long | The number of items in the list. |
-| `length` {{ non-standard_inline() }} | unsigned long | The number of items in the list. |
+- {{domxref("SVGLengthList.length", "length")}}
+  - : The number of items in the list.
+- {{domxref("SVGLengthList.numberOfItems", "numberOfItems")}}
+  - : The number of items in the list.
 
 ## Instance methods
 
-<table class="standard-table">
-  <thead>
-    <tr>
-      <th>Name &#x26; Arguments</th>
-      <th>Return</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code><strong>clear</strong>()</code>
-      </td>
-      <td><em>void</em></td>
-      <td>
-        <p>
-          Clears all existing current items from the list, with the result being
-          an empty list.
-        </p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code><strong>initialize</strong>(</code
-        ><code>in {{ domxref("SVGLength") }} <em>newItem</em></code
-        ><code>)</code>
-      </td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        <p>
-          Clears all existing current items from the list and re-initializes the
-          list to hold the single item specified by the parameter. If the
-          inserted item is already in a list, it is removed from its previous
-          list before it is inserted into this list. The inserted item is the
-          item itself and not a copy. The return value is the item inserted into
-          the list.
-        </p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code><strong>getItem</strong>(in unsigned long <em>index</em>)</code>
-      </td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        <p>
-          Returns the specified item from the list. The returned item is the
-          item itself and not a copy. Any changes made to the item are
-          immediately reflected in the list. The first item is number 0.
-        </p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code
-          ><strong>insertItemBefore</strong>(in
-          {{ domxref("SVGLength") }} <em>newItem</em>, in unsigned
-          long <em>index</em>)</code
-        >
-      </td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        <p>
-          Inserts a new item into the list at the specified position. The first
-          item is number 0. If <code>newItem</code> is already in a list, it is
-          removed from its previous list before it is inserted into this list.
-          The inserted item is the item itself and not a copy. If the item is
-          already in this list, note that the index of the item to insert before
-          is before the removal of the item. If the <code>index</code> is equal
-          to 0, then the new item is inserted at the front of the list. If the
-          index is greater than or equal to <code>numberOfItems</code>, then the
-          new item is appended to the end of the list.
-        </p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code><strong>replaceItem</strong>(</code
-        ><code
-          >in {{ domxref("SVGLength") }} <em>newItem</em>, in unsigned
-          long <em>index</em></code
-        ><code>)</code>
-      </td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        <p>
-          Replaces an existing item in the list with a new item. If
-          <code>newItem</code> is already in a list, it is removed from its
-          previous list before it is inserted into this list. The inserted item
-          is the item itself and not a copy. If the item is already in this
-          list, note that the index of the item to replace is before the removal
-          of the item.
-        </p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>INDEX_SIZE_ERR</code> is raised if the index number is greater
-            than or equal to <code>numberOfItems</code>.
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code
-          ><strong>removeItem</strong>(in unsigned long <em>index</em>)</code
-        >
-      </td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        <p>Removes an existing item from the list.</p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>INDEX_SIZE_ERR</code> is raised if the index number is greater
-            than or equal to <code>numberOfItems</code>.
-          </li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code
-          ><strong>appendItem</strong>(in {{ domxref("SVGLength") }}
-          <em>newItem</em>)</code
-        >
-      </td>
-      <td>{{ domxref("SVGLength") }}</td>
-      <td>
-        <p>
-          Inserts a new item at the end of the list. If <code>newItem</code> is
-          already in a list, it is removed from its previous list before it is
-          inserted into this list. The inserted item is the item itself and not
-          a copy.
-        </p>
-        <p><strong>Exceptions:</strong></p>
-        <ul>
-          <li>
-            a {{ domxref("DOMException") }} with code
-            <code>NO_MODIFICATION_ALLOWED_ERR</code> is raised when the list
-            corresponds to a read only attribute or when the object itself is
-            read only.
-          </li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
+- {{domxref("SVGLengthList.appendItem", "appendItem()")}}
+  - : Inserts a new item at the end of the list.
+- {{domxref("SVGLengthList.clear", "clear()")}}
+  - : Clears all existing current items from the list, with the result being an empty list.
+- {{domxref("SVGLengthList.initialize", "initialize()")}}
+  - : Clears all existing current items from the list and re-initializes the list to hold the single item specified by the parameter.
+- {{domxref("SVGLengthList.getItem", "getItem()")}}
+  - : Returns the specified item from the list.
+- {{domxref("SVGLengthList.insertItemBefore", "insertItemBefore()")}}
+  - : Inserts a new item into the list at the specified position.
+- {{domxref("SVGLengthList.removeItem", "removeItem()")}}
+  - : Removes an existing item from the list.
+- {{domxref("SVGLengthList.replaceItem", "replaceItem()")}}
+  - : Replaces an existing item in the list with a new item.
+
+## Examples
+
+### Using SVGLengthList
+
+`SVGLengthList` can be retrived from {{domxref("SVGAnimatedLengthList")}}, which itself is retrievable from many animatable length attributes, such as {{domxref("SVGTextPositioningElement.x")}}.
+
+#### HTML
+
+```html
+<svg
+  viewBox="0 0 200 100"
+  xmlns="http://www.w3.org/2000/svg"
+  width="200"
+  height="100">
+  <text id="text1" x="10" y="50">Hello</text>
+</svg>
+<button id="equally-distribute">Equally distribute letters</button>
+<button id="reset-spacing">Reset spacing</button>
+<div>
+  <b>Current <code>SVGLengthList</code></b>
+  <pre><output id="output"></output></pre>
+</div>
+```
+
+#### JavaScript
+
+```js
+const text = document.getElementById("text1");
+const output = document.getElementById("output");
+const list = text.x.baseVal;
+function equallyDistribute() {
+  list.clear();
+  for (let i = 0; i < text.textContent.length; i++) {
+    const length = text.ownerSVGElement.createSVGLength();
+    length.value = i * 20 + 10;
+    list.appendItem(length);
+  }
+  printList();
+}
+function resetSpacing() {
+  const length = text.ownerSVGElement.createSVGLength();
+  length.value = 10;
+  list.initialize(length);
+  printList();
+}
+function printList() {
+  output.textContent = "";
+  for (let i = 0; i < list.length; i++) {
+    output.innerText += list.getItem(i).value + "\n";
+  }
+}
+printList();
+
+document
+  .getElementById("equally-distribute")
+  .addEventListener("click", equallyDistribute);
+document
+  .getElementById("reset-spacing")
+  .addEventListener("click", resetSpacing);
+```
+
+#### Result
+
+{{EmbedLiveSample("Using SVGLengthList", "", "300")}}
+
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("SVGNumberList")}}
+- {{domxref("SVGPointList")}}
+- {{domxref("SVGStringList")}}
+- {{domxref("SVGTransformList")}}

--- a/files/en-us/web/api/svglengthlist/initialize/index.md
+++ b/files/en-us/web/api/svglengthlist/initialize/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGLengthList.initialize
 
 {{APIRef("SVG")}}
 
-The **`initialize()`** method of the {{domxref("SVGLengthList")}} interface clears all existing current items from the list and re-initializes the list to hold the single item specified by the parameter. If the inserted item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. The return value is the item inserted into the list.
+The **`initialize()`** method of the {{domxref("SVGLengthList")}} interface clears all existing items from the list and re-initializes the list to hold the single item specified by the parameter. If the inserted item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. The return value is the item inserted into the list.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ The {{domxref("SVGLength")}} that was added to the list.
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/svglengthlist/initialize/index.md
+++ b/files/en-us/web/api/svglengthlist/initialize/index.md
@@ -1,0 +1,43 @@
+---
+title: "SVGLengthList: initialize() method"
+short-title: initialize()
+slug: Web/API/SVGLengthList/initialize
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.initialize
+---
+
+{{APIRef("SVG")}}
+
+The **`initialize()`** method of the {{domxref("SVGLengthList")}} interface clears all existing current items from the list and re-initializes the list to hold the single item specified by the parameter. If the inserted item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. The return value is the item inserted into the list.
+
+## Syntax
+
+```js-nolint
+initialize(newItem)
+```
+
+### Parameters
+
+- `newItem`
+  - : The {{domxref("SVGLength")}} to add to the list.
+
+### Return value
+
+The {{domxref("SVGLength")}} that was added to the list.
+
+### Exceptions
+
+- {{domxref("DOMException")}} `NoModificationAllowedError`
+  - : Thrown when the list is read-only.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/insertitembefore/index.md
+++ b/files/en-us/web/api/svglengthlist/insertitembefore/index.md
@@ -1,0 +1,45 @@
+---
+title: "SVGLengthList: insertItemBefore() method"
+short-title: insertItemBefore()
+slug: Web/API/SVGLengthList/insertItemBefore
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.insertItemBefore
+---
+
+{{APIRef("SVG")}}
+
+The **`insertItemBefore()`** method of the {{domxref("SVGLengthList")}} interface inserts a new item into the list at the specified position. The first item is number 0. If the new item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. If the item is already in this list, note that the index of the item to insert before is before the removal of the item. If the index is equal to 0, then the new item is inserted at the front of the list. If the index is greater than or equal to the {{domxref("SVGLengthList.length", "length")}}, then the new item is appended to the end of the list.
+
+## Syntax
+
+```js-nolint
+insertItemBefore(newItem, index)
+```
+
+### Parameters
+
+- `newItem`
+  - : The {{domxref("SVGLength")}} to add to the list.
+- `index`
+  - : A non-negative integer that specifies the index of the item to insert the new item before.
+
+### Return value
+
+The {{domxref("SVGLength")}} that was added to the list.
+
+### Exceptions
+
+- {{domxref("DOMException")}} `NoModificationAllowedError`
+  - : Thrown when the list is read-only.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/insertitembefore/index.md
+++ b/files/en-us/web/api/svglengthlist/insertitembefore/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGLengthList.insertItemBefore
 
 {{APIRef("SVG")}}
 
-The **`insertItemBefore()`** method of the {{domxref("SVGLengthList")}} interface inserts a new item into the list at the specified position. The first item is number 0. If the new item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. If the item is already in this list, note that the index of the item to insert before is before the removal of the item. If the index is equal to 0, then the new item is inserted at the front of the list. If the index is greater than or equal to the {{domxref("SVGLengthList.length", "length")}}, then the new item is appended to the end of the list.
+The **`insertItemBefore()`** method of the {{domxref("SVGLengthList")}} interface inserts a new item into the list at the specified position. The first item is indexed 0. If the new item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. If the item is already in this list, note that the index of the item to insert before is before the removal of the item. If the index is equal to 0, then the new item is inserted at the front of the list. If the index is greater than or equal to the {{domxref("SVGLengthList.length", "length")}}, then the new item is appended to the end of the list.
 
 ## Syntax
 
@@ -34,7 +34,7 @@ The {{domxref("SVGLength")}} that was added to the list.
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/svglengthlist/length/index.md
+++ b/files/en-us/web/api/svglengthlist/length/index.md
@@ -1,0 +1,19 @@
+---
+title: "SVGLengthList: length property"
+short-title: length
+slug: Web/API/SVGLengthList/length
+page-type: web-api-instance-property
+browser-compat: api.SVGLengthList.length
+---
+
+{{APIRef("SVG")}}
+
+The **`length`** property of the {{domxref("SVGLengthList")}} interface returns the number of items in the list. It is an alias of {{domxref("SVGLengthList.numberOfItems", "numberOfItems")}} to make SVG lists more [array-like](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array-like_objects).
+
+## Value
+
+A non-negative integer that represents the number of items in the list.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} for a complete example.

--- a/files/en-us/web/api/svglengthlist/numberofitems/index.md
+++ b/files/en-us/web/api/svglengthlist/numberofitems/index.md
@@ -1,0 +1,19 @@
+---
+title: "SVGLengthList: numberOfItems property"
+short-title: numberOfItems
+slug: Web/API/SVGLengthList/numberOfItems
+page-type: web-api-instance-property
+browser-compat: api.SVGLengthList.numberOfItems
+---
+
+{{APIRef("SVG")}}
+
+The **`numberOfItems`** property of the {{domxref("SVGLengthList")}} interface returns the number of items in the list. {{domxref("SVGLengthList.length", "length")}} is an alias of of it.
+
+## Value
+
+A non-negative integer that represents the number of items in the list.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} for a complete example.

--- a/files/en-us/web/api/svglengthlist/removeitem/index.md
+++ b/files/en-us/web/api/svglengthlist/removeitem/index.md
@@ -34,7 +34,7 @@ The {{domxref("SVGLength")}} that was removed from the list.
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 

--- a/files/en-us/web/api/svglengthlist/removeitem/index.md
+++ b/files/en-us/web/api/svglengthlist/removeitem/index.md
@@ -1,0 +1,45 @@
+---
+title: "SVGLengthList: removeItem() method"
+short-title: removeItem()
+slug: Web/API/SVGLengthList/removeItem
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.removeItem
+---
+
+{{APIRef("SVG")}}
+
+The **`removeItem()`** method of the {{domxref("SVGLengthList")}} interface removes an existing item at the given index from the list.
+
+## Syntax
+
+```js-nolint
+removeItem(index)
+```
+
+### Parameters
+
+- `index`
+  - : A non-negative integer that specifies the index of the item to delete.
+
+### Return value
+
+The {{domxref("SVGLength")}} that was removed from the list.
+
+### Exceptions
+
+- {{domxref("DOMException")}} `NoModificationAllowedError`
+  - : Thrown when the list is read-only.
+- {{domxref("DOMException")}} `IndexSizeError`
+  - : Thrown when the index is out of bounds for the list.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/replaceitem/index.md
+++ b/files/en-us/web/api/svglengthlist/replaceitem/index.md
@@ -1,0 +1,47 @@
+---
+title: "SVGLengthList: replaceItem() method"
+short-title: replaceItem()
+slug: Web/API/SVGLengthList/replaceItem
+page-type: web-api-instance-method
+browser-compat: api.SVGLengthList.replaceItem
+---
+
+{{APIRef("SVG")}}
+
+The **`replaceItem()`** method of the {{domxref("SVGLengthList")}} interface replaces an existing item in the list with a new item. If the new item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. If the item is already in this list, note that the index of the item to replace is before the removal of the item.
+
+## Syntax
+
+```js-nolint
+replaceItem(newItem, index)
+```
+
+### Parameters
+
+- `newItem`
+  - : The {{domxref("SVGLength")}} to add to the list.
+- `index`
+  - : A non-negative integer that specifies the index of the item to delete.
+
+### Return value
+
+The {{domxref("SVGLength")}} that was added the list.
+
+### Exceptions
+
+- {{domxref("DOMException")}} `NoModificationAllowedError`
+  - : Thrown when the list is read-only.
+- {{domxref("DOMException")}} `IndexSizeError`
+  - : Thrown when the index is out of bounds for the list.
+
+## Examples
+
+See {{domxref("SVGLengthList")}} a complete example.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svglengthlist/replaceitem/index.md
+++ b/files/en-us/web/api/svglengthlist/replaceitem/index.md
@@ -36,7 +36,7 @@ The {{domxref("SVGLength")}} that was added the list.
 
 ## Examples
 
-See {{domxref("SVGLengthList")}} a complete example.
+See {{domxref("SVGLengthList")}} for a complete example.
 
 ## Specifications
 


### PR DESCRIPTION
This PR writes the pages for `SVGLengthList` because the landing page is not the correct structure. Once accepted we can use the same format for the other SVG lists.