### PR TITLE
Replace use of "three" to describe lists of functions including more than 3

### DIFF
--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -78,7 +78,7 @@ Broadly speaking, JavaScript has four kinds of functions:
 - Async function: returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise); can be paused and resumed with the [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) operator
 - Async generator function: returns an [`AsyncGenerator`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator) object; both the `await` and `yield` operators can be used
 
-For every kind of function, there are three ways to define it:
+For every kind of function, there are multiple ways to define it:
 
 - Declaration
   - : [`function`](/en-US/docs/Web/JavaScript/Reference/Statements/function), [`function*`](/en-US/docs/Web/JavaScript/Reference/Statements/function*), [`async function`](/en-US/docs/Web/JavaScript/Reference/Statements/async_function), [`async function*`](/en-US/docs/Web/JavaScript/Reference/Statements/async_function*)


### PR DESCRIPTION
Replace use of "three" to describe lists of more than 3

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This list of functions includes 4 functions for each of the function types despite the text before the list saying there are "three" ways to define them.  

Additionally each of these lists are not exhaustive since, for example, arrow functions could technically also be listed under "expressions" but are not (they are called out below so not ignored).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Prevents confusion where 3 seems to be referring to a list of 4.

Future-proofing for if/when these lists are expanded to include other variations. For example if arrow functions are included in the main list they would not have a generator variation which would put them one way less than the others.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
