### PR TITLE
Fixed a typo in the mediacapabilities.decodingInfo video example

### DIFF
--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -262,7 +262,7 @@ const videoConfig = {
 };
 
 // check support and performance
-navigator.mediaCapabilities.decodingInfo(audioConfig).then((result) => {
+navigator.mediaCapabilities.decodingInfo(videoConfig).then((result) => {
   if (result.supported) {
     log(
       `The video configuration is supported${result.smooth ? ", smooth" : ", not smooth"}${result.powerEfficient ? ", power efficient" : ", not power efficient"}.`,


### PR DESCRIPTION
In the example demonstrating using the function for a video file the constant "audioConfig" is referenced instead of "videoConfig" which is defined right above the function call.

Changed the function call to use videoConfig.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

Fixing a typo in the JavaScript MediaCapabilities.decodingInfo video example.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

To help increase the correctness of the very useful MDN docs.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
