### PR TITLE
Client-side form validation: Fix input element styling

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -750,7 +750,7 @@ input#mail {
 }
 
 /* This is our style for the invalid fields */
-input.invalid {
+input#mail.invalid {
   border-color: #900;
   background-color: #fdd;
 }

--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -755,7 +755,7 @@ input.invalid {
   background-color: #fdd;
 }
 
-input:focus:invalid {
+input:focus.invalid {
   outline: none;
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
- The example under **Validating forms without a built-in API** doesn't use the constraint validation API and is meant to use `.invalid` class selector instead of `:invalid` pseudo class selector. Hence, I've changed the `input:focus:invalid` selector to `input:focus.invalid`.
- The `border-color: #900;` declaration wasn't overriding the border styling added in the `input#mail` selector that precedes it because the `input#mail` selector has a higher specificity. By changing the `input.invalid` selector to `input#mail.invalid`, it now has a higher specificity and the styling successfully applies.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I have made these changes to correct mistakes and to make sure readers aren't confused.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
N/A


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
