### PR TITLE
docs(manifest): Improvements to `name`, `short_name`, `start_url`

### DIFF
--- a/files/en-us/glossary/application_context/index.md
+++ b/files/en-us/glossary/application_context/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **application context** is a top-level {{glossary("browsing context")}} to which a [web application manifest](/en-US/docs/Web/Manifest) is applied.
+An **application context** is a top-level {{glossary("browsing context")}} to which a [web application manifest](/en-US/docs/Web/Manifest) is applied. The members of an applied manifest affect the presentation or behavior of the browsing context.
 
 The manifest is applied after the application context is created but before navigation begins to either a start URL or a deep link. A **deep link** is a URL that directs users to a specific page within the web app, bypassing the home page.
 

--- a/files/en-us/glossary/application_context/index.md
+++ b/files/en-us/glossary/application_context/index.md
@@ -6,15 +6,22 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-An **application context** is a top-level {{glossary("browsing context")}} to which a [web application manifest](/en-US/docs/Web/Manifest) is applied. The members of an applied manifest affect the presentation or behavior of the browsing context.
+**Application context** refers to the top-level {{glossary("browsing context")}} of a web application.
+It determines how an app's browsing context, such as a tab or a window, is presented and behaves.
 
-The manifest is applied after the application context is created but before navigation begins to either a start URL or a deep link. A **deep link** is a URL that directs users to a specific page within the web app, bypassing the home page.
+Web developers define the application context in the [web app's manifest file](/en-US/docs/Web/Manifest).
+They use the [`scope`](/en-US/docs/Web/Manifest/scope) member in the manifest to specify the set of URLs that are considered part of the application context and to which the manifest applies.
+
+The manifest is applied after the application context is created but before navigation begins to either a start URL or a deep link.
+A **start URL** is the initial page of the web app.
+A **deep link** is a URL that directs users to a specific page within the web app, bypassing the home page.
+The application context ensures that the app's defined behavior and presentation are maintained within its scope.
 
 When an application context is created, browsers must immediately navigate to a start URL or a deep link.
 This navigation replaces the current entry in the browsing history.
 If the application context is created to navigate to a deep link, the browser navigates directly to that deep link; otherwise, it navigates to the start URL.
 
-Note that the start URL is not necessarily the value of the [`start_url`](/en-US/docs/Web/Manifest/start_url) member in the manifest. Browsers may ignore the specified `start_url` or may allow users to change its value when adding the application to their device's home screen or bookmarking it.
+Note that the start URL is not necessarily the value of the [`start_url`](/en-US/docs/Web/Manifest/start_url) member in the manifest. Browsers may ignore the specified `start_url` or may allow users to change its value when adding the web app to their device's home screen or bookmarking it.
 
 ## See also
 

--- a/files/en-us/glossary/application_context/index.md
+++ b/files/en-us/glossary/application_context/index.md
@@ -1,18 +1,23 @@
 ---
-title: Application Context
+title: Application context
 slug: Glossary/Application_context
 page-type: glossary-definition
 ---
 
 {{GlossarySidebar}}
 
-An **application context** is a top-level {{glossary("browsing context")}} that has a [manifest](/en-US/docs/Web/Manifest) applied to it.
+An **application context** is a top-level {{glossary("browsing context")}} to which a [web application manifest](/en-US/docs/Web/Manifest) is applied.
 
-If an application context is created as a result of the user agent being asked to navigate to a deep link, the user agent must immediately navigate to the deep link with replacement enabled. Otherwise, when the application context is created, the user agent must immediately navigate to the start URL with replacement enabled.
+The manifest is applied after the application context is created but before navigation begins to either a start URL or a deep link. A **deep link** is a URL that directs users to a specific page within the web app, bypassing the home page.
 
-Please note that the start URL is not necessarily the value of the start_url member: the user or user agent could have changed it when the application was added to home-screen or otherwise bookmarked.
+When an application context is created, browsers must immediately navigate to a start URL or a deep link.
+This navigation replaces the current entry in the browsing history.
+If the application context is created to navigate to a deep link, the browser navigates directly to that deep link; otherwise, it navigates to the start URL.
+
+Note that the start URL is not necessarily the value of the [`start_url`](/en-US/docs/Web/Manifest/start_url) member in the manifest. Browsers may ignore the specified `start_url` or may allow users to change its value when adding the application to their device's home screen or bookmarking it.
 
 ## See also
 
-- [Progressive web apps (PWA)](/en-US/docs/Web/Progressive_web_apps)
 - [`scope`](/en-US/docs/Web/Manifest/scope)
+- [Web app manifests](/en-US/docs/Web/Manifest)
+- [Progressive web apps (PWA)](/en-US/docs/Web/Progressive_web_apps)

--- a/files/en-us/glossary/application_context/index.md
+++ b/files/en-us/glossary/application_context/index.md
@@ -6,7 +6,7 @@ page-type: glossary-definition
 
 {{GlossarySidebar}}
 
-**Application context** refers to the top-level {{glossary("browsing context")}} of a web application.
+**Application context** refers to the top-level {{glossary("browsing context")}} of a [web application](/en-US/docs/Web/Progressive_web_apps).
 It determines how an app's browsing context, such as a tab or a window, is presented and behaves.
 
 Web developers define the application context in the [web app's manifest file](/en-US/docs/Web/Manifest).

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -28,9 +28,6 @@ The `name` manifest member serves as the {{Glossary("Accessible_name", "accessib
 
 In space-constrained contexts where the full `name` may not fit, such as on a device's home screen or in the application switcher, the value of the [`short_name`](/en-US/docs/Web/Manifest/short_name) property (if defined) may be used instead.
 
-> [!NOTE]
-> For Chromium-based browsers, a `name` or `short_name` is required in the manifest for the web app to be installable.
-
 ### Best practices for naming your web app
 
 Consider the following factors when selecting a name for your web app:

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -7,7 +7,7 @@ browser-compat: html.manifest.name
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `name` manifest member is used to specify the name of your web application as it's typically displayed to users.
+The `name` manifest member is used to specify the full name of your web application as it's usually displayed to users, such as in application lists or as a label for your application's icon.
 
 ## Syntax
 
@@ -15,7 +15,6 @@ The `name` manifest member is used to specify the name of your web application a
 /* Full names of web apps */
 "name": "Daily Task Planner"
 "name": "Recipe and Pantry Tracker"
-"name": "Mindful Meditation"
 ```
 
 ### Values
@@ -30,22 +29,24 @@ The `name` manifest member serves as the {{Glossary("Accessible_name", "accessib
 > [!NOTE]
 > For Chromium-based browsers, a `name` or `short_name` is required in the manifest for the web app to be installable.
 
-Consider the following points when selecting a name for your web app:
+### Best practices for naming your web app
 
+Consider the following factors when selecting a name for your web app:
+
+- Length of the name, especially if you're not providing a separate `short_name`
 - How well it indicates the purpose or nature of your app
 - Whether it is clear and easy to understand and remember
-- Its length, especially if you're not providing a separate `short_name`
-- How it will appear in different contexts, such as in app lists or home screen
-- Its uniqueness compared to existing apps
-- Its cultural sensitivity and appropriateness for your target audience
-- How well it translates or is perceived in different languages if your app targets a global audience
-- Whether it has any trademark conflicts
+- How it appears in different contexts, such as in app lists or home screen
+- How easily it can be differentiated from other similar apps
+- Cultural sensitivity and appropriateness for your target audience
+- How well it translates or is perceived in different languages if your app target is a global audience
+- Potential trademark conflicts
 
 ## Examples
 
 ### Adding a name for your web app
 
-For a web app that helps users navigate trails and plan their hiking adventures, you can add the following `name` to the app manifest:
+For a web app that helps users navigate trails and plan their hiking adventures, you might add the following `name` to the app manifest:
 
 ```json
 "name": "Trail Navigator"

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -24,7 +24,9 @@ The `name` manifest member is used to specify the full name of your web applicat
 
 ## Description
 
-The `name` manifest member serves as the {{Glossary("Accessible_name", "accessible name")}} for your installed app. It is displayed to users in various contexts, such as in a list of other installed web apps, as a label for your app's icon, or in the application switcher or task manager. In space-constrained contexts, such as on a device's home screen or in the application switcher, where the full `name` may not fit, the [`short_name`](/en-US/docs/Web/Manifest/short_name) value may be used instead, if available.
+The `name` manifest member serves as the {{Glossary("Accessible_name", "accessible name")}} for your installed app. It is displayed to users in various contexts, such as in a list of other installed web apps, as a label for your app's icon, or in the application switcher or task manager.
+
+In space-constrained contexts where the full `name` may not fit, such as on a device's home screen or in the application switcher, the value of the [`short_name`](/en-US/docs/Web/Manifest/short_name) property (if defined) may be used instead.
 
 > [!NOTE]
 > For Chromium-based browsers, a `name` or `short_name` is required in the manifest for the web app to be installable.

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -11,8 +11,11 @@ The `name` manifest member is used to specify the name of your web application a
 
 ## Syntax
 
-```json
-"name": "<app-name>"
+```json-nolint
+/* Full names of web apps */
+"name": "Daily Task Planner"
+"name": "Recipe and Pantry Tracker"
+"name": "Mindful Meditation"
 ```
 
 ### Keys

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -18,7 +18,7 @@ The `name` manifest member is used to specify the name of your web application a
 "name": "Mindful Meditation"
 ```
 
-### Keys
+### Values
 
 - `name`
   - : A string that specifies the full name of your web app.

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -7,31 +7,52 @@ browser-compat: html.manifest.name
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>String</code></td>
-    </tr>
-  </tbody>
-</table>
+The `name` manifest member is used to specify the name of your web application as it's typically displayed to users.
 
-The `name` member is a string that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon). `name` is directionality-capable, which means it can be displayed left-to-right or right-to-left based on the values of the [`dir`](/en-US/docs/Web/Manifest) and [`lang`](/en-US/docs/Web/Manifest) manifest members.
+## Syntax
+
+```json
+"name": "<app-name>"
+```
+
+- `name`
+  - : A string that specifies the full name of your web app.
+
+## Description
+
+The `name` manifest member serves as the {{Glossary("Accessible_name", "accessible name")}} for your installed app. It is displayed to users in various contexts, such as in a list of other installed web apps, as a label for your app's icon, or in the application switcher or task manager. In space-constrained contexts, such as on a device's home screen or in the application switcher, where the full `name` may not fit, the [`short_name`](/en-US/docs/Web/Manifest/short_name) value may be used instead, if available.
+
+> [!NOTE]
+> For Chromium-based browsers, a `name` or `short_name` is required in the manifest for the web app to be installable.
+
+Consider the following points when selecting a name for your web app:
+
+- How well it indicates the purpose or nature of your app
+- Whether it is clear and easy to understand and remember
+- Its length, especially if you're not providing a separate `short_name`
+- How it will appear in different contexts, such as in app lists or home screen
+- Its uniqueness compared to existing apps
+- Its cultural sensitivity and appropriateness for your target audience
+- How well it translates or is perceived in different languages if your app targets a global audience
+- Whether it has any trademark conflicts
 
 ## Examples
 
-Simple `name` in left-to-right language:
+### Adding a name for your web app
+
+For a web app that helps users navigate trails and plan their hiking adventures, you can add the following `name` to the app manifest:
 
 ```json
-"name": "Awesome application"
+"name": "Trail Navigator"
 ```
 
-Right-to-left `name` in Arabic:
+The app name `Trail Navigator` effectively describes the app's purpose, is easy to read and remember, and is likely to be understood by a wide audience. It uses familiar terms that outdoor enthusiasts might readily understand.
+
+If you want, you can also add a `short_name`:
 
 ```json
-"dir": "rtl",
-"lang": "ar",
-"name": "!أنا من التطبيق"
+"name": "Trail Navigator",
+"short_name": "TrailNav"
 ```
 
 ## Specifications
@@ -41,3 +62,8 @@ Right-to-left `name` in Arabic:
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`short_name`](/en-US/docs/Web/Manifest/short_name) manifest member
+- [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable

--- a/files/en-us/web/manifest/name/index.md
+++ b/files/en-us/web/manifest/name/index.md
@@ -15,6 +15,8 @@ The `name` manifest member is used to specify the name of your web application a
 "name": "<app-name>"
 ```
 
+### Keys
+
 - `name`
   - : A string that specifies the full name of your web app.
 

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -15,7 +15,6 @@ The `short_name` manifest member is used to specify a short name for your web ap
 /* Short names of web apps */
 "short_name": "TaskPlanner"
 "short_name": "RecipePantry"
-"short_name": "Meditate"
 ```
 
 ### Values
@@ -32,7 +31,7 @@ Browsers may use `short_name` in place of [`name`](/en-US/docs/Web/Manifest/name
 
 Keep the following points in mind when selecting a short name for your web app:
 
-- It should reflect a concise version of your app's `name`.
+- It should be a concise version of your app's `name`.
 - While aiming for brevity, it should still be recognizable and meaningful.
 - Consider how it will appear in space-constrained contexts.
 - Follow the same guidelines for cultural sensitivity and trademark as for `name`.

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -26,9 +26,6 @@ The `short_name` manifest member is used to specify a short name for your web ap
 
 Browsers may use `short_name` in place of [`name`](/en-US/docs/Web/Manifest/name) when there is insufficient space to display the full name, such as on a device's home screen, in the application switcher, or in other space-constrained contexts.
 
-> [!NOTE]
-> For Chromium-based browsers, a `short_name` or `name` is required in the manifest for the web app to be installable.
-
 Keep the following points in mind when selecting a short name for your web app:
 
 - It should be a concise version of your app's `name`.

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -7,34 +7,43 @@ browser-compat: html.manifest.short_name
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>String</code></td>
-    </tr>
-  </tbody>
-</table>
+The `short_name` manifest member is used to specify a short name for your web application, which may be used when the full [`name`](/en-US/docs/Web/Manifest/name) is too long for the available space.
 
-The `short_name` member is a string that represents the name of the web application displayed to the user if there is not enough space to display [`name`](/en-US/docs/Web/Manifest/name) (e.g., as a label for an icon on the phone home screen). `short_name` is directionality-capable, which means it can be displayed left-to-right or right-to-left based on the value of the [`dir`](/en-US/docs/Web/Manifest) and [`lang`](/en-US/docs/Web/Manifest) manifest members.
+## Syntax
+
+```json
+"short_name": "<short-app-name>"
+```
+
+- `short_name`
+  - : A string that specifies a short version of your web app's [`name`](/en-US/docs/Web/Manifest/name).
+
+## Description
+
+Browsers may use `short_name` in place of [`name`](/en-US/docs/Web/Manifest/name) when there is insufficient space to display the full name, such as on a device's home screen, in the application switcher, or in other space-constrained contexts.
+
+> [!NOTE]
+> For Chromium-based browsers, a `name` or `short_name` is required in the manifest for the web app to be installable.
+
+Keep the following points in mind when selecting a short name for your web app:
+
+- It should reflect a concise version of your app's `name`.
+- While aiming for brevity, it should still be recognizable and meaningful.
+- Consider how it will appear in space-constrained contexts.
+- Follow the same guidelines for cultural sensitivity and trademark as for `name`.
 
 ## Examples
 
-Simple `short_name` in left-to-right language:
+### Adding a short name for your web app
+
+Consider a web app that helps users plan and log their hiking adventures. The `name` has been defined as `Trail Navigator`. A `short_name` can be added to the manifest as follows:
 
 ```json
-"name": "Awesome application",
-"short_name": "Awesome app"
+"name": "Trail Navigator",
+"short_name": "TrailNav"
 ```
 
-`short_name` in Arabic, which will be displayed right-to-left:
-
-```json
-"dir": "rtl",
-"lang": "ar",
-"name": "تطبيق رائع",
-"short_name": "رائع"
-```
+The app's short name `TrailNav` is concise and is suitable for limited space contexts. It maintains a connection to the app's full name and is easy to remember.
 
 ## Specifications
 
@@ -43,3 +52,8 @@ Simple `short_name` in left-to-right language:
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`name`](/en-US/docs/Web/Manifest/name) manifest member
+- [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -18,7 +18,7 @@ The `short_name` manifest member is used to specify a short name for your web ap
 "short_name": "Meditate"
 ```
 
-### Keys
+### Values
 
 - `short_name`
   - : A string that specifies a short version of your web app's [`name`](/en-US/docs/Web/Manifest/name).

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -11,8 +11,11 @@ The `short_name` manifest member is used to specify a short name for your web ap
 
 ## Syntax
 
-```json
-"short_name": "<short-app-name>"
+```json-nolint
+/* Short names of web apps */
+"short_name": "TaskPlanner"
+"short_name": "RecipePantry"
+"short_name": "Meditate"
 ```
 
 ### Keys
@@ -25,7 +28,7 @@ The `short_name` manifest member is used to specify a short name for your web ap
 Browsers may use `short_name` in place of [`name`](/en-US/docs/Web/Manifest/name) when there is insufficient space to display the full name, such as on a device's home screen, in the application switcher, or in other space-constrained contexts.
 
 > [!NOTE]
-> For Chromium-based browsers, a `name` or `short_name` is required in the manifest for the web app to be installable.
+> For Chromium-based browsers, a `short_name` or `name` is required in the manifest for the web app to be installable.
 
 Keep the following points in mind when selecting a short name for your web app:
 

--- a/files/en-us/web/manifest/short_name/index.md
+++ b/files/en-us/web/manifest/short_name/index.md
@@ -15,6 +15,8 @@ The `short_name` manifest member is used to specify a short name for your web ap
 "short_name": "<short-app-name>"
 ```
 
+### Keys
+
 - `short_name`
   - : A string that specifies a short version of your web app's [`name`](/en-US/docs/Web/Manifest/name).
 
@@ -43,7 +45,7 @@ Consider a web app that helps users plan and log their hiking adventures. The `n
 "short_name": "TrailNav"
 ```
 
-The app's short name `TrailNav` is concise and is suitable for limited space contexts. It maintains a connection to the app's full name and is easy to remember.
+The app's shorter name `TrailNav` is concise and is suitable for limited space contexts. It maintains a connection to the app's full name and is easy to remember.
 
 ## Specifications
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -64,7 +64,7 @@ Browsers have flexibility in how they handle `start_url`. They may:
 
 ### Specifying an absolute starting URL
 
-Let's say the manifest file for your web app is linked from `https://example.com/index.html`.
+Let's say the manifest file for your web app is at `https://example.com/resources/manifest.json` and is linked from `https://example.com/index.html`.
 You want a custom starting point when users launch the installed app from their devices, which is different from the default entry page for your web app.
 You can specify this starting URL in your manifest file like so:
 
@@ -72,25 +72,22 @@ You can specify this starting URL in your manifest file like so:
 "start_url": "https://example.com/dashboard.html"
 ```
 
-The `start_url` value above is valid because it is same-origin with `https://example.com/index.html`.
-
-In contrast, the following `start_url` will be considered invalid:
+- The `start_url` value above is valid because it is same-origin with `https://example.com/index.html`.
+- If you don't specify a `start_url`, the browser will fallback to using `https://example.com/index.html`.
+- The `start_url` below is invalid because it is not same-origin with the linking page, so the browser will fallback to using `https://example.com/index.html`:
 
 ```json example-bad
 "start_url": "https://other-domain.com/dashboard.html"
 ```
 
-In this case, the app launch will fallback to using `https://example.com/index.html`.
-
 ### Specifying a relative starting URL
 
-The above example used an absolute `start_url`. Assuming the manifest file's URL is `https://example.com/resources/manifest.json`, you could also specify the same starting point using a relative URL like so:
+You could specify the same starting point using a relative URL as shown below.
+This relative URL will resolve to `https://example.com/dashboard.html` using the manifest file's URL (`https://example.com/resources/manifest.json`) as the base.
 
 ```json
 "start_url": "../dashboard.html"
 ```
-
-Using the manifest file's URL as the base, this relative URL will also resolve to the same location: `https://example.com/dashboard.html`.
 
 ## Specifications
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -9,7 +9,8 @@ browser-compat: html.manifest.start_url
 
 The `start_url` manifest member is used to specify the URL that should be opened when a user launches your web application, such as when tapping the application's icon on their device's home screen or in an application list.
 
-> [!NOTE] > [Browsers have flexibility](#browser_flexibility) in how they the handle `start_url` and may not always use the specified value.
+> [!NOTE]
+> The `start_url` is a hint for browsers. [Browsers have flexibility](#browser_flexibility) in how they the handle `start_url` and may not always use the specified value.
 
 ## Syntax
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -9,6 +9,8 @@ browser-compat: html.manifest.start_url
 
 The `start_url` manifest member is used to specify the URL that should be opened when a user launches your web application, such as when tapping the application's icon on their device's home screen or in an application list.
 
+> [!NOTE] > [Browsers have flexibility](#browser_flexibility) in how they the handle `start_url` and may not always use the specified value.
+
 ## Syntax
 
 ```json-nolint
@@ -35,6 +37,8 @@ The `start_url` manifest member is used to specify the URL that should be opened
 
 ## Description
 
+### Best practices
+
 To ensure the same entry point to your app for all users, specify a `start_url`.
 This URL should navigate users to an important page of your app, such as a dashboard.
 Consider features that users would want to access immediately after launching the app.
@@ -45,9 +49,10 @@ Avoid specifying a generic starting page.
 For security reasons, the `start_url` must be same-origin with the manifest URL.
 If a non-same-origin `start_url` is specified, browsers will fallback to using the page that links to the manifest as the default starting page.
 
-Browsers have flexibility in how they handle `start_url`.
-They may ignore the specified value or provide users with a choice not to use it.
-They may also allow users to modify the URL, such as when creating a bookmark for the web app or at any later time.
+### Browser flexibility
+
+Browsers may ignore the specified `start_url` value or provide users with a choice not to use it.
+Browsers may allow users to modify the URL, such as when creating a bookmark for the web app or at any later time.
 As a result, the `start_url` you specify may not be the one ultimately used.
 It is important for you to keep this in mind while designing your app to allow for variations in `start_url`.
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -40,10 +40,10 @@ The `start_url` manifest member is used to specify the URL that should be opened
 
 The `start_url` allows you to recommend an appropriate common entry point for all users.
 
-Note however that browsers are not required to use the specified URL.
-They might ignore the specified value or provide users with alternative choices.
-The might also allow users to modify the URL at a later time, such as when creating a bookmark for the web app.
-Keep this in mind when designing your app .
+Note, however, that browsers are not required to use the specified URL.
+They may ignore the specified value or provide users with a choice not to use it.
+They may also allow users to modify the URL when creating a bookmark for the web app or at a later time.
+Keep this in mind when designing your app to allow for variations in `start_url`.
 
 ### Best practices
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -10,7 +10,7 @@ browser-compat: html.manifest.start_url
 The `start_url` manifest member is used to specify the URL that should be opened when a user launches your web application, such as when tapping the application's icon on their device's home screen or in an application list.
 
 > [!NOTE]
-> The `start_url` is a hint for browsers. [Browsers have flexibility](#browser_flexibility) in how they the handle `start_url` and may not always use the specified value.
+> The `start_url` is a hint for browsers. [Browsers have flexibility](#description) in how they the handle `start_url` and may not always use the specified value.
 
 ## Syntax
 
@@ -38,9 +38,15 @@ The `start_url` manifest member is used to specify the URL that should be opened
 
 ## Description
 
+The `start_url` allows you to recommend an appropriate common entry point for all users.
+
+Note however that browsers are not required to use the specified URL.
+They might ignore the specified value or provide users with alternative choices.
+The might also allow users to modify the URL at a later time, such as when creating a bookmark for the web app.
+Keep this in mind when designing your app .
+
 ### Best practices
 
-To ensure the same entry point to your app for all users, specify a `start_url`.
 This URL should navigate users to an important page of your app, such as a dashboard.
 Consider features that users would want to access immediately after launching the app.
 If your app's main page is at the root of your site, you can set the `start_url` to `/`.
@@ -49,13 +55,6 @@ Avoid specifying a generic starting page.
 
 For security reasons, the `start_url` must be same-origin with the manifest URL.
 If a non-same-origin `start_url` is specified, browsers will fallback to using the page that links to the manifest as the default starting page.
-
-### Browser flexibility
-
-Browsers may ignore the specified `start_url` value or provide users with a choice not to use it.
-Browsers may allow users to modify the URL, such as when creating a bookmark for the web app or at any later time.
-As a result, the `start_url` you specify may not be the one ultimately used.
-It is important for you to keep this in mind while designing your app to allow for variations in `start_url`.
 
 ## Privacy considerations
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -27,17 +27,13 @@ The `start_url` manifest member is used to specify the URL that should be opened
 
   - : A string that represents the starting URL of a web app.
     The URL can be absolute or relative.
-    If the value is relative, it is resolved against the manifest file's URL.
+    If the value is relative, it is resolved against the manifest URL.
 
-    The value must be same-origin with the URL of the page from which the web app is installed.
-    The value must also be within the defined [scope](/en-US/docs/Web/Manifest/scope).
+    The `start_url` must be within the [scope](/en-US/docs/Web/Manifest/scope) of the web app and must be same-origin with the manifest URL.
 
-    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the installation page URL), the URL of the page from which the web app was installed is used.
+    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the manifest URL), the URL of the page that links to the manifest is used.
 
 ## Description
-
-Users can install your web app from any page within its [scope](/en-US/docs/Web/Manifest/scope).
-In the absence of a `start_url`, this installation page becomes the default starting point when the app is launched, which can result in different starting pages across users.
 
 To ensure the same entry point to your app for all users, specify a `start_url`.
 This URL should navigate users to an important page of your app, such as a dashboard.
@@ -46,9 +42,8 @@ If your app's main page is at the root of your site, you can set the `start_url`
 You can also specify a deep link (e.g., `https://myapp.com/product/whatsnew`) to direct users to specific content within your app.
 Avoid specifying a generic starting page.
 
-For security reasons, the `start_url` must be same-origin with the app installation page.
-If a non-same-origin `start_url` is specified, browsers will fallback to using the app installation page as the default starting page.
-This ensures that the app can only start within the {{Glossary("Application_context", "app's context")}}.
+For security reasons, the `start_url` must be same-origin with the manifest URL.
+If a non-same-origin `start_url` is specified, browsers will fallback to using the page that links to the manifest as the default starting page.
 
 Browsers have flexibility in how they handle `start_url`.
 They may ignore the specified value or provide users with a choice not to use it.
@@ -81,7 +76,7 @@ It is important for you to keep this in mind while designing your app to allow f
 
 ### Specifying an absolute starting URL
 
-Let's say the manifest file for your hiking web app is at `https://hikingpro.com/resources/manifest.json`, and the app is installed from `https://hikingpro.com/index.html`.
+Let's say the manifest file for your hiking web app is at `https://hikingpro.com/resources/manifest.json`, and `https://hikingpro.com/index.html` links to the manifest file.
 You want users to land on the `trailhub.html` page when they launch the app.
 You can specify this starting URL in your manifest file like so:
 
@@ -89,13 +84,15 @@ You can specify this starting URL in your manifest file like so:
 "start_url": "https://hikingpro.com/trailhub.html"
 ```
 
-The `start_url` value above is valid because it is same-origin with the installation page URL (`https://hikingpro.com/index.html`).
+This `start_url` value is valid because it is same-origin with the manifest URL (`https://hikingpro.com/resources/manifest.json`).
 
-If you don't specify a `start_url` or if the `start_url` you specify is not same-origin with the installation page URL (as shown below), browsers will display the installation page instead of the trailhub page when users launch the app:
+The following `start_url` is invalid because it is not the same-origin with the manifest URL:
 
 ```json example-bad
 "start_url": "https://other-domain.com/trailhub.html"
 ```
+
+In the above case, `https://hikingpro.com/index.html` will be used as the default starting page when users launch the app.
 
 ### Specifying a relative starting URL
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -7,7 +7,7 @@ browser-compat: html.manifest.start_url
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `start_url` manifest member is used to specify the URL that should be loaded when a user launches your web application, such as when tapping the app's icon on the home screen or in a device's application menu.
+The `start_url` manifest member is used to specify the URL that should be opened when a user launches your web application, such as when tapping the application's icon on their device's home screen or in an application list.
 
 ## Syntax
 
@@ -24,20 +24,37 @@ The `start_url` manifest member is used to specify the URL that should be loaded
 ### Values
 
 - `start_url`
+
   - : A string that represents the starting URL of a web app.
-    The value must be same-origin with the page that links to the manifest file.
+    The URL can be absolute or relative.
     If the value is relative, it is resolved against the manifest file's URL.
-    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the linking page), the URL of the page that links to the manifest file is used as a fallback.
+
+    The value must be same-origin with the URL of the page from which the web app is installed.
+    The value must also be within the defined [scope](/en-US/docs/Web/Manifest/scope).
+
+    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the installation page URL), the URL of the page from which the web app was installed is used.
 
 ## Description
 
-The `start_url` must be same-origin with the page that links to the manifest file for security reasons. If the URL is missing or invalid, the linking page is used as a fallback to ensure there's always a valid starting point for the app.
+Users can install your web app from any page within its [scope](/en-US/docs/Web/Manifest/scope).
+In the absence of a `start_url`, this installation page becomes the default starting point when the app is launched, which can result in different starting pages across users.
 
-Browsers have flexibility in how they handle `start_url`. They may:
+To ensure the same entry point to your app for all users, specify a `start_url`.
+This URL should navigate users to an important page of your app, such as a dashboard.
+Consider features that users would want to access immediately after launching the app.
+If your app's main page is at the root of your site, you can set the `start_url` to `/`.
+You can also specify a deep link (e.g., `https://myapp.com/product/whatsnew`) to direct users to specific content within your app.
+Avoid specifying a generic starting page.
 
-- Ignore the specified value.
-- Provide users with a choice not to use it.
-- Allow users to inspect and modify the URL, such as when creating a bookmark for the web app or any time later. Therefore, when developing your app, keep in mind that the `start_url` may be altered. This flexibility provided by browsers can help protect user privacy. See [Privacy considerations](#privacy_considerations) for more details.
+For security reasons, the `start_url` must be same-origin with the app installation page.
+If a non-same-origin `start_url` is specified, browsers will fallback to using the app installation page as the default starting page.
+This ensures that the app can only start within the {{Glossary("Application_context", "app's context")}}.
+
+Browsers have flexibility in how they handle `start_url`.
+They may ignore the specified value or provide users with a choice not to use it.
+They may also allow users to modify the URL, such as when creating a bookmark for the web app or at any later time.
+As a result, the `start_url` you specify may not be the one ultimately used.
+It is important for you to keep this in mind while designing your app to allow for variations in `start_url`.
 
 > [!NOTE]
 > For Chromium-based browsers, a `start_url` is required in the manifest for the web app to be installable.
@@ -46,47 +63,47 @@ Browsers have flexibility in how they handle `start_url`. They may:
 
 - **Fingerprinting**:
 
-  While you can potentially encode strings into `start_url` that uniquely identify a user (e.g., server-assigned identifiers, such as `?user=123`, `/user/123/`, or `https://user123.foo.bar`), it is considered a bad practice.
-  The information would represent a fingerprint that remains even when users clear site data, without users being aware of this privacy-sensitive information.
-
-  > [!NOTE]
-  > It is recommended that you don't include any information in `start_url` that could uniquely identify users.
+  Encoding strings into `start_url` to uniquely identify users (e.g., server-assigned identifiers, such as `?user=123`, `/user/123/`, or `https://user123.foo.bar`) creates a persistent fingerprint.
+  Users may not be aware that their privacy-sensitive information can persist even after they've cleared site data.
+  It is bad practice to include any information in `start_url` that could uniquely identify users.
 
   Browsers may offer protection against this type of fingerprinting.
-  For example, when a user clears data from an origin, the browser may prompt users to uninstall apps that are within the scope of that origin.
-  This would remove any potential fingerprint from the app's `start_url`.
+  For example, when users clear data from an origin, browsers may prompt them to uninstall apps that are within that origin's scope.
+  This removes any potential fingerprint from the app's `start_url`.
 
 - **Launch tracking**:
 
-  You can potentially add a `start_url` to indicate that the app was launched from outside the browser (e.g., `"start_url": "index.html?launcher=homescreen"`). While this can be useful for analytics and other customizations, be cautious about potential privacy implications. This information could be used as part of a user's digital fingerprint.
+  Adding parameters to a `start_url` to indicate that the app was launched from outside the browser (e.g., `"start_url": "index.html?launcher=homescreen"`) can be useful for analytics and customizations.
+  However, this information could be used as part of a user's digital fingerprint.
+  Consider the potential privacy implications when implementing such tracking.
 
 ## Examples
 
 ### Specifying an absolute starting URL
 
-Let's say the manifest file for your web app is at `https://example.com/resources/manifest.json` and is linked from `https://example.com/index.html`.
-You want a custom starting point when users launch the installed app from their devices, which is different from the default entry page for your web app.
+Let's say the manifest file for your hiking web app is at `https://hikingpro.com/resources/manifest.json`, and the app is installed from `https://hikingpro.com/index.html`.
+You want users to land on the `trailhub.html` page when they launch the app.
 You can specify this starting URL in your manifest file like so:
 
 ```json
-"start_url": "https://example.com/dashboard.html"
+"start_url": "https://hikingpro.com/trailhub.html"
 ```
 
-- The `start_url` value above is valid because it is same-origin with `https://example.com/index.html`.
-- If you don't specify a `start_url`, the browser will fallback to using `https://example.com/index.html`.
-- The `start_url` below is invalid because it is not same-origin with the linking page, so the browser will fallback to using `https://example.com/index.html`:
+The `start_url` value above is valid because it is same-origin with the installation page URL (`https://hikingpro.com/index.html`).
+
+If you don't specify a `start_url` or if the `start_url` you specify is not same-origin with the installation page URL (as shown below), browsers will display the installation page instead of the trailhub page when users launch the app:
 
 ```json example-bad
-"start_url": "https://other-domain.com/dashboard.html"
+"start_url": "https://other-domain.com/trailhub.html"
 ```
 
 ### Specifying a relative starting URL
 
-You could specify the same starting point using a relative URL as shown below.
-This relative URL will resolve to `https://example.com/dashboard.html` using the manifest file's URL (`https://example.com/resources/manifest.json`) as the base.
+For your hiking app in the previous scenario, you can specify the same starting point using a relative URL, as shown below.
+This relative URL will resolve to `https://hikingpro.com/trailhub.html` using the manifest file's URL (`https://hikingpro.com/resources/manifest.json`) as the base.
 
 ```json
-"start_url": "../dashboard.html"
+"start_url": "../trailhub.html"
 ```
 
 ## Specifications
@@ -99,5 +116,7 @@ This relative URL will resolve to `https://example.com/dashboard.html` using the
 
 ## See also
 
-- [Same-origin policy](/en-US/docs/Web/Security/Same-origin_policy)
+- {{Glossary("Application_context", "Application context")}}
+- {{Glossary("Same-origin_policy", "Same-origin policy")}}
 - [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable
+- [Security on the web](/en-US/docs/Web/Security)

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -51,9 +51,6 @@ They may also allow users to modify the URL, such as when creating a bookmark fo
 As a result, the `start_url` you specify may not be the one ultimately used.
 It is important for you to keep this in mind while designing your app to allow for variations in `start_url`.
 
-> [!NOTE]
-> For Chromium-based browsers, a `start_url` is required in the manifest for the web app to be installable.
-
 ## Privacy considerations
 
 - **Fingerprinting**:

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -7,31 +7,36 @@ browser-compat: html.manifest.start_url
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>String</code></td>
-    </tr>
-  </tbody>
-</table>
+The `start_url` manifest member is used to specify the URL that should be loaded when a web application is launched.
 
-The `start_url` member is a string that represents the _start URL of the web application_ — the preferred URL that should be loaded when the user launches the web application (e.g., when the user taps on the web application's icon from a device's application menu or homescreen).
-
-A valid `start_url` needs to be same-origin with the document that references the manifest. If `start_url` is unspecified or invalid in any way (such as not a string, not a valid URL, or not a same-origin with the document), the document URL is used.
+a string that represents the _start URL of the web application_ — the preferred URL that should be loaded when the user launches the web application (e.g., when the user taps on the web application's icon from a device's application menu or homescreen).
 
 > [!NOTE]
 > The `start_url` member is purely advisory, and a user agent may ignore it or allow the user to alter it at install time or afterwards.
 
+## Syntax
+
+```json
+"start_url": "<url>"
+```
+
+### Keys
+
+- `start_url`
+  - : A string that represents the starting URL of a web app.
+    The value must be same-origin with the document that references the manifest.
+    If the `start_url` is relative, it is resolved against the manifest URL.
+    If the `start_url` is unspecified or invalid (e.g., not a string, not a valid URL, or not same-origin with the document), the document URL is used as a fallback.
+
 ## Examples
 
-### Absolute URL
+### Specifying an absolute starting URL
 
 ```json
 "start_url": "https://example.com"
 ```
 
-### Relative URL
+### Specifying a relative starting URL
 
 If the URL is relative, the manifest URL is used as the base URL to resolve it.
 
@@ -46,3 +51,5 @@ If the URL is relative, the manifest URL is used as the base URL to resolve it.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -11,8 +11,14 @@ The `start_url` manifest member is used to specify the URL that should be loaded
 
 ## Syntax
 
-```json
-"start_url": "<url>"
+```json-nolint
+/* Absolute URLs */
+"start_url": "https://example.com/myapp"
+"start_url": "https://myapp.com/home"
+
+/* Relative URLs */
+"start_url": "/"
+"start_url": "../index.html"
 ```
 
 ### Keys
@@ -20,8 +26,8 @@ The `start_url` manifest member is used to specify the URL that should be loaded
 - `start_url`
   - : A string that represents the starting URL of a web app.
     The value must be same-origin with the page that links to the manifest file.
-    If `<url>` is relative, it is resolved against the manifest file's URL.
-    If `start_url` is unspecified or `<url>` is invalid (i.e., not a string, not a valid URL, or not same-origin with the linking page), the URL of the page that links to the manifest file is used as a fallback.
+    If the value is relative, it is resolved against the manifest file's URL.
+    If `start_url` is unspecified or the value is invalid (i.e., not a string, not a valid URL, or not same-origin with the linking page), the URL of the page that links to the manifest file is used as a fallback.
 
 ## Description
 

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -7,12 +7,7 @@ browser-compat: html.manifest.start_url
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
 
-The `start_url` manifest member is used to specify the URL that should be loaded when a web application is launched.
-
-a string that represents the _start URL of the web application_ — the preferred URL that should be loaded when the user launches the web application (e.g., when the user taps on the web application's icon from a device's application menu or homescreen).
-
-> [!NOTE]
-> The `start_url` member is purely advisory, and a user agent may ignore it or allow the user to alter it at install time or afterwards.
+The `start_url` manifest member is used to specify the URL that should be loaded when a user launches your web application, such as when tapping the app's icon on the home screen or in a device's application menu.
 
 ## Syntax
 
@@ -24,25 +19,72 @@ a string that represents the _start URL of the web application_ — the preferre
 
 - `start_url`
   - : A string that represents the starting URL of a web app.
-    The value must be same-origin with the document that references the manifest.
-    If the `start_url` is relative, it is resolved against the manifest URL.
-    If the `start_url` is unspecified or invalid (e.g., not a string, not a valid URL, or not same-origin with the document), the document URL is used as a fallback.
+    The value must be same-origin with the page that links to the manifest file.
+    If `<url>` is relative, it is resolved against the manifest file's URL.
+    If `start_url` is unspecified or `<url>` is invalid (i.e., not a string, not a valid URL, or not same-origin with the linking page), the URL of the page that links to the manifest file is used as a fallback.
+
+## Description
+
+The `start_url` must be same-origin with the page that links to the manifest file for security reasons. If the URL is missing or invalid, the linking page is used as a fallback to ensure there's always a valid starting point for the app.
+
+Browsers have flexibility in how they handle `start_url`. They may:
+
+- Ignore the specified value.
+- Provide users with a choice not to use it.
+- Allow users to inspect and modify the URL, such as when creating a bookmark for the web app or any time later. Therefore, when developing your app, keep in mind that the `start_url` may be altered. This flexibility provided by browsers can help protect user privacy. See [Privacy considerations](#privacy_considerations) for more details.
+
+> [!NOTE]
+> For Chromium-based browsers, a `start_url` is required in the manifest for the web app to be installable.
+
+## Privacy considerations
+
+- **Fingerprinting**:
+
+  While you can potentially encode strings into `start_url` that uniquely identify a user (e.g., server-assigned identifiers, such as `?user=123`, `/user/123/`, or `https://user123.foo.bar`), it is considered a bad practice.
+  The information would represent a fingerprint that remains even when users clear site data, without users being aware of this privacy-sensitive information.
+
+  > [!NOTE]
+  > It is recommended that you don't include any information in `start_url` that could uniquely identify users.
+
+  Browsers may offer protection against this type of fingerprinting.
+  For example, when a user clears data from an origin, the browser may prompt users to uninstall apps that are within the scope of that origin.
+  This would remove any potential fingerprint from the app's `start_url`.
+
+- **Launch tracking**:
+
+  You can potentially add a `start_url` to indicate that the app was launched from outside the browser (e.g., `"start_url": "index.html?launcher=homescreen"`). While this can be useful for analytics and other customizations, be cautious about potential privacy implications. This information could be used as part of a user's digital fingerprint.
 
 ## Examples
 
 ### Specifying an absolute starting URL
 
+Let's say the manifest file for your web app is linked from `https://example.com/index.html`.
+You want a custom starting point when users launch the installed app from their devices, which is different from the default entry page for your web app.
+You can specify this starting URL in your manifest file like so:
+
 ```json
-"start_url": "https://example.com"
+"start_url": "https://example.com/dashboard.html"
 ```
+
+The `start_url` value above is valid because it is same-origin with `https://example.com/index.html`.
+
+In contrast, the following `start_url` will be considered invalid:
+
+```json example-bad
+"start_url": "https://other-domain.com/dashboard.html"
+```
+
+In this case, the app launch will fallback to using `https://example.com/index.html`.
 
 ### Specifying a relative starting URL
 
-If the URL is relative, the manifest URL is used as the base URL to resolve it.
+The above example used an absolute `start_url`. Assuming the manifest file's URL is `https://example.com/resources/manifest.json`, you could also specify the same starting point using a relative URL like so:
 
 ```json
-"start_url": "../startpoint.html"
+"start_url": "../dashboard.html"
 ```
+
+Using the manifest file's URL as the base, this relative URL will also resolve to the same location: `https://example.com/dashboard.html`.
 
 ## Specifications
 
@@ -53,3 +95,6 @@ If the URL is relative, the manifest URL is used as the base URL to resolve it.
 {{Compat}}
 
 ## See also
+
+- [Same-origin policy](/en-US/docs/Web/Security/Same-origin_policy)
+- [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable

--- a/files/en-us/web/manifest/start_url/index.md
+++ b/files/en-us/web/manifest/start_url/index.md
@@ -21,7 +21,7 @@ The `start_url` manifest member is used to specify the URL that should be loaded
 "start_url": "../index.html"
 ```
 
-### Keys
+### Values
 
 - `start_url`
   - : A string that represents the starting URL of a web app.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This work is part of improving the web/manifest docs.

Notable changes in this PR:

- `name` and `short_name`:
    - Added "Description" (info from spec plus some general guidelines) and "See also" sections
    - Removed reference to `dir` and `lang` because they are not implemented (https://developer.mozilla.org/en-US/docs/Web/Manifest)
    - Updated examples and added prose

- `start_url`:
   - "Description" and "Privacy considerations" sections cover info from the spec
   - Added more explanation in examples

### Motivation

To ensure all sections have sufficient explanation, all caveats from spec are covered, and the pages follow a similar template

### Additional details

- Spec links:
  - https://w3c.github.io/manifest/#name-member
  - https://w3c.github.io/manifest/#short_name-member
  - https://w3c.github.io/manifest/#start_url-member

### Related issues and pull requests

Tracking issue: https://github.com/mdn/mdn/issues/560

