### PR TITLE
Reporting API - tidy up CSPViolationReportBody

### DIFF
--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -1,0 +1,48 @@
+---
+title: "CSPViolationReportBody: blockedURL property"
+short-title: blockedURL
+slug: Web/API/CSPViolationReportBody/blockedURL
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.blockedURL
+---
+
+{{APIRef("Reporting API")}}
+
+The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface represent the URL of the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+
+## Value
+
+An string containing the blocked URL.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the blocked URL in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Value: ${reports[0].body.blockedURL}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the blocked URL of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.blockedURI")}}

--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -30,7 +30,7 @@ If the value is not the URL of a resource, it must be one of the following strin
     For example, a {{domxref("TrustedTypePolicy")}} was created using {{domxref("TrustedTypePolicyFactory/createPolicy", "window.trustedTypes.createPolicy()")}} with a name that wasn't listed in the `trusted-types` directive, or the new policy did not provide adequate sanitization.
 - `trusted-types-sink`
   - : A resource that violated the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directive.
-    For example, the directive was set to `script` but the a sink for sanitized data, such as the {{domxref("Element.innerHTML")}} property did not use a {{domxref("TrustedTypePolicy")}} to sanitize the data before passing it to `innerHTML`.
+    For example, the directive was set to `script` but the document did not use a {{domxref("TrustedTypePolicy")}} to sanitize data before passing it to a sink such as {{domxref("Element.innerHTML")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -8,21 +8,42 @@ browser-compat: api.CSPViolationReportBody.blockedURL
 
 {{APIRef("Reporting API")}}
 
-The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface represent the URL of a resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string value or URL that represents the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
 ## Value
 
-An string containing the URL of the blocked resource.
+An string containing a value or URL that represents the resource that violated the policy.
+
+If the value is not an URL of a resource, it must be one of the following strings:
+
+- `inline`
+  - : An unsafe inline resource.
+    For example, an inline script that was used when [`'unsafe-inline'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-inline) was not specified in the CSP.
+- `eval`
+  - : An unsafe `eval()`.
+    For example, `eval` was used but [`'unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-eval) was not specified in the CSP.
+- `wasm-eval`
+  - : An unsafe WASM evaluation.
+    For example, `eval` was used but [`'wasm-unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#wasm-unsafe-eval) was not specified in the CSP.
+- `trusted-types-policy`
+  - : A resource that violated the [`trusted-types`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directive.
+    For example, a {{domxref("TrustedTypePolicy")}} was created using {{domxref("TrustedTypePolicyFactory/createPolicy", "window.trustedTypes.createPolicy()")}} with a name that wasn't listed in the `trusted-types` directive, or the new policy did not provide adequate sanitization.
+- `trusted-types-sink`
+  - : A resource that violated the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directive.
+    For example, the directive was set to `script` but the a sink for sanitized data, such as the {{domxref("Element.innerHTML")}} property did not use a {{domxref("TrustedTypePolicy")}} to sanitize the data before passing it to `innerHTML`.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the blocked URL in the first entry of the reports array.
+The following examples show HTML that would result some of the `blockedURL` values outlined above.
+
+The examples assume that you have a JavaScript file named `main.js` imported into your script from the same domain.
+The script, which is shown below, creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function is invoked, we log the `blockedURL` in the first entry of the reports array.
 
 ```js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Value: ${reports[0].body.blockedURL}`);
+    console.log(`blockedURL: ${reports[0].body.blockedURL}`);
   },
   {
     types: ["csp-violation"],
@@ -34,6 +55,146 @@ observer.observe();
 ```
 
 Note that while there might be multiple reports in the returned array, for brevity we only log the blocked URL of the first report.
+
+### blockedURL for an external resource
+
+The HTML below sets a policy of `Content-Security-Policy: default-src 'self'`, which only allows resources from the same site to be loaded, and then attempts to load a script from the external site `https://apis.google.com`.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <!-- This should generate a CSP violation -->
+    <script src="https://apis.google.com/js/platform.js"></script>
+  </body>
+</html>
+```
+
+The result of logging the `blockedURL` would be:
+
+```plain
+blockedURL: https://apis.google.com/js/platform.js
+```
+
+### blockedURL for unsafe-inline resources
+
+The HTML below demonstrates the conditions that would result in a `blockedURL` of `inline`.
+This sets a policy of `Content-Security-Policy: default-src 'self'`, which does not allow inline scripts to be executed, causing a violation because the page contains an inline script.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+The result of logging the `blockedURL` would be:
+
+```plain
+Value: blockedURL
+```
+
+### blockedURL for trusted-types-policy resources
+
+The HTML below demonstrates the conditions that would result in a `blockedURL` of `trusted-types-policy`.
+First it defines a policy that allows `'unsafe-inline'` scripts to be executed.
+It also uses the `trusted-types` directive to specify that a {{domxref("TrustedTypePolicy")}} with the name `myPolicy` is allowed to be created.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' 'report-sample' 'unsafe-inline'; trusted-types myPolicy" />
+    <script src="main.js"></script>
+  </head>
+
+  <body></body>
+
+  <script>
+    const policy = trustedTypes.createPolicy("somePolicy", {
+      createHTML: (string) => {
+        // Incorrect sanitization logic
+        return DOMPurify.sanitize(string);
+      },
+    });
+  </script>
+</html>
+```
+
+In the script a policy is created with the name `somePolicy`.
+Because this is not listed in the `trusted-types` directive it is a CSP violation, and we'd see the log output:
+
+```plain
+blockedURL: trusted-types-policy
+```
+
+Note that if we changed the name of the allowed policy to `somePolicy`, the page would no longer be in violation.
+
+### blockedURL for trusted-types-sink resources
+
+The HTML below demonstrates the conditions that would result in a `blockedURL` of `trusted-types-sink`.
+First it defines a policy that allows `'unsafe-inline'` scripts to be executed, and as in the previous example it use the `trusted-types` directive to specify that a {{domxref("TrustedTypePolicy")}} with the name `myPolicy` is allowed to be created.
+
+In addition, it specifies the directive `require-trusted-types-for 'script'`, which enforces that sinks should only be passed content that has been sanitized using a trusted type.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' 'report-sample' 'unsafe-inline'; trusted-types 'myPolicy'; require-trusted-types-for 'script'" />
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <input type="text" id="userInput" />
+    <button onclick="updateContent()">Update Content</button>
+    <div id="content"></div>
+  </body>
+
+  <script>
+    const policy = trustedTypes.createPolicy("somePolicy", {
+      createHTML: (string) => {
+        // Incorrect sanitization logic
+        return DOMPurify.sanitize(string);
+      },
+    });
+
+    function updateContent() {
+      const userInput = document.getElementById("userInput").value;
+
+      // Passing unsanitized content - a violation of the policy
+      document.getElementById("content").innerHTML = userInput;
+
+      //Correct use of the policy
+      //const sanitizedInput = policy.createHTML(userInput);
+      //document.getElementById("content").innerHTML = sanitizedInput;
+    }
+  </script>
+</html>
+```
+
+The `updateContent()` method passes unsanitized content to the element's `innerHTML` property, which will cause a CSP violation (note that code that would not cause the violation is commented out).
+
+We'd see the log output:
+
+```plain
+blockedURL: trusted-types-sink
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -8,11 +8,11 @@ browser-compat: api.CSPViolationReportBody.blockedURL
 
 {{APIRef("Reporting API")}}
 
-The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface represent the URL of the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface represent the URL of a resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
 ## Value
 
-An string containing the blocked URL.
+An string containing the URL of the blocked resource.
 
 ## Examples
 

--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -8,23 +8,23 @@ browser-compat: api.CSPViolationReportBody.blockedURL
 
 {{APIRef("Reporting API")}}
 
-The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string value or URL that represents the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`blockedURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string value that represents the resource that was blocked because it violates a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
 ## Value
 
 An string containing a value or URL that represents the resource that violated the policy.
 
-If the value is not an URL of a resource, it must be one of the following strings:
+If the value is not the URL of a resource, it must be one of the following strings:
 
 - `inline`
-  - : An unsafe inline resource.
+  - : An inline resource.
     For example, an inline script that was used when [`'unsafe-inline'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-inline) was not specified in the CSP.
 - `eval`
-  - : An unsafe `eval()`.
-    For example, `eval` was used but [`'unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-eval) was not specified in the CSP.
+  - : An `eval()`.
+    For example, `eval()` was used but [`'unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-eval) was not specified in the CSP.
 - `wasm-eval`
-  - : An unsafe WASM evaluation.
-    For example, `eval` was used but [`'wasm-unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#wasm-unsafe-eval) was not specified in the CSP.
+  - : An WASM evaluation.
+    For example, `eval()` was used but [`'wasm-unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#wasm-unsafe-eval) was not specified in the CSP.
 - `trusted-types-policy`
   - : A resource that violated the [`trusted-types`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directive.
     For example, a {{domxref("TrustedTypePolicy")}} was created using {{domxref("TrustedTypePolicyFactory/createPolicy", "window.trustedTypes.createPolicy()")}} with a name that wasn't listed in the `trusted-types` directive, or the new policy did not provide adequate sanitization.
@@ -34,7 +34,7 @@ If the value is not an URL of a resource, it must be one of the following string
 
 ## Examples
 
-The following examples show HTML that would result some of the `blockedURL` values outlined above.
+The following examples show HTML that would result in some of the `blockedURL` values outlined above.
 
 The examples assume that you have a JavaScript file named `main.js` imported into your script from the same domain.
 The script, which is shown below, creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.

--- a/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/blockedurl/index.md
@@ -27,7 +27,7 @@ If the value is not the URL of a resource, it must be one of the following strin
     For example, `eval()` was used but [`'wasm-unsafe-eval'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#wasm-unsafe-eval) was not specified in the CSP.
 - `trusted-types-policy`
   - : A resource that violated the [`trusted-types`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directive.
-    For example, a {{domxref("TrustedTypePolicy")}} was created using {{domxref("TrustedTypePolicyFactory/createPolicy", "window.trustedTypes.createPolicy()")}} with a name that wasn't listed in the `trusted-types` directive, or the new policy did not provide adequate sanitization.
+    For example, a {{domxref("TrustedTypePolicy")}} was created using {{domxref("TrustedTypePolicyFactory/createPolicy", "window.trustedTypes.createPolicy()")}} with a name that wasn't listed in the CSP `trusted-types` directive.
 - `trusted-types-sink`
   - : A resource that violated the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directive.
     For example, the directive was set to `script` but the document did not use a {{domxref("TrustedTypePolicy")}} to sanitize data before passing it to a sink such as {{domxref("Element.innerHTML")}}.

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -105,7 +105,7 @@ columnNumber: 13
 
 Note that the column number is different for the two browsers.
 Chrome always appears to report `0`.
-The value on Firefox appears to point to the second character after the end of the opening `<script>` element.
+The value on Firefox represents the first character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -105,7 +105,7 @@ columnNumber: 13
 
 Note that the column number is different for the two browsers.
 Chrome always appears to report `0`.
-The value on Firefox represents the first character after the end of the opening `<script>` element.
+The value on Firefox represents the position of the first character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -1,0 +1,53 @@
+---
+title: "CSPViolationReportBody: columnNumber property"
+short-title: columnNumber
+slug: Web/API/CSPViolationReportBody/columnNumber
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.columnNumber
+---
+
+{{APIRef("Reporting API")}}
+
+The **`columnNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the column in the source file that caused the reported CSP violation.
+
+This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.lineNumber")}}, as it provides the location of the column in that file and line where the error occurred.
+
+## Value
+
+An integer, or `null` if the column is not known.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    const cspViolationBody = reports[0].body;
+    console.log(`File: ${cspViolationBody.sourceFile}`);
+    console.log(`Line: ${cspViolationBody.lineNumber}`);
+    console.log(`Column: ${cspViolationBody.columnNumber}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.columnNumber")}}

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -28,7 +28,7 @@ This example triggers a CSP violation using an inline script, and reports the vi
 
 #### HTML
 
-The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same origin, but does not allow inline scripts to be executed.
 The document also includes an inline script, which should therefore trigger a CSP violation.
 
 ```html

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -8,26 +8,67 @@ browser-compat: api.CSPViolationReportBody.columnNumber
 
 {{APIRef("Reporting API")}}
 
-The **`columnNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the column in the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`columnNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the column number in the source file that triggered the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
+
+Note that the browser extracts the value from _the global object_ of the file that triggered the violation.
+If the resource that triggers the CSP violation is not loaded, the value will be `null`.
+See {{domxref("CSPViolationReportBody.sourceFile")}} for more information.
 
 This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.lineNumber")}}, as it provides the location of the column in that file and line that resulted in a violation.
 
 ## Value
 
-An integer, or `null` if the column is not known.
+An integer containing the column number that triggered the violation, or `null`.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+### CSP inline script violation
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+
+#### HTML
+
+The HTML file below uses the {{htmlelment("meta")}} element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which should therefore trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; report-to csp-endpoint" />
+    <meta
+      http-equiv="Reporting-Endpoints"
+      content="csp-endpoint='https://example.com/csp-reports'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
 Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
     const cspViolationBody = reports[0].body;
-    console.log(`File: ${cspViolationBody.sourceFile}`);
-    console.log(`Line: ${cspViolationBody.lineNumber}`);
-    console.log(`Column: ${cspViolationBody.columnNumber}`);
+    console.log(`sourceFile: ${cspViolationBody.sourceFile}`);
+    console.log(`lineNumber: ${cspViolationBody.lineNumber}`);
+    console.log(`columnNumber: ${cspViolationBody.columnNumber}`);
   },
   {
     types: ["csp-violation"],
@@ -38,7 +79,26 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
+
+```plain
+sourceFile: http://127.0.0.1:9999/inline/
+lineNumber: 17
+columnNumber: 0
+```
+
+Note that the column number is (incorrectly) set to `0`.
+The result is similar for Firefox, which correctly reports the `columnNumber`.
+
+```plain
+sourceFile: http://127.0.0.1:9999/inline/
+lineNumber: 17
+columnNumber: 13
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -86,7 +86,7 @@ Note that while there might be multiple reports in the returned array, for brevi
 If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
 
 ```plain
-sourceFile: http://127.0.0.1:9999/inline/
+sourceFile: http://127.0.0.1:9999/test/
 lineNumber: 17
 columnNumber: 0
 ```
@@ -95,7 +95,7 @@ Note that the column number is (incorrectly) set to `0`.
 The result is similar for Firefox, which correctly reports the `columnNumber`.
 
 ```plain
-sourceFile: http://127.0.0.1:9999/inline/
+sourceFile: http://127.0.0.1:9999/test/
 lineNumber: 17
 columnNumber: 13
 ```

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -28,7 +28,7 @@ This example triggers a CSP violation using an inline script, and reports the vi
 
 #### HTML
 
-The HTML file below uses the {{htmlelment("meta")}} element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
 The document also includes an inline script, which should therefore trigger a CSP violation.
 
 ```html

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -59,7 +59,7 @@ The document above also loads the external script `main.js`, which is shown belo
 Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
 
 The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
 // main.js

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -83,22 +83,29 @@ Note that while there might be multiple reports in the returned array, for brevi
 
 #### Results
 
-If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
+You can try this out using a [local server](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server).
+Copy the above code into `test/index.html` and `test/main.js` and run the server in the root directory.
+Assuming the address of the local server is `http://127.0.0.1:9999`, you can then load the HTML file from `http://127.0.0.1:9999/test/` (or `http://127.0.0.1:9999/test/index.html`).
+
+With the above setup, the output of the log on Chrome is:
 
 ```plain
 sourceFile: http://127.0.0.1:9999/test/
-lineNumber: 17
+lineNumber: 15
 columnNumber: 0
 ```
 
-Note that the column number is (incorrectly) set to `0`.
-The result is similar for Firefox, which correctly reports the `columnNumber`.
+The result is similar for Firefox:
 
 ```plain
 sourceFile: http://127.0.0.1:9999/test/
-lineNumber: 17
+lineNumber: 15
 columnNumber: 13
 ```
+
+Note that the column number is different for the two browsers.
+Chrome always appears to report `0`.
+The value on Firefox appears to point to the second character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/columnnumber/index.md
@@ -8,9 +8,9 @@ browser-compat: api.CSPViolationReportBody.columnNumber
 
 {{APIRef("Reporting API")}}
 
-The **`columnNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the column in the source file that caused the reported CSP violation.
+The **`columnNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the column in the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
-This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.lineNumber")}}, as it provides the location of the column in that file and line where the error occurred.
+This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.lineNumber")}}, as it provides the location of the column in that file and line that resulted in a violation.
 
 ## Value
 

--- a/files/en-us/web/api/cspviolationreportbody/disposition/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/disposition/index.md
@@ -1,0 +1,53 @@
+---
+title: "CSPViolationReportBody: disposition property"
+short-title: disposition
+slug: Web/API/CSPViolationReportBody/disposition
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.disposition
+---
+
+{{APIRef("Reporting API")}}
+
+The **`disposition`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates whether the user agent is configured to enforce [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violations or only report them.
+
+## Value
+
+Possible values are:
+
+- `"enforce"`
+  - : The policy is enforced and the resource request is blocked.
+- `"report"`
+  - : The violation is reported but the resource request is not blocked.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the disposition in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Disposition: ${reports[0].body.disposition}`); // For example: "enforce"
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the disposition of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.disposition")}}

--- a/files/en-us/web/api/cspviolationreportbody/disposition/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/disposition/index.md
@@ -27,7 +27,8 @@ Each time the callback function in invoked, we log the disposition in the first 
 ```js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Disposition: ${reports[0].body.disposition}`); // For example: "enforce"
+    console.log(`Disposition: ${reports[0].body.disposition}`);
+    // For example: "enforce"
   },
   {
     types: ["csp-violation"],

--- a/files/en-us/web/api/cspviolationreportbody/disposition/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/disposition/index.md
@@ -22,7 +22,7 @@ Possible values are:
 ## Examples
 
 In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the disposition in the first entry of the reports array.
+Each time the callback function is invoked, we log the disposition in the first entry of the reports array.
 
 ```js
 const observer = new ReportingObserver(

--- a/files/en-us/web/api/cspviolationreportbody/disposition/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/disposition/index.md
@@ -21,13 +21,52 @@ Possible values are:
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function is invoked, we log the disposition in the first entry of the reports array.
+### CSP inline script violation showing the disposition
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+The `disposition` is logged.
+
+#### HTML
+
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which should therefore trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; report-to csp-endpoint" />
+    <meta
+      http-equiv="Reporting-Endpoints"
+      content="csp-endpoint='https://example.com/csp-reports'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Disposition: ${reports[0].body.disposition}`);
+    const cspViolationBody = reports[0].body;
+    console.log(`disposition: ${cspViolationBody.disposition}`);
     // For example: "enforce"
   },
   {
@@ -39,7 +78,19 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the disposition of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+If serving the above code, the log output would be:
+
+```plain
+disposition: enforce
+```
+
+> [!NOTE]
+> If `Content-Security-Policy-Reporting-Only` was enabled the disposition would be `report`.
+> Note however, that `Content-Security-Policy-Reporting-Only` must be served: it can't be set in the `<meta>` element as we have done above.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
@@ -16,13 +16,68 @@ A string containing the URL of the document or worker that violated the CSP.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the document URL in the first entry of the reports array.
+### CSP inline script violation showing referrer
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+We navigate to the page from another page and log the `referrer`, `documentURL`, and `blockedURL`.
+
+#### HTML
+
+First we define our referrer page `/bounce/index.html`.
+This is a very simple HTML page that has a link to another file `../report_sample/index.html`.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <ul>
+      <li><a href="../report_sample/">report sample</a></li>
+    </ul>
+  </body>
+</html>
+```
+
+The `../report_sample/index.html` HTML file is defined below.
+This uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `script-src-elem` to `self`, which allows scripts to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which will trigger a CSP violation.
+
+```html
+<!doctype html>
+<!-- /report_sample/index.html -->
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src-elem 'self' 'report-sample'" />
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The report sample above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the violation `documentURL`, `referrer`, and `blockedURL` to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Document: ${reports[0].body.documentURL}`);
+    console.log(`documentURL: ${reports[0].body.referrer}`);
+    console.log(`referrer: ${reports[0].body.referrer}`);
+    console.log(`blockedURL: ${reports[0].body.blockedURL}`);
   },
   {
     types: ["csp-violation"],
@@ -33,7 +88,19 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the document URL of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+The console output for the above code would look a bit like that below (the site will depend on how the pages are served):
+
+```plain
+documentURL: http://127.0.0.1:9999/report_sample/
+referrer: http://127.0.0.1:9999/bounce/
+blockedURL: inline
+```
+
+Note that `referrer` is the page we navigated form, `documentURL` is the page with the CSP violation, and `blockedURL` is not an URL at all in this case, but an indication that the violation was caused by an unsafe inline script.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
@@ -24,7 +24,7 @@ We navigate to the page from another page and log the `referrer`, `documentURL`,
 #### HTML
 
 First we define our referrer page `/bounce/index.html`.
-This is a very simple HTML page that has a link to another file `../report_sample/index.html`.
+This page just contains a link to another page `../report_sample/index.html`.
 
 ```html
 <!doctype html>
@@ -100,7 +100,7 @@ referrer: http://127.0.0.1:9999/bounce/
 blockedURL: inline
 ```
 
-Note that `referrer` is the page we navigated form, `documentURL` is the page with the CSP violation, and `blockedURL` is not an URL at all in this case, but an indication that the violation was caused by an unsafe inline script.
+Note that `referrer` is the page we navigated from, `documentURL` is the page with the CSP violation, and `blockedURL` is not an URL at all in this case, but an indication that the violation was caused by an inline script.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
@@ -8,11 +8,11 @@ browser-compat: api.CSPViolationReportBody.documentURL
 
 {{APIRef("Reporting API")}}
 
-The **`documentURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the URL of the document or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
+The **`documentURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the URL of the document or worker that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
 ## Value
 
-A string containing the URL of the document or worker in which the violation occurred.
+A string containing the URL of the document or worker that violated the CSP.
 
 ## Examples
 

--- a/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/documenturl/index.md
@@ -1,0 +1,48 @@
+---
+title: "CSPViolationReportBody: documentURL property"
+short-title: documentURL
+slug: Web/API/CSPViolationReportBody/documentURL
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.documentURL
+---
+
+{{APIRef("Reporting API")}}
+
+The **`documentURL`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the URL of the document or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
+
+## Value
+
+A string containing the URL of the document or worker in which the violation occurred.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the document URL in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Document: ${reports[0].body.documentURL}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the document URL of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.documentURI")}}

--- a/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
@@ -56,7 +56,7 @@ The document above also loads the external script `main.js`, which is shown belo
 Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
 
 The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the effectiveDirective and `originalPolicy` of the violation to the console.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the effectiveDirective and `originalPolicy` of the violation to the console.
 
 ```js
 // main.js

--- a/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSPViolationReportBody.effectiveDirective
 
 The **`effectiveDirective`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the effective [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
 
-Note that this contains the specific directive that was effectively violated, such as `script-src-elem`, and not the policy that was specified, which may have been the (more general) `default-src`.
+Note that this contains the specific directive that was effectively violated, such as [`script-src-elem`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem) for violations related to script elements, and not the policy that was specified, which may have been the (more general) [`default-src`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src).
 
 ## Value
 
@@ -18,14 +18,54 @@ A string representing the effective [`Content-Security-Policy` directive](/en-US
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the directive in the first entry of the reports array.
+### CSP inline script violation
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+In particular, it logs the `effectiveDirective` and the `originalPolicy`, making the difference clear.
+
+#### HTML
+
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which should trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; report-to csp-endpoint" />
+    <meta
+      http-equiv="Reporting-Endpoints"
+      content="csp-endpoint='https://example.com/csp-reports'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the effectiveDirective and `originalPolicy` of the violation to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Directive: ${reports[0].body.effectiveDirective}`);
-    // For example: style-src-elem
+    console.log(`effectiveDirective: ${reports[0].body.effectiveDirective}`);
+    // effectiveDirective: script-src-elem
+    console.log(`originalPolicy: ${reports[0].body.originalPolicy}`);
+    // originalPolicy: default-src 'self'; report-to csp-endpoint
   },
   {
     types: ["csp-violation"],
@@ -36,7 +76,21 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the `effectiveDirective` of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+The console output for the above code is:
+
+```plain
+effectiveDirective: script-src-elem
+originalPolicy: default-src 'self'; report-to csp-endpoint
+```
+
+Note that the `orginalPolicy` matches the `<meta>` content of the `Content-Security-Policy` directive in the HTML, and specifies that the policy is `self` by default (`default-src 'self'`).
+
+The `effectiveDirective` is `script-src-elem`, which specifies valid sources for JavaScript {{htmlelement("script")}} elements.
+This is the specific directive that has effectively been violated, even though `default-src` was set in the policy.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSPViolationReportBody.effectiveDirective
 
 {{APIRef("Reporting API")}}
 
-The **`effectiveDirective`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents effective [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
+The **`effectiveDirective`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the effective [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
 
 Note that this contains the specific directive that was effectively violated, such as `script-src-elem`, and not the policy that was specified, which may have been the (more general) `default-src`.
 

--- a/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
@@ -24,7 +24,8 @@ Each time the callback function in invoked, we log the directive in the first en
 ```js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Directive: ${reports[0].body.effectiveDirective}`); // For example: style-src-elem
+    console.log(`Directive: ${reports[0].body.effectiveDirective}`);
+    // For example: style-src-elem
   },
   {
     types: ["csp-violation"],

--- a/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/effectivedirective/index.md
@@ -1,0 +1,50 @@
+---
+title: "CSPViolationReportBody: effectiveDirective property"
+short-title: effectiveDirective
+slug: Web/API/CSPViolationReportBody/effectiveDirective
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.effectiveDirective
+---
+
+{{APIRef("Reporting API")}}
+
+The **`effectiveDirective`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents effective [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) directive that was violated.
+
+Note that this contains the specific directive that was effectively violated, such as `script-src-elem`, and not the policy that was specified, which may have been the (more general) `default-src`.
+
+## Value
+
+A string representing the effective [`Content-Security-Policy` directive](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#directives) that was violated.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the directive in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Directive: ${reports[0].body.effectiveDirective}`); // For example: style-src-elem
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the `effectiveDirective` of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.effectiveDirective")}}

--- a/files/en-us/web/api/cspviolationreportbody/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/index.md
@@ -28,7 +28,7 @@ These reports similarly have a `type` of `"csp-violation"`, and a `body` propert
 _Also inherits properties from its parent interface, {{DOMxRef("ReportBody")}}._
 
 - {{domxref("CSPViolationReportBody.blockedURL")}} {{ReadOnlyInline}}
-  - : A string representing the URL of the resource that was blocked because it violates the CSP.
+  - : A string representing either the type or the URL of the resource that was blocked because it violates the CSP.
 - {{domxref("CSPViolationReportBody.columnNumber")}} {{ReadOnlyInline}}
   - : The column number in the script at which the violation occurred.
 - {{domxref("CSPViolationReportBody.disposition")}} {{ReadOnlyInline}}
@@ -64,10 +64,16 @@ _Also inherits methods from its parent interface, {{DOMxRef("ReportBody")}}._
 To obtain a `CSPViolationReportBody` object, you must configure your page so that a CSP violation will occur.
 In this example, we will set our CSP to only allow content from the site's own origin, and then attempt to load a script from `apis.google.com`, which is an external origin.
 
-First, we will set our {{HTTPHeader("Content-Security-Policy")}} header:
+First, we will set our {{HTTPHeader("Content-Security-Policy")}} header in the HTTP response:
 
 ```http
 Content-Security-Policy: default-src 'self';
+```
+
+or in the HTML [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
 ```
 
 Then, we will attempt to load an external script:
@@ -82,7 +88,10 @@ Finally, we will create a new {{domxref("ReportingObserver")}} object to listen 
 ```js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    const cspViolation = reports[0];
+    reports.forEach((violation) => {
+      console.log(violation);
+      console.log(JSON.stringify(violation));
+    });
   },
   {
     types: ["csp-violation"],
@@ -93,7 +102,7 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-If we were to log the violation report object, it would look similar to the object below.
+Above we log the each violation report object and a JSON-string version of the object, which might look similar to the object below.
 Note that the `body` is an instance of the `CSPViolationReportBody` and the `type` is `"csp-violation"`.
 
 ```js
@@ -130,7 +139,7 @@ Reporting-Endpoints: csp-endpoint="https://example.com/csp-report-to"
 Content-Security-Policy: default-src 'self'; report-to csp-endpoint
 ```
 
-As before, we can trigger the violation by loading an external script from a location that is not allowed by our CSP header:
+As before, we can trigger a violation by loading an external script from a location that is not allowed by our CSP header:
 
 ```html
 <!-- This should generate a CSP violation -->
@@ -153,7 +162,7 @@ As you can see from the example below, the `type` is `"csp-violation"` and the `
       "lineNumber": 1441,
       "originalPolicy": "default-src 'self'; report-to csp-endpoint",
       "referrer": "https://www.google.com/",
-      "sample": "console.log(\"lo\")",
+      "sample": "",
       "sourceFile": "https://example.com/csp-report-to",
       "statusCode": 200
     },

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -105,7 +105,7 @@ columnNumber: 13
 
 Note that the column number is different for the two browsers.
 Chrome always appears to report `0`.
-The value on Firefox appears to point to the second character after the end of the opening `<script>` element.
+The value on Firefox represents the first character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -105,7 +105,7 @@ columnNumber: 13
 
 Note that the column number is different for the two browsers.
 Chrome always appears to report `0`.
-The value on Firefox represents the first character after the end of the opening `<script>` element.
+The value on Firefox represents the position of the first character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -53,6 +53,8 @@ The document also includes an inline script, which should therefore trigger a CS
 </html>
 ```
 
+Copy the above code into a file `test/index.html`.
+
 #### JavaScript (main.js)
 
 The document above also loads the external script `main.js`, which is shown below.
@@ -81,12 +83,14 @@ observer.observe();
 
 Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
 
+Copy the code above into `test/main.js` alongside the `index.html` file.
+
 #### Results
 
-If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
+If using a local server to load the HTML from `http://127.0.0.1:9999/test/` (or `http://127.0.0.1:9999/test/index.html`), the output of the log on Chrome is:
 
 ```plain
-sourceFile: http://127.0.0.1:9999/inline/
+sourceFile: http://127.0.0.1:9999/test/
 lineNumber: 17
 columnNumber: 0
 ```
@@ -95,7 +99,7 @@ Note that the column number is (incorrectly) set to `0`.
 The result is similar for Firefox, which correctly reports the `columnNumber`.
 
 ```plain
-sourceFile: http://127.0.0.1:9999/inline/
+sourceFile: http://127.0.0.1:9999/test/
 lineNumber: 17
 columnNumber: 13
 ```

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -8,9 +8,9 @@ browser-compat: api.CSPViolationReportBody.lineNumber
 
 {{APIRef("Reporting API")}}
 
-The **`lineNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the line in the source file that caused the reported CSP violation.
+The **`lineNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the line in the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
-This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, as it provides the location of the line in that file and the column where the error occurred.
+This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, as it provides the location of the line in that file and the column that resulted in a violation.
 
 ## Value
 

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -8,26 +8,67 @@ browser-compat: api.CSPViolationReportBody.lineNumber
 
 {{APIRef("Reporting API")}}
 
-The **`lineNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the line in the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`lineNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the line number in the source file that triggered the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
+
+Note that the browser extracts the value from _the global object_ of the file that triggered the violation.
+If the resource that triggers the CSP violation is not loaded, the value will be `null`.
+See {{domxref("CSPViolationReportBody.sourceFile")}} for more information.
 
 This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, as it provides the location of the line in that file and the column that resulted in a violation.
 
 ## Value
 
-An integer, or `null` if the line number is not known.
+An integer containing the line number that triggered the violation, or `null`.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+### CSP inline script violation
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+
+#### HTML
+
+The HTML file below uses the {{htmlelment("meta")}} element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which should therefore trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; report-to csp-endpoint" />
+    <meta
+      http-equiv="Reporting-Endpoints"
+      content="csp-endpoint='https://example.com/csp-reports'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
 Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
     const cspViolationBody = reports[0].body;
-    console.log(`File: ${cspViolationBody.sourceFile}`);
-    console.log(`Line: ${cspViolationBody.lineNumber}`);
-    console.log(`Column: ${cspViolationBody.columnNumber}`);
+    console.log(`sourceFile: ${cspViolationBody.sourceFile}`);
+    console.log(`lineNumber: ${cspViolationBody.lineNumber}`);
+    console.log(`columnNumber: ${cspViolationBody.columnNumber}`);
   },
   {
     types: ["csp-violation"],
@@ -38,7 +79,26 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
+
+```plain
+sourceFile: http://127.0.0.1:9999/inline/
+lineNumber: 17
+columnNumber: 0
+```
+
+Note that the column number is (incorrectly) set to `0`.
+The result is similar for Firefox, which correctly reports the `columnNumber`.
+
+```plain
+sourceFile: http://127.0.0.1:9999/inline/
+lineNumber: 17
+columnNumber: 13
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -28,7 +28,7 @@ This example triggers a CSP violation using an inline script, and reports the vi
 
 #### HTML
 
-The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same origin, but does not allow inline scripts to be executed.
 The document also includes an inline script, which should therefore trigger a CSP violation.
 
 ```html
@@ -52,8 +52,6 @@ The document also includes an inline script, which should therefore trigger a CS
   </body>
 </html>
 ```
-
-Copy the above code into a file `test/index.html`.
 
 #### JavaScript (main.js)
 
@@ -83,26 +81,31 @@ observer.observe();
 
 Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
 
-Copy the code above into `test/main.js` alongside the `index.html` file.
-
 #### Results
 
-If using a local server to load the HTML from `http://127.0.0.1:9999/test/` (or `http://127.0.0.1:9999/test/index.html`), the output of the log on Chrome is:
+You can try this out using a [local server](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server).
+Copy the above code into `test/index.html` and `test/main.js` and run the server in the root directory.
+Assuming the address of the local server is `http://127.0.0.1:9999`, you can then load the HTML file from `http://127.0.0.1:9999/test/` (or `http://127.0.0.1:9999/test/index.html`).
+
+With the above setup, the output of the log on Chrome is:
 
 ```plain
 sourceFile: http://127.0.0.1:9999/test/
-lineNumber: 17
+lineNumber: 15
 columnNumber: 0
 ```
 
-Note that the column number is (incorrectly) set to `0`.
-The result is similar for Firefox, which correctly reports the `columnNumber`.
+The result is similar for Firefox:
 
 ```plain
 sourceFile: http://127.0.0.1:9999/test/
-lineNumber: 17
+lineNumber: 15
 columnNumber: 13
 ```
+
+Note that the column number is different for the two browsers.
+Chrome always appears to report `0`.
+The value on Firefox appears to point to the second character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -28,7 +28,7 @@ This example triggers a CSP violation using an inline script, and reports the vi
 
 #### HTML
 
-The HTML file below uses the {{htmlelment("meta")}} element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
 The document also includes an inline script, which should therefore trigger a CSP violation.
 
 ```html

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -1,0 +1,53 @@
+---
+title: "CSPViolationReportBody: lineNumber property"
+short-title: lineNumber
+slug: Web/API/CSPViolationReportBody/lineNumber
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.lineNumber
+---
+
+{{APIRef("Reporting API")}}
+
+The **`lineNumber`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the line in the source file that caused the reported CSP violation.
+
+This property is most useful alongside {{domxref("CSPViolationReportBody.sourceFile")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, as it provides the location of the line in that file and the column where the error occurred.
+
+## Value
+
+An integer, or `null` if the line number is not known.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    const cspViolationBody = reports[0].body;
+    console.log(`File: ${cspViolationBody.sourceFile}`);
+    console.log(`Line: ${cspViolationBody.lineNumber}`);
+    console.log(`Column: ${cspViolationBody.columnNumber}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.lineNumber")}}

--- a/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/linenumber/index.md
@@ -59,7 +59,7 @@ The document above also loads the external script `main.js`, which is shown belo
 Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
 
 The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
 // main.js

--- a/files/en-us/web/api/cspviolationreportbody/originalpolicy/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/originalpolicy/index.md
@@ -58,7 +58,7 @@ The document above also loads the external script `main.js`, which is shown belo
 Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
 
 The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the effectiveDirective and `originalPolicy` of the violation to the console.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the effectiveDirective and `originalPolicy` of the violation to the console.
 
 ```js
 // main.js

--- a/files/en-us/web/api/cspviolationreportbody/originalpolicy/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/originalpolicy/index.md
@@ -19,14 +19,55 @@ A string representing the policy whose enforcement uncovered the violation.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the policy in the first entry of the reports array.
+### CSP inline script violation
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+In particular, it logs the `effectiveDirective` and the `originalPolicy`, making the difference clear.
+
+#### HTML
+
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which should trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; report-to csp-endpoint" />
+    <!-- This is the (original) CSP policy -->
+    <meta
+      http-equiv="Reporting-Endpoints"
+      content="csp-endpoint='https://example.com/csp-reports'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the effectiveDirective and `originalPolicy` of the violation to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Document: ${reports[0].body.originalPolicy}`);
-    // For example: "default-src 'self'; report-to csp-endpoint",
+    console.log(`effectiveDirective: ${reports[0].body.effectiveDirective}`);
+    // effectiveDirective: script-src-elem
+    console.log(`originalPolicy: ${reports[0].body.originalPolicy}`);
+    // originalPolicy: default-src 'self'; report-to csp-endpoint
   },
   {
     types: ["csp-violation"],
@@ -37,7 +78,21 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the original policy of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+The console output for the above code is:
+
+```plain
+effectiveDirective: script-src-elem
+originalPolicy: default-src 'self'; report-to csp-endpoint
+```
+
+Note that the `orginalPolicy` matches the `<meta>` content of the `Content-Security-Policy` directive in the HTML, and specifies that the policy is `self` by default (`default-src 'self'`).
+
+The `effectiveDirective` is `script-src-elem`, which specifies valid sources for JavaScript {{htmlelement("script")}} elements.
+This is the specific directive that has effectively been violated, even though `default-src` was set in the policy.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/originalpolicy/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/originalpolicy/index.md
@@ -1,0 +1,52 @@
+---
+title: "CSPViolationReportBody: originalPolicy property"
+short-title: originalPolicy
+slug: Web/API/CSPViolationReportBody/originalPolicy
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.originalPolicy
+---
+
+{{APIRef("Reporting API")}}
+
+The **`originalPolicy`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) whose enforcement uncovered the violation.
+
+This is the string in the {{HTTPHeader("Content-Security-Policy")}} HTTP response header that contains the list of [directives](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#directives) and their values that make the CSP policy.
+Note that differs from the {{domxref("CSPViolationReportBody.effectiveDirective","effectiveDirective")}}, which is the specific directive that is effectively being violated (and which might not be explicitly listed in the policy if `default-src` is used).
+
+## Value
+
+A string representing the policy whose enforcement uncovered the violation.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the policy in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Document: ${reports[0].body.originalPolicy}`);
+    // For example: "default-src 'self'; report-to csp-endpoint",
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the original policy of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.originalPolicy")}}

--- a/files/en-us/web/api/cspviolationreportbody/referrer/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/referrer/index.md
@@ -8,25 +8,81 @@ browser-compat: api.CSPViolationReportBody.referrer
 
 {{APIRef("Reporting API")}}
 
-The **`referrer`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the referrer whose enforcement uncovered the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
-This will be the URL of the web page that made the request, or `null`.
+The **`referrer`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the URL of the referring page of the resource who's [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) was violated.
+
+The referrer is the page that caused the page with the CSP violation to be loaded. For example, if we followed a link to a page with a CSP violation, the `referrer` is the page that we navigated from.
 
 ## Value
 
-A string representing the URL for the referrer of the resources whose policy was violated, or `null`.
+A string representing the URL for the referrer of the page with the CSP violation, or null.
 
 Note that if the referrer is an HTTP URL then any username, password or fragment is removed.
 If the URL scheme is not `http:` then just the scheme is returned.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the referrer in the first entry of the reports array.
+### CSP inline script violation showing referrer
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+We navigate to the page from another page and log the `referrer`, `documentURL`, and `blockedURL`.
+
+#### HTML
+
+First we define our referrer page `/bounce/index.html`.
+This is a very simple HTML page that has a link to another file `../report_sample/index.html`.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <ul>
+      <li><a href="../report_sample/">report sample</a></li>
+    </ul>
+  </body>
+</html>
+```
+
+The `../report_sample/index.html` HTML file is defined below.
+This uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `script-src-elem` to `self`, which allows scripts to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which will trigger a CSP violation.
+
+```html
+<!doctype html>
+<!-- /report_sample/index.html -->
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src-elem 'self' 'report-sample'" />
+    <script src="main.js"></script>
+  </head>
+  <body>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The report sample above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the violation `documentURL`, `referrer`, and `blockedURL` to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Referrer: ${reports[0].body.referrer}`);
+    console.log(`documentURL: ${reports[0].body.referrer}`);
+    console.log(`referrer: ${reports[0].body.referrer}`);
+    console.log(`blockedURL: ${reports[0].body.blockedURL}`);
   },
   {
     types: ["csp-violation"],
@@ -37,7 +93,19 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the referrer of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+The console output for the above code would look a bit like that below (the site will depend on how the pages are served):
+
+```plain
+documentURL: http://127.0.0.1:9999/report_sample/
+referrer: http://127.0.0.1:9999/bounce/
+blockedURL: inline
+```
+
+Note that `referrer` is the page we navigated form, `documentURL` is the page with the CSP violation, and `blockedURL` is not an URL at all in this case, but an indication that the violation was caused by an unsafe inline script.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/referrer/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/referrer/index.md
@@ -1,0 +1,53 @@
+---
+title: "CSPViolationReportBody: referrer property"
+short-title: referrer
+slug: Web/API/CSPViolationReportBody/referrer
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.referrer
+---
+
+{{APIRef("Reporting API")}}
+
+The **`referrer`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that represents the referrer whose enforcement uncovered the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
+This will be the URL of the web page that made the request, or `null`.
+
+## Value
+
+A string representing the URL for the referrer of the resources whose policy was violated, or `null`.
+
+Note that if the referrer is an HTTP URL then any username, password or fragment is removed.
+If the URL scheme is not `http:` then just the scheme is returned.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the referrer in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Referrer: ${reports[0].body.referrer}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the referrer of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.referrer")}}
+- {{httpheader("Referer")}}

--- a/files/en-us/web/api/cspviolationreportbody/referrer/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/referrer/index.md
@@ -16,8 +16,8 @@ The referrer is the page that caused the page with the CSP violation to be loade
 
 A string representing the URL for the referrer of the page with the CSP violation, or null.
 
-Note that if the referrer is an HTTP URL then any username, password or fragment is removed.
-If the URL scheme is not `http:` then just the scheme is returned.
+Note that if the referrer is an HTTP(S) URL then any username, password or fragment is removed.
+If the URL scheme is not `http:` or `https:` then just the scheme is returned.
 
 ## Examples
 
@@ -29,7 +29,7 @@ We navigate to the page from another page and log the `referrer`, `documentURL`,
 #### HTML
 
 First we define our referrer page `/bounce/index.html`.
-This is a very simple HTML page that has a link to another file `../report_sample/index.html`.
+This page just contains a link to another page `../report_sample/index.html`.
 
 ```html
 <!doctype html>
@@ -105,7 +105,7 @@ referrer: http://127.0.0.1:9999/bounce/
 blockedURL: inline
 ```
 
-Note that `referrer` is the page we navigated form, `documentURL` is the page with the CSP violation, and `blockedURL` is not an URL at all in this case, but an indication that the violation was caused by an unsafe inline script.
+Note that `referrer` is the page we navigated from, `documentURL` is the page with the CSP violation, and `blockedURL` is not an URL at all in this case, but an indication that the violation was caused by an unsafe inline script.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/sample/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sample/index.md
@@ -1,0 +1,56 @@
+---
+title: "CSPViolationReportBody: sample property"
+short-title: sample
+slug: Web/API/CSPViolationReportBody/sample
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.sample
+---
+
+{{APIRef("Reporting API")}}
+
+The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a sample of the resource that caused the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
+
+This is usually the first 40 characters of the inline script, event handler, or style that contains the violation — external resources causing a violation will not generate a sample.
+If not populated it is the empty string `""`.
+
+Note that this is only populated for CSP [`script-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#script-src) and [`style-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#style-src) violations, when the corresponding `Content-Security-Policy` directive contains the [`'report-sample'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#report-sample) keyword.
+
+> [!NOTE] Violation reports should be considered attacker-controlled data.
+> The content of this field _in particular_ should be sanitized before storing or rendering.
+
+## Value
+
+A string containing a sample of the resource that caused the violation, usually the first 40 characters, or the empty string.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the sample in the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`Sample: ${reports[0].body.sample}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the sample of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.sample")}}

--- a/files/en-us/web/api/cspviolationreportbody/sample/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sample/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSPViolationReportBody.sample
 
 {{APIRef("Reporting API")}}
 
-The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a part of the resource that was in violation of the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a part of the resource that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
 This sample is usually the first 40 characters of the inline script, event handler, or style that violated a CSP restriction.
 If not populated it is the empty string `""`.
@@ -21,7 +21,7 @@ In addition, a sample is only included if the `Content-Security-Policy` directiv
 
 ## Value
 
-A string containing a sample of the resource that caused the violation, usually the first 40 characters, or the empty string.
+A string containing a sample of the resource that violated the CSP, usually the first 40 characters, or the empty string.
 
 ## Examples
 

--- a/files/en-us/web/api/cspviolationreportbody/sample/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sample/index.md
@@ -8,9 +8,9 @@ browser-compat: api.CSPViolationReportBody.sample
 
 {{APIRef("Reporting API")}}
 
-The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a sample of the resource that caused the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation.
+The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a sample of the resource that was in violation of the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
-This is usually the first 40 characters of the inline script, event handler, or style that contains the violation — external resources causing a violation will not generate a sample.
+This is usually the first 40 characters of the inline script, event handler, or style that violated a CSP restriction — external resources that violate the CSP will not generate a sample.
 If not populated it is the empty string `""`.
 
 Note that this is only populated for CSP [`script-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#script-src) and [`style-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#style-src) violations, when the corresponding `Content-Security-Policy` directive contains the [`'report-sample'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#report-sample) keyword.

--- a/files/en-us/web/api/cspviolationreportbody/sample/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sample/index.md
@@ -21,17 +21,53 @@ In addition, a sample is only included if the `Content-Security-Policy` directiv
 
 ## Value
 
-A string containing a sample of the resource that violated the CSP, usually the first 40 characters, or the empty string.
+A string containing a sample of the inline resource that violated the CSP, usually the first 40 characters, or the empty string.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the sample in the first entry of the reports array.
+### CSP inline script violation
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+We also add `'report-sample'` to the CSP in order to populate a `sample` in the body.
+
+#### HTML
+
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `script-src-elem` to `self`, which allows scripts to be loaded from the same domain, but does not allow inline scripts to be executed.
+We include `'report-sample'` in the directive so that a sample is generated.
+The document also includes an inline script, which should trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src-elem 'self' 'report-sample'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the violation `sample` to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`Sample: ${reports[0].body.sample}`);
+    console.log(`sample: ${reports[0].body.sample}`);
   },
   {
     types: ["csp-violation"],
@@ -42,7 +78,17 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that while there might be multiple reports in the returned array, for brevity we only log the sample of the first report.
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+The console output for the above code is:
+
+```plain
+sample: const int = 4;
+```
+
+In this case the sample contains the entire content of the inline script.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/sample/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sample/index.md
@@ -8,12 +8,13 @@ browser-compat: api.CSPViolationReportBody.sample
 
 {{APIRef("Reporting API")}}
 
-The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a sample of the resource that was in violation of the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`sample`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a string that contains a part of the resource that was in violation of the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
-This is usually the first 40 characters of the inline script, event handler, or style that violated a CSP restriction — external resources that violate the CSP will not generate a sample.
+This sample is usually the first 40 characters of the inline script, event handler, or style that violated a CSP restriction.
 If not populated it is the empty string `""`.
 
-Note that this is only populated for CSP [`script-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#script-src) and [`style-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#style-src) violations, when the corresponding `Content-Security-Policy` directive contains the [`'report-sample'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#report-sample) keyword.
+Note that this is only populated when attempting to load _inline_ scripts, event handlers, or styles that violate CSP [`script-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#script-src) and [`style-src*`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#style-src) rules — external resources that violate the CSP will not generate a sample.
+In addition, a sample is only included if the `Content-Security-Policy` directive that was violated also contains the [`'report-sample'`](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#report-sample) keyword.
 
 > [!NOTE] Violation reports should be considered attacker-controlled data.
 > The content of this field _in particular_ should be sanitized before storing or rendering.

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -108,7 +108,7 @@ columnNumber: 13
 
 Note that the column number is different for the two browsers.
 Chrome always appears to report `0`.
-The value on Firefox appears to point to the second character after the end of the opening `<script>` element.
+The value on Firefox represents the position of the first character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -1,0 +1,53 @@
+---
+title: "CSPViolationReportBody: sourceFile property"
+short-title: sourceFile
+slug: Web/API/CSPViolationReportBody/sourceFile
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.sourceFile
+---
+
+{{APIRef("Reporting API")}}
+
+The **`sourceFile`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the path of the source file that caused the reported CSP violation.
+
+This property is most useful alongside {{domxref("CSPViolationReportBody.lineNumber")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, which provide the location of the violation within the file.
+
+## Value
+
+A string, or `null` if the path is not known.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    const cspViolationBody = reports[0].body;
+    console.log(`File: ${cspViolationBody.sourceFile}`);
+    console.log(`Line: ${cspViolationBody.lineNumber}`);
+    console.log(`Column: ${cspViolationBody.columnNumber}`);
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.sourceFile")}}

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -31,7 +31,7 @@ This example triggers a CSP violation using an inline script, and reports the vi
 
 #### HTML
 
-The HTML file below uses the {{htmlelment("meta")}} element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
 The document also includes an inline script, which should therefore trigger a CSP violation.
 
 ```html

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -89,7 +89,7 @@ Note that while there might be multiple reports in the returned array, for brevi
 If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
 
 ```plain
-sourceFile: http://127.0.0.1:9999/inline/
+sourceFile: http://127.0.0.1:9999/test/
 lineNumber: 17
 columnNumber: 0
 ```
@@ -98,7 +98,7 @@ Note that the column number is (incorrectly) set to `0`.
 The result is similar for Firefox, which correctly reports the `columnNumber`.
 
 ```plain
-sourceFile: http://127.0.0.1:9999/inline/
+sourceFile: http://127.0.0.1:9999/test/
 lineNumber: 17
 columnNumber: 13
 ```

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -12,8 +12,10 @@ The **`sourceFile`** read-only property of the {{domxref("CSPViolationReportBody
 
 For a violation triggered by the use of an inline script, `sourceFile` is the URL of the current document.
 Similarly, if a document successfully loads a script that then violates the document CSP, the `sourceFile` is the URL of the script.
+
 Note however that if a document with a CSP that blocks external resources attempts to load an external resource, `sourceFile` will be `null`.
-This is because the browser extracts the value from _the global object_ of the file that triggered the violation: in this case the external resource is never loaded and therefore has no corresponding global object.
+This is because the browser extracts the value from _the global object_ of the file that triggered the violation.
+Because of the CSP restriction the external resource is never loaded, and therefore has no corresponding global object.
 
 This property is most useful alongside {{domxref("CSPViolationReportBody.lineNumber")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, which provide the location within the file that resulted in a violation.
 
@@ -92,7 +94,8 @@ lineNumber: 17
 columnNumber: 0
 ```
 
-The result is the same for Firefox (except that it correctly reports the columnNumber).
+Note that the column number is (incorrectly) set to `0`.
+The result is similar for Firefox, which correctly reports the `columnNumber`.
 
 ```plain
 sourceFile: http://127.0.0.1:9999/inline/

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -62,7 +62,7 @@ The document above also loads the external script `main.js`, which is shown belo
 Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
 
 The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
+Each time the callback function is invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
 // main.js

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -8,26 +8,68 @@ browser-compat: api.CSPViolationReportBody.sourceFile
 
 {{APIRef("Reporting API")}}
 
-The **`sourceFile`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the path of the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+The **`sourceFile`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the URL of the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
+
+For a violation triggered by the use of an inline script, `sourceFile` is the URL of the current document.
+Similarly, if a document successfully loads a script that then violates the document CSP, the `sourceFile` is the URL of the script.
+Note however that if a document with a CSP that blocks external resources attempts to load an external resource, `sourceFile` will be `null`.
+This is because the browser extracts the value from _the global object_ of the file that triggered the violation: in this case the external resource is never loaded and therefore has no corresponding global object.
 
 This property is most useful alongside {{domxref("CSPViolationReportBody.lineNumber")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, which provide the location within the file that resulted in a violation.
 
 ## Value
 
-A string, or `null` if the path is not known.
+A string containing the URL of the file that triggered the violation, or `null`.
 
 ## Examples
 
-In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+### CSP inline script violation
+
+This example triggers a CSP violation using an inline script, and reports the violation using a {{domxref("ReportingObserver")}}.
+
+#### HTML
+
+The HTML file below uses the {{htmlelment("meta")}} element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The document also includes an inline script, which should therefore trigger a CSP violation.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; report-to csp-endpoint" />
+    <meta
+      http-equiv="Reporting-Endpoints"
+      content="csp-endpoint='https://example.com/csp-reports'" />
+    <script src="main.js"></script>
+    <title>CSP: Violation due to inline script</title>
+  </head>
+  <body>
+    <h1>CSP: Violation due to inline script</h1>
+    <script>
+      const int = 4;
+    </script>
+  </body>
+</html>
+```
+
+#### JavaScript (main.js)
+
+The document above also loads the external script `main.js`, which is shown below.
+Because this is loaded from the same domain as the HTML, it is not blocked by the CSP.
+
+The script creates a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
 Each time the callback function in invoked, we get the body of the first entry of the reports array, and use it to log the file, line, and column of the violation to the console.
 
 ```js
+// main.js
 const observer = new ReportingObserver(
   (reports, observer) => {
     const cspViolationBody = reports[0].body;
-    console.log(`File: ${cspViolationBody.sourceFile}`);
-    console.log(`Line: ${cspViolationBody.lineNumber}`);
-    console.log(`Column: ${cspViolationBody.columnNumber}`);
+    console.log(`sourceFile: ${cspViolationBody.sourceFile}`);
+    console.log(`lineNumber: ${cspViolationBody.lineNumber}`);
+    console.log(`columnNumber: ${cspViolationBody.columnNumber}`);
   },
   {
     types: ["csp-violation"],
@@ -39,6 +81,24 @@ observer.observe();
 ```
 
 Note that while there might be multiple reports in the returned array, for brevity we only log the values of the first element.
+
+#### Results
+
+If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
+
+```plain
+sourceFile: http://127.0.0.1:9999/inline/
+lineNumber: 17
+columnNumber: 0
+```
+
+The result is the same for Firefox (except that it correctly reports the columnNumber).
+
+```plain
+sourceFile: http://127.0.0.1:9999/inline/
+lineNumber: 17
+columnNumber: 13
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -8,9 +8,9 @@ browser-compat: api.CSPViolationReportBody.sourceFile
 
 {{APIRef("Reporting API")}}
 
-The **`sourceFile`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the path of the source file that caused the reported CSP violation.
+The **`sourceFile`** read-only property of the {{domxref("CSPViolationReportBody")}} interface indicates the path of the source file that violated the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP).
 
-This property is most useful alongside {{domxref("CSPViolationReportBody.lineNumber")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, which provide the location of the violation within the file.
+This property is most useful alongside {{domxref("CSPViolationReportBody.lineNumber")}} and {{domxref("CSPViolationReportBody.columnNumber")}}, which provide the location within the file that resulted in a violation.
 
 ## Value
 

--- a/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/sourcefile/index.md
@@ -31,7 +31,7 @@ This example triggers a CSP violation using an inline script, and reports the vi
 
 #### HTML
 
-The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same domain, but does not allow inline scripts to be executed.
+The HTML file below uses the [`<meta>`](/en-US/docs/Web/HTML/Element/meta) element to set the {{httpheader('Content-Security-Policy')}} `default-src` to `self`, which allows scripts and other resources to be loaded from the same origin, but does not allow inline scripts to be executed.
 The document also includes an inline script, which should therefore trigger a CSP violation.
 
 ```html
@@ -86,22 +86,29 @@ Note that while there might be multiple reports in the returned array, for brevi
 
 #### Results
 
-If serving the above code using a local server (on `http://127.0.0.1:9999/`), the output of the log on Chrome is:
+You can try this out using a [local server](/en-US/docs/Learn/Common_questions/Tools_and_setup/set_up_a_local_testing_server).
+Copy the above code into `test/index.html` and `test/main.js` and run the server in the root directory.
+Assuming the address of the local server is `http://127.0.0.1:9999`, you can then load the HTML file from `http://127.0.0.1:9999/test/` (or `http://127.0.0.1:9999/test/index.html`).
+
+With the above setup, the output of the log on Chrome is:
 
 ```plain
 sourceFile: http://127.0.0.1:9999/test/
-lineNumber: 17
+lineNumber: 15
 columnNumber: 0
 ```
 
-Note that the column number is (incorrectly) set to `0`.
-The result is similar for Firefox, which correctly reports the `columnNumber`.
+The result is similar for Firefox:
 
 ```plain
 sourceFile: http://127.0.0.1:9999/test/
-lineNumber: 17
+lineNumber: 15
 columnNumber: 13
 ```
+
+Note that the column number is different for the two browsers.
+Chrome always appears to report `0`.
+The value on Firefox appears to point to the second character after the end of the opening `<script>` element.
 
 ## Specifications
 

--- a/files/en-us/web/api/cspviolationreportbody/statuscode/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/statuscode/index.md
@@ -1,0 +1,48 @@
+---
+title: "CSPViolationReportBody: statusCode property"
+short-title: statusCode
+slug: Web/API/CSPViolationReportBody/statusCode
+page-type: web-api-instance-property
+browser-compat: api.CSPViolationReportBody.statusCode
+---
+
+{{APIRef("Reporting API")}}
+
+The **`statusCode`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a number representing the [HTTP status code](/en-US/docs/Web/HTTP/Status) of the window or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
+
+## Value
+
+A number representing the HTTP status code of the window or worker in which the violation occurred.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
+Each time the callback function in invoked, we log the status code for the first entry of the reports array.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    console.log(`statusCode: ${reports[0].body.statusCode}`); // For example: 200
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that while there might be multiple reports in the returned array, for brevity we only log the status code of the first report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SecurityPolicyViolationEvent.statusCode")}}

--- a/files/en-us/web/api/cspviolationreportbody/statuscode/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/statuscode/index.md
@@ -8,11 +8,11 @@ browser-compat: api.CSPViolationReportBody.statusCode
 
 {{APIRef("Reporting API")}}
 
-The **`statusCode`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a number representing the [HTTP status code](/en-US/docs/Web/HTTP/Status) of the window or worker in which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation occurred.
+The **`statusCode`** read-only property of the {{domxref("CSPViolationReportBody")}} interface is a number representing the [HTTP status code](/en-US/docs/Web/HTTP/Status) of the response to the request that triggered a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/CSP) violation (when loading a window or worker).
 
 ## Value
 
-A number representing the HTTP status code of the window or worker in which the violation occurred.
+A number representing the HTTP status code of the response to the request that triggered the CSP violation.
 
 ## Examples
 

--- a/files/en-us/web/api/cspviolationreportbody/statuscode/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/statuscode/index.md
@@ -17,12 +17,13 @@ A number representing the HTTP status code of the response to the request that t
 ## Examples
 
 In this example we create a new {{domxref("ReportingObserver")}} to observe content violation reports of type `"csp-violation"`.
-Each time the callback function in invoked, we log the status code for the first entry of the reports array.
+Each time the callback function is invoked, we log the status code for the first entry of the reports array.
 
 ```js
 const observer = new ReportingObserver(
   (reports, observer) => {
-    console.log(`statusCode: ${reports[0].body.statusCode}`); // For example: 200
+    console.log(`statusCode: ${reports[0].body.statusCode}`);
+    // For example: 200
   },
   {
     types: ["csp-violation"],

--- a/files/en-us/web/api/cspviolationreportbody/tojson/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/tojson/index.md
@@ -1,0 +1,57 @@
+---
+title: "CSPViolationReportBody: toJSON() method"
+short-title: toJSON()
+slug: Web/API/CSPViolationReportBody/toJSON
+page-type: web-api-instance-method
+browser-compat: api.CSPViolationReportBody.toJSON
+---
+
+{{APIRef("Reporting API")}}
+
+The **`toJSON()`** method of the {{domxref("CSPViolationReportBody")}} interface is a _serializer_, which returns a JSON representation of the `CSPViolationReportBody` object.
+
+This is used by the reporting API when creating a serialized version of a violation report to send to a reporting endpoint.
+
+## Syntax
+
+```js-nolint
+toJSON()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A JSON object that is the serialization of the {{domxref("CSPViolationReportBody")}} object.
+
+## Examples
+
+In this example we create a new {{domxref("ReportingObserver")}} to observe CSP violation reports, then return a JSON representation of the first entry.
+
+```js
+const observer = new ReportingObserver(
+  (reports, observer) => {
+    const firstReport = reports[0];
+    console.log(firstReport.toJSON());
+  },
+  {
+    types: ["csp-violation"],
+    buffered: true,
+  },
+);
+
+observer.observe();
+```
+
+Note that we call `toJSON()` on the `firstReport`, which is a {{domxref("Report")}} instance.
+This results in the `toJSON()` in this interface being called to serialize the `body` of the report.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/cspviolationreportbody/tojson/index.md
+++ b/files/en-us/web/api/cspviolationreportbody/tojson/index.md
@@ -10,6 +10,8 @@ browser-compat: api.CSPViolationReportBody.toJSON
 
 The **`toJSON()`** method of the {{domxref("CSPViolationReportBody")}} interface is a _serializer_, which returns a JSON representation of the `CSPViolationReportBody` object.
 
+The existence of a `toJSON()` method allows `CSPViolationReportBody` objects to be converted to a string using the {{jsxref("JSON.stringify()")}} method.
+
 This is used by the reporting API when creating a serialized version of a violation report to send to a reporting endpoint.
 
 ## Syntax
@@ -34,7 +36,10 @@ In this example we create a new {{domxref("ReportingObserver")}} to observe CSP 
 const observer = new ReportingObserver(
   (reports, observer) => {
     const firstReport = reports[0];
+    // Log JSON object
     console.log(firstReport.toJSON());
+    // Log JSON object as a string
+    console.log(JSON.stringify(firstReport));
   },
   {
     types: ["csp-violation"],
@@ -45,8 +50,10 @@ const observer = new ReportingObserver(
 observer.observe();
 ```
 
-Note that we call `toJSON()` on the `firstReport`, which is a {{domxref("Report")}} instance.
-This results in the `toJSON()` in this interface being called to serialize the `body` of the report.
+We call `toJSON()` on the `firstReport`, which is a {{domxref("Report")}} instance, which in turn results in the `toJSON()` defined in this interface being called to serialize the `body` of the report.
+
+For the purpose of demonstration we also call `JSON.stringify()` on `firstReport` to create a string containing the JSON data.
+When sending or storing report information it is more common to do this than use `toJSON()` directly.
 
 ## Specifications
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -4,7 +4,11 @@ slug: Web/API/Reporting_API
 page-type: web-api-overview
 status:
   - experimental
-spec-urls: https://w3c.github.io/reporting/#intro
+spec-urls:
+  - https://w3c.github.io/reporting/#intro
+  - https://w3c.github.io/webappsec-csp/#cspviolationreportbody
+  - https://wicg.github.io/deprecation-reporting/#deprecationreportbody
+  - https://wicg.github.io/intervention-reporting/#intervention-report
 ---
 
 {{SeeCompatTable}}{{DefaultAPISidebar("Reporting API")}}
@@ -96,7 +100,7 @@ These HTTP response headers define the endpoints where reports are sent.
 
 - {{HTTPHeader("Reporting-Endpoints")}}
   - : Sets the name and URL of reporting endpoints.
-    These can be used in the `report-to` directive, which may be used with a number of HTTP headers including {{httpheader("Content-Security-Policy")}}.
+    These endpoints can be used in the `report-to` directive, which may be used with a number of HTTP headers including {{httpheader("Content-Security-Policy")}} and or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
 - {{HTTPHeader("Report-To")}} {{deprecated_inline}}
   - : Sets the name and URL of reporting endpoint groups, which may be used with a number of HTTP headers including `Content-Security-Policy`.
 
@@ -152,12 +156,9 @@ This causes a deprecation report to be generated; because of the event handler w
 
 ## Browser compatibility
 
-Support is at an early stage right now. Firefox supports the JavaScript API and the `Report-To` header behind preferences:
+The API is supported by Chromium browsers, and by Firefox behind a preference (`dom.reporting.enabled`).
 
-- JavaScript API: `dom.reporting.enabled` (enabled in nightly only)
-- HTTP header: `dom.reporting.header.enabled`
-
-Chrome is also working on an implementation: [information about Chrome implementation](https://developer.chrome.com/docs/capabilities/web-apis/reporting-api).
+See the specific interfaces for more detailed support information.
 
 ## See also
 

--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
@@ -32,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.blockedURL`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.blockedurl)
+- {{domxref("CSPViolationReportBody.blockedURL")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -32,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.columnNumber`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.columnnumber)
+- {{domxref("CSPViolationReportBody.columnNumber")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
@@ -37,4 +37,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.disposition`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.disposition)
+- {{domxref("CSPViolationReportBody.disposition")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
@@ -32,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.documentURL`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.documenturl)
+{{domxref("CSPViolationReportBody.documentURL")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
@@ -32,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-{{domxref("CSPViolationReportBody.documentURL")}}
+- {{domxref("CSPViolationReportBody.documentURL")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
@@ -34,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.effectiveDirective`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.effectivedirective)
+- {{domxref("CSPViolationReportBody.effectiveDirective")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
@@ -32,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.lineNumber`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.linenumber)
+- {{domxref("CSPViolationReportBody.lineNumber")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
@@ -34,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.originalPolicy`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.originalpolicy)
+- {{domxref("CSPViolationReportBody.originalPolicy")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
@@ -33,4 +33,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.referrer`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.referrer)
+- {{domxref("CSPViolationReportBody.referrer")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
@@ -38,4 +38,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.sample`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.sample)
+- {{domxref("CSPViolationReportBody.sample")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
@@ -34,4 +34,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.sourceFile`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.sourcefile)
+- {{domxref("CSPViolationReportBody.sourceFile")}}

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
@@ -32,4 +32,4 @@ document.addEventListener("securitypolicyviolation", (e) => {
 
 ## See also
 
-- [`CSPViolationReportBody.statusCode`](/en-US/docs/Web/API/CSPViolationReportBody#cspviolationreportbody.statuscode)
+- {{domxref("CSPViolationReportBody.statusCode")}}


### PR DESCRIPTION
This adds missing property docs for [`CSPViolationReportBody`](https://developer.mozilla.org/en-US/docs/Web/API/CSPViolationReportBody), fixes up cross links to here from [`SecurityPolicyViolationEvent`](https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent), and fixes the compat statements on the REporting API top page.

It should all be pretty correct, albeit a bit repetative, because all the examples are the same, and the properties in the event and body are also almost identical.

Related docs work can be tracked in #35279

Fixes #29292