### PR TITLE
Remove unused `previousTimeStamp` variable in first `requestAnimationFrame()` example

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -66,11 +66,11 @@ milliseconds) with `0.1 * elapsed`. The element's final position is 200px
 const element = document.getElementById("some-element-you-want-to-animate");
 let start;
 
-function step(timeStamp) {
+function step(timestamp) {
   if (start === undefined) {
-    start = timeStamp;
+    start = timestamp;
   }
-  const elapsed = timeStamp - start;
+  const elapsed = timestamp - start;
 
   // Math.min() is used here to make sure the element stops at exactly 200px
   const shift = Math.min(0.1 * elapsed, 200);
@@ -99,12 +99,12 @@ and the first call to the callback function.
 ```js
 let zero;
 requestAnimationFrame(firstFrame);
-function firstFrame(timeStamp) {
-  zero = timeStamp;
-  animate(timeStamp);
+function firstFrame(timestamp) {
+  zero = timestamp;
+  animate(timestamp);
 }
-function animate(timeStamp) {
-  const value = (timeStamp - zero) / duration;
+function animate(timestamp) {
+  const value = (timestamp - zero) / duration;
   if (value < 1) {
     element.style.opacity = value;
     requestAnimationFrame((t) => animate(t));
@@ -114,14 +114,14 @@ function animate(timeStamp) {
 
 This example uses {{domxref("AnimationTimeline/currentTime", "document.timeline.currentTime")}} to set a zero value
 before the first call to `requestAnimationFrame`. `document.timeline.currentTime`
-aligns with the `timeStamp` argument, so the zero value is equivalent to the
+aligns with the `timestamp` argument, so the zero value is equivalent to the
 0th frame's timestamp.
 
 ```js
 const zero = document.timeline.currentTime;
 requestAnimationFrame(animate);
-function animate(timeStamp) {
-  const value = (timeStamp - zero) / duration; // animation-timing-function: linear
+function animate(timestamp) {
+  const value = (timestamp - zero) / duration; // animation-timing-function: linear
   if (value < 1) {
     element.style.opacity = value;
     requestAnimationFrame((t) => animate(t));

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -76,7 +76,6 @@ function step(timeStamp) {
   const shift = Math.min(0.1 * elapsed, 200);
   element.style.transform = `translateX(${shift}px)`;
   if (shift < 200) {
-    previousTimeStamp = timeStamp;
     requestAnimationFrame(step);
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR does two things:

1. It removes the statement containing the assignment to `previousTimeStamp` in the first `requestAnimationFrame()` example. The variable is unused besides the assignment.

2. It renames `timeStamp` variables to `timestamp` everywhere on the page, per convention and also the fact that "timestamp" is a single word and so shouldn't be camel-cased.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Removing the unused variable should make the example code easier to grok.

<!-- ❓ Why are you making these changes and how do they help readers? -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
