### PR TITLE
Improve SVGGeometryElement#{isPointInFill,isPointInStroke} examples

### DIFF
--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -8,9 +8,7 @@ browser-compat: api.SVGGeometryElement.isPointInFill
 
 {{APIRef("SVG")}}
 
-The **`SVGGeometryElement.isPointInFill()`** method determines whether a given point is within the
-fill shape of an element. The `point` argument is interpreted as a point in the local coordinate
-system of the element.
+The **`isPointInFill()`** method of the {{domxref("SVGGeometryElement")}} interface determines whether a given point is within the fill shape of an element. The `point` argument is interpreted as a point in the local coordinate system of the element.
 
 ## Syntax
 
@@ -21,8 +19,7 @@ isPointInFill(point)
 ### Parameters
 
 - `point`
-  - : A {{domxref("DOMPointInit")}} object interpreted as a point in the local coordinate system
-    of the element.
+  - : An object representing a point interpreted in the local coordinate system of the element. It is converted to a {{domxref("DOMPoint")}} object using the same algorithm as [`DOMPoint.fromPoint()`](/en-US/docs/Web/API/DOMPoint/fromPoint_static).
 
 ### Return value
 
@@ -69,7 +66,7 @@ for (const point of points) {
     const pointObj = { x: point[0], y: point[1] };
     isPointInFill = circle.isPointInFill(pointObj);
   } catch {
-    // Fallback for browsers that don't support DOMPointInit as an argument
+    // Fallback for browsers that don't support DOMPoint as an argument
     const pointObj = svg.createSVGPoint();
     pointObj.x = point[0];
     pointObj.y = point[1];
@@ -85,10 +82,7 @@ for (const point of points) {
   pointEl.cx.baseVal.value = point[0];
   pointEl.cy.baseVal.value = point[1];
   pointEl.r.baseVal.value = 5;
-  const pathEl = document.createElementNS(
-    "http://www.w3.org/2000/svg",
-    "path",
-  );
+  const pathEl = document.createElementNS("http://www.w3.org/2000/svg", "path");
   if (isPointInFill) {
     pointEl.setAttribute("fill", "rgb(0 170 0 / 50%)");
     pointEl.setAttribute("stroke", "rgb(0 170 0)");

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -8,11 +8,9 @@ browser-compat: api.SVGGeometryElement.isPointInFill
 
 {{APIRef("SVG")}}
 
-The **`SVGGeometryElement.isPointInFill()`** method determines
-whether a given point is within the fill shape of an element. Normal hit testing rules
-apply; the value of the {{cssxref("pointer-events")}} property on the element determines
-whether a point is considered to be within the fill. The `point` argument is
-interpreted as a point in the local coordinate system of the element.
+The **`SVGGeometryElement.isPointInFill()`** method determines whether a given point is within the
+fill shape of an element. The `point` argument is interpreted as a point in the local coordinate
+system of the element.
 
 ## Syntax
 
@@ -23,7 +21,7 @@ isPointInFill(point)
 ### Parameters
 
 - `point`
-  - : A DOMPointInit object interpreted as a point in the local coordinate system
+  - : A {{domxref("DOMPointInit")}} object interpreted as a point in the local coordinate system
     of the element.
 
 ### Return value
@@ -45,8 +43,8 @@ A boolean indicating whether the given point is within the fill or not.
     cx="50"
     cy="50"
     r="45"
-    fill="white"
-    stroke="black"
+    fill="rgb(0 0 0 / 25%)"
+    stroke="rgb(0 0 0 / 50%)"
     stroke-width="10" />
 </svg>
 ```
@@ -57,21 +55,21 @@ A boolean indicating whether the given point is within the fill or not.
 const svg = document.getElementsByTagName("svg")[0];
 const circle = document.getElementById("circle");
 const points = [
-  ["10", "10"],
-  ["40", "30"],
-  ["70", "40"],
-  ["15", "75"],
-  ["83", "83"],
+  [10, 10],
+  [40, 30],
+  [70, 40],
+  [15, 75],
+  [83, 83],
 ];
 
 for (const point of points) {
   let isPointInFill;
 
   try {
-    const pointObj = new DOMPoint(point[0], point[1]);
+    const pointObj = { x: point[0], y: point[1] };
     isPointInFill = circle.isPointInFill(pointObj);
-  } catch (e) {
-    // Fallback for browsers that don't support DOMPoint as an argument
+  } catch {
+    // Fallback for browsers that don't support DOMPointInit as an argument
     const pointObj = svg.createSVGPoint();
     pointObj.x = point[0];
     pointObj.y = point[1];
@@ -84,17 +82,31 @@ for (const point of points) {
     "http://www.w3.org/2000/svg",
     "circle",
   );
-  pointEl.style.cx = point[0];
-  pointEl.style.cy = point[1];
-  pointEl.style.r = 5;
-  pointEl.style.fill = isPointInFill ? "seagreen" : "rgb(255 0 0 / 50%)";
-  svg.appendChild(pointEl);
+  pointEl.cx.baseVal.value = point[0];
+  pointEl.cy.baseVal.value = point[1];
+  pointEl.r.baseVal.value = 5;
+  const pathEl = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "path",
+  );
+  if (isPointInFill) {
+    pointEl.setAttribute("fill", "rgb(0 170 0 / 50%)");
+    pointEl.setAttribute("stroke", "rgb(0 170 0)");
+    pathEl.setAttribute("stroke", "rgb(0 170 0)");
+    pathEl.setAttribute("d", `M ${point[0] - 5} ${point[1]} h 10 m -5 -5 v 10`);
+  } else {
+    pointEl.setAttribute("fill", "rgb(170 0 0 / 50%)");
+    pointEl.setAttribute("stroke", "rgb(170 0 0)");
+    pathEl.setAttribute("stroke", "rgb(170 0 0)");
+    pathEl.setAttribute("d", `M ${point[0] - 5} ${point[1]} h 10`);
+  }
+  svg.append(pointEl, pathEl);
 }
 ```
 
 ### Result
 
-{{EmbedLiveSample("Examples", "150", "155")}}
+{{EmbedLiveSample("Examples", "150", "150")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -8,12 +8,9 @@ browser-compat: api.SVGGeometryElement.isPointInStroke
 
 {{APIRef("SVG")}}
 
-The **`SVGGeometryElement.isPointInStroke()`** method
-determines whether a given point is within the stroke shape of an element. Normal hit
-testing rules apply; the value of the {{cssxref("pointer-events")}} property on the
-element determines whether a point is considered to be within the stroke. The
-`point` argument is interpreted as a point in the local coordinate system of
-the element.
+The **`SVGGeometryElement.isPointInStroke()`** method determines whether a given point is within the
+stroke shape of an element. The `point` argument is interpreted as a point in the local coordinate
+system of the element.
 
 ## Syntax
 
@@ -24,7 +21,7 @@ isPointInStroke(point)
 ### Parameters
 
 - `point`
-  - : An object interpreted as a point in the local coordinate system
+  - : A {{domxref("DOMPointInit")}} object interpreted as a point in the local coordinate system
     of the element.
 
 ### Return value
@@ -46,8 +43,8 @@ A boolean indicating whether the given point is within the stroke or not.
     cx="50"
     cy="50"
     r="45"
-    fill="white"
-    stroke="black"
+    fill="rgb(0 0 0 / 25%)"
+    stroke="rgb(0 0 0 / 50%)"
     stroke-width="10" />
 </svg>
 ```
@@ -58,21 +55,21 @@ A boolean indicating whether the given point is within the stroke or not.
 const svg = document.getElementsByTagName("svg")[0];
 const circle = document.getElementById("circle");
 const points = [
-  ["10", "10"],
-  ["40", "30"],
-  ["70", "40"],
-  ["15", "75"],
-  ["83", "83"],
+  [10, 10],
+  [40, 30],
+  [70, 40],
+  [15, 75],
+  [83, 83],
 ];
 
 for (const point of points) {
   let isPointInStroke;
 
   try {
-    const pointObj = new DOMPoint(point[0], point[1]);
-    isPointInFill = circle.isPointInStroke(pointObj);
-  } catch (e) {
-    // Fallback for browsers that don't support DOMPoint as an argument
+    const pointObj = { x: point[0], y: point[1] };
+    isPointInStroke = circle.isPointInStroke(pointObj);
+  } catch {
+    // Fallback for browsers that don't support DOMPointInit as an argument
     const pointObj = svg.createSVGPoint();
     pointObj.x = point[0];
     pointObj.y = point[1];
@@ -85,11 +82,25 @@ for (const point of points) {
     "http://www.w3.org/2000/svg",
     "circle",
   );
-  pointEl.style.cx = point[0];
-  pointEl.style.cy = point[1];
-  pointEl.style.r = 5;
-  pointEl.style.fill = isPointInStroke ? "seagreen" : "rgb(255 0 0 / 50%)";
-  svg.appendChild(pointEl);
+  pointEl.cx.baseVal.value = point[0];
+  pointEl.cy.baseVal.value = point[1];
+  pointEl.r.baseVal.value = 5;
+  const pathEl = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "path",
+  );
+  if (isPointInStroke) {
+    pointEl.setAttribute("fill", "rgb(0 170 0 / 50%)");
+    pointEl.setAttribute("stroke", "rgb(0 170 0)");
+    pathEl.setAttribute("stroke", "rgb(0 170 0)");
+    pathEl.setAttribute("d", `M ${point[0] - 5} ${point[1]} h 10 m -5 -5 v 10`);
+  } else {
+    pointEl.setAttribute("fill", "rgb(170 0 0 / 50%)");
+    pointEl.setAttribute("stroke", "rgb(170 0 0)");
+    pathEl.setAttribute("stroke", "rgb(170 0 0)");
+    pathEl.setAttribute("d", `M ${point[0] - 5} ${point[1]} h 10`);
+  }
+  svg.append(pointEl, pathEl);
 }
 ```
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -8,9 +8,7 @@ browser-compat: api.SVGGeometryElement.isPointInStroke
 
 {{APIRef("SVG")}}
 
-The **`SVGGeometryElement.isPointInStroke()`** method determines whether a given point is within the
-stroke shape of an element. The `point` argument is interpreted as a point in the local coordinate
-system of the element.
+The **`isPointInStroke()`** method of the {{domxref("SVGGeometryElement")}} interface determines whether a given point is within the stroke shape of an element. The `point` argument is interpreted as a point in the local coordinate system of the element.
 
 ## Syntax
 
@@ -21,8 +19,7 @@ isPointInStroke(point)
 ### Parameters
 
 - `point`
-  - : A {{domxref("DOMPointInit")}} object interpreted as a point in the local coordinate system
-    of the element.
+  - : An object representing a point interpreted in the local coordinate system of the element. It is converted to a {{domxref("DOMPoint")}} object using the same algorithm as [`DOMPoint.fromPoint()`](/en-US/docs/Web/API/DOMPoint/fromPoint_static).
 
 ### Return value
 
@@ -69,7 +66,7 @@ for (const point of points) {
     const pointObj = { x: point[0], y: point[1] };
     isPointInStroke = circle.isPointInStroke(pointObj);
   } catch {
-    // Fallback for browsers that don't support DOMPointInit as an argument
+    // Fallback for browsers that don't support DOMPoint as an argument
     const pointObj = svg.createSVGPoint();
     pointObj.x = point[0];
     pointObj.y = point[1];
@@ -85,10 +82,7 @@ for (const point of points) {
   pointEl.cx.baseVal.value = point[0];
   pointEl.cy.baseVal.value = point[1];
   pointEl.r.baseVal.value = 5;
-  const pathEl = document.createElementNS(
-    "http://www.w3.org/2000/svg",
-    "path",
-  );
+  const pathEl = document.createElementNS("http://www.w3.org/2000/svg", "path");
   if (isPointInStroke) {
     pointEl.setAttribute("fill", "rgb(0 170 0 / 50%)");
     pointEl.setAttribute("stroke", "rgb(0 170 0)");


### PR DESCRIPTION
changed pages:
- https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInFill
- https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke
---
- changed examples:
	- don't use `pointEl.style.r`, `pointEl.style.cx`, `pointEl.style.cy` because they don't exist in firefox
	- don't use `isPointInFill` variable that is not declared in https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke#javascript
	- use `{ x: point[0], y: point[1] }` instead of `new DOMPoint(point[0], point[1])` to show that object class doesn't matter in browsers that support <q cite="https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke#browser_compatibility">Accepts a `DOMPoint` as `point` parameter</q>
	- look different to see region where fill and stroke overlap
- changed `DOMPoint`→`DOMPointInit` in parameters
---
What does <q cite="https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke">Normal hit testing rules apply; the value of the [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) property on the element determines
whether a point is considered to be within the fill.</q> mean?
Adding `pointer-events="none"` or `style="pointer-events:none"` to big circle has no effect.