### PR TITLE
fix(ci): ignore deleted file in log-url-isuses script

### DIFF
--- a/scripts/log-url-issues.js
+++ b/scripts/log-url-issues.js
@@ -123,9 +123,11 @@ function getFragmentDetails(fromStaging = true) {
         .filter((header) => !addedFragments.includes(header))
         .filter((header) => {
           // check if another header with same name exists in the file
-          const headerAnchors = getFileAnchors(
-            `${rootDir}/files/en-us/${path}/index.md`,
-          );
+          const absPath = `${rootDir}/files/en-us/${path}/index.md`;
+          if (!fs.existsSync(absPath)) {
+            return true;
+          }
+          const headerAnchors = getFileAnchors(absPath);
           return !headerAnchors.includes(header);
         })
         .forEach((header) => {


### PR DESCRIPTION
## Summary

When  a file is deleted then the `log-url-issues` script throws following error:

```
Error: ENOENT: no such file or directory, open '/home/runner/work/content/content/files/en-us/web/http/basics_of_http/index.md'
    at Object.openSync (node:fs:596:3)
    at Object.readFileSync (node:fs:464:35)
    at getFileContent (file:///home/runner/work/content/content/scripts/log-url-issues.js:30:22)
    at getFileAnchors (file:///home/runner/work/content/content/scripts/log-url-issues.js:39:19)
    at file:///home/runner/work/content/content/scripts/log-url-issues.js:126:33
    at Array.filter (<anonymous>)
    at getFragmentDetails (file:///home/runner/work/content/content/scripts/log-url-issues.js:124:10)
    at file:///home/runner/work/content/content/scripts/log-url-issues.js:[15](https://github.com/mdn/content/actions/runs/10739132976/job/29784189803?pr=35774#step:4:16)0:3
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/home/runner/work/content/content/files/en-us/web/http/basics_of_http/index.md'
```

## Problem

While fixing https://github.com/mdn/content/pull/35577, we started reading files containing the header to check for duplicate headers. So, it throws an error when trying to read the deleted file to check if duplicate headers with the same names exist.

## Solution

If a file is deleted don't try to check duplicate headers in it.