### PR TITLE
Make meaning of parentheses for regex explicit in URL Pattern API

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -27,8 +27,8 @@ can contain:
 - Non-capturing groups (`/books{/old}?`) which make parts of a pattern optional
   or be matched multiple times.
 - {{jsxref("RegExp")}} groups (`/books/(\\d+)`) which make arbitrarily complex
-  regex matches with a few [limitations](#regex_matchers_limitations). _Note the
-  parentheses define the contents as a regex and are not part of the regex._
+  regex matches with a few [limitations](#regex_matchers_limitations). _Note that the
+  parentheses are not part of the regex but instead define their contents as a regex._
 
 You can find details about the syntax in the [pattern syntax](#pattern_syntax)
 section below.

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -27,7 +27,8 @@ can contain:
 - Non-capturing groups (`/books{/old}?`) which make parts of a pattern optional
   or be matched multiple times.
 - {{jsxref("RegExp")}} groups (`/books/(\\d+)`) which make arbitrarily complex
-  regex matches with a few [limitations](#regex_matchers_limitations).
+  regex matches with a few [limitations](#regex_matchers_limitations). _Note the
+  parentheses define the contents as a regex and are not part of the regex._
 
 You can find details about the syntax in the [pattern syntax](#pattern_syntax)
 section below.
@@ -79,9 +80,9 @@ match the shortest possible string.
 ### Regex matchers
 
 Instead of using the default match rules for a group, you can use a regex for
-each group. This regex defines the matching rules for the group. Below is an
-example of a regex matcher on a named group that constrains the group to only
-match if it contains one or more digits:
+each group by including a regex in parentheses. This regex defines the matching
+rules for the group. Below is an example of a regex matcher on a named group
+that constrains the group to only match if it contains one or more digits:
 
 ```js
 const pattern = new URLPattern("/books/:id(\\d+)", "https://example.com");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

A URLPattern uses parentheses to define Regexs as shown in one fo the examples currently on MDN:

```js
const pattern = new URLPattern("/books/:id(\\d+)", "https://example.com");
```

Here the `(\\d+)` is a regex as it's surrounded by parentheses. However it's not obvious that parentheses are what allow you to use regular expressions since they are so common (especially in regexes themselves when they defined groups) so this is easily missed. So I'm suggesting wording to make this more explicit.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I didn't understand this and wasted a lot of time on it. I'm hoping to avoid others doing the same.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

I also raised an issue for the spec to see if they want to make it clearer too:
https://github.com/whatwg/urlpattern/issues/229

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
