### PR TITLE
URLPattern: add link to Go implementation

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -749,5 +749,5 @@ console.log(result.pathname.groups.action); // 'view'
   [on GitHub](https://github.com/kenchris/urlpattern-polyfill)
 - The pattern syntax used by URLPattern is similar to the syntax used by
   [path-to-regexp](https://github.com/pillarjs/path-to-regexp)
-- [An implementation in Go](https://github.com/golang/go/)
+- [An implementation in Go](https://github.com/dunglas/go-urlpattern)
   of the standard is also available

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -749,3 +749,5 @@ console.log(result.pathname.groups.action); // 'view'
   [on GitHub](https://github.com/kenchris/urlpattern-polyfill)
 - The pattern syntax used by URLPattern is similar to the syntax used by
   [path-to-regexp](https://github.com/pillarjs/path-to-regexp)
+- [An implementation in Go](https://github.com/golang/go/)
+  of the standard is also available


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add a link to the Go implementation I wrote of the URL Pattern standard.

### Motivation

I hope it can be useful for Go developers.
