### PR TITLE
fix microformats links

### DIFF
--- a/files/en-us/web/html/microformats/index.md
+++ b/files/en-us/web/html/microformats/index.md
@@ -6,7 +6,7 @@ page-type: guide
 
 {{HTMLSidebar}}
 
-[_Microformats_](https://microformats.org/) are standards used to embed semantics and structured data in HTML, and provide an API to be used by social web applications, search engines, aggregators, and other tools. These minimal patterns of HTML are used for marking up entities that range from fundamental to domain-specific information, such as people, organizations, events, and locations.
+[_Microformats_](https://microformats.org/wiki/Main_Page) are standards used to embed semantics and structured data in HTML, and provide an API to be used by social web applications, search engines, aggregators, and other tools. These minimal patterns of HTML are used for marking up entities that range from fundamental to domain-specific information, such as people, organizations, events, and locations.
 
 - To create a microformats object, `h-*` class names are used in the class attribute.
 - To add a property to an object, the `p-*`, `u-*`, `dt-*`, `e-*` class names are used on one of the object's descendants.
@@ -472,6 +472,6 @@ Supported in all browsers' support for the class attribute and its DOM API.
 
 - [class attribute](/en-US/docs/Web/HTML/Global_attributes/class)
 - [Microformat](https://en.wikipedia.org/wiki/Microformat) on Wikipedia
-- [Microformats official website](https://microformats.org/)
+- [Microformats official website](https://microformats.org/wiki/Main_Page)
 - [Search engines support](https://microformats.org/wiki/search_engines) on Microformats official website
 - [Microformats on IndieWebCamp](https://indieweb.org/microformats)


### PR DESCRIPTION
The microformats website links sometimes redirect to questionable content. Following is the suggestion from the website owner:
> From Tantek:
> Thanks for the heads-up
> Please use https://microformats.org/wiki/ by default

The `https://microformats.org/wiki/` redirects to `https://microformats.org/wiki/Main_Page` so the PR updates the content to use the later URL.