### PR TITLE
fix(ci): recycle the weekly spelling check issue

### DIFF
--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -24,6 +24,8 @@ jobs:
           npm install
           echo Running spelling check...
           output=$(npx cspell --no-progress --gitignore --config .vscode/cspell.json "**/*.md" || exit 0)
+          output=$(node scripts/linkify-logs.js "${output}")
+          output=$(echo "$output" | sed 's/^/- /')
           echo "$output"
           echo "OUTPUT<<EOF" >> $GITHUB_ENV
           echo "$output" >> $GITHUB_ENV
@@ -35,16 +37,13 @@ jobs:
           comment_body=$(cat<<EOM
           Typos and unknown words:
 
-          ~~~
           ${OUTPUT}
-          ~~~
 
           > [!TIP]
           > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
           EOM
           )
           comment_body+=$'\n\n'$(echo "(comment last updated: $(date +'%Y-%m-%d %H:%M:%S'))")
-
           gh api \
             --method PATCH \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -31,7 +31,7 @@ jobs:
           echo "$output" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Report issues
+      - name: Report spellcheck errors
         if: env.OUTPUT != ''
         run: |
           comment_body=$(cat<<EOM

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -29,20 +29,28 @@ jobs:
           echo "$output" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Create an issue
+      - name: Report issues
         if: env.OUTPUT != ''
-        uses: dacbd/create-issue-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: Weekly spelling check
-          body: |
-            Typos and unknown words:
+        run: |
+          log_data=$(cat<<EOM
+          Typos and unknown words:
 
-            ```
-            ${{ env.OUTPUT }}
-            ```
+          ~~~
+          ${OUTPUT}
+          ~~~
 
-            > [!TIP]
-            > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (`AABBCC` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
+          > [!TIP]
+          > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (`AABBCC` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
+          EOM
+          )
+
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/mdn/content/issues/35634 \
+            -f "state=open" \
+            -f "body=${log_data}"
         env:
           OUTPUT: ${{ env.OUTPUT }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -40,7 +40,7 @@ jobs:
           ~~~
 
           > [!TIP]
-          > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (`AABBCC` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
+          > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
           EOM
           )
 

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Report issues
         if: env.OUTPUT != ''
         run: |
-          log_data=$(cat<<EOM
+          comment_body=$(cat<<EOM
           Typos and unknown words:
 
           ~~~
@@ -43,6 +43,7 @@ jobs:
           > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
           EOM
           )
+          comment_body+=$'\n\n'$(echo "(comment last updated: $(date +'%Y-%m-%d %H:%M:%S'))")
 
           gh api \
             --method PATCH \
@@ -50,7 +51,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/mdn/content/issues/35634 \
             -f "state=open" \
-            -f "body=${log_data}"
+            -f "body=${comment_body}"
         env:
           OUTPUT: ${{ env.OUTPUT }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -43,7 +43,7 @@ jobs:
           > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
           EOM
           )
-          comment_body+=$'\n\n'$(echo "(comment last updated: $(date +'%Y-%m-%d %H:%M:%S'))")
+          comment_body+=$'\n\n'$(echo "_(comment last updated: $(date +'%Y-%m-%d %H:%M:%S'))_")
           gh api \
             --method PATCH \
             -H "Accept: application/vnd.github+json" \

--- a/scripts/linkify-logs.js
+++ b/scripts/linkify-logs.js
@@ -1,0 +1,16 @@
+/*
+ *  The script converts file paths to GitHub source links in the provided text.
+ *  Usage: node scripts/linkify-logs.js ${logs}
+ */
+
+const logs = process.argv[2];
+
+console.log(
+  logs.replaceAll(/(files\/.*?\/index.md):?(\d+)?/g, (_, path, lineNo) => {
+    let link = `[${path}](https://github.com/mdn/content/blob/main/${path}?plain=1`;
+    if (lineNo) {
+      return link + `#L${lineNo}):${lineNo}`;
+    }
+    return link + `)`;
+  }),
+);

--- a/scripts/linkify-logs.js
+++ b/scripts/linkify-logs.js
@@ -6,11 +6,13 @@
 const logs = process.argv[2];
 
 console.log(
-  logs.replaceAll(/(files\/.*?\/index.md):?(\d+)?/g, (_, path, lineNo) => {
-    let link = `[${path}](https://github.com/mdn/content/blob/main/${path}?plain=1`;
-    if (lineNo) {
-      return link + `#L${lineNo}):${lineNo}`;
-    }
-    return link + `)`;
-  }),
+  logs.replaceAll(
+    /(files\/.*?\/index.md):?(\d+)?:?(\d+)?/g,
+    (_, path, lineNo, columnNo) => {
+      if (lineNo) {
+        return `[${path}:${lineNo}:${columnNo}](https://github.com/mdn/content/blob/main/${path}?plain=1#L${lineNo})`;
+      }
+      return `[${path}](https://github.com/mdn/content/blob/main/${path}?plain=1)`;
+    },
+  ),
 );


### PR DESCRIPTION
Recently, we implemented a weekly spelling check bot. It creates an issue every Monday to report typos and new words. We do not wish to flood the repo with such issues over a long period of time.

The PR updates the bot workflow to reuse the existing(35634) issue. The new code does so by updating the issue's opening comment and reopening the issue.


## Testing

I tested the code in my fork.
- recycled issue: https://github.com/OnkarRuikar/content/issues/29
- [corresponding workflow run](https://github.com/OnkarRuikar/content/actions/runs/10697424433/job/29654578144#step:4:48)