### PR TITLE
docs: mention drawArrays gl_PointSize

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -56,6 +56,9 @@ None ({{jsxref("undefined")}}).
 gl.drawArrays(gl.POINTS, 0, 8);
 ```
 
+> [!NOTE]
+> If `mode` is `POINTS`, [`gl_PointSize`](https://www.opengl.org/sdk/docs/man4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -32,6 +32,9 @@ drawArrays(mode, first, count)
     - [`gl.TRIANGLE_FAN`](https://en.wikipedia.org/wiki/Triangle_fan)
     - `gl.TRIANGLES`: Draws a triangle for a group of three vertices.
 
+    > [!NOTE]
+    > If `mode` is `POINTS`, [`gl_PointSize`](https://www.opengl.org/sdk/docs/man4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
+
 - `first`
   - : A {{domxref("WebGL_API/Types", "GLint")}} specifying the starting index in the array of vector points.
 - `count`
@@ -55,9 +58,6 @@ None ({{jsxref("undefined")}}).
 ```js
 gl.drawArrays(gl.POINTS, 0, 8);
 ```
-
-> [!NOTE]
-> If `mode` is `POINTS`, [`gl_PointSize`](https://www.opengl.org/sdk/docs/man4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Makes note of `gl_PointSize`'s undefinedness.

### Motivation

This silent error may cause problems - it's worth noting.

### Additional details

https://www.opengl.org/sdk/docs/man4/html/gl_PointSize.xhtml
