### PR TITLE
Correct reference of the document example

### DIFF
--- a/files/en-us/web/api/document_object_model/using_the_document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/using_the_document_object_model/index.md
@@ -38,7 +38,7 @@ The Document API, also sometimes called the DOM API, allows you to modify a DOM 
 
 ## Reading and modifying the tree
 
-Suppose the author wants to change the header of the above document and write two paragraphs instead of one. The following script would do the job:
+Suppose the author wants to change the header of the below document and write two paragraphs instead of one. The following script would do the job:
 
 ### HTML
 


### PR DESCRIPTION
Since we have additional document example below, the description needs to point out the one on the below instead the first one.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update pointing to the correct document for the section

### Motivation

For better reading experience when referencing examples on the page.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
