### PR TITLE
FF131 Relnote - Text fragments supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/131/index.md
+++ b/files/en-us/mozilla/firefox/releases/131/index.md
@@ -38,6 +38,9 @@ This article provides information about the changes in Firefox 131 that affect d
 
 ### APIs
 
+- [Text fragments](/en-US/docs/Web/URI/Fragment/Text_fragments) are now supported, allowing users to link to and highlight specific portions of text in a web page. This feature uses a particular syntax in the [URL fragment](/en-US/docs/Web/URI/Fragment) that identifies the target based on patterns in the rendered text.
+  Website developers can also use the existence of the {{domxref("Document.fragmentDirective")}} property (an instance of the {{domxref("FragmentDirective")}} interface) to feature check for text fragment support, and the {{CSSxRef("::target-text")}} pseudo element to select and style text that has been selected using a text fragment link. ([Firefox bug 1914877](https://bugzil.la/1914877))
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF131 supports text fragment links in https://bugzilla.mozilla.org/show_bug.cgi?id=1914877 , along with the associated developer API. This adds a release note.

Related docs work can be tracked in #35703