### PR TITLE
Fix code example on CSS relative colors

### DIFF
--- a/files/en-us/web/css/css_colors/relative_colors/index.md
+++ b/files/en-us/web/css/css_colors/relative_colors/index.md
@@ -35,14 +35,14 @@ The browser converts the origin color to a syntax compatible with the color func
 
 Let's look at relative color syntax in action. The below CSS is used to style two {{htmlelement("div")}} elements, one with a absolute background color — `red` — and one with a relative background color created with the `rgb()` function, based on the same `red` color value:
 
-```html hidden
+```html hidden live-sample___simple-relative-color
 <div id="container">
   <div class="item" id="one"></div>
   <div class="item" id="two"></div>
 </div>
 ```
 
-```css hidden
+```css hidden live-sample___simple-relative-color
 #container {
   display: flex;
   width: 100vw;
@@ -56,7 +56,7 @@ Let's look at relative color syntax in action. The below CSS is used to style tw
 }
 ```
 
-```css
+```css live-sample___simple-relative-color
 #one {
   background-color: red;
 }
@@ -68,7 +68,7 @@ Let's look at relative color syntax in action. The below CSS is used to style tw
 
 The output is as follows:
 
-{{ EmbedLiveSample("General syntax", "100%", "200") }}
+{{ EmbedLiveSample("simple-relative-color", "100%", "200") }}
 
 The relative color uses the [`rgb()`](/en-US/docs/Web/CSS/color_value/rgb) function, which takes `red` as the origin color, converts it to an equivalent `rgb()` color (`rgb(255 0 0)`) and then defines the new color as having a red channel of value `200` and green and blue channels with a value the same as the origin color (it uses the `g` and `b` values made available inside the function by the browser, which are both equal to `0`).
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added [code block IDs](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Live_samples#grouping_code_blocks)

### Motivation

Prevent unrelated snippets breaking first example on [Relative colors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors)

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #35479

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
