### PR TITLE
Clarify note on customized built-ins support in Safari

### DIFF
--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -18,8 +18,7 @@ There are two types of custom element:
 
 - **Customized built-in elements** inherit from standard HTML elements such as {{domxref("HTMLImageElement")}} or {{domxref("HTMLParagraphElement")}}. Their implementation extends the behavior of select instances of the standard element.
 
-  > [!NOTE]
-  > [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
+  > [!NOTE] > [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
 
 ## Implementing a custom element
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -14,12 +14,12 @@ This article introduces custom elements, and walks through some examples.
 
 There are two types of custom element:
 
+- **Autonomous custom elements** inherit from the HTML element base class {{domxref("HTMLElement")}}. You have to implement their behavior from scratch.
+
 - **Customized built-in elements** inherit from standard HTML elements such as {{domxref("HTMLImageElement")}} or {{domxref("HTMLParagraphElement")}}. Their implementation extends the behavior of select instances of the standard element.
 
   > [!NOTE]
-  > Please see the [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute reference for caveats on implementation reality of custom built-in elements.
-
-- **Autonomous custom elements** inherit from the HTML element base class {{domxref("HTMLElement")}}. You have to implement their behavior from scratch.
+  > [Safari does not plan to support custom built-in elements](https://github.com/WebKit/standards-positions/issues/97) and [browser vendors are exploring alternative solutions to customizing built-ins](https://github.com/WICG/webcomponents/issues/1029). Check the [browser compatibility](#browser_compatibility) section for support information.
 
 ## Implementing a custom element
 


### PR DESCRIPTION
### Description

Re-order the custom element types to put the most supported type first and make the note about customized built-ins more useful.

I replaced the note here with the note from the is= attribute page, which is a lot more clear and informative.

### Motivation

The "Using Custom Elements" page lists customized build-ins first in the discussion of types of custom elements, even though it isn't and won't be supported in Safari. It seems like we should mention the cross-browser supported feature first.

Also, the note on this page doesn't actually say anything about the implementation status, but links to the is= attribute, making it harder to see that Safari will not implement the feature.

### Additional details

### Related issues and pull requests
