### PR TITLE
Reword HTMLCollection.namedItem replacement

### DIFF
--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -11,6 +11,8 @@ browser-compat: api.HTMLCollection.namedItem
 The **`namedItem()`** method of the {{domxref("HTMLCollection")}} interface returns
 the first {{domxref("Element")}} in the collection whose `id` or `name` attribute match the specified name, or `null` if no element matches.
 
+In JavaScript, instead of calling `collection.namedItem("value")`, you can also directly access the name on the collection, like `collection["value"]`, unless the name collides with one of the existing `HTMLCollection` properties.
+
 ## Syntax
 
 ```js-nolint
@@ -19,11 +21,12 @@ namedItem(key)
 
 ### Parameters
 
-- `key` is a string representing the value of the `id` or `name` attribute of the element we are looking for.
+- `key`
+  - : A string representing the value of the `id` or `name` attribute of the element we are looking for.
 
 ### Return value
 
-- `item` is the first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching the _key_, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if there are none.
+The first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching the `key`, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if there is none. Always returns `null` if `key` is the empty string.
 
 ## Example
 

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -11,8 +11,6 @@ browser-compat: api.HTMLCollection.namedItem
 The **`namedItem()`** method of the {{domxref("HTMLCollection")}} interface returns
 the first {{domxref("Element")}} in the collection whose `id` or `name` attribute match the specified name, or `null` if no element matches.
 
-In JavaScript, using the array bracket syntax with a {{jsxref("String")}}, like `collection["value"]` is equivalent to `collection.namedItem("value")`.
-
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
In JavaScript, all non-Symbol property key values (including index numbers) are converted to Strings, so there is no way for the language to differentiate between `collection[1]` and `collection["1"]`. That means that `namedItem` and computed property access cannot be equivalent since `namedItem` doesn't return elements by index while computed property access does.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
