### PR TITLE
Update two manifest member (BCD data removed)

### DIFF
--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -34,4 +34,4 @@ The `categories` member is an array of strings defining the names of categories 
 
 ## Browser compatibility
 
-The feature is not implemented by any browser yet.
+This manifest member is used by app stores and catalogs when publishing and listing web apps, so browser compatibility is not applicable. Browsers may parse this information, but it's optional and doesn't affect the core functionality of a web app.

--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -34,4 +34,4 @@ The `categories` member is an array of strings defining the names of categories 
 
 ## Browser compatibility
 
-The feature is not supported by any of the browser implement yet.
+The feature is not implemented by any browser yet.

--- a/files/en-us/web/manifest/categories/index.md
+++ b/files/en-us/web/manifest/categories/index.md
@@ -2,7 +2,7 @@
 title: categories
 slug: Web/Manifest/categories
 page-type: web-manifest-member
-browser-compat: html.manifest.categories
+spec-urls: https://w3c.github.io/manifest-app-info/#categories-member
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}
@@ -34,4 +34,4 @@ The `categories` member is an array of strings defining the names of categories 
 
 ## Browser compatibility
 
-{{Compat}}
+The feature is not supported by any of the browser implement yet.

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -93,4 +93,4 @@ The `screenshots` member is an array of objects each representing a screenshot. 
 
 ## Browser compatibility
 
-The feature is not implemented by any browser yet.
+This manifest member is used by app stores and catalogs when publishing and listing web apps, so browser compatibility is not applicable. Browsers may parse this information, but it's optional and doesn't affect the core functionality of a web app.

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -93,4 +93,4 @@ The `screenshots` member is an array of objects each representing a screenshot. 
 
 ## Browser compatibility
 
-The feature is not supported by any of the browser implement yet.
+The feature is not implemented by any browser yet.

--- a/files/en-us/web/manifest/screenshots/index.md
+++ b/files/en-us/web/manifest/screenshots/index.md
@@ -4,7 +4,7 @@ slug: Web/Manifest/screenshots
 page-type: web-manifest-member
 status:
   - experimental
-browser-compat: html.manifest.screenshots
+spec-urls: https://w3c.github.io/manifest-app-info/#screenshots-member
 ---
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/Manifest")}}{{SeeCompatTable}}
@@ -93,4 +93,4 @@ The `screenshots` member is an array of objects each representing a screenshot. 
 
 ## Browser compatibility
 
-{{Compat}}
+The feature is not supported by any of the browser implement yet.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

see https://github.com/mdn/browser-compat-data/pull/23774, the two's BCD data is removed, but the two is still standard: so `browser-compat` key removed and `spec-urls` key added, also update *Browser compatibility* section with a sentence explaining the support status

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
