### PR TITLE
Fix definition of XHR.send() body parameter

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -39,7 +39,7 @@ send(body)
   - : A body of data to be sent in the XHR request. This can be:
 
     - A {{domxref("Document")}}, in which case it is serialized before being sent.
-    - An `XMLHttpRequestBodyInit`, which [per the Fetch spec](https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit) can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, or a string literal.
+    - An `XMLHttpRequestBodyInit`, which [per the Fetch spec](https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit) can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, or a string.
     - `null`
 
     If no value is specified for the body, a default value of `null` is used.

--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -39,7 +39,7 @@ send(body)
   - : A body of data to be sent in the XHR request. This can be:
 
     - A {{domxref("Document")}}, in which case it is serialized before being sent.
-    - An `XMLHttpRequestBodyInit`, which [per the Fetch spec](https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit) can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, or a string literal or object.
+    - An `XMLHttpRequestBodyInit`, which [per the Fetch spec](https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit) can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, or a string literal.
     - `null`
 
     If no value is specified for the body, a default value of `null` is used.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send#body

* Remove `object` from the permissible types for the `body` parameter of `XHR.send()`.
* Change `string literal` to `string`, since string variables are also allowed.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

>[body](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send#body)
>  A body of data to be sent in the XHR request. This can be:
>* An XMLHttpRequestBodyInit, which [per the Fetch spec](https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit) can be a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob), an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), a [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), a [DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView), a [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData), a [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams), or a **string literal or object**.

As specified in the [Fetch spec](https://fetch.spec.whatwg.org/#bodyinit-unions), `send()` takes a `USVString`, but not an object.

I believe this is a mistake caused by the migration of the docs to Markdown.

The docs [originally said ](https://web.archive.org/web/20170908174323/https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send) `or USVString object`.
This was changed in 68f8aa5e6b5b35c0f13d73ed297e9cfb840a9be1 to `or string object`.
It was changed again in b0cbf649020570e98046d76f007a4452fd40c976 to the current version of `or a string literal or object`.

The TypeScript [lib.dom.d.ts definition](https://github.com/microsoft/TypeScript/blob/7976d9cef5be76372e610c28806fca351ab5d70f/src/lib/dom.generated.d.ts#L27888) has this defined correctly:

```ts
type XMLHttpRequestBodyInit = Blob | BufferSource | FormData | URLSearchParams | string;
```

<!-- ### Additional details -->

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
