### PR TITLE
"indexStart" in String.prototype.slice(indexStart) is optional, too

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -15,13 +15,14 @@ returns it as a new string, without modifying the original string.
 ## Syntax
 
 ```js-nolint
+slice()
 slice(indexStart)
 slice(indexStart, indexEnd)
 ```
 
 ### Parameters
 
-- `indexStart`
+- `indexStart` {{optional_inline}}
   - : The index of the first character to include in the returned substring.
 - `indexEnd` {{optional_inline}}
   - : The index of the first character to exclude from the returned substring.


### PR DESCRIPTION
Probably, we need to add some example for "slice()" with no arguments, which will return the copy of the string

![image](https://github.com/user-attachments/assets/f5f961bb-00a4-4e88-953f-fdc1c6ab51a8)

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
