### PR TITLE
Remove browser-compat for pages not actually using it

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -2,7 +2,6 @@
 title: API constructor subpage template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_constructor_subpage_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheConstructor
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -2,7 +2,6 @@
 title: API event subpage template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_event_subpage_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheEvent_event
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -2,7 +2,6 @@
 title: API method subpage template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_method_subpage_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheMethod
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -2,7 +2,6 @@
 title: API property subpage template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_property_subpage_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheProperty
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -2,7 +2,6 @@
 title: API reference page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/API_reference_page_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheInterface
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -2,7 +2,6 @@
 title: CSS function page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/CSS_function_page_template
 page-type: mdn-writing-guide
-browser-compat: css.functions.NameOfTheFunction
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -2,7 +2,6 @@
 title: CSS property page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template
 page-type: mdn-writing-guide
-browser-compat: css.properties.NameOfTheProperty
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -2,7 +2,6 @@
 title: CSS selector page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/CSS_selector_page_template
 page-type: mdn-writing-guide
-browser-compat: css.selectors.NameOfTheSelector
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -2,7 +2,6 @@
 title: HTML element page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/HTML_element_page_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheElement
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -2,7 +2,6 @@
 title: HTTP header page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/HTTP_header_page_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheHeader
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -2,7 +2,6 @@
 title: SVG element page template
 slug: MDN/Writing_guidelines/Page_structures/Page_types/SVG_element_page_template
 page-type: mdn-writing-guide
-browser-compat: path.to.feature.NameOfTheElement
 ---
 
 {{MDNSidebar}}

--- a/files/en-us/web/api/storage_access_api/related_website_sets/index.md
+++ b/files/en-us/web/api/storage_access_api/related_website_sets/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Storage_Access_API/Related_website_sets
 page-type: guide
 status:
   - non-standard
-browser-compat: api.document.requestStorageAccessFor
 spec-urls: https://wicg.github.io/first-party-sets/
 ---
 

--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -2,7 +2,6 @@
 title: "@color-profile"
 slug: Web/CSS/@color-profile
 page-type: css-at-rule
-browser-compat: css.at-rules.color-profile
 spec-urls: https://www.w3.org/TR/css-color-5/#at-profile
 ---
 

--- a/files/en-us/web/css/@font-feature-values/font-display/index.md
+++ b/files/en-us/web/css/@font-feature-values/font-display/index.md
@@ -2,7 +2,6 @@
 title: font-display
 slug: Web/CSS/@font-feature-values/font-display
 page-type: css-at-rule-descriptor
-browser-compat: css.at-rules.font-feature-values.font-display
 spec-urls: https://drafts.csswg.org/css-fonts/#descdef-font-feature-values-font-display
 ---
 

--- a/files/en-us/web/css/_colon_-moz-drag-over/index.md
+++ b/files/en-us/web/css/_colon_-moz-drag-over/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:-moz-drag-over
 page-type: css-pseudo-class
 status:
   - non-standard
-browser-compat: css.selectors.-moz-drag-over
 ---
 
 {{CSSRef}}{{Non-standard_header}}

--- a/files/en-us/web/css/_colon_current/index.md
+++ b/files/en-us/web/css/_colon_current/index.md
@@ -2,7 +2,6 @@
 title: ":current"
 slug: Web/CSS/:current
 page-type: css-pseudo-class
-browser-compat: css.selectors.current
 spec-urls: https://drafts.csswg.org/selectors/#the-current-pseudo
 ---
 

--- a/files/en-us/web/css/color_value/device-cmyk/index.md
+++ b/files/en-us/web/css/color_value/device-cmyk/index.md
@@ -2,7 +2,6 @@
 title: device-cmyk()
 slug: Web/CSS/color_value/device-cmyk
 page-type: css-function
-browser-compat: css.types.color.device-cmyk
 spec-urls: https://drafts.csswg.org/css-color-5/#device-cmyk
 ---
 

--- a/files/en-us/web/css/css_scrollbars_styling/index.md
+++ b/files/en-us/web/css/css_scrollbars_styling/index.md
@@ -2,9 +2,6 @@
 title: CSS scrollbars styling
 slug: Web/CSS/CSS_scrollbars_styling
 page-type: css-module
-browser-compat:
-  - css.properties.scrollbar-color
-  - css.properties.scrollbar-width
 spec-urls: https://drafts.csswg.org/css-scrollbars/
 ---
 

--- a/files/en-us/web/http/headers/alt-used/index.md
+++ b/files/en-us/web/http/headers/alt-used/index.md
@@ -2,7 +2,7 @@
 title: Alt-Used
 slug: Web/HTTP/Headers/Alt-Used
 page-type: http-header
-browser-compat: http.headers.Alt-Used
+spec-urls: https://datatracker.ietf.org/doc/html/rfc7838
 ---
 
 {{HTTPSidebar}}
@@ -32,13 +32,9 @@ Alt-Used: <host>:<port>
 Alt-Used: alternate.example.net
 ```
 
-<!-- ## Specifications
+## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}} -->
 
 ## See also
 

--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -2,7 +2,7 @@
 title: Forwarded
 slug: Web/HTTP/Headers/Forwarded
 page-type: http-header
-browser-compat: http.headers.Forwarded
+spec-urls: https://datatracker.ietf.org/doc/html/rfc7239
 ---
 
 {{HTTPSidebar}}

--- a/files/en-us/web/http/status/425/index.md
+++ b/files/en-us/web/http/status/425/index.md
@@ -23,6 +23,10 @@ See {{HTTPHeader("Early-Data")}} for more information.
 
 {{Specifications}}
 
+## Browser compatibility
+
+{{Compat}}
+
 ## See also
 
 - [HTTP response status codes](/en-US/docs/Web/HTTP/Status)


### PR DESCRIPTION
Most of these BCD keys don't even exist, and should be removed. In the future when BCD data gets added they will be automatically re-populated via MDN-graph.