### PR TITLE
fix(api): add allow clipboard-read to clipboard live samples

### DIFF
--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -127,7 +127,7 @@ Copy the butterfly image on the left by right-clicking the image and selecting "
 Then click on the empty frame on the right.
 The example will fetch the image data from the clipboard and display the image in the empty frame.
 
-{{EmbedLiveSample("Reading image data from clipboard", "100%", "200")}}
+{{EmbedLiveSample("Reading image data from clipboard", "100%", "250", "", "", "", "clipboard-read")}}
 
 > [!NOTE]
 > If prompted, grant permission in order to paste the image.
@@ -242,7 +242,7 @@ async function pasteData() {
 Copy some text or the butterfly (JPG) image below (to copy images right-click on them and then select "Copy image" from the context menu).
 Select the indicated frame below to paste this information from the clipboard into the frame.
 
-{{EmbedLiveSample("Reading data from the clipboard", "100%", "450")}}
+{{EmbedLiveSample("Reading data from the clipboard", "100%", "500", "", "", "", "clipboard-read")}}
 
 Notes:
 
@@ -346,7 +346,7 @@ pasteUnsanitizedButton.addEventListener("click", async () => {
 
 First click the "Copy HTML" button to write the HTML code from the first textarea to the clipboard. Then either click the "Paste HTML" button or the "Paste unsanitized HTML" button to paste the sanitized or unsanitized HTML code into the second textarea.
 
-{{EmbedLiveSample("Reading unsanitized HTML from the clipboard", "100%", "220")}}
+{{EmbedLiveSample("Reading unsanitized HTML from the clipboard", "100%", "250", "", "", "", "clipboard-read")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -346,7 +346,7 @@ pasteUnsanitizedButton.addEventListener("click", async () => {
 
 First click the "Copy HTML" button to write the HTML code from the first textarea to the clipboard. Then either click the "Paste HTML" button or the "Paste unsanitized HTML" button to paste the sanitized or unsanitized HTML code into the second textarea.
 
-{{EmbedLiveSample("Reading unsanitized HTML from the clipboard", "100%", "250", "", "", "", "clipboard-read")}}
+{{EmbedLiveSample("Reading unsanitized HTML from the clipboard", "100%", "250", "", "", "", "clipboard-read; clipboard-write")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -203,7 +203,7 @@ img {
 The result is shown below.
 First click on the blue square, and then select the text "Paste here" and use your OS-specific keyboard combinatations to paste from the clipboard (such as `Ctrl+V` on Windows).
 
-{{embedlivesample("write_canvas_contents_to_the_clipboard", "", "400")}}
+{{embedlivesample("write_canvas_contents_to_the_clipboard", "", "420", "", "", "", "clipboard-read")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -203,7 +203,7 @@ img {
 The result is shown below.
 First click on the blue square, and then select the text "Paste here" and use your OS-specific keyboard combinatations to paste from the clipboard (such as `Ctrl+V` on Windows).
 
-{{embedlivesample("write_canvas_contents_to_the_clipboard", "", "420", "", "", "", "clipboard-read")}}
+{{embedlivesample("write_canvas_contents_to_the_clipboard", "", "420", "", "", "", "clipboard-write")}}
 
 ## Specifications
 


### PR DESCRIPTION
- fix #35862

Cross-origin iframes need to [mention permissions explicitly now](https://www.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes/).