### PR TITLE
Add missing specifications sections

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -141,9 +141,7 @@ playButton.addEventListener("click", () => {
 
 ## Specifications
 
-Since the August 29 2014 [Web Audio API specification](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor) publication, this feature has been deprecated. It is no longer on track to become a standard.
-
-It was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.md
@@ -49,7 +49,7 @@ None ({{jsxref("undefined")}}).
 
 ## Specifications
 
-This method is no longer on a standardization track. It is kept for compatibility purposes. Use the constructor {{domxref("CompositionEvent.CompositionEvent", "CompositionEvent()")}}.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -43,10 +43,7 @@ It has been superseded by a modern, but incompatible, [CSS Typed Object Model AP
 
 ## Browser compatibility
 
-This feature was originally defined in the [DOM Style Level 2](https://www.w3.org/TR/DOM-Level-2-Style/) specification, but has been dropped from any
-standardization effort since then.
-
-It has been superseded by a modern, but incompatible, [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) that is now on the standard track.
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -220,7 +220,7 @@ function insertText(newText, selector) {
 
 ## Specifications
 
-This feature is not part of any current specification, but there is an [unofficial draft](https://w3c.github.io/editing/docs/execCommand/) attempting to specify it.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/fgcolor/index.md
+++ b/files/en-us/web/api/document/fgcolor/index.md
@@ -34,6 +34,10 @@ in hexadecimal).
 
 Another alternative is `document.body.text`, although this is [deprecated in HTML 4.01](https://www.w3.org/TR/html401/struct/global.html#adef-text) in favor of the CSS alternative above.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/document/linkcolor/index.md
+++ b/files/en-us/web/api/document/linkcolor/index.md
@@ -32,9 +32,7 @@ document.linkColor = "blue";
 
 ## Specifications
 
-HTML5
-
-`Document.linkColor` is [deprecated in DOM Level 2 HTML](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-26809268).
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/xmlencoding/index.md
+++ b/files/en-us/web/api/document/xmlencoding/index.md
@@ -25,7 +25,7 @@ Then, the result should be "UTF-16".
 
 ## Specifications
 
-This feature is not part of any specification anymore. It is no more on track to become a standard.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/xmlversion/index.md
+++ b/files/en-us/web/api/document/xmlversion/index.md
@@ -22,7 +22,7 @@ if (document.createElement("foo").tagName === "FOO") {
 
 ## Specifications
 
-This feature is not part of any specification anymore. It is no more on track to become a standard.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmlallcollection/item/index.md
+++ b/files/en-us/web/api/htmlallcollection/item/index.md
@@ -25,6 +25,10 @@ item(nameOrIndex)
 
 If `nameOrIndex` represents an index, `item()` returns the {{domxref("Element")}} at the specified index, or `null` if `nameOrIndex` is less than zero or greater than or equal to the length property. If `nameOrIndex` represents a name, `item()` returns the same value as {{domxref("HTMLAllCollection/namedItem", "namedItem()")}}.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/htmlcollection/item/index.md
+++ b/files/en-us/web/api/htmlcollection/item/index.md
@@ -50,6 +50,10 @@ const img0 = images.item(0); // You can use the item() method this way
 const img1 = images[1]; // But this notation is easier and more common
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/htmlfontelement/color/index.md
+++ b/files/en-us/web/api/htmlfontelement/color/index.md
@@ -40,7 +40,7 @@ f.color = "green";
 
 ## Specifications
 
-The `<font>` element has been deprecated and is no longer supported and, as a result, neither is `<font>.color`.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmlfontelement/face/index.md
+++ b/files/en-us/web/api/htmlfontelement/face/index.md
@@ -40,8 +40,7 @@ f.face = "arial";
 
 ## Specifications
 
-The `<font>` element has been deprecated and is no longer supported and, as a result, neither is
-`<font>.face`.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmlfontelement/size/index.md
+++ b/files/en-us/web/api/htmlfontelement/size/index.md
@@ -59,8 +59,7 @@ f.size = "6";
 
 ## Specifications
 
-The `<font>` element has been deprecated and is no longer supported and, as a result, neither is
-`<font>.size`.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmlformelement/encoding/index.md
+++ b/files/en-us/web/api/htmlformelement/encoding/index.md
@@ -10,6 +10,10 @@ browser-compat: api.HTMLFormElement.encoding
 
 The **`HTMLFormElement.encoding`** property is an alternative name for the {{domxref("HTMLFormElement.enctype","enctype")}} element on the DOM {{domxref("HTMLFormElement")}} object.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/htmlhtmlelement/version/index.md
+++ b/files/en-us/web/api/htmlhtmlelement/version/index.md
@@ -15,6 +15,10 @@ browser-compat: api.HTMLHtmlElement.version
 
 Returns version information about the document type definition (DTD) of a document. While this property is recognized by Mozilla, the return value for this property is always an empty string.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.md
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.md
@@ -58,7 +58,7 @@ With that, the image is a link to the HTML file describing the image in more det
 
 ## Specifications
 
-This feature is not part of any current specification. It is no longer on track to become a standard.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/align/index.md
+++ b/files/en-us/web/api/htmltableelement/align/index.md
@@ -31,7 +31,7 @@ t.align = "center";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification [_HTMLTableElement.align_](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-23180977).
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/border/index.md
+++ b/files/en-us/web/api/htmltableelement/border/index.md
@@ -27,9 +27,7 @@ t.border = "2";
 
 ## Specifications
 
-W3C DOM 2 HTML Specification [_HTMLTableElement.border_](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-50969400).
-
-This attribute is deprecated in HTML 4.0.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/cellpadding/index.md
+++ b/files/en-us/web/api/htmltableelement/cellpadding/index.md
@@ -29,7 +29,7 @@ t.cellPadding = "10";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification [_HTMLTableElement.cellPadding_](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-59162158).
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/cellspacing/index.md
+++ b/files/en-us/web/api/htmltableelement/cellspacing/index.md
@@ -34,7 +34,7 @@ t.cellSpacing = "10";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification [_HTMLTableElement.cellSpacing_](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-68907883).
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/frame/index.md
+++ b/files/en-us/web/api/htmltableelement/frame/index.md
@@ -48,7 +48,7 @@ t.border = "2px";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/rules/index.md
+++ b/files/en-us/web/api/htmltableelement/rules/index.md
@@ -38,7 +38,7 @@ t.rules = "all";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/summary/index.md
+++ b/files/en-us/web/api/htmltableelement/summary/index.md
@@ -25,7 +25,7 @@ HTMLTableElement.summary = "Usage statistics";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmltableelement/width/index.md
+++ b/files/en-us/web/api/htmltableelement/width/index.md
@@ -25,7 +25,7 @@ mytable.width = "75%";
 
 ## Specifications
 
-- W3C DOM 2 HTML Specification [_HTMLTableElement.width_](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-77447361)
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/idbdatabase/close_event/index.md
+++ b/files/en-us/web/api/idbdatabase/close_event/index.md
@@ -87,6 +87,10 @@ dBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbdatabase/versionchange_event/index.md
+++ b/files/en-us/web/api/idbdatabase/versionchange_event/index.md
@@ -84,6 +84,10 @@ dBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbopendbrequest/blocked_event/index.md
+++ b/files/en-us/web/api/idbopendbrequest/blocked_event/index.md
@@ -113,6 +113,10 @@ DBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbopendbrequest/upgradeneeded_event/index.md
+++ b/files/en-us/web/api/idbopendbrequest/upgradeneeded_event/index.md
@@ -87,6 +87,10 @@ dBOpenRequest.onupgradeneeded = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbrequest/error_event/index.md
+++ b/files/en-us/web/api/idbrequest/error_event/index.md
@@ -124,6 +124,10 @@ DBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbrequest/success_event/index.md
+++ b/files/en-us/web/api/idbrequest/success_event/index.md
@@ -90,6 +90,10 @@ openRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbtransaction/abort_event/index.md
+++ b/files/en-us/web/api/idbtransaction/abort_event/index.md
@@ -125,6 +125,10 @@ DBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbtransaction/complete_event/index.md
+++ b/files/en-us/web/api/idbtransaction/complete_event/index.md
@@ -87,6 +87,10 @@ DBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/idbtransaction/error_event/index.md
+++ b/files/en-us/web/api/idbtransaction/error_event/index.md
@@ -126,6 +126,10 @@ dBOpenRequest.onsuccess = (event) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/mediasource/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/mediasource/index.md
@@ -46,6 +46,10 @@ if ("MediaSource" in window && MediaSource.isTypeSupported(mimeCodec)) {
 // …
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -61,6 +61,10 @@ For tracks containing video sources from the user's screen contents, the followi
 - {{domxref("MediaTrackSupportedConstraints.logicalSurface", "logicalSurface")}}
   - : A Boolean value which is `true` if the {{domxref("MediaTrackConstraints.logicalSurface", "logicalSurface")}} constraint is supported in the current environment.
 
+## Specifications
+
+{{Specifications}}
+
 ## See also
 
 - [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API)

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.md
@@ -142,9 +142,7 @@ simulateClick();
 
 ## Specifications
 
-This feature is not part of any specification. It is no longer on track to becoming a standard.
-
-Use the {{domxref("MouseEvent.MouseEvent", "MouseEvent()")}} constructor instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/navigator/getusermedia/index.md
+++ b/files/en-us/web/api/navigator/getusermedia/index.md
@@ -95,10 +95,11 @@ if (navigator.getUserMedia) {
 }
 ```
 
-## Browser compatibility
+## Specifications
 
-> [!WARNING]
-> New code should use {{domxref("MediaDevices.getUserMedia")}} instead.
+{{Specifications}}
+
+## Browser compatibility
 
 {{Compat}}
 

--- a/files/en-us/web/api/performance/navigation/index.md
+++ b/files/en-us/web/api/performance/navigation/index.md
@@ -28,8 +28,7 @@ A {{domxref("PerformanceNavigation")}} object.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performance/timing/index.md
+++ b/files/en-us/web/api/performance/timing/index.md
@@ -27,8 +27,7 @@ A {{domxref("PerformanceTiming")}} object.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -46,8 +46,7 @@ _The `Performance` interface doesn't inherit any methods._
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.md
@@ -25,8 +25,7 @@ An `unsigned short`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancenavigation/type/index.md
+++ b/files/en-us/web/api/performancenavigation/type/index.md
@@ -68,8 +68,7 @@ Possible values are:
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/connectend/index.md
+++ b/files/en-us/web/api/performancetiming/connectend/index.md
@@ -30,8 +30,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/connectstart/index.md
+++ b/files/en-us/web/api/performancetiming/connectstart/index.md
@@ -29,8 +29,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.md
@@ -28,8 +28,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
@@ -26,8 +26,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.md
@@ -33,8 +33,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/domloading/index.md
+++ b/files/en-us/web/api/performancetiming/domloading/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.md
@@ -26,8 +26,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -76,8 +76,7 @@ _The `PerformanceTiming`_ _interface doesn't inherit any methods._
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.md
@@ -26,8 +26,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/navigationstart/index.md
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/redirectend/index.md
+++ b/files/en-us/web/api/performancetiming/redirectend/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/requeststart/index.md
+++ b/files/en-us/web/api/performancetiming/requeststart/index.md
@@ -28,8 +28,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/responseend/index.md
+++ b/files/en-us/web/api/performancetiming/responseend/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/responsestart/index.md
+++ b/files/en-us/web/api/performancetiming/responsestart/index.md
@@ -26,8 +26,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.md
@@ -25,8 +25,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.md
@@ -27,8 +27,7 @@ An `unsigned long long`.
 
 ## Specifications
 
-This feature is no longer on track to become a standard, as the [Navigation Timing specification](https://w3c.github.io/navigation-timing/#obsolete) has marked it as deprecated.
-Use the {{domxref("PerformanceNavigationTiming")}} interface instead.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/presentationavailability/value/index.md
+++ b/files/en-us/web/api/presentationavailability/value/index.md
@@ -14,6 +14,10 @@ The **`value`** attribute _MUST_ return the last value from which it was set. Th
 
 The `onchange` attribute is an [event handler](https://www.w3.org/TR/presentation-api/#dfn-event-handler) whose corresponding [event handler event type](https://www.w3.org/TR/presentation-api/#dfn-event-handler-event-type) is `change`.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/binarytype/index.md
+++ b/files/en-us/web/api/presentationconnection/binarytype/index.md
@@ -15,6 +15,10 @@ When a {{DOMxRef("PresentationConnection")}} object is created, its `binaryType`
 > [!NOTE]
 > The `binaryType` attribute allows authors to control how binary data is exposed to scripts. By setting the attribute to `"blob"`, binary data is returned in `Blob` form; by setting it to `"arraybuffer"`, it is returned in {{JSxRef("ArrayBuffer")}} form. The attribute defaults to `"arraybuffer"`. This attribute has no effect on data sent in a string form.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/close/index.md
+++ b/files/en-us/web/api/presentationconnection/close/index.md
@@ -26,6 +26,10 @@ None.
 
 None ({{jsxref("undefined")}}).
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/id/index.md
+++ b/files/en-us/web/api/presentationconnection/id/index.md
@@ -12,6 +12,10 @@ browser-compat: api.PresentationConnection.id
 
 The **`id`** attribute specifies the [presentation identifier](https://www.w3.org/TR/presentation-api/#dfn-presentation-identifier) of a [presentation connection](https://www.w3.org/TR/presentation-api/#dfn-presentation-connection).
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/state/index.md
+++ b/files/en-us/web/api/presentationconnection/state/index.md
@@ -17,6 +17,10 @@ The **`state`** attribute reflects the [presentation connection](https://www.w3.
 - **`closed`**: The [presentation connection](https://www.w3.org/TR/presentation-api/#dfn-presentation-connection) has been closed or could not be opened. The connection may be reopened by calling [`reconnect()`](https://www.w3.org/TR/presentation-api/#dom-presentationrequest-reconnect). No communication is possible in this state.
 - **`terminated`**: The [receiving browsing context](https://www.w3.org/TR/presentation-api/#dfn-receiving-browsing-context) has terminated. Any [presentation connection](https://www.w3.org/TR/presentation-api/#dfn-presentation-connection) to that [presentation](https://www.w3.org/TR/presentation-api/#dfn-presentation) has also terminated and cannot be reopened. No communication is possible.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/terminate/index.md
+++ b/files/en-us/web/api/presentationconnection/terminate/index.md
@@ -26,6 +26,10 @@ None.
 
 None ({{jsxref("undefined")}}).
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnectionavailableevent/connection/index.md
+++ b/files/en-us/web/api/presentationconnectionavailableevent/connection/index.md
@@ -14,6 +14,10 @@ When an incoming connection is created, a [receiving user agent](https://www.w3.
 
 The event is fired for all connections that are created when [monitoring incoming presentation connections](https://www.w3.org/TR/presentation-api/#dfn-monitoring-incoming-presentation-connections).
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationrequest/getavailability/index.md
+++ b/files/en-us/web/api/presentationrequest/getavailability/index.md
@@ -54,6 +54,10 @@ When the `getAvailability()` method is called, the user agent _MUST_ run the fol
 9. Run the algorithm to [monitor the list of available presentation displays](https://www.w3.org/TR/presentation-api/#dfn-monitor-the-list-of-available-presentation-displays).
 10. [Resolve](https://www.w3.org/TR/presentation-api/#dfn-resolving-a-promise) _P_ with _A_.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationrequest/reconnect/index.md
+++ b/files/en-us/web/api/presentationrequest/reconnect/index.md
@@ -53,6 +53,10 @@ _P_, a [Promise](https://www.w3.org/TR/presentation-api/#dfn-promise).
 
 10. [Reject](https://www.w3.org/TR/presentation-api/#dfn-rejecting-a-promise) _P_ with a [`NotFoundError`](https://www.w3.org/TR/presentation-api/#dfn-notfounderror) exception.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -2,7 +2,6 @@
 title: RequestInit
 slug: Web/API/RequestInit
 page-type: web-api-interface
-browser-compat: api.RequestInit
 spec-urls: https://fetch.spec.whatwg.org/#requestinit
 ---
 

--- a/files/en-us/web/api/rtcdatachannel/open_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/open_event/index.md
@@ -67,6 +67,10 @@ dc.onopen = (ev) => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/scriptprocessornode/buffersize/index.md
+++ b/files/en-us/web/api/scriptprocessornode/buffersize/index.md
@@ -25,9 +25,7 @@ See [`BaseAudioContext.createScriptProcessor()`](/en-US/docs/Web/API/BaseAudioCo
 
 ## Specifications
 
-Since the August 29, 2014 [Web Audio API specification](https://www.w3.org/TR/webaudio/#ScriptProcessorNode) publication, this feature has been deprecated. It is no longer on track to become a standard.
-
-It was replaced by [AudioWorklets](/en-US/docs/Web/API/AudioWorklet) and the {{domxref("AudioWorkletNode")}} interface.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/selection/modify/index.md
+++ b/files/en-us/web/api/selection/modify/index.md
@@ -108,7 +108,7 @@ function modify() {
 
 ## Specifications
 
-_This method is not part of any specification._
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/sourcebuffer/changetype/index.md
+++ b/files/en-us/web/api/sourcebuffer/changetype/index.md
@@ -55,6 +55,10 @@ If the {{domxref("MediaSource.readyState", "readyState")}} property of the paren
 will set the `readyState` property to `"open"` and
 fire a simple event named {{domxref("MediaSource.sourceopen_event", "sourceopen")}} at the parent media source.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedangle/index.md
+++ b/files/en-us/web/api/svganimatedangle/index.md
@@ -85,6 +85,10 @@ The `SVGAnimatedAngle` interface is used for attributes of basic type [\<angle>]
 
 The `SVGAnimatedAngle` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedboolean/index.md
+++ b/files/en-us/web/api/svganimatedboolean/index.md
@@ -79,6 +79,10 @@ The `SVGAnimatedBoolean` interface is used for attributes of type boolean which 
 
 The `SVGAnimatedBoolean` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedinteger/index.md
+++ b/files/en-us/web/api/svganimatedinteger/index.md
@@ -79,6 +79,10 @@ The `SVGAnimatedInteger` interface is used for attributes of basic type [\<integ
 
 The `SVGAnimatedInteger` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedlengthlist/index.md
+++ b/files/en-us/web/api/svganimatedlengthlist/index.md
@@ -88,6 +88,10 @@ The `SVGAnimatedLengthList` interface is used for attributes of type {{ domxref(
 
 The `SVGAnimatedLengthList` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatednumber/index.md
+++ b/files/en-us/web/api/svganimatednumber/index.md
@@ -79,6 +79,10 @@ The `SVGAnimatedNumber` interface is used for attributes of basic type [\<Number
 
 The `SVGAnimatedNumber` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatednumberlist/index.md
+++ b/files/en-us/web/api/svganimatednumberlist/index.md
@@ -61,6 +61,10 @@ The `SVGAnimatedNumber` interface is used for attributes which take a list of nu
 
 The `SVGAnimatedNumberList` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedpreserveaspectratio/index.md
+++ b/files/en-us/web/api/svganimatedpreserveaspectratio/index.md
@@ -55,6 +55,10 @@ The `SVGAnimatedPreserveAspectRatio` interface is used for attributes of type {{
 
 The `SVGAnimatedPreserveAspectRatio` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedrect/index.md
+++ b/files/en-us/web/api/svganimatedrect/index.md
@@ -83,6 +83,10 @@ The `SVGAnimatedRect` interface is used for attributes of basic {{ domxref("SVGR
 
 _The `SVGAnimatedRect` interface do not provide any specific methods._
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svganimatedtransformlist/index.md
+++ b/files/en-us/web/api/svganimatedtransformlist/index.md
@@ -88,6 +88,10 @@ The `SVGAnimatedTransformList` interface is used for attributes which take a lis
 
 The `SVGAnimatedTransformList` interface doesn't provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svglength/index.md
+++ b/files/en-us/web/api/svglength/index.md
@@ -356,6 +356,10 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
   </tbody>
 </table>
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svglengthlist/index.md
+++ b/files/en-us/web/api/svglengthlist/index.md
@@ -298,6 +298,10 @@ An `SVGLengthList` is indexable and can be accessed like an array.
   </tbody>
 </table>
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svgnumberlist/index.md
+++ b/files/en-us/web/api/svgnumberlist/index.md
@@ -308,6 +308,10 @@ An `SVGNumberList` is indexable and can be accessed like an array.
   </tbody>
 </table>
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svgpoint/index.md
+++ b/files/en-us/web/api/svgpoint/index.md
@@ -36,6 +36,10 @@ s.y = 10;
 s.x = 10;
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svgpreserveaspectratio/index.md
+++ b/files/en-us/web/api/svgpreserveaspectratio/index.md
@@ -255,6 +255,10 @@ An `SVGPreserveAspectRatio` object can be designated as read only, which means t
 
 The `SVGPreserveAspectRatio` interface do not provide any specific methods.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svgstringlist/index.md
+++ b/files/en-us/web/api/svgstringlist/index.md
@@ -297,6 +297,10 @@ An `SVGStringList` object can be designated as read only, which means that attem
   </tbody>
 </table>
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/svgtransform/index.md
+++ b/files/en-us/web/api/svgtransform/index.md
@@ -363,6 +363,10 @@ An `SVGTransform` object can be designated as read only, which means that attemp
   </tbody>
 </table>
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
@@ -70,6 +70,10 @@ const sampler = gl.createSampler();
 gl.samplerParameteri(sampler, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/webglobject/index.md
+++ b/files/en-us/web/api/webglobject/index.md
@@ -34,6 +34,14 @@ WebGL 2:
 - {{domxref("WebGLTransformFeedback")}}
 - {{domxref("WebGLVertexArrayObject")}} (and `WebGLVertexArrayObjectOES`)
 
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
 ## See also
 
 - [`WebGLRenderingContext.isContextLost()`](/en-US/docs/Web/API/WebGLRenderingContext/isContextLost)

--- a/files/en-us/web/api/window/appinstalled_event/index.md
+++ b/files/en-us/web/api/window/appinstalled_event/index.md
@@ -44,6 +44,10 @@ window.onappinstalled = () => {
 };
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/window/beforeinstallprompt_event/index.md
+++ b/files/en-us/web/api/window/beforeinstallprompt_event/index.md
@@ -93,6 +93,10 @@ installButton.addEventListener("click", async () => {
 });
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/window/releaseevents/index.md
+++ b/files/en-us/web/api/window/releaseevents/index.md
@@ -52,7 +52,7 @@ See also [`window.captureEvents`](/en-US/docs/Web/API/Window/captureEvents)
 
 ## Specifications
 
-This is not part of any specification.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -31,6 +31,10 @@ None ({{jsxref("undefined")}}).
 const result = location.toString(); // Returns 'https://developer.mozilla.org/en-US/docs/Web'
 ```
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/html/element/dir/index.md
+++ b/files/en-us/web/html/element/dir/index.md
@@ -29,7 +29,7 @@ Like all other HTML elements, this element supports the [global attributes](/en-
 
 ## Specifications
 
-Not part of any current specifications.
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/svg/attribute/class/index.md
+++ b/files/en-us/web/svg/attribute/class/index.md
@@ -135,6 +135,10 @@ The following elements can use the `class` attribute:
 - {{ SVGElement("tspan") }}
 - {{ SVGElement("use") }}
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/svg/attribute/clip-rule/index.md
+++ b/files/en-us/web/svg/attribute/clip-rule/index.md
@@ -94,6 +94,10 @@ The following elements can use the `clip-rule` attribute, but only if they are i
 
 - [Graphics elements](/en-US/docs/Web/SVG/Element#graphics_elements)
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/svg/attribute/cursor/index.md
+++ b/files/en-us/web/svg/attribute/cursor/index.md
@@ -54,6 +54,10 @@ The following elements can use the `cursor` attribute
 - [Container elements](/en-US/docs/Web/SVG/Element#container_elements)
 - [Graphics elements](/en-US/docs/Web/SVG/Element#graphics_elements)
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/uri/authority/index.md
+++ b/files/en-us/web/uri/authority/index.md
@@ -40,6 +40,10 @@ user@host:port
 - `https://cnn.example.com&story=breaking_news@10.0.0.1`
   - : A misleading URL that looks like it's pointing to a trusted website. However, the host name is `10.0.0.1`, and the `cnn.example.com&story=breaking_news` part is the "user".
 
+## Specifications
+
+{{Specifications}}
+
 ## See also
 
 - [URIs](/en-US/docs/Web/URI)

--- a/files/en-us/web/uri/fragment/index.md
+++ b/files/en-us/web/uri/fragment/index.md
@@ -32,6 +32,10 @@ The **fragment** of a URI is the last part of the URI, starting with the `#` cha
 - `#t=10,20`
   - : The video or audio will start playing from the 10th second.
 
+## Specifications
+
+{{Specifications}}
+
 ## See also
 
 - [URIs](/en-US/docs/Web/URI)

--- a/files/en-us/web/uri/schemes/index.md
+++ b/files/en-us/web/uri/schemes/index.md
@@ -44,6 +44,10 @@ protocol:
     - `ws` / `wss`
       - : [WebSocket connections (Secure)](/en-US/docs/Web/API/WebSockets_API)
 
+## Specifications
+
+{{Specifications}}
+
 ## See also
 
 - [URIs](/en-US/docs/Web/URI)


### PR DESCRIPTION
The live specifications are here: https://w3c.github.io/selection-api/#dom-selection-modify

I am not sure if my change works or not though. I could not find documentation for the `{{Specifications}}` tag. I noticed that other documentation pages (like the one for `Selection.toString()`) uses them and it works fine, so I just copied from there. Please let me know if there's another way to achieve this correctly. Thanks!