### PR TITLE
Removing distracting/inaccurate commentary

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/try/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/try/index.md
@@ -92,31 +92,6 @@ async function doSomething(action) {
 }
 ```
 
-### Calling try() on a non-Promise constructor
-
-`Promise.try()` is a generic method. It can be called on any constructor that implements the same signature as the `Promise()` constructor. For example, we can call it on a constructor that passes `console.log` as the `resolve` and `reject` functions to `executor`:
-
-```js
-class NotPromise {
-  constructor(executor) {
-    // The "resolve" and "reject" functions behave nothing like the native
-    // promise's, but Promise.try() just calls resolve
-    executor(
-      (value) => console.log("Resolved", value),
-      (reason) => console.log("Rejected", reason),
-    );
-  }
-}
-
-const p = Promise.try.call(NotPromise, () => "hello");
-// Logs: Resolved hello
-
-const p2 = Promise.try.call(NotPromise, () => {
-  throw new Error("oops");
-});
-// Logs: Rejected Error: oops
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/promise/try/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/try/index.md
@@ -38,19 +38,7 @@ You may have an API that takes a callback. The callback may be synchronous or as
 new Promise((resolve) => resolve(func()));
 ```
 
-Except that `Promise.try()` is perhaps more concise and readable. To be more exact, the following is a more faithful representation of the implementation of `Promise.try()` (although it should still not be used as a polyfill):
-
-```js
-new Promise((resolve, reject) => {
-  try {
-    resolve(func());
-  } catch (error) {
-    reject(error);
-  }
-});
-```
-
-For the built-in `Promise()` constructor, errors thrown from the executor are automatically caught and turned into rejections, so these two examples are equivalent.
+For the built-in `Promise()` constructor, errors thrown from the executor are automatically caught and turned into rejections, so these two examples are equivalent, except that `Promise.try()` is perhaps more concise and readable.
 
 Note that `Promise.try()` is _not_ equivalent to this, despite being highly similar:
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/try/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/try/index.md
@@ -32,13 +32,13 @@ A {{jsxref("Promise")}} that is:
 
 ## Description
 
-You may have an API that takes a callback. The callback may be synchronous or asynchronous. You want to handle everything uniformly by wrapping the result in a promise. The most straightforward way might be {{jsxref("Promise/resolve", "Promise.resolve(func())")}}. The problem is that if `func()` synchronously throws an error, this error would not be caught and turned into a rejected promise. The correct way to do so is the following, which `Promise.try(func)` is exactly equivalent to:
+You may have an API that takes a callback. The callback may be synchronous or asynchronous. You want to handle everything uniformly by wrapping the result in a promise. The most straightforward way might be {{jsxref("Promise/resolve", "Promise.resolve(func())")}}. The problem is that if `func()` synchronously throws an error, this error would not be caught and turned into a rejected promise. The *common* way to do so is the following, which `Promise.try(func)` is essentially:
 
 ```js
 new Promise((resolve) => resolve(func()));
 ```
 
-For the built-in `Promise()` constructor, errors thrown from the executor are automatically caught and turned into rejections, so these two examples are equivalent, except that `Promise.try()` is perhaps more concise and readable.
+For the built-in `Promise()` constructor, errors thrown from the executor are automatically caught and turned into rejections, so these two examples are largely equivalent, except that `Promise.try()` is perhaps more concise and readable.
 
 Note that `Promise.try()` is _not_ equivalent to this, despite being highly similar:
 


### PR DESCRIPTION
The example (with try..catch) is more verbose, unnecessary, and distracting, so I removed it.

It's also misleading to claim that's "more "faithful to the spec, as it's not *more* faithful, but just a different way of accomplishing the same thing; it merely obviates machinery (basically, try..catch) that's already in the Promise constructor.