### PR TITLE
Reword an incorrect assertion about listbox children

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
@@ -13,7 +13,7 @@ The `listbox` role is used for lists from which a user may select one or more it
 
 ## Description
 
-The `listbox` role is used to identify an element that creates a list from which a user may select one or more static items, similar to the HTML {{HTMLElement('select')}} element. Unlike {{HTMLElement('select')}}, a listbox can contain images. Each child of a listbox should have a role of [option](https://www.w3.org/TR/2010/WD-wai-aria-20100916/roles#option).
+The `listbox` role is used to identify an element that creates a list from which a user may select one or more static items, similar to the HTML {{HTMLElement('select')}} element. Unlike {{HTMLElement('select')}}, a listbox can contain images. Listboxes contain children whose role is [option](https://www.w3.org/TR/2010/WD-wai-aria-20100916/roles#option) or elements whose role is [group](https://www.w3.org/TR/2010/WD-wai-aria-20100916/roles#group) which in turn contain children whose role is option.
 
 It is highly recommended using the HTML select element, or a group of radio buttons if only one item can be selected, or a group of checkboxes if multiple items can be selected, because there is a lot of keyboard interactivity to manage focus for all the descendants, and native HTML elements provide this functionality for you for free.
 

--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
@@ -13,7 +13,7 @@ The `listbox` role is used for lists from which a user may select one or more it
 
 ## Description
 
-The `listbox` role is used to identify an element that creates a list from which a user may select one or more static items, similar to the HTML {{HTMLElement('select')}} element. Unlike {{HTMLElement('select')}}, a listbox can contain images. Listboxes contain children whose role is [option](https://www.w3.org/TR/2010/WD-wai-aria-20100916/roles#option) or elements whose role is [group](https://www.w3.org/TR/2010/WD-wai-aria-20100916/roles#group) which in turn contain children whose role is option.
+The `listbox` role is used to identify an element that creates a list from which a user may select one or more static items, similar to the HTML {{HTMLElement('select')}} element. Unlike {{HTMLElement('select')}}, a listbox can contain images. Listboxes contain children whose role is [`option`](/en-US/docs/Web/Accessibility/ARIA/Roles/option_role) or elements whose role is [`group`](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) which in turn contain children whose role is `option`.
 
 It is highly recommended using the HTML select element, or a group of radio buttons if only one item can be selected, or a group of checkboxes if multiple items can be selected, because there is a lot of keyboard interactivity to manage focus for all the descendants, and native HTML elements provide this functionality for you for free.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

* This change deletes a snippet of text that states that each child of a listbox should have a role of option. This assertion is incorrect since roles such as presentation and group are valid children of listboxes.

### Motivation

* To remove an incorrect assertion which would make developers hesitant to use roles other than option in their listboxes.

### Additional details

https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
