### PR TITLE
Add/complete BCD keys for SVG attributes

### DIFF
--- a/files/en-us/web/svg/attribute/attributename/index.md
+++ b/files/en-us/web/svg/attribute/attributename/index.md
@@ -2,7 +2,7 @@
 title: attributeName
 slug: Web/SVG/Attribute/attributeName
 page-type: svg-attribute
-spec-urls: https://svgwg.org/specs/animations/#AttributeNameAttribute
+browser-compat: svg.elements.animate.attributeName
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/attributetype/index.md
+++ b/files/en-us/web/svg/attribute/attributetype/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/attributeType
 page-type: svg-attribute
 status:
   - deprecated
-spec-urls: https://www.w3.org/TR/SVG11/animate.html#AttributeTypeAttribute
+browser-compat: svg.elements.animate.attributeType
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/baseprofile/index.md
+++ b/files/en-us/web/svg/attribute/baseprofile/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/baseProfile
 page-type: svg-attribute
 status:
   - deprecated
-spec-urls: https://www.w3.org/TR/SVG11/struct.html#SVGElementBaseProfileAttribute
+browser-compat: svg.elements.svg.baseProfile
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/calcmode/index.md
+++ b/files/en-us/web/svg/attribute/calcmode/index.md
@@ -2,7 +2,7 @@
 title: calcMode
 slug: Web/SVG/Attribute/calcMode
 page-type: svg-attribute
-spec-urls: https://svgwg.org/specs/animations/#CalcModeAttribute
+browser-compat: svg.elements.animateMotion.calcMode
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/clippathunits/index.md
+++ b/files/en-us/web/svg/attribute/clippathunits/index.md
@@ -2,7 +2,7 @@
 title: clipPathUnits
 slug: Web/SVG/Attribute/clipPathUnits
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/css-masking-1/#element-attrdef-clippath-clippathunits
+browser-compat: svg.elements.clipPath.clipPathUnits
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/crossorigin/index.md
+++ b/files/en-us/web/svg/attribute/crossorigin/index.md
@@ -2,7 +2,9 @@
 title: "SVG attribute: crossorigin"
 slug: Web/SVG/Attribute/crossorigin
 page-type: svg-attribute
-browser-compat: svg.elements.image.crossorigin
+browser-compat:
+  - svg.elements.feImage.crossorigin
+  - svg.elements.image.crossorigin
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/cx/index.md
+++ b/files/en-us/web/svg/attribute/cx/index.md
@@ -2,9 +2,10 @@
 title: cx
 slug: Web/SVG/Attribute/cx
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/geometry.html#CX
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCXAttribute
+browser-compat:
+  - svg.elements.circle.cx
+  - svg.elements.ellipse.cx
+  - svg.elements.radialGradient.cx
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/cy/index.md
+++ b/files/en-us/web/svg/attribute/cy/index.md
@@ -2,9 +2,10 @@
 title: cy
 slug: Web/SVG/Attribute/cy
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/geometry.html#CY
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCYAttribute
+browser-compat:
+  - svg.elements.circle.cy
+  - svg.elements.ellipse.cy
+  - svg.elements.radialGradient.cy
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/dx/index.md
+++ b/files/en-us/web/svg/attribute/dx/index.md
@@ -2,10 +2,12 @@
 title: dx
 slug: Web/SVG/Attribute/dx
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fedropshadow-dx
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feoffset-dx
-  - https://svgwg.org/svg2-draft/text.html#TextElementDXAttribute
+browser-compat:
+  - svg.elements.feDropShadow.dx
+  - svg.elements.feOffset.dx
+  - svg.elements.glyphRef.dx
+  - svg.elements.text.dx
+  - svg.elements.tspan.dx
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/dy/index.md
+++ b/files/en-us/web/svg/attribute/dy/index.md
@@ -2,10 +2,12 @@
 title: dy
 slug: Web/SVG/Attribute/dy
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fedropshadow-dy
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feoffset-dy
-  - https://svgwg.org/svg2-draft/text.html#TextElementDYAttribute
+browser-compat:
+  - svg.elements.feDropShadow.dy
+  - svg.elements.feOffset.dy
+  - svg.elements.glyphRef.dy
+  - svg.elements.text.dy
+  - svg.elements.tspan.dy
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/edgemode/index.md
+++ b/files/en-us/web/svg/attribute/edgemode/index.md
@@ -2,7 +2,9 @@
 title: edgeMode
 slug: Web/SVG/Attribute/edgeMode
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-edgemode
+browser-compat:
+  - svg.elements.feConvolveMatrix.edgeMode
+  - svg.elements.feGaussianBlur.edgeMode
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/g1/index.md
+++ b/files/en-us/web/svg/attribute/g1/index.md
@@ -4,7 +4,9 @@ slug: Web/SVG/Attribute/g1
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.hkern.g1
+browser-compat:
+  - svg.elements.hkern.g1
+  - svg.elements.vkern.g1
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/g2/index.md
+++ b/files/en-us/web/svg/attribute/g2/index.md
@@ -4,7 +4,9 @@ slug: Web/SVG/Attribute/g2
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.hkern.g2
+browser-compat:
+  - svg.elements.hkern.g2
+  - svg.elements.vkern.g2
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/gradienttransform/index.md
+++ b/files/en-us/web/svg/attribute/gradienttransform/index.md
@@ -2,7 +2,9 @@
 title: gradientTransform
 slug: Web/SVG/Attribute/gradientTransform
 page-type: svg-attribute
-browser-compat: svg.elements.linearGradient.gradientTransform
+browser-compat:
+  - svg.elements.linearGradient.gradientTransform
+  - svg.elements.radialGradient.gradientTransform
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/gradientunits/index.md
+++ b/files/en-us/web/svg/attribute/gradientunits/index.md
@@ -2,9 +2,9 @@
 title: gradientUnits
 slug: Web/SVG/Attribute/gradientUnits
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientUnitsAttribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientUnitsAttribute
+browser-compat:
+  - svg.elements.linearGradient.gradientUnits
+  - svg.elements.radialGradient.gradientUnits
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/height/index.md
+++ b/files/en-us/web/svg/attribute/height/index.md
@@ -2,12 +2,15 @@
 title: height
 slug: Web/SVG/Attribute/height
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-height
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-height
-  - https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-height
-  - https://svgwg.org/svg2-draft/geometry.html#Sizing
-  - https://svgwg.org/svg2-draft/pservers.html#PatternElementHeightAttribute
+browser-compat:
+  - svg.elements.filter.height
+  - svg.elements.foreignObject.height
+  - svg.elements.image.height
+  - svg.elements.mask.height
+  - svg.elements.pattern.height
+  - svg.elements.rect.height
+  - svg.elements.svg.height
+  - svg.elements.use.height
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/horiz-adv-x/index.md
+++ b/files/en-us/web/svg/attribute/horiz-adv-x/index.md
@@ -4,7 +4,10 @@ slug: Web/SVG/Attribute/horiz-adv-x
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.font.horiz-adv-x
+browser-compat:
+  - svg.elements.font.horiz-adv-x
+  - svg.elements.glyph.horiz-adv-x
+  - svg.elements.missing-glyph.horiz-adv-x
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/in/index.md
+++ b/files/en-us/web/svg/attribute/in/index.md
@@ -2,7 +2,21 @@
 title: in
 slug: Web/SVG/Attribute/in
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-in
+browser-compat:
+  - svg.elements.feBlend.in
+  - svg.elements.feColorMatrix.in
+  - svg.elements.feComponentTransfer.in
+  - svg.elements.feComposite.in
+  - svg.elements.feConvolveMatrix.in
+  - svg.elements.feDiffuseLighting.in
+  - svg.elements.feDisplacementMap.in
+  - svg.elements.feDropShadow.in
+  - svg.elements.feGaussianBlur.in
+  - svg.elements.feMergeNode.in
+  - svg.elements.feMorphology.in
+  - svg.elements.feOffset.in
+  - svg.elements.feSpecularLighting.in
+  - svg.elements.feTile.in
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/in2/index.md
+++ b/files/en-us/web/svg/attribute/in2/index.md
@@ -2,10 +2,10 @@
 title: in2
 slug: Web/SVG/Attribute/in2
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fedisplacementmap-in2
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-in2
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feblend-in2
+browser-compat:
+  - svg.elements.feBlend.in2
+  - svg.elements.feComposite.in2
+  - svg.elements.feDisplacementMap.in2
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/k/index.md
+++ b/files/en-us/web/svg/attribute/k/index.md
@@ -4,7 +4,9 @@ slug: Web/SVG/Attribute/k
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.hkern.k
+browser-compat:
+  - svg.elements.hkern.k
+  - svg.elements.vkern.k
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/kernelunitlength/index.md
+++ b/files/en-us/web/svg/attribute/kernelunitlength/index.md
@@ -2,10 +2,10 @@
 title: kernelUnitLength
 slug: Web/SVG/Attribute/kernelUnitLength
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-kernelunitlength
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-kernelunitlength
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-kernelunitlength
+browser-compat:
+  - svg.elements.feConvolveMatrix.kernelUnitLength
+  - svg.elements.feDiffuseLighting.kernelUnitLength
+  - svg.elements.feSpecularLighting.kernelUnitLength
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/lengthadjust/index.md
+++ b/files/en-us/web/svg/attribute/lengthadjust/index.md
@@ -2,7 +2,9 @@
 title: lengthAdjust
 slug: Web/SVG/Attribute/lengthAdjust
 page-type: svg-attribute
-browser-compat: svg.elements.text.lengthAdjust
+browser-compat:
+  - svg.elements.text.lengthAdjust
+  - svg.elements.tspan.lengthAdjust
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/name/index.md
+++ b/files/en-us/web/svg/attribute/name/index.md
@@ -4,9 +4,7 @@ slug: Web/SVG/Attribute/name
 page-type: svg-attribute
 status:
   - deprecated
-spec-urls:
-  - https://www.w3.org/TR/SVG11/fonts.html#FontFaceNameElementNameAttribute
-  - https://www.w3.org/TR/SVG11/color.html#ColorProfileElementNameAttribute
+browser-compat: svg.elements.font-face-name.name
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/operator/index.md
+++ b/files/en-us/web/svg/attribute/operator/index.md
@@ -2,9 +2,9 @@
 title: operator
 slug: Web/SVG/Attribute/operator
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-femorphology-operator
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-operator
+browser-compat:
+  - svg.elements.feComposite.operator
+  - svg.elements.feMorphology.operator
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/origin/index.md
+++ b/files/en-us/web/svg/attribute/origin/index.md
@@ -2,7 +2,7 @@
 title: origin
 slug: Web/SVG/Attribute/origin
 page-type: svg-attribute
-spec-urls: https://svgwg.org/specs/animations/#OriginAttribute
+browser-compat: svg.elements.animateMotion.origin
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/overline-position/index.md
+++ b/files/en-us/web/svg/attribute/overline-position/index.md
@@ -2,6 +2,7 @@
 title: overline-position
 slug: Web/SVG/Attribute/overline-position
 page-type: svg-attribute
+browser-compat: svg.elements.font-face.overline-position
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/overline-thickness/index.md
+++ b/files/en-us/web/svg/attribute/overline-thickness/index.md
@@ -2,6 +2,7 @@
 title: overline-thickness
 slug: Web/SVG/Attribute/overline-thickness
 page-type: svg-attribute
+browser-compat: svg.elements.font-face.overline-thickness
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/path/index.md
+++ b/files/en-us/web/svg/attribute/path/index.md
@@ -2,9 +2,9 @@
 title: path
 slug: Web/SVG/Attribute/path
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/text.html#TextPathElementPathAttribute
-  - https://svgwg.org/specs/animations/#AnimateMotionElementPathAttribute
+browser-compat:
+  - svg.elements.animateMotion.path
+  - svg.elements.textPath.path
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/points/index.md
+++ b/files/en-us/web/svg/attribute/points/index.md
@@ -2,9 +2,9 @@
 title: points
 slug: Web/SVG/Attribute/points
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#PolygonElementPointsAttribute
-  - https://svgwg.org/svg2-draft/shapes.html#PolylineElementPointsAttribute
+browser-compat:
+  - svg.elements.polygon.points
+  - svg.elements.polyline.points
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/preserveaspectratio/index.md
+++ b/files/en-us/web/svg/attribute/preserveaspectratio/index.md
@@ -2,9 +2,12 @@
 title: preserveAspectRatio
 slug: Web/SVG/Attribute/preserveAspectRatio
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-preserveaspectratio
-  - https://svgwg.org/svg2-draft/coords.html#PreserveAspectRatioAttribute
+browser-compat:
+  - svg.elements.feImage.preserveAspectRatio
+  - svg.elements.image.preserveAspectRatio
+  - svg.elements.svg.preserveAspectRatio
+  - svg.elements.symbol.preserveAspectRatio
+  - svg.elements.view.preserveAspectRatio
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/r/index.md
+++ b/files/en-us/web/svg/attribute/r/index.md
@@ -2,9 +2,9 @@
 title: r
 slug: Web/SVG/Attribute/r
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/geometry.html#R
-  - https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementRAttribute
+browser-compat:
+  - svg.elements.circle.r
+  - svg.elements.radialGradient.r
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/refx/index.md
+++ b/files/en-us/web/svg/attribute/refx/index.md
@@ -2,9 +2,7 @@
 title: refX
 slug: Web/SVG/Attribute/refX
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/painting.html#MarkerElementRefXAttribute
-  - https://svgwg.org/svg2-draft/struct.html#SymbolElementRefXAttribute
+browser-compat: svg.elements.marker.refX
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/refy/index.md
+++ b/files/en-us/web/svg/attribute/refy/index.md
@@ -2,9 +2,7 @@
 title: refY
 slug: Web/SVG/Attribute/refY
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/painting.html#MarkerElementRefYAttribute
-  - https://svgwg.org/svg2-draft/struct.html#SymbolElementRefYAttribute
+browser-compat: svg.elements.marker.refY
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/rotate/index.md
+++ b/files/en-us/web/svg/attribute/rotate/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/rotate
 page-type: svg-attribute
 status:
   - experimental
-spec-urls: https://svgwg.org/specs/animations/#RotateAttribute
+browser-compat: svg.elements.animateMotion.rotate
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/rx/index.md
+++ b/files/en-us/web/svg/attribute/rx/index.md
@@ -2,7 +2,9 @@
 title: rx
 slug: Web/SVG/Attribute/rx
 page-type: svg-attribute
-spec-urls: https://svgwg.org/svg2-draft/geometry.html#RX
+browser-compat:
+  - svg.elements.ellipse.rx
+  - svg.elements.rect.rx
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/ry/index.md
+++ b/files/en-us/web/svg/attribute/ry/index.md
@@ -2,7 +2,9 @@
 title: ry
 slug: Web/SVG/Attribute/ry
 page-type: svg-attribute
-spec-urls: https://svgwg.org/svg2-draft/geometry.html#RY
+browser-compat:
+  - svg.elements.ellipse.ry
+  - svg.elements.rect.ry
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/specularexponent/index.md
+++ b/files/en-us/web/svg/attribute/specularexponent/index.md
@@ -2,9 +2,9 @@
 title: specularExponent
 slug: Web/SVG/Attribute/specularExponent
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-specularexponent
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-specularexponent
+browser-compat:
+  - svg.elements.feSpecularLighting.specularExponent
+  - svg.elements.feSpotLight.specularExponent
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/spreadmethod/index.md
+++ b/files/en-us/web/svg/attribute/spreadmethod/index.md
@@ -2,7 +2,9 @@
 title: spreadMethod
 slug: Web/SVG/Attribute/spreadMethod
 page-type: svg-attribute
-browser-compat: svg.elements.linearGradient.spreadMethod
+browser-compat:
+  - svg.elements.linearGradient.spreadMethod
+  - svg.elements.radialGradient.spreadMethod
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/strikethrough-position/index.md
+++ b/files/en-us/web/svg/attribute/strikethrough-position/index.md
@@ -2,6 +2,7 @@
 title: strikethrough-position
 slug: Web/SVG/Attribute/strikethrough-position
 page-type: svg-attribute
+browser-compat: svg.elements.font-face.strikethrough-position
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/strikethrough-thickness/index.md
+++ b/files/en-us/web/svg/attribute/strikethrough-thickness/index.md
@@ -2,6 +2,7 @@
 title: strikethrough-thickness
 slug: Web/SVG/Attribute/strikethrough-thickness
 page-type: svg-attribute
+browser-compat: svg.elements.font-face.strikethrough-thickness
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/surfacescale/index.md
+++ b/files/en-us/web/svg/attribute/surfacescale/index.md
@@ -2,9 +2,9 @@
 title: surfaceScale
 slug: Web/SVG/Attribute/surfaceScale
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-surfacescale
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-surfacescale
+browser-compat:
+  - svg.elements.feDiffuseLighting.surfaceScale
+  - svg.elements.feSpecularLighting.surfaceScale
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/textlength/index.md
+++ b/files/en-us/web/svg/attribute/textlength/index.md
@@ -2,7 +2,10 @@
 title: textLength
 slug: Web/SVG/Attribute/textLength
 page-type: svg-attribute
-browser-compat: svg.elements.text.textLength
+browser-compat:
+  - svg.elements.text.textLength
+  - svg.elements.textPath.textLength
+  - svg.elements.tspan.textLength
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/transform/index.md
+++ b/files/en-us/web/svg/attribute/transform/index.md
@@ -2,10 +2,7 @@
 title: transform
 slug: Web/SVG/Attribute/transform
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.csswg.org/css-transforms/#svg-transform
-  - https://drafts.csswg.org/css-transforms/#svg-transform
-  - https://svgwg.org/svg2-draft/coords.html#TransformProperty
+browser-compat: svg.global_attributes.transform
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/u1/index.md
+++ b/files/en-us/web/svg/attribute/u1/index.md
@@ -4,7 +4,9 @@ slug: Web/SVG/Attribute/u1
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.hkern.u1
+browser-compat:
+  - svg.elements.hkern.u1
+  - svg.elements.vkern.u1
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/u2/index.md
+++ b/files/en-us/web/svg/attribute/u2/index.md
@@ -4,7 +4,9 @@ slug: Web/SVG/Attribute/u2
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.hkern.u2
+browser-compat:
+  - svg.elements.hkern.u2
+  - svg.elements.vkern.u2
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/underline-position/index.md
+++ b/files/en-us/web/svg/attribute/underline-position/index.md
@@ -2,6 +2,7 @@
 title: underline-position
 slug: Web/SVG/Attribute/underline-position
 page-type: svg-attribute
+browser-compat: svg.elements.font-face.underline-position
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/underline-thickness/index.md
+++ b/files/en-us/web/svg/attribute/underline-thickness/index.md
@@ -2,6 +2,7 @@
 title: underline-thickness
 slug: Web/SVG/Attribute/underline-thickness
 page-type: svg-attribute
+browser-compat: svg.elements.font-face.underline-thickness
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/values/index.md
+++ b/files/en-us/web/svg/attribute/values/index.md
@@ -2,9 +2,7 @@
 title: values
 slug: Web/SVG/Attribute/values
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fecolormatrix-values
-  - https://svgwg.org/specs/animations/#ValuesAttribute
+browser-compat: svg.elements.feColorMatrix.values
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/vert-adv-y/index.md
+++ b/files/en-us/web/svg/attribute/vert-adv-y/index.md
@@ -4,7 +4,10 @@ slug: Web/SVG/Attribute/vert-adv-y
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.font.vert-adv-y
+browser-compat:
+  - svg.elements.font.vert-adv-y
+  - svg.elements.glyph.vert-adv-y
+  - svg.elements.missing-glyph.vert-adv-y
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/vert-origin-x/index.md
+++ b/files/en-us/web/svg/attribute/vert-origin-x/index.md
@@ -4,7 +4,10 @@ slug: Web/SVG/Attribute/vert-origin-x
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.font.vert-origin-x
+browser-compat:
+  - svg.elements.font.vert-origin-x
+  - svg.elements.glyph.vert-origin-x
+  - svg.elements.missing-glyph.vert-origin-x
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/vert-origin-y/index.md
+++ b/files/en-us/web/svg/attribute/vert-origin-y/index.md
@@ -4,7 +4,10 @@ slug: Web/SVG/Attribute/vert-origin-y
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.font.vert-origin-y
+browser-compat:
+  - svg.elements.font.vert-origin-y
+  - svg.elements.glyph.vert-origin-y
+  - svg.elements.missing-glyph.vert-origin-y
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/attribute/viewbox/index.md
@@ -2,7 +2,11 @@
 title: viewBox
 slug: Web/SVG/Attribute/viewBox
 page-type: svg-attribute
-spec-urls: https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute
+browser-compat:
+  - svg.elements.marker.viewBox
+  - svg.elements.svg.viewBox
+  - svg.elements.symbol.viewBox
+  - svg.elements.view.viewBox
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/width/index.md
+++ b/files/en-us/web/svg/attribute/width/index.md
@@ -2,12 +2,15 @@
 title: width
 slug: Web/SVG/Attribute/width
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-width
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-width
-  - https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-width
-  - https://svgwg.org/svg2-draft/geometry.html#Sizing
-  - https://svgwg.org/svg2-draft/pservers.html#PatternElementWidthAttribute
+browser-compat:
+  - svg.elements.filter.width
+  - svg.elements.foreignObject.width
+  - svg.elements.image.width
+  - svg.elements.mask.width
+  - svg.elements.pattern.width
+  - svg.elements.rect.width
+  - svg.elements.svg.width
+  - svg.elements.use.width
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -2,9 +2,9 @@
 title: x1
 slug: Web/SVG/Attribute/x1
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementX1Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX1Attribute
+browser-compat:
+  - svg.elements.line.x1
+  - svg.elements.linearGradient.x1
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -2,9 +2,9 @@
 title: x2
 slug: Web/SVG/Attribute/x2
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementX2Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX2Attribute
+browser-compat:
+  - svg.elements.line.x2
+  - svg.elements.linearGradient.x2
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/xlink_colon_show/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_show/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/xlink:show
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.xlink_show
+browser-compat: svg.elements.a.xlink_show
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/xlink_colon_title/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_title/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/xlink:title
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.xlink_title
+browser-compat: svg.elements.a.xlink_title
 ---
 
 {{SVGRef}}{{Deprecated_Header}}

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -2,9 +2,9 @@
 title: y1
 slug: Web/SVG/Attribute/y1
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementY1Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY1Attribute
+browser-compat:
+  - svg.elements.line.y1
+  - svg.elements.linearGradient.y1
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -2,9 +2,9 @@
 title: y2
 slug: Web/SVG/Attribute/y2
 page-type: svg-attribute
-spec-urls:
-  - https://svgwg.org/svg2-draft/shapes.html#LineElementY2Attribute
-  - https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY2Attribute
+browser-compat:
+  - svg.elements.line.y2
+  - svg.elements.linearGradient.y2
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/z/index.md
+++ b/files/en-us/web/svg/attribute/z/index.md
@@ -2,9 +2,9 @@
 title: z
 slug: Web/SVG/Attribute/z
 page-type: svg-attribute
-spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fepointlight-z
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-z
+browser-compat:
+  - svg.elements.fePointLight.z
+  - svg.elements.feSpotLight.z
 ---
 
 {{SVGRef}}

--- a/files/en-us/web/svg/attribute/zoomandpan/index.md
+++ b/files/en-us/web/svg/attribute/zoomandpan/index.md
@@ -4,7 +4,9 @@ slug: Web/SVG/Attribute/zoomAndPan
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.elements.svg.zoomAndPan
+browser-compat:
+  - svg.elements.svg.zoomAndPan
+  - svg.elements.view.zoomAndPan
 ---
 
 {{SVGRef}}{{Deprecated_Header}}


### PR DESCRIPTION
I've added automated check to ensure all pages have complete and valid BCD references. This PR updates the BCD keys for SVG attributes. Most of them don't render a compat table, but it's still nice to use `browser-compat` instead of `spec-urls` for the spec list.