### PR TITLE
Correcting a grammatical error in index.md

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -745,7 +745,7 @@ AuthorSchema.virtual("name").get(function () {
 
 // Virtual for author's URL
 AuthorSchema.virtual("url").get(function () {
-  // We don't use an arrow function as we'll need the this object
+  // We don't use an arrow function as we'll need this object
   return `/catalog/author/${this._id}`;
 });
 


### PR DESCRIPTION
The word "the" has been written before "this" to indicate an object that has led to a grammatical mistake.

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
