### PR TITLE
Fix two markdown syntax errors causing rendering issues on `postTask`

### DIFF
--- a/files/en-us/web/api/scheduler/posttask/index.md
+++ b/files/en-us/web/api/scheduler/posttask/index.md
@@ -129,7 +129,7 @@ runTask2();
 ### Permanent priorities
 
 [Task priorities](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) may be set using `priority` parameter in the optional second argument.
-Priorities that are set in this way cannot be changed (are [immutable]/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#mutable_and_immutable_task_priority)).
+Priorities that are set in this way cannot be changed (are [immutable](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#mutable_and_immutable_task_priority)).
 
 Below we post two groups of three tasks, each member in reverse order of priority.
 The final task has the default priority.
@@ -175,7 +175,7 @@ bckg 2
 ### Changing task priorities
 
 [Task priorities](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) can also take their initial value from a {{domxref("TaskSignal")}} passed to `postTask()` in the optional second argument.
-If set in this way, the priority of the task [can then be changed]/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#mutable_and_immutable_task_priority) using the controller associated with the signal.
+If set in this way, the priority of the task [can then be changed](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#mutable_and_immutable_task_priority) using the controller associated with the signal.
 
 > [!NOTE]
 > Setting and changing task priorities using a signal only works when the `options.priority` argument to `postTask()` is not set, and when the `options.signal` is a {{domxref("TaskSignal")}} (and not an {{domxref("AbortSignal")}}).


### PR DESCRIPTION
### Description

Fix two markdown syntax errors causing rendering issues on the [postTask page](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/postTask).

### Motivation

We are looking at implementing `postTask` in Sinon (https://github.com/sinonjs/fake-timers/issues/418) and I checked the reference. The rendering was including the broken markdown due to missing a starting parenthesis, which was making it harder to read and use.

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
