### PR TITLE
Split WebGLRenderingContext.compressedTexImage2D and WebGL2RenderingContext.compressedTexImage3D

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -10014,7 +10014,6 @@
 /en-US/docs/Web/API/WebGL2RenderingContext/clearBufferfv	/en-US/docs/Web/API/WebGL2RenderingContext/clearBuffer
 /en-US/docs/Web/API/WebGL2RenderingContext/clearBufferiv	/en-US/docs/Web/API/WebGL2RenderingContext/clearBuffer
 /en-US/docs/Web/API/WebGL2RenderingContext/clearBufferuiv	/en-US/docs/Web/API/WebGL2RenderingContext/clearBuffer
-/en-US/docs/Web/API/WebGL2RenderingContext/compressedTexImage3D	/en-US/docs/Web/API/WebGLRenderingContext/compressedTexImage2D
 /en-US/docs/Web/API/WebGL2RenderingContext/samplerParameterf	/en-US/docs/Web/API/WebGL2RenderingContext/samplerParameter
 /en-US/docs/Web/API/WebGL2RenderingContext/samplerParameteri	/en-US/docs/Web/API/WebGL2RenderingContext/samplerParameter
 /en-US/docs/Web/API/WebGL2RenderingContext/uniform1ui	/en-US/docs/Web/API/WebGL2RenderingContext/uniform

--- a/files/en-us/web/api/webgl2renderingcontext/compressedteximage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedteximage3d/index.md
@@ -1,15 +1,15 @@
 ---
-title: "WebGLRenderingContext: compressedTexImage2D() method"
-short-title: compressedTexImage2D()
-slug: Web/API/WebGLRenderingContext/compressedTexImage2D
+title: "WebGL2RenderingContext: compressedTexImage3D() method"
+short-title: compressedTexImage3D()
+slug: Web/API/WebGL2RenderingContext/compressedTexImage3D
 page-type: web-api-instance-method
-browser-compat: api.WebGLRenderingContext.compressedTexImage2D
+browser-compat: api.WebGL2RenderingContext.compressedTexImage3D
 ---
 
 {{APIRef("WebGL")}}
 
-The **`compressedTexImage2D()`** method of the {{domxref("WebGLRenderingContext")}} interface
-of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specify a two-dimensional texture image in a compressed format.
+The **`compressedTexImage3D()`** method of the {{domxref("WebGL2RenderingContext")}} interface
+of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specify a three-dimensional texture image in a compressed format.
 
 Compressed image formats must be enabled by [WebGL extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) before
 using these methods.
@@ -17,16 +17,12 @@ using these methods.
 ## Syntax
 
 ```js-nolint
-// WebGL 1:
-compressedTexImage2D(target, level, internalformat, width, height, border)
-compressedTexImage2D(target, level, internalformat, width, height, border, pixels)
-
-// Additionally available in WebGL 2:
 // read from buffer bound to gl.PIXEL_UNPACK_BUFFER
-compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, offset)
-compressedTexImage2D(target, level, internalformat, width, height, border, srcData)
-compressedTexImage2D(target, level, internalformat, width, height, border, srcData, srcOffset)
-compressedTexImage2D(target, level, internalformat, width, height, border, srcData, srcOffset, srcLengthOverride)
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset)
+
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, srcData)
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, srcData, srcOffset)
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, srcData, srcOffset, srcLengthOverride)
 ```
 
 ### Parameters
@@ -34,21 +30,10 @@ compressedTexImage2D(target, level, internalformat, width, height, border, srcDa
 - `target`
 
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the binding point (target) of the active texture.
-    Possible values for `compressedTexImage2D`:
+    Possible values for `compressedTexImage3D`:
 
-    - `gl.TEXTURE_2D`: A two-dimensional texture.
-    - `gl.TEXTURE_CUBE_MAP_POSITIVE_X`: Positive X face for a cube-mapped
-      texture.
-    - `gl.TEXTURE_CUBE_MAP_NEGATIVE_X`: Negative X face for a cube-mapped
-      texture.
-    - `gl.TEXTURE_CUBE_MAP_POSITIVE_Y`: Positive Y face for a cube-mapped
-      texture.
-    - `gl.TEXTURE_CUBE_MAP_NEGATIVE_Y`: Negative Y face for a cube-mapped
-      texture.
-    - `gl.TEXTURE_CUBE_MAP_POSITIVE_Z`: Positive Z face for a cube-mapped
-      texture.
-    - `gl.TEXTURE_CUBE_MAP_NEGATIVE_Z`: Negative Z face for a cube-mapped
-      texture.
+    - `gl.TEXTURE_2D_ARRAY`
+    - `gl.TEXTURE_3D`
 
 - `level`
   - : A {{domxref("WebGL_API/Types", "GLint")}} specifying the level of detail. Level 0 is the base image
@@ -57,7 +42,8 @@ compressedTexImage2D(target, level, internalformat, width, height, border, srcDa
 
   - : A {{domxref("WebGL_API/Types", "GLenum")}} specifying the compressed image format. Compressed image
     formats must be enabled by [WebGL extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) before
-    using this method. All values are possible for `compressedTexImage2D`. Possible
+    using this method. See
+    [compressed texture formats](/en-US/docs/Web/API/WebGL_API/Compressed_texture_formats) for which are valid for `compressedTexImage3D`. Possible
     values:
 
     - When using the {{domxref("WEBGL_compressed_texture_s3tc")}} extension:
@@ -143,36 +129,10 @@ compressedTexImage2D(target, level, internalformat, width, height, border, srcDa
 - `offset`
   - : A {{domxref("WebGL_API/Types", "GLintptr")}} specifying the offset in bytes from which to read from the
     buffer bound to `gl.PIXEL_UNPACK_BUFFER`.
-- `pixels`
-  - : A {{jsxref("TypedArray")}} or a {{jsxref("DataView")}} that will be used as a data store for the
-    compressed image data in memory.
 
 ### Return value
 
 None ({{jsxref("undefined")}}).
-
-## Examples
-
-```js
-const ext =
-  gl.getExtension("WEBGL_compressed_texture_s3tc") ||
-  gl.getExtension("MOZ_WEBGL_compressed_texture_s3tc") ||
-  gl.getExtension("WEBKIT_WEBGL_compressed_texture_s3tc");
-
-const texture = gl.createTexture();
-gl.bindTexture(gl.TEXTURE_2D, texture);
-gl.compressedTexImage2D(
-  gl.TEXTURE_2D,
-  0,
-  ext.COMPRESSED_RGBA_S3TC_DXT5_EXT,
-  512,
-  512,
-  0,
-  textureData,
-);
-gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-```
 
 ## Specifications
 
@@ -185,9 +145,9 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 ## See also
 
 - [Using WebGL extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions)
-- {{domxref("WebGLRenderingContext.compressedTexSubImage2D()")}}
 - {{domxref("WebGL2RenderingContext.compressedTexSubImage3D()")}}
-- {{domxref("WebGL2RenderingContext.compressedTexImage3D()")}}
+- {{domxref("WebGLRenderingContext.compressedTexSubImage2D()")}}
+- {{domxref("WebGLRenderingContext.compressedTexImage2D()")}}
 - {{domxref("WEBGL_compressed_texture_s3tc")}}
 - {{domxref("WEBGL_compressed_texture_s3tc_srgb")}}
 - {{domxref("WEBGL_compressed_texture_etc")}}

--- a/files/en-us/web/api/webgl2renderingcontext/compressedteximage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedteximage3d/index.md
@@ -9,7 +9,7 @@ browser-compat: api.WebGL2RenderingContext.compressedTexImage3D
 {{APIRef("WebGL")}}
 
 The **`compressedTexImage3D()`** method of the {{domxref("WebGL2RenderingContext")}} interface
-of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specify a three-dimensional texture image in a compressed format.
+of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specifies a three-dimensional texture image in a compressed format.
 
 Compressed image formats must be enabled by [WebGL extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) before
 using these methods.

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
@@ -9,7 +9,7 @@ browser-compat: api.WebGLRenderingContext.compressedTexImage2D
 {{APIRef("WebGL")}}
 
 The **`compressedTexImage2D()`** method of the {{domxref("WebGLRenderingContext")}} interface
-of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specify a two-dimensional texture image in a compressed format.
+of the [WebGL API](/en-US/docs/Web/API/WebGL_API) specifies a two-dimensional texture image in a compressed format.
 
 Compressed image formats must be enabled by [WebGL extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) before
 using these methods.


### PR DESCRIPTION
These are two separate methods on different interfaces, with different parameters and support. Other 2D/3D methods are already split across the two interfaces, so I think this one should too.