### PR TITLE
Permission API updates

### DIFF
--- a/files/en-us/web/api/geolocation/getcurrentposition/index.md
+++ b/files/en-us/web/api/geolocation/getcurrentposition/index.md
@@ -10,6 +10,10 @@ browser-compat: api.Geolocation.getCurrentPosition
 
 The **`getCurrentPosition()`** method of the {{domxref("Geolocation")}} interface is used to get the current position of the device.
 
+Note that in addition to requiring a secure context this feature may be blocked by the [`geolocation`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation) `Permissions-Policy`, and also requires that explicit permission be granted by the user.
+If required, the user will be prompted when this method is called.
+The permission state can be queried using the `geolocation` user permission in the [Permissions API](/en-US/docs/Web/API/Permissions_API).
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/geolocation/watchposition/index.md
+++ b/files/en-us/web/api/geolocation/watchposition/index.md
@@ -11,6 +11,16 @@ browser-compat: api.Geolocation.watchPosition
 The **`watchPosition()`** method of the {{domxref("Geolocation")}} interface is used to register a handler function that will be called automatically each time the position of the device changes.
 You can also, optionally, specify an error handling callback function.
 
+Note that in addition to requiring a secure context this feature may be gated by the [`geolocation`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation) `Permissions-Policy`, and also requires that explicit permission be granted by the user.
+If required, the user will be prompted when this method is called.
+The permission state can be queried using the `geolocation` user permission in the [Permissions API](/en-US/docs/Web/API/Permissions_API).
+
+If the method is called in a secure context and
+
+, Geolocation is a powerful feature that requires express permission from an end-user before any location data is shared with a web application. This requirement is normatively enforced by the check permission steps on which the getCurrentPosition() and watchPosition() methods rely.
+
+An end-user will generally give express permission through a user interface, which usually present a range of permission lifetimes that the end-user can choose from. The choice of lifetimes vary across user agents, but they are typically time-based (e.g., "a day"), or until browser is closed, or the user might even be given the choice for the permission to be granted indefinitely. The permission lifetimes dictate how long a user agent grants a permission before that permission is automatically reverted back to its default permission state, prompting the end-user to make a new choice upon subsequent use.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/geolocation/watchposition/index.md
+++ b/files/en-us/web/api/geolocation/watchposition/index.md
@@ -11,15 +11,9 @@ browser-compat: api.Geolocation.watchPosition
 The **`watchPosition()`** method of the {{domxref("Geolocation")}} interface is used to register a handler function that will be called automatically each time the position of the device changes.
 You can also, optionally, specify an error handling callback function.
 
-Note that in addition to requiring a secure context this feature may be gated by the [`geolocation`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation) `Permissions-Policy`, and also requires that explicit permission be granted by the user.
+Note that in addition to requiring a secure context this feature may be blocked by the [`geolocation`](/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation) `Permissions-Policy`, and also requires that explicit permission be granted by the user.
 If required, the user will be prompted when this method is called.
 The permission state can be queried using the `geolocation` user permission in the [Permissions API](/en-US/docs/Web/API/Permissions_API).
-
-If the method is called in a secure context and
-
-, Geolocation is a powerful feature that requires express permission from an end-user before any location data is shared with a web application. This requirement is normatively enforced by the check permission steps on which the getCurrentPosition() and watchPosition() methods rely.
-
-An end-user will generally give express permission through a user interface, which usually present a range of permission lifetimes that the end-user can choose from. The choice of lifetimes vary across user agents, but they are typically time-based (e.g., "a day"), or until browser is closed, or the user might even be given the choice for the permission to be granted indefinitely. The permission lifetimes dictate how long a user agent grants a permission before that permission is automatically reverted back to its default permission state, prompting the end-user to make a new choice upon subsequent use.
 
 ## Syntax
 

--- a/files/en-us/web/api/geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/index.md
@@ -51,20 +51,21 @@ For further information on Geolocation usage, read [Using the Geolocation API](/
 The Geolocation API allows users to programmatically access location information in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
 
 Access may further be controlled by the [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) directive {{HTTPHeader("Permissions-Policy/geolocation","geolocation")}}.
-The default allowlist for `geolocation` is `self`, which allows access to position information only same-origin nested frames.
-Third party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third party origin:
+The default allowlist for `geolocation` is `self`, which allows access to location information in same-origin nested frames only.
+Third party usage is enabled by setting a `Permissions-Policy` response header to grant permission to a particular third party origin:
 
 ```http
 Permissions-Policy: geolocation=(self b.example.com)
 ```
 
-Then the `allow="geolocation"` attribute must be added the frame container element for sources from that origin:
+The `allow="geolocation"` attribute must then be added to the iframe element with sources from that origin:
 
 ```html
 <iframe src="https://b.example.com" allow="geolocation"/></iframe>
 ```
 
-Geolocation is a powerful feature, and end users must additionally grant explicit permission via a prompt when either {{domxref("Geolocation.getCurrentPosition()")}} or {{domxref("Geolocation.watchPosition()")}} is called (unless the permission state is already `granted` or `denied`).
+Geolocation data may reveal information that the device owner does not want to share.
+Therefore, users must grant explicit permission via a prompt when either {{domxref("Geolocation.getCurrentPosition()")}} or {{domxref("Geolocation.watchPosition()")}} is called (unless the permission state is already `granted` or `denied`).
 The lifetime of a granted permission depends on the user agent, and may be time based, session based, or even permanent.
 The [Permissions API](/en-US/docs/Web/API/Permissions_API) `geolocation` permission can be used to test whether access to use location information is `granted`, `denied` or `prompt` (requires user acknowledgement of a prompt).
 

--- a/files/en-us/web/api/geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/index.md
@@ -46,6 +46,28 @@ For further information on Geolocation usage, read [Using the Geolocation API](/
 - {{domxref("Navigator.geolocation")}}
   - : The entry point into the API. Returns a {{domxref("Geolocation")}} object instance, from which all other functionality can be accessed.
 
+## Security considerations
+
+The Geolocation API allows users to programmatically access location information in [secure contexts](/en-US/docs/Web/Security/Secure_Contexts).
+
+Access may further be controlled by the [Permissions Policy](/en-US/docs/Web/HTTP/Permissions_Policy) directive {{HTTPHeader("Permissions-Policy/geolocation","geolocation")}}.
+The default allowlist for `geolocation` is `self`, which allows access to position information only same-origin nested frames.
+Third party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third party origin:
+
+```http
+Permissions-Policy: geolocation=(self b.example.com)
+```
+
+Then the `allow="geolocation"` attribute must be added the frame container element for sources from that origin:
+
+```html
+<iframe src="https://b.example.com" allow="geolocation"/></iframe>
+```
+
+Geolocation is a powerful feature, and end users must additionally grant explicit permission via a prompt when either {{domxref("Geolocation.getCurrentPosition()")}} or {{domxref("Geolocation.watchPosition()")}} is called (unless the permission state is already `granted` or `denied`).
+The lifetime of a granted permission depends on the user agent, and may be time based, session based, or even permanent.
+The [Permissions API](/en-US/docs/Web/API/Permissions_API) `geolocation` permission can be used to test whether access to use location information is `granted`, `denied` or `prompt` (requires user acknowledgement of a prompt).
+
 ## Examples
 
 See [Using the Geolocation API](/en-US/docs/Web/API/Geolocation_API/Using_the_Geolocation_API#examples) for example code.

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -10,6 +10,10 @@ browser-compat: api.Permissions.query
 
 The **`query()`** method of the {{domxref("Permissions")}} interface returns the state of a user permission on the global scope.
 
+The permissions supported by each browser versions are listed in the [compatibility data of the `Permissions` interface](/en-US/docs/Web/API/Permissions#browser_compatibility) (see also the relevant source code for [Firefox values](https://searchfox.org/mozilla-central/source/dom/webidl/Permissions.webidl#10), [Chromium values](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/permissions/permission_descriptor.idl), and [WebKit values](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/permissions/PermissionName.idl)).
+
+The APIs that are gated by each permission are listed in [Permission-aware APIs](/en-US/docs/Web/API/Permissions_API#permission-aware_apis) in the [Permissions API](/en-US/docs/Web/API/Permissions_API) overview topic.
+
 ## Syntax
 
 ```js-nolint
@@ -20,20 +24,26 @@ query(permissionDescriptor)
 
 - `permissionDescriptor`
 
-  - : An object that sets options for the `query` operation consisting of a comma-separated list of name-value pairs. The available options are:
+  - : An object that sets options for the `query` operation.
+    The available options for this descriptor depend on the permission type.
+
+    All permissions have a name:
 
     - `name`
-      - : The name of the API whose permissions you want to query. Each browser supports a different set of values. You'll find Firefox values [there](https://searchfox.org/mozilla-central/source/dom/webidl/Permissions.webidl#10), Chromium values [there](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/permissions/permission_descriptor.idl), and WebKit values [there](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/permissions/PermissionName.idl).
-    - `userVisibleOnly`
-      - : (Push only, not supported in Firefox — see the Browser Support section below) Indicates whether you want to show a notification for every message or be able to send silent push notifications. The default is `false`.
-    - `sysex` (MIDI only)
-      - : Indicates whether you need and/or receive system exclusive messages. The default is `false`.
+      - : A string containing the name of the API whose permissions you want to query.
+        The returned {{jsxref("Promise")}} will reject with a {{jsxref("TypeError")}} if the permission name is not supported by the browser.
 
-> [!NOTE]
-> As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is granted (e.g. by the user, in the relevant permissions dialog), `navigator.permissions.query()` will return `true` for both `notifications` and `push`.
+    For the `push` permissions you can also specify:
 
-> [!NOTE]
-> The `persistent-storage` permission allows an origin to use a persistent box (i.e., [persistent storage](https://storage.spec.whatwg.org/#persistence)) for its storage, as per the [Storage API](https://storage.spec.whatwg.org/).
+    - `userVisibleOnly` {{optional_inline}}
+      - : (Push only, not supported in Firefox — see the Browser Support section below) Indicates whether you want to show a notification for every message or be able to send silent push notifications.
+        The default is `false`.
+
+    For the `midi` permission you can also specify:
+
+    - `sysex` {{optional_inline}}
+      - : Indicates whether you need and/or receive system exclusive messages.
+        The default is `false`.
 
 ### Return value
 

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -10,7 +10,8 @@ browser-compat: api.Permissions.query
 
 The **`query()`** method of the {{domxref("Permissions")}} interface returns the state of a user permission on the global scope.
 
-The permissions supported by each browser versions are listed in the [compatibility data of the `Permissions` interface](/en-US/docs/Web/API/Permissions#browser_compatibility) (see also the relevant source code for [Firefox values](https://searchfox.org/mozilla-central/source/dom/webidl/Permissions.webidl#10), [Chromium values](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/permissions/permission_descriptor.idl), and [WebKit values](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/permissions/PermissionName.idl)).
+The user permission names are defined in the respective specifications for each feature.
+The permissions supported by different browser versions are listed in the [compatibility data of the `Permissions` interface](/en-US/docs/Web/API/Permissions#browser_compatibility) (see also the relevant source code for [Firefox values](https://searchfox.org/mozilla-central/source/dom/webidl/Permissions.webidl#10), [Chromium values](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/permissions/permission_descriptor.idl), and [WebKit values](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/permissions/PermissionName.idl)).
 
 The APIs that are gated by each permission are listed in [Permission-aware APIs](/en-US/docs/Web/API/Permissions_API#permission-aware_apis) in the [Permissions API](/en-US/docs/Web/API/Permissions_API) overview topic.
 
@@ -30,7 +31,7 @@ query(permissionDescriptor)
     All permissions have a name:
 
     - `name`
-      - : A string containing the name of the API whose permissions you want to query.
+      - : A string containing the name of the API whose permissions you want to query, such as `camera`, `bluetooth`, `camera`, `geolocation` (see [`Permissions`](/en-US/docs/Web/API/Permissions#browser_compatibility) for a more complete list).
         The returned {{jsxref("Promise")}} will reject with a {{jsxref("TypeError")}} if the permission name is not supported by the browser.
 
     For the `push` permissions you can also specify:

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -10,66 +10,56 @@ browser-compat: api.Permissions.revoke
 
 {{APIRef("Permissions API")}}{{AvailableInWorkers}}{{deprecated_header}}
 
-The **`revoke()`** method of the
-{{domxref("Permissions")}} interface reverts a currently set permission back to its
-default state, which is usually `prompt`.
-This method is called on the global {{domxref("Permissions")}} object
-{{domxref("navigator.permissions")}}.
+The **`revoke()`** method of the {{domxref("Permissions")}} interface reverts a currently set permission back to its default state, which is usually `prompt`.
+This method is called on the global {{domxref("Permissions")}} object {{domxref("navigator.permissions")}}.
 
-This method is removed from the main permissions API specification because its use case is unclear. Permissions are managed by the browser and the current permission model does not involve the site developer being able to imperatively request or revoke permissions. Browsers have shipped this API behind preferences but it's unlikely to reach the standards track. For more context, see the [original discussion to remove `permissions.revoke()`](https://github.com/w3c/permissions/issues/46).
+This method is removed from the main permissions API specification because its use case is unclear.
+Permissions are managed by the browser and the current permission model does not involve the site developer being able to imperatively request or revoke permissions. Browsers have shipped this API behind preferences but it's unlikely to reach the standards track.
+For more context, see the [original discussion to remove `permissions.revoke()`](https://github.com/w3c/permissions/issues/46).
 
 ## Syntax
 
 ```js-nolint
-revoke(descriptor)
+revoke(permissionDescriptor)
 ```
 
 ### Parameters
 
-- `descriptor`
+- `permissionDescriptor`
 
-  - : An object based on the `PermissionDescriptor` dictionary that sets
-    options for the operation consisting of a comma-separated list of name-value pairs.
-    The available options are:
+  - : An object that sets options for the `revoke` operation.
+    The available options for this descriptor depend on the permission type.
+
+    All permissions have a name:
 
     - `name`
-      - : The name of the API whose permissions you want to query. Each browser supports a different set of values. You can consult the [Firefox values](https://searchfox.org/mozilla-central/source/dom/webidl/Permissions.webidl#10), the [Chromium values](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/modules/permissions/permission_descriptor.idl), and the [WebKit values](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/permissions/PermissionName.idl).
-    - `userVisibleOnly`
-      - : (Push only, not supported in Firefox — see the
-        [Browser compatibility](#browser_compatibility) section below) Indicates whether you want to
-        show a notification for every message or be able to send silent push
-        notifications. The default is `false`.
-    - `sysex` (MIDI only)
-      - : Indicates whether you need and/or receive system
-        exclusive messages. The default is `false`.
+      - : A string containing the name of the API whose permissions you want to query.
+        The returned {{jsxref("Promise")}} will reject with a {{jsxref("TypeError")}} if the permission name is not supported by the browser.
 
-> [!NOTE]
-> As of Firefox 44, the permissions for [Notifications](/en-US/docs/Web/API/Notifications_API) and [Push](/en-US/docs/Web/API/Push_API) have been merged. If permission is
-> granted (e.g. by the user, in the relevant permissions dialog),
-> `navigator.permissions.query()` will return `true` for both
-> `notifications` and `push`.
+    For the `push` permissions you can also specify:
 
-> [!NOTE]
-> The `persistent-storage` permission allows an
-> origin to use a persistent box (i.e., [persistent storage](https://storage.spec.whatwg.org/#persistence)) for its
-> storage, as per the [Storage API](https://storage.spec.whatwg.org/).
+    - `userVisibleOnly` {{optional_inline}}
+      - : (Push only, not supported in Firefox — see the Browser Support section below) Indicates whether you want to show a notification for every message or be able to send silent push notifications.
+        The default is `false`.
+
+    For the `midi` permission you can also specify:
+
+    - `sysex` {{optional_inline}}
+      - : Indicates whether you need and/or receive system exclusive messages.
+        The default is `false`.
 
 ### Return value
 
-A {{jsxref("Promise")}} that calls its fulfillment handler with a
-{{domxref("PermissionStatus")}} object indicating the result of the request.
+A {{jsxref("Promise")}} that calls its fulfillment handler with a {{domxref("PermissionStatus")}} object indicating the result of the request.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Retrieving the `PermissionDescriptor` information failed in some way, or
-    the permission doesn't exist or is currently unsupported (e.g. `midi`, or
-    `push` with `userVisibleOnly`).
+  - : Retrieving the `PermissionDescriptor` information failed in some way, or the permission doesn't exist or is currently unsupported (e.g. `midi`, or `push` with `userVisibleOnly`).
 
 ## Examples
 
-This function can be used by an app to request that its own Geolocation API permission
-be revoked.
+This function can be used by an app to request that its own Geolocation API permission be revoked.
 
 ```js
 function revokePermission() {

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -25,8 +25,26 @@ The Permissions API provides the tools to allow developers to implement a consis
 The `permissions` property has been made available on the {{domxref("Navigator")}} object, both in the standard browsing context and the worker context ({{domxref("WorkerNavigator")}} — so permission checks are available inside workers), and returns a {{domxref("Permissions")}} object that provides access to the Permissions API functionality.
 
 Once you have this object you can then use the {{domxref("Permissions.query()")}} method to return a promise that resolves with the {{domxref("PermissionStatus")}} for a specific API.
-Note that if the status is `prompt` the user must acknowledge a prompt to grant access to the feature.
-The mechanism for launching this prompt will depend on the specific API — it is not defined as part of the Permissions API.
+
+### Requesting permission
+
+If the permission status is `prompt`, the user must acknowledge a prompt to grant access to the feature.
+
+The mechanism that triggers this prompt will depend on the specific API — it is not defined as part of the Permissions API.
+Generally the trigger is code calling a method to access or open the feature, or that registers for notifications from the feature that will subsequently access it.
+
+Note that not all features require a prompt.
+Permission might be granted by a `Permission Policy`, implicitly by {{glossary("transient activation")}}, or via some other mechanism.
+
+### Revoking permission
+
+Permission revocation is not managed by the API.
+More specifically, a {{domxref("Permissions.revoke()")}} method was proposed, but has since been removed from those browsers where it was implemented.
+
+Users can manually remove permission for particular sites using browser settings:
+
+- **Firefox**: _Hamburger Menu > Settings > Privacy & Security > Permissions_ (then select the **Settings** button for the permission of interest).
+- **Chrome**: _Hamburger Menu > Settings > Show advanced settings_. In the _Privacy_ section, click _Content Settings_. In the resulting dialog, find the _Location_ section and select _Ask when a site tries to…_. Finally, click _Manage Exceptions_ and remove the permissions you granted to the sites you are interested in.
 
 ### Permission-aware APIs
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -11,16 +11,16 @@ spec-urls: https://w3c.github.io/permissions/
 
 {{DefaultAPISidebar("Permissions API")}}{{AvailableInWorkers}}
 
-The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context.
+The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context, such as a web page or worker.
 For example, it can be used to determine if permission to access a particular feature or API has been granted, denied, or requires specific user permission.
-
-The permissions from this API effectively aggregate all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, and user prompts.
-So, for example, if an API is restricted by permissions policy, the returned permission would be `denied` and the user would not be prompted for access.
 
 ## Concepts and usage
 
 Historically different APIs handle their own permissions inconsistently — for example the [Notifications API](/en-US/docs/Web/API/Notifications_API) provided its own methods for requesting permissions and checking permission status, whereas the [Geolocation API](/en-US/docs/Web/API/Geolocation) did not.
-The Permissions API provides the tools to allow developers to implement a consistent and better user experience for working with permissions.
+The Permissions API provides the tools to allow developers to implement a consistent user experience for working with permissions.
+
+The permissions from this API effectively aggregate all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, requirements for user interaction, and user prompts.
+So, for example, if an API is restricted by permissions policy, the returned permission would be `denied` and the user would not be prompted for access.
 
 The `permissions` property has been made available on the {{domxref("Navigator")}} object, both in the standard browsing context and the worker context ({{domxref("WorkerNavigator")}} — so permission checks are available inside workers), and returns a {{domxref("Permissions")}} object that provides access to the Permissions API functionality.
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -25,7 +25,8 @@ The Permissions API provides the tools to allow developers to implement a consis
 The `permissions` property has been made available on the {{domxref("Navigator")}} object, both in the standard browsing context and the worker context ({{domxref("WorkerNavigator")}} — so permission checks are available inside workers), and returns a {{domxref("Permissions")}} object that provides access to the Permissions API functionality.
 
 Once you have this object you can then use the {{domxref("Permissions.query()")}} method to return a promise that resolves with the {{domxref("PermissionStatus")}} for a specific API.
-Note that if the status is `prompt` the user must acknowledge a prompt before accessing the feature, and that the mechanism for launching this prompt will depend on the specific API — it is not defined as part of the Permissions API.
+Note that if the status is `prompt` the user must acknowledge a prompt to grant access to the feature.
+The mechanism for launching this prompt will depend on the specific API — it is not defined as part of the Permissions API.
 
 ### Permission-aware APIs
 
@@ -33,8 +34,9 @@ Not all APIs' permission statuses can be queried using the Permissions API.
 A non-exhaustive list of permission-aware APIs includes:
 
 - [Background Synchronization API](/en-US/docs/Web/API/Background_Synchronization_API): `background-sync` (should always be granted)
+- [Clipboard_API](/en-US/docs/Web/API/Clipboard_API#security_considerations): `clipboard-read`, `clipboard-write`
 - [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API): `compute-pressure`
-- [Geolocation API](/en-US/docs/Web/API/Geolocation_API): `geolocation`
+- [Geolocation API](/en-US/docs/Web/API/Geolocation_API#security_considerations): `geolocation`
 - [Local Font Access API](/en-US/docs/Web/API/Local_Font_Access_API): `local-fonts`
 - [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API): `microphone`, `camera`
 - [Notifications API](/en-US/docs/Web/API/Notifications_API): `notifications`
@@ -44,6 +46,7 @@ A non-exhaustive list of permission-aware APIs includes:
 - [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs): `accelerometer`, `gyroscope`, `magnetometer`, `ambient-light-sensor`
 - [Storage Access API](/en-US/docs/Web/API/Storage_Access_API): `storage-access`, `top-level-storage-access`
 - [Storage API](/en-US/docs/Web/API/Storage_API): `persistent-storage`
+- [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API): `bluetooth`
 - [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API): `midi`
 - [Window Management API](/en-US/docs/Web/API/Window_Management_API): `window-management`
 
@@ -61,9 +64,10 @@ A non-exhaustive list of permission-aware APIs includes:
 
 ## Examples
 
-We have created a simple example called Location Finder. You can [run the example live](https://chrisdavidmills.github.io/location-finder-permissions-api/), or [view the source code on GitHub](https://github.com/chrisdavidmills/location-finder-permissions-api/tree/gh-pages).
+We have created a simple example called Location Finder.
+You can [run the example live](https://chrisdavidmills.github.io/location-finder-permissions-api/), [view the source code on GitHub](https://github.com/chrisdavidmills/location-finder-permissions-api/tree/gh-pages), or read more about how it works in our article [Using the Permissions API](/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API).
 
-Read more about how it works in our article [Using the Permissions API](/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API).
+The [`Permissions.query()` example](/en-US/docs/Web/API/Permissions/query#test_support_for_various_permissions) also so shows code that tests most permissions on the current browser and logs the result.
 
 ## Specifications
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -11,9 +11,10 @@ spec-urls: https://w3c.github.io/permissions/
 
 {{DefaultAPISidebar("Permissions API")}}{{AvailableInWorkers}}
 
-The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context. For example, the Permissions API can be used to determine if permission to access a particular API has been granted or denied, or requires specific user permission.
+The **Permissions API** provides a consistent programmatic way to query the status of API permissions attributed to the current context.
+For example, it can be used to determine if permission to access a particular feature or API has been granted, denied, or requires specific user permission.
 
-Note that the permissions from this API effectively aggregate all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, and user prompts.
+The permissions from this API effectively aggregate all security restrictions for the context, including any requirement for an API to be used in a secure context, [Permissions-Policy](/en-US/docs/Web/HTTP/Headers/Permissions-Policy) restrictions applied to the document, and user prompts.
 So, for example, if an API is restricted by permissions policy, the returned permission would be `denied` and the user would not be prompted for access.
 
 ## Concepts and usage
@@ -46,12 +47,6 @@ A non-exhaustive list of permission-aware APIs includes:
 - [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API): `midi`
 - [Window Management API](/en-US/docs/Web/API/Window_Management_API): `window-management`
 
-## Examples
-
-We have created a simple example called Location Finder. You can [run the example live](https://chrisdavidmills.github.io/location-finder-permissions-api/), or [view the source code on GitHub](https://github.com/chrisdavidmills/location-finder-permissions-api/tree/gh-pages).
-
-Read more about how it works in our article [Using the Permissions API](/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API).
-
 ## Interfaces
 
 - {{domxref("Permissions")}}
@@ -63,6 +58,12 @@ Read more about how it works in our article [Using the Permissions API](/en-US/d
 
 - {{domxref("Navigator.permissions")}} and {{domxref("WorkerNavigator.permissions")}} {{ReadOnlyInline}}
   - : Provides access to the {{domxref("Permissions")}} object from the main context and worker context respectively.
+
+## Examples
+
+We have created a simple example called Location Finder. You can [run the example live](https://chrisdavidmills.github.io/location-finder-permissions-api/), or [view the source code on GitHub](https://github.com/chrisdavidmills/location-finder-permissions-api/tree/gh-pages).
+
+Read more about how it works in our article [Using the Permissions API](/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API).
 
 ## Specifications
 

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -83,12 +83,3 @@ The {{domxref("Permissions.query()")}} method takes a `PermissionDescriptor` dic
 ### Responding to permission state changes
 
 You'll notice that we're listening to the {{domxref("PermissionStatus.change_event", "change")}} event in the code above, attached to the {{domxref("PermissionStatus")}} object — this allows us to respond to any changes in the permission status for the API we are interested in. At the moment we are just reporting the change in state.
-
-## Conclusion and future work
-
-At the moment this doesn't offer much more than what we had already. If we choose to never share our location from the permission prompt (deny permission), then we can't get back to the permission prompt without using the browser menu options:
-
-- **Firefox**: _Hamburger Menu > Settings > Privacy & Security > Permissions_ (then select the **Settings** button for the permission of interest).
-- **Chrome**: _Hamburger Menu > Settings > Show advanced settings_. In the _Privacy_ section, click _Content Settings_. In the resulting dialog, find the _Location_ section and select _Ask when a site tries to…_. Finally, click _Manage Exceptions_ and remove the permissions you granted to the sites you are interested in.
-
-There are proposals to add the ability for sites to imperatively [request](https://github.com/WICG/permissions-request) and [revoke](https://github.com/WICG/permissions-revoke) permissions, but there has not been much progress as the use case is unclear and they have faced opposition from browser vendors. See the discussions to [remove `permissions.request()`](https://github.com/w3c/permissions/issues/83) and [remove `permissions.revoke()`](https://github.com/w3c/permissions/issues/46) from the main specification.

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -2,13 +2,11 @@
 title: Using the Permissions API
 slug: Web/API/Permissions_API/Using_the_Permissions_API
 page-type: guide
-status:
-  - experimental
 ---
 
 {{DefaultAPISidebar("Permissions API")}}
 
-This article provides a basic guide to using the W3C [Permissions API](/en-US/docs/Web/API/Permissions_API), which provides a programmatic way to query the status of API permissions attributed to the current context.
+This article provides a basic guide to using the [Permissions API](/en-US/docs/Web/API/Permissions_API), which provides a programmatic way to query the status of API permissions attributed to the current context.
 
 ## The trouble with asking for permission…
 
@@ -90,7 +88,7 @@ You'll notice that we're listening to the {{domxref("PermissionStatus.change_eve
 
 At the moment this doesn't offer much more than what we had already. If we choose to never share our location from the permission prompt (deny permission), then we can't get back to the permission prompt without using the browser menu options:
 
-- **Firefox**: _Tools > Page Info > Permissions > Access Your Location_. Select _Always Ask_.
+- **Firefox**: _Hamburger Menu > Settings > Privacy & Security > Permissions_ (then select the **Settings** button for the permission of interest).
 - **Chrome**: _Hamburger Menu > Settings > Show advanced settings_. In the _Privacy_ section, click _Content Settings_. In the resulting dialog, find the _Location_ section and select _Ask when a site tries to…_. Finally, click _Manage Exceptions_ and remove the permissions you granted to the sites you are interested in.
 
 There are proposals to add the ability for sites to imperatively [request](https://github.com/WICG/permissions-request) and [revoke](https://github.com/WICG/permissions-revoke) permissions, but there has not been much progress as the use case is unclear and they have faced opposition from browser vendors. See the discussions to [remove `permissions.request()`](https://github.com/w3c/permissions/issues/83) and [remove `permissions.revoke()`](https://github.com/w3c/permissions/issues/46) from the main specification.


### PR DESCRIPTION
This is a "refresh" of the Permissions API docs. I'm doing it as part of looking at addition of `microphone` and `camera` permissions. The docs are a bit dated - they won't be perfect after this, but they will be better.

The main change is to try to cut back some of the future looking behaviour that was written back when this was created. The story is now stable:
- Permissions aggregate the permission to use an api from permissions policy, secure context, user prompt, or whatever else accesses it.
- You can query the current permission.
- That's it - revoking the permission is not supported in the API, and neither is requesting it.

I also added a security considerations section for the Geolocation overview page. Next iteration of these docs I'd hope to perhaps do this for all the permission using APIs. From that I could add a list of things that cause the permission prompt to this doc.

Related docs work can be tracked in #35765