### PR TITLE
FF124Relnote - WebSocket constructor HTTP(s) and relative URL

### DIFF
--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -29,7 +29,7 @@ No notable changes.
 ### APIs
 
 - [`AbortSignal.any()`](/en-US/docs/Web/API/AbortSignal/any_static) is now supported, allowing a composite signal to be created that can be used to abort an operation from multiple signal sources. ([Firefox bug 1830781](https://bugzil.la/1830781)).
-- The [`WebSocket()` constructor](/en-US/docs/Web/API/WebSocket/WebSocket#url) now allows HTTPS, HTTP, and relative URLs. They are often more ergonomic than using WSS and WSS URLs ([Firefox bug 1797449](https://bugzil.la/1797449)).
+- The [`WebSocket()` constructor](/en-US/docs/Web/API/WebSocket/WebSocket#url) now allows HTTPS, HTTP, and relative URLs. They are often more ergonomic than using WS and WSS URLs ([Firefox bug 1797449](https://bugzil.la/1797449)).
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 

--- a/files/en-us/mozilla/firefox/releases/124/index.md
+++ b/files/en-us/mozilla/firefox/releases/124/index.md
@@ -29,6 +29,7 @@ No notable changes.
 ### APIs
 
 - [`AbortSignal.any()`](/en-US/docs/Web/API/AbortSignal/any_static) is now supported, allowing a composite signal to be created that can be used to abort an operation from multiple signal sources. ([Firefox bug 1830781](https://bugzil.la/1830781)).
+- The [`WebSocket()` constructor](/en-US/docs/Web/API/WebSocket/WebSocket#url) now allows HTTPS, HTTP, and relative URLs. They are often more ergonomic than using WSS and WSS URLs ([Firefox bug 1797449](https://bugzil.la/1797449)).
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 


### PR DESCRIPTION
FF124 supports HTTPS, HTTP and relative URLS being passed to the WebSocket constructor. This adds a release note.

Related docs work in #26731