### PR TITLE
Fix typo/meaning (eTLD -> eTLD+1)

### DIFF
--- a/files/en-us/glossary/etld/index.md
+++ b/files/en-us/glossary/etld/index.md
@@ -22,7 +22,7 @@ However, this does not work as a general rule, because many registrars allow org
 
 Because this is a matter of the registrar's policies, it's impossible to tell algorithmically whether a given domain name suffix (like `ac.uk`) is publicly registrable or not. The [Public Suffix List](https://publicsuffix.org/) is a list of all suffixes under which organizations can directly register names: that is, it is a list of eTLDs.
 
-The related concept **eTLD+1** means an eTLD plus the next part of the domain name. Because eTLDs are registrable, all domains with the same eTLD+1 are owned by the same organization.
+The related concept **eTLD+1** means an eTLD plus the next part of the domain name. Because eTLD+1s are registrable, all domains with the same eTLD+1 are owned by the same organization.
 
 For example, all the following are eTLD+1 domains:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Corrected which domains are registrable.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

As described in the first sentence on the same page, eTLDs are not registrable but domains under it are.

> The term eTLD stands for "effective top-level domain" and is a domain under which domains can be registered by a single organization.

<!-- ❓ Why are you making these changes and how do they help readers? -->
