### PR TITLE
fix for FF131 incorrect bugzilla link

### DIFF
--- a/files/en-us/mozilla/firefox/releases/131/index.md
+++ b/files/en-us/mozilla/firefox/releases/131/index.md
@@ -42,7 +42,7 @@ This article provides information about the changes in Firefox 131 that affect d
 
 ### APIs
 
-- The {{domxref('PointerEvent.altitudeAngle','altitudeAngle')}} and {{domxref('PointerEvent.azimuthAngle','azimuthAngle')}} properties of the {{domxref('PointerEvent')}} interface are supported, providing the angle between the pointer/stylus and the screen (X-Y plane), and the rotation of the stylus over the screen relative to its x-axis, respectively. ([Firefox bug 1909673](https://bugzil.la/1909673)).
+- The {{domxref('PointerEvent.altitudeAngle','altitudeAngle')}} and {{domxref('PointerEvent.azimuthAngle','azimuthAngle')}} properties of the {{domxref('PointerEvent')}} interface are supported, providing the angle between the pointer/stylus and the screen (X-Y plane), and the rotation of the stylus over the screen relative to its x-axis, respectively. ([Firefox bug 1656377](https://bugzil.la/1656377)).
 - [Text fragments](/en-US/docs/Web/URI/Fragment/Text_fragments) are now supported, allowing users to link to and highlight specific portions of text in a web page. This feature uses a particular syntax in the [URL fragment](/en-US/docs/Web/URI/Fragment) that identifies the target based on patterns in the rendered text.
   Website developers can also use the existence of the {{domxref("Document.fragmentDirective")}} property (an instance of the {{domxref("FragmentDirective")}} interface) to feature check for text fragment support, and the {{CSSxRef("::target-text")}} pseudo element to select and style text that has been selected using a text fragment link. ([Firefox bug 1914877](https://bugzil.la/1914877))
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

On the releases 131 page, the bugzilla linked for altitudeAngle and azimuthAngle is [Firefox bug 1909673](https://bugzilla.mozilla.org/show_bug.cgi?id=1909673) when it should be [1656377](https://bugzilla.mozilla.org/show_bug.cgi?id=1656377)

Fixes https://github.com/mdn/content/issues/35869 

