### PR TITLE
Added event listener instead of oninput attribute 

### DIFF
--- a/files/en-us/web/html/element/output/index.md
+++ b/files/en-us/web/html/element/output/index.md
@@ -35,11 +35,28 @@ Many browsers implement this element as an [`aria-live`](/en-US/docs/Web/Accessi
 In the following example, the form provides a slider whose value can range between `0` and `100`, and an {{HTMLElement("input")}} element into which you can enter a second number. The two numbers are added together, and the result is displayed in the `<output>` element each time the value of any of the controls changes.
 
 ```html
-<form oninput="result.value=parseInt(a.value)+parseInt(b.value)">
+<form>
   <input type="range" id="b" name="b" value="50" /> +
   <input type="number" id="a" name="a" value="10" /> =
   <output name="result" for="a b">60</output>
 </form>
+```
+
+```js
+document.addEventListener("DOMContentLoaded", function () {
+  const a = document.getElementById("a");
+  const b = document.getElementById("b");
+  const result = document.querySelector('output[name="result"]');
+
+  function updateResult() {
+    result.value = parseInt(a.value) + parseInt(b.value);
+  }
+
+  a.addEventListener("input", updateResult);
+  b.addEventListener("input", updateResult);
+
+  updateResult();
+});
 ```
 
 ### Result

--- a/files/en-us/web/html/element/output/index.md
+++ b/files/en-us/web/html/element/output/index.md
@@ -54,8 +54,8 @@ function updateResult() {
   result.value = aValue + bValue;
 }
 
-a.addEventListener("input", updateResult);
-b.addEventListener("input", updateResult);
+form.addEventListener("input", updateResult);
+
 updateResult();
 ```
 

--- a/files/en-us/web/html/element/output/index.md
+++ b/files/en-us/web/html/element/output/index.md
@@ -35,7 +35,7 @@ Many browsers implement this element as an [`aria-live`](/en-US/docs/Web/Accessi
 In the following example, the form provides a slider whose value can range between `0` and `100`, and an {{HTMLElement("input")}} element into which you can enter a second number. The two numbers are added together, and the result is displayed in the `<output>` element each time the value of any of the controls changes.
 
 ```html
-<form>
+<form id="example-form">
   <input type="range" id="b" name="b" value="50" /> +
   <input type="number" id="a" name="a" value="10" /> =
   <output name="result" for="a b">60</output>
@@ -43,20 +43,20 @@ In the following example, the form provides a slider whose value can range betwe
 ```
 
 ```js
-document.addEventListener("DOMContentLoaded", function () {
-  const a = document.getElementById("a");
-  const b = document.getElementById("b");
-  const result = document.querySelector('output[name="result"]');
+const form = document.getElementById("example-form");
+const a = form.elements["a"];
+const b = form.elements["b"];
+const result = form.elements["result"];
 
-  function updateResult() {
-    result.value = parseInt(a.value) + parseInt(b.value);
-  }
+function updateResult() {
+  const aValue = parseInt(a.value);
+  const bValue = parseInt(b.value);
+  result.value = aValue + bValue;
+}
 
-  a.addEventListener("input", updateResult);
-  b.addEventListener("input", updateResult);
-
-  updateResult();
-});
+a.addEventListener("input", updateResult);
+b.addEventListener("input", updateResult);
+updateResult();
 ```
 
 ### Result


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Added event listener in JS section instead of oninput attribute at `/en-US/docs/Web/HTML/Element/output`

### Motivation

These changes were required in issue [https://github.com/mdn/content/issues/35470](35470)

### Related issues and pull requests

Fixes #35470 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
