### PR TITLE
Change wrongly used `<input>` to `<button>`

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_accessibility/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_accessibility/index.md
@@ -118,7 +118,7 @@ Doing this will populate our `editFieldRef` and `editButtonRef` with references 
 console.log(editButtonRef.current);
 ```
 
-You'll see that the value of `editButtonRef.current` is `null` when the component first renders, but if you click an "Edit" button, it will log the `<input>` element to the console. This is because the ref is populated only after the component renders, and clicking the "Edit" button causes the component to re-render. Be sure to delete this log before moving on.
+You'll see that the value of `editButtonRef.current` is `null` when the component first renders, but if you click an "Edit" button, it will log the `<button>` element to the console. This is because the ref is populated only after the component renders, and clicking the "Edit" button causes the component to re-render. Be sure to delete this log before moving on.
 
 > [!NOTE]
 > Your logs will appear 6 times because we have 3 instances of `<Todo />` in our app and React renders our components twice in development.


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Here, it logs the button element because we are using `editButtonRef.current` and not `editFieldRef`
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

Because it really confuses the reader when instead of the (wrongly) expected `<input>` element, the `<button>` element is logged

### Additional details


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
