### PR TITLE
Remove outdated reference to W3C DOM spec

### DIFF
--- a/files/en-us/web/api/document/getelementsbytagname/index.md
+++ b/files/en-us/web/api/document/getelementsbytagname/index.md
@@ -33,10 +33,6 @@ getElementsByTagName(name)
 
 A live {{domxref("HTMLCollection")}} of found elements in the order they appear in the tree.
 
-> **Note:** [The latest W3C specification](https://dom.spec.whatwg.org/#interface-document) says returned value is an
-> `HTMLCollection`; however, this method returns a {{domxref("NodeList")}} in
-> WebKit browsers. See [Firefox bug 14869](https://bugzil.la/14869) for details.
-
 ## Examples
 
 In the following example, `getElementsByTagName()` starts from a particular

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -28,12 +28,12 @@ getElementsByTagNameNS(namespace, name)
 
 ### Return value
 
-A live {{DOMxRef("NodeList")}} (but see the note below) of
+A live {{DOMxRef("HTMLCollection")}} (but see the note below) of
 found elements in the order they appear in the tree.
 
 > [!NOTE]
-> While the W3C specification says returned value is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} in Firefox.
-> Opera returns a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. As of January 2012, only in WebKit browsers is the returned value a pure `NodeList`.
+> In DOM level 3 and earlier, the returned value is a {{DOMxRef("NodeList")}}, but this method has always returned a `HTMLCollection` in Firefox.
+> Older versions of Opera return a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. 
 > See [bug 14869](https://bugzil.la/14869) for details.
 
 > [!NOTE]

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -32,11 +32,6 @@ A live {{DOMxRef("HTMLCollection")}} (but see the note below) of
 found elements in the order they appear in the tree.
 
 > [!NOTE]
-> In DOM level 3 and earlier, the returned value is a {{DOMxRef("NodeList")}}, but this method has always returned a `HTMLCollection` in Firefox.
-> Older versions of Opera return a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`.
-> See [bug 14869](https://bugzil.la/14869) for details.
-
-> [!NOTE]
 > Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.
 > See the [developer release note for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6#dom) and a note in Browser compatibility section in {{domxref("Element.getElementsByTagNameNS")}} for details.
 

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -33,7 +33,7 @@ found elements in the order they appear in the tree.
 
 > [!NOTE]
 > In DOM level 3 and earlier, the returned value is a {{DOMxRef("NodeList")}}, but this method has always returned a `HTMLCollection` in Firefox.
-> Older versions of Opera return a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. 
+> Older versions of Opera return a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`.
 > See [bug 14869](https://bugzil.la/14869) for details.
 
 > [!NOTE]

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -20,19 +20,17 @@ getElementsByTagNameNS(namespace, name)
 ### Parameters
 
 - `namespace`
-  - : The namespace URI of elements to look for (see
-    {{domxref("Element.namespaceURI", "element.namespaceURI")}}).
+  - : The namespace URI of elements to look for (see {{domxref("Element.namespaceURI", "element.namespaceURI")}}).
 - `name`
-  - : Either the local name of elements to look for or the special
-    value `*`, which matches all elements (see {{domxref("Element.localName", "element.localName")}}).
+
+  - : Either the local name of elements to look for or the special value `*`, which matches all elements (see {{domxref("Element.localName", "element.localName")}}).
+
+    > [!NOTE]
+    > Unlike {{domxref("document.getElementsByTagName()")}}, the parameters for `getElementsByTagNameNS()` are case-sensitive.
 
 ### Return value
 
 A live {{DOMxRef("HTMLCollection")}} of found elements in the order they appear in the tree.
-
-> [!NOTE]
-> Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.
-> See the [developer release note for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6#dom) and a note in Browser compatibility section in {{domxref("Element.getElementsByTagNameNS")}} for details.
 
 ## Examples
 

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -28,8 +28,7 @@ getElementsByTagNameNS(namespace, name)
 
 ### Return value
 
-A live {{DOMxRef("HTMLCollection")}} (but see the note below) of
-found elements in the order they appear in the tree.
+A live {{DOMxRef("HTMLCollection")}} of found elements in the order they appear in the tree.
 
 > [!NOTE]
 > Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
The specified return value is `HTMLCollection` in the current DOM living standard. Changed wording to reflect this.

Latest versions of Opera and WebKit also return the correct `HTMLCollection`, so the note was entirely outdated (and could be removed outright).