### PR TITLE
fix: correct `short-title` for `shadowRootSerializable`

### DIFF
--- a/files/en-us/web/api/htmltemplateelement/shadowrootserializable/index.md
+++ b/files/en-us/web/api/htmltemplateelement/shadowrootserializable/index.md
@@ -1,6 +1,6 @@
 ---
 title: "HTMLTemplateElement: shadowRootSerializable property"
-short-title: content
+short-title: shadowRootSerializable
 slug: Web/API/HTMLTemplateElement/shadowRootSerializable
 page-type: web-api-instance-property
 browser-compat: api.HTMLTemplateElement.shadowRootSerializable


### PR DESCRIPTION
The `HTMLTemplateElement.shadowRootSerializable` property is listed as `HTMLTemplateElement.content` in the navigation. This commit should fix that.