### PR TITLE
Fix typo in manifest member name

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -67,9 +67,9 @@ Chromium-based browsers, including Google Chrome, Samsung Internet, and Microsof
 - [`icons`](/en-US/docs/Web/Manifest/icons) must contain a 192px and a 512px icon
 - [`start_url`](/en-US/docs/Web/Manifest/start_url)
 - [`display`](/en-US/docs/Web/Manifest/display) and/or [`display_override`](/en-US/docs/Web/Manifest/display_override)
-- [`prefer-related-application`](/en-US/docs/Web/Manifest/prefer_related_applications) must be `false` or not present
+- [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) must be `false` or not present
 
-For a full description of every member, see the [web app manifest reference documentation](/en-US/docs/Web/Manifest).
+For a full description of every member, see the [Web app manifest](/en-US/docs/Web/Manifest) reference documentation.
 
 ### HTTPS, localhost, or loopback are required
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

- Fixing the manifest member name to `prefer_related_applications` (with underscores and an "s" at the end)
- Also fixing the slight nit in the link to the reference documentation

### Motivation

To keep content accurate
