### PR TITLE
Change the default value of `credential` option of `Worker` constructor

### DIFF
--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -31,7 +31,7 @@ new Worker(aURL, options)
     - `type`
       - : A string specifying the type of worker to create. The value can be `classic` or `module`. If not specified, the default used is `classic`.
     - `credentials`
-      - : A string specifying the type of credentials to use for the worker. The value can be `omit`, `same-origin`, or _`include`. If not specified, or if type is `classic`, the default used is `same-origin` (no credentials required)._
+      - : A string specifying the type of credentials to use for the worker. The value can be `omit`, `same-origin`, or _`include`. If not specified, or if type is `classic`, the default used is `same-origin` (only include credentials for same-origin requests)._
     - `name`
       - : A string specifying an identifying name for the {{domxref("DedicatedWorkerGlobalScope")}} representing the scope of the worker, which is mainly useful for debugging purposes.
 

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -31,7 +31,7 @@ new Worker(aURL, options)
     - `type`
       - : A string specifying the type of worker to create. The value can be `classic` or `module`. If not specified, the default used is `classic`.
     - `credentials`
-      - : A string specifying the type of credentials to use for the worker. The value can be `omit`, `same-origin`, or _`include`. If not specified, or if type is `classic`, the default used is `omit` (no credentials required)._
+      - : A string specifying the type of credentials to use for the worker. The value can be `omit`, `same-origin`, or _`include`. If not specified, or if type is `classic`, the default used is `same-origin` (no credentials required)._
     - `name`
       - : A string specifying an identifying name for the {{domxref("DedicatedWorkerGlobalScope")}} representing the scope of the worker, which is mainly useful for debugging purposes.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changed the default value of `credential` option of `Worker` constructor from `omit` to `same-origin`.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

https://github.com/whatwg/html/pull/3656 changed the default value and the page was stale.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

- https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts:~:text=same%2Dorigin%22%2C-,credentials%20mode%20is%20%22same%2Dorigin%22,-%2C%20parser%20metadata
- https://html.spec.whatwg.org/multipage/workers.html#workers:~:text=RequestCredentials%20credentials%20%3D%20%22same%2Dorigin%22%3B%20//%20credentials%20is%20only%20used%20if%20type%20is%20%22module%22

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
