### PR TITLE
Fix typo in "Element: mouseenter event" article

### DIFF
--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Element.mouseenter_event
 
 The **`mouseenter`** event is fired at an {{domxref("Element")}} when a pointing device (usually a mouse) is initially moved so that its hotspot is within the element at which the event was fired.
 
-Note that "moving into an event" refers to the element's position in the DOM tree, not to its visual position. For example, if a child element is positioned so it is placed outside its parent, then moving into the child element will trigger `mouseenter` on the parent element, even though the pointer is still outside the bounds of the parent element.
+Note that "moving into an element" refers to the element's position in the DOM tree, not to its visual position. For example, if a child element is positioned so it is placed outside its parent, then moving into the child element will trigger `mouseenter` on the parent element, even though the pointer is still outside the bounds of the parent element.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This PR replaces a single word ("event") with a different word ("element").

### Motivation

Based on the surrounding context in this and the previous paragraph, it seems like "element" was the intended word, and "event" was an accident.

### Additional details

No additional relevant details come to my mind.

### Related issues and pull requests

I did not search for related issues and pull requests. It seems unlikely that there would be any.
