### PR TITLE
Fix typo in "Element: mouseleave event" article

### DIFF
--- a/files/en-us/web/api/element/mouseleave_event/index.md
+++ b/files/en-us/web/api/element/mouseleave_event/index.md
@@ -14,7 +14,7 @@ The **`mouseleave`** event is fired at an {{domxref("Element")}} when the cursor
 
 The `mouseleave` and `mouseout` events will not be triggered when the element is replaced or removed from the DOM.
 
-Note that "moving out of an event" refers to the element's position in the DOM tree, not to its visual position. For example, if two sibling elements are positioned so one is placed inside the other, then moving from the outer element into the inner element will trigger `mouseleave` on the outer element, even though the pointer is still in the bounds of the outer element.
+Note that "moving out of an element" refers to the element's position in the DOM tree, not to its visual position. For example, if two sibling elements are positioned so one is placed inside the other, then moving from the outer element into the inner element will trigger `mouseleave` on the outer element, even though the pointer is still in the bounds of the outer element.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This PR replaces a single word ("event") with a different word ("element").

### Motivation

Based on the surrounding context in this and the previous paragraph, it seems like "element" was the intended word, and "event" was an accident.

### Additional details

See "Related issues and pull requests" below.

### Related issues and pull requests

This PR is similar to [another PR](https://github.com/mdn/content/pull/35843) ('Fix typo in "Element: mouseenter event" article') that was accepted today.