### PR TITLE
add information about <param> element deprecation

### DIFF
--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -325,7 +325,7 @@ If you find yourself needing to embed plugin content, this is the kind of inform
     </tr>
     <tr>
       <td>
-        <em>accurate </em>{{glossary("MIME type", 'media type')}}
+        <em>Accurate </em>{{glossary("MIME type", "media type")}}
         of the embedded content
       </td>
       <td><a href="/en-US/docs/Web/HTML/Element/embed#type"><code>type</code></a></td>
@@ -333,7 +333,7 @@ If you find yourself needing to embed plugin content, this is the kind of inform
     </tr>
     <tr>
       <td>
-        height and width (in CSS pixels) of the box controlled by the plugin
+        Height and width (in CSS pixels) of the box controlled by the plugin
       </td>
       <td>
          <a href="/en-US/docs/Web/HTML/Element/embed#height"><code>height</code></a><br /><a href="/en-US/docs/Web/HTML/Element/embed#width"><code>width</code></a>
@@ -343,10 +343,10 @@ If you find yourself needing to embed plugin content, this is the kind of inform
       </td>
     </tr>
     <tr>
-      <td>names and values, to feed the plugin as parameters</td>
-      <td>ad hoc attributes with those names and values</td>
+      <td>Independent HTML content as a fallback for an unavailable resource</td>
+      <td>Not supported (<code>&#x3C;noembed></code> is obsolete)</td>
       <td>
-        contained within opening and closing
+        Contained within the opening and closing
         <code>&#x3C;object></code> tags
       </td>
     </tr>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -346,16 +346,8 @@ If you find yourself needing to embed plugin content, this is the kind of inform
       <td>names and values, to feed the plugin as parameters</td>
       <td>ad hoc attributes with those names and values</td>
       <td>
-        single-tag {{htmlelement("param")}} elements, contained within
-        <code>&#x3C;object></code> ({{htmlelement("param")}} element is deprecated. See {{htmlelement("param")}} for more information)
-      </td>
-    </tr>
-    <tr>
-      <td>independent HTML content as fallback for an unavailable resource</td>
-      <td>not supported (<code>&#x3C;noembed></code> is obsolete)</td>
-      <td>
-        contained within <code>&#x3C;object></code>, after
-        <code>&#x3C;param></code> elements
+        contained within opening and closing
+        <code>&#x3C;object></code> tags
       </td>
     </tr>
   </tbody>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -346,8 +346,8 @@ If you find yourself needing to embed plugin content, this is the kind of inform
       <td>names and values, to feed the plugin as parameters</td>
       <td>ad hoc attributes with those names and values</td>
       <td>
-        single-tag {{htmlelement("param")}} elements, contained within
-        <code>&#x3C;object></code>
+        single-tag {{htmlelement("param")}} (deprecated. See {{htmlelement("param")}} for more information) elements, contained within
+        <code>&#x3C;object></code> 
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -347,7 +347,7 @@ If you find yourself needing to embed plugin content, this is the kind of inform
       <td>ad hoc attributes with those names and values</td>
       <td>
         single-tag {{htmlelement("param")}} elements, contained within
-        <code>&#x3C;object></code> (<param> element is deprecated. See {{htmlelement("param")}} for more information)
+        <code>&#x3C;object></code> ({{htmlelement("param")}} element is deprecated. See {{htmlelement("param")}} for more information)
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -347,7 +347,7 @@ If you find yourself needing to embed plugin content, this is the kind of inform
       <td>ad hoc attributes with those names and values</td>
       <td>
         single-tag {{htmlelement("param")}} (deprecated. See {{htmlelement("param")}} for more information) elements, contained within
-        <code>&#x3C;object></code> 
+        <code>&#x3C;object></code>
       </td>
     </tr>
     <tr>

--- a/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/other_embedding_technologies/index.md
@@ -346,8 +346,8 @@ If you find yourself needing to embed plugin content, this is the kind of inform
       <td>names and values, to feed the plugin as parameters</td>
       <td>ad hoc attributes with those names and values</td>
       <td>
-        single-tag {{htmlelement("param")}} (deprecated. See {{htmlelement("param")}} for more information) elements, contained within
-        <code>&#x3C;object></code>
+        single-tag {{htmlelement("param")}} elements, contained within
+        <code>&#x3C;object></code> (<param> element is deprecated. See {{htmlelement("param")}} for more information)
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

This PR adds information about <param> element deprecation and linked [param page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param) for more information.

Fixes https://github.com/mdn/content/issues/35681 


