### PR TITLE
Adding missing space

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
@@ -19,7 +19,7 @@ which provides further information about a characteristic's value.
     to.
 - {{DOMxRef("BluetoothRemoteGATTDescriptor.uuid")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the UUID of the characteristic descriptor, for
-    example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient
+    example '`00002902-0000-1000-8000-00805f9b34fb`' for the Client
     Characteristic Configuration descriptor.
 - {{DOMxRef("BluetoothRemoteGATTDescriptor.value")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the currently cached descriptor value. This value gets updated when the

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
@@ -11,7 +11,7 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.uuid
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`BluetoothRemoteGATTDescriptor.uuid`** read-only property returns the {{Glossary("UUID")}} of the characteristic descriptor.
-For example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient Characteristic Configuration descriptor.
+For example '`00002902-0000-1000-8000-00805f9b34fb`' for the Client Characteristic Configuration descriptor.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

There was a missing space between "the" and "Client".

### Motivation

I was looking at that page of the documentation and I thought that it was annoying to see a little mistake in it.

### Additional details

None...

### Related issues and pull requests

GitHub didn't tell me if there is another pull request for that file.


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
