### PR TITLE
chore(http): clarifications about Server header, link to HTTP Observatory, OWASP Secure Headers Project

### DIFF
--- a/files/en-us/learn/server-side/first_steps/website_security/index.md
+++ b/files/en-us/learn/server-side/first_steps/website_security/index.md
@@ -140,6 +140,10 @@ A number of other concrete steps you can take are:
 - Keep track of the most popular threats (the [current OWASP list is here](https://owasp.org/www-project-top-ten/)) and address the most common vulnerabilities first.
 - Use [vulnerability scanning tools](https://owasp.org/www-community/Vulnerability_Scanning_Tools) to perform automated security testing on your site. Later on, your very successful website may also find bugs by offering a bug bounty [like Mozilla does here](https://www.mozilla.org/en-US/security/bug-bounty/faq-webapp/).
 - Only store and display data that you need. For example, if your users must store sensitive information like credit card details, only display enough of the card number that it can be identified by the user, and not enough that it can be copied by an attacker and used on another site. The most common pattern at this time is to only display the last 4 digits of a credit card number.
+- Keep software up-to-date.
+  Most servers have regular security updates that fix or mitigate known vulnerabilities.
+  If possible, schedule regular automated updates, and ideally, schedule updates during times when your website has the lowest amount of traffic.
+  It's best to back up your data before updating and test new software versions to make sure there's no compatibility issues on your server.
 
 Web frameworks can help mitigate many of the more common vulnerabilities.
 

--- a/files/en-us/web/http/headers/server/index.md
+++ b/files/en-us/web/http/headers/server/index.md
@@ -7,13 +7,10 @@ browser-compat: http.headers.Server
 
 {{HTTPSidebar}}
 
-The **`Server`** header describes the
-software used by the origin server that handled the request — that is, the server that
-generated the response.
+The **`Server`** header describes the software used by the origin server that handled the request and generated a response.
 
 > [!WARNING]
-> Avoid overly-detailed `Server` values, as they can reveal information that
-> may make it (slightly) easier for attackers to exploit known security holes.
+> The presence of this header in responses, especially when it contains fine-grained implementation details about server software, may make known vulnerabilities easier to detect.
 
 <table class="properties">
   <tbody>
@@ -36,15 +33,13 @@ Server: <product>
 
 ## Directives
 
-- \<product>
-  - : A name of the software or the product that handled the request. Usually in a format
-    similar to {{HTTPHeader('User-Agent')}}.
+- `<product>`
+  - : A name of the software or the product that handled the request.
+    Usually in a format similar to {{HTTPHeader('User-Agent')}}.
 
-How much detail to include is an interesting balance to strike; exposing the OS version
-is probably a bad idea, as mentioned in the earlier warning about overly-detailed
-values. However, exposed Apache versions helped browsers to work around a bug of the
-versions with {{HTTPHeader('Content-Encoding')}} and
-{{HTTPHeader('Range')}} in combination.
+Too much detail in the `Server` header is not advised for response latency and for the security reasons mentioned above.
+It's debatable whether obscuring the information in this header provides much benefit because fingerprinting server software is possible via other means.
+In general, a more robust approach to server security is to ensure software is regularly updated or patched against known vulnerabilities instead.
 
 ## Examples
 
@@ -63,3 +58,5 @@ Server: Apache/2.4.1 (Unix)
 ## See also
 
 - {{HTTPHeader("Allow")}}
+- [HTTP Observatory](/en-US/observatory)
+- [Prevent information disclosure via HTTP headers](https://owasp.org/www-project-secure-headers/index.html#prevent-information-disclosure-via-http-headers) - OWASP Secure Headers Project

--- a/files/en-us/web/http/headers/server/index.md
+++ b/files/en-us/web/http/headers/server/index.md
@@ -9,8 +9,15 @@ browser-compat: http.headers.Server
 
 The **`Server`** header describes the software used by the origin server that handled the request and generated a response.
 
+The benefits of advertising the server type and version via this header are that it helps with analytics and identifying how widespread specific interoperability issues are.
+Historically, clients have used the server version information to avoid known limitations, such as inconsistent support for [range requests](/en-US/docs/Web/HTTP/Range_requests) in specific software versions.
+
 > [!WARNING]
 > The presence of this header in responses, especially when it contains fine-grained implementation details about server software, may make known vulnerabilities easier to detect.
+
+Too much detail in the `Server` header is not advised for response latency and the security reason mentioned above.
+It's debatable whether obscuring the information in this header provides much benefit because fingerprinting server software is possible via other means.
+In general, a more robust approach to server security is to ensure software is regularly updated or patched against known vulnerabilities instead.
 
 <table class="properties">
   <tbody>
@@ -36,10 +43,6 @@ Server: <product>
 - `<product>`
   - : A name of the software or the product that handled the request.
     Usually in a format similar to {{HTTPHeader('User-Agent')}}.
-
-Too much detail in the `Server` header is not advised for response latency and for the security reasons mentioned above.
-It's debatable whether obscuring the information in this header provides much benefit because fingerprinting server software is possible via other means.
-In general, a more robust approach to server security is to ensure software is regularly updated or patched against known vulnerabilities instead.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Fixes #33543

### Motivation

>The directive section suggests that revealing Apache versions helps browsers work around bugs.
Instead, developers should patch bugs without exposing vulnerable information to potential attackers.
Thus, revealing server information contradicts the security warnings in the document.

This wording is inspired by the spec:

>The "Server" header field contains information about the software used by the origin server to handle the request, which is often used by clients to help identify the scope of reported interoperability problems, to work around or __tailor requests to avoid particular server limitations__, 

We should be a little careful about the wording here, even if that's historically true, we shouldn't be encouraging clients to behave differently based on `Server` values.

__modifications:__
- clarifications about security through obscurity
- mention "software updates" in website security section

__Additions:__
- links to HTTP Observatory
- links to OWASP Secure Headers Project
