### PR TITLE
add note that the void operator doesn't work on arrow function iifes

### DIFF
--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -74,7 +74,7 @@ This is a bit longer than wrapping the function expression in parentheses, which
 })();
 ```
 
-Note that this trick only applies to IIFEs defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error. You should use parentheses around the arrow function instead.
+Note that this trick only applies to IIFEs defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error. Arrow function expressions always require parentheses around them when being called.
 
 ```js example-bad
 void () => { console.log('iife!'); }(); // SyntaxError: Malformed arrow function parameter list

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -74,10 +74,10 @@ This is a bit longer than wrapping the function expression in parentheses, which
 })();
 ```
 
-Note also that this trick only applies to immediately-invoked functions defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error.
+Note that this trick only applies to immediately-invoked functions defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error.
 
 ```js
-void () => { console.log('iife!')! }(); // SyntaxError: Malformed arrow function parameter list
+void () => { console.log('iife!'); }(); // SyntaxError: Malformed arrow function parameter list
 ```
 
 ### JavaScript URIs

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -77,7 +77,7 @@ This is a bit longer than wrapping the function expression in parentheses, which
 Note that this trick only applies to IIFEs defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error. Arrow function expressions always require parentheses around them when being called.
 
 ```js example-bad
-void () => { console.log('iife!'); }(); // SyntaxError: Malformed arrow function parameter list
+void () => { console.log("iife!"); }(); // SyntaxError: Malformed arrow function parameter list
 ```
 
 ### JavaScript URIs

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -74,7 +74,7 @@ This is a bit longer than wrapping the function expression in parentheses, which
 })();
 ```
 
-Note that this trick only applies to immediately-invoked functions defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error.
+Note that this trick only applies to IIFEs defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error. You should use parentheses around the arrow function instead.
 
 ```js example-bad
 void () => { console.log('iife!'); }(); // SyntaxError: Malformed arrow function parameter list

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -76,7 +76,7 @@ This is a bit longer than wrapping the function expression in parentheses, which
 
 Note that this trick only applies to immediately-invoked functions defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error.
 
-```js
+```js example-bad
 void () => { console.log('iife!'); }(); // SyntaxError: Malformed arrow function parameter list
 ```
 

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -74,6 +74,12 @@ This is a bit longer than wrapping the function expression in parentheses, which
 })();
 ```
 
+Note also that this trick only applies to immediately-invoked functions defined with the `function` keyword. Attempting to use the `void` operator to avoid parentheses for an arrow function results in a syntax error.
+
+```js
+void () => { console.log('iife!')! }(); // SyntaxError: Malformed arrow function parameter list
+```
+
 ### JavaScript URIs
 
 When a browser follows a [`javascript:` URI](/en-US/docs/Web/URI/Schemes/javascript), it evaluates the code in the URI


### PR DESCRIPTION
### Description

Add a note that using the `void` operator to avoid wrapping IIFEs in parentheses is not applicable to arrow functions.

### Motivation

The docs make it feel to the user like using the `void` operator is a good habit to get in for IIFEs. However, in modern JS, where arrow functions are largely preferred for function expressions in general, including for IIFEs, this isn't possible. The addition in this PR clarifies that the `void` operator for IIFEs is not a generalizable pattern in modern JS.