### PR TITLE
New pages: HTML<formelement>Element.name

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/name/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/name/index.md
@@ -1,0 +1,36 @@
+---
+title: "HTMLButtonElement: name property"
+short-title: name
+slug: Web/API/HTMLButtonElement/name
+page-type: web-api-instance-property
+browser-compat: api.HTMLButtonElement.name
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`name`** property of the {{domxref("HTMLButtonElement")}} interface indicates the name of the {{HTMLElement("button")}} element or the empty string if the element has no name. It reflects the element's [`name`](/en-US/docs/Web/HTML/Element/button#name) attribute.
+
+## Value
+
+A string representing the element's name.
+
+## Example
+
+```js
+const buttonElement = document.querySelector("#myButton");
+console.log(`Element's name: ${buttonElement.name}`);
+buttonElement.name = "newName";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLButtonElement.value")}}
+- {{domxref("HTMLButtonElement.type")}}

--- a/files/en-us/web/api/htmlfieldsetelement/name/index.md
+++ b/files/en-us/web/api/htmlfieldsetelement/name/index.md
@@ -1,0 +1,41 @@
+---
+title: "HTMLFieldSetElement: name property"
+short-title: name
+slug: Web/API/HTMLFieldSetElement/name
+page-type: web-api-instance-property
+browser-compat: api.HTMLFieldSetElement.name
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`name`** property of the {{domxref("HTMLFieldSetElement")}} interface indicates the name of the {{HTMLElement("fieldset")}} element. It reflects the element's [`name`](/en-US/docs/Web/HTML/Element/fieldset#name) attribute.
+
+## Value
+
+A string representing the element's name.
+
+## Example
+
+```js
+const fs = document.querySelector("fieldset");
+console.log(`Element's name: ${fs.name}`);
+fs.name = "billing"; // sets or updates the element's name
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLFieldSetElement.elements")}}
+- {{domxref("HTMLFieldSetElement.disabled")}}
+- {{domxref("HTMLLegendElement")}}
+- {{domxref("HTMLFormElement")}}
+- {{HTMLElement("fieldset")}}
+- {{HTMLElement("legend")}}
+- {{HTMLElement("form")}}

--- a/files/en-us/web/api/htmloutputelement/name/index.md
+++ b/files/en-us/web/api/htmloutputelement/name/index.md
@@ -1,0 +1,37 @@
+---
+title: "HTMLOutputElement: name property"
+short-title: name
+slug: Web/API/HTMLOutputElement/name
+page-type: web-api-instance-property
+browser-compat: api.HTMLOutputElement.name
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`name`** property of the {{domxref("HTMLOutputElement")}} interface indicates the name of the {{HTMLElement("output")}} element. It reflects the element's [`name`](/en-US/docs/Web/HTML/Element/output#name) attribute.
+
+## Value
+
+A string representing the element's name.
+
+## Example
+
+```js
+const outputElement = document.querySelector("#log");
+console.log(`Element's name: ${outputElement.name}`);
+outputElement.name = "sum"; // sets or updates the element's name
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLOutputElement.defaultValue")}}
+- {{domxref("HTMLOutputElement.htmlFor")}}
+- {{domxref("HTMLOutputElement.labels")}}

--- a/files/en-us/web/api/htmlselectelement/name/index.md
+++ b/files/en-us/web/api/htmlselectelement/name/index.md
@@ -1,0 +1,37 @@
+---
+title: "HTMLSelectElement: name property"
+short-title: name
+slug: Web/API/HTMLSelectElement/name
+page-type: web-api-instance-property
+browser-compat: api.HTMLSelectElement.name
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`name`** property of the {{domxref("HTMLSelectElement")}} interface indicates the name of the {{HTMLElement("select")}} element. It reflects the element's [`name`](/en-US/docs/Web/HTML/Element/select#name) attribute.
+
+## Value
+
+A string representing the element's name.
+
+## Example
+
+```js
+const selectElement = document.querySelector("#planets");
+console.log(`Element's name: ${selectElement.name}`);
+selectElement.name = "galaxies"; // sets or updates the element's name
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLSelectElement.value")}}
+- {{domxref("HTMLSelectElement.selectedIndex")}}
+- {{domxref("HTMLSelectElement.options")}}

--- a/files/en-us/web/api/htmltextareaelement/name/index.md
+++ b/files/en-us/web/api/htmltextareaelement/name/index.md
@@ -1,0 +1,36 @@
+---
+title: "HTMLTextAreaElement: name property"
+short-title: name
+slug: Web/API/HTMLTextAreaElement/name
+page-type: web-api-instance-property
+browser-compat: api.HTMLTextAreaElement.name
+---
+
+{{ApiRef("HTML DOM")}}
+
+The **`name`** property of the {{domxref("HTMLTextAreaElement")}} interface indicates the name of the {{HTMLElement("textarea")}} element. It reflects the element's [`name`](/en-US/docs/Web/HTML/Element/textarea#name) attribute.
+
+## Value
+
+A string representing the element's name.
+
+## Example
+
+```js
+const textareaElement = document.querySelector("#message");
+console.log(`Element's name: ${textareaElement.name}`);
+textareaElement.name = "response"; // sets or updates the element's name
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLTextAreaElement.value")}}
+- {{domxref("HTMLTextAreaElement.textLength")}}


### PR DESCRIPTION
the missing form API name property pages.
Related to #35544