### PR TITLE
Dark theme support in embedded options pages fix

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
@@ -26,6 +26,7 @@ To create an options page, write an HTML file defining the page. This page can i
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="dark light" />
   </head>
 
   <body>
@@ -38,6 +39,8 @@ To create an options page, write an HTML file defining the page. This page can i
   </body>
 </html>
 ```
+
+Note the use of `<meta name="color-scheme" content="dark light">`. This enables automatic switching between light and dark themes in the embedded UI based on the user's browser preferences.
 
 JavaScript running in the page can use all the [WebExtension APIs](/en-US/docs/Mozilla/Add-ons/WebExtensions/API) that the add-on has [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for. In particular, you can use the [`storage`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage) API to persist preferences.
 

--- a/files/en-us/mozilla/firefox/releases/127/index.md
+++ b/files/en-us/mozilla/firefox/releases/127/index.md
@@ -74,6 +74,7 @@ This article provides information about the changes in Firefox 127 that affect d
 - [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) for Manifest V3 extensions are now displayed to users during installation ([Firefox bug 1889402](https://bugzil.la/1889402)). However, if an extension update requests new host permissions, these are not shown to the user. See ([Firefox bug 1893232](https://bugzil.la/1893232)).
 - Addition of the {{WebExtAPIRef("runtime.getContexts")}} function that returns information about the contexts associated with the extension ([Firefox bug 1875480](https://bugzil.la/1875480)).
 - For Manifest V3 extensions, adds fall back to the user-defined shortcuts for the special [`_execute_browser_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts) command if there are no user-defined shortcuts for `_execute_action`. This enables extensions migrating from Manifest V2 to V3 to preserve any user-defined shortcuts for the browser action ([Firefox bug 1797811](https://bugzil.la/1797811)).
+- Extensions with an embedded [options page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Options_pages) now support automatic switching to the dark theme based on user preferences ([Firefox bug 1888866](https://bugzil.la/1888866)).
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Adds a release note and updates the options UI page with details of the updated favorite colors example and note about the addition of `<meta name="color-scheme" content="dark light" />` to support automatic theme switching. Provides documentation for [Bug 1888866](https://bugzilla.mozilla.org/show_bug.cgi?id=1888866) Addons options_ui browser_style false doesn't properly handle dark mode on macOS

### Related issues and pull requests

The corresponding change to the favorite colours example is in https://github.com/mdn/webextensions-examples/pull/567
