### PR TITLE
XMLSerializer: Note that the output might not be valid XML

### DIFF
--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -10,7 +10,7 @@ browser-compat: api.XMLSerializer
 The `XMLSerializer` interface provides the {{domxref("XMLSerializer.serializeToString", "serializeToString()")}} method to construct an XML string representing a {{Glossary("DOM")}} tree.
 
 > [!NOTE]
-> The resulting XML string is not guaranteed to necessarily be valid XML, for instance, if element names or attribute names are not permissible XML names.
+> The resulting XML string is not guaranteed to be well-formed XML.
 
 ## Constructor
 

--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -9,6 +9,9 @@ browser-compat: api.XMLSerializer
 
 The `XMLSerializer` interface provides the {{domxref("XMLSerializer.serializeToString", "serializeToString()")}} method to construct an XML string representing a {{Glossary("DOM")}} tree.
 
+> [!NOTE]
+> The resulting XML string is not guaranteed to necessarily be valid XML, for instance, if element names or attribute names are not permissible XML names.
+
 ## Constructor
 
 - {{domxref("XMLSerializer.XMLSerializer", "XMLSerializer()")}}


### PR DESCRIPTION
See discussion at https://bugzilla.mozilla.org/1914813. I initially thought this was a browser bug but this method is in fact specified to produce possibly-invalid XML.