### PR TITLE
Make sentence clearer in "Using container size and style queries" page

### DIFF
--- a/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/css_containment/container_size_and_style_queries/index.md
@@ -108,7 +108,7 @@ In the above example, the styles within the container query block will apply to 
 
 In the above example, the element has two container names, `wide` and `narrow`. The descendants of any elements with `class="sizeContainer"` will get the styles from the `wide` or `narrow` query applied (or both if an element is precisely 20em wide).
 
-The default value `container-type: normal` prevents the container from being a query container, meaning the element is not a size container but it can still be a [style container](#container_style_queries). The default value `container-name: none` states the container has no name, but it does not prevent the element from matching unnamed queries.
+The default value `container-type: normal` prevents the container from being a size container, but it can still be a [style container](#container_style_queries). The default value `container-name: none` states the container has no name, but it does not prevent the element from matching unnamed queries.
 
 With container queries, we are not limited to size queries! You can also query a container's style features.
 


### PR DESCRIPTION
### Description

It is incorrect to say that "The default value `container-type: normal` prevents the container from being a query container".

### Motivation

See above.

### Additional details

Thank you. 🙏

### Related issues and pull requests

Relates to #35767

This is a follow-up to [this comment](https://github.com/mdn/content/pull/35767#discussion_r1754849093) in the above PR.