### PR TITLE
HTML autocorrect attribute

### DIFF
--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -65,9 +65,9 @@ function log(text) {
 
 #### JavaScript
 
-The code first checks whether the `autocorrect` is supported by checking if it is present on the prototype.
-If it is present a click handler is added to allow you to toggle the value.
-If it is not present the UI hides the interactive elements and logs that `autocorrect` is not supported.
+The code first checks whether the `autocorrect` is supported by checking if it is present on the `HTMLElement` prototype.
+If it is present, a click handler is added to allow you to toggle the value.
+If it is not present, the UI hides the interactive elements and logs that `autocorrect` is not supported.
 
 ```js
 const toggleButton = document.querySelector("button");

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -1,0 +1,127 @@
+---
+title: "HTMLElement: autocorrect property"
+short-title: autocorrect
+slug: Web/API/HTMLElement/autocorrect
+page-type: web-api-instance-property
+browser-compat: api.HTMLElement.autocorrect
+---
+
+{{APIRef("HTML DOM")}}
+
+The **`autocorrect`** property of the {{domxref("HTMLElement")}} interface controls whether or not user text input is automatically corrected for spelling and/or punctuation errors.
+
+While it is available on all HTML elements, it is only relevant to editable text elements:
+
+- {{htmlelement("input")}} elements and {{domxref("HTMLInputElement")}} objects, except for [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email), and [`url`](/en-US/docs/Web/HTML/Element/input/url), which do not support autocorrection.
+- {{htmlelement("textarea")}} elements and {{domxref("HTMLTextAreaElement")}} objects.
+- Any element that has the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set.
+
+Editable text elements (other than the exceptions listed above) have autocorrection enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
+Explicitly setting the attribute overrides the default.
+
+It reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
+
+## Value
+
+`true` if autocorrection is enabled, and `false` otherwise.
+
+Note that values are reflected from the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute, which takes values `on` and `off`.
+The getter may return an inherited state as the attribute may be inherited from a parent {{htmlelement("form")}} element for elements of type {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}} (the attribute is not inherited for elements that are nested within an element made editable by adding the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute).
+The setter always sets the value on the selected element.
+
+## Examples
+
+### Blahs
+
+The following example shows how to control capitalization behavior for user input via script:
+
+```html
+<div>Current capitalization behavior is: <span id="ac-label"></span></div>
+<div id="ac-element" contenteditable="true" autocapitalize="default">
+  input here
+</div>
+<select id="ac-controller" type="checkbox" checked>
+  <option value="default">default</option>
+  <option value="none">none</option>
+  <option value="sentences">sentences</option>
+  <option value="words">words</option>
+  <option value="characters">characters</option></select
+>Select the capitalization behavior
+```
+
+```js
+const label = document.getElementById("autocorrect-label");
+const element = document.getElementById("ac-element");
+const controller = document.getElementById("ac-controller");
+
+controller.addEventListener("input", (e) => {
+  const behavior = e.target.value;
+  label.textContent = behavior;
+  element.autocapitalize = behavior;
+});
+```
+
+{{EmbedLiveSample('Blah', 600, 200)}}
+
+### Autocorrection inheritance
+
+This example shows how you can set and get the autocorrection state
+
+```html
+<button id="toggleAutocorrect">Enable Autocorrect</button>
+<input type="text" id="textinput" autocorrect="off" />
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const toggleButton = document.querySelector("button");
+const inputTextElement = document.querySelector("#textinput");
+
+if (inputTextElement.autocorrect) {
+  toggleButton.addEventListener("click", (e) => {
+    toggleButton.textContent = inputTextElement.autocorrect
+      ? "Disable"
+      : "Enable";
+    inputTextElement.autocorrect = !inputTextElement.autocorrect;
+    log(`autocorrect: ${inputTextElement.autocorrect}`);
+  });
+} else {
+  toggleButton.hidden = true;
+  inputTextElement.hidden = true;
+  log("autocomplete not supported");
+}
+```
+
+{{EmbedLiveSample("Autocorrection inheritance", "100%", "200")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize) HTML global attribute

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -94,7 +94,7 @@ if (`autocorrect` in HTMLElement.prototype) {
 
 #### Result
 
-Toggle the button to enable autocorrect, and then enter invalid text into the text box, such as "Carot".
+Activate the button to toggle the autocorrect value. Enter invalid text into the text box, such as "Carot".
 This should be corrected automatically when the feature is enabled.
 
 {{EmbedLiveSample("Enable and disable autocorrection", "100%", "200")}}

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -73,19 +73,22 @@ If it is not present, the UI hides the interactive elements and logs that `autoc
 const toggleButton = document.querySelector("button");
 const searchInput = document.querySelector("#searchinput");
 
-if (`autocorrect` in HTMLElement.prototype) {
-  toggleButton.textContent = searchInput.autocorrect ? "Disable" : "Enable";
+function setButtonText() {
+  toggleButton.textContent = searchInput.autocorrect ? "Enabled" : "Disabled";
   log(`autocorrect: ${searchInput.autocorrect}`);
+}
+
+if (`autocorrect` in HTMLElement.prototype) {
+  setButtonText();
 
   toggleButton.addEventListener("click", (e) => {
-    toggleButton.textContent = searchInput.autocorrect ? "Disable" : "Enable";
     searchInput.autocorrect = !searchInput.autocorrect;
-    log(`autocorrect: ${searchInput.autocorrect}`);
+    setButtonText();
   });
 } else {
   toggleButton.hidden = true;
   searchInput.hidden = true;
-  log("autcorrect not supported");
+  log("autocorrect not supported");
 }
 ```
 

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -16,60 +16,30 @@ While it is available on all HTML elements, it is only relevant to editable text
 - {{htmlelement("textarea")}} elements and {{domxref("HTMLTextAreaElement")}} objects.
 - Any element that has the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set.
 
-Editable text elements (other than the exceptions listed above) have autocorrection enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
-Explicitly setting the attribute overrides the default.
+Editable text elements (other than the exceptions listed above) have auto-correction enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
+Elements nested within an element that was made editable using the `contenteditable` do not inherit its auto-correction attribute.
+Explicitly setting the attribute on an element overrides the default and any inherited value.
 
-It reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
+The property reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
 
 ## Value
 
-`true` if autocorrection is enabled, and `false` otherwise.
-
-Note that values are reflected from the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute, which takes values `on` and `off`.
-The getter may return an inherited state as the attribute may be inherited from a parent {{htmlelement("form")}} element for elements of type {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, or {{htmlelement("textarea")}} (the attribute is not inherited for elements that are nested within an element made editable by adding the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute).
-The setter always sets the value on the selected element.
+`true` if autocorrection is enabled for the element, and `false` otherwise.
 
 ## Examples
 
-### Blahs
+### Enable and disable autocorrection
 
-The following example shows how to control capitalization behavior for user input via script:
+This example shows how you can enable and disable the autocorrection state programmatically.
 
-```html
-<div>Current capitalization behavior is: <span id="ac-label"></span></div>
-<div id="ac-element" contenteditable="true" autocapitalize="default">
-  input here
-</div>
-<select id="ac-controller" type="checkbox" checked>
-  <option value="default">default</option>
-  <option value="none">none</option>
-  <option value="sentences">sentences</option>
-  <option value="words">words</option>
-  <option value="characters">characters</option></select
->Select the capitalization behavior
-```
+#### HTML
 
-```js
-const label = document.getElementById("autocorrect-label");
-const element = document.getElementById("ac-element");
-const controller = document.getElementById("ac-controller");
-
-controller.addEventListener("input", (e) => {
-  const behavior = e.target.value;
-  label.textContent = behavior;
-  element.autocapitalize = behavior;
-});
-```
-
-{{EmbedLiveSample('Blah', 600, 200)}}
-
-### Autocorrection inheritance
-
-This example shows how you can set and get the autocorrection state
+The HTML markup defines a toggle button and an {{htmlelement("input")}} element of [`type="search"`](/en-US/docs/Web/HTML/Element/input/search).
+Note that if autocorrection is supported, it will be enabled by default.
 
 ```html
-<button id="toggleAutocorrect">Enable Autocorrect</button>
-<input type="text" id="textinput" autocorrect="off" />
+<button id="toggleAutocorrect"></button>
+<input type="search" id="searchinput" />
 ```
 
 ```html hidden
@@ -93,26 +63,38 @@ function log(text) {
 }
 ```
 
+#### JavaScript
+
+The code first checks whether the `autocorrect` is supported by checking if it is present on the prototype.
+If it is present a click handler is added to allow you to toggle the value.
+If it is not present the UI hides the interactive elements and logs that `autocorrect` is not supported.
+
 ```js
 const toggleButton = document.querySelector("button");
-const inputTextElement = document.querySelector("#textinput");
+const searchInput = document.querySelector("#searchinput");
 
-if (inputTextElement.autocorrect) {
+if (`autocorrect` in HTMLElement.prototype) {
+  log(`autocorrect: ${searchInput.autocorrect}`);
   toggleButton.addEventListener("click", (e) => {
     toggleButton.textContent = inputTextElement.autocorrect
       ? "Disable"
       : "Enable";
-    inputTextElement.autocorrect = !inputTextElement.autocorrect;
-    log(`autocorrect: ${inputTextElement.autocorrect}`);
+    inputTextElement.autocorrect = !searchInput.autocorrect;
+    log(`autocorrect: ${searchInput.autocorrect}`);
   });
 } else {
   toggleButton.hidden = true;
-  inputTextElement.hidden = true;
+  searchInput.hidden = true;
   log("autocomplete not supported");
 }
 ```
 
-{{EmbedLiveSample("Autocorrection inheritance", "100%", "200")}}
+#### Result
+
+Toggle the button to enable autocorrect, and then enter invalid text into the text box, such as "Carot".
+This should be corrected automatically.
+
+{{EmbedLiveSample("Enable and disable autocorrection", "100%", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -10,21 +10,11 @@ browser-compat: api.HTMLElement.autocorrect
 
 The **`autocorrect`** property of the {{domxref("HTMLElement")}} interface controls whether or not user text input is automatically corrected for spelling and/or punctuation errors.
 
-While it is available on all HTML elements, it is only relevant to editable text elements:
-
-- User editable {{htmlelement("input")}} elements and {{domxref("HTMLInputElement")}} objects, except for [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email), and [`url`](/en-US/docs/Web/HTML/Element/input/url), which do not support autocorrection.
-- {{htmlelement("textarea")}} elements and {{domxref("HTMLTextAreaElement")}} objects.
-- Any element that is [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable).
-
-Editable text elements (other than the exceptions listed above) have auto-correction enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
-Elements nested within an element that was made editable using the `contenteditable` do not inherit its auto-correction attribute.
-Explicitly setting the attribute on an element overrides any inherited value.
-
 The property reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
 
 ## Value
 
-`true` if autocorrection is enabled for the element, and `false` otherwise.
+`true` if auto-correction is enabled for the element, and `false` otherwise.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -85,14 +85,14 @@ if (`autocorrect` in HTMLElement.prototype) {
 } else {
   toggleButton.hidden = true;
   searchInput.hidden = true;
-  log("autocomplete not supported");
+  log("autcorrect not supported");
 }
 ```
 
 #### Result
 
 Toggle the button to enable autocorrect, and then enter invalid text into the text box, such as "Carot".
-This should be corrected automatically.
+This should be corrected automatically when the feature is enabled.
 
 {{EmbedLiveSample("Enable and disable autocorrection", "100%", "200")}}
 

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -12,13 +12,13 @@ The **`autocorrect`** property of the {{domxref("HTMLElement")}} interface contr
 
 While it is available on all HTML elements, it is only relevant to editable text elements:
 
-- {{htmlelement("input")}} elements and {{domxref("HTMLInputElement")}} objects, except for [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email), and [`url`](/en-US/docs/Web/HTML/Element/input/url), which do not support autocorrection.
+- User editable {{htmlelement("input")}} elements and {{domxref("HTMLInputElement")}} objects, except for [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email), and [`url`](/en-US/docs/Web/HTML/Element/input/url), which do not support autocorrection.
 - {{htmlelement("textarea")}} elements and {{domxref("HTMLTextAreaElement")}} objects.
-- Any element that has the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set.
+- Any element that is [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable).
 
 Editable text elements (other than the exceptions listed above) have auto-correction enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
 Elements nested within an element that was made editable using the `contenteditable` do not inherit its auto-correction attribute.
-Explicitly setting the attribute on an element overrides the default and any inherited value.
+Explicitly setting the attribute on an element overrides any inherited value.
 
 The property reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
 

--- a/files/en-us/web/api/htmlelement/autocorrect/index.md
+++ b/files/en-us/web/api/htmlelement/autocorrect/index.md
@@ -30,12 +30,12 @@ The property reflects the value of the [`autocorrect`](/en-US/docs/Web/HTML/Glob
 
 ### Enable and disable autocorrection
 
-This example shows how you can enable and disable the autocorrection state programmatically.
+This example shows how you can enable and disable auto-correction.
 
 #### HTML
 
 The HTML markup defines a toggle button and an {{htmlelement("input")}} element of [`type="search"`](/en-US/docs/Web/HTML/Element/input/search).
-Note that if autocorrection is supported, it will be enabled by default.
+Note that if auto-correction is supported, it will be enabled by default.
 
 ```html
 <button id="toggleAutocorrect"></button>
@@ -74,12 +74,12 @@ const toggleButton = document.querySelector("button");
 const searchInput = document.querySelector("#searchinput");
 
 if (`autocorrect` in HTMLElement.prototype) {
+  toggleButton.textContent = searchInput.autocorrect ? "Disable" : "Enable";
   log(`autocorrect: ${searchInput.autocorrect}`);
+
   toggleButton.addEventListener("click", (e) => {
-    toggleButton.textContent = inputTextElement.autocorrect
-      ? "Disable"
-      : "Enable";
-    inputTextElement.autocorrect = !searchInput.autocorrect;
+    toggleButton.textContent = searchInput.autocorrect ? "Disable" : "Enable";
+    searchInput.autocorrect = !searchInput.autocorrect;
     log(`autocorrect: ${searchInput.autocorrect}`);
   });
 } else {

--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -23,10 +23,13 @@ _Also inherits properties from its parent, {{DOMxRef("Element")}}._
   - : Returns a reference to the element's anchor element, or `null` if it doesn't have one.
 - {{DOMxRef("HTMLElement.attributeStyleMap")}} {{ReadOnlyInline}}
   - : A {{DOMxRef("StylePropertyMap")}} representing the declarations of the element's [`style`](/en-US/docs/Web/HTML/Global_attributes/style) attribute.
-- {{domxref("HTMLElement.autocapitalize", "autocapitalize")}}
+- {{domxref("HTMLElement.autocapitalize")}}
   - : A string that represents the element's capitalization behavior for user input. Valid values are: `none`, `off`, `on`, `characters`, `words`, `sentences`.
 - {{domxref("HTMLElement.autofocus")}}
   - : A boolean value reflecting the [`autofocus`](/en-US/docs/Web/HTML/Element/select#autofocus) HTML global attribute, which indicates whether the control should be focused when the page loads, or when dialog or popover become shown if specified in an element inside {{htmlelement("dialog")}} elements or elements whose popover attribute is set.
+- {{domxref("HTMLElement.autocorrect")}}
+  - : A boolean that represents whether or not text input by a user should be automatically corrected.
+    This reflects the [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) HTML global attribute.
 - {{DOMxRef("HTMLElement.contentEditable")}}
   - : A string, where a value of `true` means the element is editable and a value of `false` means it isn't.
 - {{DOMxRef("HTMLElement.dataset")}} {{ReadOnlyInline}}

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -25,7 +25,7 @@ See [Validation](#validation) for details on how email addresses are validated t
 
 ## Additional attributes
 
-In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `email` inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) (except [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `email` inputs support the following attributes.
 
 ### list
 

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -25,7 +25,10 @@ See [Validation](#validation) for details on how email addresses are validated t
 
 ## Additional attributes
 
-In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) (except [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `email` inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `email` inputs support the following attributes.
+
+> [!NOTE]
+> The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute can be added to email inputs, but the stored state is always `off`.
 
 ### list
 

--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -643,16 +643,9 @@ The following non-standard attributes are also available on some browsers. As a 
   </thead>
   <tbody>
     <tr>
-      <td><a href="#autocorrect"><code>autocorrect</code></a></td>
-      <td>
-        A string indicating whether autocorrect is <code>on</code> or <code>off</code>. <strong>Safari only.</strong>
-      </td>
-    </tr>
-    <tr>
       <td><a href="#incremental"><code>incremental</code></a></td>
       <td>
-        Whether or not to send repeated {{domxref("HTMLInputElement/search_event", "search")}}
-        events to allow updating live search results while the user is still editing the value of the field.
+        Whether or not to send repeated {{domxref("HTMLInputElement/search_event", "search")}} events to allow updating live search results while the user is still editing the value of the field.
         <strong>WebKit and Blink only (Safari, Chrome, Opera, etc.).</strong>
       </td>
     </tr>
@@ -687,15 +680,6 @@ The following non-standard attributes are also available on some browsers. As a 
     </tr>
   </tbody>
 </table>
-
-- `autocorrect` {{non-standard_inline}}
-
-  - : (Safari only). A string which indicates whether to activate automatic correction while the user is editing this field. Permitted values are:
-
-    - `on`
-      - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-    - `off`
-      - : Disable automatic correction and text substitutions.
 
 - `incremental` {{non-standard_inline}}
 

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -33,7 +33,10 @@ If the [`pattern`](/en-US/docs/Web/HTML/Element/input#pattern) attribute is spec
 
 ## Additional attributes
 
-In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) (except [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, password field inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, password field inputs support the following attributes.
+
+> [!NOTE]
+> The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute can be added to password inputs, but the stored state is always `off`.
 
 ### maxlength
 

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -33,7 +33,7 @@ If the [`pattern`](/en-US/docs/Web/HTML/Element/input#pattern) attribute is spec
 
 ## Additional attributes
 
-In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, password field inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) (except [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, password field inputs support the following attributes.
 
 ### maxlength
 

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -89,18 +89,19 @@ An input field can have spell-checking enabled if it doesn't have the [readonly]
 
 The value returned by reading `spellcheck` may not reflect the actual state of spell-checking within a control, if the {{Glossary("user agent", "user agent's")}} preferences override the setting.
 
-## Non-standard attributes
-
-The following non-standard attributes are available to search input fields. As a general rule, you should avoid using them unless it can't be helped.
-
 ### autocorrect
 
-A Safari extension, the `autocorrect` attribute is a string which indicates whether to activate automatic correction while the user is editing this field. Permitted values are:
+[`autocorrect`](/en-US/docs/Web/HTML/Global_attributes#autocorrect) is a global attribute that is used to indicate whether to activate automatic spelling correction while the user is editing this field.
+Permitted values are:
 
 - `on`
   - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
 - `off`
   - : Disable automatic correction and text substitutions.
+
+## Non-standard attributes
+
+The following non-standard attributes are available to search input fields. As a general rule, you should avoid using them unless it can't be helped.
 
 ### incremental
 

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -23,7 +23,7 @@ If no validation constraints are in place for the input (see [Validation](#valid
 
 ## Additional attributes
 
-In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, search field inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, search field inputs support the following attributes.
 
 ### list
 
@@ -89,19 +89,10 @@ An input field can have spell-checking enabled if it doesn't have the [readonly]
 
 The value returned by reading `spellcheck` may not reflect the actual state of spell-checking within a control, if the {{Glossary("user agent", "user agent's")}} preferences override the setting.
 
-### autocorrect
-
-[`autocorrect`](/en-US/docs/Web/HTML/Global_attributes#autocorrect) is a global attribute that is used to indicate whether to activate automatic spelling correction while the user is editing this field.
-Permitted values are:
-
-- `on`
-  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-- `off`
-  - : Disable automatic correction and text substitutions.
-
 ## Non-standard attributes
 
-The following non-standard attributes are available to search input fields. As a general rule, you should avoid using them unless it can't be helped.
+The following non-standard attributes are available to search input fields.
+Avoid using them where possible.
 
 ### incremental
 

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -24,6 +24,16 @@ The {{HTMLElement("input")}} element's [`value`](/en-US/docs/Web/HTML/Element/in
 
 In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, telephone number inputs support the following attributes.
 
+### autocorrect
+
+The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes#autocorrect) global attribute is used to indicate whether to activate automatic spelling correction while the user is editing this field.
+Permitted values are:
+
+- `on`
+  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
+- `off`
+  - : Disable automatic correction and text substitutions.
+
 ### list
 
 The values of the list attribute is the {{domxref("Element.id", "id")}} of a {{HTMLElement("datalist")}} element located in the same document. The {{HTMLElement("datalist")}} provides a list of predefined values to suggest to the user for this input. Any values in the list that are not compatible with the [`type`](/en-US/docs/Web/HTML/Element/input#type) are not included in the suggested options. The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value.
@@ -76,15 +86,6 @@ This does _not_ set a limit on how many characters the user can enter into the f
 ## Non-standard attributes
 
 The following non-standard attributes are available to telephone number input fields. As a general rule, you should avoid using them unless it can't be helped.
-
-### autocorrect
-
-A Safari extension, the `autocorrect` attribute is a string which indicates whether to activate automatic correction while the user is editing this field. Permitted values are:
-
-- `on`
-  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-- `off`
-  - : Disable automatic correction and text substitutions.
 
 ## Using tel inputs
 

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -22,17 +22,7 @@ The {{HTMLElement("input")}} element's [`value`](/en-US/docs/Web/HTML/Element/in
 
 ## Additional attributes
 
-In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, telephone number inputs support the following attributes.
-
-### autocorrect
-
-The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes#autocorrect) global attribute is used to indicate whether to activate automatic spelling correction while the user is editing this field.
-Permitted values are:
-
-- `on`
-  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-- `off`
-  - : Disable automatic correction and text substitutions.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, telephone number inputs support the following attributes.
 
 ### list
 
@@ -82,10 +72,6 @@ A Boolean attribute which, if present, means this field cannot be edited by the 
 The `size` attribute is a numeric value indicating how many characters wide the input field should be. The value must be a number greater than zero, and the default value is 20. Since character widths vary, this may or may not be exact and should not be relied upon to be so; the resulting input may be narrower or wider than the specified number of characters, depending on the characters and the font ({{cssxref("font")}} settings in use).
 
 This does _not_ set a limit on how many characters the user can enter into the field. It only specifies approximately how many can be seen at a time. To set an upper limit on the length of the input data, use the [`maxlength`](#maxlength) attribute.
-
-## Non-standard attributes
-
-The following non-standard attributes are available to telephone number input fields. As a general rule, you should avoid using them unless it can't be helped.
 
 ## Using tel inputs
 

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -23,17 +23,7 @@ If no validation constraints are in place for the input (see [Validation](#valid
 
 ## Additional attributes
 
-In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, text inputs support the following attributes.
-
-### autocorrect
-
-The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute is a string that indicates whether to activate automatic correction while the user is editing this field.
-Permitted values are:
-
-- `on`
-  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-- `off`
-  - : Disable automatic correction and text substitutions.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, text inputs support the following attributes.
 
 ### `list`
 
@@ -98,10 +88,6 @@ The [`spellcheck`](/en-US/docs/Web/HTML/Global_attributes/spellcheck) global att
 An input field can have spell-checking enabled if it doesn't have the [readonly](#readonly) attribute set and is not disabled.
 
 The value returned by reading `spellcheck` may not reflect the actual state of spell-checking within a control, if the {{Glossary("user agent", "user agent's")}} preferences override the setting.
-
-## Non-standard attributes
-
-The following non-standard attributes are also available on some browsers. As a general rule, you should avoid using them unless it can't be helped.
 
 ## Using text inputs
 

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -25,6 +25,16 @@ If no validation constraints are in place for the input (see [Validation](#valid
 
 In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, text inputs support the following attributes.
 
+### autocorrect
+
+The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes#autocorrect) global attribute is a string that indicates whether to activate automatic correction while the user is editing this field.
+Permitted values are:
+
+- `on`
+  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
+- `off`
+  - : Disable automatic correction and text substitutions.
+
 ### `list`
 
 The values of the list attribute is the {{domxref("Element.id", "id")}} of a {{HTMLElement("datalist")}} element located in the same document. The {{HTMLElement("datalist")}} provides a list of predefined values to suggest to the user for this input. Any values in the list that are not compatible with the [`type`](/en-US/docs/Web/HTML/Element/input#type) are not included in the suggested options. The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value.
@@ -92,15 +102,6 @@ The value returned by reading `spellcheck` may not reflect the actual state of s
 ## Non-standard attributes
 
 The following non-standard attributes are also available on some browsers. As a general rule, you should avoid using them unless it can't be helped.
-
-### `autocorrect`
-
-A Safari extension, the `autocorrect` attribute is a string that indicates whether to activate automatic correction while the user is editing this field. Permitted values are:
-
-- `on`
-  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-- `off`
-  - : Disable automatic correction and text substitutions.
 
 ## Using text inputs
 

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -27,7 +27,7 @@ In addition to the attributes that operate on all {{HTMLElement("input")}} eleme
 
 ### autocorrect
 
-The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes#autocorrect) global attribute is a string that indicates whether to activate automatic correction while the user is editing this field.
+The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute is a string that indicates whether to activate automatic correction while the user is editing this field.
 Permitted values are:
 
 - `on`

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -24,7 +24,10 @@ See [Validation](#validation) for details on how URLs are validated to ensure th
 
 ## Additional attributes
 
-In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) (except [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `url` inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `url` inputs support the following attributes.
+
+> [!NOTE]
+> The [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect) global attribute can be added to url inputs, but the stored state is always `off`.
 
 ### list
 

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -90,19 +90,6 @@ An input field can have spell-checking enabled if it doesn't have the [readonly]
 
 The value returned by reading `spellcheck` may not reflect the actual state of spell-checking within a control if the {{Glossary("user agent", "user agent's")}} preferences override the setting.
 
-## Non-standard attributes
-
-The following non-standard attributes are also available on some browsers. As a general rule, you should avoid using them unless it can't be helped.
-
-### autocorrect
-
-A Safari extension, the `autocorrect` attribute is a string that indicates whether to activate automatic correction while the user is editing this field. Permitted values are:
-
-- `on`
-  - : Enable automatic correction of typos, as well as processing of text substitutions if any are configured.
-- `off`
-  - : Disable automatic correction and text substitutions.
-
 ## Using URL inputs
 
 When you create a URL input with the proper `type` value, `url`, you get automatic validation that the entered text is at least in the correct form to potentially be a legitimate URL. This can help avoid cases in which the user mistypes their website's address, or provides an invalid one.

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -24,7 +24,7 @@ See [Validation](#validation) for details on how URLs are validated to ensure th
 
 ## Additional attributes
 
-In addition to the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `url` inputs support the following attributes.
+In addition to the [global attributes](/en-US/docs/Web/HTML/Global_attributes) (except [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, `url` inputs support the following attributes.
 
 ### list
 

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -28,11 +28,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize)
 
-  - : A string that indicates whether input text is automatically capitalized and, if so, in what manner.
+  - : Controls whether inputted text is automatically capitalized and, if so, in what manner.
 
 - [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete)
 
-  - : A string that indicates whether the value of the control can be automatically completed by the browser. Possible values are:
+  - : Controls whether entered text can be automatically completed by the browser. Possible values are:
 
     - `off`: The user must explicitly enter a value into this field for every use, or the document provides its own auto-completion method; the browser does not automatically complete the entry.
     - `on`: The browser can automatically complete the value based on values that the user has entered during previous uses.
@@ -42,7 +42,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)
 
-  - : A string that indicates whether to activate automatic spelling correction and processing of text while the user is editing this `textarea`.
+  - : Controls whether automatic spelling correction and processing of text is enabled while the user is editing this `textarea`.
     Permitted values are:
 
     - `on`

--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -26,13 +26,13 @@ The `<textarea>` element also accepts several attributes common to form `<input>
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- `autocapitalize`
+- [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize)
 
-  - : Controls whether inputted text is automatically capitalized and, if so, in what manner. See the [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize) global attribute page for more information.
+  - : A string that indicates whether input text is automatically capitalized and, if so, in what manner.
 
 - [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete)
 
-  - : This attribute indicates whether the value of the control can be automatically completed by the browser. Possible values are:
+  - : A string that indicates whether the value of the control can be automatically completed by the browser. Possible values are:
 
     - `off`: The user must explicitly enter a value into this field for every use, or the document provides its own auto-completion method; the browser does not automatically complete the entry.
     - `on`: The browser can automatically complete the value based on values that the user has entered during previous uses.
@@ -40,16 +40,17 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     `<textarea>` elements that don't specify the `autocomplete` attribute inherit the `autocomplete` `on` or `off` status set on the `<textarea>`'s form owner. The form owner is either the {{HTMLElement("form")}} element that this `<textarea>` element is a descendant of or the form element whose `id` is specified by the `form` attribute of the input element. For more information, see the [`autocomplete`](/en-US/docs/Web/HTML/Element/form#autocomplete) attribute in {{HTMLElement("form")}}.
 
-- `autocorrect` {{non-standard_inline}}
+- [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)
 
-  - : A string which indicates whether to activate automatic spelling correction and processing of text substitutions (if any are configured) while the user is editing this `textarea`. Permitted values are:
+  - : A string that indicates whether to activate automatic spelling correction and processing of text while the user is editing this `textarea`.
+    Permitted values are:
 
     - `on`
       - : Enable automatic spelling correction and text substitutions.
     - `off`
       - : Disable automatic spelling correction and text substitutions.
 
-- `autofocus`
+- [`autofocus`](/en-US/docs/Web/HTML/Global_attributes/autofocus)
   - : This Boolean attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified.
 - `cols`
   - : The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is `20`.

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -38,6 +38,28 @@ The default value for elements that are not nested inside a `<form>` is `on`.
 When nested in a `<form>`, the following elements inherit their their default value of `autocorrect` from the form if it has been set: {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}.
 
 ## Examples
+### Basic example
+
+This example demonstrates basic `autocorrect` attribute usage.
+
+#### HTML
+
+We include two text `<input>` elements with different values for their `autocorrect` attributes:
+
+```html
+<label for="vegetable">A vegetable: </label>
+<input id="vegetable" name="vegetable" type="text" autocorrect="on" />
+
+<label for="fruit">A fruit: </label>
+<input id="fruit" name="fruit" type="text" autocorrect="off" />
+```end
+
+#### Results
+
+{{EmbedLiveSample("Basic example", "100%", "250")}}
+
+Enter invalid text into the fruit and vegetable text entry boxes above.
+If auto-correction is enabled on your browser, a typo in a vegetable name should be auto-corrected, but not in a fruit name.
 
 ### Enabling and disabling autocorrection
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -15,7 +15,7 @@ Autocorrection is relevant to editable text elements:
 - {{htmlelement("textarea")}} elements.
 - Any element that has the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set.
 
-Editable elements have autocorrection enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
+Editable elements have auto-correction enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
 Explicitly setting the attribute overrides the default.
 
 ## Value

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -15,7 +15,7 @@ Autocorrection is relevant to editable text elements:
 - {{htmlelement("textarea")}} elements.
 - Any element that has the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set.
 
-Elements have autocorrection enabled by default, except for within a {{htmlelement("form")}} element, where the default value is inherited from the form.
+Editable elements have autocorrection enabled by default, except for within a {{htmlelement("form")}} element, where the default value may be inherited from the form.
 Explicitly setting the attribute overrides the default.
 
 ## Value
@@ -26,17 +26,15 @@ Possible values are:
 
   - : Enable automatic correction of spelling and punctuation errors.
 
-    Setting any value other than `off`, including the empty string, is treated as `on`.
-
 - `off`
 
   - : Disable automatic correction of editable text.
 
-    The {{htmlelement("input")}} element types that don't support autocorrection always return `off`: [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email) and [`url`](/en-US/docs/Web/HTML/Element/input/url).
+The {{htmlelement("input")}} element types that don't support autocorrection always return `off`: [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email) and [`url`](/en-US/docs/Web/HTML/Element/input/url).
 
-The default value for editable elements that are not nested inside a `<form>` is `on`.
-Nested `<form>` elements inherit their their default value of `autocorrect` from the form (including {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}).
-The default value will be used if an element's `autocorrect` value is not explicitly set.
+For all other editable elements, setting any value other than `off` is always treated as `on` (including the empty string), and the default value for elements that are not nested inside a `<form>` is `on`.
+
+When nested in a `<form>`, the following elements inherit their their default value of `autocorrect` from the form if it has been set: {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}.
 
 ## Examples
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -1,0 +1,289 @@
+---
+title: autocorrect
+slug: Web/HTML/Global_attributes/autocorrect
+page-type: html-attribute
+browser-compat: html.global_attributes.autocorrect
+---
+
+{{HTMLSidebar("Global_attributes")}}
+
+The **`autocorrect`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that controls whether editable text is automatically corrected for spelling and/or punctuation errors.
+
+Autocorrection is relevant to editable text elements:
+
+- {{htmlelement("input")}} elements, except for [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email), and [`url`](/en-US/docs/Web/HTML/Element/input/url), which do not support autocorrection.
+- {{htmlelement("textarea")}} elements.
+- Any element that has the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute set.
+
+Elements have autocorrection enabled by default, except for within a {{htmlelement("form")}} element, where the default value is inherited from the form.
+Explicitly setting the attribute overrides the default.
+
+## Value
+
+Possible values are:
+
+- `on` or `""` (the empty string)
+
+  - : Enable automatic correction of spelling and punctuation errors.
+
+    Setting any value other than `off`, including the empty string, is treated as `on`.
+
+- `off`
+
+  - : Disable automatic correction of editable text.
+
+    The {{htmlelement("input")}} element types that don't support autocorrection always return `off`: [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email) and [`url`](/en-US/docs/Web/HTML/Element/input/url).
+
+The default value for editable elements that are not nested inside a `<form>` is `on`.
+Nested `<form>` elements inherit their their default value of `autocorrect` from the form (including {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}).
+The default value will be used if an element's `autocorrect` value is not explicitly set.
+
+## Examples
+
+<!-- Below is currently test code -->
+
+### Autocorrection inheritance
+
+The input element in the following example would not allow autocorrection, since it does not have an autocorrect content attribute and therefore inherits from the form element, which has an attribute of "off". However, the textarea element would allow autocorrection, since it has an autocorrect content attribute with a value of "on".
+
+```html
+<form id="formelem" autocorrect="off">
+  <input id="searchelem" type="search" />
+  <textarea id="textareaelem" autocorrect="on"></textarea>
+</form>
+```
+
+```html
+<form id="formelemnoauto">
+  <input id="searchelemcont" type="search" />
+  <textarea id="textareaelemcont" autocorrect="on"></textarea>
+</form>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const formElement = document.querySelector("#formelem");
+console.log(formElement);
+log(formElement);
+log(`formElement: ${formElement.autocorrect}`);
+
+const searchElement = document.querySelector("#searchelem");
+console.log(searchElement);
+log(searchElement);
+log(`searchElement: ${searchElement.autocorrect}`);
+
+const textAreaElement = document.querySelector("#textareaelem");
+console.log(textAreaElement);
+log(textAreaElement);
+log(`textAreaElement autocrct: ${textAreaElement.autocorrect}`);
+
+// Test if form element have a default autocorrect value
+
+const formElementNo = document.querySelector("#formelemnoauto");
+console.log(formElementNo);
+log(formElementNo);
+log(`formElementNo: ${formElementNo.autocorrect}`);
+
+const searchElementCont = document.querySelector("#searchelemcont");
+console.log(searchElementCont);
+log(searchElementCont);
+log(`searchElementCont: ${searchElementCont.autocorrect}`);
+
+const textAreaElementCont = document.querySelector("#textareaelemcont");
+console.log(textAreaElementCont);
+log(textAreaElementCont);
+log(`textAreaElementCont autocrct: ${textAreaElementCont.autocorrect}`);
+```
+
+{{EmbedLiveSample("Autocorrection inheritance", "100%", "300")}}
+
+### Setting autocorrect on an editing host
+
+```html
+<blockquote id="bq" contenteditable="true">
+  <p id="para" autocorrect="on">Edit this content to add your own quote</p>
+</blockquote>
+
+<cite id="cite" contenteditable="true" autocorrect="on"
+  >-- Write your own name here</cite
+>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js
+const bqElement = document.querySelector("#bq");
+console.log(bqElement);
+log(bqElement);
+log(`bqElement: ${bqElement.autocorrect}`);
+const paraElement = document.querySelector("#para");
+log(`paraElement: ${paraElement.autocorrect}`);
+const citeElement = document.querySelector("#cite");
+log(`citeElement: ${citeElement.autocorrect}`);
+console.log(citeElement);
+```
+
+{{EmbedLiveSample("Setting autocorrect on an editing host", "100%", "300")}}
+
+### Setting autocorrect on a password
+
+To tell the user's browser that the password field must have a valid value before the form can be submitted, specify the Boolean [`required`](/en-US/docs/Web/HTML/Element/input#required) attribute.
+
+```html
+<label for="userPassword">Password: </label>
+<input id="userPassword" type="password" autocorrect="on" />
+<input type="submit" value="Submit" />
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const passwordElement = document.querySelector("#userPassword");
+console.log(`passwordElem: ${passwordElement.autocorrect}`);
+log(`passwordElem: ${passwordElement.autocorrect}`);
+/*
+
+*/
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+{{EmbedLiveSample("Setting autocorrect on a password", "100%", "300")}}
+
+### Test
+
+#### HTML
+
+```html
+<p>Form to test different autocorrect settings:</p>
+
+<form>
+  <div>
+    <label for="default">Default: no autocorrect set</label>
+    <input type="text" id="default" name="default" />
+  </div>
+  <div>
+    <label for="off">autocorrect="off"</label>
+    <input type="text" id="off" name="off" autocorrect="off" />
+  </div>
+  <div>
+    <label for="none">autocorrect="none"</label>
+    <input type="text" id="none" name="none" autocorrect="none" />
+  </div>
+  <div>
+    <label for="on">autocorrect="on"</label>
+    <input type="text" id="on" name="on" autocorrect="on" />
+  </div>
+  <div>
+    <label for="sentences">autocorrect="sentences"</label>
+    <input
+      type="text"
+      id="sentences"
+      name="sentences"
+      autocorrect="sentences" />
+  </div>
+  <div>
+    <label for="words">autocorrect="words"</label>
+    <input type="text" id="words" name="words" autocapitalize="words" />
+  </div>
+  <div>
+    <label for="autocorrect">autocorrect="characters"</label>
+    <input
+      type="text"
+      id="characters"
+      name="characters"
+      autocorrect="characters" />
+  </div>
+  <div>
+    <label for="characters-ta">autocorrect="characters" on textarea</label>
+    <textarea
+      type="text"
+      id="characters-ta"
+      name="characters-ta"
+      autocorrect="characters">
+    </textarea>
+  </div>
+</form>
+
+<hr />
+
+<p contenteditable autocorrect="on">
+  This content is editable and has autocorrect="on" set on it
+</p>
+```
+
+```css hidden
+div {
+  margin-bottom: 20px;
+}
+```
+
+#### Result
+
+Test the effect on each input using a virtual keyboard or voice entry (keyboard entry will not work).
+
+{{ EmbedLiveSample("Test", "100%", "300")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -32,7 +32,8 @@ Possible values are:
 
 The {{htmlelement("input")}} element types that don't support auto-correction always have the `off` state: [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email) and [`url`](/en-US/docs/Web/HTML/Element/input/url).
 
-For all other editable elements, setting any value other than `off` is always treated as `on` (including the empty string), and the default value for elements that are not nested inside a `<form>` is `on`.
+For all other editable elements, setting any other value than those listed above is always treated as `on`.
+The default value for elements that are not nested inside a `<form>` is `on`.
 
 When nested in a `<form>`, the following elements inherit their their default value of `autocorrect` from the form if it has been set: {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}.
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -30,7 +30,7 @@ Possible values are:
 
   - : Disable automatic correction of editable text.
 
-The {{htmlelement("input")}} element types that don't support autocorrection always return `off`: [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email) and [`url`](/en-US/docs/Web/HTML/Element/input/url).
+The {{htmlelement("input")}} element types that don't support auto-correction always have the `off` state: [`password`](/en-US/docs/Web/HTML/Element/input/password), [`email`](/en-US/docs/Web/HTML/Element/input/email) and [`url`](/en-US/docs/Web/HTML/Element/input/url).
 
 For all other editable elements, setting any value other than `off` is always treated as `on` (including the empty string), and the default value for elements that are not nested inside a `<form>` is `on`.
 
@@ -38,245 +38,84 @@ When nested in a `<form>`, the following elements inherit their their default va
 
 ## Examples
 
-<!-- Below is currently test code -->
+### Enabling and disabling autocorrection
 
-### Autocorrection inheritance
-
-The input element in the following example would not allow autocorrection, since it does not have an autocorrect content attribute and therefore inherits from the form element, which has an attribute of "off". However, the textarea element would allow autocorrection, since it has an autocorrect content attribute with a value of "on".
-
-```html
-<form id="formelem" autocorrect="off">
-  <input id="searchelem" type="search" />
-  <textarea id="textareaelem" autocorrect="on"></textarea>
-</form>
-```
-
-```html
-<form id="formelemnoauto">
-  <input id="searchelemcont" type="search" />
-  <textarea id="textareaelemcont" autocorrect="on"></textarea>
-</form>
-```
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js
-const formElement = document.querySelector("#formelem");
-console.log(formElement);
-log(formElement);
-log(`formElement: ${formElement.autocorrect}`);
-
-const searchElement = document.querySelector("#searchelem");
-console.log(searchElement);
-log(searchElement);
-log(`searchElement: ${searchElement.autocorrect}`);
-
-const textAreaElement = document.querySelector("#textareaelem");
-console.log(textAreaElement);
-log(textAreaElement);
-log(`textAreaElement autocrct: ${textAreaElement.autocorrect}`);
-
-// Test if form element have a default autocorrect value
-
-const formElementNo = document.querySelector("#formelemnoauto");
-console.log(formElementNo);
-log(formElementNo);
-log(`formElementNo: ${formElementNo.autocorrect}`);
-
-const searchElementCont = document.querySelector("#searchelemcont");
-console.log(searchElementCont);
-log(searchElementCont);
-log(`searchElementCont: ${searchElementCont.autocorrect}`);
-
-const textAreaElementCont = document.querySelector("#textareaelemcont");
-console.log(textAreaElementCont);
-log(textAreaElementCont);
-log(`textAreaElementCont autocrct: ${textAreaElementCont.autocorrect}`);
-```
-
-{{EmbedLiveSample("Autocorrection inheritance", "100%", "300")}}
-
-### Setting autocorrect on an editing host
-
-```html
-<blockquote id="bq" contenteditable="true">
-  <p id="para" autocorrect="on">Edit this content to add your own quote</p>
-</blockquote>
-
-<cite id="cite" contenteditable="true" autocorrect="on"
-  >-- Write your own name here</cite
->
-```
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-```js
-const bqElement = document.querySelector("#bq");
-console.log(bqElement);
-log(bqElement);
-log(`bqElement: ${bqElement.autocorrect}`);
-const paraElement = document.querySelector("#para");
-log(`paraElement: ${paraElement.autocorrect}`);
-const citeElement = document.querySelector("#cite");
-log(`citeElement: ${citeElement.autocorrect}`);
-console.log(citeElement);
-```
-
-{{EmbedLiveSample("Setting autocorrect on an editing host", "100%", "300")}}
-
-### Setting autocorrect on a password
-
-To tell the user's browser that the password field must have a valid value before the form can be submitted, specify the Boolean [`required`](/en-US/docs/Web/HTML/Element/input#required) attribute.
-
-```html
-<label for="userPassword">Password: </label>
-<input id="userPassword" type="password" autocorrect="on" />
-<input type="submit" value="Submit" />
-```
-
-```html hidden
-<pre id="log"></pre>
-```
-
-```js hidden
-const logElement = document.querySelector("#log");
-function log(text) {
-  logElement.innerText = `${logElement.innerText}${text}\n`;
-  logElement.scrollTop = logElement.scrollHeight;
-}
-```
-
-```js
-const passwordElement = document.querySelector("#userPassword");
-console.log(`passwordElem: ${passwordElement.autocorrect}`);
-log(`passwordElem: ${passwordElement.autocorrect}`);
-/*
-
-*/
-```
-
-```css hidden
-#log {
-  height: 100px;
-  overflow: scroll;
-  padding: 0.5rem;
-  border: 1px solid black;
-}
-```
-
-{{EmbedLiveSample("Setting autocorrect on a password", "100%", "300")}}
-
-### Test
+This example shows how you can enable and disable auto-correction using the `autocorrect` attribute.
 
 #### HTML
 
+The HTML markup defines a {{htmlelement("button")}}, a "name" {{htmlelement("input")}} element of [`type="text"`](/en-US/docs/Web/HTML/Element/input/text), a "bio" {{htmlelement("textarea")}} element, and two {{htmlelement("label")}} elements.
+
+The "username" element has `autocorrect="off"` set because auto-correcting a name would be annoying!
+The bio does not specify a value for `autocorrect`, which means that it is enabled (we could have set any value other than `off`).
+
 ```html
-<p>Form to test different autocorrect settings:</p>
+<button id="reset">Reset</button>
+<label for="username">Name: </label>
+<input id="username" name="username" type="text" autocorrect="off" />
+<label for="bio">Biography: </label>
+<textarea id="bio" name="bio"></textarea>
+```
 
-<form>
-  <div>
-    <label for="default">Default: no autocorrect set</label>
-    <input type="text" id="default" name="default" />
-  </div>
-  <div>
-    <label for="off">autocorrect="off"</label>
-    <input type="text" id="off" name="off" autocorrect="off" />
-  </div>
-  <div>
-    <label for="none">autocorrect="none"</label>
-    <input type="text" id="none" name="none" autocorrect="none" />
-  </div>
-  <div>
-    <label for="on">autocorrect="on"</label>
-    <input type="text" id="on" name="on" autocorrect="on" />
-  </div>
-  <div>
-    <label for="sentences">autocorrect="sentences"</label>
-    <input
-      type="text"
-      id="sentences"
-      name="sentences"
-      autocorrect="sentences" />
-  </div>
-  <div>
-    <label for="words">autocorrect="words"</label>
-    <input type="text" id="words" name="words" autocapitalize="words" />
-  </div>
-  <div>
-    <label for="autocorrect">autocorrect="characters"</label>
-    <input
-      type="text"
-      id="characters"
-      name="characters"
-      autocorrect="characters" />
-  </div>
-  <div>
-    <label for="characters-ta">autocorrect="characters" on textarea</label>
-    <textarea
-      type="text"
-      id="characters-ta"
-      name="characters-ta"
-      autocorrect="characters">
-    </textarea>
-  </div>
-</form>
-
-<hr />
-
-<p contenteditable autocorrect="on">
-  This content is editable and has autocorrect="on" set on it
-</p>
+```html hidden
+<pre id="log"></pre>
 ```
 
 ```css hidden
-div {
-  margin-bottom: 20px;
+#log {
+  height: 75px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+
+button,
+input,
+textarea {
+  display: block;
 }
 ```
 
-#### Result
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
 
-Test the effect on each input using a virtual keyboard or voice entry (keyboard entry will not work).
+#### JavaScript
 
-{{ EmbedLiveSample("Test", "100%", "300")}}
+The code checks whether the `autocorrect` is supported by checking if it is present on the prototype.
+If it is not present this fact is logged.
+If it is present then the value of the `autocorrect` property for each of the text-entry elements is logged.
+
+A click handler is added for the button, which allows you to reset the entered text and the log.
+
+```js
+const resetButton = document.querySelector("#reset");
+const userNameElement = document.querySelector("#username");
+const bioElement = document.querySelector("#bio");
+
+if (!("autocorrect" in HTMLElement.prototype)) {
+  log("autocorrect not supported");
+} else {
+  log(`userNameElement.autocorrect: ${userNameElement.autocorrect}`);
+  log(`userNameElement.autocorrect: ${bioElement.autocorrect}`);
+}
+
+resetButton.addEventListener("click", (e) => {
+  userNameElement.value = "";
+  bioElement.value = "";
+});
+```
+
+#### Results
+
+Enter invalid text into the name and biography text entry boxes below.
+If auto-correction is enabled on your browser (see the log below) the text in the "Biography" should be auto-corrected, but not in the "Name" box.
+
+{{EmbedLiveSample("Enabling and disabling autocorrection", "100%", "250")}}
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/autocorrect/index.md
+++ b/files/en-us/web/html/global_attributes/autocorrect/index.md
@@ -38,6 +38,7 @@ The default value for elements that are not nested inside a `<form>` is `on`.
 When nested in a `<form>`, the following elements inherit their their default value of `autocorrect` from the form if it has been set: {{htmlelement("button")}}, {{htmlelement("fieldset")}}, {{htmlelement("input")}}, {{htmlelement("output")}}, {{htmlelement("select")}}, and {{htmlelement("textarea")}}.
 
 ## Examples
+
 ### Basic example
 
 This example demonstrates basic `autocorrect` attribute usage.
@@ -52,11 +53,11 @@ We include two text `<input>` elements with different values for their `autocorr
 
 <label for="fruit">A fruit: </label>
 <input id="fruit" name="fruit" type="text" autocorrect="off" />
-```end
+```
 
 #### Results
 
-{{EmbedLiveSample("Basic example", "100%", "250")}}
+{{EmbedLiveSample("Basic example", "100%", "75")}}
 
 Enter invalid text into the fruit and vegetable text entry boxes above.
 If auto-correction is enabled on your browser, a typo in a vegetable name should be auto-corrected, but not in a fruit name.

--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -25,6 +25,8 @@ In addition to the basic HTML global attributes, the following global attributes
   - : Associates a positioned element with an anchor element. The attribute's value is the [`id`](/en-US/docs/Web/HTML/Global_attributes/id) value of the element you want to anchor the positioned element to. The element can then be positioned [using CSS anchor positioning](/en-US/docs/Web/CSS/CSS_anchor_positioning/Using).
 - [`autocapitalize`](/en-US/docs/Web/HTML/Global_attributes/autocapitalize)
   - : Controls whether inputted text is automatically capitalized and, if so, in what manner.
+- [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)
+  - : Controls whether input text is automatically corrected for spelling errors.
 - [`autofocus`](/en-US/docs/Web/HTML/Global_attributes/autofocus)
   - : Indicates that an element is to be focused on page load, or as soon as the {{HTMLElement("dialog")}} it is part of is displayed. This attribute is a boolean, initially false.
 - [`class`](/en-US/docs/Web/HTML/Global_attributes/class)

--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -27,6 +27,7 @@ In addition to the basic HTML global attributes, the following global attributes
   - : Controls whether inputted text is automatically capitalized and, if so, in what manner.
 - [`autocorrect`](/en-US/docs/Web/HTML/Global_attributes/autocorrect)
   - : Controls whether input text is automatically corrected for spelling errors.
+    This can be applied to elements that have editable text except for {{HTMLElement("input")}} elements with the attribute: [`type="password"`](/en-US/docs/Web/HTML/Element/input/password), [`type="email"`](/en-US/docs/Web/HTML/Element/input/email), or [`type="url"`](/en-US/docs/Web/HTML/Element/input/url).
 - [`autofocus`](/en-US/docs/Web/HTML/Global_attributes/autofocus)
   - : Indicates that an element is to be focused on page load, or as soon as the {{HTMLElement("dialog")}} it is part of is displayed. This attribute is a boolean, initially false.
 - [`class`](/en-US/docs/Web/HTML/Global_attributes/class)


### PR DESCRIPTION
The global `autocorrect` attribute is now part of the standard. This documents it.

Note, in draft because I haven't been able to "see" and autocorrection behaviour in testing. Creating this PR allows me to create something that "may" allow that. 

Related docs work in #35593

 - [x] Go back and fix up BCD. I think I got it wrong for the property of the HTMLElement.