### PR TITLE
docs: fix typo from webkitEntries to webkitdirectory

### DIFF
--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -15,7 +15,7 @@ When a directory is selected, the directory and its entire hierarchy of contents
 The selected file system entries can be obtained using the {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} property.
 
 > [!NOTE]
-> This property is called `webkitEntries` in the specification due to its
+> This property is called `webkitdirectory` in the specification due to its
 > origins as a Google Chrome-specific API. It's likely to be renamed someday.
 
 ## Value


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Changes `webkitEntries` to `webkitdirectory` in note at the top of the page

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests
Fixes #35782 


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
