### PR TITLE
 docs(manifest): Improvements to `related_applications` and `prefer_related_applications`

### DIFF
--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -9,10 +9,7 @@ browser-compat: html.manifest.prefer_related_applications
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
-The `prefer_related_applications` manifest member is used to provide a hint to browsers about whether to prefer related native applications over your web application. It is typically used in conjunction with the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member.
-
-> [!NOTE]
-> For Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted.
+The `prefer_related_applications` manifest member is used to provide a hint to browsers whether to prioritize native applications specified in the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member over your web application.
 
 ## Syntax
 
@@ -25,15 +22,17 @@ The `prefer_related_applications` manifest member is used to provide a hint to b
 ### Values
 
 - `prefer_related_applications`
-  - : A boolean value.
-    - If set to `true`, browsers might prompt users to install one of the applications listed in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) instead of your web app.
-    - If set to `false` or omitted, browsers will typically prefer to install your web app over related native applications, if specified.
+  - : A boolean value:
+    - If set to `true`, browsers may prompt users to install one of the applications listed in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) instead of your web app.
+    - If set to `false` or omitted, browsers will prefer to install your web app over related native applications.
+      > [!NOTE]
+      > For Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted to make your web app installable.
 
 ## Examples
 
 ### Specifying preference for installing your web app
 
-Consider a scenario where you have both a web app and native apps for your product. If you want to offer related native apps as options but prefer users to install your web app:
+Consider a scenario where you have both a web app and native apps for your product available on Google Play Store and Windows Store. If you want to offer related native apps as options but prefer users to install your web app, you can set it up in your manifest file as shown below. Browsers will prioritize your web for installation. The native apps will still be available as alternatives.
 
 ```json
 {
@@ -44,18 +43,16 @@ Consider a scenario where you have both a web app and native apps for your produ
       "id": "com.example.hikingapp"
     },
     {
-      "platform": "itunes",
-      "url": "https://apps.apple.com/store/app/hiking/id123456789"
+      "platform": "windows",
+      "url": "https://apps.microsoft.com/store/hikingapp/9WZDNCRFHVJL"
     }
   ]
 }
 ```
 
-Your web app will be installed as the primary app, and browsers will not prompt users to install related native apps. However, the native apps will still be available as alternatives.
+### Specifying preference for installing the related native app
 
-### Specifying preference for installing related native apps
-
-In the previous scenario, if you want to encourage users to install the related native app for a better experience with certain features, you can indicate it via `prefer_related_applications`:
+To encourage users to install your native Android hiking app from Google Play Store over your web app, you can indicate it in your web app's manifest file as shown below. Browsers on Android devices will prefer installing the native app instead of the web app.
 
 ```json
 {
@@ -64,16 +61,10 @@ In the previous scenario, if you want to encourage users to install the related 
     {
       "platform": "play",
       "id": "com.example.hikingapp"
-    },
-    {
-      "platform": "itunes",
-      "url": "https://apps.apple.com/store/app/hiking/id123456789"
     }
   ]
 }
 ```
-
-Browsers might prompt users to install one of the related native app instead of your web app.
 
 ## Specifications
 

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -9,7 +9,7 @@ browser-compat: html.manifest.prefer_related_applications
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
-The `prefer_related_applications` manifest member is used to provide a hint to browsers whether to prioritize native applications specified in the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member over your web application.
+The `prefer_related_applications` manifest member is used to provide a hint to browsers whether to prefer installing native applications specified in the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member over your web application.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ The `prefer_related_applications` manifest member is used to provide a hint to b
 
 ### Specifying preference for installing your web app
 
-Consider a scenario where you have both a web app and native apps for your product available on Google Play Store and Windows Store. If you want to offer related native apps as options but prefer users to install your web app, you can set it up in your manifest file as shown below. Browsers will prioritize your web for installation. The native apps will still be available as alternatives.
+Consider a scenario where you have both a web app and native apps for your product available on Google Play Store and Windows Store. If you want to offer related native apps as options but prefer users to install your web app, you can set it up in your manifest file as shown below. Browsers will promote your web app for installation. The native apps will still be available as alternatives.
 
 ```json
 {
@@ -52,7 +52,7 @@ Consider a scenario where you have both a web app and native apps for your produ
 
 ### Specifying preference for installing the related native app
 
-To encourage users to install your native Android hiking app from Google Play Store over your web app, you can indicate it in your web app's manifest file as shown below. Browsers on Android devices will prefer installing the native app instead of the web app.
+To encourage users to install your native Android hiking app from Google Play Store in preference to the web app, you can configure your web app's manifest file as shown below.
 
 ```json
 {

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -9,18 +9,20 @@ browser-compat: html.manifest.prefer_related_applications
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>Boolean</code></td>
-    </tr>
-  </tbody>
-</table>
-
 The `prefer_related_applications` member is a boolean value that specifies that applications listed in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) should be preferred over the web application. If the `prefer_related_applications` member is set to `true`, the user agent might suggest installing one of the related applications instead of this web app.
 
 If omitted, `prefer_related_applications` defaults to `false`.
+
+## Syntax
+
+```json
+"prefer_related_applications": true
+```
+
+### Keys
+
+- `prefer_related_applications`
+  - : A boolean value that
 
 ## Examples
 

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -9,26 +9,71 @@ browser-compat: html.manifest.prefer_related_applications
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
-The `prefer_related_applications` member is a boolean value that specifies that applications listed in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) should be preferred over the web application. If the `prefer_related_applications` member is set to `true`, the user agent might suggest installing one of the related applications instead of this web app.
+The `prefer_related_applications` manifest member is used to indicate whether you prefer users to install a related native application over your web application. It is typically used in conjunction with the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member.
 
-If omitted, `prefer_related_applications` defaults to `false`.
+> [!NOTE]
+> For Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted.
 
 ## Syntax
 
-```json
+```json-nolint
+/* Boolean values */
 "prefer_related_applications": true
+"prefer_related_applications": false
 ```
 
-### Keys
+### Values
 
 - `prefer_related_applications`
-  - : A boolean value that
+  - : A boolean value.
+    - If set to `true`, browsers might prompt users to install one of the applications listed in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) instead of your web app.
+    - If set to `false` or omitted, browsers will give preference to your web app over the related applications.
 
 ## Examples
 
+### Specifying preference for your web app
+
+Consider a scenario where you have both a web app and native apps for your product. If you want to offer related native apps as options but prefer users to install your web app:
+
 ```json
-"prefer_related_applications": true
+{
+  "prefer_related_applications": false,
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "com.example.hikingapp"
+    },
+    {
+      "platform": "itunes",
+      "url": "https://apps.apple.com/store/app/hiking/id123456789"
+    }
+  ]
+}
 ```
+
+Your web app will be installed as the primary app, and browsers will not prompt users to install related native apps. However, the native apps will still be available as alternatives.
+
+### Specifying preference for native apps
+
+If you want to encourage users to install a native app for a better experience with certain features:
+
+```json
+{
+  "prefer_related_applications": true,
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "com.example.hikingapp"
+    },
+    {
+      "platform": "itunes",
+      "url": "https://apps.apple.com/store/app/hiking/id123456789"
+    }
+  ]
+}
+```
+
+Browsers might prompt users to install one of the related native apps instead of your web app.
 
 ## Specifications
 
@@ -37,3 +82,8 @@ If omitted, `prefer_related_applications` defaults to `false`.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member
+- [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable

--- a/files/en-us/web/manifest/prefer_related_applications/index.md
+++ b/files/en-us/web/manifest/prefer_related_applications/index.md
@@ -9,7 +9,7 @@ browser-compat: html.manifest.prefer_related_applications
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
-The `prefer_related_applications` manifest member is used to indicate whether you prefer users to install a related native application over your web application. It is typically used in conjunction with the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member.
+The `prefer_related_applications` manifest member is used to provide a hint to browsers about whether to prefer related native applications over your web application. It is typically used in conjunction with the [`related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member.
 
 > [!NOTE]
 > For Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted.
@@ -27,11 +27,11 @@ The `prefer_related_applications` manifest member is used to indicate whether yo
 - `prefer_related_applications`
   - : A boolean value.
     - If set to `true`, browsers might prompt users to install one of the applications listed in [`related_applications`](/en-US/docs/Web/Manifest/related_applications) instead of your web app.
-    - If set to `false` or omitted, browsers will give preference to your web app over the related applications.
+    - If set to `false` or omitted, browsers will typically prefer to install your web app over related native applications, if specified.
 
 ## Examples
 
-### Specifying preference for your web app
+### Specifying preference for installing your web app
 
 Consider a scenario where you have both a web app and native apps for your product. If you want to offer related native apps as options but prefer users to install your web app:
 
@@ -53,9 +53,9 @@ Consider a scenario where you have both a web app and native apps for your produ
 
 Your web app will be installed as the primary app, and browsers will not prompt users to install related native apps. However, the native apps will still be available as alternatives.
 
-### Specifying preference for native apps
+### Specifying preference for installing related native apps
 
-If you want to encourage users to install a native app for a better experience with certain features:
+In the previous scenario, if you want to encourage users to install the related native app for a better experience with certain features, you can indicate it via `prefer_related_applications`:
 
 ```json
 {
@@ -73,7 +73,7 @@ If you want to encourage users to install a native app for a better experience w
 }
 ```
 
-Browsers might prompt users to install one of the related native apps instead of your web app.
+Browsers might prompt users to install one of the related native app instead of your web app.
 
 ## Specifications
 

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -10,7 +10,7 @@ browser-compat: html.manifest.related_applications
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 The `related_applications` manifest member is used to specify one or more native applications that are related to your web application.
-It affects user experience when the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member is set to `true`, which indicates a preference for a native application over your web application.
+This can be used with the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member, which indicates a preference for installing either a native application or your web application.
 
 ## Syntax
 
@@ -65,10 +65,9 @@ It affects user experience when the [`prefer_related_applications`](/en-US/docs/
 
 ## Description
 
-A "related application" is a {{Glossary("native")}} application that has a relationship with your web app.
-This relationshop means the native app provides functionality similar to your web app, often with additional features or better integration with users' devices.
+A "related application" is a {{Glossary("native")}} application that provides functionality similar to your web app, often with additional features or better integration with users' devices.
 
-The `related_applications` manifest member lets you specify these platform-specific native applications that are related to your web app.
+The `related_applications` manifest member lets you identify the platform-specific native applications that are related to your web app.
 For example, consider you have a native Android app for your product available through the Google Play Store.
 It provides the same core features as your web app and integrates better with the device's notification system.
 You can use `related_applications` to specify this native Android app in your web app's manifest file.

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -10,7 +10,7 @@ browser-compat: html.manifest.related_applications
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 The `related_applications` manifest member is used to specify one or more native applications that are related to your web application.
-This can be used with the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member, which indicates a preference for installing either a native application or your web application.
+It can be used with the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member, which indicates a preference for installing either a related native application or your web application.
 
 ## Syntax
 

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -148,6 +148,6 @@ If you want to indicate to browsers that you prefer users to be given the option
 
 ## See also
 
-- [`prefer_related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member
+- [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member
 - [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable
 - {{domxref("Navigator.getInstalledRelatedApps()")}}

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -10,14 +10,12 @@ browser-compat: html.manifest.related_applications
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
 The `related_applications` manifest member is used to specify one or more native applications that are related to your web application.
-
-> [!NOTE]
-> You can set the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member to `true` if you prefer users to install the related native applications over your web app. However, for Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted.
+It affects user experience when the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member is set to `true`, which indicates a preference for a native application over your web application.
 
 ## Syntax
 
 ```json-nolint
-/* Single related native application with both url and id */
+/* Related native application on one platform specified by both url and id */
 "related_applications": [
   {
     "platform": "play",
@@ -26,7 +24,7 @@ The `related_applications` manifest member is used to specify one or more native
   }
 ]
 
-/* Single related native application with only id */
+/* Related native application on one platform specfied only by id */
 "related_applications": [
   {
     "platform": "windows",
@@ -34,7 +32,7 @@ The `related_applications` manifest member is used to specify one or more native
   }
 ]
 
-/* Multiple related native applications */
+/* Related native applications on two platforms */
 "related_applications": [
   {
     "platform": "play",
@@ -42,8 +40,8 @@ The `related_applications` manifest member is used to specify one or more native
     "id": "com.example.app1"
   },
   {
-    "platform": "itunes",
-    "url": "https://apps.apple.com/app/example-app1/id123456789"
+    "platform": "amazon",
+    "url": "https://www.amazon.com/product/dp/B000XA1000"
   }
 ]
 ```
@@ -55,25 +53,43 @@ The `related_applications` manifest member is used to specify one or more native
   - : An array of objects, each representing a platform-specific native application related to the web app. Each object must include a `platform` property and at least one of either a `url` or an `id` (or both).
 
     - `platform`
-      - : A string that identifies the platform on which the application can be found. This is a required property. See the [list of available platform values](https://github.com/w3c/manifest/wiki/Platforms).
-    - `url`
+      - : A string that identifies the platform on which the application can be found.
+        Examples include `amazon` (Amazon App Store), `play` (Google Play Store), and `windows` (Windows Store).
+        See the complete list of possible [platform values](https://github.com/w3c/manifest/wiki/Platforms).
+    - `url` {{Optional_Inline}}
       - : A string that represents the URL at which the platform-specific application can be found.
-    - `id`
+        If not specified, an `id` must be provided.
+    - `id` {{Optional_Inline}}
       - : A string with the ID used to represent the application on the specified platform.
+        If not specified, a `url` must be provided.
 
 ## Description
 
-A "related application" is an application accessible to the underlying platform that has a relationship with your web app. The `related_applications` manifest member lets you inform users about the platform-specific versions of your web app. These native applications, which are installable by or accessible to the underlying platform, provide functionality similar to your web app and might offer additional features or better integration with user's device. For example, you could specify a native Android application available through the Google Play Store, which offers the same core features as your web app but better integration with the device's notification system.
+A "related application" is a {{Glossary("native")}} application that has a relationship with your web app.
+This relationshop means the native app provides functionality similar to your web app, often with additional features or better integration with users' devices.
 
-The `related_applications` member creates a unidirectional relationship: it indicates that the native apps are related to your web app, but does not require the native apps to reference your web app in return. You can specify multiple related applications for different platforms, giving users options across various devices and operating systems.
+The `related_applications` manifest member lets you specify these platform-specific native applications that are related to your web app.
+For example, consider you have a native Android app for your product available through the Google Play Store.
+It provides the same core features as your web app and integrates better with the device's notification system.
+You can use `related_applications` to specify this native Android app in your web app's manifest file.
 
-The `related_applications` member serves multiple purposes. If you prefer users to install a related native app instead of your web app, you can use it along with the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member. By setting `prefer_related_applications` to `true`, you enable browsers to offer users a choice between installing your web app and the platform-specific version of the native app. Another scenario in which the `related_applications` information might be used is by web crawlers. They might use this data to gather more details about your web app.
+Some key points about the `related_applications` member include:
+
+- It allows you to specify multiple related apps on different platforms, giving users options for native apps across various devices and operating systems.
+- It creates a unidirectional relationship between your web app and the specified native apps.
+  The native apps are not required to reference your web app in return.
+- The data may be used by web crawlers to gather more information about the native apps related to your web app, potentially improving discoverability of these native apps.
+
+- When used with the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) member set to `true`, it enables browsers to suggest installing the related native app instead of your web app.
+
+  > [!NOTE]
+  > For Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted to make your web app installable.
 
 ## Examples
 
 ### Specifying a related native application
 
-The following example specifies minimal information in the web app's manifest file to identify the related native app:
+This example shows how to specify a related native Android app in your web app's manifest file. It uses minimal information to identify the native app available on the Google Play Store:
 
 ```json
 {
@@ -86,9 +102,9 @@ The following example specifies minimal information in the web app's manifest fi
 }
 ```
 
-### Specifying related native applications for multiple platforms
+### Specifying related native applications on multiple platforms
 
-If native versions of your web app are available on different platforms, you can specify them in your web app's manifest file like so:
+If native versions of your web app are available on both Google Play Store and Windows Store, you can specify them in your web app's manifest file like so:
 
 ```json
 {
@@ -99,10 +115,6 @@ If native versions of your web app are available on different platforms, you can
       "id": "com.example.app1"
     },
     {
-      "platform": "itunes",
-      "url": "https://apps.apple.com/app/example-app1/id123456789"
-    },
-    {
       "platform": "windows",
       "url": "https://apps.microsoft.com/store/detail/example-app1/9WZDNCRFHVJL"
     }
@@ -110,9 +122,9 @@ If native versions of your web app are available on different platforms, you can
 }
 ```
 
-### Specifying preference for installing related native apps
+### Specifying preference for installing a related native app
 
-If you want to indicate to browsers that you prefer users to install the native app instead of your web app, you can set `prefer_related_applications` to `true`.
+If you want to indicate to browsers that you prefer users to be given the option to install your native app, available on the Google App Store, instead of your web app, you can set `prefer_related_applications` to `true`. Browsers may then prompt users to install the native Android app instead of your web app.
 
 ```json
 {
@@ -120,17 +132,11 @@ If you want to indicate to browsers that you prefer users to install the native 
   "related_applications": [
     {
       "platform": "play",
-      "id": "com.example.hikingapp"
-    },
-    {
-      "platform": "itunes",
-      "url": "https://apps.apple.com/store/app/hiking/id123456789"
+      "id": "com.example.app1"
     }
   ]
 }
 ```
-
-Browsers might prompt users to install one of the related native app instead of your web app.
 
 ## Specifications
 
@@ -139,3 +145,9 @@ Browsers might prompt users to install one of the related native app instead of 
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [`prefer_related_applications`](/en-US/docs/Web/Manifest/related_applications) manifest member
+- [The web app manifest](/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest) for making your web app installable
+- {{domxref("Navigator.getInstalledRelatedApps()")}}

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -52,7 +52,7 @@ The `related_applications` manifest member is used to specify one or more native
 
 - `related_applications`
 
-  - : An object or an array of objects, each representing a platform-specific native application related to the web app. Each object must include a `platform` property and at least one of either a `url` or an `id` (or both).
+  - : An array of objects, each representing a platform-specific native application related to the web app. Each object must include a `platform` property and at least one of either a `url` or an `id` (or both).
 
     - `platform`
       - : A string that identifies the platform on which the application can be found. This is a required property. See the [list of available platform values](https://github.com/w3c/manifest/wiki/Platforms).

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -9,47 +9,128 @@ browser-compat: html.manifest.related_applications
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
 
-<table class="properties">
-  <tbody>
-    <tr>
-      <th scope="row">Type</th>
-      <td><code>Array</code></td>
-    </tr>
-  </tbody>
-</table>
-
-The `related_applications` field is an array of objects specifying native applications that are installable by, or accessible to, the underlying platform — for example, a native Android application obtainable through the Google Play Store. Such applications are intended to be alternatives to the manifest's website that provides similar/equivalent functionality — like the native app equivalent.
+The `related_applications` manifest member is used to specify one or more native applications that are related to your web application.
 
 > [!NOTE]
-> Developer can specify that the native applications are preferred over the web application by setting `prefer_related_applications` to `true`.
+> You can set the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member to `true` if you prefer users to install the related native applications over your web app. However, for Chromium-based browsers, `prefer_related_applications` should be set to `false` or omitted.
 
-## Examples
+## Syntax
 
-```json
+```json-nolint
+/* Single related application with both url and id */
 "related_applications": [
   {
     "platform": "play",
     "url": "https://play.google.com/store/apps/details?id=com.example.app1",
     "id": "com.example.app1"
-  }, {
-    "platform": "itunes",
-    "url": "https://itunes.apple.com/app/example-app1/id123456789"
-  }, {
+  }
+]
+
+/* Single related application with only id */
+"related_applications": [
+  {
     "platform": "windows",
-    "url": "https://apps.microsoft.com/store/detail/example-app1/id123456789"
+    "id": "example.app1"
+  }
+]
+
+/* Multiple related applications */
+"related_applications": [
+  {
+    "platform": "play",
+    "url": "https://play.google.com/store/apps/details?id=com.example.app1",
+    "id": "com.example.app1"
+  },
+  {
+    "platform": "itunes",
+    "url": "https://apps.apple.com/app/example-app1/id123456789"
   }
 ]
 ```
 
-## Related application properties
+### Values
 
-Application objects may contain the following properties:
+- `related_applications`
 
-| Member     | Description                                                                                                                    |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `platform` | The platform on which the application can be found. [List of available values](https://github.com/w3c/manifest/wiki/Platforms) |
-| `url`      | The URL at which the application can be found.                                                                                 |
-| `id`       | The ID used to represent the application on the specified platform.                                                            |
+  - : An object or an array of objects, each representing a platform-specific native application related to the web app. Each object must include a `platform` property and at least one of either a `url` or an `id` (or both).
+
+    - `platform`
+      - : A string that identifies the platform on which the application can be found. This is a required property. See the [list of available platform values](https://github.com/w3c/manifest/wiki/Platforms).
+    - `url`
+      - : A string that represents the URL at which the platform-specific application can be found.
+    - `id`
+      - : A string with the ID used to represent the application on the specified platform.
+
+## Description
+
+A "related application" is an application accessible to the underlying platform that has a relationship with your web app. The `related_applications` manifest member lets you inform users about the platform-specific versions of your web app. These native applications, which are installable by or accessible to the underlying platform, provide functionality similar to your web app and might offer additional features or better integration with user's device. For example, you could specify a native Android application available through the Google Play Store, which offers the same core features as your web app but better integration with the device's notification system.
+
+The `related_applications` member creates a unidirectional relationship: it indicates that the native apps are related to your web app, but does not require the native apps to reference your web app in return. You can specify multiple related applications for different platforms, giving users options across various devices and operating systems.
+
+The `related_applications` member serves multiple purposes. If you prefer users to install a related native app instead of your web app, you can use it along with the [`prefer_related_applications`](/en-US/docs/Web/Manifest/prefer_related_applications) manifest member. By setting `prefer_related_applications` to `true`, you enable browsers to offer users a choice between installing your web app and the platform-specific version of the native app. Another scenario in which the `related_applications` information might be used is by web crawlers. They might use this data to gather more details about your web app.
+
+## Examples
+
+### Specifying a related native application
+
+The following example specifies minimal information in the web app's manifest file to identify the related native app:
+
+```json
+{
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "com.example.app1"
+    }
+  ]
+}
+```
+
+### Specifying related native applications for multiple platforms
+
+If native versions of your web app are available on different platforms, you can specify them in your web app's manifest file like so:
+
+```json
+{
+  "related_applications": [
+    {
+      "platform": "play",
+      "url": "https://play.google.com/store/apps/details?id=com.example.app1",
+      "id": "com.example.app1"
+    },
+    {
+      "platform": "itunes",
+      "url": "https://apps.apple.com/app/example-app1/id123456789"
+    },
+    {
+      "platform": "windows",
+      "url": "https://apps.microsoft.com/store/detail/example-app1/9WZDNCRFHVJL"
+    }
+  ]
+}
+```
+
+### Specifying preference for installing related native apps
+
+If you want to indicate to browsers that you prefer users to install the native app instead of your web app, you can set `prefer_related_applications` to `true`.
+
+```json
+{
+  "prefer_related_applications": true,
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "com.example.hikingapp"
+    },
+    {
+      "platform": "itunes",
+      "url": "https://apps.apple.com/store/app/hiking/id123456789"
+    }
+  ]
+}
+```
+
+Browsers might prompt users to install one of the related native app instead of your web app.
 
 ## Specifications
 

--- a/files/en-us/web/manifest/related_applications/index.md
+++ b/files/en-us/web/manifest/related_applications/index.md
@@ -17,7 +17,7 @@ The `related_applications` manifest member is used to specify one or more native
 ## Syntax
 
 ```json-nolint
-/* Single related application with both url and id */
+/* Single related native application with both url and id */
 "related_applications": [
   {
     "platform": "play",
@@ -26,7 +26,7 @@ The `related_applications` manifest member is used to specify one or more native
   }
 ]
 
-/* Single related application with only id */
+/* Single related native application with only id */
 "related_applications": [
   {
     "platform": "windows",
@@ -34,7 +34,7 @@ The `related_applications` manifest member is used to specify one or more native
   }
 ]
 
-/* Multiple related applications */
+/* Multiple related native applications */
 "related_applications": [
   {
     "platform": "play",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

This work is part of improving the web/manifest docs.

Apart from normalizing the page layout to include "Syntax" and "Values", this PR includes the following changes:

- `related_apps`:
   - Added a "Description" section to move all the additional info
   - Added more examples and with prose

- `prefer_related_apps`:
   - Added more examples and with prose

### Motivation

To ensure all sections have sufficient explanation, all caveats from spec are covered, and the pages follow a similar template

### Additional details

- Spec links:
  - https://w3c.github.io/manifest/#related_applications-member
  - https://w3c.github.io/manifest/#prefer_related_applications-member

### Related issues and pull requests

Tracking issue: https://github.com/mdn/mdn/issues/560