### PR TITLE
clarifying description and code for static block 'var' hoisting

### DIFF
--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -41,7 +41,7 @@ A {{jsxref("Statements/class", "class")}} can have any number of `static {}` ini
 These are [evaluated](/en-US/docs/Web/JavaScript/Reference/Classes#evaluation_order), along with any interleaved static field initializers, in the order they are declared.
 Any static initialization of a super class is performed first, before that of its sub classes.
 
-The scope of the variables declared inside the static block is local to the block. This includes `var`, `function`, `const`, and `let` declarations. `var` declarations in the block are not hoisted.
+The scope of the variables declared inside the static block is local to the block. This includes `var`, `function`, `const`, and `let` declarations. `var` declarations _do_ hoist, but only within the block.
 
 ```js
 var y = "Outer y";
@@ -49,11 +49,15 @@ var y = "Outer y";
 class A {
   static field = "Inner y";
   static {
+    // var y only hoisted inside block
+    console.log(y);  // undefined <-- not 'Outer y'
+
     var y = this.field;
   }
 }
 
-// var defined in static block is not hoisted
+// var y defined in static block is not hoisted
+// outside the block
 console.log(y); // 'Outer y'
 ```
 

--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -50,7 +50,7 @@ class A {
   static field = "Inner y";
   static {
     // var y only hoisted inside block
-    console.log(y);  // undefined <-- not 'Outer y'
+    console.log(y); // undefined <-- not 'Outer y'
 
     var y = this.field;
   }

--- a/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/static_initialization_blocks/index.md
@@ -41,7 +41,7 @@ A {{jsxref("Statements/class", "class")}} can have any number of `static {}` ini
 These are [evaluated](/en-US/docs/Web/JavaScript/Reference/Classes#evaluation_order), along with any interleaved static field initializers, in the order they are declared.
 Any static initialization of a super class is performed first, before that of its sub classes.
 
-The scope of the variables declared inside the static block is local to the block. This includes `var`, `function`, `const`, and `let` declarations. `var` declarations _do_ hoist, but only within the block.
+The scope of the variables declared inside the static block is local to the block. This includes `var`, `function`, `const`, and `let` declarations. `var` declarations will not be hoisted out of the static block.
 
 ```js
 var y = "Outer y";


### PR DESCRIPTION
I was confused by how the "hoisting" issue with `var` inside class static blocks was explained, and illustrated with the code. I clarified that `var` *does in fact* hoist, but only within the block. Tweaked the code to illustrate that fact.