### PR TITLE
Typo fixed 

### DIFF
--- a/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
@@ -112,7 +112,7 @@ Container names also enable querying styles from elements that aren't a direct p
 
 Set `container-name: none` to prevent the container from matching any named container queries. That removes all associated container query names, but does not prevent the element from matching unnamed queries.
 
-To prevent an element from being a size container, set `container-type: normal`. This removes containment, meaning the element isn't a size container (it can still be a [style container](#container_style_queries).
+To prevent an element from being a size container, set `container-type: normal`. This removes containment, meaning the element isn't a size container (it can still be a [style container](#container_style_queries)).
 
 To prevent an element from being matched by any container queries, provide it with an unused `container-name`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

Issue Fixed #35459 
### Description
Typo fix by adding parenthesis before the period. 
<!-- ✍️ Summarize your changes in one or two sentences -->

Before:
<img width="829" alt="image" src="https://github.com/user-attachments/assets/1e27c8b1-54f6-4a38-a132-3c5ebbb4183b">


After: 
<img width="753" alt="image" src="https://github.com/user-attachments/assets/7ba93cdc-0563-4d23-81f4-0af99f445880">


### Motivation
Clean up typo from the documentation.

<!-- 🔗 Page Link -->
Page Link: MDN URL
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_size_and_style_queries

### Related issues and pull requests
