### PR TITLE
fix(ci/spellcheck): create a new issue every week

### DIFF
--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -24,12 +24,16 @@ jobs:
           npm install
           echo Running spelling check...
           output=$(npx cspell --no-progress --gitignore --config .vscode/cspell.json "**/*.md" || exit 0)
-          output=$(node scripts/linkify-logs.js "${output}")
-          output=$(echo "$output" | sed 's/^/- /')
-          echo "$output"
-          echo "OUTPUT<<EOF" >> $GITHUB_ENV
-          echo "$output" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          if [ -n "${output}" ]; then
+            output=$(node scripts/linkify-logs.js "${output}")
+            output=$(echo "$output" | sed 's/^/- /')
+            echo "$output"
+            echo "OUTPUT<<EOF" >> $GITHUB_ENV
+            echo "$output" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "No typos found! 🎉"
+          fi
 
       - name: Report spellcheck errors
         if: env.OUTPUT != ''
@@ -43,14 +47,18 @@ jobs:
           > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
           EOM
           )
-          comment_body+=$'\n\n'$(echo "_(comment last updated: $(date +'%Y-%m-%d %H:%M:%S'))_")
+
+          # create a new issue
+          # https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
           gh api \
-            --method PATCH \
+            --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mdn/content/issues/35634 \
-            -f "state=open" \
-            -f "body=${comment_body}"
+            /repos/mdn/content/issues \
+            -f "title=Weekly spelling check" \
+            -f "body=${comment_body}" \
+            -f "labels[]=reported by automation" \
+            -f "labels[]=good first issue"
         env:
           OUTPUT: ${{ env.OUTPUT }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/spelling-check-bot.yml
+++ b/.github/workflows/spelling-check-bot.yml
@@ -9,6 +9,8 @@ jobs:
   sync:
     if: github.repository == 'mdn/content'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +23,6 @@ jobs:
 
       - name: Run scripts
         run: |
-          npm install
           echo Running spelling check...
           output=$(npx cspell --no-progress --gitignore --config .vscode/cspell.json "**/*.md" || exit 0)
           if [ -n "${output}" ]; then
@@ -38,27 +39,16 @@ jobs:
       - name: Report spellcheck errors
         if: env.OUTPUT != ''
         run: |
-          comment_body=$(cat<<EOM
-          Typos and unknown words:
-
-          ${OUTPUT}
-
-          > [!TIP]
-          > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).
-          EOM
-          )
-
-          # create a new issue
-          # https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/mdn/content/issues \
-            -f "title=Weekly spelling check" \
-            -f "body=${comment_body}" \
-            -f "labels[]=reported by automation" \
-            -f "labels[]=good first issue"
+          issue=$(gh issue create --title "$TITLE" --label "$LABELS" --body "$BODY")
+          echo Issue URL ${issue}
         env:
-          OUTPUT: ${{ env.OUTPUT }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: Weekly spelling check
+          LABELS: reported by automation,good first issue
+          BODY: |
+            Typos and unknown words:
+
+            ${{ env.OUTPUT }}
+
+            > [!TIP]
+            > To exclude words from the spellchecker, you can add valid words (web technology terms or abbreviations) to the [terms-abbreviations.txt](https://github.com/mdn/content/blob/main/.vscode/terms-abbreviations.txt) dictionary for IDE autocompletion. To ignore strings that are not words (\`AABBCC\` in code, for instance), you can add them to [ignore-list.txt](https://github.com/mdn/content/blob/main/.vscode/ignore-list.txt).


### PR DESCRIPTION
- fix https://github.com/mdn/content/issues/35634

We could not agree on how the spelling error report-fix workflow would work. All the options involve complications and are not friendly to new contributors.

The PR makes the workflow report a new issue every week and adds a check: if no typos are found, don't create an issue.