### PR TITLE
Remove window prefix in requestAnimationFrame example

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -77,11 +77,11 @@ function step(timeStamp) {
   element.style.transform = `translateX(${shift}px)`;
   if (shift < 200) {
     previousTimeStamp = timeStamp;
-    window.requestAnimationFrame(step);
+    requestAnimationFrame(step);
   }
 }
 
-window.requestAnimationFrame(step);
+requestAnimationFrame(step);
 ```
 
 The following three examples illustrate different approaches to setting the zero point in time,


### PR DESCRIPTION
window prefix unnecessary and inconsistent

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes the window prefix from the one example using it.

### Motivation

Unnecessary and inconsistent with other examples. Can be confusing why its used in this one example and not in others.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
