### PR TITLE
Fixed typo in CSS/@property/syntax

### DIFF
--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -25,7 +25,7 @@ syntax: "*"; /* any valid token */
 
 ## Values
 
-A string with a supported syntax as defined by the specification. Supported syntaxes are a subset of [CSS types](/en-US/docs/Web/CSS/CSS_Types). These may be used along, or a number of types can be used in combination.
+A string with a supported syntax as defined by the specification. Supported syntaxes are a subset of [CSS types](/en-US/docs/Web/CSS/CSS_Types). These may be used alone, or a number of types can be used in combination.
 
 - `"<length>"`
   - : Any valid {{cssxref("&lt;length&gt;")}} values.


### PR DESCRIPTION
### Description
Just fixed a small typo.

### Motivation
To help with clarity and improve the quality of the documentation.

### Related issues and pull requests
Fixes #35531
