### PR TITLE
Correct Speculation Rules HTTP Status code support

### DIFF
--- a/files/en-us/web/api/speculation_rules_api/index.md
+++ b/files/en-us/web/api/speculation_rules_api/index.md
@@ -179,7 +179,9 @@ For prerender:
 Sec-Purpose: prefetch;prerender
 ```
 
-Servers can respond based on this header, for example, to log speculative load requests, return different content, or even prevent speculative loading from happening. If a non-success response code is returned (any HTTP status other than 200 or 304), then the page will not be prefetched/prerendered. This is the easiest way to prevent speculative loading, although it is usually a better approach to allow the prefetch/prerender, and use JavaScript to delay any actions that should only happen when the page is actually viewed.
+Servers can respond based on this header, for example, to log speculative load requests, return different content, or even prevent speculative loading from happening. If a non-success response code is returned (any HTTP status other than in the 200-299 range after redirects), then the page will not be prefetched/prerendered. In addition the 204 and 205 status codes also prevent prerendering.
+
+Using a non-success code (for example a 504) is the easiest way to prevent speculative loading server-side, although it is usually a better approach to allow the prefetch/prerender, and use JavaScript to delay any actions that should only happen when the page is actually viewed.
 
 ### JavaScript prefetch detection
 

--- a/files/en-us/web/api/speculation_rules_api/index.md
+++ b/files/en-us/web/api/speculation_rules_api/index.md
@@ -179,7 +179,7 @@ For prerender:
 Sec-Purpose: prefetch;prerender
 ```
 
-Servers can respond based on this header, for example, to log speculative load requests, return different content, or even prevent speculative loading from happening. If a non-success response code is returned (any HTTP status other than in the 200-299 range after redirects), then the page will not be prefetched/prerendered. In addition the 204 and 205 status codes also prevent prerendering.
+Servers can respond based on this header, for example, to log speculative load requests, return different content, or even prevent speculative loading from happening. If a non-success response code is returned (any HTTP status other than in the 200-299 range after redirects), then the page will not be prefetched/prerendered. In addition the 204 and 205 status codes also prevent prerendering (but do not prevent prefetch).
 
 Using a non-success code (for example a 504) is the easiest way to prevent speculative loading server-side, although it is usually a better approach to allow the prefetch/prerender, and use JavaScript to delay any actions that should only happen when the page is actually viewed.
 

--- a/files/en-us/web/api/speculation_rules_api/index.md
+++ b/files/en-us/web/api/speculation_rules_api/index.md
@@ -181,7 +181,7 @@ Sec-Purpose: prefetch;prerender
 
 Servers can respond based on this header, for example, to log speculative load requests, return different content, or even prevent speculative loading from happening. If a non-success response code is returned (any HTTP status other than in the 200-299 range after redirects), then the page will not be prefetched/prerendered. In addition the 204 and 205 status codes also prevent prerendering (but do not prevent prefetch).
 
-Using a non-success code (for example a 504) is the easiest way to prevent speculative loading server-side, although it is usually a better approach to allow the prefetch/prerender, and use JavaScript to delay any actions that should only happen when the page is actually viewed.
+Using a non-success code (for example a 503) is the easiest way to prevent speculative loading server-side, although it is usually a better approach to allow the prefetch/prerender, and use JavaScript to delay any actions that should only happen when the page is actually viewed.
 
 ### JavaScript prefetch detection
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
MDN [previously incorrectly stated that status codes 200 and 304 were supported for Speculation Rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#server-side_detection) based on [incorrect data in the Chrome documentation](https://developer.chrome.com/docs/web-platform/prerender-pages#detect-server-side) (that has since been corrected).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
We've had a developer report of confusion due to incorrect information:
https://github.com/WICG/nav-speculation/issues/330

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
See above links.

[Details in spec](https://wicg.github.io/nav-speculation/prerendering.html#:~:text=navigationParams%E2%80%99s%20response%27s%20status%20is%20204%20or%20205%2C)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
