### PR TITLE
fix(css): add pageOrientation properties back to csspagedesriptors page

### DIFF
--- a/files/en-us/web/api/csspagedescriptors/index.md
+++ b/files/en-us/web/api/csspagedescriptors/index.md
@@ -41,6 +41,10 @@ _This interface also inherits properties of its parent, {{domxref("CSSStyleDecla
   - : A string representing the `margin-left` property of the corresponding `@page` at-rule.
 - `marginLeft` {{experimental_inline}}
   - : A string representing the `margin-left` property of the corresponding `@page` at-rule.
+- `page-orientation` {{experimental_inline}}
+  - : A string representing the `page-orientation` property of the corresponding `@page` at-rule.
+- `pageOrientation` {{experimental_inline}}
+  - : A string representing the `page-orientation` property of the corresponding `@page` at-rule.
 - `size` {{experimental_inline}}
   - : A string representing the `size` property of the corresponding `@page` at-rule.
 


### PR DESCRIPTION
The PR addresses:
>> Going to merge. If someone thinks `page-orientation` should be restored please shout loudly.
>
> [Shout shout let it all out](https://www.youtube.com/watch?v=Ye7FKc1JQe4).

The properties have been implemented and [converted by the BCD now](https://github.com/mdn/content/pull/35291#issuecomment-2298097761).


