### PR TITLE
fragmentDirective - live examples

### DIFF
--- a/files/en-us/web/api/document/fragmentdirective/index.md
+++ b/files/en-us/web/api/document/fragmentdirective/index.md
@@ -18,15 +18,38 @@ A {{domxref("FragmentDirective")}} object.
 
 ## Examples
 
-Try running the following in a supporting browser's devtools, in a tab with one or more matched text fragments:
+### Checking if text fragments are supported
 
-```js
-document.fragmentDirective;
-// returns an empty FragmentDirective object, if supported
-// undefined otherwise
+The code below logs whether or not text fragments are supported by checking for existence of the object.
+Note that the object is empty, and at present it is mainly intended for feature detection.
+In the future, it might include other information.
+
+```html hidden
+<pre id="log"></pre>
 ```
 
-This functionality is mainly intended for feature detection at present. In the future, the `FragmentDirective` object could include additional information.
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = text;
+}
+```
+
+```css hidden
+#log {
+  height: 20px;
+}
+```
+
+```js
+if (document.fragmentDirective) {
+  log("Text fragments are supported");
+} else {
+  log("Text fragments are not supported");
+}
+```
+
+{{EmbedLiveSample("Checking if text fragments are supported","100%","30px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/fragmentdirective/index.md
+++ b/files/en-us/web/api/document/fragmentdirective/index.md
@@ -20,7 +20,7 @@ A {{domxref("FragmentDirective")}} object.
 
 ### Checking if text fragments are supported
 
-The code below logs whether or not text fragments are supported by checking for existence of the object.
+The code below logs whether or not text fragments are supported in your browser by checking for existence of the object.
 Note that the object is empty, and at present it is mainly intended for feature detection.
 In the future, it might include other information.
 
@@ -43,9 +43,9 @@ function log(text) {
 
 ```js
 if (document.fragmentDirective) {
-  log("Text fragments are supported");
+  log("Your browser supports text fragments.");
 } else {
-  log("Text fragments are not supported");
+  log("Text fragments are not supported in your browser.");
 }
 ```
 

--- a/files/en-us/web/api/fragmentdirective/index.md
+++ b/files/en-us/web/api/fragmentdirective/index.md
@@ -9,7 +9,7 @@ browser-compat: api.FragmentDirective
 
 {{APIRef("URL Fragment Text Directives")}}{{SeeCompatTable}}
 
-The **`FragmentDirective`** interface is an object exposed for feature detectability, that is, whether or not a browser supports text fragments.
+The **`FragmentDirective`** interface is an object exposed to allow code to check whether or not a browser supports text fragments.
 
 It is accessed via the {{domxref("Document.fragmentDirective")}} property.
 
@@ -23,15 +23,38 @@ None.
 
 ## Examples
 
-Try running the following in a supporting browser's devtools, in a tab with one or more matched text fragments:
+### Checking if text fragments are supported
 
-```js
-document.fragmentDirective;
-// returns an empty FragmentDirective object, if supported
-// undefined otherwise
+The code below logs whether or not text fragments are supported by checking that {{domxref("Document.fragmentDirective")}} is defined.
+Note that the object is empty, and at present is mainly intended for feature detection.
+In the future, it might include other information.
+
+```html hidden
+<pre id="log"></pre>
 ```
 
-This functionality is mainly intended for feature detection at present. In the future, the `FragmentDirective` object could include additional information.
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = text;
+}
+```
+
+```css hidden
+#log {
+  height: 20px;
+}
+```
+
+```js
+if (document.fragmentDirective) {
+  log("Text fragments are supported");
+} else {
+  log("Text fragments are not supported");
+}
+```
+
+{{EmbedLiveSample("Checking if text fragments are supported","100%","30px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/fragmentdirective/index.md
+++ b/files/en-us/web/api/fragmentdirective/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Checking if text fragments are supported
 
-The code below logs whether or not text fragments are supported by checking that {{domxref("Document.fragmentDirective")}} is defined.
+The code below logs whether or not text fragments are supported in your browser by checking that {{domxref("Document.fragmentDirective")}} is defined.
 Note that the object is empty, and at present is mainly intended for feature detection.
 In the future, it might include other information.
 
@@ -48,9 +48,9 @@ function log(text) {
 
 ```js
 if (document.fragmentDirective) {
-  log("Text fragments are supported");
+  log("Your browser supports text fragments.");
 } else {
-  log("Text fragments are not supported");
+  log("Text fragments are not supported in your browser.");
 }
 ```
 


### PR DESCRIPTION
FF131 adds support for text fragments in  https://bugzilla.mozilla.org/show_bug.cgi?id=1914877

This just adds a live example logging whether the feature is supported by checking for existence of the `Document.fragmentDirective`. Not strictly necessary, but since this is the main use of the interface, and we can check the object, it is kind of useful to do so.

I would also have added in page-examples for text fragment highlighting and the use of the CSS, but that is more challenging with live examples :-0

Related docs tracked in #35703