### PR TITLE
add api.HTMLDetailsElement.name page

### DIFF
--- a/files/en-us/web/api/htmldetailselement/index.md
+++ b/files/en-us/web/api/htmldetailselement/index.md
@@ -15,6 +15,8 @@ The **`HTMLDetailsElement`** interface provides special properties (beyond the r
 
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
+- {{domxref("HTMLDetailsElement.name")}}
+  - : A string reflecting the [`name`](/en-US/docs/Web/HTML/Element/details#name) HTML attribute, which allows you to create a group of mutually-exclusive {{htmlelement("details")}} elements. Opening one of the named `<details>` elements of this group causes other elements of the group to close.
 - {{domxref("HTMLDetailsElement.open")}}
   - : A boolean value reflecting the [`open`](/en-US/docs/Web/HTML/Element/details#open) HTML attribute, indicating whether or not the element's contents (not counting the {{HTMLElement("summary")}}) is to be shown to the user.
 

--- a/files/en-us/web/api/htmldetailselement/name/index.md
+++ b/files/en-us/web/api/htmldetailselement/name/index.md
@@ -1,0 +1,29 @@
+---
+title: "HTMLDetailsElement: name property"
+short-title: name
+slug: Web/API/HTMLDetailsElement/name
+page-type: web-api-instance-property
+browser-compat: api.HTMLDetailsElement.name
+---
+
+{{ APIRef("HTML DOM") }}
+
+The **`name`** property of the {{domxref("HTMLDetailsElement")}} interface enables multiple {{htmlelement("details")}} elements to be connected together, where only one for the `<details>` elements can be open at once. This allows developers to easily create UI features such as accordions without scripting.
+
+The name attribute specifies a group name — give multiple `<details>` elements the same name value to group them. Only one of the grouped `<details>` elements can be open at a time — opening one will cause another to close. If multiple grouped `<details>` elements are given the open attribute, only the first one in the source order will be rendered open.
+
+## Value
+
+A string which is used to group multiple `<details>` elements together. The value can be anything but can not be empty.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The {{htmlelement("details")}} and {{htmlelement("summary")}} elements

--- a/files/en-us/web/api/htmldetailselement/name/index.md
+++ b/files/en-us/web/api/htmldetailselement/name/index.md
@@ -14,7 +14,7 @@ The name attribute specifies a group name — give multiple `<details>` elements
 
 ## Value
 
-A string which is used to group multiple `<details>` elements together. The value can be anything but can not be empty.
+A string. The empty string if the element is not part of any group.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmldetailselement/name/index.md
+++ b/files/en-us/web/api/htmldetailselement/name/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLDetailsElement.name
 
 {{ APIRef("HTML DOM") }}
 
-The **`name`** property of the {{domxref("HTMLDetailsElement")}} interface enables multiple {{htmlelement("details")}} elements to be connected together, where only one for the `<details>` elements can be open at once. This allows developers to easily create UI features such as accordions without scripting.
+The **`name`** property of the {{domxref("HTMLDetailsElement")}} interface reflects the [`name`](/en-US/docs/Web/HTML/Element/details#name) attribute of {{htmlelement("details")}} elements. It enables multiple `<details>` elements to be connected together, where only one for the `<details>` elements can be open at once. This allows developers to easily create UI features such as accordions without scripting.
 
 The name attribute specifies a group name — give multiple `<details>` elements the same name value to group them. Only one of the grouped `<details>` elements can be open at a time — opening one will cause another to close. If multiple grouped `<details>` elements are given the `open` attribute, only the first one in the source order will be rendered open.
 

--- a/files/en-us/web/api/htmldetailselement/name/index.md
+++ b/files/en-us/web/api/htmldetailselement/name/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLDetailsElement.name
 
 The **`name`** property of the {{domxref("HTMLDetailsElement")}} interface enables multiple {{htmlelement("details")}} elements to be connected together, where only one for the `<details>` elements can be open at once. This allows developers to easily create UI features such as accordions without scripting.
 
-The name attribute specifies a group name — give multiple `<details>` elements the same name value to group them. Only one of the grouped `<details>` elements can be open at a time — opening one will cause another to close. If multiple grouped `<details>` elements are given the open attribute, only the first one in the source order will be rendered open.
+The name attribute specifies a group name — give multiple `<details>` elements the same name value to group them. Only one of the grouped `<details>` elements can be open at a time — opening one will cause another to close. If multiple grouped `<details>` elements are given the `open` attribute, only the first one in the source order will be rendered open.
 
 ## Value
 


### PR DESCRIPTION
### Description

- Added /API/HTMLDetailsElement/name page
- Updated /API/HTMLDetailsElement to include `name` property

### Motivation

- Working on [issue #35283](https://github.com/mdn/content/issues/35283)

### Related issues and pull requests

- [Automated BCD PR](https://github.com/mdn/browser-compat-data/pull/24118)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/24240)
- [Firefox Release note](https://github.com/mdn/content/pull/35447)