### PR TITLE
css(fix): make oveflow-wrap rename a warning

### DIFF
--- a/files/en-us/web/css/overflow-wrap/index.md
+++ b/files/en-us/web/css/overflow-wrap/index.md
@@ -7,14 +7,15 @@ browser-compat: css.properties.overflow-wrap
 
 {{CSSRef}}
 
+> [!WARNING]
+> The property was originally a nonstandard and unprefixed Microsoft extension called `word-wrap`, and was implemented by most browsers with the same name. It has since been renamed to `overflow-wrap`, with `word-wrap` being an alias.
+
 The **`overflow-wrap`** [CSS](/en-US/docs/Web/CSS) property applies to text, setting whether the browser should insert line breaks within an otherwise unbreakable string to prevent text from overflowing its line box.
 
 {{EmbedInteractiveExample("pages/css/overflow-wrap.html")}}
 
 > [!NOTE]
 > In contrast to {{cssxref("word-break")}}, `overflow-wrap` will only create a break if an entire word cannot be placed on its own line without overflowing.
-
-The property was originally a nonstandard and unprefixed Microsoft extension called `word-wrap`, and was implemented by most browsers with the same name. It has since been renamed to `overflow-wrap`, with `word-wrap` being an alias.
 
 ## Syntax
 


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/35521

The note needs to be more prominent. The redirect is [already in place](https://github.com/mdn/content/blob/62ec7fe4fd975429f115e6eeb702735e52cf2203/files/en-us/_redirects.txt#L860).

