### PR TITLE
fix: a bit difference with description for BOM character in ecma262 

### DIFF
--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -18,7 +18,7 @@ Format-control characters have no visual representation but are used to control 
 | ---------- | --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | U+200C     | Zero width non-joiner | \<ZWNJ>      | Placed between characters to prevent being connected into ligatures in certain languages ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_non-joiner)).                                                                   |
 | U+200D     | Zero width joiner     | \<ZWJ>       | Placed between characters that would not normally be connected in order to cause the characters to be rendered using their connected form in certain languages ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_joiner)). |
-| U+FEFF     | Byte order mark       | \<BOM>       | Used at the start of the script to mark it as Unicode and to allow detection of the text's encoding and byte order ([Wikipedia](https://en.wikipedia.org/wiki/Byte_order_mark)).                                                                                  |
+| U+FEFF     | Byte order mark       | \<BOM>       | Used at the start of the script to mark it as Unicode and to allow detection of the text's encoding and byte order ([Wikipedia](https://en.wikipedia.org/wiki/Byte_order_mark)).                                               |
 
 In JavaScript source text, \<ZWNJ> and \<ZWJ> are treated as [identifier](#identifiers) parts, while \<BOM> (also called a zero-width no-break space \<ZWNBSP> when not at the start of text) is treated as [white space](#white_space).
 

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -18,7 +18,7 @@ Format-control characters have no visual representation but are used to control 
 | ---------- | --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | U+200C     | Zero width non-joiner | \<ZWNJ>      | Placed between characters to prevent being connected into ligatures in certain languages ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_non-joiner)).                                                                   |
 | U+200D     | Zero width joiner     | \<ZWJ>       | Placed between characters that would not normally be connected in order to cause the characters to be rendered using their connected form in certain languages ([Wikipedia](https://en.wikipedia.org/wiki/Zero-width_joiner)). |
-| U+FEFF     | Byte order mark       | \<BOM>       | Used at the start of the script to mark it as Unicode and the text's byte order ([Wikipedia](https://en.wikipedia.org/wiki/Byte_order_mark)).                                                                                  |
+| U+FEFF     | Byte order mark       | \<BOM>       | Used at the start of the script to mark it as Unicode and to allow detection of the text's encoding and byte order ([Wikipedia](https://en.wikipedia.org/wiki/Byte_order_mark)).                                                                                  |
 
 In JavaScript source text, \<ZWNJ> and \<ZWJ> are treated as [identifier](#identifiers) parts, while \<BOM> (also called a zero-width no-break space \<ZWNBSP> when not at the start of text) is treated as [white space](#white_space).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

After I compared two descriptions for `<BOM>` character, one is from MDN while another ecma262, there has a bit difference between those two. MDN lacks of part of description "detection text's encoding`.

This pr would like to fill it~

![image](https://github.com/user-attachments/assets/26f6bff4-54dd-41db-86e3-407a9ce5d9c1)


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This change may help readers know a bit concretely about `<BOM>` in `lexical grammar` page.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-unicode-format-control-characters

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
