### PR TITLE
Fix prop name; `counter-increment` to `counter-set`

### DIFF
--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -59,7 +59,7 @@ h3::before {
 
 You can specify the increment or decrement amount after the counter name. It can be a positive or negative number, but defaults to `1` if no integer is provided.
 
-Apart from increment or decrement, counters can also be explicitly set to a value using {{cssxref("counter-set")}} property.
+Apart from being incremented or decremented, counters can also be explicitly set to a value using the {{cssxref("counter-set")}} property.
 
 ```css
 .done::before {

--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -59,7 +59,7 @@ h3::before {
 
 You can specify the increment or decrement amount after the counter name. It can be a positive or negative number, but defaults to `1` if no integer is provided.
 
-Apart from increment or decrement, counters can also be explicitly set to a value using {{cssxref("counter-increment")}} property.
+Apart from increment or decrement, counters can also be explicitly set to a value using {{cssxref("counter-set")}} property.
 
 ```css
 .done::before {


### PR DESCRIPTION
### Description

- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_counter_styles/Using_CSS_counters

Fix typo of a property name. `counter-increment` to `counter-set`

> Apart from increment or decrement, counters can also be explicitly set to a value using [counter-increment](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment) property.

```css
.done::before {
  counter-set: section 20;
}
```