### PR TITLE
Use <p> instead of <div> to separate form controls

### DIFF
--- a/files/en-us/learn/forms/sending_forms_through_javascript/index.md
+++ b/files/en-us/learn/forms/sending_forms_through_javascript/index.md
@@ -77,15 +77,14 @@ Suppose our HTML declares a `<form>` element:
 
 ```html
 <form id="userinfo">
-  <div>
+  <p>
     <label for="username">Enter your name:</label>
     <input type="text" id="username" name="username" value="Dominic" />
-  </div>
-
-  <div>
+  </p>
+  <p>
     <label for="avatar">Select an avatar</label>
     <input type="file" id="avatar" name="avatar" required />
-  </div>
+  </p>
   <input type="submit" value="Submit" />
 </form>
 ```


### PR DESCRIPTION
### Description

I've used `<p>` to separate form controls, because this approach was suggested in WHATWG's Living Standard:

> Each part of a form is considered a paragraph, and is typically separated from other parts using p elements

Same technique was used in different MDN articles, too 

### Additional details

https://html.spec.whatwg.org/dev/forms.html#writing-a-form's-user-interface
https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form