### PR TITLE
fix: fix incorrectly inserted image alt text is corrected

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/index.md
@@ -222,7 +222,7 @@ Extensions that use WebExtension APIs are provided with several user interface o
       </td>
       <td>
         <img
-          alt="Example showing the result of the firefox_code_search WebExtension&#x27;s customization of the address bar suggestions."
+          alt="Example of custom panel on developer tools"
           src="developer_panel_tab.png"
         />
       </td>

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/index.md
@@ -222,7 +222,7 @@ Extensions that use WebExtension APIs are provided with several user interface o
       </td>
       <td>
         <img
-          alt="Example of custom panel on developer tools"
+          alt="Example of a custom panel on developer tools."
           src="developer_panel_tab.png"
         />
       </td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes #35581.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I noticed something unusual in the original text while translating it into Korean, so I wanted to fix it.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Currently, both images with different contents has the same alt text.

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/be065064-3ec5-4301-8ebe-3859e1a77e56">


<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

![image](https://github.com/user-attachments/assets/1b80ab93-14ee-4753-b9d3-6383ee6f234f)

**Current alt text :** `Example showing the result of the firefox_code_search WebExtension's customization of the address bar suggestions.`

**Suggestion :** `Example of custom panel on developer tools.`

### Related issues and pull requests

#35581.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
