### PR TITLE
Fix content issues

### DIFF
--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/physics/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/physics/index.md
@@ -78,7 +78,7 @@ Try reloading `index.html` again — The ball should now be moving constantly in
 
 You can do much more with physics, for example by adding `ball.body.gravity.y = 100;` you will set the vertical gravity of the ball. As a result it will be launched upwards, but then fall due to the effects of gravity pulling it down.
 
-This kind of functionality is just the tip of the iceberg — there are various functions and variables that can help you manipulate the physics objects. Check out the official [physics documentation](https://phaser.io/docs#physics) and see the [huge collection of examples](https://samme.github.io/phaser-examples-mirror/) using the Arcade and P2 physics systems.
+This kind of functionality is just the tip of the iceberg — there are various functions and variables that can help you manipulate the physics objects. Check out the official [physics documentation](https://phaser.io/docs/#physics) and see the [huge collection of examples](https://samme.github.io/phaser-examples-mirror/) using the Arcade and P2 physics systems.
 
 ## Compare your code
 

--- a/files/en-us/learn/server-side/first_steps/web_frameworks/index.md
+++ b/files/en-us/learn/server-side/first_steps/web_frameworks/index.md
@@ -251,7 +251,7 @@ Deno is powered by [Tokio](https://tokio.rs/) — a Rust-based asynchronous runt
 
 Deno's features include:
 
-- Security by default. [Deno modules restrict permissions](https://docs.deno.com/runtime/manual/getting_started/first_steps/#runtime-security) to **file**, **network**, or **environment** access unless explicitly allowed.
+- Security by default. [Deno modules restrict permissions](https://docs.deno.com/runtime/fundamentals/security/) to **file**, **network**, or **environment** access unless explicitly allowed.
 - TypeScript support **out-of-the-box**.
 - First-class await mechanism.
 - Built-in testing facility and code formatter (`deno fmt`)

--- a/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-relevant/index.md
@@ -17,7 +17,7 @@ Examples of live regions include news marquees, stock tickers, chat windows, and
 
 The value is a space-separated list of change types, including `additions`, `removals`, and `text`, with a shorthand `all` meaning all three.
 
-When `aria-relevant` is not defined, the value is inherited from the nearest ancestor with a defined value. Inherited values are not additive; the value provided on a descendant element completely overrides any inherited value from an ancestor element. When a live region doesn't have an `aria-relevant` attribute set and has no ancestor with it set, it defaults to `additions text`, because generally text modifications and node additions are relevant, but node removals are not.
+When `aria-relevant` is not defined, the value is inherited from the nearest ancestor with a defined value. Inherited values are not additive; the value provided on a descendant element completely overrides any inherited value from an ancestor element. When a live region doesn't have an `aria-relevant` attribute set and has no ancestor with it set, it defaults to `additions text`, which means element nodes are added to the accessibility tree within the live region, AND text content or a text alternative is added to any descendant in the accessibility tree of the live region. This is because generally text modifications and node additions are relevant, but node removals are not.
 
 While not a supported value, if the value of `none` makes the most sense, it should not be a live region.
 
@@ -33,8 +33,6 @@ The values of `removals` and `all` should be used sparingly. For example, when a
   - : Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.
 - `text`
   - : Text content or a text alternative is added to any descendant in the accessibility tree of the live region.
-- `additions text` (default)
-  - : Element nodes are added to the accessibility tree within the live region AND text content or a text alternative is added to any descendant in the accessibility tree of the live region.
 
 ## Associated interfaces
 

--- a/files/en-us/web/api/content_index_api/index.md
+++ b/files/en-us/web/api/content_index_api/index.md
@@ -196,5 +196,4 @@ The {{domxref('ServiceWorkerGlobalScope.contentdelete_event', "contentdelete")}}
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindex/add/index.md
+++ b/files/en-us/web/api/contentindex/add/index.md
@@ -154,5 +154,4 @@ self.registration.index.add(item);
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindex/delete/index.md
+++ b/files/en-us/web/api/contentindex/delete/index.md
@@ -75,5 +75,4 @@ self.registration.index.delete("my-id");
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindex/getall/index.md
+++ b/files/en-us/web/api/contentindex/getall/index.md
@@ -128,5 +128,4 @@ async function createReadingList() {
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindex/index.md
+++ b/files/en-us/web/api/contentindex/index.md
@@ -163,5 +163,4 @@ const contentIndexItems = self.registration.index.getAll();
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.md
@@ -58,5 +58,4 @@ ciEvent.id; // should return 'unique-content-id'
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindexevent/id/index.md
+++ b/files/en-us/web/api/contentindexevent/id/index.md
@@ -46,5 +46,4 @@ self.addEventListener("contentdelete", (event) => {
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/index.md
@@ -56,5 +56,4 @@ self.addEventListener("contentdelete", (event) => {
 ## See also
 
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)
 - [Service Worker API, along with information about Cache and CacheStorage](/en-US/docs/Web/API/Service_Worker_API)

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.md
@@ -13,9 +13,9 @@ The **EXT_disjoint_timer_query** extension is part of the [WebGL API](/en-US/doc
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 
 > [!NOTE]
-> This extension should be available in {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts only. {{domxref("EXT_disjoint_timer_query_webgl2")}} is available in {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts .
+> This extension should be available in {{domxref("WebGLRenderingContext", "WebGL1", "", 1)}} contexts only. {{domxref("EXT_disjoint_timer_query_webgl2")}} is available in {{domxref("WebGL2RenderingContext", "WebGL 2", "", 1)}} contexts.
 >
-> In WebGL 2, the {{domxref("WebGLRenderingContext.getQueryObject")}} was renamed to {{domxref("WebGL2RenderingContext.getQueryParameter")}}.
+> In WebGL 2, the OpenGL method `getQueryObject()` is renamed to {{domxref("WebGL2RenderingContext.getQueryParameter")}}.
 > In WebGL 2, other queries (such as occlusion queries and primitive queries) are possible using {{domxref("WebGLQuery")}} objects.
 
 ## Types

--- a/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/contentdelete_event/index.md
@@ -75,4 +75,3 @@ self.oncontentdelete = (event) => {
 
 - [Content index API](/en-US/docs/Web/API/Content_Index_API)
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)

--- a/files/en-us/web/api/serviceworkerregistration/index/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index/index.md
@@ -56,4 +56,3 @@ const contentIndex = self.registration.index;
 
 - [Content Index API](/en-US/docs/Web/API/Content_Index_API)
 - [An introductory article on the Content Index API](https://developer.chrome.com/docs/capabilities/web-apis/content-indexing-api)
-- [An app which uses the Content Index API to list and remove 'save for later' content](https://contentindex.dev/)

--- a/files/en-us/web/api/svgangle/index.md
+++ b/files/en-us/web/api/svgangle/index.md
@@ -15,7 +15,7 @@ An `SVGAngle` object can be associated with a particular element. The associated
 
 Every `SVGAngle` object operates in one of two modes:
 
-1. **_Reflect the base value_** of a reflected animatable attribute (being exposed through the {{SVGAttr("baseVal")}} member of an {{domxref("SVGAnimatedAngle")}}),
+1. **_Reflect the base value_** of a reflected animatable attribute (being exposed through the {{domxref("SVGAnimatedAngle.baseVal", "baseVal")}} member of an {{domxref("SVGAnimatedAngle")}}),
 2. **_Be detached_,** which is the case for `SVGAngle` objects created with {{domxref("SVGSVGElement.createSVGAngle()")}}.
 
 ## Constants

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -33,7 +33,7 @@ drawArrays(mode, first, count)
     - `gl.TRIANGLES`: Draws a triangle for a group of three vertices.
 
     > [!NOTE]
-    > If `mode` is `POINTS`, [`gl_PointSize`](https://www.opengl.org/sdk/docs/man4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
+    > If `mode` is `POINTS`, [`gl_PointSize`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/gl_PointSize.xhtml) may need to be set for `drawArrays` to render, as its value is unknown if not explicitly written. Only some GPUs set its default as `1.0`.
 
 - `first`
   - : A {{domxref("WebGL_API/Types", "GLint")}} specifying the starting index in the array of vector points.

--- a/files/en-us/web/css/stroke-dashoffset/index.md
+++ b/files/en-us/web/css/stroke-dashoffset/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.stroke-dashoffset
 
 {{CSSRef}}
 
-The **`stroke-dashoffset`** [CSS](/en-US/docs/Web/CSS) property defines an offset for the starting point of the rendering of an [SVG](/en-US/docs/Web/SVG) element's associated {{CSSxref("stroke-dasharray", "dash array")}}. If present, it overrides the element's {{SVGAttr("stroke-dashoffset")}} attribute.
+The **`stroke-dashoffset`** [CSS](/en-US/docs/Web/CSS) property defines an offset for the starting point of the rendering of an [SVG](/en-US/docs/Web/SVG) element's associated [dash array](/en-US/docs/Web/CSS/stroke-dasharray). If present, it overrides the element's {{SVGAttr("stroke-dashoffset")}} attribute.
 
 This property applies to any SVG shape or text-content element (see {{SVGAttr("stroke-dashoffset")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
 

--- a/files/en-us/web/svg/attribute/xlink_colon_show/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_show/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Attribute/xlink:show
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.xlink_show
+browser-compat: svg.elements.a.xlink_show
 ---
 
 {{SVGRef}}{{Deprecated_Header}}


### PR DESCRIPTION
- Remove a dead link: https://contentindex.dev the site doesn't have a valid cert anymore and it's not quite useful to be in content.
- Removed `additions text` from the values list because it's not a discrete value to be explained.
- Fixed a few redirected links
- Fixed a few broken links