### PR TITLE
Homogenization of query string writing

### DIFF
--- a/.vscode/ignore-list.txt
+++ b/.vscode/ignore-list.txt
@@ -3781,7 +3781,6 @@ quaxxor
 queryphrase
 queryset
 querysets
-querystring
 quibusdam
 QUIC
 quickbrownfox

--- a/files/en-us/web/api/htmlanchorelement/search/index.md
+++ b/files/en-us/web/api/htmlanchorelement/search/index.md
@@ -16,7 +16,7 @@ Modern browsers provide
 [`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examples)
 and
 [`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
-to make it easy to parse out the parameters from the querystring.
+to make it easy to parse out the parameters from the query string.
 
 ## Value
 

--- a/files/en-us/web/api/htmlareaelement/search/index.md
+++ b/files/en-us/web/api/htmlareaelement/search/index.md
@@ -16,7 +16,7 @@ Modern browsers provide
 [`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examples)
 and
 [`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
-to make it easy to parse out the parameters from the querystring.
+to make it easy to parse out the parameters from the query string.
 
 ## Value
 

--- a/files/en-us/web/api/location/index.md
+++ b/files/en-us/web/api/location/index.md
@@ -124,7 +124,7 @@ document.body.addEventListener("click", (event) => {
 - {{domxref("Location.pathname")}}
   - : A string containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
 - {{domxref("Location.search")}}
-  - : A string containing a `'?'` followed by the parameters or "querystring" of the URL. Modern browsers provide [URLSearchParams](/en-US/docs/Web/API/URLSearchParams/get#examples) and [URL.searchParams](/en-US/docs/Web/API/URL/searchParams#examples) to make it easy to parse out the parameters from the querystring.
+  - : A string containing a `'?'` followed by the parameters or "query string" of the URL. Modern browsers provide [`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get) and [`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams) to make it easy to parse out the parameters from the query string.
 - {{domxref("Location.hash")}}
   - : A string containing a `'#'` followed by the fragment identifier of the URL.
 - {{domxref("Location.origin")}} {{ReadOnlyInline}}

--- a/files/en-us/web/http/headers/referer/index.md
+++ b/files/en-us/web/http/headers/referer/index.md
@@ -49,7 +49,7 @@ Referer: <url>
 - \<url>
   - : An absolute or partial address of the web page that makes the request.
     URL fragments (i.e. `#section`) and userinfo (i.e. `username:password` in `https\://username:password\@example.com/foo/bar/`) are not included.
-    Origin, path, and querystring may be included, depending on the [referrer policy](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives).
+    Origin, path, and query string may be included, depending on the [referrer policy](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#directives).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/headers/referrer-policy/index.md
@@ -43,7 +43,7 @@ Referrer-Policy: unsafe-url
 - `no-referrer`
   - : The {{HTTPHeader("Referer")}} header will be omitted: sent requests do not include any referrer information.
 - `no-referrer-when-downgrade`
-  - : Send the {{glossary("origin")}}, path, and querystring in {{HTTPHeader("Referer")}} when the protocol security level stays the same or improves (HTTP→HTTP, HTTP→HTTPS, HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header for requests to less secure destinations (HTTPS→HTTP, HTTPS→file).
+  - : Send the {{glossary("origin")}}, path, and query string in {{HTTPHeader("Referer")}} when the protocol security level stays the same or improves (HTTP→HTTP, HTTP→HTTPS, HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header for requests to less secure destinations (HTTPS→HTTP, HTTPS→file).
 - `origin`
   - : Send only the {{glossary("origin")}} in the {{HTTPHeader("Referer")}} header.
     For example, a document at `https://example.com/page.html` will send the referrer `https://example.com/`.
@@ -55,7 +55,7 @@ Referrer-Policy: unsafe-url
   - : Send only the origin when the protocol security level stays the same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).
 - `strict-origin-when-cross-origin` (default)
 
-  - : Send the origin, path, and querystring when performing a same-origin request. For cross-origin requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).
+  - : Send the origin, path, and query string when performing a same-origin request. For cross-origin requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS). Don't send the {{HTTPHeader("Referer")}} header to less secure destinations (HTTPS→HTTP).
 
     > [!NOTE]
     > This is the default policy if no policy is specified, or if the provided value is invalid (see spec revision [November 2020](https://github.com/whatwg/fetch/pull/1066)). Previously the default was `no-referrer-when-downgrade`.


### PR DESCRIPTION
### Description

Homogenization of query string writing for `Referrer-policy`

### Motivation

Use the same writing for the same thing

### Additional details

### Related issues and pull requests
