### PR TITLE
Add warning for create and trigger event upgrade example

### DIFF
--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -56,7 +56,7 @@ The older approach to creating events uses APIs inspired by Java. The following 
 const event = document.createEvent("Event");
 
 // Define that the event name is 'build'.
-event.initEvent("build", true, true);
+event.initEvent("build");
 
 // Listen for the event.
 elem.addEventListener(
@@ -70,10 +70,6 @@ elem.addEventListener(
 // target can be any Element or other EventTarget.
 elem.dispatchEvent(event);
 ```
-
-> [!WARNING]
-> The examples are not interchangable but represent their common usages.
-> The shown `initEvent` call passes `true` for the parameters `cancelable` and `bubbles`, which are missing and therefore `false` with the Event constructor.
 
 ### Event bubbling
 

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -71,6 +71,10 @@ elem.addEventListener(
 elem.dispatchEvent(event);
 ```
 
+> [!WARNING]
+> The examples are not interchangable but represent their common usages.
+> The shown `initEvent` call passes `true` for the parameters `cancelable` and `bubbles`, which are missing and therefore `false` with the Event constructor.
+
 ### Event bubbling
 
 It is often desirable to trigger an event from a child element, and have an ancestor catch it; optionally, with data:


### PR DESCRIPTION
### Description

There is a comparison of two different ways how to create and dispatch the events but these example are not interchangeable and there I added a warning, that this is not interchangeable and needs further reading.

### Motivation

I had an issue where I had to debug why an auto-submitted form was not transformed into an AJAX call by an event listener, that should prevented the form to be processed by the navigator but an XHR instead. The submit event has been dispatched by code using the new way and I saw the sample for the old way. The old way worked and I though it has been some regression in Firefox. Apparently the code is just not representing the same which is ok so we do not want to propagate to always pass optional variables. But it feels like the two snippets want to be the same.

### Additional details

I changed the code in the library to fix things
https://github.com/shopware/shopware/pull/4585

### Related issues and pull requests

I did not see any existing pull requests similar to this but after seeing the pull request template I looked further and there seem to be a discussion about these kind of articles in a similar manner.

Relates to https://github.com/orgs/mdn/discussions/665
Relates to https://github.com/mdn/content/issues/19590
