### PR TITLE
clarify output is not submitted with form

### DIFF
--- a/files/en-us/web/html/element/output/index.md
+++ b/files/en-us/web/html/element/output/index.md
@@ -19,7 +19,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
   - : The {{HTMLElement("form")}} element to associate the output with (its _form owner_). The value of this attribute must be the [`id`](/en-US/docs/Web/HTML/Global_attributes#id) of a `<form>` in the same document. (If this attribute is not set, the `<output>` is associated with its ancestor `<form>` element, if any.)
 
-    This attribute lets you associate `<output>` elements to `<form>`s anywhere in the document, not just inside a `<form>`. It can also override an ancestor `<form>` element.
+    This attribute lets you associate `<output>` elements to `<form>`s anywhere in the document, not just inside a `<form>`. It can also override an ancestor `<form>` element. The `<output>` element's name and content are not submitted when the form is submitted.
 
 - `name`
   - : The element's name. Used in the {{domxref("HTMLFormElement.elements", "form.elements")}} API.


### PR DESCRIPTION
this has to be listed somewhere.

> The [form](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form) attribute is used to explicitly associate the [output](https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element) element with its [form owner](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner). The [name](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name) attribute represents the element's name. The [output](https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element) element is associated with a form so that it can be easily [referenced](https://html.spec.whatwg.org/multipage/dom.html#referenced) from the event handlers of form controls; **the element's value itself is not submitted when the form is submitted.**


from https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element