### PR TITLE
white-space-collapse: Better example

### DIFF
--- a/files/en-us/web/css/white-space-collapse/index.md
+++ b/files/en-us/web/css/white-space-collapse/index.md
@@ -77,14 +77,17 @@ User agents handle white space collapsing as follows:
 
 <!-- prettier-ignore-start -->
 ```html
-<h2 class="collapse">Default behavior; all whitespace is 
-    collapsed          in the          heading     .</h2>
+<h2 class="collapse">Default behavior;
+  all   whitespace   is   collapsed
+  in    the          heading       .</h2>
 
-<h2 class="preserve">In this case all whitespace is 
-    preserved          in the          heading     .</h2>
+<h2 class="preserve">In this case
+  all   whitespace   is   preserved
+  in    the          heading       .</h2>
 
-<h2 class="preserve-breaks">In this case only the line break is 
-    preserved          in the          heading     .</h2>
+<h2 class="preserve-breaks">In this case only
+  the   line breaks  are  preserved
+  in    the          heading       .</h2>
 ```
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update the HTML used in the `white-space-collapse` example, to more clearly illustrate the behavior.

### Motivation

The previous example used two lines of text for the heading value, and broke those lines at a place where the formatted output could naturally _wrap_ anyway (in many content views).

To more clearly illustrate the behavior of white-space-collapse, switch to a three-line format so that wrapping and explicit breaking are more clearly differentiable.

### Additional Information

Obviously depending on browser width and other factors, the example might previously have looked like this:

![image](https://github.com/user-attachments/assets/c86556d5-4053-402f-b083-9ff6cf3dea32)

![image](https://github.com/user-attachments/assets/ebf29217-7e59-446b-b6e2-fe9e089260b5)

With these changes, the effect of `white-space-collapse` on line breaks is unambiguous:

![image](https://github.com/user-attachments/assets/c6b8c0ee-9a17-4b5b-839c-3a7e880061aa)

![image](https://github.com/user-attachments/assets/c707cbac-0545-4575-9008-60a691f9f87b)

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
