### PR TITLE
Add new declarativeNetRequest RuleConditions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/headerinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/headerinfo/index.md
@@ -9,11 +9,13 @@ browser-compat:
 
 {{AddonSidebar}}
 
-The response header to match for the request, declared in the {{WebExtAPIRef("declarativeNetRequest.RuleCondition", "rule.condition")}}`.excludedResponseHeaders` array or {{WebExtAPIRef("declarativeNetRequest.RuleCondition", "rule.condition")}}`.responseHeaders` array.
+The response header to match for the request, declared in the {{WebExtAPIRef("declarativeNetRequest.RuleCondition", "rule.condition")}}`.excludedResponseHeaders` array or {{WebExtAPIRef("declarativeNetRequest.RuleCondition", "rule.condition")}}`.responseHeaders` array. If specified, the array must be non-empty.
 
 When used in the condition responseHeaders, the rule matches if the request matches this response header condition. When used in the condition excludedResponseHeaders, the rule does not match if the request matches this response header condition.
 
 Each object describes one header to match or exclude. To check multiple headers, multiple objects can be specified in these arrays, or across multiple rules.
+
+> [!NOTE] Matching by headers is a relatively new feature. Make sure to feature-detect its availability before relying on it. While some browsers ignore the complete rule when an unrecognized condition is present, Chrome 121 until 127 applied the whole rule while ignoring the `responseHeaders` condition. This could result in matching more requests than intended, see [Chromium issue 347186592](https://issues.chromium.org/issues/347186592).
 
 ## Type
 
@@ -27,7 +29,7 @@ Values of this type are objects. They contain these properties:
     - `'?'` : Matches zero or one character(s).
     - `'*'` and `'?'` can be escaped with a backslash, e.g. `'\*'` and `'\?'`.
 - `excludedValues` {{optional_inline}}
-  - : An array of `string`. If specified, this condition is not matched if the header exists but its value contains at least one element in this list. This uses the same match pattern syntax as `values`.
+  - : An array of `string`. If specified, this condition is not matched if the header exists but its value contains at least one element in this list. This uses the same glob pattern syntax as `values`. If `values` and `excludedValues` are both matched, then `excludedValues` takes precedence.
 
 {{WebExtExamples("h2")}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/headerinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/headerinfo/index.md
@@ -1,0 +1,66 @@
+---
+title: declarativeNetRequest.HeaderInfo
+slug: Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/HeaderInfo
+page-type: webextension-api-type
+browser-compat:
+  - webextensions.api.declarativeNetRequest.RuleCondition.responseHeaders
+  - webextensions.api.declarativeNetRequest.RuleCondition.excludedResponseHeaders
+---
+
+{{AddonSidebar}}
+
+The response header to match for the request, declared in the {{WebExtAPIRef("declarativeNetRequest.RuleCondition", "rule.condition")}}`.excludedResponseHeaders` array or {{WebExtAPIRef("declarativeNetRequest.RuleCondition", "rule.condition")}}`.responseHeaders` array.
+
+When used in the condition responseHeaders, the rule matches if the request matches this response header condition. When used in the condition excludedResponseHeaders, the rule does not match if the request matches this response header condition.
+
+Each object describes one header to match or exclude. To check multiple headers, multiple objects can be specified in these arrays, or across multiple rules.
+
+## Type
+
+Values of this type are objects. They contain these properties:
+
+- `header`
+  - : A `string`. The name of the header. This condition matches on the name only if both values and excludedValues are not specified.
+- `values` {{optional_inline}}
+  - : An array of `string`. If specified, this condition matches if the header's value matches at least one pattern in this list. This supports case-insensitive header value matching plus the following constructs:
+    - `'*'` : Matches any number of characters.
+    - `'?'` : Matches zero or one character(s).
+    - `'*'` and `'?'` can be escaped with a backslash, e.g. `'\*'` and `'\?'`.
+- `excludedValues` {{optional_inline}}
+  - : An array of `string`. If specified, this condition is not matched if the header exists but its value contains at least one element in this list. This uses the same match pattern syntax as `values`.
+
+{{WebExtExamples("h2")}}
+
+## Browser compatibility
+
+{{Compat}}
+
+<!--
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rulecondition/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/rulecondition/index.md
@@ -42,6 +42,10 @@ Values of this type are objects. They contain these properties:
   - : An array of {{WebExtAPIRef("declarativeNetRequest.ResourceType")}}. List of resource types that the rule matches with. An empty list is not allowed. This must be specified for `"allowAllRequests"` rules and may only include the `"sub_frame"` and `"main_frame"` resource types.
 - `excludedResourceTypes` {{optional_inline}}
   - : An array of {{WebExtAPIRef("declarativeNetRequest.ResourceType")}}. List of resource types that the rule does not match on. Only one of [`resourceTypes`](#resourcetypes) and `excludedResourceTypes` should be specified. If neither of them is specified, all resource types except `"main_frame"` are blocked.
+- `responseHeaders` {{optional_inline}}
+  - : An array of {{WebExtAPIRef("declarativeNetRequest.HeaderInfo")}}. The rule matches if the request matches any response header condition in this list (if specified).
+- `excludedResponseHeaders` {{optional_inline}}
+  - : An array of {{WebExtAPIRef("declarativeNetRequest.HeaderInfo")}}. The rule does not match if the request matches any response header condition in this list (if specified). If both `excludedResponseHeaders` and `responseHeaders` are specified, then the `excludedResponseHeaders` property takes precedence.
 - `tabIds` {{optional_inline}}
   - : An array of `number`. List of {{WebExtAPIRef("tabs.Tab")}}.`id` that the rule should match. An ID of {{WebExtAPIRef("tabs.TAB_ID_NONE")}} matches requests that don't originate from a tab. An empty list is not allowed. Only supported for session-scoped rules.
 - `excludedTabIds` {{optional_inline}}


### PR DESCRIPTION
### Description

Add new declarativeNetRequest RuleConditions responseHeaders and excludedResponseHeaders and HeaderInfo information

### Motivation

Chrome 128 added https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#property-RuleCondition-excludedResponseHeaders and https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#property-RuleCondition-responseHeaders, plus the supporting dictionary https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#type-HeaderInfo.

### Additional details

https://issues.chromium.org/issues/40727004
https://bugzilla.mozilla.org/show_bug.cgi?id=1877486
https://bugs.webkit.org/show_bug.cgi?id=275158
https://github.com/w3c/webextensions/issues/460

### Related issues and pull requests

Fixes #35538
Relates to https://github.com/mdn/browser-compat-data/pull/24253
