### PR TITLE
Update datetime-local format

### DIFF
--- a/files/en-us/web/html/attributes/max/index.md
+++ b/files/en-us/web/html/attributes/max/index.md
@@ -51,14 +51,14 @@ If the value exceeds the max value allowed, the {{domxref('validityState.rangeOv
     </tr>
     <tr>
       <td>{{HTMLElement("input/time", "time")}}</td>
-      <td><code>hh:mm</code></td>
+      <td><code>HH:mm</code></td>
       <td><code>&#x3C;input type="time" max="17:00" step="900"></code></td>
     </tr>
     <tr>
       <td>
         {{HTMLElement("input/datetime-local", "datetime-local")}}
       </td>
-      <td><code>yyyy-mm-ddThh:mm</code></td>
+      <td><code>yyyy-mm-ddTHH:mm</code></td>
       <td>
         <code>&#x3C;input type="datetime-local" max="2019-12-25T23:59"></code>
       </td>

--- a/files/en-us/web/html/attributes/min/index.md
+++ b/files/en-us/web/html/attributes/min/index.md
@@ -50,14 +50,14 @@ It is valid for the input types including: {{HTMLElement("input/date", "date")}}
     </tr>
     <tr>
       <td>{{HTMLElement("input/time", "time")}}</td>
-      <td><code>hh:mm</code></td>
+      <td><code>HH:mm</code></td>
       <td><code>&#x3C;input type="time" min="09:00" step="900"></code></td>
     </tr>
     <tr>
       <td>
         {{HTMLElement("input/datetime-local", "datetime-local")}}
       </td>
-      <td><code>yyyy-mm-ddThh:mm</code></td>
+      <td><code>yyyy-mm-ddTHH:mm</code></td>
       <td>
         <code>&#x3C;input type="datetime-local" min="2019-12-25T19:30"></code>
       </td>

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -32,7 +32,7 @@ You can set a default value for the input by including a date and time inside th
 
 {{ EmbedLiveSample('Value', 600, 60) }}
 
-One thing to note is that the displayed date and time formats differ from the actual `value`; the displayed date and time are formatted according to the user's locale as reported by their operating system, whereas the date/time `value` is always formatted `YYYY-MM-DDThh:mm`. When the above value is submitted to the server, for example, it will look like `partydate=2024-06-01T08:30`.
+One thing to note is that the displayed date and time formats differ from the actual `value`; the displayed date and time are formatted according to the user's locale as reported by their operating system, whereas the date/time `value` is always formatted `YYYY-MM-DDTHH:mm`. When the above value is submitted to the server, for example, it will look like `partydate=2024-06-01T08:30`.
 
 > [!NOTE]
 > Also bear in mind that if such data is submitted via HTTP [`GET`](/en-US/docs/Web/HTTP/Methods/GET), the colon character will need to be escaped for inclusion in the URL parameters, e.g. `partydate=2024-06-01T08%3A30`. See {{jsxref("Global_Objects/encodeURI", "encodeURI()")}} for one way to do this.
@@ -50,13 +50,13 @@ In addition to the attributes common to all {{HTMLElement("input")}} elements, `
 
 ### max
 
-The latest date and time to accept. If the [`value`](/en-US/docs/Web/HTML/Element/input#value) entered into the element is later than this timestamp, the element fails [constraint validation](/en-US/docs/Web/HTML/Constraint_validation). If the value of the `max` attribute isn't a valid string that follows the format `YYYY-MM-DDThh:mm`, then the element has no maximum value.
+The latest date and time to accept. If the [`value`](/en-US/docs/Web/HTML/Element/input#value) entered into the element is later than this timestamp, the element fails [constraint validation](/en-US/docs/Web/HTML/Constraint_validation). If the value of the `max` attribute isn't a valid string that follows the format `YYYY-MM-DDTHH:mm`, then the element has no maximum value.
 
 This value must specify a date string later than or equal to the one specified by the `min` attribute.
 
 ### min
 
-The earliest date and time to accept; timestamps earlier than this will cause the element to fail [constraint validation](/en-US/docs/Web/HTML/Constraint_validation). If the value of the `min` attribute isn't a valid string that follows the format `YYYY-MM-DDThh:mm`, then the element has no minimum value.
+The earliest date and time to accept; timestamps earlier than this will cause the element to fail [constraint validation](/en-US/docs/Web/HTML/Constraint_validation). If the value of the `min` attribute isn't a valid string that follows the format `YYYY-MM-DDTHH:mm`, then the element has no minimum value.
 
 This value must specify a date string earlier than or equal to the one specified by the `max` attribute.
 
@@ -168,7 +168,7 @@ input:valid + span::after {
 > HTML form validation is _not_ a substitute for scripts that ensure that the entered data is in the proper format. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, problems can arise when improperly-formatted data is submitted (or data that is too large, is of the wrong type, and so forth).
 
 > [!NOTE]
-> With a `datetime-local` input, the date value is always normalized to the format `YYYY-MM-DDThh:mm`.
+> With a `datetime-local` input, the date value is always normalized to the format `YYYY-MM-DDTHH:mm`.
 
 ## Examples
 

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -9,7 +9,7 @@ browser-compat: html.elements.input.type_time
 
 {{htmlelement("input")}} elements of type **`time`** create input fields designed to let the user easily enter a time (hours and minutes, and optionally seconds).
 
-While the control's user interface appearance is based on the browser and operating system, the features are the same. The value is always a 24-hour `hh:mm` or `hh:mm:ss` formatted time, with leading zeros, regardless of the UI's input format.
+While the control's user interface appearance is based on the browser and operating system, the features are the same. The value is always a 24-hour `HH:mm` or `HH:mm:ss` formatted time, with leading zeros, regardless of the UI's input format.
 
 {{EmbedInteractiveExample("pages/tabbed/input-time.html", "tabbed-standard")}}
 
@@ -35,7 +35,7 @@ timeControl.value = "15:30";
 
 ### Time value format
 
-The `value` of the `time` input is always in 24-hour format that includes leading zeros: `hh:mm`, regardless of the input format, which is likely to be selected based on the user's locale (or by the user agent). If the time includes seconds (see [Using the step attribute](#using_the_step_attribute)), the format is always `hh:mm:ss`. You can learn more about the format of the time value used by this input type in [Time strings](/en-US/docs/Web/HTML/Date_and_time_formats#time_strings).
+The `value` of the `time` input is always in 24-hour format that includes leading zeros: `HH:mm`, regardless of the input format, which is likely to be selected based on the user's locale (or by the user agent). If the time includes seconds (see [Using the step attribute](#using_the_step_attribute)), the format is always `HH:mm:ss`. You can learn more about the format of the time value used by this input type in [Time strings](/en-US/docs/Web/HTML/Date_and_time_formats#time_strings).
 
 In this example, you can see the time input's value by entering a time and seeing how it changes afterward.
 
@@ -69,7 +69,7 @@ startTime.addEventListener(
 
 {{EmbedLiveSample("Time_value_format", 600, 80)}}
 
-When a form including a `time` input is submitted, the value is encoded before being included in the form's data. The form's data entry for a time input will always be in the form `name=hh%3Amm`, or `name=hh%3Amm%3Ass` if seconds are included (see [Using the step attribute](#using_the_step_attribute)).
+When a form including a `time` input is submitted, the value is encoded before being included in the form's data. The form's data entry for a time input will always be in the form `name=HH%3Amm`, or `name=HH%3Amm%3Ass` if seconds are included (see [Using the step attribute](#using_the_step_attribute)).
 
 ## Additional attributes
 

--- a/files/en-us/web/javascript/reference/global_objects/date/totimestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/totimestring/index.md
@@ -27,11 +27,11 @@ A string representing the time portion of the given date (see description for th
 
 ## Description
 
-{{jsxref("Date")}} instances refer to a specific point in time. `toTimeString()` interprets the date in the local timezone and formats the _time_ part in English. It always uses the format of `hh:mm:ss GMT±xxxx (TZ)`, where:
+{{jsxref("Date")}} instances refer to a specific point in time. `toTimeString()` interprets the date in the local timezone and formats the _time_ part in English. It always uses the format of `HH:mm:ss GMT±xxxx (TZ)`, where:
 
 | Format String | Description                                                                                           |
 | ------------- | ----------------------------------------------------------------------------------------------------- |
-| `hh`          | Hour, as two digits with leading zero if required                                                     |
+| `HH`          | Hour, as two digits with leading zero if required                                                     |
 | `mm`          | Minute, as two digits with leading zero if required                                                   |
 | `ss`          | Seconds, as two digits with leading zero if required                                                  |
 | `±xxxx`       | The local timezone's offset — two digits for hours and two digits for minutes (e.g. `-0500`, `+0800`) |

--- a/files/en-us/web/javascript/reference/global_objects/date/toutcstring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/toutcstring/index.md
@@ -27,7 +27,7 @@ A string representing the given date using the UTC time zone (see description fo
 
 ## Description
 
-The value returned by `toUTCString()` is a string in the form `Www, dd Mmm yyyy hh:mm:ss GMT`, where:
+The value returned by `toUTCString()` is a string in the form `Www, dd Mmm yyyy HH:mm:ss GMT`, where:
 
 | Format String | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
@@ -35,7 +35,7 @@ The value returned by `toUTCString()` is a string in the form `Www, dd Mmm yyyy 
 | `dd`          | Day of month, as two digits with leading zero if required    |
 | `Mmm`         | Month, as three letters (e.g. `Jan`, `Feb`)                  |
 | `yyyy`        | Year, as four or more digits with leading zeroes if required |
-| `hh`          | Hour, as two digits with leading zero if required            |
+| `HH`          | Hour, as two digits with leading zero if required            |
 | `mm`          | Minute, as two digits with leading zero if required          |
 | `ss`          | Seconds, as two digits with leading zero if required         |
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The time should be in 24 hour format. `hh` is for 12 hour.

```js
dayjs('2019-12-25T19:30').format('YYYY-MM-DDThh:mm'); // 2019-12-25T07:30

dayjs('2019-12-25T19:30').format('YYYY-MM-DDTHH:mm') // 2019-12-25T19:30
```

```php
\Carbon\Carbon::parse('2019-12-25T19:30')->isoformat('YYYY-MM-DDThh:mm'); // 2019-12-25T07:30
\Carbon\Carbon::parse('2019-12-25T19:30')->isoformat('YYYY-MM-DDTHH:mm'); // 2019-12-25T19:30
```

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
