### PR TITLE
fix: update redirected URLs from developer.chrome.com domain

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/colorarray/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/colorarray/index.md
@@ -25,7 +25,7 @@ For example, opaque red is `[255, 0, 0, 255]`.
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#type-ColorArray) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#type-ColorArray) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
@@ -54,7 +54,7 @@ browser.action.onClicked.addListener((tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-disable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-disable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
@@ -46,7 +46,7 @@ browser.action.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-enable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-enable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
@@ -65,7 +65,7 @@ browser.action.getBadgeBackgroundColor({}).then(onGot, onFailure);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
@@ -62,7 +62,7 @@ gettingBadgeText.then(gotBadgeText);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-getBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
@@ -69,7 +69,7 @@ browser.action.getBadgeTextColor({}).then(onGot, onFailure);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
@@ -62,7 +62,7 @@ gettingPopup.then(gotPopup);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-getPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
@@ -70,7 +70,7 @@ browser.action.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-getTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getusersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getusersettings/index.md
@@ -59,7 +59,7 @@ gettingUserSettings.then(gotSettings);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getUserSettings) API.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-getUserSettings) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/imagedatatype/index.md
@@ -20,7 +20,7 @@ An [`ImageData`](/en-US/docs/Web/API/ImageData) object.
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#type-ImageDataType) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#type-ImageDataType) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
@@ -79,7 +79,7 @@ With the `action` API, you can:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/) API. This documentation is derived from [`action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action) API. This documentation is derived from [`action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/onclicked/index.md
@@ -70,7 +70,7 @@ browser.action.onClicked.addListener((tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#event-onClicked) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#event-onClicked) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
@@ -84,7 +84,7 @@ browser.action.onClicked.addListener((tab) => {
 The default color in Firefox is: `[217, 0, 0, 255]`.
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
@@ -71,7 +71,7 @@ browser.action.onClicked.addListener(increment);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
@@ -78,7 +78,7 @@ browser.action.onClicked.addListener((tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -158,7 +158,7 @@ browser.action.onClicked.addListener((tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setIcon) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setIcon) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
@@ -100,7 +100,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
@@ -74,7 +74,7 @@ browser.action.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/api/action#method-setTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
@@ -27,4 +27,4 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
@@ -46,4 +46,4 @@ clearAlarm.then(onCleared);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -43,4 +43,4 @@ clearAlarms.then(onClearedAll);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -84,7 +84,7 @@ browser.alarms.create("my-periodic-alarm", {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -48,4 +48,4 @@ getAlarm.then(gotAlarm);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/getall/index.md
@@ -44,4 +44,4 @@ browser.alarms.getAll().then(gotAll);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/index.md
@@ -43,4 +43,4 @@ To use this API you need to have the "alarms" [permission](/en-US/docs/Mozilla/A
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/onalarm/index.md
@@ -56,4 +56,4 @@ browser.alarms.onAlarm.addListener(handleAlarm);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/alarms/) API.
+> This API is based on Chromium's [`chrome.alarms`](https://developer.chrome.com/docs/extensions/reference/api/alarms) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -43,7 +43,7 @@ An {{jsxref("object")}} with the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#type-BookmarkTreeNode) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#type-BookmarkTreeNode) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -20,7 +20,7 @@ The **`bookmarks.BookmarkTreeNodeUnmodifiable`** type is used to indicate the re
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#type-BookmarkTreeNodeUnmodifiable) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#type-BookmarkTreeNodeUnmodifiable) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -58,7 +58,7 @@ createBookmark.then(onCreated);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-create) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-create) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -31,7 +31,7 @@ An {{jsxref("object")}} containing some combination of the following fields:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#type-CreateDetails) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#type-CreateDetails) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -52,7 +52,7 @@ gettingBookmarks.then(onFulfilled, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-get) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-get) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -56,7 +56,7 @@ gettingChildren.then(onFulfilled, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-getChildren) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-getChildren) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getrecent/index.md
@@ -53,7 +53,7 @@ browser.bookmarks.getRecent(1).then(onFulfilled, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-getRecent) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-getRecent) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -75,7 +75,7 @@ browser.bookmarks.getSubTree(subTreeID).then(logSubTree, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-getSubTree) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-getSubTree) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/gettree/index.md
@@ -70,7 +70,7 @@ gettingTree.then(logTree, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-getTree) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-getTree) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/index.md
@@ -73,7 +73,7 @@ Extensions cannot create, modify, or delete bookmarks in the root node of the bo
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -71,7 +71,7 @@ movingBookmark.then(onMoved, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-move) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-move) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchanged/index.md
@@ -68,7 +68,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onChanged) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onChanged) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onchildrenreordered/index.md
@@ -68,7 +68,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onChildrenReordered) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onChildrenReordered) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/oncreated/index.md
@@ -57,7 +57,7 @@ browser.bookmarks.onCreated.addListener(handleCreated);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onCreated) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onCreated) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportbegan/index.md
@@ -61,7 +61,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onImportBegan) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onImportBegan) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onimportended/index.md
@@ -61,7 +61,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onImportEnded) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onImportEnded) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -80,7 +80,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onMoved) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onMoved) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onremoved/index.md
@@ -73,7 +73,7 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#event-onRemoved) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#event-onRemoved) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -57,7 +57,7 @@ removingBookmark.then(onRemoved, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-remove) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-remove) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -64,7 +64,7 @@ searchingBookmarks.then(removeMDN, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-removeTree) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-removeTree) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -95,7 +95,7 @@ browser.browserAction.onClicked.addListener(checkActiveTab);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-search) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-search) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -76,7 +76,7 @@ browser.bookmarks.search({ title: "MDN" }).then(updateFolders, onRejected);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/bookmarks/#method-update) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.bookmarks`](https://developer.chrome.com/docs/extensions/reference/api/bookmarks#method-update) API. This documentation is derived from [`bookmarks.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/bookmarks.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/colorarray/index.md
@@ -25,7 +25,7 @@ For example, opaque red is `[255, 0, 0, 255]`.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#type-ColorArray) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#type-ColorArray) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -51,7 +51,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-disable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-disable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -43,7 +43,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-enable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-enable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -62,7 +62,7 @@ browser.browserAction.getBadgeBackgroundColor({}).then(onGot, onFailure);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -59,7 +59,7 @@ gettingBadgeText.then(gotBadgeText);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -66,7 +66,7 @@ browser.browserAction.getBadgeTextColor({}).then(onGot, onFailure);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -59,7 +59,7 @@ gettingPopup.then(gotPopup);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-getTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/imagedatatype/index.md
@@ -20,7 +20,7 @@ An [`ImageData`](/en-US/docs/Web/API/ImageData) object.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#type-ImageDataType) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#type-ImageDataType) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/index.md
@@ -76,7 +76,7 @@ With the `browserAction` API, you can:
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/onclicked/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#event-onClicked) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#event-onClicked) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -81,7 +81,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -68,7 +68,7 @@ browser.browserAction.onClicked.addListener(increment);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -155,7 +155,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setIcon) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setIcon) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -97,7 +97,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -71,7 +71,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.browserAction`](https://developer.chrome.com/docs/extensions/mv2/reference/browserAction#method-setTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/datatypeset/index.md
@@ -50,7 +50,7 @@ Values of this type are objects. They contain the following properties:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/index.md
@@ -68,7 +68,7 @@ To use this API you must have the "browsingData" [API permission](/en-US/docs/Mo
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -47,7 +47,7 @@ Values of this type are objects. They contain the following properties:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/remove/index.md
@@ -82,7 +82,7 @@ browser.browsingData
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -53,7 +53,7 @@ browser.browsingData.removeCache({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecookies/index.md
@@ -83,7 +83,7 @@ browser.browsingData.removeCookies({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removedownloads/index.md
@@ -78,7 +78,7 @@ browser.browsingData.removeDownloads({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeformdata/index.md
@@ -78,7 +78,7 @@ browser.browsingData.removeFormData({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removehistory/index.md
@@ -78,7 +78,7 @@ browser.browsingData.removeHistory({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removelocalstorage/index.md
@@ -56,7 +56,7 @@ browser.browsingData.removeLocalStorage({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removepasswords/index.md
@@ -78,7 +78,7 @@ browser.browsingData.removePasswords({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removeplugindata/index.md
@@ -78,7 +78,7 @@ browser.browsingData.removePluginData({}).then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/settings/index.md
@@ -63,7 +63,7 @@ browser.browsingData.settings().then(onGotSettings, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/browsingData/) API.
+> This API is based on Chromium's [`chrome.browsingData`](https://developer.chrome.com/docs/extensions/reference/api/browsingData) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/captiveportal/canonicalurl/index.md
@@ -16,7 +16,7 @@ Return the canonical URL of the captive-portal detection page. Read-only.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#property-TAB_ID_NONE) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#property-TAB_ID_NONE) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -13,7 +13,7 @@ The WebExtension `clipboard` API exists primarily because the standard Clipboard
 
 Reading from the clipboard is not supported by this API, because the clipboard can already be read using the standard web platform APIs. See [Interacting with the clipboard](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard#reading_from_the_clipboard).
 
-This API is based on Chrome's [`clipboard`](https://developer.chrome.com/docs/extensions/reference/clipboard/) API, but that API is only available for Chrome apps, not extensions.
+This API is based on Chrome's [`clipboard`](https://developer.chrome.com/docs/apps/reference/clipboard) API, but that API is only available for Chrome apps, not extensions.
 
 To use this API you need the `"clipboardWrite"` extension [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
 
@@ -29,4 +29,4 @@ To use this API you need the `"clipboardWrite"` extension [permission](/en-US/do
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.clipboard`](https://developer.chrome.com/docs/extensions/reference/clipboard/) API.
+> This API is based on Chromium's [`chrome.clipboard`](https://developer.chrome.com/docs/apps/reference/clipboard) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/setimagedata/index.md
@@ -11,7 +11,7 @@ Copies an image to the clipboard. The image is re-encoded before it is written t
 
 The image is provided as an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) containing the encoded image. JPEG and PNG formats are supported.
 
-Although this API is based on Chrome's [`clipboard.setImageData()`](https://developer.chrome.com/docs/extensions/reference/clipboard/) API, there are some differences:
+Although this API is based on Chrome's [`clipboard.setImageData()`](https://developer.chrome.com/docs/apps/reference/clipboard) API, there are some differences:
 
 - The Chrome API is only for apps, not extensions.
 - This API requires only the `"clipboardWrite"` permission, while the Chrome version also requires the `"clipboard"` permission.
@@ -68,4 +68,4 @@ fetch(browser.runtime.getURL("image.png"))
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.clipboard`](https://developer.chrome.com/docs/extensions/reference/clipboard/) API.
+> This API is based on Chromium's [`chrome.clipboard`](https://developer.chrome.com/docs/apps/reference/clipboard) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -29,4 +29,4 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/commands/) API.
+> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/getall/index.md
@@ -43,7 +43,7 @@ getCommands.then(logCommands);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/commands/) API.
+> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
@@ -37,7 +37,7 @@ Listen for the user executing commands that you have registered using the [`comm
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/commands/) API.
+> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -73,4 +73,4 @@ browser.commands.onCommand.addListener((command) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/commands/) API.
+> This API is based on Chromium's [`chrome.commands`](https://developer.chrome.com/docs/extensions/reference/api/commands) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -72,7 +72,7 @@ gettingAll.then(logCookies);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#type-Cookie) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#type-Cookie) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookiestore/index.md
@@ -57,7 +57,7 @@ browser.cookies.getAllCookieStores().then((stores) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#type-CookieStore) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#type-CookieStore) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -80,7 +80,7 @@ getActive.then(getCookie);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#method-get) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#method-get) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -88,7 +88,7 @@ browser.cookies
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#method-getAll) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#method-getAll) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getallcookiestores/index.md
@@ -48,7 +48,7 @@ Each member of the `cookieStores` array is a {{WebExtAPIRef("cookies.CookieStore
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#method-getAllCookieStores) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#method-getAllCookieStores) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/index.md
@@ -116,7 +116,7 @@ When first-party isolation is off, the `firstPartyDomain` parameter is optional 
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchanged/index.md
@@ -77,7 +77,7 @@ browser.cookies.onChanged.addListener((changeInfo) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#event-onChanged) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#event-onChanged) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/onchangedcause/index.md
@@ -46,7 +46,7 @@ browser.cookies.onChanged.addListener((changeInfo) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#type-OnChangedCause) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#type-OnChangedCause) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -79,7 +79,7 @@ getActive.then(removeCookie);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#method-remove) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#method-remove) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -85,7 +85,7 @@ function setCookie(tabs) {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/cookies/#method-set) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.cookies`](https://developer.chrome.com/docs/extensions/reference/api/cookies#method-set) API. This documentation is derived from [`cookies.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/cookies.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -164,7 +164,7 @@ inspectButton.addEventListener("click", () => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/index.md
@@ -8,7 +8,7 @@ browser-compat: webextensions.api.devtools.inspectedWindow
 {{AddonSidebar}}
 
 > [!NOTE]
-> This page describes the WebExtensions devtools APIs as they exist in Firefox 54. Although the APIs are based on the [Chrome devtools APIs](https://developer.chrome.com/docs/extensions/mv3/devtools/), there are still many features that are not yet implemented in Firefox, and therefore are not documented here. To see which features are currently missing please see [Limitations of the devtools APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools#limitations_of_the_devtools_apis).
+> This page describes the WebExtensions devtools APIs as they exist in Firefox 54. Although the APIs are based on the [Chrome devtools APIs](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools), there are still many features that are not yet implemented in Firefox, and therefore are not documented here. To see which features are currently missing please see [Limitations of the devtools APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools#limitations_of_the_devtools_apis).
 
 The `devtools.inspectedWindow` API lets a devtools extension interact with the window that the developer tools are attached to.
 
@@ -33,7 +33,7 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.inspectedWindow`](https://developer.chrome.com/docs/extensions/reference/devtools_inspectedWindow/) API.
+> This API is based on Chromium's [`chrome.devtools.inspectedWindow`](https://developer.chrome.com/docs/extensions/reference/api/devtools/inspectedWindow) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -52,7 +52,7 @@ reloadButton.addEventListener("click", () => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/tabid/index.md
@@ -43,7 +43,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/gethar/index.md
@@ -48,7 +48,7 @@ logRequestsButton.addEventListener("click", logRequests);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.network`](https://developer.chrome.com/docs/extensions/reference/devtools_network/) API.
+> This API is based on Chromium's [`chrome.devtools.network`](https://developer.chrome.com/docs/extensions/reference/api/devtools/network) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/index.md
@@ -30,7 +30,7 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.network`](https://developer.chrome.com/docs/extensions/reference/devtools_network/) API.
+> This API is based on Chromium's [`chrome.devtools.network`](https://developer.chrome.com/docs/extensions/reference/api/devtools/network) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onnavigated/index.md
@@ -54,7 +54,7 @@ browser.devtools.network.onNavigated.addListener(handleNavigated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/network/onrequestfinished/index.md
@@ -64,7 +64,7 @@ browser.devtools.network.onRequestFinished.addListener(handleRequestFinished);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/create/index.md
@@ -66,7 +66,7 @@ browser.devtools.panels
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elements/index.md
@@ -16,4 +16,4 @@ An [`ElementsPanel`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/pane
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/createsidebarpane/index.md
@@ -60,7 +60,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/index.md
@@ -26,7 +26,7 @@ An `ElementsPanel` represents the HTML/CSS inspector in the browser's devtools. 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/elementspanel/onselectionchanged/index.md
@@ -56,4 +56,4 @@ browser.devtools.panels.elements.onSelectionChanged.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/mv3/devtools/) API.
+> This API is based on Chromium's [`chrome.devtools`](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionpanel/index.md
@@ -50,7 +50,7 @@ browser.devtools.panels
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/index.md
@@ -36,7 +36,7 @@ To create an `ExtensionSidebarPane`, call the [`browser.devtools.panels.elements
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onhidden/index.md
@@ -58,4 +58,4 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/onshown/index.md
@@ -62,4 +62,4 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setexpression/index.md
@@ -58,7 +58,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setobject/index.md
@@ -59,7 +59,7 @@ browser.devtools.panels.elements.createSidebarPane("My pane").then(onCreated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/extensionsidebarpane/setpage/index.md
@@ -47,7 +47,7 @@ function onCreated(sidebarPane) {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/index.md
@@ -8,7 +8,7 @@ browser-compat: webextensions.api.devtools.panels
 {{AddonSidebar}}
 
 > [!NOTE]
-> Although the APIs are based on the [Chrome devtools APIs](https://developer.chrome.com/docs/extensions/mv3/devtools/), there are still many features that are not yet implemented in Firefox, and therefore are not documented here. To see which features are currently missing please see [Limitations of the devtools APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools#limitations_of_the_devtools_apis).
+> Although the APIs are based on the [Chrome devtools APIs](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools), there are still many features that are not yet implemented in Firefox, and therefore are not documented here. To see which features are currently missing please see [Limitations of the devtools APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/Extending_the_developer_tools#limitations_of_the_devtools_apis).
 
 The `devtools.panels` API lets a devtools extension define its user interface inside the devtools window.
 
@@ -51,7 +51,7 @@ Like all the `devtools` APIs, this API is only available to code running in the 
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/onthemechanged/index.md
@@ -52,4 +52,4 @@ browser.devtools.panels.onThemeChanged.addListener((newThemeName) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/panels/themename/index.md
@@ -22,4 +22,4 @@ This is a string whose possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/devtools_panels/) API.
+> This API is based on Chromium's [`chrome.devtools.panels`](https://developer.chrome.com/docs/extensions/reference/api/devtools/panels) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/dom/openorclosedshadowroot/index.md
@@ -40,4 +40,4 @@ A {{DOMxRef("ShadowRoot")}} object instance, regardless of whether its
 ## See also
 
 - {{DOMxRef("Element.shadowRoot")}}
-- [`chrome.dom.openOrClosedShadowRoot`](https://developer.chrome.com/docs/extensions/reference/dom/#method-openOrClosedShadowRoot)
+- [`chrome.dom.openOrClosedShadowRoot`](https://developer.chrome.com/docs/extensions/reference/api/dom#method-openOrClosedShadowRoot)

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/acceptdanger/index.md
@@ -37,7 +37,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). When
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-acceptDanger) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-acceptDanger) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-BooleanDelta) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-BooleanDelta) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/cancel/index.md
@@ -52,7 +52,7 @@ canceling.then(onCanceled, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-cancel) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-cancel) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/dangertype/index.md
@@ -42,7 +42,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-DangerType) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DangerType) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-DoubleDelta) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DoubleDelta) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -102,7 +102,7 @@ downloading.then(onStartedDownload, onFailed);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-download) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-download) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -63,7 +63,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-DownloadItem) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DownloadItem) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -75,7 +75,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-DownloadQuery) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DownloadQuery) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadtime/index.md
@@ -28,7 +28,7 @@ A `DownloadTime` can be one of three different types:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-DownloadTime) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-DownloadTime) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/erase/index.md
@@ -76,7 +76,7 @@ erasing.then(onErased, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-erase) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-erase) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/filenameconflictaction/index.md
@@ -29,7 +29,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-FilenameConflictAction) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-FilenameConflictAction) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -75,7 +75,7 @@ searching.then(getIcon, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-getFileIcon) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-getFileIcon) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/index.md
@@ -79,7 +79,7 @@ To use this API you need to have the "downloads" [API permission](/en-US/docs/Mo
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/interruptreason/index.md
@@ -61,7 +61,7 @@ Miscellaneous:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-InterruptReason) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-InterruptReason) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -95,7 +95,7 @@ browser.downloads.onChanged.addListener(handleChanged);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#event-onChanged) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#event-onChanged) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/oncreated/index.md
@@ -58,7 +58,7 @@ browser.downloads.onCreated.addListener(handleCreated);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#event-onCreated) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#event-onCreated) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onerased/index.md
@@ -63,7 +63,7 @@ let erasing = browser.downloads.erase({
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#event-onErased) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#event-onErased) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/open/index.md
@@ -65,7 +65,7 @@ searching.then(openDownload, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-open) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-open) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/pause/index.md
@@ -50,7 +50,7 @@ pausing.then(onPaused, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-pause) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-pause) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/removefile/index.md
@@ -70,7 +70,7 @@ searching.then(remove, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-removeFile) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-removeFile) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/resume/index.md
@@ -52,7 +52,7 @@ resuming.then(onResumed, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-resume) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-resume) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/search/index.md
@@ -124,7 +124,7 @@ You can see this code in action in our [latest-download](https://github.com/mdn/
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-search) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-search) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/setshelfenabled/index.md
@@ -34,7 +34,7 @@ This API is also available as `browser.downloads.setShelfEnabled()`.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-setShelfEnabled) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-setShelfEnabled) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/show/index.md
@@ -64,7 +64,7 @@ searching.then(openDownload, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-show) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-show) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/showdefaultfolder/index.md
@@ -38,7 +38,7 @@ showBtn.onclick = () => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#method-showDefaultFolder) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#method-showDefaultFolder) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/state/index.md
@@ -32,7 +32,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-State) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-State) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/#type-StringDelta) API.
+> This API is based on Chromium's [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/api/downloads#type-StringDelta) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/event/index.md
@@ -37,7 +37,7 @@ Values of this type are objects.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/events/#type-Event) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events#type-Event) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/index.md
@@ -25,7 +25,7 @@ Common types used by APIs that dispatch events.
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/events/) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -31,7 +31,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/events/#type-Rule) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events#type-Rule) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -95,7 +95,7 @@ However, note that these last two patterns will not match the last component of 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/events/#type-UrlFilter) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.events`](https://developer.chrome.com/docs/extensions/reference/api/events#type-UrlFilter) API. This documentation is derived from [`events.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getbackgroundpage/index.md
@@ -56,7 +56,7 @@ page.foo(); // -> "I'm defined in background.js"
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-getBackgroundPage) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getBackgroundPage) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -38,7 +38,7 @@ This API is also available as `browser.extension.getExtensionTabs()`.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-getExtensionTabs) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getExtensionTabs) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/geturl/index.md
@@ -49,7 +49,7 @@ let fullURL = browser.extension.getURL("beasts/frog.html");
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-getURL) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getURL) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -70,7 +70,7 @@ const windows = browser.extension.getViews({ type: "popup" });
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-getViews) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-getViews) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
@@ -56,7 +56,7 @@ Utilities related to your extension. Get URLs to resources packages with your ex
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/inincognitocontext/index.md
@@ -26,7 +26,7 @@ A _boolean_ value indicate if the current script is running in a private tab or 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#property-inIncognitoContext) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#property-inIncognitoContext) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedfileschemeaccess/index.md
@@ -45,7 +45,7 @@ isAllowed.then(logIsAllowed);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-isAllowedFileSchemeAccess) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-isAllowedFileSchemeAccess) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/isallowedincognitoaccess/index.md
@@ -43,7 +43,7 @@ isAllowed.then(logIsAllowed);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-isAllowedIncognitoAccess) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-isAllowedIncognitoAccess) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/lasterror/index.md
@@ -19,7 +19,7 @@ An alias for {{WebExtAPIRef("runtime.lastError")}}.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#property-lastError) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#property-lastError) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequest/index.md
@@ -55,7 +55,7 @@ Events have three functions:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#event-onRequest) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#event-onRequest) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -55,7 +55,7 @@ Events have three functions:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#event-onRequestExternal) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#event-onRequestExternal) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -46,7 +46,7 @@ This API is also available as `browser.extension.sendRequest()` in a [version th
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-sendRequest) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-sendRequest) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/setupdateurldata/index.md
@@ -31,7 +31,7 @@ browser.extension.setUpdateUrlData(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#method-setUpdateUrlData) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#method-setUpdateUrlData) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/viewtype/index.md
@@ -20,7 +20,7 @@ Values of this type are strings. Possible values are: `"tab"`, `"popup"`, `"side
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/extension/#type-ViewType) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extension`](https://developer.chrome.com/docs/extensions/reference/api/extension#type-ViewType) API. This documentation is derived from [`extension.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/extension.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -38,7 +38,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/extensionTypes/#type-ImageDetails) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-ImageDetails) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imageformat/index.md
@@ -20,7 +20,7 @@ Values of this type are strings. Possible values are: `"jpeg"`, `"png"`.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/extensionTypes/#type-ImageFormat) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-ImageFormat) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/index.md
@@ -29,7 +29,7 @@ Some common types used in other WebExtension APIs.
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/extensionTypes/) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/runat/index.md
@@ -26,7 +26,7 @@ The default value is `"document_idle"`.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/extensionTypes/#type-RunAt) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.extensionTypes`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-RunAt) API. This documentation is derived from [`extension_types.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/extension_types.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -99,7 +99,7 @@ browser.history
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#method-addUrl) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-addUrl) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteall/index.md
@@ -51,7 +51,7 @@ deleteAllHistory();
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#method-deleteAll) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-deleteAll) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleterange/index.md
@@ -58,7 +58,7 @@ browser.history.deleteRange({
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#method-deleteRange) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-deleteRange) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/deleteurl/index.md
@@ -95,7 +95,7 @@ searching.then(onGot);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#method-deleteUrl) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-deleteUrl) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/getvisits/index.md
@@ -70,7 +70,7 @@ searching.then(listVisits);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#method-getVisits) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-getVisits) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/historyitem/index.md
@@ -33,7 +33,7 @@ This is an object with the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#type-HistoryItem) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#type-HistoryItem) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/index.md
@@ -68,7 +68,7 @@ To use this API, an extension must request the "history" [permission](/en-US/doc
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -62,7 +62,7 @@ browser.history.onTitleChanged.addListener(handleTitleChanged);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#event-onVisited) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#event-onVisited) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisited/index.md
@@ -60,7 +60,7 @@ browser.history.onVisited.addListener(onVisited);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#event-onVisited) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#event-onVisited) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/onvisitremoved/index.md
@@ -66,7 +66,7 @@ browser.history.onVisitRemoved.addListener(onRemoved);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#event-onVisitRemoved) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#event-onVisitRemoved) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/search/index.md
@@ -115,7 +115,7 @@ browser.history
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#method-search) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#method-search) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/transitiontype/index.md
@@ -43,7 +43,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#type-TransitionType) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#type-TransitionType) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -31,7 +31,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/history/#type-VisitItem) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.history`](https://developer.chrome.com/docs/extensions/reference/api/history#type-VisitItem) API. This documentation is derived from [`history.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/history.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/detectlanguage/index.md
@@ -64,7 +64,7 @@ detecting.then(onLanguageDetected);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/i18n/#method-detectLanguage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-detectLanguage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getacceptlanguages/index.md
@@ -46,7 +46,7 @@ gettingAcceptLanguages.then(onGot);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/i18n/#method-getAcceptLanguages) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-getAcceptLanguages) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -78,7 +78,7 @@ If `target.url` is "https\://developer.mozilla.org", then the value of message, 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/i18n/#method-getMessage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-getMessage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getuilanguage/index.md
@@ -41,7 +41,7 @@ console.log(uiLanguage);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/i18n/#method-getUILanguage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#method-getUILanguage) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/index.md
@@ -34,7 +34,7 @@ See the [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Interna
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/i18n/) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
 
 ## See also
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/languagecode/index.md
@@ -20,7 +20,7 @@ Values of this type are strings.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/i18n/#type-LanguageCode) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.i18n`](https://developer.chrome.com/docs/extensions/reference/api/i18n#type-LanguageCode) API. This documentation is derived from [`i18n.json`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/extensions/common/api/i18n.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/getredirecturl/index.md
@@ -42,4 +42,4 @@ let redirectURL = browser.identity.getRedirectURL();
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`identity`](https://developer.chrome.com/docs/extensions/reference/identity/) API.
+> This API is based on Chromium's [`identity`](https://developer.chrome.com/docs/extensions/reference/api/identity) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/index.md
@@ -64,7 +64,7 @@ This will tend to be specific to the service provider, but in general it means c
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.identity`](https://developer.chrome.com/docs/extensions/reference/identity/) API.
+> This API is based on Chromium's [`chrome.identity`](https://developer.chrome.com/docs/extensions/reference/api/identity) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/identity/launchwebauthflow/index.md
@@ -67,7 +67,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). If t
 
 ## Examples
 
-This function authorizes an extension to access a user's Google data, according to the documentation at <https://developers.google.com/identity/protocols/OAuth2UserAgent>. Validation of the returned access token isn't shown here:
+This function authorizes an extension to access a user's Google data, according to the documentation at <https://developers.google.com/identity/protocols/oauth2/javascript-implicit-flow>. Validation of the returned access token isn't shown here:
 
 ```js
 function validate(redirectURL) {
@@ -99,4 +99,4 @@ function getAccessToken() {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`identity`](https://developer.chrome.com/docs/extensions/reference/identity/) API.
+> This API is based on Chromium's [`identity`](https://developer.chrome.com/docs/extensions/reference/api/identity) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/idlestate/index.md
@@ -20,7 +20,7 @@ Values of this type are strings. Possible values are: `"active"`, `"idle"`, `"lo
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/idle/#type-IdleState) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#type-IdleState) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/index.md
@@ -35,7 +35,7 @@ To use this API you need to have the "idle" [permission](/en-US/docs/Mozilla/Add
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/idle/) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/onstatechanged/index.md
@@ -58,7 +58,7 @@ browser.idle.onStateChanged.addListener(newState);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/idle/#event-onStateChanged) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#event-onStateChanged) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/querystate/index.md
@@ -52,7 +52,7 @@ querying.then(onGot);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/idle/#method-queryState) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#method-queryState) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/idle/setdetectioninterval/index.md
@@ -37,7 +37,7 @@ browser.idle.setDetectionInterval(15);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/idle/#method-setDetectionInterval) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.idle`](https://developer.chrome.com/docs/extensions/reference/api/idle#method-setDetectionInterval) API. This documentation is derived from [`idle.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/idle.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/extensioninfo/index.md
@@ -78,7 +78,7 @@ It is an object with the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#type-ExtensionInfo) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#type-ExtensionInfo) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/get/index.md
@@ -52,7 +52,7 @@ getting.then(got);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-get) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-get) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getall/index.md
@@ -53,7 +53,7 @@ gettingAll.then(gotAll);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-getAll) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getAll) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbyid/index.md
@@ -55,7 +55,7 @@ browser.management.getPermissionWarningsById(id).then(gotWarnings);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-getPermissionWarningsById) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getPermissionWarningsById) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getpermissionwarningsbymanifest/index.md
@@ -66,7 +66,7 @@ gettingWarnings.then(gotWarnings, gotError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-getPermissionWarningsByManifest) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getPermissionWarningsByManifest) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/getself/index.md
@@ -47,7 +47,7 @@ gettingSelf.then(gotSelf);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-getSelf) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-getSelf) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/index.md
@@ -63,7 +63,7 @@ Most of these operations require the "management" [API permission](/en-US/docs/M
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/ondisabled/index.md
@@ -56,7 +56,7 @@ browser.management.onDisabled.addListener((info) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#event-onDisabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onDisabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onenabled/index.md
@@ -56,7 +56,7 @@ browser.management.onEnabled.addListener((info) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#event-onEnabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onEnabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/oninstalled/index.md
@@ -56,7 +56,7 @@ browser.management.onInstalled.addListener((info) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#event-onInstalled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onInstalled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/onuninstalled/index.md
@@ -56,7 +56,7 @@ browser.management.onUninstalled.addListener((info) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#event-onUninstalled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#event-onUninstalled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/setenabled/index.md
@@ -61,7 +61,7 @@ toggleEnabled(id);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-setEnabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-setEnabled) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -62,7 +62,7 @@ uninstalling.then(null, onCanceled);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-uninstall) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-uninstall) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -76,7 +76,7 @@ uninstalling.then(null, onCanceled);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/management/#method-uninstallSelf) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.management`](https://developer.chrome.com/docs/extensions/reference/api/management#method-uninstallSelf) API. This documentation is derived from [`management.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/management.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/action_menu_top_level_limit/index.md
@@ -20,7 +20,7 @@ For compatibility with other browsers, Firefox makes this property available via
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#property-ACTION_MENU_TOP_LEVEL_LIMIT) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#property-ACTION_MENU_TOP_LEVEL_LIMIT) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -61,7 +61,7 @@ Note that "launcher" is not supported.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#type-ContextType) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#type-ContextType) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -203,7 +203,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#method-create) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#method-create) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -9,7 +9,7 @@ browser-compat: webextensions.api.menus
 
 Add items to the browser's menu system.
 
-This API is modeled on Chrome's ["contextMenus"](https://developer.chrome.com/docs/extensions/reference/contextMenus/) API, which enables Chrome extensions to add items to the browser's context menu. The `browser.menus` API adds a few features to Chrome's API.
+This API is modeled on Chrome's ["contextMenus"](https://developer.chrome.com/docs/extensions/reference/api/contextMenus) API, which enables Chrome extensions to add items to the browser's context menu. The `browser.menus` API adds a few features to Chrome's API.
 
 Before Firefox 55 this API was also originally named `contextMenus`, and that name has been retained as an alias, so you can use `contextMenus` to write code that works in Firefox and also in other browsers.
 
@@ -173,7 +173,7 @@ browser.menus.create(
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/itemtype/index.md
@@ -29,7 +29,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#type-ItemType) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#type-ItemType) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -57,7 +57,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#type-OnClickData) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#type-OnClickData) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -64,7 +64,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#event-onClicked) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#event-onClicked) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/remove/index.md
@@ -64,7 +64,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#method-remove) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#method-remove) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/removeall/index.md
@@ -63,7 +63,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#method-removeAll) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#method-removeAll) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/update/index.md
@@ -151,7 +151,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/contextMenus/#method-update) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus#method-update) API. This documentation is derived from [`context_menus.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/context_menus.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/clear/index.md
@@ -63,4 +63,4 @@ browser.browserAction.onClicked.addListener(handleClick);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -82,4 +82,4 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/#method-create) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications#method-create) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/getall/index.md
@@ -76,4 +76,4 @@ browser.notifications.getAll().then(logNotifications);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/index.md
@@ -55,4 +55,4 @@ To use this API, you need to have the "notifications" [permission](/en-US/docs/M
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -73,4 +73,4 @@ Note that `appIconMaskUrl` and `isClickable` are not supported.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onbuttonclicked/index.md
@@ -46,4 +46,4 @@ Events have three functions:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclicked/index.md
@@ -54,4 +54,4 @@ browser.notifications.onClicked.addListener((notificationId) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onclosed/index.md
@@ -56,4 +56,4 @@ browser.notifications.onClosed.addListener((notificationId) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/onshown/index.md
@@ -59,4 +59,4 @@ browser.notifications.onShown.addListener(logShown);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -44,4 +44,4 @@ Currently Firefox only supports "basic" here.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/update/index.md
@@ -91,4 +91,4 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/notifications/) API.
+> This API is based on Chromium's [`chrome.notifications`](https://developer.chrome.com/docs/extensions/reference/api/notifications) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/index.md
@@ -53,4 +53,4 @@ The omnibox API provides the extension a way to customize the suggestions displa
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/ondeletesuggestion/index.md
@@ -53,6 +53,6 @@ browser.omnibox.onDeleteSuggestion.addListener(logDeletedSuggestion);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.
 >
 > Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputcancelled/index.md
@@ -45,4 +45,4 @@ browser.omnibox.onInputCancelled.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputchanged/index.md
@@ -126,4 +126,4 @@ browser.omnibox.onInputEntered.addListener((url, disposition) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -126,4 +126,4 @@ browser.omnibox.onInputEntered.addListener((url, disposition) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentereddisposition/index.md
@@ -27,4 +27,4 @@ Values of this type are strings. They may take any one of the following values:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputstarted/index.md
@@ -50,4 +50,4 @@ browser.omnibox.onInputStarted.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/setdefaultsuggestion/index.md
@@ -43,4 +43,4 @@ browser.omnibox.setDefaultSuggestion({
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [chrome.omnibox](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [chrome.omnibox](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/suggestresult/index.md
@@ -27,4 +27,4 @@ Values of this type are objects. They have the following properties:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/omnibox/) API.
+> This API is based on Chromium's [`chrome.omnibox`](https://developer.chrome.com/docs/extensions/reference/api/omnibox) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/getpopup/index.md
@@ -61,7 +61,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-getPopup) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-getPopup) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/gettitle/index.md
@@ -56,7 +56,7 @@ browser.pageAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-getTitle) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-getTitle) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/hide/index.md
@@ -41,7 +41,7 @@ browser.pageAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-hide) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-hide) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/imagedatatype/index.md
@@ -20,7 +20,7 @@ An [`ImageData`](/en-US/docs/Web/API/ImageData) object, e.g. from a {{htmlelemen
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#type-ImageDataType) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#type-ImageDataType) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/index.md
@@ -59,7 +59,7 @@ Page actions are for actions that are only relevant to particular pages (such as
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/onclicked/index.md
@@ -69,7 +69,7 @@ browser.pageAction.onClicked.addListener(() => {});
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#event-onClicked) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#event-onClicked) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -96,7 +96,7 @@ browser.pageAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-setIcon) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-setIcon) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/setpopup/index.md
@@ -63,7 +63,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-setPopup) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-setPopup) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/settitle/index.md
@@ -52,7 +52,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tabInfo) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-setTitle) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-setTitle) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/show/index.md
@@ -57,7 +57,7 @@ browser.contextMenus.onClicked.addListener((info, tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/reference/pageAction/#method-show) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.pageAction`](https://developer.chrome.com/docs/extensions/mv2/reference/pageAction#method-show) API. This documentation is derived from [`page_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/page_action.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/contains/index.md
@@ -75,4 +75,4 @@ console.log(testResult4); // false: "https://example.org/", `origins` doesn't ma
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/getall/index.md
@@ -44,4 +44,4 @@ console.log(currentPermissions.origins); // [ "*://*.mozilla.org/*" ]
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/index.md
@@ -63,4 +63,4 @@ For advice on designing your request for runtime permissions, to maximize the li
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onadded/index.md
@@ -55,4 +55,4 @@ browser.permissions.onAdded.addListener(handleAdded);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/onremoved/index.md
@@ -55,4 +55,4 @@ browser.permissions.onRemoved.addListener(handleRemoved);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -25,4 +25,4 @@ An {{jsxref("object")}} with the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/remove/index.md
@@ -55,4 +55,4 @@ document.querySelector("#remove").addEventListener("click", remove);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/request/index.md
@@ -77,4 +77,4 @@ document
 > Currently has a [bug with requesting origins](https://bugzil.la/1411873) and [requesting permissions on the about:addons page](https://bugzil.la/1382953).
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/permissions/) API.
+> This API is based on Chromium's [`chrome.permissions`](https://developer.chrome.com/docs/extensions/reference/api/permissions) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/index.md
@@ -27,7 +27,7 @@ To use the privacy API, you must have the "privacy" [API permission](/en-US/docs
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/privacy/) API.
+> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/network/index.md
@@ -30,7 +30,7 @@ Default values for these properties tend to vary across browsers.
 - `httpsOnlyMode`
 
   - : This setting allows your extension to determine if a user has enabled
-    [HTTPS-Only mode](https://support.mozilla.org/kb/https-only-prefs). This property is read-only on all platforms. Its underlying value is a string that may take one of three values:
+    [HTTPS-Only mode](https://support.mozilla.org/en-US/kb/https-only-prefs). This property is read-only on all platforms. Its underlying value is a string that may take one of three values:
 
     - `"always"`: HTTPS-Only mode is on.
     - `"never"`: HTTPS-Only mode is off.
@@ -80,7 +80,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/privacy/) API. This documentation is derived from [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API. This documentation is derived from [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/services/index.md
@@ -51,4 +51,4 @@ getting.then((got) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/privacy/) API.
+> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -103,7 +103,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/privacy/) API. This documentation is derived from [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.privacy`](https://developer.chrome.com/docs/extensions/reference/api/privacy) API. This documentation is derived from [`privacy.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/privacy.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/index.md
@@ -14,7 +14,7 @@ The advantage of the {{WebExtAPIRef("proxy.onRequest")}} approach is that the co
 Apart from this API, extensions can also use the [`browserSettings.proxyConfig`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/settings) property to configure global proxy settings.
 
 > [!NOTE]
-> Chrome, Edge, and Opera have [an extension API also called "proxy"](https://developer.chrome.com/docs/extensions/reference/proxy/) which is functionally similar to this API, in that extensions can use it to implement a proxying policy. However, the design of the Chrome API is completely different to this API. Because this API is incompatible with the Chrome `proxy` API, this API is only available through the `browser` namespace.
+> Chrome, Edge, and Opera have [an extension API also called "proxy"](https://developer.chrome.com/docs/extensions/reference/api/proxy) which is functionally similar to this API, in that extensions can use it to implement a proxying policy. However, the design of the Chrome API is completely different to this API. Because this API is incompatible with the Chrome `proxy` API, this API is only available through the `browser` namespace.
 
 To use this API you need to have the "proxy" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). Also, where you want to intercept requests, you also need [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the URLs of intercepted requests.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -107,7 +107,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-connect) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-connect) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connectnative/index.md
@@ -61,7 +61,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-connectNative) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-connectNative) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getbackgroundpage/index.md
@@ -22,7 +22,7 @@ This is an asynchronous function that returns a {{JSxRef("Promise")}}.
 > [!NOTE]
 > In Firefox, this method cannot be used in Private Browsing mode — it always returns `null`. For more info see [Firefox bug 1329304](https://bugzil.la/1329304).
 >
-> In Chrome, this method is available only with persistent background pages, which are not available in Manifest V3, so consider using Manifest V2. See the [this](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/) for details.
+> In Chrome, this method is available only with persistent background pages, which are not available in Manifest V3, so consider using Manifest V2. See the [this](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers) for details.
 >
 > Consider using {{WebExtAPIRef("runtime.sendMessage","runtime.sendMessage()")}} or {{WebExtAPIRef("runtime.connect","runtime.connect()")}}, which work correctly in both scenarios above.
 
@@ -76,7 +76,7 @@ getting.then(onGot, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-getBackgroundPage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getBackgroundPage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getmanifest/index.md
@@ -39,7 +39,7 @@ console.log(manifest.name);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-getManifest) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getManifest) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getpackagedirectoryentry/index.md
@@ -47,7 +47,7 @@ browser.runtime.getPackageDirectoryEntry((directoryEntry) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-getPackageDirectoryEntry) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getPackageDirectoryEntry) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getplatforminfo/index.md
@@ -44,7 +44,7 @@ gettingInfo.then(gotPlatformInfo);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-getPlatformInfo) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getPlatformInfo) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/geturl/index.md
@@ -46,7 +46,7 @@ console.log(fullURL);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-getURL) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getURL) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/id/index.md
@@ -26,7 +26,7 @@ A `string` representing the add-on ID. If the extension specifies an ID in its [
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#property-id) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#property-id) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -114,7 +114,7 @@ It also provides messaging APIs enabling you to:
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/lasterror/index.md
@@ -73,7 +73,7 @@ setCookie.then(logCookie, logError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#property-lastError) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#property-lastError) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -44,7 +44,7 @@ Values of this type are objects. They contain the following properties:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-MessageSender) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-MessageSender) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -56,7 +56,7 @@ browser.runtime.onBrowserUpdateAvailable.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onBrowserUpdateAvailable) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onBrowserUpdateAvailable) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnect/index.md
@@ -100,7 +100,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onConnect) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onConnect) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onconnectexternal/index.md
@@ -86,7 +86,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onConnectExternal) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onConnectExternal) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -71,7 +71,7 @@ browser.runtime.onInstalled.addListener(handleInstalled);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onInstalled) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onInstalled) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalledreason/index.md
@@ -29,7 +29,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-OnInstalledReason) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-OnInstalledReason) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessage/index.md
@@ -282,7 +282,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onmessageexternal/index.md
@@ -91,7 +91,7 @@ browser.runtime.onMessageExternal.addListener(handleMessage);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onMessageExternal) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onMessageExternal) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequired/index.md
@@ -46,7 +46,7 @@ Events have three functions:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onRestartRequired) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onRestartRequired) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onrestartrequiredreason/index.md
@@ -24,7 +24,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-OnRestartRequiredReason) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-OnRestartRequiredReason) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onstartup/index.md
@@ -59,7 +59,7 @@ browser.runtime.onStartup.addListener(handleStartup);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onStartup) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onStartup) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspend/index.md
@@ -56,7 +56,7 @@ browser.runtime.onSuspend.addListener(handleSuspend);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onSuspend) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onSuspend) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onsuspendcanceled/index.md
@@ -52,7 +52,7 @@ browser.runtime.onSuspendCanceled.addListener(handleSuspendCanceled);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onSuspendCanceled) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onSuspendCanceled) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onupdateavailable/index.md
@@ -64,7 +64,7 @@ browser.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#event-onUpdateAvailable) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onUpdateAvailable) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/openoptionspage/index.md
@@ -49,7 +49,7 @@ opening.then(onOpened, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-openOptionsPage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-openOptionsPage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -27,7 +27,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-PlatformArch) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformArch) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -27,7 +27,7 @@ Values of this type are objects, which contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-PlatformInfo) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformInfo) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -20,7 +20,7 @@ Values of this type are strings. Possible values are: `"arm"`, `"x86-32"`, `"x86
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-PlatformNaclArch) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformNaclArch) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -37,7 +37,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-PlatformOs) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformOs) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -93,7 +93,7 @@ Values of this type are objects. They contain the following properties:
 
 ## Lifecycle
 
-The lifecycle of a `Port` is described [in the Chrome docs](https://developer.chrome.com/docs/extensions/mv3/messaging/#port-lifetime).
+The lifecycle of a `Port` is described [in the Chrome docs](https://developer.chrome.com/docs/extensions/develop/concepts/messaging#port-lifetime).
 
 There is, however, one important difference between Firefox and Chrome, stemming from the fact that the `runtime.connect` and `tabs.connect` APIs are broadcast channels. This means that there may be potentially more than one recipient, and this results in ambiguity when one of the contexts with a `runtime.onConnect` call is closed. In Chrome, a port stays active as long as there is any other recipient. In Firefox, the port closes when any of the contexts unloads. In other words, the disconnection condition,
 
@@ -219,7 +219,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-Port) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-Port) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/reload/index.md
@@ -38,7 +38,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-reload) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-reload) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -63,7 +63,7 @@ requestingCheck.then(onRequested, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-requestUpdateCheck) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-requestUpdateCheck) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheckstatus/index.md
@@ -27,7 +27,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#type-RequestUpdateCheckStatus) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-RequestUpdateCheckStatus) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -119,7 +119,7 @@ browser.runtime.onMessage.addListener(handleMessage);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-sendMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-sendMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendnativemessage/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-sendNativeMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-sendNativeMessage) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/setuninstallurl/index.md
@@ -50,7 +50,7 @@ settingUrl.then(onSetURL, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/runtime/#method-setUninstallURL) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.runtime`](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-setUninstallURL) API. This documentation is derived from [`runtime.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/runtime.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/contentscriptfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/contentscriptfilter/index.md
@@ -23,4 +23,4 @@ Values of this type are objects. They contain these properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#type-ContentScriptFilter) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-ContentScriptFilter) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -122,4 +122,4 @@ browser.action.onClicked.addListener(async (tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-executeScript) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-executeScript) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executionworld/index.md
@@ -35,4 +35,4 @@ Values of this type are strings. Possible values are:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#type-ExecutionWorld) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-ExecutionWorld) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
@@ -70,4 +70,4 @@ console.log(scripts.map((script) => script.id)); // ["script-2"]
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-getRegisteredContentScripts) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-getRegisteredContentScripts) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
@@ -54,4 +54,4 @@ Alternatively, you can get permission temporarily in the active tab and only in 
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
@@ -31,4 +31,4 @@ Values of this type are objects. They contain these properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#type-InjectionTarget) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-InjectionTarget) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
@@ -98,4 +98,4 @@ browser.action.onClicked.addListener(async (tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-insertCSS) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-insertCSS) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -58,4 +58,4 @@ try {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-registerContentScripts) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-registerContentScripts) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -41,4 +41,4 @@ Values of this type are objects. They contain these properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#type-RegisteredContentScript) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#type-RegisteredContentScript) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
@@ -79,4 +79,4 @@ browser.action.onClicked.addListener(async (tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-removeCSS) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-removeCSS) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
@@ -54,4 +54,4 @@ try {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-unregisterContentScripts) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-unregisterContentScripts) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
@@ -67,4 +67,4 @@ try {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/scripting/#method-updateContentScripts) API.
+> This API is based on Chromium's [`chrome.scripting`](https://developer.chrome.com/docs/extensions/reference/api/scripting#method-updateContentScripts) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/index.md
@@ -64,7 +64,7 @@ To use the sessions API you must have the "sessions" [API permission](/en-US/doc
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/max_session_results/index.md
@@ -14,7 +14,7 @@ This value represents the maximum number of sessions that will be returned by a 
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/onchanged/index.md
@@ -72,7 +72,7 @@ browser.sessions.onChanged.addListener(restoreMostRecent);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/restore/index.md
@@ -65,7 +65,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -36,7 +36,7 @@ Values of this type are objects. They contain the following properties:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/sessions/) API.
+> This API is based on Chromium's [`chrome.sessions`](https://developer.chrome.com/docs/extensions/reference/api/sessions) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -63,7 +63,7 @@ gettingPanel.then(onGot);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/imagedatatype/index.md
@@ -20,7 +20,7 @@ An [`ImageData`](/en-US/docs/Web/API/ImageData) object.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/index.md
@@ -13,7 +13,7 @@ A [sidebar](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Sidebars) i
 
 The `sidebarAction` API is closely modeled on the {{WebExtAPIRef("browserAction")}} API.
 
-The sidebarAction API is based on Opera's [sidebarAction API](https://dev.opera.com/extensions/sidebar-action-api/). However, note that the following are not yet supported: `setBadgeText()`, `getBadgeText()`, `setBadgeBackgroundColor()`, `getBadgeBackgroundColor()`, `onFocus`, `onBlur`.
+The sidebarAction API is based on Opera's [sidebarAction API](https://help.opera.com/en/extensions/sidebar-action-api/). However, note that the following are not yet supported: `setBadgeText()`, `getBadgeText()`, `setBadgeBackgroundColor()`, `getBadgeBackgroundColor()`, `onFocus`, `onBlur`.
 
 ## Types
 
@@ -50,7 +50,7 @@ The sidebarAction API is based on Opera's [sidebarAction API](https://dev.opera.
 - [annotate-page](https://github.com/mdn/webextensions-examples/tree/main/annotate-page)
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -130,4 +130,4 @@ browser.browserAction.onClicked.addListener(toggle);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -83,7 +83,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -76,7 +76,7 @@ browser.browserAction.onClicked.addListener(setTitleForTab);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Opera's [`chrome.sidebarAction`](https://dev.opera.com/extensions/sidebar-action-api/) API.
+> This API is based on Opera's [`chrome.sidebarAction`](https://help.opera.com/en/extensions/sidebar-action-api/) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/index.md
@@ -59,7 +59,7 @@ You can examine the stored data under the Extension Storage item in the [Storage
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/local/index.md
@@ -49,7 +49,7 @@ The `local` object implements the events defined on the {{WebExtAPIRef("storage.
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#property-local) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#property-local) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -11,7 +11,7 @@ A {{WebExtAPIRef("storage.StorageArea")}} object that represents the `managed` s
 
 ## Provisioning managed storage
 
-The procedure for provisioning managed storage varies between browsers. For Chrome instructions, see the ["Manifest for storage areas"](https://developer.chrome.com/docs/extensions/mv3/manifest/storage/) article.
+The procedure for provisioning managed storage varies between browsers. For Chrome instructions, see the ["Manifest for storage areas"](https://developer.chrome.com/docs/extensions/reference/manifest/storage) article.
 
 For Firefox, you need to create a JSON manifest file in a specific format and location. For the details of manifest syntax and location, see [Native manifests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests).
 
@@ -60,7 +60,7 @@ The `managed` object implements the events defined on the {{WebExtAPIRef("storag
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#property-managed) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#property-managed) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -72,7 +72,7 @@ browser.storage.onChanged.addListener(logStorageChange);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#event-onChanged) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#event-onChanged) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/session/index.md
@@ -45,7 +45,7 @@ The `session` object implements the events defined on the {{WebExtAPIRef("storag
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#property-session) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#property-session) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/clear/index.md
@@ -49,4 +49,4 @@ clearStorage.then(onCleared, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -154,4 +154,4 @@ gettingItem.then(onGot); // -> Object { kitten: Object }
 ```
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -41,4 +41,4 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -40,7 +40,7 @@ Values of this type are objects.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#type-StorageArea) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#type-StorageArea) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -68,7 +68,7 @@ browser.storage.local.onChanged.addListener(logStorageChange);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#event-StorageArea-onChanged) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#event-StorageArea-onChanged) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/remove/index.md
@@ -54,4 +54,4 @@ removeKitten.then(onRemoved, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/set/index.md
@@ -88,4 +88,4 @@ browser.storage.local.get("monster").then(gotMonster, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
@@ -42,4 +42,4 @@ A {{jsxref("Promise")}} that is fulfilled with no arguments if the operation suc
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -25,7 +25,7 @@ browser-compat: webextensions.api.storage.StorageChange
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#type-StorageChange) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#type-StorageChange) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/sync/index.md
@@ -101,7 +101,7 @@ The `sync` object implements the events defined on the {{WebExtAPIRef("storage.S
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/storage/#property-sync) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.storage`](https://developer.chrome.com/docs/extensions/reference/api/storage#property-sync) API. This documentation is derived from [`storage.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/storage.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -57,7 +57,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-captureVisibleTab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-captureVisibleTab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -62,7 +62,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-captureVisibleTab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-captureVisibleTab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -73,7 +73,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-connect) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-connect) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -104,7 +104,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-create) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-create) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/detectlanguage/index.md
@@ -80,7 +80,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-detectLanguage) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-detectLanguage) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/discard/index.md
@@ -75,7 +75,7 @@ discarding.then(onDiscarded, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-discard) API.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-discard) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/duplicate/index.md
@@ -74,7 +74,7 @@ querying.then(duplicateFirstTab, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-duplicate) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-duplicate) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -184,7 +184,7 @@ executing.then(onExecuted, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-executeScript) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-executeScript) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/get/index.md
@@ -52,7 +52,7 @@ browser.tabs.onActivated.addListener(logListener);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-get) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-get) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -40,7 +40,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getAllInWindow) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getAllInWindow) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getcurrent/index.md
@@ -54,7 +54,7 @@ gettingCurrent.then(onGot, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getCurrent) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getCurrent) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -40,7 +40,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getSelected) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getSelected) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -67,7 +67,7 @@ gettingZoom.then(onGot, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getZoom) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getZoom) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -52,7 +52,7 @@ gettingZoomSettings.then(onGot, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -55,7 +55,7 @@ goingBack.then(onGoBack, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -55,7 +55,7 @@ goingForward.then(onGoForward, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-getZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -48,7 +48,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-highlight) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-highlight) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -163,7 +163,7 @@ Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a s
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -101,7 +101,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-insertCSS) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-insertCSS) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -128,7 +128,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-move) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-move) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -27,7 +27,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-MutedInfo) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-MutedInfo) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinforeason/index.md
@@ -27,7 +27,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-MutedInfoReason) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-MutedInfoReason) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -67,7 +67,7 @@ browser.tabs.onActivated.addListener(handleActivated);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onActivated) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onActivated) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivechanged/index.md
@@ -56,7 +56,7 @@ Events have three functions:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onActiveChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onActiveChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
@@ -69,7 +69,7 @@ browser.tabs.onAttached.addListener(handleAttached);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onAttached) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onAttached) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/oncreated/index.md
@@ -58,7 +58,7 @@ browser.tabs.onCreated.addListener(handleCreated);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onCreated) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onCreated) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
@@ -69,7 +69,7 @@ browser.tabs.onDetached.addListener(handleDetached);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onDetached) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onDetached) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlightchanged/index.md
@@ -56,7 +56,7 @@ Events have three functions:
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onHighlightChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onHighlightChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
@@ -67,7 +67,7 @@ browser.tabs.onHighlighted.addListener(handleHighlighted);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onHighlighted) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onHighlighted) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -73,7 +73,7 @@ browser.tabs.onMoved.addListener(handleMoved);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onMoved) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onMoved) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
@@ -69,7 +69,7 @@ browser.tabs.onRemoved.addListener(handleRemoved);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onRemoved) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onRemoved) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
@@ -61,7 +61,7 @@ browser.tabs.onReplaced.addListener(handleReplaced);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onReplaced) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onReplaced) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onselectionchanged/index.md
@@ -58,7 +58,7 @@ Events have three functions:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onSelectionChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onSelectionChanged) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -221,7 +221,7 @@ browser.tabs.onUpdated.addListener(handleUpdated, filter);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onUpdated) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onUpdated) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
@@ -71,7 +71,7 @@ browser.tabs.onZoomChange.addListener(handleZoomed);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#event-onZoomChange) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#event-onZoomChange) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -145,7 +145,7 @@ browser.tabs.query({ url: "*://*.mozilla.org/*" }).then(logTabs, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-query) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-query) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -71,7 +71,7 @@ reloading.then(onReloaded, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-reload) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-reload) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -67,7 +67,7 @@ removing.then(onRemoved, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-remove) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-remove) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -75,7 +75,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-insertCSS) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-insertCSS) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendmessage/index.md
@@ -102,7 +102,7 @@ browser.runtime.onMessage.addListener((request) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-sendMessage) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-sendMessage) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/sendrequest/index.md
@@ -41,7 +41,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-sendRequest) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-sendRequest) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -62,7 +62,7 @@ setting.then(null, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-setZoom) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-setZoom) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -55,7 +55,7 @@ setting.then(onSet, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-setZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-setZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -85,7 +85,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-Tab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-Tab) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab_id_none/index.md
@@ -16,7 +16,7 @@ A special ID value given to tabs that are not browser tabs (for example, tabs in
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#property-TAB_ID_NONE) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#property-TAB_ID_NONE) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tabstatus/index.md
@@ -20,7 +20,7 @@ Values of this type are strings. Possible values are: `"loading"` and `"complete
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-TabStatus) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-TabStatus) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -123,7 +123,7 @@ querying.then(updateFirstTab, onError);
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#method-update) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-update) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/windowtype/index.md
@@ -25,7 +25,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-WindowType) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-WindowType) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -27,7 +27,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-ZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-ZoomSettings) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsmode/index.md
@@ -27,7 +27,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-ZoomSettingsMode) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-ZoomSettingsMode) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettingsscope/index.md
@@ -29,7 +29,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/tabs/#type-ZoomSettingsScope) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.tabs`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-ZoomSettingsScope) API. This documentation is derived from [`tabs.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/tabs.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/get/index.md
@@ -102,7 +102,7 @@ browser.topSites
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/topSites/) API.
+> This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/api/topSites) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/index.md
@@ -30,7 +30,7 @@ To use the topSites API you must have the "topSites" [API permission](/en-US/doc
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/topSites/) API.
+> This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/api/topSites) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/topsites/mostvisitedurl/index.md
@@ -29,7 +29,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/topSites/) API.
+> This API is based on Chromium's [`chrome.topSites`](https://developer.chrome.com/docs/extensions/reference/api/topSites) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/clear/index.md
@@ -53,7 +53,7 @@ clearing.then(onCleared);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/types/) API.
+> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/get/index.md
@@ -74,7 +74,7 @@ getting.then((got) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/types/) API.
+> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/index.md
@@ -11,7 +11,7 @@ A `BrowserSetting` is an object representing a browser setting.
 
 It provides methods to set and get the setting's underlying value, to clear any change you've made to it, and to listen for changes to its value.
 
-Note that while this object is based on the [ChromeSetting](https://developer.chrome.com/docs/extensions/reference/types/#type-ChromeSetting) type, this object does not distinguish between setting the value in normal browsing windows and in private browsing windows. This means that all parts of the API relating to private browsing (such as the `scope` option to `ChromeSetting.set()`) are not implemented.
+Note that while this object is based on the [ChromeSetting](https://developer.chrome.com/docs/extensions/reference/api/types#type-ChromeSetting) type, this object does not distinguish between setting the value in normal browsing windows and in private browsing windows. This means that all parts of the API relating to private browsing (such as the `scope` option to `ChromeSetting.set()`) are not implemented.
 
 ## Methods
 
@@ -34,7 +34,7 @@ Note that while this object is based on the [ChromeSetting](https://developer.ch
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/types/) API.
+> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/onchange/index.md
@@ -76,7 +76,7 @@ Events have three functions:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/types/) API.
+> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/browsersetting/set/index.md
@@ -73,7 +73,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/types/) API.
+> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/types/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/types/index.md
@@ -18,7 +18,7 @@ Defines the `BrowserSetting` type, which is used to represent a browser setting.
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/types/) API.
+> This API is based on Chromium's [`chrome.types`](https://developer.chrome.com/docs/extensions/reference/api/types) API.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getallframes/index.md
@@ -85,7 +85,7 @@ browser.browserAction.onClicked.addListener(() => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#method-getAllFrames) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#method-getAllFrames) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/getframe/index.md
@@ -74,7 +74,7 @@ gettingFrame.then(onGot, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#method-getFrame) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#method-getFrame) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/index.md
@@ -79,7 +79,7 @@ To use this API you need to have the "webNavigation" [permission](/en-US/docs/Mo
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -83,7 +83,7 @@ browser.webNavigation.onBeforeNavigate.addListener(logOnBefore, filter);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -89,7 +89,7 @@ browser.webNavigation.onCommitted.addListener(logOnCommitted, filter);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -81,7 +81,7 @@ browser.webNavigation.onCompleted.addListener(logOnCompleted, filter);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -97,7 +97,7 @@ browser.webNavigation.onCreatedNavigationTarget.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -84,7 +84,7 @@ browser.webNavigation.onDOMContentLoaded.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -100,7 +100,7 @@ browser.webNavigation.onErrorOccurred.addListener(logOnErrorOccurred, filter);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -90,7 +90,7 @@ browser.webNavigation.onHistoryStateUpdated.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -90,7 +90,7 @@ browser.webNavigation.onReferenceFragmentUpdated.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onBeforeNavigate) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ontabreplaced/index.md
@@ -68,7 +68,7 @@ browser.webNavigation.onTabReplaced.addListener(logOnTabReplaced);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onTabReplaced) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#event-onTabReplaced) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitionqualifier/index.md
@@ -29,7 +29,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#type-TransitionQualifier) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#type-TransitionQualifier) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/transitiontype/index.md
@@ -45,7 +45,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/webNavigation/#type-TransitionType) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webNavigation`](https://developer.chrome.com/docs/extensions/reference/api/webNavigation#type-TransitionType) API. This documentation is derived from [`web_navigation.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/web_navigation.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -50,7 +50,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#type-BlockingResponse) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-BlockingResponse) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/handlerbehaviorchanged/index.md
@@ -64,7 +64,7 @@ flushingCache.then(onFlushed, onError);
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#method-handlerBehaviorChanged) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#method-handlerBehaviorChanged) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -27,7 +27,7 @@ An `array` of `object`s. Each object has the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#type-HttpHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-HttpHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -143,7 +143,7 @@ To do this, you must have the `"webRequestBlocking"` API permission as well as t
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/max_handler_behavior_changed_calls_per_10_minutes/index.md
@@ -18,7 +18,7 @@ This property is read-only.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#property-MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#property-MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -328,7 +328,7 @@ browser.webRequest.onErrorOccurred.addListener(completed, { urls: [target] });
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onAuthRequired) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onAuthRequired) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -170,7 +170,7 @@ browser.webRequest.onBeforeRedirect.addListener(logResponse, {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onBeforeRedirect) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRedirect) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -323,7 +323,7 @@ browser.webRequest.onBeforeRequest.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onBeforeRequest) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRequest) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -261,7 +261,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onBeforeSendHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeSendHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -171,7 +171,7 @@ browser.webRequest.onCompleted.addListener(logResponse, { urls: [target] });
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onCompleted) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onCompleted) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -173,7 +173,7 @@ browser.webRequest.onErrorOccurred.addListener(logError, { urls: [target] });
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onErrorOccurred) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onErrorOccurred) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -229,7 +229,7 @@ browser.webRequest.onHeadersReceived.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onHeadersReceived) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onHeadersReceived) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -170,7 +170,7 @@ browser.webRequest.onResponseStarted.addListener(logResponse, {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onResponseStarted) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onResponseStarted) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -166,7 +166,7 @@ browser.webRequest.onSendHeaders.addListener(
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#event-onSendHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onSendHeaders) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -31,7 +31,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#type-RequestFilter) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-RequestFilter) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/resourcetype/index.md
@@ -71,7 +71,7 @@ Values of this type are strings. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#type-ResourceType) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-ResourceType) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/webRequest/#type-UploadData) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.webRequest`](https://developer.chrome.com/docs/extensions/reference/api/webRequest#type-UploadData) API. This documentation is derived from [`web_request.json`](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/web_request.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/create/index.md
@@ -140,7 +140,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-create) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-create) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/createtype/index.md
@@ -25,7 +25,7 @@ Values of this type are `strings`. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#type-CreateType) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-CreateType) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -70,7 +70,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-get) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-get) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -67,7 +67,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-getAll) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-getAll) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -66,7 +66,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-getCurrent) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-getCurrent) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -64,7 +64,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-getLastFocused) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-getLastFocused) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/index.md
@@ -62,7 +62,7 @@ Interact with browser windows. You can use this API to get information about ope
 {{WebExtExamples("h2")}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onboundschanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onboundschanged/index.md
@@ -54,7 +54,7 @@ browser.windows.onBoundsChanged.addListener((window) => {
 {{Compat}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#event-onBoundsChanged) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onBoundsChanged) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -54,7 +54,7 @@ browser.windows.onCreated.addListener((window) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#event-onCreated) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onCreated) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -57,7 +57,7 @@ browser.windows.onFocusChanged.addListener((windowId) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#event-onFocusChanged) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onFocusChanged) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -54,7 +54,7 @@ browser.windows.onRemoved.addListener((windowId) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#event-onRemoved) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#event-onRemoved) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/remove/index.md
@@ -72,7 +72,7 @@ In Firefox, the same could be achieved with the `.allowScriptsToClose` window cr
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-remove) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-remove) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/update/index.md
@@ -78,7 +78,7 @@ browser.browserAction.onClicked.addListener((tab) => {
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#method-update) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-update) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -47,7 +47,7 @@ Values of this type are `objects`. They contain the following properties:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#type-Window) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-Window) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_current/index.md
@@ -16,7 +16,7 @@ browser-compat: webextensions.api.windows.WINDOW_ID_CURRENT
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#property-WINDOW_ID_CURRENT) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#property-WINDOW_ID_CURRENT) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window_id_none/index.md
@@ -16,7 +16,7 @@ The `windowId` value that represents the absence of a browser window.
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#property-WINDOW_ID_NONE) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#property-WINDOW_ID_NONE) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowstate/index.md
@@ -33,7 +33,7 @@ macOS compatibility: Beginning in macOS 10.10, the default maximizing behavior f
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#type-WindowState) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-WindowState) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/windowtype/index.md
@@ -25,7 +25,7 @@ Values of this type are `strings`. Possible values are:
 {{WebExtExamples}}
 
 > [!NOTE]
-> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/windows/#type-WindowType) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
+> This API is based on Chromium's [`chrome.windows`](https://developer.chrome.com/docs/extensions/reference/api/windows#type-WindowType) API. This documentation is derived from [`windows.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/windows.json) in the Chromium code.
 
 <!--
 // Copyright 2015 The Chromium Authors. All rights reserved.

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -11,7 +11,7 @@ The introduction of the browser extensions API created a uniform landscape for t
 Maximizing the reach of your browser extension means developing it for at least two browsers, possibly more. This article looks at the main challenges faced when creating a cross-browser extension and suggests how to address these challenges.
 
 > [!NOTE]
-> The main browsers have adopted Manifest V3. This manifest version provides better compatibility between the browser extension environments, such as promises for handling asynchronous events. In addition to the information in this guide, refer to the Manifest V3 migration guides for [Firefox](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/) and [Chrome](https://developer.chrome.com/docs/extensions/migrating/).
+> The main browsers have adopted Manifest V3. This manifest version provides better compatibility between the browser extension environments, such as promises for handling asynchronous events. In addition to the information in this guide, refer to the Manifest V3 migration guides for [Firefox](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/) and [Chrome](https://developer.chrome.com/docs/extensions/develop/migrate).
 
 ## Cross-platform extension coding hurdles
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -20,7 +20,7 @@ However, there are significant differences between Chrome (and Chromium-based br
 - Asynchronous APIs:
 
   - **In Firefox and Safari:** Asynchronous APIs are implemented using promises.
-  - **In Chrome:** In Manifest V2, asynchronous APIs are implemented using callbacks. In Manifest V3, support is provided for [promises](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#promises) on most appropriate methods. (cf. [Chrome bug 328932](https://crbug.com/328932)) Callbacks are supported in Manifest V3 for backward compatibility.
+  - **In Chrome:** In Manifest V2, asynchronous APIs are implemented using callbacks. In Manifest V3, support is provided for [promises](https://developer.chrome.com/docs/extensions/develop/migrate#promises) on most appropriate methods. (cf. [Chrome bug 328932](https://crbug.com/328932)) Callbacks are supported in Manifest V3 for backward compatibility.
 
 The rest of this page details these and other incompatibilities.
 
@@ -59,7 +59,7 @@ The rest of this page details these and other incompatibilities.
   setCookie.then(logCookie, logError);
   ```
 
-- **In Chrome:** In Manifest V2, asynchronous APIs use callbacks to return values and {{WebExtAPIRef("runtime.lastError")}} to communicate errors. In Manifest V3, callbacks are supported for backward compatibility, along with support for [promises](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#promises) on most appropriate methods.
+- **In Chrome:** In Manifest V2, asynchronous APIs use callbacks to return values and {{WebExtAPIRef("runtime.lastError")}} to communicate errors. In Manifest V3, callbacks are supported for backward compatibility, along with support for [promises](https://developer.chrome.com/docs/extensions/develop/migrate#promises) on most appropriate methods.
 
   ```js
   function logCookie(c) {
@@ -112,8 +112,8 @@ Firefox and Chrome include a Proxy API. However, the design of these two APIs is
 
 - **In Firefox**: Proxies are set using the [proxy.settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/settings) property or [proxy.onRequest](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/onRequest) to provide [ProxyInfo](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo) dynamically.
   See [proxy](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy) for more information on the API.
-- **In Chrome**: Proxy settings are defined in a [`proxy.ProxyConfig`](https://developer.chrome.com/docs/extensions/reference/proxy/#type-ProxyConfig) object. Depending on Chrome's proxy settings, the settings may contain [`proxy.ProxyRules`](https://developer.chrome.com/docs/extensions/reference/proxy/#type-ProxyRules) or a [`proxy.PacScript`](https://developer.chrome.com/docs/extensions/reference/proxy/#type-PacScript). Proxies are set using the [proxy.settings](https://developer.chrome.com/docs/extensions/reference/proxy/#property-settings) property.
-  See [chrome.proxy](https://developer.chrome.com/docs/extensions/reference/proxy/) for more information on the API.
+- **In Chrome**: Proxy settings are defined in a [`proxy.ProxyConfig`](https://developer.chrome.com/docs/extensions/reference/api/proxy#type-ProxyConfig) object. Depending on Chrome's proxy settings, the settings may contain [`proxy.ProxyRules`](https://developer.chrome.com/docs/extensions/reference/api/proxy#type-ProxyRules) or a [`proxy.PacScript`](https://developer.chrome.com/docs/extensions/reference/api/proxy#type-PacScript). Proxies are set using the [proxy.settings](https://developer.chrome.com/docs/extensions/reference/api/proxy#property-settings) property.
+  See [chrome.proxy](https://developer.chrome.com/docs/extensions/reference/api/proxy) for more information on the API.
 
 #### Tabs API
 
@@ -159,7 +159,7 @@ When calling `tabs.remove()`:
 
 #### DeclarativeContent API
 
-- **In Firefox:** Chrome's [declarativeContent](https://developer.chrome.com/docs/extensions/reference/declarativeContent/) API [is not implemented](https://bugzil.la/1435864). In addition, Firefox [will not support](https://bugzil.la/1323433#c16) the `declarativeContent.RequestContentScript` API (which is rarely used and is unavailable in stable releases of Chrome).
+- **In Firefox:** Chrome's [declarativeContent](https://developer.chrome.com/docs/extensions/reference/api/declarativeContent) API [is not implemented](https://bugzil.la/1435864). In addition, Firefox [will not support](https://bugzil.la/1323433#c16) the `declarativeContent.RequestContentScript` API (which is rarely used and is unavailable in stable releases of Chrome).
 
 ### Miscellaneous incompatibilities
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -222,7 +222,7 @@ This is accomplished by exposing more privileged XHR and fetch instances in the 
 > This is not possible in Manifest V3, as `content.XMLHttpRequest` and `content.fetch()` are not available.
 
 > [!NOTE]
-> In Chrome, starting with version 73, and Firefox, starting with version 101 when using Manifest V3, content scripts are subject to the same [CORS](/en-US/docs/Web/HTTP/CORS) policy as the page they are running within. Only backend scripts have elevated cross-domain privileges. See [Changes to Cross-Origin Requests in Chrome Extension Content Scripts](https://www.chromium.org/Home/chromium-security/extension-content-script-fetches).
+> In Chrome, starting with version 73, and Firefox, starting with version 101 when using Manifest V3, content scripts are subject to the same [CORS](/en-US/docs/Web/HTTP/CORS) policy as the page they are running within. Only backend scripts have elevated cross-domain privileges. See [Changes to Cross-Origin Requests in Chrome Extension Content Scripts](https://www.chromium.org/Home/chromium-security/extension-content-script-fetches/).
 
 ## Communicating with background scripts
 

--- a/files/en-us/mozilla/add-ons/webextensions/differences_between_api_implementations/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/differences_between_api_implementations/index.md
@@ -25,7 +25,7 @@ There are two API namespaces in use:
 
 JavaScript provides several ways to handle asynchronous events. The proposed extensions API standard is to use promises. The promises approach offers significant advantages when dealing with chained asynchronous event calls.
 
-Firefox and Safari implement promises for the extensions API. All other browsers use callbacks. In Manifest V3, Chrome, Edge, and Opera provided for [promises](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#promises) on most appropriate methods. (cf. [Chrome bug 328932](https://crbug.com/328932))
+Firefox and Safari implement promises for the extensions API. All other browsers use callbacks. In Manifest V3, Chrome, Edge, and Opera provided for [promises](https://developer.chrome.com/docs/extensions/develop/migrate#promises) on most appropriate methods. (cf. [Chrome bug 328932](https://crbug.com/328932))
 
 If you are unfamiliar with how JavaScript can handle asynchronous events or promises, look at [Getting to know asynchronous JavaScript: Callbacks, Promises and Async/Await](https://medium.com/codebuddies/getting-to-know-asynchronous-javascript-callbacks-promises-and-async-await-17e0673281ee) or the MDN [Using promises](/en-US/docs/Web/JavaScript/Guide/Using_promises) page.
 

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -7,7 +7,7 @@ page-type: guide
 {{AddonSidebar}}
 
 > [!NOTE]
-> This page describes the devtools APIs in Firefox 55. Although the APIs are based on the [Chrome devtools APIs](https://developer.chrome.com/docs/extensions/mv3/devtools/), Firefox does not implement all those features; therefore, not all features are documented here. To see which features are missing, refer to [Limitations of the devtools APIs](#limitations_of_the_devtools_apis).
+> This page describes the devtools APIs in Firefox 55. Although the APIs are based on the [Chrome devtools APIs](https://developer.chrome.com/docs/extensions/how-to/devtools/extend-devtools), Firefox does not implement all those features; therefore, not all features are documented here. To see which features are missing, refer to [Limitations of the devtools APIs](#limitations_of_the_devtools_apis).
 
 You can use WebExtensions APIs to extend the browser's built-in developer tools. To create a devtools extension, include the "[devtools_page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page)" key in your [manifest.json](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file:
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/index.md
@@ -33,7 +33,7 @@ The version string consists of 1 to 4 numbers separated by dots, for example, `1
 Extension stores and browsers may enforce or warn if the version string doesn't comply with this format. They may also apply restrictions to the range of numbers available. For example:
 
 - [addons.mozilla.org](https://addons.mozilla.org/) (AMO) allows version strings using numbers of up to nine digits, complying with this regular expression `^(0|[1-9][0-9]{0,8})([.](0|[1-9][0-9]{0,8})){0,3}$`. Also, from Firefox 108, a warning is provided if an extension is installed with a version number that doesn't match this format.
-- The Chrome Web Store requires [numbers between 0 and 65535](https://developer.chrome.com/docs/extensions/mv3/manifest/version/) and does not permit all-zero extension strings. For example, 0.0 or 0.0.0.0 are not permitted.
+- The Chrome Web Store requires [numbers between 0 and 65535](https://developer.chrome.com/docs/extensions/reference/manifest/version) and does not permit all-zero extension strings. For example, 0.0 or 0.0.0.0 are not permitted.
 
 It may be possible to create an extension that appears to have a valid version number when run in a browser but doesn't comply with store requirements. Particular care should be taken when developing cross-browser extensions that use large number elements.
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
@@ -28,7 +28,7 @@ browser-compat: webextensions.manifest.version_name
   </tbody>
 </table>
 
-In addition to the [version](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) field, which is used for update purposes, [version_name](https://developer.chrome.com/docs/extensions/mv3/manifest/version/) can be set to a descriptive version string and will be used for display purposes if present.
+In addition to the [version](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) field, which is used for update purposes, [version_name](https://developer.chrome.com/docs/extensions/reference/manifest/version) can be set to a descriptive version string and will be used for display purposes if present.
 
 If no **version_name** is present, the **version** field will be used for display purposes as well.
 

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -33,7 +33,7 @@ drawArrays(mode, first, count)
     - `gl.TRIANGLES`: Draws a triangle for a group of three vertices.
 
     > [!NOTE]
-    > If `mode` is `POINTS`, [`gl_PointSize`](https://www.opengl.org/sdk/docs/man4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
+    > If `mode` is `POINTS`, [`gl_PointSize`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
 
 - `first`
   - : A {{domxref("WebGL_API/Types", "GLint")}} specifying the starting index in the array of vector points.

--- a/files/en-us/web/tutorials/index.md
+++ b/files/en-us/web/tutorials/index.md
@@ -133,7 +133,7 @@ These resources are created by forward-thinking companies and web developers who
   - : Reliable and in-depth information on ECMAScript 2015.
 - [JavaScript Patterns](https://github.com/chuanxshi/javascript-patterns)
   - : A JavaScript pattern and anti-pattern collection that covers function patterns, jQuery patterns, jQuery plugin patterns, design patterns, general patterns, literals and constructor patterns, object creation patterns, code reuse patterns, DOM.
-- [How browsers work](https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/)
+- [How browsers work](https://web.dev/articles/howbrowserswork)
   - : A detailed research article describing different modern browsers, their engines, page rendering etc.
 - [JavaScript Videos](https://github.com/bolshchikov/js-must-watch)
   - : A collection of JavaScript videos to watch.


### PR DESCRIPTION
It is better to update redirected URLs before they start reporting 404. Once the URL starts reporting 404, finding the new location sometimes becomes almost impossible.

To make reviewing easier, the PR focuses only on redirects from `developer.chrome.com` domain, which is the primary source of redirects at the moment.

