### PR TITLE
Change Notification().silent default

### DIFF
--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -89,7 +89,7 @@ new Notification(title, options)
     - `silent` {{optional_inline}}
       - : A boolean value specifying whether the
         notification is silent (no sounds or vibrations issued), regardless of the device
-        settings. The default is `null`. If `true`, then `vibrate` must not be present.
+        settings. The default, `null`, means to respect device defaults. If `true`, then `vibrate` must not be present.
 
 ### Return value
 

--- a/files/en-us/web/api/notification/silent/index.md
+++ b/files/en-us/web/api/notification/silent/index.md
@@ -16,8 +16,7 @@ settings. This is specified in the `silent` option of the
 
 ## Value
 
-A boolean value. `false` is the default; `true` makes
-the notification silent.
+A boolean value or `null`. If `true`, the notification is silent; if `null`, the device's default settings are respected.
 
 ## Examples
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/26812. The constructor option was already changed in #31706, so this PR only fixes the `silent` page. It's a new change so I've also filed https://github.com/mdn/browser-compat-data/issues/24276 to get it documented.