### PR TITLE
Fix time calc on cancelAnimationFrame

### DIFF
--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -31,7 +31,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-const start = Date.now();
+const start = document.timeline.currentTime;
 
 let myReq;
 


### PR DESCRIPTION
### Description

Updates the [code example](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame#examples) on the `cancelAnimationFrame` page. Progress time calculation will now be as expected.

### Related issues and pull requests

Fixes #31840
