### PR TITLE
update AsyncGenerator

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -21,9 +21,9 @@ There's no JavaScript entity that corresponds to the `AsyncGenerator` constructo
 
 ```js
 async function* createAsyncGenerator() {
-  yield await Promise.resolve(1);
-  yield await Promise.resolve(2);
-  yield await Promise.resolve(3);
+  yield Promise.resolve(1);
+  yield Promise.resolve(2);
+  yield Promise.resolve(3);
 }
 const asyncGen = createAsyncGenerator();
 asyncGen.next().then((res) => console.log(res.value)); // 1

--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -22,8 +22,8 @@ There's no JavaScript entity that corresponds to the `AsyncGenerator` constructo
 ```js
 async function* createAsyncGenerator() {
   yield Promise.resolve(1);
-  yield Promise.resolve(2);
-  yield Promise.resolve(3);
+  yield await Promise.resolve(2);
+  yield 3;
 }
 const asyncGen = createAsyncGenerator();
 asyncGen.next().then((res) => console.log(res.value)); // 1

--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/return/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/return/index.md
@@ -71,9 +71,9 @@ If no `value` argument is passed into the `return()` method, the promise will re
 
 ```js
 async function* createAsyncGenerator() {
-  yield await Promise.resolve(1);
+  yield Promise.resolve(1);
   yield await Promise.resolve(2);
-  yield await Promise.resolve(3);
+  yield 3;
 }
 const asyncGen = createAsyncGenerator();
 asyncGen.next().then((res) => console.log(res)); // { value: 1, done: false }


### PR DESCRIPTION
Although the return value of AsyncGenerator is valid, the await here in the example is unnecessary and can lead to misunderstanding.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Remove the await keyword from the example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
