### PR TITLE
 docs(manifest): Improve `theme_color` member page

### DIFF
--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -24,10 +24,10 @@ This color application can provide a more native app-like experience for your we
 
   - : A string that specifies a [valid color value](/en-US/docs/Web/CSS/color_value).
 
-  > [!NOTE]
-  > Browsers may ignore the alpha component of the color based on the context.
-  > In most environments, `theme_color` cannot be transparent.
-  > It's recommended to use fully opaque colors (alpha value of 1 or 100%) to ensure consistent behavior across different platforms and browsers.
+    > [!NOTE]
+    > Browsers may ignore the alpha component of the color based on the context.
+    > In most environments, `theme_color` cannot be transparent.
+    > It's recommended to use fully opaque colors (alpha value of 1 or 100%) to ensure consistent behavior across different platforms and browsers.
 
 ## Description
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -39,22 +39,22 @@ You can override this default in the following ways:
 
 - Using the [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color) value of the `name` attribute in the HTML `<meta>` element: You can specify a theme color for a web page that's different from the manifest `theme_color` specified for your app. This enables you to set unique theme colors for individual pages within your app.
 
-```html
-<meta name="theme-color" content="#9370DB" />
-```
+  ```html
+  <meta name="theme-color" content="#9370DB" />
+  ```
 
 - Combining the `<meta name="theme-color">` element with media queries: You can specify the theme color to be used based on user's color scheme preference.
 
-```html
-<meta
-  name="theme-color"
-  content="#F4E6D8"
-  media="(prefers-color-scheme: light)" />
-<meta
-  name="theme-color"
-  content="#5D4037"
-  media="(prefers-color-scheme: dark)" />
-```
+  ```html
+  <meta
+    name="theme-color"
+    content="#F4E6D8"
+    media="(prefers-color-scheme: light)" />
+  <meta
+    name="theme-color"
+    content="#5D4037"
+    media="(prefers-color-scheme: dark)" />
+  ```
 
 These override methods provide you the flexibility to adapt your app's appearance for specific pages or user preferences, improving the overall user experience.
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -7,9 +7,10 @@ browser-compat: html.manifest.theme_color
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `theme_color` member specifies the default theme color for your web application's user interface.
+The `theme_color` member specifies the default color for your web application's user interface.
 This color may be applied to various browser UI elements, such as the toolbar, address bar, and status bar.
 It can be particularly noticeable in contexts like the task switcher or when the app is added to the home screen.
+
 This color application can provide a more native app-like experience for your web app, especially when it's loaded in [standalone](/en-US/docs/Web/Manifest/display#standalone) mode.
 
 ## Syntax
@@ -32,12 +33,12 @@ This color application can provide a more native app-like experience for your we
 ## Description
 
 While optional, specifying a `theme_color` allows you to extend your app's visual identity beyond its content areas.
-Choose a `theme_color` that aligns with your app's brand guidelines, which can enhance user recognition and recall, particularly when your app is viewed alongside other applications or system interfaces.
+Choose a `theme_color` that aligns with your app's brand guidelines, as this can enhance user recognition and recall, particularly when your app is viewed alongside other applications or system interfaces.
 
 In browsers that support `theme_color`, the value specified in the manifest file serves as the default theme color for your web app across all pages where the manifest is applied.
 You can override this default in the following ways:
 
-- Using the [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color) value of the `name` attribute in the HTML `<meta>` element: You can specify a theme color for a web page that's different from the manifest `theme_color` specified for your app. This enables you to set unique theme colors for individual pages within your app.
+- Using the [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color) value of the `name` attribute in the HTML `<meta>` element: You can specify a theme color for a web page that's different from the manifest `theme_color` specified for your app. This enables you to set different theme colors for individual pages within your app.
 
   ```html
   <meta name="theme-color" content="#9370DB" />

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -7,21 +7,89 @@ browser-compat: html.manifest.theme_color
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>String</code></td>
-    </tr>
-  </tbody>
-</table>
+The `theme_color` member specifies the default theme color for your web application's user interface. This color may be applied to various browser UI elements, such as the toolbar, address bar, and status bar. It can be particularly noticeable in contexts like the task switcher or when the app is added to the home screen. This color application can provide a more native app-like experience for your web app, especially when it's loaded in [standalone](/en-US/docs/Web/Manifest/display#standalone) mode.
 
-The `theme_color` member is a string that defines the default theme color for the application. This sometimes affects how the OS displays the site (e.g., on Android's task switcher, the theme color surrounds the site).
+## Syntax
+
+```json
+"theme_color": "colorValue"
+```
+
+### Values
+
+- colorValue
+
+  - : A string that specifies a [valid color value](/en-US/docs/Web/CSS/color_value).
+
+  > [!NOTE]
+  > Browsers may ignore the alpha component of the color based on the context. In most environments, `theme_color` cannot be transparent. It's recommended to use fully opaque colors (alpha value of 1 or 100%) to ensure consistent behavior across different platforms and browsers.
+
+## Description
+
+While optional, specifying a `theme_color` allows you to extend your app's visual identity beyond its content areas. Choose a `theme_color` that aligns with your app's brand guidelines, which can enhance user recognition and recall, particularly when your app is viewed alongside other applications or system interfaces.
+
+In browsers that support `theme_color`, the value specified in the manifest file serves as the default theme color for your web app across all pages where the manifest is applied. You can override this default in the following ways:
+
+- Using the [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color) value of the `name` attribute in the HTML `<meta>` element: You can specify a theme color for a web page that's different from the manifest `theme_color` specified for your app. This enables you to set unique theme colors for individual pages within your app.
+
+```html
+<meta name="theme-color" content="#9370DB" />
+```
+
+- Combining the `<meta name="theme-color">` element with media queries: You can specify the theme color to be used based on user's color scheme preference.
+
+```html
+<meta
+  name="theme-color"
+  content="#F4E6D8"
+  media="(prefers-color-scheme: light)" />
+<meta
+  name="theme-color"
+  content="#5D4037"
+  media="(prefers-color-scheme: dark)" />
+```
+
+These override methods provide you the flexibility to adapt your app's appearance for specific pages or user preferences, improving the overall user experience.
+
+Browsers may also adjust the applied theme color based on user preferences. If a user has set a preference for light or dark mode, browsers may override the manifest `theme_color` value to support any [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) media query defined in your app's CSS.
+
+```css
+body {
+  background: #f8f9fa;
+  color: #212529;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #212529;
+    color: #f8f9fa;
+  }
+}
+```
 
 ## Examples
 
+### Using a named color
+
 ```json
 "theme_color": "red"
+```
+
+### Using an RGB value
+
+```json
+"theme_color": "rgb(66, 133, 244)"
+```
+
+### Using a hexadecimal value
+
+```json
+{
+  "name": "MyWebApp",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ff4500"
+}
 ```
 
 ## Specifications
@@ -31,3 +99,9 @@ The `theme_color` member is a string that defines the default theme color for th
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`display`](/en-US/docs/Web/Manifest/display) manifest member
+- [`background_color`](/en-US/docs/Web/Manifest/background_color) manifest member
+- [`scope`](/en-US/docs/Web/Manifest/scope) manifest member

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -16,12 +16,12 @@ This color application can provide a more native app-like experience for your we
 ## Syntax
 
 ```json
-"theme_color": "colorValue"
+"theme_color": "<color-value>"
 ```
 
 ### Values
 
-- `colorValue`
+- `<color-value>`
 
   - : A string that specifies a [valid color value](/en-US/docs/Web/CSS/color_value).
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -94,7 +94,7 @@ body {
 
 ```json
 {
-  "name": "MyWebApp",
+  "name": "My First App",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#ff4500"

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -20,7 +20,7 @@ This color application can provide a more native app-like experience for your we
 
 ### Values
 
-- colorValue
+- `colorValue`
 
   - : A string that specifies a [valid color value](/en-US/docs/Web/CSS/color_value).
 

--- a/files/en-us/web/manifest/theme_color/index.md
+++ b/files/en-us/web/manifest/theme_color/index.md
@@ -7,7 +7,10 @@ browser-compat: html.manifest.theme_color
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `theme_color` member specifies the default theme color for your web application's user interface. This color may be applied to various browser UI elements, such as the toolbar, address bar, and status bar. It can be particularly noticeable in contexts like the task switcher or when the app is added to the home screen. This color application can provide a more native app-like experience for your web app, especially when it's loaded in [standalone](/en-US/docs/Web/Manifest/display#standalone) mode.
+The `theme_color` member specifies the default theme color for your web application's user interface.
+This color may be applied to various browser UI elements, such as the toolbar, address bar, and status bar.
+It can be particularly noticeable in contexts like the task switcher or when the app is added to the home screen.
+This color application can provide a more native app-like experience for your web app, especially when it's loaded in [standalone](/en-US/docs/Web/Manifest/display#standalone) mode.
 
 ## Syntax
 
@@ -22,13 +25,17 @@ The `theme_color` member specifies the default theme color for your web applicat
   - : A string that specifies a [valid color value](/en-US/docs/Web/CSS/color_value).
 
   > [!NOTE]
-  > Browsers may ignore the alpha component of the color based on the context. In most environments, `theme_color` cannot be transparent. It's recommended to use fully opaque colors (alpha value of 1 or 100%) to ensure consistent behavior across different platforms and browsers.
+  > Browsers may ignore the alpha component of the color based on the context.
+  > In most environments, `theme_color` cannot be transparent.
+  > It's recommended to use fully opaque colors (alpha value of 1 or 100%) to ensure consistent behavior across different platforms and browsers.
 
 ## Description
 
-While optional, specifying a `theme_color` allows you to extend your app's visual identity beyond its content areas. Choose a `theme_color` that aligns with your app's brand guidelines, which can enhance user recognition and recall, particularly when your app is viewed alongside other applications or system interfaces.
+While optional, specifying a `theme_color` allows you to extend your app's visual identity beyond its content areas.
+Choose a `theme_color` that aligns with your app's brand guidelines, which can enhance user recognition and recall, particularly when your app is viewed alongside other applications or system interfaces.
 
-In browsers that support `theme_color`, the value specified in the manifest file serves as the default theme color for your web app across all pages where the manifest is applied. You can override this default in the following ways:
+In browsers that support `theme_color`, the value specified in the manifest file serves as the default theme color for your web app across all pages where the manifest is applied.
+You can override this default in the following ways:
 
 - Using the [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color) value of the `name` attribute in the HTML `<meta>` element: You can specify a theme color for a web page that's different from the manifest `theme_color` specified for your app. This enables you to set unique theme colors for individual pages within your app.
 
@@ -51,7 +58,8 @@ In browsers that support `theme_color`, the value specified in the manifest file
 
 These override methods provide you the flexibility to adapt your app's appearance for specific pages or user preferences, improving the overall user experience.
 
-Browsers may also adjust the applied theme color based on user preferences. If a user has set a preference for light or dark mode, browsers may override the manifest `theme_color` value to support any [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) media query defined in your app's CSS.
+Browsers may also adjust the applied theme color based on user preferences.
+If a user has set a preference for light or dark mode, browsers may override the manifest `theme_color` value to support any [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) media query defined in your app's CSS.
 
 ```css
 body {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR focuses on the [`theme_color`](https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color) member page as part of the effort to improve web/manifest documentation.

Key changes:
- Addition of "Syntax", "Description", and "See also" sections
- "Description" section includes:
  - Importance of `theme_color`
  - Methods to override `theme_color`
  - Support for `prefers-color-scheme`

### Motivation

To clarify the usage and relevance of `theme_color` and align the documentation more closely with the specification

### Additional details

Spec: https://w3c.github.io/manifest/#theme_color-member

### Related issues and pull requests

Tracking issue: https://github.com/mdn/mdn/issues/560
PR to standardize the format across manifest member: https://github.com/mdn/content/pull/35557

