### PR TITLE
feat(*): add VideoFrame to createImageBitmap

### DIFF
--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -33,6 +33,7 @@ createImageBitmap(image, sx, sy, sw, sh, options)
     - {{domxref("ImageData")}}
     - {{domxref("ImageBitmap")}}
     - {{domxref("OffscreenCanvas")}}
+    - {{domxref("VideoFrame")}}
 - `sx`
   - : The x coordinate of the reference point of the rectangle from which the `ImageBitmap` will be extracted.
 - `sy`


### PR DESCRIPTION
### Description

Added VideoFrame as a source for createImageBitmap

### Motivation

According specification 
VideoFrame can be passed to createImageBitmap

### Additional details
(https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap-dev)

