### PR TITLE
Add link to Event interface in close event article

### DIFF
--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -90,3 +90,4 @@ closeButton.addEventListener("click", () => {
 ## See also
 
 - HTML [`<dialog>`](/en-US/docs/Web/HTML/Element/dialog) element
+- The [`Event`](/en-US/docs/Web/API/Event) interface


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add link to Event interface in close event article

### Motivation

I didn't see any other way to get from this article to the general Event article without searching for it explicitly.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
