### PR TITLE
Document CSSKeyframesRule.length

### DIFF
--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.md
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.md
@@ -10,6 +10,9 @@ browser-compat: api.CSSKeyframesRule.cssRules
 
 The read-only **`cssRules`** property of the {{domxref("CSSKeyframeRule")}} interface returns a {{domxref("CSSRuleList")}} containing the rules in the keyframes [at-rule](/en-US/docs/Web/CSS/At-rule).
 
+> [!NOTE]
+> The `CSSKeyframeRule` itself is indexable like an array, and functions similarly to its `cssRules` property.
+
 ## Value
 
 A {{domxref('CSSRuleList')}}.

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -19,6 +19,8 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
   - : Represents the name of the keyframes, used by the {{cssxref("animation-name")}} property.
 - {{domxref("CSSKeyframesRule.cssRules")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("CSSRuleList")}} of the keyframes in the list.
+- {{domxref("CSSKeyframesRule.length")}} {{ReadOnlyInline}}
+  - : Returns the number of keyframes in the list.
 
 ## Instance methods
 
@@ -32,6 +34,8 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
   - : Returns a keyframe rule corresponding to the given key. The key is a string containing an index of the keyframe to be returned, resolving to a percentage between `0%` and `100%`. If no such keyframe exists, `findRule` returns `null`.
 
 ## Example
+
+### Using CSSKeyframesRule
 
 The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
 `myRules[0]` returns a `CSSKeyframesRule` object.
@@ -49,8 +53,24 @@ The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule"
 ```
 
 ```js
-let myRules = document.styleSheets[0].cssRules;
-let keyframes = myRules[0]; // a CSSKeyframesRule
+const myRules = document.styleSheets[0].cssRules;
+const keyframes = myRules[0]; // a CSSKeyframesRule
+```
+
+### Accessing indexes
+
+`CSSKeyframesRule` can be indexed like an array, and functions similar to its {{domxref("CSSKeyframesRule.cssRules", "cssRules")}} property.
+
+```js
+const keyframes = document.styleSheets[0].cssRules[0];
+
+for (let i = 0; i < keyframes.length; i++) {
+  console.log(keyframes[i].keyText);
+}
+
+// Output:
+// 0%
+// 100%
 ```
 
 ## Specifications

--- a/files/en-us/web/api/csskeyframesrule/length/index.md
+++ b/files/en-us/web/api/csskeyframesrule/length/index.md
@@ -1,0 +1,46 @@
+---
+title: "CSSKeyframesRule: length property"
+short-title: length
+slug: Web/API/CSSKeyframesRule/length
+page-type: web-api-instance-property
+browser-compat: api.CSSKeyframesRule.length
+---
+
+{{APIRef("CSSOM") }}
+
+The read-only **`length`** property of the {{domxref("CSSKeyframeRule")}} interface returns the number of {{domxref("CSSKeyframeRule")}} objects in its list. You can then access each keyframe rule by its index directly on the `CSSKeyframeRule` object.
+
+## Value
+
+A non-negative integer. It should have the same value as the `length` of the {{domxref("CSSKeyframesRule.cssRules", "cssRules")}} property.
+
+## Examples
+
+The CSS includes a keyframes at-rule. This will be the first {{domxref("CSSRule")}} returned by `document.styleSheets[0].cssRules`.
+`myRules[0]` returns a {{domxref("CSSKeyframesRule")}} object. The `cssRules` property returns a {{domxref("CSSRuleList")}} containing two rules.
+
+```css
+@keyframes slidein {
+  from {
+    transform: translateX(0%);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+```
+
+```js
+const myRules = document.styleSheets[0].cssRules;
+const keyframes = myRules[0]; // a CSSKeyframesRule
+console.log(keyframes.length); // 2
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
Easy docs, mostly copied from other properties. Found in web docs backlog.