### PR TITLE
Fix GPUInternalError

### DIFF
--- a/files/en-us/web/api/gpuinternalerror/index.md
+++ b/files/en-us/web/api/gpuinternalerror/index.md
@@ -9,7 +9,7 @@ browser-compat: api.GPUInternalError
 
 {{APIRef("WebGPU API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`GPUInternalError`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} describes an application error indicating that an operation did not pass the WebGPU API's validation constraints.
+The **`GPUInternalError`** interface of the {{domxref("WebGPU API", "WebGPU API", "", "nocode")}} describes an application error indicating that an operation failed for a system or implementation-specific reason, even when all validation requirements were satisfied.
 
 It represents one of the types of errors surfaced by {{domxref("GPUDevice.popErrorScope")}} and the {{domxref("GPUDevice.uncapturederror_event", "uncapturederror")}} event.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
Fix the explanation in the first paragraph.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->
This commit is copying the explanation from [the index page of WebGPU API](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API).

The current explanation

> The GPUInternalError interface of the [WebGPU API](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API) describes an application error indicating that an operation did not pass the WebGPU API's validation constraints.

Looks like the same as one for [GPUValidationError](https://developer.mozilla.org/en-US/docs/Web/API/GPUValidationError) and doesn't look suit for `GPUInternalError`.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
