### PR TITLE
Fix incorrect selector in `::view-transition-group` docs

### DIFF
--- a/files/en-us/web/css/_doublecolon_view-transition-group/index.md
+++ b/files/en-us/web/css/_doublecolon_view-transition-group/index.md
@@ -53,7 +53,7 @@ In addition, the element's transform is animated from the "old" view state's scr
 ## Examples
 
 ```css
-view-transition-group(embed-container) {
+::view-transition-group(embed-container) {
   animation-duration: 0.3s;
   animation-timing-function: ease;
   z-index: 1;


### PR DESCRIPTION
### Description

Fix incorrect selector in `::view-transition-group` docs

### Motivation

The incorrect selector may cause confusion, so I fixed it.